### PR TITLE
Testsuite: Add extra fixes to the testsuite after pushing Salt bundle

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap.py
+++ b/spacewalk/certs-tools/rhn_bootstrap.py
@@ -178,6 +178,7 @@ def getDefaultOptions():
             'allow-config-actions': 0,
             'allow-remote-commands': 0,
             'no-bundle': 0,
+            'force-bundle': 0,
             'no-gpg': 0,
             'no-up2date': 0,
             'up2date': 0,
@@ -250,6 +251,9 @@ def getOptionsTable():
         Option('--no-bundle',
                action='store_true',
                help='boolean; avoid installing salt minion bundle (venv-salt-minion) instead of salt minion (currently %s)' % getSetString(defopts['no-bundle'])),
+        Option('--force-bundle',
+               action='store_true',
+               help='boolean; Force installing salt minion bundle (venv-salt-minion) instead of salt minion (currently %s)' % getSetString(defopts['force-bundle'])),
         Option('--no-gpg',
                action='store_true',
                help='(not recommended) boolean; turn off GPG checking by the clients (currently %s)' % getSetString(defopts['no-gpg'])),
@@ -319,6 +323,7 @@ Note: for mgr-bootstrap to work, certain files are expected to be
             'allow-config-actions': not not options.allow_config_actions,
             'allow-remote-commands': not not options.allow_remote_commands,
             'no-bundle': not not options.no_bundle,
+            'force-bundle': not not options.force_bundle,
             'no-gpg': not not options.no_gpg,
             'no-up2date': not not options.no_up2date,
             'up2date': not not options.up2date,
@@ -395,7 +400,7 @@ ERROR: the value of --overrides and --script cannot be the same!
         options.http_proxy_password = ''
 
     # forcing numeric values
-    for opt in ['allow_config_actions', 'allow_remote_commands',
+    for opt in ['allow_config_actions', 'allow_remote_commands', 'force_bundle',
         'no_bundle', 'no_gpg', 'no_up2date', 'traditional', 'up2date', 'verbose']:
         # operator.truth should return (0, 1) or (False, True) depending on
         # the version of python; passing any of those values through int()

--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -341,7 +341,7 @@ function test_repo_exists() {{
 }}
 
 function test_venv_enabled() {{
-    if [ $FORCE_VENV_SALT_MINION -e 1 ]; then
+    if [ $FORCE_VENV_SALT_MINION -eq 1 ]; then
         VENV_ENABLED=1
     elif [ $AVOID_VENV_SALT_MINION -ne 1 ]; then
         local repourl="$CLIENT_REPO_URL"

--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -157,6 +157,10 @@ CLIENT_REPOS_ROOT=
 # even if it available in the bootstrap repo
 AVOID_VENV_SALT_MINION={avoid_venv}
 
+# Force installing venv-salt-minion instead salt-minion
+# even if it is NOT available in the bootstrap repo
+FORCE_VENV_SALT_MINION={force_venv}
+
 #
 # -----------------------------------------------------------------------------
 # DO NOT EDIT BEYOND THIS POINT -----------------------------------------------
@@ -251,6 +255,7 @@ def getHeader(productName, options, orgCACert, isRpmYN, pubname, apachePubDirect
                           orgCACert=orgCACert,
                           isRpmYN=isRpmYN,
                           avoid_venv=1 if bool(options.no_bundle) else 0,
+                          force_venv=1 if bool(options.force_bundle) else 0,
                           using_ssl=1,
                           using_gpg=0 if bool(options.no_gpg) else 1,
                           allow_config_actions=options.allow_config_actions,
@@ -336,7 +341,9 @@ function test_repo_exists() {{
 }}
 
 function test_venv_enabled() {{
-    if [ $AVOID_VENV_SALT_MINION -ne 1 ]; then
+    if [ $FORCE_VENV_SALT_MINION -e 1 ]; then
+        VENV_ENABLED=1
+    elif [ $AVOID_VENV_SALT_MINION -ne 1 ]; then
         local repourl="$CLIENT_REPO_URL"
         if [ "$INSTALLER" == "zypper" ] || [ "$INSTALLER" == "yum" ]; then
             ARCH=$(rpm --eval "%{{_host_cpu}}")

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,5 @@
+- Allow "--force-bundle" attribute when generating bootstrap script
+
 -------------------------------------------------------------------
 Fri Nov 05 13:36:40 CET 2021 - jgonzalez@suse.com
 

--- a/testsuite/features/core/proxy_register_as_minion_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_script.feature
@@ -20,8 +20,17 @@ Feature: Setup Uyuni proxy
     And I install proxy pattern on the proxy
     And I let squid use avahi on the proxy
 
+  @susemanager
   Scenario: Create the bootstrap script for the proxy and use it
     When I execute mgr-bootstrap "--script=bootstrap-proxy.sh --no-up2date"
+    Then I should get "* bootstrap script (written):"
+    And I should get "    '/srv/www/htdocs/pub/bootstrap/bootstrap-proxy.sh'"
+    When I fetch "pub/bootstrap/bootstrap-proxy.sh" to "proxy"
+    And I run "sh ./bootstrap-proxy.sh" on "proxy"
+
+  @uyuni
+  Scenario: Create the bootstrap script for the proxy and use it
+    When I execute mgr-bootstrap "--script=bootstrap-proxy.sh --no-up2date --force-bundle"
     Then I should get "* bootstrap script (written):"
     And I should get "    '/srv/www/htdocs/pub/bootstrap/bootstrap-proxy.sh'"
     When I fetch "pub/bootstrap/bootstrap-proxy.sh" to "proxy"

--- a/testsuite/features/secondary/min_salt_mgrcompat_state.feature
+++ b/testsuite/features/secondary/min_salt_mgrcompat_state.feature
@@ -9,8 +9,8 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     Given I am authorized for the "Admin" section
 
   Scenario: Remove mgrcompat module from minion synced modules and schedule Hardware Refresh
-    Given I remove "/var/cache/salt/minion/extmods/states/mgrcompat.py" from "sle_minion"
-    And I remove "/var/cache/salt/minion/extmods/states/__pycache__/mgrcompat*" from "sle_minion"
+    Given I remove "minion/extmods/states/mgrcompat.py" from salt cache on "sle_minion"
+    And I remove "minion/extmods/states/__pycache__/mgrcompat*" from salt cache on "sle_minion"
     And I am on the Systems overview page of this "sle_minion"
     When I follow "Hardware"
     And I click on "Schedule Hardware Refresh"
@@ -18,9 +18,9 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     And I wait until event "Hardware List Refresh scheduled by admin" is completed
 
   Scenario: Remove saltutil grain and mgrcompat module from minion and schedule Hardware Refresh
-    Given I remove "/var/cache/salt/minion/extmods/states/mgrcompat.py" from "sle_minion"
-    And I remove "/var/cache/salt/minion/extmods/states/__pycache__/mgrcompat*" from "sle_minion"
-    And I store "grains: {__suse_reserved_saltutil_states_support: False}" into file "/etc/salt/minion.d/custom_grains.conf" on "sle_minion"
+    Given I remove "minion/extmods/states/mgrcompat.py" from salt cache on "sle_minion"
+    And I remove "minion/extmods/states/__pycache__/mgrcompat*" from salt cache on "sle_minion"
+    And I store "grains: {__suse_reserved_saltutil_states_support: False}" into file "custom_grains.conf" in salt minion config directory on "sle_minion"
     And I refresh salt-minion grains on "sle_minion"
     And I am on the Systems overview page of this "sle_minion"
     When I follow "Hardware"
@@ -37,7 +37,7 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     Then "sle_minion" should not be registered
 
   Scenario: Enable new module.run syntax on the minion and perform registration
-    Given I store "use_superseded: [module.run]" into file "/etc/salt/minion.d/custom_modulerun.conf" on "sle_minion"
+    Given I store "use_superseded: [module.run]" into file "custom_modulerun.conf" in salt minion config directory on "sle_minion"
     When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle_minion" as "hostname"
@@ -69,8 +69,8 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
 
   Scenario: Cleanup: Delete profile of the minion and disable new module.run syntax
     Given I am on the Systems overview page of this "sle_minion"
-    And I remove "/etc/salt/minion.d/custom_modulerun.conf" from "sle_minion"
-    And I remove "/etc/salt/minion.d/custom_grains.conf" from "sle_minion"
+    And I remove "custom_modulerun.conf" from salt minion config directory on "sle_minion"
+    And I remove "custom_grains.conf" from salt minion config directory on "sle_minion"
     When I follow "Delete System"
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"

--- a/testsuite/features/secondary/min_salt_software_states.feature
+++ b/testsuite/features/secondary/min_salt_software_states.feature
@@ -117,7 +117,7 @@ Feature: Salt package states
   Scenario: Use Salt presence mechanism on an unreachable minion
     Then I follow "States" in the content area
     And I run "pkill salt-minion" on "sle_minion" without error control
-    And I run "pkill venv-salt-minion" on "sle_minion" without error control
+    And I run "pkill python.original" on "sle_minion" without error control
     And I follow "Highstate" in the content area
     And I click on "Show full highstate output"
     And I wait until I see "No reply from minion" text

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1680,6 +1680,8 @@ end
 When(/^I apply "([^"]*)" local salt state on "([^"]*)"$/) do |state, host|
   node = get_target(host)
   salt_call = $product == 'Uyuni' ? "venv-salt-call" : "salt-call"
+  if host == 'server'
+    salt_call = 'salt-call'
   source = File.dirname(__FILE__) + '/../upload_files/salt/' + state + '.sls'
   remote_file = '/usr/share/susemanager/salt/' + state + '.sls'
   return_code = file_inject(node, source, remote_file)

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1682,6 +1682,7 @@ When(/^I apply "([^"]*)" local salt state on "([^"]*)"$/) do |state, host|
   salt_call = $product == 'Uyuni' ? "venv-salt-call" : "salt-call"
   if host == 'server'
     salt_call = 'salt-call'
+  end
   source = File.dirname(__FILE__) + '/../upload_files/salt/' + state + '.sls'
   remote_file = '/usr/share/susemanager/salt/' + state + '.sls'
   return_code = file_inject(node, source, remote_file)

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -609,7 +609,8 @@ When(/^I set the activation key "([^"]*)" in the bootstrap script on the server$
 end
 
 When(/^I create bootstrap script and set the activation key "([^"]*)" in the bootstrap script on the proxy$/) do |key|
-  $proxy.run('mgr-bootstrap')
+  force_bundle = $product == 'Uyuni' ? '--force-bundle' : ''
+  $proxy.run("mgr-bootstrap #{force_bundle}")
   $proxy.run("sed -i '/^ACTIVATION_KEYS=/c\\ACTIVATION_KEYS=#{key}' /srv/www/htdocs/pub/bootstrap/bootstrap.sh")
   output, code = $proxy.run('cat /srv/www/htdocs/pub/bootstrap/bootstrap.sh')
   raise "Key: #{key} not included" unless output.include? key
@@ -640,9 +641,11 @@ When(/^I bootstrap (traditional|minion) client "([^"]*)" using bootstrap script 
 
   # Prepare bootstrap script for different types of clients
   client = client_type == 'traditional' ? '--traditional' : ''
+  force_bundle = $product == 'Uyuni' ? '--force-bundle' : ''
+
   node = get_target(host)
   gpg_keys = get_gpg_keys(node, target)
-  cmd = "mgr-bootstrap #{client} &&
+  cmd = "mgr-bootstrap #{client} #{force_bundle} &&
   sed -i s\'/^exit 1//\' /srv/www/htdocs/pub/bootstrap/bootstrap.sh &&
   sed -i '/^ACTIVATION_KEYS=/c\\ACTIVATION_KEYS=#{key}' /srv/www/htdocs/pub/bootstrap/bootstrap.sh &&
   chmod 644 /srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT &&

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -232,6 +232,23 @@ When(/^I synchronize all Salt dynamic modules on "([^"]*)"$/) do |host|
   $server.run("salt #{system_name} saltutil.sync_all")
 end
 
+When(/^I remove "([^"]*)" from salt cache on "([^"]*)"$/) do |filename, host|
+  node = get_target(host)
+  salt_cache = $product == 'Uyuni' ? "/var/cache/venv-salt-minion/" : "/var/cache/salt/"
+  file_delete(node, "#{salt_cache}#{filename}")
+end
+
+When(/^I remove "([^"]*)" from salt minion config directory on "([^"]*)"$/) do |filename, host|
+  node = get_target(host)
+  salt_config = $product == 'Uyuni' ? "/etc/venv-salt-minion/minion.d/" : "/etc/salt/minion.d/"
+  file_delete(node, "#{salt_config}#{filename}")
+end
+
+When(/^I store "([^"]*)" into file "([^"]*)" in salt minion config directory on "([^"]*)"$/) do |content, filename, host|
+  salt_config = $product == 'Uyuni' ? "/etc/venv-salt-minion/minion.d/" : "/etc/salt/minion.d/"
+  step %(I store "#{content}" into file "#{salt_config}#{filename}" from "#{host}")
+end
+
 When(/^I ([^ ]*) the "([^"]*)" formula$/) do |action, formula|
   # Complicated code because the checkbox is not a <input type=checkbox> but an <i>
   xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-square-o']" if action == 'check'


### PR DESCRIPTION
## What does this PR change?

This PR fixes some more issues detected in Uyuni Master acceptance tests after pushing the Salt bundle:

- Add `--force-bundle` to bootstrap script generator to force Salt bundle installation
- Fix typo in bash comparison during bootstrap
- Implement new steps to operate minion config and cache files and encapsulate logic for bundle
- Do not call `venv-salt-call` in server
- Set right process name in order to pkill targets venv-salt-minion
-  Pass `--force-bundle` when generating bootstrap scripts for minions in Uyuni

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/16421

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
