### PR TITLE
Fix typo configure proxy

### DIFF
--- a/proxy/installer/configure-proxy.sh
+++ b/proxy/installer/configure-proxy.sh
@@ -325,7 +325,7 @@ SQUID_DIR=/etc/squid
 UP2DATE_FILE=$SYSCONFIG_DIR/up2date
 SYSTEMID_PATH=$(awk -F '=[[:space:]]*' '/^[[:space:]]*systemIdPath[[:space:]]*=/ {print $2}' $UP2DATE_FILE)
 
-systemctl status salt-minion > /dev/null 2>&1 || systemctl status venv-salt-minion > /dev/null 2>&1 ||
+systemctl status salt-minion > /dev/null 2>&1 || systemctl status venv-salt-minion > /dev/null 2>&1
 if [ $? -eq 0 ]; then
     /usr/sbin/fetch-certificate $SYSTEMID_PATH
     PROPOSED_PARENT=$(grep ^[[:blank:]]*master /etc/salt/minion.d/susemanager.conf | sed -e "s/.*:[[:blank:]]*//")

--- a/proxy/installer/fetch-certificate.py
+++ b/proxy/installer/fetch-certificate.py
@@ -23,7 +23,10 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('destination', default='/etc/sysconfig/rhn/systemid')
     args = parser.parse_args()
-    opts = salt.config.minion_config('/etc/salt/minion', cache_minion_id=True)
+    if os.path.exists('/etc/venv-salt-minion/minion'):
+        opts = salt.config.minion_config('/etc/venv-salt-minion/minion', cache_minion_id=True)
+    else:
+        opts = salt.config.minion_config('/etc/salt/minion', cache_minion_id=True)
 
     if not os.path.isdir(os.path.dirname(args.destination)):
         print("There is a problem with the provided destination.")

--- a/proxy/installer/spacewalk-proxy-installer.spec
+++ b/proxy/installer/spacewalk-proxy-installer.spec
@@ -57,6 +57,7 @@ Requires:       rhn-client-tools > 2.8.4
 Requires:       rhnlib
 %endif
 Requires:       libxslt
+Requires:       salt
 Requires:       spacewalk-certs-tools >= 1.6.4
 %if 0%{?pylint_check}
 BuildRequires:  python3-rhn-client-tools


### PR DESCRIPTION
## What does this PR change?

Fix a typo and make fetch-certificate use venv-salt-minion when it is installed.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/16421

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
