### PR TITLE
Drop old and stale logic

### DIFF
--- a/proxy/installer/configure-proxy.sh
+++ b/proxy/installer/configure-proxy.sh
@@ -430,11 +430,6 @@ SQUID_VER_MAJOR=$(squid -v | awk -F'[ .]' '/Version/ {print $4}')
 if [ $SQUID_VER_MAJOR -ge 3 ] ; then
     # squid 3.X has acl 'all' built-in
     SQUID_REWRITE="$SQUID_REWRITE s/^acl all.*//;"
-    # squid 3.2 and later need none instead of -1 for range_offset_limit
-    SQUID_VER_MINOR=$(squid -v | awk -F'[ .]' '/Version/ {print $5}')
-    if [[ $SQUID_VER_MAJOR -ge 4 || ( $SQUID_VER_MAJOR -eq 3 && $SQUID_VER_MINOR -ge 2 ) ]] ; then
-        SQUID_REWRITE="$SQUID_REWRITE s/^range_offset_limit.*/range_offset_limit none/;"
-    fi
 fi
 sed "$SQUID_REWRITE" < $DIR/squid.conf  > $SQUID_DIR/squid.conf
 sed -e "s|\${session.ca_chain:/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT}|$CA_CHAIN|g" \


### PR DESCRIPTION
## What does this PR change?

No longer valid code-logic since commit 49d04c45a9b5c34569af6b0e9140a5fcca3d8ffa

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: see PR's description

- [x] **DONE**

## Test coverage
- No tests: see PR's description

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
