### PR TITLE
package locking XMLRPC API

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
@@ -888,7 +888,8 @@ SELECT p.package_id,
        p.epoch,
        p.name_id,
        p.evr_id,
-       p.arch
+       p.arch,
+       l.pending 
   FROM rhnlockedpackages l
   LEFT JOIN (
 SELECT pkg.id AS package_id,
@@ -1227,6 +1228,24 @@ SELECT DISTINCT pa.label, pa.name
    AND cpac.channel_arch_id = ca.id
    AND ca.label
     IN (%s)
+  </query>
+</mode>
+
+<mode name="packages_available_to_user">
+  <query params="org_id">
+SELECT 1
+  FROM rhnPackage P
+ WHERE p.id IN (%s)
+   AND (   P.org_id = :org_id
+        OR EXISTS (SELECT 1
+                     FROM rhnOrgChannelTreeView CT inner join rhnChannelPackage CP on CT.id = CP.channel_id
+                    WHERE CT.org_id = :org_id
+                      AND CP.package_id = P.id)
+        OR EXISTS (SELECT 1
+                     FROM rhnSharedChannelTreeView CT inner join rhnChannelPackage CP on CT.id = CP.channel_id
+                    WHERE CT.org_id = :org_id
+                      AND CP.package_id = P.id)
+       )
   </query>
 </mode>
 

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageFactory.java
@@ -102,6 +102,17 @@ public class PackageFactory extends HibernateFactory {
     }
 
     /**
+     * Lookup Packages by IDs
+     * @param ids list of id to search for
+     * @return list of Packages found
+     */
+    private static List<Package> lookupById(List<Long> ids) {
+        Map<String, Object> params = new HashMap<String, Object>();
+        return (List<Package>)
+                singleton.listObjectsByNamedQuery("Package.findByIds", params, ids, "pids");
+    }
+
+    /**
      * Returns true if the Package with the given name and evr ids exists in the
      * Channel whose id is cid.
      * @param cid Channel id to look in
@@ -137,6 +148,18 @@ public class PackageFactory extends HibernateFactory {
     }
 
     /**
+     * Lookup Packages by the id, in the context of a given user. Does security
+     * check to verify that the user has access to the packages.
+     * @param ids List of the Package to search for
+     * @param user the user doing the search
+     * @return List of packages found
+     */
+    public static List<Package> lookupByIdAndUser(List<Long> ids, User user) {
+        return lookupByIdAndOrg(ids, user.getOrg());
+    }
+
+
+    /**
      * Lookup a Package by the id, in the context of a given org. Does security
      * check to verify that the org has access to the package.
      * @param id of the Package to search for
@@ -150,6 +173,22 @@ public class PackageFactory extends HibernateFactory {
             return null;
         }
         return lookupById(id);
+    }
+
+    /**
+     * Lookup Packages by the id, in the context of a given org. Does security
+     * check to verify that the org has access to the package.
+     * @param ids List of the Packages to search for
+     * @param org the org which much have access to the package
+     * @return List of Packages found
+     */
+    public static List<Package> lookupByIdAndOrg(List<Long> ids, Org org) {
+        if (!UserManager.verifyPackagesAccess(org, ids)) {
+            // User doesn't have access to the package... return null as if it
+            // doesn't exist.
+            return Collections.emptyList();
+        }
+        return lookupById(ids);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/Package_satellite.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/Package_satellite.hbm.xml
@@ -185,6 +185,10 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <![CDATA[from com.redhat.rhn.domain.rhnpackage.Package as p where p.id = :id]]>
     </query>
 
+    <query name="Package.findByIds">
+        <![CDATA[from com.redhat.rhn.domain.rhnpackage.Package as p where p.id in (:pids)]]>
+    </query>
+
     <query name="Package.findByPackageName">
         <![CDATA[from com.redhat.rhn.domain.rhnpackage.Package as p where p.packageName = :packageName]]>
     </query>

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/LockPackageAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/LockPackageAction.java
@@ -43,12 +43,12 @@ import org.apache.struts.action.ActionMapping;
 import org.apache.struts.action.ActionMessages;
 import org.apache.struts.action.DynaActionForm;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -104,17 +104,18 @@ public class LockPackageAction extends BaseSystemPackagesAction {
 
         DataResult<PackageListItem> lockedPackagesResult =
                 PackageManager.systemLockedPackages(sid, null);
-        for (PackageListItem pkg : lockedPackagesResult) {
-            if (!context.isSubmitted()) {
+
+        if (!context.isSubmitted()) {
+            for (PackageListItem pkg : lockedPackagesResult) {
                 // pre-select locked
                 pkgsToSelect.add(pkg.getIdCombo() + "~*~" + pkg.getNvrea());
             }
-
-            Package lockedPkg = PackageManager.lookupByIdAndUser(pkg.getPackageId(), user);
-            if (lockedPkg != null) {
-                pkgsAlreadyLocked.add(lockedPkg);
-            }
         }
+
+        List<Package> pkgsFindAlreadyLocked = PackageManager.lookupByIdAndUser(
+                lockedPackagesResult.stream().map(PackageListItem::getPackageId)
+                        .collect(Collectors.toList()), user);
+        pkgsAlreadyLocked.addAll(pkgsFindAlreadyLocked);
 
         SessionSetHelper helper = new SessionSetHelper(request);
         if (isSubmitted(form)) {
@@ -198,7 +199,7 @@ public class LockPackageAction extends BaseSystemPackagesAction {
         RequestContext context = new RequestContext(request);
         Long sid = context.getRequiredParam("sid");
         User user = context.getCurrentUser();
-        List<Package> pkgsToUnlock = new ArrayList<Package>();
+        Set<Package> pkgsToUnlock = new HashSet<Package>();
         String[] selectedPkgs = ListTagHelper.getSelected(LIST_NAME, request);
 
         if (selectedPkgs != null) {
@@ -212,7 +213,7 @@ public class LockPackageAction extends BaseSystemPackagesAction {
 
         PackageManager.setPendingStatusOnLockedPackages(pkgsToUnlock,
                                                         PackageManager.PKG_PENDING_UNLOCK);
-        ActionManager.schedulePackageLock(user, server, pkgsAlreadyLocked, scheduleDate);
+        ActionManager.schedulePackageLock(user, pkgsAlreadyLocked, scheduleDate, server);
     }
 
     /**
@@ -255,7 +256,7 @@ public class LockPackageAction extends BaseSystemPackagesAction {
 
             // Ensure pending locks and already locked items are sent to the client
             pkgsToLock.addAll(pkgsAlreadyLocked);
-            ActionManager.schedulePackageLock(user, server, pkgsToLock, scheduleDate);
+            ActionManager.schedulePackageLock(user, pkgsToLock, scheduleDate, server);
         }
         else {
             LockPackageAction.LOG.info("No packages to lock");

--- a/java/code/src/com/redhat/rhn/frontend/dto/PackageListItem.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/PackageListItem.java
@@ -486,7 +486,7 @@ public class PackageListItem extends IdComboDto {
         String e = (this.getEpoch() != null) ? this.getEpoch() : "0";
         String v = (this.getVersion() != null) ? this.getVersion() : "0";
         String r = (this.getRelease() != null) ? this.getRelease() : "0";
-        return this.getName() + "-" + e + "-" + v + "-" + r;
+        return this.getName() + "-" + e + ":" + v + "-" + r;
     }
 
     /**
@@ -499,7 +499,7 @@ public class PackageListItem extends IdComboDto {
         String v = (this.getVersion() != null) ? this.getVersion() : "0";
         String r = (this.getRelease() != null) ? this.getRelease() : "0";
         String a = (this.getArch() != null) ? this.getArch() : "0";
-        return this.getName() + "-" + e + "-" + v + "-" + r + "-" + a;
+        return this.getName() + "-" + e + ":" + v + "-" + r + "." + a;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -1430,15 +1430,15 @@ public class ActionManager extends BaseManager {
     /**
      * Schedules one or more package lock actions for the given server.
      * @param scheduler the scheduler
-     * @param server the server
+     * @param servers the servers
      * @param packages set of packages
      * @param earliest earliest occurrence of this action
      * @return Currently scheduled PackageAction
      * @throws TaskomaticApiException if there was a Taskomatic error
      * (typically: Taskomatic is down)
      */
-    public static Action schedulePackageLock(User scheduler, Server server,
-            Set<Package> packages, Date earliest)
+    public static Action schedulePackageLock(User scheduler,
+            Set<Package> packages, Date earliest, Server...servers)
         throws TaskomaticApiException {
         List<Map<String, Long>> packagesList = new ArrayList<Map<String, Long>>();
         for (Package pkg : packages) {
@@ -1454,7 +1454,7 @@ public class ActionManager extends BaseManager {
             packagesList,
             ActionFactory.TYPE_PACKAGES_LOCK,
             earliest,
-            server
+            servers
         );
     }
 

--- a/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
+++ b/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
@@ -419,6 +419,17 @@ public class PackageManager extends BaseManager {
     }
 
     /**
+     * Find packages by using the id column of rhnPackage
+     * @param ids List of package id
+     * @param user The user performing the lookup
+     * @return List of Package objects
+     */
+    public static List<Package> lookupByIdAndUser(List<Long> ids, User user) {
+        return PackageFactory.lookupByIdAndUser(ids, user);
+    }
+
+
+    /**
      * Returns a dataResult containing all of the packages available to an
      * errata. Picks the right query depending on whether or not the errata
      * is published.
@@ -688,7 +699,7 @@ public class PackageManager extends BaseManager {
      * @param sid Server ID.
      * @param packages List of packages to unlock.
      */
-    public static void unlockPackages(Long sid, List<Package> packages) {
+    public static void unlockPackages(Long sid, Set<Package> packages) {
         for (Package pkg : packages) {
             Map params = new HashMap();
             params.put("sid", sid);
@@ -771,15 +782,12 @@ public class PackageManager extends BaseManager {
     /**
      * Sets the pending status on locked packages. If parameter "pendingStatus" is null,
      * the packages in the set are considered locked.
-     * @param pkgs List of packages.
+     * @param pkgs Set of packages.
      * @param pendingStatus Status for all of them.
      */
-    public static void setPendingStatusOnLockedPackages(List<Package> pkgs,
+    public static void setPendingStatusOnLockedPackages(Set<Package> pkgs,
                                                         String pendingStatus) {
-        for (int i = 0; i < pkgs.size(); i++) {
-            PackageManager.setPendingStatusOnLockedPackage(pkgs.get(i).getId(),
-                                                           pendingStatus);
-        }
+        pkgs.forEach(x -> PackageManager.setPendingStatusOnLockedPackage(x.getId(), pendingStatus));
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/user/UserManager.java
+++ b/java/code/src/com/redhat/rhn/manager/user/UserManager.java
@@ -112,7 +112,26 @@ public class UserManager extends BaseManager {
         params.put("pid", packageId);
         params.put("org_id", org.getId());
         DataResult dr = m.execute(params);
+        /*
+         * Ok... this query will result in returning a single row containing '1' if the
+         * org has access to this channel. If the org *does not* have access to the given
+         * package (org the package doesn't exist), nothing will be returned from the query
+         * and we will end up with an empty DataResult object.
+         */
+        return (!dr.isEmpty());
+    }
 
+    /**
+     * Verifies that a given org has access to a given list of packages.
+     * @param org The org in question
+     * @param packageIds The ids of the packages in question
+     * @return Returns true if the org has access to the package, false otherwise.
+     */
+    public static boolean verifyPackagesAccess(Org org, List<Long> packageIds) {
+        SelectMode m = ModeFactory.getMode("Package_queries", "packages_available_to_user");
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("org_id", org.getId());
+        DataResult dr = m.execute(params, packageIds);
         /*
          * Ok... this query will result in returning a single row containing '1' if the
          * org has access to this channel. If the org *does not* have access to the given

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add new endpoints to packages API: schedulePackageLockChange, listPackagesLockStatus
 - fix XML syntax in cobbler snippets (bsc#1193694)
 - Migrate the displaying of the date/time to rhn:formatDate
 - Suggest Product Migration when patch for CVE is in a successor Product (bsc#1191360)


### PR DESCRIPTION
## What does this PR change?
Add new endpoints to packages API: schedulePackageLockChange, listLocks
Minor changes:
 - allow `ActionManager.schedulePackageLock` to take as argument a list of server
 - fix format mismatch between PackageListItem class and Package class NEVRA
 - add package_id `system.listInstalledPackages`
 - system.listInstalledPackages object in a more readable order 
## GUI diff

No difference.

- [x] **DONE**

## Documentation
API Documentation 
- [x] **DONE**

## Test coverage
- N/A

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15573

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
