### PR TITLE
Fix libvirt engine config destinion for Salt Bundle

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/virt/engine-events.sls
+++ b/susemanager-utils/susemanager-sls/salt/virt/engine-events.sls
@@ -1,5 +1,6 @@
 {% if pillar['virt_entitled'] %}
-/etc/salt/minion.d/libvirt-events.conf:
+{% set minion_config_dir = salt["config.get"]("config_dir") %}
+{{  minion_config_dir }}/minion.d/libvirt-events.conf:
   file.managed:
     - contents: |
         engines:
@@ -10,7 +11,7 @@
 
 {% else %}
 
-/etc/salt/minion.d/libvirt-events.conf:
+{{ minion_config_dir }}/minion.d/libvirt-events.conf:
   file.absent
 
 {% endif %}

--- a/susemanager-utils/susemanager-sls/salt/virt/engine-events.sls
+++ b/susemanager-utils/susemanager-sls/salt/virt/engine-events.sls
@@ -1,6 +1,6 @@
 {% if pillar['virt_entitled'] %}
 {% set minion_config_dir = salt["config.get"]("config_dir") %}
-{{  minion_config_dir }}/minion.d/libvirt-events.conf:
+{{ minion_config_dir }}/minion.d/libvirt-events.conf:
   file.managed:
     - contents: |
         engines:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix libvirt engine config destination for Salt Bundle
 - Allow "mgr_force_venv_salt_minion" as pillar when bootstrapping
   in order to force venv-salt-minion installation
 


### PR DESCRIPTION
## What does this PR change?

When using `venv-salt-minion` package, the minion configuration file should be placed at `/etc/venv-salt-minion/minion.d/`

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/16421

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
