### PR TITLE
Support Postgresql14

### DIFF
--- a/java/code/src/com/suse/manager/webui/utils/LoginHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/LoginHelper.java
@@ -68,13 +68,13 @@ public class LoginHelper {
 
     private static Logger log = Logger.getLogger(LoginHelper.class);
     private static final String DEFAULT_KERB_USER_PASSWORD = "0";
-    private static final Long MIN_PG_DB_VERSION = 100001L;
-    private static final Long MAX_PG_DB_VERSION = 139999L;
-    private static final String MIN_PG_DB_VERSION_STRING = "10";
-    private static final String MAX_PG_DB_VERSION_STRING = "13";
-    private static final Double OS_VERSION_CHECK = 15.3;
-    private static final Long OS_VERSION_MIN_DB_VERSION = 130000L;
-    private static final String OS_VERSION_WANTED_DB_VERSION = "13";
+    private static final Long MIN_PG_DB_VERSION = 120001L;
+    private static final Long MAX_PG_DB_VERSION = 149999L;
+    private static final String MIN_PG_DB_VERSION_STRING = "12";
+    private static final String MAX_PG_DB_VERSION_STRING = "14";
+    private static final Double OS_VERSION_CHECK = 15.4;
+    private static final Long OS_VERSION_MIN_DB_VERSION = 140000L;
+    private static final String OS_VERSION_WANTED_DB_VERSION = "14";
     public static final String DEFAULT_URL_BOUNCE = "/rhn/YourRhn.do";
 
     /**

--- a/java/code/src/com/suse/manager/webui/utils/LoginHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/LoginHelper.java
@@ -68,9 +68,9 @@ public class LoginHelper {
 
     private static Logger log = Logger.getLogger(LoginHelper.class);
     private static final String DEFAULT_KERB_USER_PASSWORD = "0";
-    private static final Long MIN_PG_DB_VERSION = 120001L;
+    private static final Long MIN_PG_DB_VERSION = 130001L;
     private static final Long MAX_PG_DB_VERSION = 149999L;
-    private static final String MIN_PG_DB_VERSION_STRING = "12";
+    private static final String MIN_PG_DB_VERSION_STRING = "13";
     private static final String MAX_PG_DB_VERSION_STRING = "14";
     private static final Double OS_VERSION_CHECK = 15.4;
     private static final Long OS_VERSION_MIN_DB_VERSION = 140000L;

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- require postgresql14 on SLE15 SP4
+
 -------------------------------------------------------------------
 Fri Dec 03 12:21:41 CET 2021 - jgonzalez@suse.com
 

--- a/schema/spacewalk/spacewalk-schema-upgrade
+++ b/schema/spacewalk/spacewalk-schema-upgrade
@@ -7,13 +7,13 @@ use Spacewalk::Setup ();
 use IPC::Open3 ();
 use File::Basename;
 
-my $MIN_PG_DB_VERSION = 100001;
-my $MAX_PG_DB_VERSION = 139999;
-my $MIN_PG_DB_VERSION_STRING = "10";
-my $MAX_PG_DB_VERSION_STRING = "13";
-my $OS_VERSION_CHECK = 15.3;
-my $OS_VERSION_MIN_DB_VERSION = 130000;
-my $OS_VERSION_WANTED_DB_VERSION = "13";
+my $MIN_PG_DB_VERSION = 140001;
+my $MAX_PG_DB_VERSION = 149999;
+my $MIN_PG_DB_VERSION_STRING = "14";
+my $MAX_PG_DB_VERSION_STRING = "14";
+my $OS_VERSION_CHECK = 15.4;
+my $OS_VERSION_MIN_DB_VERSION = 140000;
+my $OS_VERSION_WANTED_DB_VERSION = "14";
 my $SCHEMA_UPGRADE_DIR = '/etc/sysconfig/rhn/schema-upgrade';
 my $SCHEMA_UPGRADE_LOGDIR = '/var/log/spacewalk/schema-upgrade';
 

--- a/schema/spacewalk/spacewalk-schema-upgrade
+++ b/schema/spacewalk/spacewalk-schema-upgrade
@@ -7,9 +7,9 @@ use Spacewalk::Setup ();
 use IPC::Open3 ();
 use File::Basename;
 
-my $MIN_PG_DB_VERSION = 140001;
+my $MIN_PG_DB_VERSION = 130001;
 my $MAX_PG_DB_VERSION = 149999;
-my $MIN_PG_DB_VERSION_STRING = "14";
+my $MIN_PG_DB_VERSION_STRING = "13";
 my $MAX_PG_DB_VERSION_STRING = "14";
 my $OS_VERSION_CHECK = 15.4;
 my $OS_VERSION_MIN_DB_VERSION = 140000;

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,5 @@
+- require postgresql14 on SLE15 SP4
+
 -------------------------------------------------------------------
 Fri Dec 03 12:32:54 CET 2021 - jgonzalez@suse.com
 

--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,5 @@
+- check DB version on SUSE 15.4
+
 -------------------------------------------------------------------
 Fri Nov 05 14:13:23 CET 2021 - jgonzalez@suse.com
 

--- a/spacewalk/admin/spacewalk-startup-helper
+++ b/spacewalk/admin/spacewalk-startup-helper
@@ -40,6 +40,9 @@ check_database() {
             if [ $VERSION_ID == "15.3" -a "${VARR[0]}" != "13" ]; then
                 echo "Database version '${VARR[0]}' is not supported for SUSE Manager/Uyuni on $PRETTY_NAME. Perform database migration."
                 exit 1
+            elif [ $VERSION_ID == "15.4" -a "${VARR[0]}" != "14" ]; then
+                echo "Database version '${VARR[0]}' is not supported for SUSE Manager/Uyuni on $PRETTY_NAME. Perform database migration."
+                exit 1
             fi
             perform_db_schema_upgrade
             check_schema_version

--- a/spacewalk/package/spacewalk.changes
+++ b/spacewalk/package/spacewalk.changes
@@ -1,3 +1,5 @@
+- require postgresql14 on SLE15 SP4
+
 -------------------------------------------------------------------
 Fri Nov 05 13:35:34 CET 2021 - jgonzalez@suse.com
 

--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -105,18 +105,18 @@ Requires:       spacewalk-backend-sql-postgresql
 Requires:       spacewalk-java-postgresql
 Requires:       perl(DBD::Pg)
 %if 0%{?suse_version}
-%if 0%{?sle_version} >= 150300
+%if 0%{?sle_version} >= 150400
+Requires:       postgresql14
+Requires:       postgresql14-contrib
+# we do not support postgresql versions > 14.x yet
+Conflicts:      postgresql-implementation >= 15
+Conflicts:      postgresql-contrib-implementation >= 15
+%else # not sle_version >= 150300
 Requires:       postgresql13
 Requires:       postgresql13-contrib
 # we do not support postgresql versions > 13.x yet
 Conflicts:      postgresql-implementation >= 14
 Conflicts:      postgresql-contrib-implementation >= 14
-%else # not sle_version >= 150300
-Requires:       postgresql12
-Requires:       postgresql12-contrib
-# we do not support postgresql versions > 13.x yet
-Conflicts:      postgresql-implementation >= 13
-Conflicts:      postgresql-contrib-implementation >= 13
 %endif # if sle_version >= 150300
 %else # not suse_version
 Requires:       postgresql >= 12

--- a/spacewalk/spacewalk-setup-postgresql/spacewalk-setup-postgresql.changes
+++ b/spacewalk/spacewalk-setup-postgresql/spacewalk-setup-postgresql.changes
@@ -1,3 +1,6 @@
+- require postgresql14 on SLE15 SP4
+- cleanup unused dependencies
+
 -------------------------------------------------------------------
 Mon Aug 09 10:40:48 CEST 2021 - jgonzalez@suse.com
 

--- a/spacewalk/spacewalk-setup-postgresql/spacewalk-setup-postgresql.spec
+++ b/spacewalk/spacewalk-setup-postgresql/spacewalk-setup-postgresql.spec
@@ -27,12 +27,17 @@ URL:            https://github.com/uyuni-project/uyuni
 Source0:        https://github.com/spacewalkproject/spacewalk/archive/%{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
-Requires:       postgresql-server > 8.4
-%if 0%{?rhel} == 5
-Requires:       postgresql84-contrib
-Requires:       postgresql84-pltcl
+%if 0%{?suse_version}
+%if 0%{?sle_version} >= 150400
+Requires:       postgresql14-server
+Requires:       postgresql14-contrib
 %else
-Requires:       postgresql-contrib >= 8.4
+Requires:       postgresql13-server
+Requires:       postgresql13-contrib
+%endif
+%else
+Requires:       postgresql-server > 12
+Requires:       postgresql-contrib >= 12
 %endif
 Requires:       lsof
 Requires:       spacewalk-dobby
@@ -53,11 +58,6 @@ install -m 0755 bin/* %{buildroot}/%{_bindir}
 install -d -m 755 %{buildroot}/%{_datadir}/spacewalk/setup/defaults.d
 install -m 0644 setup/defaults.d/* %{buildroot}/%{_datadir}/spacewalk/setup/defaults.d/
 install -m 0644 setup/*.conf %{buildroot}/%{_datadir}/spacewalk/setup/
-
-# Comment this parameter on PSQL 9.5
-%if 0%{?fedora} >= 24
-sed -i '/^checkpoint_segments/d' %{buildroot}/%{_datadir}/spacewalk/setup/postgresql.conf
-%endif
 
 %files
 %defattr(-,root,root,-)


### PR DESCRIPTION
## What does this PR change?

Change the database dependencies and checks to require on SUSE 15.4 a postgresql 14 DB

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- https://github.com/uyuni-project/uyuni-docs/pull/1317

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Partly fix https://github.com/SUSE/spacewalk/issues/16348

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
