### PR TITLE
Testsuite: Restart minion after libvirtd daemon is up and running

### DIFF
--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -30,7 +30,10 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I check "virtualization_host"
     And I click on "Update Properties"
     Then I should see a "Since you added a Virtualization system type to the system" text
-    And I restart salt-minion on "kvm_server"
+
+  Scenario: Allow minion to finish the current tasks
+    Then I wait for "5" seconds
+    Then I restart salt-minion on "kvm_server"
 
   Scenario: Enable the virtualization host formula for KVM
     When I follow "Formulas" in the content area

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -31,10 +31,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I click on "Update Properties"
     Then I should see a "Since you added a Virtualization system type to the system" text
 
-  Scenario: Allow minion to finish the current tasks
-    Then I wait for "5" seconds
-    Then I restart salt-minion on "kvm_server"
-
   Scenario: Enable the virtualization host formula for KVM
     When I follow "Formulas" in the content area
     Then I should see a "Choose formulas" text
@@ -58,6 +54,9 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I click on "Apply Highstate"
     And I wait until event "Apply highstate scheduled by admin" is completed
     Then service "libvirtd" is enabled on "kvm_server"
+
+  Scenario: Restart the minion to enable libvirt_events engine configuration
+    Then I restart salt-minion on "kvm_server"
 
   Scenario: Prepare a KVM test virtual machine and list it
     When I delete default virtual network on "kvm_server"

--- a/testsuite/features/secondary/minxen_guests.feature
+++ b/testsuite/features/secondary/minxen_guests.feature
@@ -31,10 +31,6 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And I click on "Update Properties"
     Then I should see a "Since you added a Virtualization system type to the system" text
 
-  Scenario: Allow minion to finish the current tasks
-    Then I wait for "5" seconds
-    Then I restart salt-minion on "xen_server"
-
   Scenario: Enable the virtualization host formula for Xen
     When I follow "Formulas" in the content area
     Then I should see a "Choose formulas" text
@@ -59,6 +55,9 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And I click on "Apply Highstate"
     And I wait until event "Apply highstate scheduled by admin" is completed
     Then service "libvirtd" is enabled on "xen_server"
+
+  Scenario: Restart the minion to enable libvirt_events engine configuration
+    Then I restart salt-minion on "xen_server"
 
   Scenario: Prepare a Xen test virtual machine and list it
     When I follow "Virtualization" in the content area

--- a/testsuite/features/secondary/minxen_guests.feature
+++ b/testsuite/features/secondary/minxen_guests.feature
@@ -30,7 +30,10 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And I check "virtualization_host"
     And I click on "Update Properties"
     Then I should see a "Since you added a Virtualization system type to the system" text
-    And I restart salt-minion on "xen_server"
+
+  Scenario: Allow minion to finish the current tasks
+    Then I wait for "5" seconds
+    Then I restart salt-minion on "xen_server"
 
   Scenario: Enable the virtualization host formula for Xen
     When I follow "Formulas" in the content area


### PR DESCRIPTION
## What does this PR change?

During the previous test steps, the testsuite is enabling the "Virtualization Host" system type, and this triggers a Salt call to apply a state to add the configuration file that enables the `libvirt_events` engine for the minion.
 
After this, the `salt-minion` (or bundle) is restarted in order to start the engine according to the new configuration.

The problem here is that the restart is done before the `libvirtd` daemon is actually up and running, so the `libvirt_events` engine is failing to start:

```
2021-11-30 10:20:24,047 [salt.loaded.int.engines.libvirt_events:762 ][ERROR   ][25231] Failed to connect socket to '/var/run/libvirt/libvirt-sock-ro': No such file or directory
Traceback (most recent call last):
  File "/usr/lib/venv-salt-minion/lib/python3.9/site-packages/salt/engines/libvirt_events.py", line 738, in start
    cnx = libvirt.openReadOnly(uri)
  File "/usr/lib/venv-salt-minion/lib64/python3.9/site-packages/libvirt.py", line 350, in openReadOnly
    raise libvirtError('virConnectOpenReadOnly() failed')
libvirt.libvirtError: Failed to connect socket to '/var/run/libvirt/libvirt-sock-ro': No such file or directory
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/16421

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
