### PR TITLE
Various fixes

### DIFF
--- a/testsuite/features/build_validation/add_custom_repositories/add_ceos7_repositories.feature
+++ b/testsuite/features/build_validation/add_custom_repositories/add_ceos7_repositories.feature
@@ -2,7 +2,7 @@
 # Licensed under the terms of the MIT license.
 
 @ceos7_minion
-Feature: Adding the CentOS 7 distribution custom repositories
+Feature: Add the CentOS 7 distribution custom repositories
 
   Scenario: Download the iso of CentOS 7 DVD and mount it on the server
     When I mount as "centos-7-iso" the ISO from "http://minima-mirror-bv.mgr.prv.suse.net/pub/centos/7/isos/x86_64/CentOS-7-x86_64-DVD-2003.iso" in the server

--- a/testsuite/features/build_validation/add_custom_repositories/add_ceos8_repositories.feature
+++ b/testsuite/features/build_validation/add_custom_repositories/add_ceos8_repositories.feature
@@ -2,7 +2,7 @@
 # Licensed under the terms of the MIT license.
 
 @ceos8_minion
-Feature: Adding the CentOS 8 distribution custom repositories
+Feature: Add the CentOS 8 distribution custom repositories
   In order to use CentOS 8 channels with Red Hat "modules"
   As a SUSE Manager administrator
   I want to filter them out to remove the modules information

--- a/testsuite/features/build_validation/add_custom_repositories/add_maintenance_update_repository.template
+++ b/testsuite/features/build_validation/add_custom_repositories/add_maintenance_update_repository.template
@@ -2,7 +2,7 @@
 # Licensed under the terms of the MIT license.
 
 @<client>
-Feature: Adding a Maintenance Update custom channel and the custom repositories for <client>
+Feature: Add a Maintenance Update custom channel and the custom repositories for <client>
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -26,7 +26,7 @@ Then(/^I can see all system information for "([^"]*)"$/) do |host|
   node = get_target(host)
   step %(I should see a "#{node.hostname}" text)
   kernel_version, _code = node.run('uname -r')
-  puts 'i should see kernel version: ' + kernel_version
+  puts 'I should see kernel version: ' + kernel_version
   step %(I should see a "#{kernel_version.strip}" text)
   os_version, os_family = get_os_version(node)
   # skip this test for centos and ubuntu systems
@@ -64,7 +64,7 @@ When(/^I wait at most (\d+) seconds until event "([^"]*)" is completed$/) do |fi
   steps %(
     When I follow "Events"
     And I follow "Pending"
-    And I wait at most 60 seconds until I do not see "#{event}" text, refreshing the page
+    And I wait at most 90 seconds until I do not see "#{event}" text, refreshing the page
     And I follow "History"
     And I wait until I see "System History" text
     And I wait until I see "#{event}" text, refreshing the page

--- a/testsuite/features/step_definitions/datepicker_steps.rb
+++ b/testsuite/features/step_definitions/datepicker_steps.rb
@@ -114,7 +114,7 @@ Then(/^the time field should be set to "([^"]*)"$/) do |expected_time|
   m_compat = find('input#date_minute', visible: false)
   ampm_compat = find('input#date_am_pm', visible: false)
 
-  raise 'invalid hidden hour' if h_compat.value.to_i != h % 12
-  raise 'invalid hidden minute' if m_compat.value.to_i != m
-  raise 'invalid hidden AM/PM' if ampm_compat.value.to_i != (h >= 12 ? 1 : 0)
+  raise StandardError, 'invalid hidden hour' if h_compat.value.to_i != h % 12
+  raise StandardError, 'invalid hidden minute' if m_compat.value.to_i != m
+  raise StandardError, 'invalid hidden AM/PM' if ampm_compat.value.to_i != (h >= 12 ? 1 : 0)
 end

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -5,15 +5,15 @@
 # Texts and links
 #
 
-Then(/^I should see a "(.*)" text in the content area$/) do |txt|
+Then(/^I should see a "(.*)" text in the content area$/) do |text|
   within('#spacewalk-content') do
-    raise "Text #{txt} not found" unless has_content?(txt)
+    raise "Text '#{text}' not found" unless has_content?(text)
   end
 end
 
-Then(/^I should not see a "(.*)" text in the content area$/) do |txt|
+Then(/^I should not see a "(.*)" text in the content area$/) do |text|
   within('#spacewalk-content') do
-    raise "Text #{txt} found" unless has_no_content?(txt)
+    raise "Text '#{text}' found" unless has_no_content?(text)
   end
 end
 
@@ -34,19 +34,19 @@ Then(/^the current path is "([^"]*)"$/) do |arg1|
 end
 
 When(/^I wait until I see "([^"]*)" text$/) do |text|
-  raise "Text #{text} not found" unless has_text?(text, wait: DEFAULT_TIMEOUT)
+  raise "Text '#{text}' not found" unless has_text?(text, wait: DEFAULT_TIMEOUT)
 end
 
 When(/^I wait until I do not see "([^"]*)" text$/) do |text|
-  raise "Text #{text} found" unless has_no_text?(text, wait: DEFAULT_TIMEOUT)
+  raise "Text '#{text}' found" unless has_no_text?(text, wait: DEFAULT_TIMEOUT)
 end
 
 When(/^I wait at most (\d+) seconds until I see "([^"]*)" text$/) do |seconds, text|
-  raise "Text #{text} not found" unless has_content?(text, wait: seconds.to_i)
+  raise "Text '#{text}' not found" unless has_content?(text, wait: seconds.to_i)
 end
 
 When(/^I wait until I see "([^"]*)" text or "([^"]*)" text$/) do |text1, text2|
-  raise "Text #{text1} or #{text2} not found" unless has_content?(text1, wait: DEFAULT_TIMEOUT) || has_content?(text2, wait: DEFAULT_TIMEOUT)
+  raise "Text '#{text1}' or '#{text2}' not found" unless has_content?(text1, wait: DEFAULT_TIMEOUT) || has_content?(text2, wait: DEFAULT_TIMEOUT)
 end
 
 When(/^I wait until I see "([^"]*)" text, refreshing the page$/) do |text|
@@ -67,7 +67,7 @@ end
 
 When(/^I wait at most (\d+) seconds until I do not see "([^"]*)" text, refreshing the page$/) do |seconds, text|
   next if has_no_text?(text, wait: 3)
-  repeat_until_timeout(message: "Couldn't find text '#{text}'", timeout: seconds.to_i) do
+  repeat_until_timeout(message: "I still see text '#{text}'", timeout: seconds.to_i) do
     break if has_no_text?(text, wait: 3)
     begin
       accept_prompt do
@@ -568,19 +568,19 @@ end
 #
 Then(/^I should see a "([^"]*)" text$/) do |text|
   text.gsub! '$PRODUCT', $product # TODO: Get rid of this substitution, using another step
-  raise "Text #{text} not found" unless has_content?(text)
+  raise "Text '#{text}' not found" unless has_content?(text)
 end
 
 Then(/^I should see a "([^"]*)" text or "([^"]*)" text$/) do |text1, text2|
-  raise "Text #{text1} and #{text2} are not found" unless has_content?(text1) || has_content?(text2)
+  raise "Text '#{text1}' and '#{text2}' not found" unless has_content?(text1) || has_content?(text2)
 end
 
 #
 # Test for text in a snippet textarea
 #
-Then(/^I should see "([^"]*)" in the textarea$/) do |arg1|
+Then(/^I should see "([^"]*)" in the textarea$/) do |text|
   within('textarea') do
-    raise "Text #{arg1} not found" unless has_content?(arg1)
+    raise "Text '#{text}' not found" unless has_content?(text)
   end
 end
 
@@ -588,14 +588,14 @@ end
 # Test for a text in the whole page using regexp
 #
 Then(/^I should see a text like "([^"]*)"$/) do |title|
-  raise "Text #{title} not found" unless has_content?(Regexp.new(title))
+  raise "Regular expression '#{title}' not found" unless has_content?(Regexp.new(title))
 end
 
 #
 # Test for a text not allowed in the whole page
 #
 Then(/^I should not see a "([^"]*)" text$/) do |text|
-  raise "#{text} found on the page! FAIL" unless has_no_content?(text)
+  raise "Text '#{text}' found on the page" unless has_no_content?(text)
 end
 
 #
@@ -624,13 +624,13 @@ end
 
 Then(/^I should see a "([^"]*)" text in element "([^"]*)"$/) do |text, element|
   within(:xpath, "//div[@id=\"#{element}\" or @class=\"#{element}\"]") do
-    raise "Text #{text} not found in #{element}" unless has_content?(text)
+    raise "Text '#{text}' not found in #{element}" unless has_content?(text)
   end
 end
 
 Then(/^I should not see a "([^"]*)" text in element "([^"]*)"$/) do |text, element|
   within(:xpath, "//div[@id=\"#{element}\" or @class=\"#{element}\"]") do
-    raise "Text #{text} found in #{element}" if has_content?(text)
+    raise "Text '#{text}' found in #{element}" if has_content?(text)
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

Various test suite fixes:
 * 90 seconds max to pick an event ; apparently, our BV hypervisors are slower than test suite ones
 * wrong error message "Couldn't find text" when the problem is that the text was found

and cosmetical changes:
 * quotes in many other error messages, for readability
 * feature titles
 * new syntax for `raise` to make rubocop happy

## Links

Ports:
* 4.1: SUSE/spacewalk#16451
* 4.2: SUSE/spacewalk#16450


## Changelogs

- [x] No changelog needed
