### PR TITLE
Fix of system-history report query

### DIFF
--- a/reporting/reports/data/system-history
+++ b/reporting/reports/data/system-history
@@ -46,7 +46,7 @@ sql:
 						and rhnkickstartsession.kickstart_id = rhnksdata.id
 					)
 				when rhnactiontype.label = 'scap.xccdf_eval' then (
-					select rhnxccdftestresult.identifier
+					select distinct rhnxccdftestresult.identifier
 					from rhnxccdftestresult, rhnactionscap
 					where rhnaction.id = rhnactionscap.action_id
 						and rhnxccdftestresult.action_scap_id = rhnactionscap.id

--- a/reporting/spacewalk-reports.changes
+++ b/reporting/spacewalk-reports.changes
@@ -1,3 +1,7 @@
+- Fixes query for system-history report to prevent more than one
+  row returned by a subquery with rhnxccdftestresult.identifier
+  (bsc#1191192)
+
 -------------------------------------------------------------------
 Fri Nov 05 13:52:03 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fixes the traceback and error `more than one row returned by a subquery used as an expression` on calling `spacewalk-report system-history`

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Links

Fixes https://github.com/SUSE/spacewalk/issues/16060
Tracks https://github.com/SUSE/spacewalk/pull/16452

## Changelogs

- Fixes query for system-history report to prevent more than one
  row returned by a subquery with rhnxccdftestresult.identifier
  (bsc#1191192)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
