### PR TITLE
Add Salt Bundle to bootstrap repos definitions

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -179,7 +179,8 @@ PKGLIST12 = [
 ONLYSLE12 = [
     "libzmq3",
     "gio-branding-SLE",
-    "wallpaper-branding-SLE"
+    "wallpaper-branding-SLE",
+    "venv-salt-minion",
 ]
 
 PKGLIST12_X86_ARM = [
@@ -352,7 +353,8 @@ RES7 = [
     "mgr-daemon|spacewalksd",
     "suseRegisterInfo",
     "python2-suseRegisterInfo",
-    "python2-hwdata"
+    "python2-hwdata",
+    "venv-salt-minion",
 ]
 
 RES7_X86 = [
@@ -382,7 +384,8 @@ RES8 = [
     "python3-pysocks",
     "python3-pytz",
     "python3-setuptools",
-    "python3-distro"
+    "python3-distro",
+    "venv-salt-minion",
 ]
 
 RES8_X86 = [
@@ -451,6 +454,7 @@ PKGLIST15_SALT = [
     "salt",
     "python3-salt",
     "salt-minion",
+    "venv-salt-minion",
 ]
 
 PKGLIST15SP0SP1_SALT = [
@@ -605,6 +609,7 @@ PKGLISTUBUNTU1804 = [
     "python3-distro",
     "python3-gnupg",
     "gnupg",
+    "venv-salt-minion",
 ]
 
 PKGLISTUBUNTU2004 = [
@@ -624,6 +629,7 @@ PKGLISTUBUNTU2004 = [
     "salt-common",
     "salt-minion",
     "gnupg",
+    "venv-salt-minion",
 ]
 
 PKGLISTDEBIAN9 = [
@@ -685,6 +691,7 @@ PKGLISTDEBIAN9 = [
     "dmidecode",
     "gnupg",
     "gnupg1",
+    "venv-salt-minion",
 ]
 
 
@@ -744,6 +751,7 @@ PKGLISTDEBIAN10 = [
     "salt-common",
     "salt-minion",
     "gnupg",
+    "venv-salt-minion",
 ]
 
 PKGLISTASTRALINUXOREL = [

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,6 @@
+- Add Salt Bundle (venv-salt-minion) to bootstrap repositories
+  definitions for all relevant system types
+
 -------------------------------------------------------------------
 Tue Nov 16 10:09:13 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Adds Salt Bundle (`venv-salt-minion`) to all relevant system types

## GUI diff

No difference.

## Documentation
https://github.com/uyuni-project/uyuni-docs/pull/1309


## Test coverage
- Cucumber tests were added before

## Changelogs

- Add Salt Bundle (venv-salt-minion) to bootstrap repositories
  definitions for all relevant system types

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
