### PR TITLE
Use "venv-salt-minion" instead of Salt for docker states

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/services/docker.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/docker.sls
@@ -30,7 +30,11 @@ mgr_docker_service:
 mgr_min_salt:
   pkg.installed:
     - pkgs:
+{%- if salt['pkg.version']('venv-salt-minion') %}
+      - venv-salt-minion
+{%- else %}
       - salt: '>=2016.11.1'
       - salt-minion: '>=2016.11.1'
+{%- endif %}
     - order: last
 {% endif %}

--- a/susemanager-utils/susemanager-sls/salt/services/docker.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/docker.sls
@@ -1,9 +1,11 @@
 {% if pillar['addon_group_types'] is defined and 'container_build_host' in pillar['addon_group_types'] %}
+{% set use_venv_salt = salt['pkg.version']('venv-salt-minion') %}
 mgr_install_docker:
   pkg.installed:
     - pkgs:
       - git-core
       - docker: '>=1.9.0'
+{%- if not use_venv_salt %}
 {%- if grains['pythonversion'][0] == 3 %}
     {%- if grains['osmajorrelease'] == 12 %}
       - python3-docker-py: '>=1.6.0'
@@ -19,6 +21,7 @@ mgr_install_docker:
       - python2-salt
     {%- endif %}
 {%- endif %}
+{%- endif %}
 
 mgr_docker_service:
   service.running:
@@ -30,7 +33,7 @@ mgr_docker_service:
 mgr_min_salt:
   pkg.installed:
     - pkgs:
-{%- if salt['pkg.version']('venv-salt-minion') %}
+{%- if use_venv_salt %}
       - venv-salt-minion
 {%- else %}
       - salt: '>=2016.11.1'

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Use venv-salt-minion instead of salt for docker states
 - Fix libvirt engine config destination for Salt Bundle
 - Allow "mgr_force_venv_salt_minion" as pillar when bootstrapping
   in order to force venv-salt-minion installation


### PR DESCRIPTION
## What does this PR change?

This PR makes Docker states to use `venv-salt-minion` instead of `salt` in Docker state.

This fixes ramdom issues in the testsuite, as the salt-minion package is being installed and makes the following zypper commands to fail because zypper is already running:

```
 FAIL: zypper mr --disable os_pool_repo os_update_repo returned 7. output : System management is locked by the application with pid 7442 (/usr/bin/zypper).
Close this application before trying again.
 (RuntimeError)
./features/support/lavanda.rb:57:in `run'
./features/step_definitions/common_steps.rb:789:in `/^I disable repositories after installing Docker$/'
features/init_clients/buildhost_bootstrap.feature:75:in `And I disable repositories after installing Docker'
``` 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/16421

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
