### PR TITLE
CI: remove previous Packages.gz

### DIFF
--- a/susemanager-utils/testing/automation/publish-rpms.sh
+++ b/susemanager-utils/testing/automation/publish-rpms.sh
@@ -53,6 +53,7 @@ cd $repo_dir
 echo ${obs_repo} | grep "Ubuntu" -i
 if [  ${?} -eq 0 ];then
     dpkg-scanpackages -m . /dev/null > Packages
+    rm -f Packages.gz
     gzip Packages
 else
      createrepo .


### PR DESCRIPTION
## What does this PR change?

CI fix

gzip does not create the Packages.gz because it already
exists.

## GUI diff

No difference.



- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links



- X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
