### PR TITLE
Fix problem with "allow_vendor_change" flags to SLS

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -1087,7 +1087,7 @@ public class SaltServerActionService {
                         .sorted()
                         .collect(Collectors.toList())
                 );
-                params.put("allowVendorChange", allowVendorChange);
+                params.put(ALLOW_VENDOR_CHANGE, allowVendorChange);
                 params.put(PARAM_UPDATE_STACK_PATCHES,
                     entry.getKey().stream()
                         .filter(e -> e.isUpdateStack())

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -1602,7 +1602,7 @@ public class SaltServerActionService {
         Map<String, Object> distupgrade = new HashMap<>();
         susemanager.put("distupgrade", distupgrade);
         distupgrade.put("dryrun", action.getDetails().isDryRun());
-        distupgrade.put("allowVendorChange", action.getDetails().isAllowVendorChange());
+        distupgrade.put(ALLOW_VENDOR_CHANGE, action.getDetails().isAllowVendorChange());
         distupgrade.put("channels", subbed.stream()
                 .sorted()
                 .map(c -> "susemanager:" + c.getLabel())

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Pass the "allow_vendor_change" flag using the right name when installing patches
 - Fix legacy timepicker passing wrong time to the backend if server and
   user time differ (bsc#1192699)
 - Fix legacy timepicker passing wrong time to the backend if selected

--- a/susemanager-utils/susemanager-sls/salt/distupgrade/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/distupgrade/init.sls
@@ -5,7 +5,7 @@ spmigration:
     - dist_upgrade: True
     - dryrun: {{ salt['pillar.get']('susemanager:distupgrade:dryrun', False) }}
 {% if grains['osrelease_info'][0] >= 12 %}
-    - novendorchange: {{ not salt['pillar.get']('susemanager:distupgrade:allowVendorChange', False) }}
+    - novendorchange: {{ not salt['pillar.get']('susemanager:distupgrade:allow_vendor_change', False) }}
 {% else %}
     - fromrepo: {{ salt['pillar.get']('susemanager:distupgrade:channels', []) }}
 {% endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Align allow_vendor_change pillar name across SLS files
 - Use venv-salt-minion instead of salt for docker states
 - Fix libvirt engine config destination for Salt Bundle
 - Allow "mgr_force_venv_salt_minion" as pillar when bootstrapping


### PR DESCRIPTION
## What does this PR change?

This PR fixes a problem which causes a failures in the Uyuni acceptance tests:

```
Install a patch on the client via Salt through the UI.Install a patch on the minion
```

The `allow_vendor_change` flag was passed as `allowVendorChange` for `patchinstall` state, while this state expects `allow_vendor_change`:

https://github.com/uyuni-project/uyuni/blob/f2da01e22c748024811d5f11844112764636baf1/susemanager-utils/susemanager-sls/salt/packages/patchinstall.sls#L24

This PR also aligns the rest of SLS files so all use `allow_vendor_change` as the pillar data that needs to be consumed by the SLS files.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/16421

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
