### PR TITLE
Add restart_feature to testsuite

### DIFF
--- a/testsuite/features/secondary/srv_restart.feature
+++ b/testsuite/features/secondary/srv_restart.feature
@@ -1,0 +1,12 @@
+# Copyright (c) 2021 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Restart the spacewak services via UI 
+
+  Scenario:Restart the SUSE Manager through the WebUI Admin option Log in as admin user
+    Given I am authorized for the "Admin" section
+    When I follow the left menu "Admin > Manager Configuration > Restart"
+    And I check "restart"
+    And I click on "Restart"
+    And I wait for "300" seconds
+    And I wait until radio button "restart" is unchecked, refreshing the page

--- a/testsuite/features/secondary/srv_restart.feature
+++ b/testsuite/features/secondary/srv_restart.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 # After clicking the button we wait until we dont see the text. This normally
 # means that the page was refreshed, but in case of a timeout or other error,

--- a/testsuite/features/secondary/srv_restart.feature
+++ b/testsuite/features/secondary/srv_restart.feature
@@ -1,12 +1,18 @@
 # Copyright (c) 2021 SUSE LLC
 # Licensed under the terms of the MIT license.
+# After clicking the button we wait until we dont see the text. This normally
+# means that the page was refreshed, but in case of a timeout or other error,
+# we included a manual refresh and a simple navigation step to make sure the UI
+# is indeed up and running after the restart.
 
-Feature: Restart the spacewak services via UI 
+Feature: Restart the spacewalk services via UI
 
-  Scenario:Restart the SUSE Manager through the WebUI Admin option Log in as admin user
+  Scenario: Restart the SUSE Manager through the WebUI Admin option
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Manager Configuration > Restart"
     And I check "restart"
     And I click on "Restart"
-    And I wait for "300" seconds
-    And I wait until radio button "restart" is unchecked, refreshing the page
+    And I wait until I see "SUSE Manager restarting" text
+    And I wait at most "300" seconds until I do not see "SUSE Manager restarting" text
+    And I refresh the page
+    Then I follow the left menu "Admin > Manager Configuration > Restart"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1156,6 +1156,21 @@ And(/^I wait until radio button "([^"]*)" is checked, refreshing the page$/) do 
   end
 end
 
+When(/^I wait until radio button "([^"]*)" is unchecked, refreshing the page$/) do |button|
+  unless has_unchecked_field?(button)
+    repeat_until_timeout(message: "I can still find checked radio button #{button}") do
+      break if has_unchecked_field?(button)
+      begin
+        accept_prompt do
+          execute_script 'window.location.reload()'
+        end
+      rescue Capybara::ModalNotFound
+        # ignored
+      end
+    end
+  end
+end
+
 Then(/^I check the first notification message$/) do
   if count_table_items == '0'
     puts "There are no notification messages, nothing to do then"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1156,21 +1156,6 @@ And(/^I wait until radio button "([^"]*)" is checked, refreshing the page$/) do 
   end
 end
 
-When(/^I wait until radio button "([^"]*)" is unchecked, refreshing the page$/) do |button|
-  unless has_unchecked_field?(button)
-    repeat_until_timeout(message: "I can still find checked radio button #{button}") do
-      break if has_unchecked_field?(button)
-      begin
-        accept_prompt do
-          execute_script 'window.location.reload()'
-        end
-      rescue Capybara::ModalNotFound
-        # ignored
-      end
-    end
-  end
-end
-
 Then(/^I check the first notification message$/) do
   if count_table_items == '0'
     puts "There are no notification messages, nothing to do then"

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -79,6 +79,20 @@ When(/^I wait at most (\d+) seconds until I do not see "([^"]*)" text, refreshin
   end
 end
 
+When(/^I wait at most "([^"]*)" seconds until I do not see "([^"]*)" text$/) do |seconds, text|
+  next if has_no_text?(text, wait: 3)
+  repeat_until_timeout(message: "I still see text '#{text}'", timeout: seconds.to_i) do
+    break if has_no_text?(text, wait: 3)
+    begin
+      accept_prompt do
+       # execute_script 'window.location.reload()'
+      end
+    rescue Capybara::ModalNotFound
+      # ignored
+    end
+  end
+end
+
 When(/^I wait at most (\d+) seconds until the event is completed, refreshing the page$/) do |timeout|
   last = Time.now
   next if has_content?("This action's status is: Completed.", wait: 3)

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -85,7 +85,7 @@ When(/^I wait at most "([^"]*)" seconds until I do not see "([^"]*)" text$/) do 
     break if has_no_text?(text, wait: 3)
     begin
       accept_prompt do
-       # execute_script 'window.location.reload()'
+      # execute_script 'window.location.reload()'
       end
     rescue Capybara::ModalNotFound
       # ignored

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2021 SUSE LLC.
+# Copyright (c) 2010-2022 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 #
@@ -83,13 +83,6 @@ When(/^I wait at most "([^"]*)" seconds until I do not see "([^"]*)" text$/) do 
   next if has_no_text?(text, wait: 3)
   repeat_until_timeout(message: "I still see text '#{text}'", timeout: seconds.to_i) do
     break if has_no_text?(text, wait: 3)
-    begin
-      accept_prompt do
-      # execute_script 'window.location.reload()'
-      end
-    rescue Capybara::ModalNotFound
-      # ignored
-    end
   end
 end
 

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -58,5 +58,6 @@
 - features/secondary/min_change_software_channel.feature
 - features/secondary/min_retracted_patches.feature
 - features/secondary/proxy_cobbler_pxeboot.feature
+- features/secondary/srv_restart.feature
 
 ## Secondary features END ##


### PR DESCRIPTION
## What does this PR change?

Add a feature to the testsuite that check if the server can be restarted through the WebUI 
Admin > Manager Configuration > Restart  options. In case of timeout, we refresh manually and navigate again to the same page to see that indeed the server was restarted.

Issue: https://github.com/SUSE/spacewalk/issues/9619

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9619
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
