### PR TITLE
Get rid of cluster tests

### DIFF
--- a/testsuite/config/cucumber.yml
+++ b/testsuite/config/cucumber.yml
@@ -14,7 +14,6 @@ content_lifecycle_management: --tags @scope_content_lifecycle_management
 res: --tags @scope_res
 recurring_actions: --tags @scope_recurring_actions
 maintenance_windows: --tags @scope_maintenance_windows
-cluster_management: --tags @scope_cluster_management
 building_container_images: --tags @scope_building_container_images
 kubernetes_integration: --tags @scope_kubernetes_integration
 openscap: --tags @scope_openscap

--- a/testsuite/features/secondary/srv_user_configuration_salt_states.feature
+++ b/testsuite/features/secondary/srv_user_configuration_salt_states.feature
@@ -51,7 +51,6 @@ Feature: Create organizations, users, groups, and activation keys using Salt sta
     And I should see "role_activation_key_admin" as checked
     And I should see "role_image_admin" as unchecked
     And I should see "role_config_admin" as checked
-    And I should see "role_cluster_admin" as unchecked
     And I should see "role_channel_admin" as unchecked
     And I should see "role_system_group_admin" as unchecked
 


### PR DESCRIPTION
## What does this PR change?

Get rid of Caasp/cluster tests, due to https://github.com/SUSE/spacewalk/issues/16456
Same for 4.1 and 4.2 due to https://github.com/SUSE/spacewalk/issues/16456

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were deleted

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
