### PR TITLE
Wait for page to be loaded in KVM tests

### DIFF
--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -152,6 +152,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
   Scenario: Attach an image to a cdrom on a KVM virtual machine
     When I click on "Edit" in row "test-vm"
+    And I wait until I do not see "Loading..." text
     And I store "" into file "/tmp/test-image.iso" on "kvm_server"
     And I wait until I do not see "Loading..." text
     And I enter "/tmp/test-image.iso" as "disk2_source_file"
@@ -202,11 +203,13 @@ Feature: Be able to manage KVM virtual machines via the GUI
   Scenario: Show the virtual storage pools and volumes for KVM
     When I refresh the "test-pool0" storage pool of this "kvm_server"
     And I follow "Storage"
+    And I wait until I do not see "Loading..." text
     And I open the sub-list of the product "test-pool0"
     Then I wait until I see "test-vm2_system" text
 
   Scenario: delete a running KVM virtual machine
     When I follow "Virtualization" in the content area
+    And I wait until I do not see "Loading..." text
     And I click on "Delete" in row "test-vm2"
     And I click on "Delete" in "Delete Guest" modal
     Then I should not see a "test-vm2" virtual machine on "kvm_server"
@@ -231,27 +234,32 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
   Scenario: delete a running KVM UEFI virtual machine
     When I follow "Virtualization" in the content area
+    And I wait until I do not see "Loading..." text
     And I click on "Delete" in row "test-vm2"
     And I click on "Delete" in "Delete Guest" modal
     Then I should not see a "test-vm2" virtual machine on "kvm_server"
 
   Scenario: Refresh a virtual storage pool for KVM
     When I follow "Storage"
+    And I wait until I do not see "Loading..." text
     And I click on "Refresh" in tree item "test-pool0"
     And I wait at most 600 seconds until the tree item "test-pool0" has no sub-list
 
   Scenario: Stop a virtual storage pool for KVM
     When I follow "Storage"
+    And I wait until I do not see "Loading..." text
     And I click on "Stop" in tree item "test-pool0"
     And I wait at most 600 seconds until the tree item "test-pool0" contains "inactive" text
 
   Scenario: Start a virtual storage pool for KVM
     When I follow "Storage"
+    And I wait until I do not see "Loading..." text
     And I click on "Start" in tree item "test-pool0"
     And I wait at most 600 seconds until the tree item "test-pool0" contains "running" text
 
   Scenario: Delete a virtual storage pool for KVM
     When I follow "Storage"
+    And I wait until I do not see "Loading..." text
     And I click on "Delete" in tree item "test-pool0"
     And I check "purge"
     And I click on "Delete" in "Delete Virtual Storage Pool" modal
@@ -274,6 +282,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
   Scenario: Edit a virtual storage pool for KVM
     When I follow "Storage"
+    And I wait until I do not see "Loading..." text
     And I click on "Edit Pool" in tree item "test-pool1"
     And I wait until I see "General" text
     And I enter "0711" as "target_mode"
@@ -285,6 +294,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
   Scenario: Delete a virtual volume
     When I follow "Storage"
+    And I wait until I do not see "Loading..." text
     And I open the sub-list of the product "tmp"
     And I click on "Delete" in tree item "test-net0.xml"
     And I click on "Delete" in "Delete Virtual Storage Volume" modal
@@ -292,11 +302,13 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
   Scenario: List virtual networks
     When I follow "Networks"
+    And I wait until I do not see "Loading..." text
     Then I wait until I see "test-net0" text
     And I should see a "test-net1" text
 
   Scenario: Stop virtual network
     When I follow "Networks"
+    And I wait until I do not see "Loading..." text
     Then table row for "test-net1" should contain "running"
     When I click on "Stop" in row "test-net1"
     And I click on "Stop" in "Stop Network" modal
@@ -305,12 +317,14 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
   Scenario: Start virtual network
     When I follow "Networks"
+    And I wait until I do not see "Loading..." text
     And I click on "Start" in row "test-net1"
     Then I wait until table row for "test-net1" contains button "Stop"
     And table row for "test-net1" should contain "running"
 
   Scenario: Delete virtual network
     When I follow "Networks"
+    And I wait until I do not see "Loading..." text
     And I click on "Delete" in row "test-net1"
     And I click on "Delete" in "Delete Network" modal
     Then I wait until I do not see "test-net1" text
@@ -339,6 +353,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
   Scenario: Edit a virtual network
     Given I am on the "Virtualization" page of this "kvm_server"
     When I follow "Networks"
+    And I wait until I do not see "Loading..." text
     And I click on "Stop" in row "test-net2"
     And I click on "Stop" in "Stop Network" modal
     Then I wait until table row for "test-net2" contains button "Start"


### PR DESCRIPTION
## What does this PR change?

See title

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Cucumber tests were fixed

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
