### PR TITLE
Testuite: Do not enable Salt bundle for PXE minion bootstrap script

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -609,7 +609,7 @@ When(/^I set the activation key "([^"]*)" in the bootstrap script on the server$
 end
 
 When(/^I create bootstrap script and set the activation key "([^"]*)" in the bootstrap script on the proxy$/) do |key|
-  #FIXME: Remove once pxeboot autoinstallation contains venv-salt-minion
+  # FIXME: Remove once pxeboot autoinstallation contains venv-salt-minion
   # force_bundle = $product == 'Uyuni' ? '--force-bundle' : ''
   # $proxy.run("mgr-bootstrap #{force_bundle}")
   $proxy.run("mgr-bootstrap ")

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -609,7 +609,7 @@ When(/^I set the activation key "([^"]*)" in the bootstrap script on the server$
 end
 
 When(/^I create bootstrap script and set the activation key "([^"]*)" in the bootstrap script on the proxy$/) do |key|
-  # FIXME: Remove once pxeboot autoinstallation contains venv-salt-minion
+  # WORKAROUND: Revert once pxeboot autoinstallation contains venv-salt-minion
   # force_bundle = $product == 'Uyuni' ? '--force-bundle' : ''
   # $proxy.run("mgr-bootstrap #{force_bundle}")
   $proxy.run("mgr-bootstrap ")

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -609,8 +609,11 @@ When(/^I set the activation key "([^"]*)" in the bootstrap script on the server$
 end
 
 When(/^I create bootstrap script and set the activation key "([^"]*)" in the bootstrap script on the proxy$/) do |key|
-  force_bundle = $product == 'Uyuni' ? '--force-bundle' : ''
-  $proxy.run("mgr-bootstrap #{force_bundle}")
+  #FIXME: Remove once pxeboot autoinstallation contains venv-salt-minion
+  # force_bundle = $product == 'Uyuni' ? '--force-bundle' : ''
+  # $proxy.run("mgr-bootstrap #{force_bundle}")
+  $proxy.run("mgr-bootstrap ")
+
   $proxy.run("sed -i '/^ACTIVATION_KEYS=/c\\ACTIVATION_KEYS=#{key}' /srv/www/htdocs/pub/bootstrap/bootstrap.sh")
   output, code = $proxy.run('cat /srv/www/htdocs/pub/bootstrap/bootstrap.sh')
   raise "Key: #{key} not included" unless output.include? key


### PR DESCRIPTION
## What does this PR change?

This PR fixes a problem caused by one of testsuite fixes introduced in https://github.com/uyuni-project/uyuni/pull/4500.

Particularly for this scenario, we don't want to generate a bootstrap script that enabled the Salt bundle. The reasoning here is that, currently, based on the autoyast profile we're using, the "pxeboot" minion is autoinstalled using the "SLE basesystem" channels, and we don't have any `venv-salt-minion` package there. 

So, since autoinstallation happens without `venv-salt-minion`, we cannot generate a bootstrap script that enables the bundle.

**NOTES:**
- This step I'm fixing is currently only used by this single PXE boot for retail scenario.
- In case we want to really use the bundle on this context, we would need to adapt the autoyast profile, and provide a client tools channel that contains the `venv-salt-minion` package.

After this PR is merged, the following scenarios should be green:
```
failed Bootstrap the PXE boot minion
failed Check connection from bootstrapped terminal to proxy
failed Install a package on the bootstrapped terminal
failed Cleanup: remove a package on the bootstrapped terminal
failed Cleanup: delete all imported Retail terminals
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/16421

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
