### PR TITLE
Improve logging in tftpsync receiver

### DIFF
--- a/tftpsync/susemanager-tftpsync-recv/add.wsgi
+++ b/tftpsync/susemanager-tftpsync-recv/add.wsgi
@@ -33,7 +33,7 @@ logger.setLevel(logging.INFO)
 
 # create RotatingFileHandler handler and set level to INFO
 ch = logging.handlers.RotatingFileHandler("/var/log/tftpsync/tftpsync.log",
-                                          mode='a', maxBytes=1048576, backupCount=3)
+                                          mode='a', maxBytes=1048576, backupCount=10)
 ch.setLevel(logging.INFO)
 
 # create formatter
@@ -122,7 +122,7 @@ def application(environ, start_response):
             # remove tmp file if exists
             if tfname and os.path.exists(tfname):
                 os.unlink(tfname)
-            logger.error("Writing file failed: %s" % e)
+            logger.error("Writing file failed: %s", e, exc_info=True)
             content = "Writing file failed"
 
     # remove tmp file if exists

--- a/tftpsync/susemanager-tftpsync-recv/delete.wsgi
+++ b/tftpsync/susemanager-tftpsync-recv/delete.wsgi
@@ -30,7 +30,7 @@ logger.setLevel(logging.INFO)
 
 # create RotatingFileHandler handler and set level to INFO
 ch = logging.handlers.RotatingFileHandler("/var/log/tftpsync/tftpsync.log",
-                                          mode='a', maxBytes=1048576, backupCount=3)
+                                          mode='a', maxBytes=1048576, backupCount=10)
 ch.setLevel(logging.INFO)
 
 # create formatter
@@ -85,7 +85,7 @@ def application(environ, start_response):
                 status = '200 OK'
                 content = "removing file '%s', status: %s" % (path, status)
             except Exception as e:
-                logger.debug("os.remove(%s) failed: %s" % (path, e))
+                logger.error("os.remove(%s) failed: %s", path, e, exc_info=True)
                 content = "removing %s failed" % path
         else:
             # success, if file not exists: we achieved what we wanted


### PR DESCRIPTION
## What does this PR change?

Print stacktrace on error and increase the number of backup files to have the full history when running the testsuite.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
