### PR TITLE
do not build python 2 package for SLE15

### DIFF
--- a/client/rhel/rhnlib/rhnlib.changes
+++ b/client/rhel/rhnlib/rhnlib.changes
@@ -1,3 +1,5 @@
+- do not build python 2 package for SLE15
+
 -------------------------------------------------------------------
 Mon Aug 09 10:56:00 CEST 2021 - jgonzalez@suse.com
 

--- a/client/rhel/rhnlib/rhnlib.spec
+++ b/client/rhel/rhnlib/rhnlib.spec
@@ -19,18 +19,21 @@
 
 %if 0%{?fedora} || 0%{?suse_version} > 1320 || 0%{?rhel} >= 8
 %global build_py3   1
-%endif
-
-%{!?__python2:%global __python2 /usr/bin/python2}
 %{!?__python3:%global __python3 /usr/bin/python3}
-
-%if %{undefined python2_sitelib}
-%global python2_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
-%endif
 
 %if %{undefined python3_sitelib}
 %global python3_sitelib %(%{__python3} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
 %endif
+%endif
+
+%if !(0%{?rhel} >= 8 || 0%{?sle_version} >= 150400 )
+%global build_py2   1
+%{!?__python2:%global __python2 /usr/bin/python2}
+%if %{undefined python2_sitelib}
+%global python2_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
+%endif
+%endif
+
 
 %if "%{_vendor}" == "debbuild"
 # For making sure we can set the right args for deb distros
@@ -60,6 +63,7 @@ BuildArch:      noarch
 %description
 rhnlib is a collection of python modules used by the Spacewalk (http://spacewalk.redhat.com) software.
 
+%if 0%{?build_py2}
 %package -n python2-rhnlib
 Summary:        Python libraries for the Spacewalk project
 Group:          Development/Libraries
@@ -107,6 +111,7 @@ Obsoletes:      rhnlib < %{version}-%{release}
 %description -n python2-rhnlib
 rhnlib is a collection of python modules used by the Spacewalk software.
 
+%endif # 0%{?build_py2}
 
 %if 0%{?build_py3}
 %package -n python3-rhnlib
@@ -139,7 +144,8 @@ Conflicts:      spacewalk-proxy < 1.3.6
 
 %description -n python3-rhnlib
 rhnlib is a collection of python modules used by the Spacewalk software.
-%endif
+
+%endif # 0%{?build_py2}
 
 %prep
 %setup -q
@@ -152,21 +158,27 @@ if [ ! -e setup.cfg ]; then
 fi
 
 %build
+%if 0%{?build_py2}
 make -f Makefile.rhnlib PYTHON=%{__python2}
+%endif
 %if 0%{?build_py3}
 make -f Makefile.rhnlib PYTHON=%{__python3}
 %endif
 
 %install
+%if 0%{?build_py2}
 %{__python2} setup.py install %{!?is_deb:-O1}%{?is_deb:--no-compile -O0} --skip-build --root $RPM_BUILD_ROOT %{?is_deb:--install-layout=deb} --prefix=%{_prefix}
+%endif
 %if 0%{?build_py3}
 %{__python3} setup.py install %{!?is_deb:-O1}%{?is_deb:--no-compile -O0} --skip-build --root $RPM_BUILD_ROOT %{?is_deb:--install-layout=deb} --prefix=%{_prefix}
 %endif
 
+%if 0%{?build_py2}
 %files -n python2-rhnlib
 %defattr(-,root,root)
 %doc ChangeLog COPYING README TODO
 %{python2_sitelib}/*
+%endif
 
 %if 0%{?build_py3}
 %files -n python3-rhnlib

--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
@@ -1,3 +1,5 @@
+- do not build python 2 package for SLE15
+
 -------------------------------------------------------------------
 Tue Nov 16 10:04:57 CET 2021 - jgonzalez@suse.com
 

--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.spec
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.spec
@@ -23,7 +23,7 @@
 %global __python /usr/bin/python3
 %endif
 
-%if !(0%{?rhel} >= 8)
+%if !(0%{?rhel} >= 8 || 0%{?sle_version} >= 150400 )
 %global build_py2   1
 %endif
 
@@ -677,7 +677,9 @@ rm -f $RPM_BUILD_ROOT/%{python3_sitelib}/up2date_client/gui.*
 %endif
 
 %if 0%{?suse_version}
+%if 0%{?build_py2}
 %py_compile -O %{buildroot}/%{python_sitelib}
+%endif
 %if 0%{?build_py3}
 %py3_compile -O %{buildroot}/%{python3_sitelib}
 %endif

--- a/client/tools/mgr-cfg/mgr-cfg.changes
+++ b/client/tools/mgr-cfg/mgr-cfg.changes
@@ -1,3 +1,5 @@
+- do not build python 2 package for SLE15
+
 -------------------------------------------------------------------
 Fri Nov 05 13:33:47 CET 2021 - jgonzalez@suse.com
 

--- a/client/tools/mgr-cfg/mgr-cfg.spec
+++ b/client/tools/mgr-cfg/mgr-cfg.spec
@@ -36,7 +36,7 @@
 %global __python /usr/bin/python2 
 %endif
 
-%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || 0%{?suse_version} || 0%{?ubuntu} || 0%{?debian}
+%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || (0%{?suse_version} && 0%{?suse_version} < 1500) || 0%{?ubuntu} || 0%{?debian}
 %global build_py2   1
 %endif
 

--- a/client/tools/mgr-osad/mgr-osad.changes
+++ b/client/tools/mgr-osad/mgr-osad.changes
@@ -1,3 +1,5 @@
+- do not build python 2 package for SLE15
+
 -------------------------------------------------------------------
 Fri Nov 05 13:34:38 CET 2021 - jgonzalez@suse.com
 

--- a/client/tools/mgr-osad/mgr-osad.spec
+++ b/client/tools/mgr-osad/mgr-osad.spec
@@ -39,7 +39,7 @@
 %global default_py3 1
 %endif
 
-%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || 0%{?suse_version}
+%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || (0%{?suse_version} && 0%{?suse_version} < 1500)
 %global build_py2   1
 %endif
 
@@ -150,6 +150,7 @@ BuildRequires:  python3-devel
 Python 3 specific files for %{name}
 %endif
 
+%if 0%{?build_py2}
 %package -n python2-mgr-osa-common
 Summary:        OSA common files
 Group:          System Environment/Daemons
@@ -163,6 +164,7 @@ Provides:       python2-osa-common = %{oldversion}
 
 %description -n python2-mgr-osa-common
 Python 2 common files needed by mgr-osad and mgr-osa-dispatcher
+%endif
 
 %if 0%{?build_py3}
 %package -n python3-mgr-osa-common
@@ -211,6 +213,7 @@ OSA dispatcher is supposed to run on the Spacewalk server. It gets information
 from the Spacewalk server that some command needs to be execute on the client;
 that message is transported via jabber protocol to OSAD agent on the clients.
 
+%if 0%{?build_py2}
 %package -n python2-mgr-osa-dispatcher
 Summary:        OSA dispatcher
 Group:          System Environment/Daemons
@@ -228,6 +231,7 @@ Requires:       python2-mgr-osa-common = %{version}-%{release}
 
 %description -n python2-mgr-osa-dispatcher
 Python 2 specific files for osa-dispatcher.
+%endif
 
 %if 0%{?build_py3}
 %package -n python3-mgr-osa-dispatcher
@@ -254,12 +258,20 @@ sed -i 's@^#!/usr/bin/python$@#!/usr/bin/python3 -s@' invocation.py
 %endif
 
 %build
+%if 0%{?build_py2}
 make -f Makefile.osad all PYTHONPATH=%{python_sitelib}
+%endif
+%if 0%{?build_py3}
+make -f Makefile.osad all PYTHONPATH=%{python3_sitelib}
+%endif
 
 %install
 install -d $RPM_BUILD_ROOT%{rhnroot}
+%if 0%{?build_py2}
 make -f Makefile.osad install PREFIX=$RPM_BUILD_ROOT ROOT=%{rhnroot} INITDIR=%{_initrddir} \
         PYTHONPATH=%{python_sitelib} PYTHONVERSION=%{python_version}
+%endif
+
 %if 0%{?build_py3}
 make -f Makefile.osad install PREFIX=$RPM_BUILD_ROOT ROOT=%{rhnroot} INITDIR=%{_initrddir} \
         PYTHONPATH=%{python3_sitelib} PYTHONVERSION=%{python3_version}
@@ -288,17 +300,14 @@ install -m 0644 osad.service $RPM_BUILD_ROOT/%{_unitdir}/
 install -m 0644 osa-dispatcher.service $RPM_BUILD_ROOT/%{_unitdir}/
 %endif
 
-%if ! 0%{?build_py2}
-rm -rf $RPM_BUILD_ROOT/%{python_sitelib}/osad/osad*
-rm -f $RPM_BUILD_ROOT/usr/sbin/osad-%{python_version}
-%endif
-
 mkdir -p %{buildroot}%{_var}/log/rhn
 touch %{buildroot}%{_var}/log/osad
 touch %{buildroot}%{_var}/log/rhn/osa-dispatcher.log
 
 %if 0%{?suse_version}
+%if 0%{?build_py2}
 %py_compile -O %{buildroot}/%{python_sitelib}
+%endif
 %if 0%{?build_py3}
 %py3_compile -O %{buildroot}/%{python3_sitelib}
 %endif
@@ -518,12 +527,14 @@ fi
 %attr(770,root,%{apache_group}) %dir %{_var}/log/rhn
 %endif
 
+%if 0%{?build_py2}
 %files -n python2-mgr-osa-dispatcher
 %defattr(-,root,root)
 %attr(755,root,root) %{_sbindir}/osa-dispatcher-%{python_version}
 %dir %{python_sitelib}/osad
 %{python_sitelib}/osad/osa_dispatcher.py*
 %{python_sitelib}/osad/dispatcher_client.py*
+%endif
 
 %if 0%{?build_py3}
 %files -n python3-mgr-osa-dispatcher
@@ -536,11 +547,13 @@ fi
 %{python3_sitelib}/osad/__pycache__/dispatcher_client.*
 %endif
 
+%if 0%{?build_py2}
 %files -n python2-mgr-osa-common
 %defattr(-,root,root)
 %{python_sitelib}/osad/__init__.py*
 %{python_sitelib}/osad/jabber_lib.py*
 %{python_sitelib}/osad/rhn_log.py*
+%endif
 
 %if 0%{?build_py3}
 %files -n python3-mgr-osa-common

--- a/client/tools/mgr-push/mgr-push.changes
+++ b/client/tools/mgr-push/mgr-push.changes
@@ -1,3 +1,5 @@
+- do not build python 2 package for SLE15
+
 -------------------------------------------------------------------
 Mon Aug 09 10:51:12 CEST 2021 - jgonzalez@suse.com
 

--- a/client/tools/mgr-push/mgr-push.spec
+++ b/client/tools/mgr-push/mgr-push.spec
@@ -28,7 +28,7 @@
 %global default_py3 1
 %endif
 
-%if !( 0%{?rhel} >= 8 )
+%if !( 0%{?rhel} >= 8 || 0%{?suse_version} >= 1500 )
 %global build_py2   1
 %endif
 

--- a/client/tools/mgr-virtualization/mgr-virtualization.changes
+++ b/client/tools/mgr-virtualization/mgr-virtualization.changes
@@ -1,3 +1,5 @@
+- do not build python 2 package for SLE15
+
 -------------------------------------------------------------------
 Mon Aug 09 10:51:53 CEST 2021 - jgonzalez@suse.com
 

--- a/client/tools/mgr-virtualization/mgr-virtualization.spec
+++ b/client/tools/mgr-virtualization/mgr-virtualization.spec
@@ -35,7 +35,7 @@
 %global default_py3 1
 %endif
 
-%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || 0%{?suse_version}
+%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || (0%{?suse_version} && 0%{?suse_version} < 1500)
 %global build_py2   1
 %endif
 
@@ -214,18 +214,9 @@ sed -i 's,@PYTHON@,/usr/bin/python,; s,@PYTHONPATH@,%{python_sitelib},;' \
 
 %if 0%{?suse_version}
 rm -f $RPM_BUILD_ROOT/%{_initrddir}/rhn-virtualization-host
-%endif
-
-%if 0%{?suse_version}
+%if 0%{?build_py2}
 %py_compile -O %{buildroot}/%{python_sitelib}
-%if 0%{?build_py3}
-%py3_compile -O %{buildroot}/%{python3_sitelib}
 %endif
-%endif
-
-%if 0%{?suse_version}
-rm -f $RPM_BUILD_ROOT/%{_initrddir}/rhn-virtualization-host
-%py_compile -O %{buildroot}/%{python_sitelib}
 %if 0%{?build_py3}
 %py3_compile -O %{buildroot}/%{python3_sitelib}
 %endif

--- a/client/tools/spacewalk-koan/spacewalk-koan.changes
+++ b/client/tools/spacewalk-koan/spacewalk-koan.changes
@@ -1,3 +1,5 @@
+- do not build python 2 package for SLE15
+
 -------------------------------------------------------------------
 Mon Aug 09 11:01:18 CEST 2021 - jgonzalez@suse.com
 

--- a/client/tools/spacewalk-koan/spacewalk-koan.spec
+++ b/client/tools/spacewalk-koan/spacewalk-koan.spec
@@ -25,7 +25,7 @@
 %global default_py3 1
 %endif
 
-%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || 0%{?suse_version}
+%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || (0%{?suse_version} && 0%{?suse_version} < 1500)
 %global build_py2   1
 %endif
 

--- a/client/tools/spacewalk-oscap/spacewalk-oscap.changes
+++ b/client/tools/spacewalk-oscap/spacewalk-oscap.changes
@@ -1,3 +1,5 @@
+- do not build python 2 package for SLE15
+
 -------------------------------------------------------------------
 Mon Aug 09 11:01:49 CEST 2021 - jgonzalez@suse.com
 

--- a/client/tools/spacewalk-oscap/spacewalk-oscap.spec
+++ b/client/tools/spacewalk-oscap/spacewalk-oscap.spec
@@ -22,7 +22,7 @@
 %global default_py3 1
 %endif
 
-%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || 0%{?suse_version}
+%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || (0%{?suse_version} && 0%{?suse_version} < 1500)
 %global build_py2   1
 %endif
 

--- a/suseRegisterInfo/suseRegisterInfo.changes
+++ b/suseRegisterInfo/suseRegisterInfo.changes
@@ -1,3 +1,5 @@
+- do not build python 2 package for SLE15
+
 -------------------------------------------------------------------
 Mon Aug 09 11:08:57 CEST 2021 - jgonzalez@suse.com
 

--- a/suseRegisterInfo/suseRegisterInfo.spec
+++ b/suseRegisterInfo/suseRegisterInfo.spec
@@ -21,8 +21,12 @@
 %global default_py3 1
 %endif
 
+%if !( 0%{?rhel} >= 8 || 0%{?suse_version} >= 1500 )
+%global build_py2   1
 %global __python /usr/bin/python2
 %{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
+%endif
+
 %define pythonX %{?default_py3:python3}%{!?default_py3:python2}
 
 Name:           suseRegisterInfo
@@ -51,6 +55,7 @@ Requires:       e2fsprogs
 This tool read data from the local system required
 for a registration
 
+%if 0%{?build_py2}
 %package -n python2-%{name}
 Summary:        Python 2 specific files for %{name}
 Group:          Productivity/Other
@@ -65,6 +70,8 @@ BuildRequires:  python-devel
 
 %description -n python2-%{name}
 Python 2 specific files for %{name}.
+
+%endif # 0%{?build_py2}
 
 %if 0%{?build_py3}
 %package -n python3-%{name}
@@ -87,14 +94,18 @@ Python 2 specific files for %{name}.
 %install
 mkdir -p %{buildroot}/usr/lib/suseRegister/bin/
 install -m 0755 suseRegister/parse_release_info %{buildroot}/usr/lib/suseRegister/bin/parse_release_info
+%if 0%{?build_py2}
 make -C suseRegister install PREFIX=$RPM_BUILD_ROOT PYTHONPATH=%{python_sitelib} PYTHON_BIN=%{pythonX}
+%endif
 
 %if 0%{?build_py3}
 make -C suseRegister install PREFIX=$RPM_BUILD_ROOT PYTHONPATH=%{python3_sitelib} PYTHON_BIN=%{pythonX}
 %endif
 
 %if 0%{?suse_version}
+%if 0%{?build_py2}
 %py_compile -O %{buildroot}/%{python_sitelib}
+%endif
 %if 0%{?build_py3}
 %py3_compile -O %{buildroot}/%{python3_sitelib}
 %endif
@@ -106,9 +117,11 @@ make -C suseRegister install PREFIX=$RPM_BUILD_ROOT PYTHONPATH=%{python3_sitelib
 %dir /usr/lib/suseRegister/bin
 /usr/lib/suseRegister/bin/parse_release_info
 
+%if 0%{?build_py2}
 %files -n python2-%{name}
 %defattr(-,root,root)
 %{python_sitelib}/suseRegister
+%endif
 
 %if 0%{?build_py3}
 %files -n python3-%{name}


### PR DESCRIPTION
## What does this PR change?

python 2 got dropped from SLE15 and we never shipped python 2 versions of these packages.
Stop try to build them

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/15418

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
