### PR TITLE
Allow configuring SSH port when bootstrapping SSH-only minions 

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
@@ -37,6 +37,7 @@ public class MinionServer extends Server implements SaltConfigurable {
     private String minionId;
     private String osFamily;
     private String kernelLiveVersion;
+    private Integer sshPushPort;
     private Set<AccessToken> accessTokens = new HashSet<>();
     private Set<Pillar> pillars = new HashSet<>();
 
@@ -95,6 +96,14 @@ public class MinionServer extends Server implements SaltConfigurable {
      */
     public void setKernelLiveVersion(String kernelLiveVersionIn) {
         this.kernelLiveVersion = kernelLiveVersionIn;
+    }
+
+    public Integer getSSHPushPort() {
+        return sshPushPort;
+    }
+
+    public void setSSHPushPort(Integer sshPushPortIn) {
+        this.sshPushPort = sshPushPortIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/ServerPath.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerPath.java
@@ -41,6 +41,15 @@ public class ServerPath extends BaseDomainHelper {
     }
 
     /**
+     * @param positionIn the server position in the path chain
+     * @param hostnameIn the hostname of the server
+     */
+    public ServerPath(Long positionIn, String hostnameIn) {
+        this.position = positionIn;
+        this.hostname = hostnameIn;
+    }
+
+    /**
      * Gets the id.
      *
      * @return the id

--- a/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
@@ -193,6 +193,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
             <property name="minionId" column="minion_id" />
             <property name="osFamily" column="os_family"  type="string" length="32" />
             <property name="kernelLiveVersion" column="kernel_live_version"  type="string" length="255" />
+            <property name="sshPushPort" column="ssh_push_port" access="field"/>
             <set name="accessTokens" lazy="true" inverse="true">
                 <key column="minion_id"/>
                 <one-to-many class="com.redhat.rhn.domain.channel.AccessToken"/>

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -61,6 +61,7 @@ import com.suse.manager.webui.services.SaltStateGeneratorService;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.MinionPendingRegistrationService;
+import com.suse.manager.webui.services.impl.SaltSSHService;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.manager.webui.utils.salt.custom.MinionStartupGrains;
 import com.suse.salt.netapi.datatypes.target.MinionList;
@@ -126,31 +127,35 @@ public class RegisterMinionEventMessageAction implements MessageAction {
         Optional<MinionStartupGrains> startupGrainsOpt = Opt.or(registerMinionEventMessage.getMinionStartupGrains(),
                 () -> saltApi.getGrains(registerMinionEventMessage.getMinionId(),
                         new TypeToken<MinionStartupGrains>() { }, "machine_id", "saltboot_initrd", "susemanager"));
-        registerMinion(registerMinionEventMessage.getMinionId(), false, empty(), empty(),  startupGrainsOpt);
+        registerMinion(registerMinionEventMessage.getMinionId(), false, empty(), empty(), empty(),  startupGrainsOpt);
     }
 
     /**
      * Temporary HACK: Run the registration for a minion with given id.
      * Will be extracted to a separate class, this is here only because of easier rebasing.
      * @param minionId minion id
-     * @param activationKeyOverride label of activation key to be applied to the system.
-     *                              If left empty, activation key from grains will be used.
+     * @param sshPushPort the port to use for bootstrapping
      * @param proxyId the proxy to which the minion connects, if any
+     * @param activationKeyOverride label of activation key to be applied to the system.
+ *                              If left empty, activation key from grains will be used.
      */
-    public void registerSSHMinion(String minionId, Optional<Long> proxyId, Optional<String> activationKeyOverride) {
+    public void registerSSHMinion(String minionId, Integer sshPushPort, Optional<Long> proxyId,
+                                  Optional<String> activationKeyOverride) {
         Optional<MinionStartupGrains> startupGrainsOpt = saltApi.getGrains(minionId,
                 new TypeToken<MinionStartupGrains>() { }, "machine_id", "saltboot_initrd", "susemanager");
-        registerMinion(minionId, true, proxyId, activationKeyOverride, startupGrainsOpt);
+        registerMinion(minionId, true, of(sshPushPort), proxyId, activationKeyOverride, startupGrainsOpt);
     }
+
     /**
-     * Performs minion registration or reactivation..
+     * Performs minion registration or reactivation.
      * @param minionId minion id
      * @param isSaltSSH true if a salt-ssh system is bootstrapped
+     * @param sshPort the port to use for ssh only bootstrapping
      * @param activationKeyOverride label of activation key to be applied to the system.
      *                       If left empty, activation key from grains will be used.
      * @param startupGrains Grains needed for initial phase of registration
      */
-    private void registerMinion(String minionId, boolean isSaltSSH, Optional<Long> proxyId,
+    private void registerMinion(String minionId, boolean isSaltSSH, Optional<Integer> sshPort, Optional<Long> proxyId,
                                 Optional<String> activationKeyOverride, Optional<MinionStartupGrains> startupGrains) {
         Opt.consume(startupGrains,
             ()-> LOG.error("Aborting: needed grains are not found for minion: " + minionId),
@@ -165,7 +170,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                 Optional<String> machineIdOpt = grains.getMachineId();
                 Opt.consume(machineIdOpt,
                     ()-> LOG.error("Aborting: cannot find machine id for minion: " + minionId),
-                    machineId -> registerMinion(minionId, isSaltSSH, proxyId, activationKeyOverride,
+                    machineId -> registerMinion(minionId, isSaltSSH, sshPort, proxyId, activationKeyOverride,
                             validReactivationKey, machineId, saltbootInitrd));
             });
     }
@@ -193,15 +198,16 @@ public class RegisterMinionEventMessageAction implements MessageAction {
      *
      * @param minionId minion id
      * @param isSaltSSH true if a salt-ssh system is bootstrapped
+     * @param sshPort the port to use for ssh only bootstrapping
      * @param actKeyOverride label of activation key to be applied to the system.
      *                       If left empty, activation key from grains will be used.
      * @param reActivationKey valid reactivation key
      * @param machineId Machine Id of the minion
      * @param saltbootInitrd saltboot_initrd, to be used for retail minions
      */
-    private void registerMinion(String minionId, boolean isSaltSSH, Optional<Long> saltSSHProxyId,
-                                Optional<String> actKeyOverride, Optional<String> reActivationKey, String machineId,
-                                boolean saltbootInitrd) {
+    private void registerMinion(String minionId, boolean isSaltSSH, Optional<Integer> sshPort,
+                                Optional<Long> saltSSHProxyId, Optional<String> actKeyOverride,
+                                Optional<String> reActivationKey, String machineId, boolean saltbootInitrd) {
         Opt.consume(reActivationKey,
             //Case A: Registration
             () -> {
@@ -210,7 +216,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                         Opt.consume(MinionServerFactory.findByMinionId(minionId),
                             () -> {
                                 // Case 1.1 - new registration
-                                finalizeMinionRegistration(minionId, machineId, saltSSHProxyId, actKeyOverride,
+                                finalizeMinionRegistration(minionId, machineId, sshPort, saltSSHProxyId, actKeyOverride,
                                         isSaltSSH);
                             },
                             minionServer -> {
@@ -230,7 +236,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                                 Opt.consume(server.asMinionServer(),
                                     () -> {
                                         // traditional client wants migration to salt
-                                        finalizeMinionRegistration(minionId, machineId, saltSSHProxyId,
+                                        finalizeMinionRegistration(minionId, machineId, sshPort, saltSSHProxyId,
                                                 actKeyOverride, isSaltSSH);
                                     },
                                     registeredMinion -> {
@@ -262,7 +268,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
             //Case B : Reactivation
             rk -> {
                 reactivateSystem(minionId, machineId, rk);
-                finalizeMinionRegistration(minionId, machineId, saltSSHProxyId, actKeyOverride, isSaltSSH);
+                finalizeMinionRegistration(minionId, machineId, sshPort, saltSSHProxyId, actKeyOverride, isSaltSSH);
             }
         );
     }
@@ -390,12 +396,14 @@ public class RegisterMinionEventMessageAction implements MessageAction {
      * Complete the minion registration with information from grains
      * @param minionId the minion id
      * @param machineId the machine id that we are trying to register
+     * @param sshPort the port to use for ssh only bootstrapping
      * @param saltSSHProxyId optional proxy id for saltssh in case it is used
      * @param activationKeyOverride optional label of activation key to be applied to the system
      * @param isSaltSSH true if a salt-ssh system is bootstrapped
      */
     public void finalizeMinionRegistration(String minionId,
                                            String machineId,
+                                           Optional<Integer> sshPort,
                                            Optional<Long> saltSSHProxyId,
                                            Optional<String> activationKeyOverride,
                                            boolean isSaltSSH) {
@@ -482,6 +490,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
 
             if (isSaltSSH) {
                 minion.updateServerPaths(saltSSHProxyId);
+                minion.setSSHPushPort(sshPort.orElse(SaltSSHService.SSH_PUSH_PORT));
             }
             else {
                 minion.updateServerPaths(master);

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -375,7 +375,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
      * We migrate the existing system and change the machine id.
      */
     public void testRegisterDuplicateMinionId() throws Exception {
-        MinionPendingRegistrationService.addMinion(user, MINION_ID, ContactMethodUtil.DEFAULT, Optional.empty());
+        MinionPendingRegistrationService.addMinion(user, MINION_ID, ContactMethodUtil.DEFAULT);
         MinionServer server = MinionServerFactoryTest.createTestMinionServer(user);
         server.setMinionId(MINION_ID);
         server.setHostname(MINION_ID);
@@ -425,7 +425,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
      * Case 2.2 - fail with RegisterMinionException
      */
     public void testAlreadyRegisteredMinionWithSameMachineId2() throws Exception {
-        MinionPendingRegistrationService.addMinion(user, MINION_ID, ContactMethodUtil.DEFAULT, Optional.empty());
+        MinionPendingRegistrationService.addMinion(user, MINION_ID, ContactMethodUtil.DEFAULT);
         MinionServer server1 = MinionServerFactoryTest.createTestMinionServer(user);
         server1.setMinionId(MINION_ID);
         server1.setHostname(MINION_ID);
@@ -1116,7 +1116,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
     public void testRegisterRHELMinionWithRESActivationKeyTwoBaseChannels() throws Exception {
         Channel resChannelI386 = RhelUtilsTest.createResChannel(user, "7", "ia32", "res-i386");
         Channel resChannelX8664 = RhelUtilsTest.createResChannel(user, "7", "x86_64", "res-x86_64");
-        MinionPendingRegistrationService.addMinion(user, MINION_ID, ContactMethodUtil.DEFAULT, Optional.empty());
+        MinionPendingRegistrationService.addMinion(user, MINION_ID, ContactMethodUtil.DEFAULT);
         HibernateFactory.getSession().flush();
         MinionStartupGrains minionStartUpGrains =  new MinionStartupGrains.MinionStartupGrainsBuilder()
                 .machineId(MACHINE_ID).saltbootInitrd(false)
@@ -1371,7 +1371,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
      */
     public void testRegisterSystemFromDifferentOrg() throws Exception {
         User creator = UserFactory.lookupById(UserTestUtils.createUser("chuck", "rangers"));
-        MinionPendingRegistrationService.addMinion(creator, MINION_ID, ContactMethodUtil.DEFAULT, Optional.empty());
+        MinionPendingRegistrationService.addMinion(creator, MINION_ID, ContactMethodUtil.DEFAULT);
         try {
             executeTest(
                     SLES_NO_AK_EXPECTATIONS,
@@ -1396,7 +1396,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
      */
     public void testRegisterSystemWithAKAndCreator() throws Exception {
         User creator = UserFactory.lookupById(UserTestUtils.createUser("chuck", "rangers"));
-        MinionPendingRegistrationService.addMinion(creator, MINION_ID, ContactMethodUtil.DEFAULT, Optional.empty());
+        MinionPendingRegistrationService.addMinion(creator, MINION_ID, ContactMethodUtil.DEFAULT);
         try {
             executeTest(
                     SLES_EXPECTATIONS,
@@ -1686,7 +1686,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         ManagedServerGroup branchGroup = ServerGroupFactory.create("Branch001", "Branch group",
                 user.getOrg());
 
-        MinionPendingRegistrationService.addMinion(user, MINION_ID, ContactMethodUtil.DEFAULT, Optional.empty());
+        MinionPendingRegistrationService.addMinion(user, MINION_ID, ContactMethodUtil.DEFAULT);
         MinionStartupGrains minionStartUpGrains =  new MinionStartupGrains.MinionStartupGrainsBuilder()
                 .machineId(MACHINE_ID).saltbootInitrd(true)
                 .createMinionStartUpGrains();

--- a/java/code/src/com/suse/manager/webui/controllers/MinionsAPI.java
+++ b/java/code/src/com/suse/manager/webui/controllers/MinionsAPI.java
@@ -55,7 +55,6 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Predicate;
@@ -160,8 +159,7 @@ public class MinionsAPI {
      */
     public String accept(Request request, Response response, User user) {
         String target = request.params("target");
-        MinionPendingRegistrationService.addMinion(
-                user, target, ContactMethodUtil.DEFAULT, Optional.empty());
+        MinionPendingRegistrationService.addMinion(user, target, ContactMethodUtil.DEFAULT);
         try {
             saltApi.acceptKey(target);
         }

--- a/java/code/src/com/suse/manager/webui/controllers/utils/RegularMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/RegularMinionBootstrapper.java
@@ -92,8 +92,7 @@ public class RegularMinionBootstrapper extends AbstractMinionBootstrapper {
     protected BootstrapResult bootstrapInternal(BootstrapParameters input, User user,
                                                 String defaultContactMethod) {
         String minionId = input.getHost();
-        MinionPendingRegistrationService.addMinion(
-                user, minionId, defaultContactMethod, Optional.empty());
+        MinionPendingRegistrationService.addMinion(user, minionId, defaultContactMethod);
 
         // If a key is pending for this minion, temporarily reject it
         boolean weRejectedIt = false;

--- a/java/code/src/com/suse/manager/webui/controllers/utils/SSHMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/SSHMinionBootstrapper.java
@@ -95,9 +95,9 @@ public class SSHMinionBootstrapper extends AbstractMinionBootstrapper {
         try {
             if (result.isSuccess()) {
                 Optional<List<String>> proxyPath = params.getProxyId()
-                        .map(proxyId -> ServerFactory.lookupById(proxyId))
-                        .map(proxy -> SaltSSHService.proxyPathToHostnames(
-                                proxy.getServerPaths(), proxy));
+                                                         .map(ServerFactory::lookupById)
+                                                         .map(SaltSSHService::proxyPathToHostnames);
+
                 MinionPendingRegistrationService.addMinion(user, minionId,
                         result.getContactMethod().orElse(defaultContactMethod),
                         proxyPath);

--- a/java/code/src/com/suse/manager/webui/controllers/utils/SSHMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/SSHMinionBootstrapper.java
@@ -36,6 +36,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -94,9 +95,10 @@ public class SSHMinionBootstrapper extends AbstractMinionBootstrapper {
         String minionId = params.getHost();
         try {
             if (result.isSuccess()) {
-                Optional<List<String>> proxyPath = params.getProxyId()
-                                                         .map(ServerFactory::lookupById)
-                                                         .map(SaltSSHService::proxyPathToHostnames);
+                List<String> proxyPath = params.getProxyId()
+                                               .map(ServerFactory::lookupById)
+                                               .map(SaltSSHService::proxyPathToHostnames)
+                                               .orElse(Collections.emptyList());
 
                 MinionPendingRegistrationService.addMinion(user, minionId,
                         result.getContactMethod().orElse(defaultContactMethod),

--- a/java/code/src/com/suse/manager/webui/controllers/utils/SSHMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/SSHMinionBootstrapper.java
@@ -100,12 +100,16 @@ public class SSHMinionBootstrapper extends AbstractMinionBootstrapper {
                                                .map(SaltSSHService::proxyPathToHostnames)
                                                .orElse(Collections.emptyList());
 
-                MinionPendingRegistrationService.addMinion(user, minionId,
+                MinionPendingRegistrationService.addMinion(
+                        user,
+                        minionId,
                         result.getContactMethod().orElse(defaultContactMethod),
-                        proxyPath);
-                getRegisterAction().registerSSHMinion(
-                        minionId, params.getProxyId(),
-                        params.getFirstActivationKey());
+                        proxyPath,
+                        params.getPort().orElse(SSH_PUSH_PORT)
+                );
+
+                getRegisterAction().registerSSHMinion(minionId, params.getPort().orElse(SSH_PUSH_PORT),
+                    params.getProxyId(), params.getFirstActivationKey());
             }
         }
         finally {
@@ -130,8 +134,6 @@ public class SSHMinionBootstrapper extends AbstractMinionBootstrapper {
         if (StringUtils.isEmpty(input.getUser())) {
             params.setUser(getSSHUser());
         }
-
-        params.setPort(Optional.of(SSH_PUSH_PORT));
 
         return params;
     }

--- a/java/code/src/com/suse/manager/webui/controllers/utils/test/SSHMinionBootstrapperTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/test/SSHMinionBootstrapperTest.java
@@ -59,7 +59,7 @@ public class SSHMinionBootstrapperTest extends AbstractMinionBootstrapperTestBas
                 RegisterMinionEventMessageAction action =
                         mock(RegisterMinionEventMessageAction.class);
                 context().checking(new Expectations() {{
-                    allowing(action).registerSSHMinion("myhost", Optional.empty(), activationKeyLabel);
+                    allowing(action).registerSSHMinion("myhost", 6022, Optional.empty(), activationKeyLabel);
                 }});
                 return action;
             }

--- a/java/code/src/com/suse/manager/webui/services/impl/MinionPendingRegistrationService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/MinionPendingRegistrationService.java
@@ -37,17 +37,16 @@ public class MinionPendingRegistrationService {
      */
     public static class PendingMinion {
 
-        private String contactMethod;
-        private User creator;
-        private Optional<List<String>> proxyPath;
+        private final String contactMethod;
+        private final User creator;
+        private final List<String> proxyPath;
 
         /**
          * @param creatorIn user who accepted the key or bootstrapped the system
          * @param contactMethodIn the contact method
          * @param proxyPathIn the proxy path
          */
-        public PendingMinion(User creatorIn, String contactMethodIn,
-                Optional<List<String>> proxyPathIn) {
+        public PendingMinion(User creatorIn, String contactMethodIn, List<String> proxyPathIn) {
             this.contactMethod = contactMethodIn;
             this.creator = creatorIn;
             this.proxyPath = proxyPathIn;
@@ -70,7 +69,7 @@ public class MinionPendingRegistrationService {
         /**
          * @return the proxy path
          */
-        public Optional<List<String>> getProxyPath() {
+        public List<String> getProxyPath() {
             return proxyPath;
         }
     }
@@ -89,10 +88,19 @@ public class MinionPendingRegistrationService {
      * @param creator user who accepted the key or bootstrapped the system
      * @param minionId minion id to be added
      * @param contactMethod the contact method of the minion
+     */
+    public static void addMinion(User creator, String minionId, String contactMethod) {
+        addMinion(creator, minionId, contactMethod, Collections.emptyList());
+    }
+
+    /**
+     * Adds minion id to the database.
+     * @param creator user who accepted the key or bootstrapped the system
+     * @param minionId minion id to be added
+     * @param contactMethod the contact method of the minion
      * @param proxyPath list of proxies hostnames in the order they connect through
      */
-    public static void addMinion(User creator, String minionId, String contactMethod,
-                                 Optional<List<String>> proxyPath) {
+    public static void addMinion(User creator, String minionId, String contactMethod, List<String> proxyPath) {
         minionIds.put(minionId, new PendingMinion(creator, contactMethod, proxyPath));
     }
 

--- a/java/code/src/com/suse/manager/webui/services/impl/MinionPendingRegistrationService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/MinionPendingRegistrationService.java
@@ -33,23 +33,34 @@ public class MinionPendingRegistrationService {
 
     /**
      * Information about the minion to bootstrap
-     * (contact method, creator user and proxy path)
+     * (contact method, creator user, proxy path and ssh port)
      */
     public static class PendingMinion {
 
         private final String contactMethod;
         private final User creator;
         private final List<String> proxyPath;
+        private final Integer sshPushPort;
+
+        /**
+         * @param creatorIn user who accepted the key or bootstrapped the system
+         * @param contactMethodIn the contact method
+         */
+        public PendingMinion(User creatorIn, String contactMethodIn) {
+            this(creatorIn, contactMethodIn, Collections.emptyList(), null);
+        }
 
         /**
          * @param creatorIn user who accepted the key or bootstrapped the system
          * @param contactMethodIn the contact method
          * @param proxyPathIn the proxy path
+         * @param portIn the ssh port
          */
-        public PendingMinion(User creatorIn, String contactMethodIn, List<String> proxyPathIn) {
+        public PendingMinion(User creatorIn, String contactMethodIn, List<String> proxyPathIn, Integer portIn) {
             this.contactMethod = contactMethodIn;
             this.creator = creatorIn;
             this.proxyPath = proxyPathIn;
+            this.sshPushPort = portIn;
         }
 
         /**
@@ -72,6 +83,13 @@ public class MinionPendingRegistrationService {
         public List<String> getProxyPath() {
             return proxyPath;
         }
+
+        /**
+         * @return an optional wrapping the ssh port or empty if not supported.
+         */
+        public Optional<Integer> getSSHPushPort() {
+            return Optional.ofNullable(sshPushPort);
+        }
     }
 
 
@@ -90,7 +108,7 @@ public class MinionPendingRegistrationService {
      * @param contactMethod the contact method of the minion
      */
     public static void addMinion(User creator, String minionId, String contactMethod) {
-        addMinion(creator, minionId, contactMethod, Collections.emptyList());
+        minionIds.put(minionId, new PendingMinion(creator, contactMethod));
     }
 
     /**
@@ -99,9 +117,11 @@ public class MinionPendingRegistrationService {
      * @param minionId minion id to be added
      * @param contactMethod the contact method of the minion
      * @param proxyPath list of proxies hostnames in the order they connect through
+     * @param sshPort the ssh port for ssh only minions
      */
-    public static void addMinion(User creator, String minionId, String contactMethod, List<String> proxyPath) {
-        minionIds.put(minionId, new PendingMinion(creator, contactMethod, proxyPath));
+    public static void addMinion(User creator, String minionId, String contactMethod, List<String> proxyPath,
+                                 Integer sshPort) {
+        minionIds.put(minionId, new PendingMinion(creator, contactMethod, proxyPath, sshPort));
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
@@ -64,7 +64,6 @@ import com.suse.salt.netapi.utils.Xor;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.map.HashedMap;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.text.StrSubstitutor;
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -79,6 +78,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -141,7 +141,7 @@ public class SaltSSHService {
             "services.salt-minion",
             "services.docker");
     private final String SALT_USER = "admin";
-    private final String SALT_PASSWORD = com.redhat.rhn.common.conf.Config.get().getString("server.secret_key");;
+    private final String SALT_PASSWORD = com.redhat.rhn.common.conf.Config.get().getString("server.secret_key");
     private final AuthModule AUTH_MODULE = AuthModule.FILE;
 
     private final AuthMethod PW_AUTH = new AuthMethod(new PasswordAuth(SALT_USER, SALT_PASSWORD, AuthModule.FILE));
@@ -340,15 +340,12 @@ public class SaltSSHService {
     }
 
     /**
-     * @param serverPaths a set ot {@link ServerPath}
-     * @param lastProxy the last proxy in the chain
+     * @param proxy the proxy server
      * @return a list of proxy hostnames, the last one being connected
      * directly to the minion
      */
-    public static List<String> proxyPathToHostnames(Set<ServerPath> serverPaths,
-                                                    Server lastProxy) {
-        String lastProxyHostname = lastProxy.getHostname();
-        return proxyPathToHostnames(serverPaths, Optional.of(lastProxyHostname));
+    public static List<String> proxyPathToHostnames(Server proxy) {
+        return proxyPathToHostnames(proxy.getServerPaths(), Optional.of(proxy.getHostname()));
     }
 
     /**
@@ -357,26 +354,27 @@ public class SaltSSHService {
      * @return a list of proxy hostnames, the last one being connected
      * directly to the minion
      */
-    public static List<String> proxyPathToHostnames(Set<ServerPath> serverPaths,
-                                                    Optional<String> lastProxy) {
-        if (CollectionUtils.isEmpty(serverPaths) && !lastProxy.isPresent()) {
+    public static List<String> proxyPathToHostnames(Set<ServerPath> serverPaths, Optional<String> lastProxy) {
+        if (CollectionUtils.isEmpty(serverPaths) && lastProxy.isEmpty()) {
             return Collections.emptyList();
         }
+
         List<ServerPath> proxyPath = sortServerPaths(serverPaths);
-        List<String> hostnamePath = new ArrayList<>();
-        hostnamePath.addAll(proxyPath.stream().map(p -> p.getHostname())
-                .collect(Collectors.toList()));
-        lastProxy.ifPresent(p -> hostnamePath.add(p));
+        List<String> hostnamePath = proxyPath.stream().map(ServerPath::getHostname).collect(Collectors.toList());
+
+        lastProxy.ifPresent(hostnamePath::add);
+
         return hostnamePath;
     }
 
     private static List<ServerPath> sortServerPaths(Set<ServerPath> serverPaths) {
-        List<ServerPath> proxyPath = Optional.ofNullable(serverPaths)
-                .map(p -> new ArrayList<>(p))
-                .orElseGet(ArrayList<ServerPath>::new);
-        Collections.sort(proxyPath, (p1, p2) ->
-                -ObjectUtils.compare(p1.getPosition(), p2.getPosition()));
-        return proxyPath;
+        if (CollectionUtils.isEmpty(serverPaths)) {
+            return new ArrayList<>();
+        }
+
+        return serverPaths.stream()
+                          .sorted(Comparator.comparing(ServerPath::getPosition).reversed())
+                          .collect(Collectors.toList());
     }
 
     /**
@@ -533,10 +531,10 @@ public class SaltSSHService {
         List<String> bootstrapProxyPath;
         if (parameters.getProxyId().isPresent()) {
             bootstrapProxyPath = parameters.getProxyId()
-                    .map(proxyId -> ServerFactory.lookupById(proxyId))
-                    .map(proxy -> proxyPathToHostnames(proxy.getServerPaths(), proxy))
-                    .orElseThrow(() -> new SaltException(
-                            "Proxy not found for id: " + parameters.getProxyId().get()));
+                                           .map(ServerFactory::lookupById)
+                                           .map(SaltSSHService::proxyPathToHostnames)
+                                           .orElseThrow(() -> new SaltException(
+                                                   "Proxy not found for id: " + parameters.getProxyId().get()));
         }
         else {
             bootstrapProxyPath = Collections.emptyList();

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
@@ -228,12 +228,8 @@ public class SaltSSHService {
                     MinionPendingRegistrationService.get(mid).ifPresent(minion -> {
                         roster.addHost(mid, getSSHUser(), Optional.empty(),
                                 Optional.of(SSH_PUSH_PORT),
-                                remotePortForwarding(minion.getProxyPath().orElse(null),
-                                        minion.getContactMethod()),
-                                sshProxyCommandOption(
-                                        minion.getProxyPath().orElse(null),
-                                        minion.getContactMethod(),
-                                        mid),
+                                remotePortForwarding(minion.getProxyPath(), minion.getContactMethod()),
+                                sshProxyCommandOption(minion.getProxyPath(), minion.getContactMethod(), mid),
                                 sshTimeout,
                                 minionOpts(mid, minion.getContactMethod())
                         );
@@ -470,12 +466,8 @@ public class SaltSSHService {
                                 getSSHUser(),
                                 Optional.empty(),
                                 Optional.of(SSH_PUSH_PORT),
-                                remotePortForwarding(minion.getProxyPath().orElse(null),
-                                        minion.getContactMethod()),
-                                sshProxyCommandOption(
-                                        minion.getProxyPath().orElse(null),
-                                        minion.getContactMethod(),
-                                        mid),
+                                remotePortForwarding(minion.getProxyPath(), minion.getContactMethod()),
+                                sshProxyCommandOption(minion.getProxyPath(), minion.getContactMethod(), mid),
                                 getSshPushTimeout(),
                                 minionOpts(mid, minion.getContactMethod()))
                 );

--- a/java/code/src/com/suse/manager/webui/services/impl/test/SaltSSHServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/test/SaltSSHServiceTest.java
@@ -42,12 +42,12 @@ public class SaltSSHServiceTest extends JMockBaseTestCaseWithUser {
     }
 
     public void testProxyCommandNoProxy() {
-        Optional<String> res = SaltSSHService.sshProxyCommandOption(Collections.emptyList(), "ssh-push", "minion");
+        Optional<String> res = SaltSSHService.sshProxyCommandOption(Collections.emptyList(), "ssh-push", "minion", 22);
         assertFalse(res.isPresent());
     }
 
     public void testProxyCommandSSHPush1Proxy() {
-        Optional<String> res = SaltSSHService.sshProxyCommandOption(List.of("proxy1"), "ssh-push", "minion");
+        Optional<String> res = SaltSSHService.sshProxyCommandOption(List.of("proxy1"), "ssh-push", "minion", 22);
         assertTrue(res.isPresent());
         assertEquals(
                 "ProxyCommand='" +
@@ -57,8 +57,7 @@ public class SaltSSHServiceTest extends JMockBaseTestCaseWithUser {
     }
 
     public void testProxyCommandSSHPushTunnel1Proxy() {
-        Optional<String> res = SaltSSHService.sshProxyCommandOption(
-                List.of("proxy1"), "ssh-push-tunnel", "minion");
+        Optional<String> res = SaltSSHService.sshProxyCommandOption(List.of("proxy1"), "ssh-push-tunnel", "minion", 22);
         assertTrue(res.isPresent());
         assertEquals(
                 "ProxyCommand='" +
@@ -73,7 +72,7 @@ public class SaltSSHServiceTest extends JMockBaseTestCaseWithUser {
 
     public void testProxyCommandSSHPush2Proxies() {
         Optional<String> res = SaltSSHService.sshProxyCommandOption(
-                Arrays.asList("proxy1", "proxy2"), "ssh-push", "minion");
+                Arrays.asList("proxy1", "proxy2"), "ssh-push", "minion", 22);
         assertTrue(res.isPresent());
         assertEquals(
                 "ProxyCommand='" +
@@ -86,7 +85,7 @@ public class SaltSSHServiceTest extends JMockBaseTestCaseWithUser {
 
     public void testProxyCommandSSHPushTunnel2Proxies() {
         Optional<String> res = SaltSSHService.sshProxyCommandOption(
-                Arrays.asList("proxy1", "proxy2"), "ssh-push-tunnel", "minion");
+                Arrays.asList("proxy1", "proxy2"), "ssh-push-tunnel", "minion", 22);
         assertTrue(res.isPresent());
         assertEquals(
                 "ProxyCommand='" +

--- a/java/code/src/com/suse/manager/webui/services/impl/test/SaltSSHServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/test/SaltSSHServiceTest.java
@@ -15,6 +15,7 @@
 package com.suse.manager.webui.services.impl.test;
 
 import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.domain.server.ServerPath;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 
 import com.suse.manager.webui.services.impl.SaltSSHService;
@@ -23,7 +24,9 @@ import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Tests for SaltSSHService.
@@ -44,7 +47,7 @@ public class SaltSSHServiceTest extends JMockBaseTestCaseWithUser {
     }
 
     public void testProxyCommandSSHPush1Proxy() {
-        Optional<String> res = SaltSSHService.sshProxyCommandOption(Arrays.asList("proxy1"), "ssh-push", "minion");
+        Optional<String> res = SaltSSHService.sshProxyCommandOption(List.of("proxy1"), "ssh-push", "minion");
         assertTrue(res.isPresent());
         assertEquals(
                 "ProxyCommand='" +
@@ -55,7 +58,7 @@ public class SaltSSHServiceTest extends JMockBaseTestCaseWithUser {
 
     public void testProxyCommandSSHPushTunnel1Proxy() {
         Optional<String> res = SaltSSHService.sshProxyCommandOption(
-                Arrays.asList("proxy1"), "ssh-push-tunnel", "minion");
+                List.of("proxy1"), "ssh-push-tunnel", "minion");
         assertTrue(res.isPresent());
         assertEquals(
                 "ProxyCommand='" +
@@ -96,5 +99,25 @@ public class SaltSSHServiceTest extends JMockBaseTestCaseWithUser {
                         "ssh -i /home/mgruser/.ssh/mgr_own_id -W minion:22 -o StrictHostKeyChecking=no " +
                         "-o User=mgruser minion'",
                 res.get());
+    }
+
+    public void testProxyPathToHostnames() {
+        final Set<ServerPath> serverPaths = Set.of(
+                new ServerPath(1L, "rhn"),
+                new ServerPath(0L, "junit"),
+                new ServerPath(2L, "test")
+        );
+
+        assertEquals(List.of("test", "rhn", "junit", "unitTest"),
+                SaltSSHService.proxyPathToHostnames(serverPaths, Optional.of("unitTest")));
+
+        assertEquals(List.of("unitTest"),
+                SaltSSHService.proxyPathToHostnames(Collections.emptySet(), Optional.of("unitTest")));
+
+        assertEquals(List.of("test", "rhn", "junit"),
+                SaltSSHService.proxyPathToHostnames(serverPaths, Optional.empty()));
+
+        assertEquals(Collections.emptyList(),
+                SaltSSHService.proxyPathToHostnames(Collections.emptySet(), Optional.empty()));
     }
 }

--- a/java/code/src/com/suse/manager/webui/services/impl/test/SaltServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/test/SaltServiceTest.java
@@ -58,8 +58,8 @@ public class SaltServiceTest extends JMockBaseTestCaseWithUser {
     }
 
     public void testfilterSSHMinionIdsBootstrap() {
-        MinionPendingRegistrationService.addMinion(user, "m1", ContactMethodUtil.SSH_PUSH, Optional.empty());
-        MinionPendingRegistrationService.addMinion(user, "m2", ContactMethodUtil.DEFAULT, Optional.empty());
+        MinionPendingRegistrationService.addMinion(user, "m1", ContactMethodUtil.SSH_PUSH);
+        MinionPendingRegistrationService.addMinion(user, "m2", ContactMethodUtil.DEFAULT);
         List<String> minionIds = new ArrayList<>();
         minionIds.add("m1");
         minionIds.add("m2");

--- a/java/code/src/com/suse/utils/Opt.java
+++ b/java/code/src/com/suse/utils/Opt.java
@@ -15,6 +15,8 @@
 package com.suse.utils;
 
 
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -121,5 +123,20 @@ public class Opt {
         else {
             return second.get();
         }
+    }
+
+    /**
+     * Wraps the first non-null value into an optional.
+     * @param values an array of values
+     * @param <T> The type of the values
+     * @return the first non-null value from the given array, or empty if all the values are null.
+     */
+    @SafeVarargs
+    public static <T> Optional<T> wrapFirstNonNull(T... values) {
+        if (values == null) {
+            return Optional.empty();
+        }
+
+        return Arrays.stream(values).filter(Objects::nonNull).findFirst();
     }
 }

--- a/java/code/src/com/suse/utils/test/OptTest.java
+++ b/java/code/src/com/suse/utils/test/OptTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.utils.test;
+
+import com.redhat.rhn.testing.RhnBaseTestCase;
+
+import com.suse.utils.Opt;
+
+import java.util.Optional;
+
+public class OptTest extends RhnBaseTestCase {
+
+    public void testWrapFirstNonNull() {
+        assertEquals(Optional.of("test"), Opt.wrapFirstNonNull(null, "test", null));
+        assertEquals(Optional.of("this"), Opt.wrapFirstNonNull("this", "is", "a", "test"));
+        assertEquals(Optional.empty(), Opt.wrapFirstNonNull());
+        assertEquals(Optional.empty(), Opt.wrapFirstNonNull(null, null, null, null));
+    }
+}
+

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add support for custom SSH port for SSH minions
 - UI and API call for changing proxy
 - Use an 'allow' filter for the kernel packages with live patching
   filter templates (bsc#1191460)

--- a/schema/spacewalk/common/tables/suseMinionInfo.sql
+++ b/schema/spacewalk/common/tables/suseMinionInfo.sql
@@ -21,7 +21,8 @@ CREATE TABLE suseMinionInfo
                                 ON DELETE CASCADE,
     minion_id           VARCHAR(256) NOT NULL,
     os_family           VARCHAR(32),
-    kernel_live_version VARCHAR(255)
+    kernel_live_version VARCHAR(255),
+    ssh_push_port       NUMERIC
 )
 
 ;

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Add support for custom SSH port for SSH minions
 - Fix changing of existing proxy path
 - Add pillars to Apply States action
 - require postgresql14 on SLE15 SP4

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.4-to-susemanager-schema-4.3.5/001-add-ssh-port-minion.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.4-to-susemanager-schema-4.3.5/001-add-ssh-port-minion.sql
@@ -1,0 +1,2 @@
+ALTER TABLE suseMinionInfo ADD COLUMN IF NOT EXISTS
+    ssh_push_port NUMERIC;

--- a/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
+++ b/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
@@ -146,7 +146,6 @@ class BootstrapMinions extends React.Component<Props, State> {
   manageWithSSHChanged(event) {
     this.setState({
       manageWithSSH: event.target.checked,
-      port: "",
     });
   }
 
@@ -377,7 +376,6 @@ class BootstrapMinions extends React.Component<Props, State> {
                 onChange={this.portChanged}
                 onKeyPress={window.numericValidate}
                 value={this.state.port}
-                disabled={this.state.manageWithSSH}
                 title={t("Port range: 1 - 65535")}
               />
             </div>

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Add support for custom SSH port for SSH minions
 - UI for changing proxy
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

This PR adds the option to use a custom SSH port to manage a SSH-only minion. The port is configured through the UI and it's stored in the database

## GUI diff

The port field is no longer disabled when choosing "Manage system completely via SSH (will not install an agent)":

After:
![2021-12-09](https://user-images.githubusercontent.com/2292684/145377163-759cef9d-316e-48c5-b099-5b3fdce7ac92.png)

- [X] **DONE**

## Documentation
- No documentation change needed: The documentation does not reference any limitation in the choice of the SSH port.

- [X] **DONE**

## Test coverage
- Unit tests were added
- Cucumber tests WIP

- [ ] **DONE**

## Links

Fixes SUSE/spacewalk/issues/12283

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
