### PR TITLE
Proxy: update the cached channels when handling listChannels

### DIFF
--- a/backend/server/handlers/xmlrpc/up2date.py
+++ b/backend/server/handlers/xmlrpc/up2date.py
@@ -130,6 +130,22 @@ class Up2date(rhnHandler):
         # log the entry
         log_debug(1, self.server_id)
         channelList = rhnChannel.channels_for_server(self.server_id)
+
+        loginDict = {
+            'X-RHN-Server-Id': self.server_id,
+            'X-RHN-Auth-Channels': rhnChannel.getSubscribedChannels(self.server_id),
+        }
+
+        # Duplicate these values in the headers so that the proxy can
+        # intercept and cache them without parseing the xmlrpc.
+        transport = rhnFlags.get('outputTransportOptions')
+        for k, v in list(loginDict.items()):
+            # Special case for channels
+            if k.lower() == 'x-rhn-auth-channels'.lower():
+                # Concatenate the channel information column-separated
+                transport[k] = [':'.join(x) for x in v]
+            else:
+                transport[k] = v
         return channelList
 
     def subscribeChannels(self, system_id, channelNames, username, passwd):

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Add headers to update proxy auth token in listChannels (bsc#1193585)
+
 -------------------------------------------------------------------
 Tue Dec 07 09:54:28 CET 2021 - jgonzalez@suse.com
 

--- a/proxy/proxy/broker/rhnBroker.py
+++ b/proxy/proxy/broker/rhnBroker.py
@@ -406,12 +406,13 @@ class BrokerHandler(SharedHandler):
 
         log_debug(2, "Action is %s" % headers['X-RHN-Action'])
         # Now, is it a login? If so, cache the session token.
-        if headers['X-RHN-Action'] != 'login':
-            # Don't care
-            return
+        if headers['X-RHN-Action'] == 'login':
+            # A login. Cache the session token
+            self.__cacheClientSessionToken(headers)
+        elif headers['X-RHN-Action'] == 'listChannels':
+            # Store the new channels in the session token
+            self.__update_token_channels(headers)
 
-        # A login. Cache the session token
-        self.__cacheClientSessionToken(headers)
 
     def __local_GET_handler(self, req):
         """ GETs: authenticate user, and service local GETs.
@@ -529,14 +530,11 @@ class BrokerHandler(SharedHandler):
         l = len(prefix)
         tokenKeys = [x for x in list(headers.keys()) if x[:l].lower() == prefix]
         for k in tokenKeys:
-            if k.lower() == 'x-rhn-auth-channels':
-                # Multivalued header
-                #values = headers.getHeaderValues(k)
-                values = self._get_header(k)
-                token[k] = [x.split(':') for x in values]
-            else:
+            if k.lower() != 'x-rhn-auth-channels':
                 # Single-valued header
                 token[k] = headers[k]
+
+        token = self.__update_token_channels(headers, token)
 
         # Dump the proxy's clock skew in the dict
         serverTime = float(token['X-RHN-Auth-Server-Time'])
@@ -545,6 +543,28 @@ class BrokerHandler(SharedHandler):
         # Save the token
         self.proxyAuth.set_client_token(self.clientServerId, token)
         return token
+
+
+    def __update_token_channels(self, headers, token=None):
+        if not self.clientServerId:
+            # Get the server ID
+            if 'X-RHN-Server-ID' not in headers:
+                log_debug(3, "Client server ID not found in headers")
+                # XXX: no client server ID in headers, should we care?
+                #raise rhnFault(1000, _("Client Server ID not found in headers!"))
+                return None
+            self.clientServerId = headers['X-RHN-Server-ID']
+
+        if 'X-RHN-Auth-Channels' in headers:
+            if not token:
+                token = self.proxyAuth.get_client_token(self.clientServerId)
+            # Multivalued header
+            token['X-RHN-Auth-Channels'] = [x.split(':') for x in self._get_header('X-RHN-Auth-Channels')]
+
+        # Save the token
+        self.proxyAuth.set_client_token(self.clientServerId, token)
+        return token
+
 
     def __callLocalRepository(self, req_type, identifier, funct, params):
         """ Contacts the local repository and retrieves files"""

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,6 @@
+- Update the token in case a channel can't be found in the cache.
+  (bsc#1193585)
+
 -------------------------------------------------------------------
 Fri Nov 05 13:51:07 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

When running a `zypper ref` on a client behind a proxy, the channel authentication is made against the proxy cached token... which is never updated when changing the channels.

This PR adds the `X-RHN-Auth-Channels` token to the `listChannels` response and modifies to proxy to use them to update the cached token. This way `zypper` triggers the auth token update on the proxy before trying to get data from them!

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered
- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/16488

See https://bugzilla.suse.com/show_bug.cgi?id=1193585

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
