### PR TITLE
Indentation for 4th level navigation element

### DIFF
--- a/branding/css/susemanager-theme.less
+++ b/branding/css/susemanager-theme.less
@@ -526,6 +526,16 @@ header, nav.navbar-pf {
                     padding-left: 4.4em;
                   }
                 }
+                /* Fourth Level */
+                > ul {
+                  > li {
+                    > div {
+                      > a {
+                        padding-left: 5.8em;
+                      }
+                    }
+                  }
+                }
               }
             }
           }

--- a/branding/css/uyuni-theme.less
+++ b/branding/css/uyuni-theme.less
@@ -523,6 +523,16 @@ header, nav.navbar-pf {
                     padding-left: 5em;
                   }
                 }
+                /* Fourth Level */
+                > ul {
+                  > li {
+                    > div {
+                      > a {
+                        padding-left: 7em;
+                      }
+                    }
+                  }
+                }
               }
             }
           }

--- a/branding/spacewalk-branding.changes
+++ b/branding/spacewalk-branding.changes
@@ -1,3 +1,5 @@
+- Add correct indentation for 4th level in the navigation panel
+
 -------------------------------------------------------------------
 Mon Aug 09 10:58:28 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

There was an explicit left-padding missing for a 4th-level navigation element. That's why the deepest path of the Audit section wasn't indented correctly.

## GUI diff

Before:
![image](https://user-images.githubusercontent.com/42077282/145696505-2812d4d3-14da-4a91-a616-bbd5b23c6070.png)

After:
![image](https://user-images.githubusercontent.com/42077282/145696482-2ab7da4d-1dcc-4f09-9657-cb94860249f2.png)


- [X] **DONE**

## Documentation
- No documentation needed: bugfix

- [X] **DONE**

## Test coverage
- No tests: Not applicable?

- [X] **DONE**

## Links

Not applicable. There seemed to be no issues raised with the problem solved here.

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
