### PR TITLE
QA: Disable IPv4 forwarding on branch formula

### DIFF
--- a/testsuite/features/build_validation/init_clients/proxy.feature
+++ b/testsuite/features/build_validation/init_clients/proxy.feature
@@ -82,6 +82,14 @@ Feature: Setup SUSE Manager proxy
     And I click on "Save Formula"
     Then I should see a "Formula saved" text
 
+  @proxy
+  @private_net
+  Scenario: Parametrize the branch network
+    When I follow first "Branch Network" in the content area
+    And I uncheck enable route box
+    And I click on "Save Formula"
+    Then I should see a "Formula saved" text
+
 @private_net
   Scenario: Let avahi work on the branch server
     When I open avahi port on the proxy

--- a/testsuite/features/core/proxy_branch_network.feature
+++ b/testsuite/features/core/proxy_branch_network.feature
@@ -74,6 +74,7 @@ Feature: Setup Uyuni for Retail branch network
     And I enter the local IP address of "proxy" in IP field
     # bsc#1132908 - Branch network formula closes IPv6 default route, potentially making further networking fail
     And I check enable SLAAC with routing box
+    And I uncheck enable route box
     And I enter "example" in branch id field
     And I click on "Save Formula"
     Then I should see a "Formula saved" text
@@ -200,3 +201,9 @@ Feature: Setup Uyuni for Retail branch network
     And name resolution should work on terminal "sle_client"
     And terminal "sle_minion" should have got a retail network IP address
     And name resolution should work on terminal "sle_minion"
+
+@proxy
+@private_net
+  Scenario: The terminals should not reach the server
+    Then "sle_client" should not communicate with the server
+    And "sle_minion" should not communicate with the server

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -25,8 +25,14 @@ end
 
 Then(/^"([^"]*)" should communicate with the server$/) do |host|
   node = get_target(host)
-  node.run("ping -c1 #{$server.full_hostname}")
-  $server.run("ping -c1 #{node.full_hostname}")
+  node.run("ping -c1 #{$server.ip}")
+  $server.run("ping -c1 #{node.ip}")
+end
+
+Then(/^"([^"]*)" should not communicate with the server$/) do |host|
+  node = get_target(host)
+  node.run_until_fail("ping -c1 #{$server.ip}")
+  $server.run_until_fail("ping -c1 #{node.ip}")
 end
 
 Then(/^the clock from "([^"]*)" should be exact$/) do |host|

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -165,6 +165,14 @@ When(/^I check "([^"]*)" if not checked$/) do |arg1|
   check(arg1) unless has_checked_field?(arg1)
 end
 
+When(/^I check (.*) box$/) do |checkbox_name|
+  check BOX_IDS[checkbox_name]
+end
+
+When(/^I uncheck (.*) box$/) do |checkbox_name|
+  check BOX_IDS[checkbox_name]
+end
+
 When(/^I select "([^"]*)" from "([^"]*)"$/) do |option, field|
   xpath_option = ".//*[contains(@class, 'class-#{field}__option') and contains(text(),'#{option}')]"
   xpath_field = "//*[contains(@class, 'class-#{field}__control')]/../*[@name='#{field}']/.."

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -493,12 +493,6 @@ When(/^I press minus sign in (.*) section$/) do |section|
   find(:xpath, "//div[@id='#{sectionids[section]}']/div[1]/i[@class='fa fa-minus']").click
 end
 
-When(/^I check (.*) box$/) do |box|
-  boxids = { 'enable SLAAC with routing' => 'branch_network#firewall#enable_SLAAC_with_routing',
-             'include forwarders'        => 'bind#config#include_forwarders' }
-  check boxids[box]
-end
-
 Then(/^the timezone on "([^"]*)" should be "([^"]*)"$/) do |minion, timezone|
   node = get_target(minion)
   output, _code = node.run('date +%Z')

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -96,6 +96,10 @@ FIELD_IDS = { 'NIC'                             => 'branch_network#nic',
               'language'                        => 'keyboard_and_language#language',
               'keyboard layout'                 => 'keyboard_and_language#keyboard_layout' }.freeze
 
+BOX_IDS = { 'enable SLAAC with routing' => 'branch_network#firewall#enable_SLAAC_with_routing',
+            'include forwarders'        => 'bind#config#include_forwarders',
+            'enable route'              => 'branch_network#firewall#enable_route' }.freeze
+
 BULLET_STYLE = { 'failing' => 'fa-times text-danger',
                  'warning' => 'fa-hand-o-right text-danger',
                  'success' => 'fa-check text-success',


### PR DESCRIPTION
## What does this PR change?

Related card: https://github.com/SUSE/spacewalk/issues/16486

We want to make the systems in the private network to not have access to any external server outside the private network. This way catch this kind of issues earlier.

For now, this PR prevents this communication if the systems are configured with IPv4.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.2
- Manager-4.1

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
