### PR TITLE
mgr-cfg: fix python selinux package name depending on build target (bsc#1193600)

### DIFF
--- a/client/tools/mgr-cfg/mgr-cfg.changes
+++ b/client/tools/mgr-cfg/mgr-cfg.changes
@@ -1,3 +1,4 @@
+- Fix python selinux package name depending on build target (bsc#1193600)
 - do not build python 2 package for SLE15
 
 -------------------------------------------------------------------

--- a/client/tools/mgr-cfg/mgr-cfg.spec
+++ b/client/tools/mgr-cfg/mgr-cfg.spec
@@ -95,9 +95,11 @@ Requires:       %{pythonX}-%{name} = %{version}-%{release}
 %if 0%{?suse_version}
 # provide rhn directories and no selinux on suse
 BuildRequires:  spacewalk-client-tools
-%if %{?suse_version} >= 1110
-# Only on SLES11
+%if %{?suse_version} >= 1110 && 0%{?suse_version} < 1500
 Requires:       python-selinux
+%endif
+%if %{?suse_version} >= 1110 && 0%{?suse_version} >= 1500
+Requires:       python3-selinux
 %endif
 %else
 Requires:       libselinux-python

--- a/client/tools/mgr-cfg/mgr-cfg.spec
+++ b/client/tools/mgr-cfg/mgr-cfg.spec
@@ -95,7 +95,7 @@ Requires:       %{pythonX}-%{name} = %{version}-%{release}
 %if 0%{?suse_version}
 # provide rhn directories and no selinux on suse
 BuildRequires:  spacewalk-client-tools
-%if %{?suse_version} >= 1110 && 0%{?suse_version} < 1500
+%if 0%{?suse_version} >= 1110 && 0%{?suse_version} < 1500
 Requires:       python-selinux
 %endif
 %if 0%{?suse_version} >= 1500

--- a/client/tools/mgr-cfg/mgr-cfg.spec
+++ b/client/tools/mgr-cfg/mgr-cfg.spec
@@ -98,7 +98,7 @@ BuildRequires:  spacewalk-client-tools
 %if %{?suse_version} >= 1110 && 0%{?suse_version} < 1500
 Requires:       python-selinux
 %endif
-%if %{?suse_version} >= 1110 && 0%{?suse_version} >= 1500
+%if 0%{?suse_version} >= 1500
 Requires:       python3-selinux
 %endif
 %else


### PR DESCRIPTION
## What does this PR change?

This PR fixes a problem with `mgr-cfg` package that is shipped in the client tools channels.

For instance in SLE15SP4, we do not build python2 subpackage but there is a hardcoded `Requires: python-selinux` that is going to make the build to fail as this package is not longer existing.

This PR fixes this "Require" to resolve properly depending on the build target.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **not needed**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/16508

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
