### PR TITLE
require python macros for building

### DIFF
--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- require python macros for building
 - Add headers to update proxy auth token in listChannels (bsc#1193585)
 
 -------------------------------------------------------------------

--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -83,6 +83,7 @@ BuildRequires:  python3-debian
 BuildRequires:  python3-rhn-client-tools
 BuildRequires:  python3-rhnlib >= 2.5.74
 BuildRequires:  python3-rpm
+BuildRequires:  python3-rpm-macros
 BuildRequires:  python3-uyuni-common-libs
 
 %description

--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
@@ -1,3 +1,4 @@
+- require python macros for building
 - do not build python 2 package for SLE15
 
 -------------------------------------------------------------------

--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.spec
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.spec
@@ -275,6 +275,7 @@ Requires:       python3-dbus
 Requires:       python3-gobject-base
 %endif
 BuildRequires:  python3-devel
+BuildRequires:  python3-rpm-macros
 %endif
 
 %ifnarch s390 s390x

--- a/client/tools/mgr-custom-info/mgr-custom-info.changes
+++ b/client/tools/mgr-custom-info/mgr-custom-info.changes
@@ -1,3 +1,5 @@
+- require python macros for building
+
 -------------------------------------------------------------------
 Fri Nov 05 13:34:16 CET 2021 - jgonzalez@suse.com
 

--- a/client/tools/mgr-custom-info/mgr-custom-info.spec
+++ b/client/tools/mgr-custom-info/mgr-custom-info.spec
@@ -38,6 +38,7 @@ BuildArch:      noarch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 %if 0%{?build_py3}
 BuildRequires:  python3-devel
+BuildRequires:  python3-rpm-macros
 Requires:       python3-rhnlib
 %else
 BuildRequires:  python-devel

--- a/client/tools/mgr-osad/mgr-osad.changes
+++ b/client/tools/mgr-osad/mgr-osad.changes
@@ -1,3 +1,4 @@
+- require python macros for building
 - do not build python 2 package for SLE15
 
 -------------------------------------------------------------------

--- a/client/tools/mgr-osad/mgr-osad.spec
+++ b/client/tools/mgr-osad/mgr-osad.spec
@@ -145,6 +145,7 @@ Requires:       python3-rhn-client-tools >= 2.8.4
 Requires:       python3-rhnlib >= 4.2.2
 Requires:       python3-uyuni-common-libs
 BuildRequires:  python3-devel
+BuildRequires:  python3-rpm-macros
 
 %description -n python3-%{name}
 Python 3 specific files for %{name}

--- a/client/tools/mgr-virtualization/mgr-virtualization.changes
+++ b/client/tools/mgr-virtualization/mgr-virtualization.changes
@@ -1,3 +1,4 @@
+- require python macros for building
 - do not build python 2 package for SLE15
 
 -------------------------------------------------------------------

--- a/client/tools/mgr-virtualization/mgr-virtualization.spec
+++ b/client/tools/mgr-virtualization/mgr-virtualization.spec
@@ -109,6 +109,7 @@ Obsoletes:      python3-%{oldname}-common < %{oldversion}
 Requires:       python3-rhn-client-tools
 Requires:       python3-uyuni-common-libs
 BuildRequires:  python3-devel
+BuildRequires:  python3-rpm-macros
 
 %description -n python3-%{name}-common
 This package contains files that are needed by the rhn-virtualization-host

--- a/client/tools/spacewalk-client-cert/spacewalk-client-cert.changes
+++ b/client/tools/spacewalk-client-cert/spacewalk-client-cert.changes
@@ -1,3 +1,5 @@
+- require python macros for building
+
 -------------------------------------------------------------------
 Mon Aug 09 10:59:54 CEST 2021 - jgonzalez@suse.com
 

--- a/client/tools/spacewalk-client-cert/spacewalk-client-cert.spec
+++ b/client/tools/spacewalk-client-cert/spacewalk-client-cert.spec
@@ -35,6 +35,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 %if 0%{?build_py3}
 BuildRequires:  python3-devel
+BuildRequires:  python3-rpm-macros
 Requires:       python3-rhn-client-tools
 Requires:       python3-rhn-setup
 %else

--- a/client/tools/spacewalk-oscap/spacewalk-oscap.changes
+++ b/client/tools/spacewalk-oscap/spacewalk-oscap.changes
@@ -1,3 +1,4 @@
+- require python macros for building
 - do not build python 2 package for SLE15
 
 -------------------------------------------------------------------

--- a/client/tools/spacewalk-oscap/spacewalk-oscap.spec
+++ b/client/tools/spacewalk-oscap/spacewalk-oscap.spec
@@ -80,6 +80,7 @@ Requires:       python3-rhn-check >= 2.8.4
 Requires:       python3-rhnlib >= 2.8.3
 BuildRequires:  python3-devel
 BuildRequires:  python3-rhnlib >= 2.8.3
+BuildRequires:  python3-rpm-macros
 
 %description -n python3-%{name}
 Python 3 specific files for %{name}.

--- a/client/tools/spacewalk-remote-utils/spacewalk-remote-utils.changes
+++ b/client/tools/spacewalk-remote-utils/spacewalk-remote-utils.changes
@@ -1,3 +1,5 @@
+- require python macros for building
+
 -------------------------------------------------------------------
 Mon Aug 09 10:38:21 CEST 2021 - jgonzalez@suse.com
 

--- a/client/tools/spacewalk-remote-utils/spacewalk-remote-utils.spec
+++ b/client/tools/spacewalk-remote-utils/spacewalk-remote-utils.spec
@@ -35,6 +35,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 %if 0%{?build_py3}
 BuildRequires:  python3-devel
+BuildRequires:  python3-rpm-macros
 Requires:       python3-rhnlib
 %else
 BuildRequires:  python-devel

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,5 @@
+- require python macros for building
+
 -------------------------------------------------------------------
 Tue Nov 16 10:02:53 CET 2021 - jgonzalez@suse.com
 

--- a/spacecmd/spacecmd.spec
+++ b/spacecmd/spacecmd.spec
@@ -79,6 +79,7 @@ BuildRequires:  python3
 BuildRequires:  python3-dev
 %else
 BuildRequires:  python3-devel
+BuildRequires:  python3-rpm-macros
 %endif
 Requires:       python3
 Requires:       python3-rpm

--- a/suseRegisterInfo/suseRegisterInfo.changes
+++ b/suseRegisterInfo/suseRegisterInfo.changes
@@ -1,3 +1,4 @@
+- require python macros for building
 - do not build python 2 package for SLE15
 
 -------------------------------------------------------------------

--- a/suseRegisterInfo/suseRegisterInfo.spec
+++ b/suseRegisterInfo/suseRegisterInfo.spec
@@ -80,6 +80,7 @@ Group:          Productivity/Other
 Requires:       %{name} = %{version}-%{release}
 Requires:       python3
 BuildRequires:  python3-devel
+BuildRequires:  python3-rpm-macros
 
 %description -n python3-%{name}
 Python 2 specific files for %{name}.

--- a/susemanager-utils/mgr-libmod/mgr-libmod.changes
+++ b/susemanager-utils/mgr-libmod/mgr-libmod.changes
@@ -1,3 +1,5 @@
+- require python macros for building
+
 -------------------------------------------------------------------
 Mon Aug 09 10:50:10 CEST 2021 - jgonzalez@suse.com
 

--- a/susemanager-utils/mgr-libmod/mgr-libmod.spec
+++ b/susemanager-utils/mgr-libmod/mgr-libmod.spec
@@ -27,6 +27,7 @@ Requires(pre):  coreutils
 Requires:       python3-libmodulemd
 BuildRequires:  python3-mock
 BuildRequires:  python3-pytest
+BuildRequires:  python3-rpm-macros
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 URL:            https://github.com/uyuni-project/uyuni

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- require python macros for building
 - Add Debian 11 repositories
 
 -------------------------------------------------------------------

--- a/utils/spacewalk-utils.spec
+++ b/utils/spacewalk-utils.spec
@@ -34,6 +34,7 @@ BuildArch:      noarch
 BuildRequires:  docbook-utils
 BuildRequires:  fdupes
 BuildRequires:  python3
+BuildRequires:  python3-rpm-macros
 %if 0%{?pylint_check}
 BuildRequires:  python3-solv
 BuildRequires:  python3-uyuni-common-libs

--- a/uyuni/common-libs/uyuni-common-libs.changes
+++ b/uyuni/common-libs/uyuni-common-libs.changes
@@ -1,3 +1,5 @@
+- require python macros for building
+
 -------------------------------------------------------------------
 Mon Aug 09 11:12:24 CEST 2021 - jgonzalez@suse.com
 

--- a/uyuni/common-libs/uyuni-common-libs.spec
+++ b/uyuni/common-libs/uyuni-common-libs.spec
@@ -77,6 +77,7 @@ Python 2 libraries required by both Uyuni server and client tools.
 Summary:        Uyuni server and client tools libraries for python3
 Group:          Development/Languages/Python
 BuildRequires:  python3-devel
+BuildRequires:  python3-rpm-macros
 Conflicts:      %{name} < 1.7.0
 %if 0%{?suse_version}
 Requires:       python3-base


### PR DESCRIPTION
## What does this PR change?

We get build errors because python rpm macros are not installed by default in the build system

https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-prs-ci-tests/977/

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
