### PR TITLE
Add hash to venv enabled txt

### DIFF
--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -1,12 +1,14 @@
 #!/usr/bin/python3
 
-import sys
-import os
 import glob
+import hashlib
+import os
 import shutil
 import subprocess
+import sys
 import time
 import traceback
+
 from optparse import OptionParser
 from rhn import rhnLockfile
 from spacewalk.server import rhnSQL
@@ -585,9 +587,16 @@ def create_repo(label, options, mgr_bootstrap_data, additional=[]):
             rel_path = os.path.relpath(file_path, start=destdirtmp)
             (l_path, ext) = rel_path.rsplit('.', 1)
             if ext:
+                dg = hashlib.sha256()
+                with open(file_path, "rb") as pkg_fh:
+                    while True:
+                        buff = pkg_fh.read(0x1000)
+                        if not buff:
+                            break
+                        dg.update(buff)
                 (l_path, arch) = l_path.rsplit('.' if ext == 'rpm' else '_', 1)
                 with open(os.path.join(destdirtmp, "venv-enabled-{}.txt".format(arch)), "w") as venv_enabled_file:
-                    venv_enabled_file.write("{}\n".format(rel_path))
+                    venv_enabled_file.write("{}  {}\n".format(dg.hexdigest(), rel_path))
                     venv_enabled_file.close()
         # move tmp dir to final location
         if os.path.exists(destdir):

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- Add sha256 hash to venv-enabled-ARCH.txt file generated
+  with mgr-create-bootstrap-repo
 - Enable bootstrapping for Debian 11
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Appends sha256 hash to `venv-enabled-ARCH.txt` files generated with `mgr-create-bootstrap-repo`.
The file is used to detect if the bootstrap repo contains Salt Bundle.

The hash is required for checking if we need to update Salt Bundle on salt-ssh managed systems.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Changelogs

- Add sha256 hash to venv-enabled-ARCH.txt file generated with mgr-create-bootstrap-repo

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
