### PR TITLE
Testsuite: Test for changing proxy

### DIFF
--- a/testsuite/features/secondary/min_move_from_and_to_proxy.feature
+++ b/testsuite/features/secondary/min_move_from_and_to_proxy.feature
@@ -1,0 +1,102 @@
+# Copyright (c) 2021 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@sle_minion
+@proxy
+Feature: Move a minion from a proxy to direct connection
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Delete minion system profile before bootstrap
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Delete System"
+    Then I should see a "Confirm System Profile Deletion" text
+    When I click on "Delete Profile"
+    And I wait until I see "has been deleted" text
+    Then "sle_minion" should not be registered
+
+  Scenario: Bootstrap a minion
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I enter the hostname of "sle_minion" as "hostname"
+    And I enter "22" as "port"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I select "1-SUSE-KEY-x86_64" from "activationKeys"
+    And I select the hostname of "proxy" from "proxies"
+    And I click on "Bootstrap"
+    And I wait until I see "Successfully bootstrapped host!" text
+    And I wait until onboarding is completed for "sle_minion"
+
+  Scenario: Check the new bootstrapped minion in System Overview page
+    When I follow the left menu "Salt > Keys"
+    Then I should see a "accepted" text
+    And the Salt master can reach "sle_minion"
+
+  Scenario: Check initial connection from minion to proxy
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see "proxy" short hostname
+
+  Scenario: Check initial registration on proxy of minion
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Details" in the content area
+    And I follow "Proxy" in the content area
+    Then I should see "sle_minion" hostname
+
+  Scenario: Change from proxy to direct connection
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    And I follow "Change" in the content area
+    And I select "None" from "proxies"
+    And I click on "Change Proxy"
+    And I wait until I see "scheduled" text
+    And I follow "Events"
+    And I follow "History"
+    And I wait until I see the event "Apply states [bootstrap.set_proxy] scheduled by admin" completed during last minute, refreshing the page
+    And I wait until I see the event "Apply states [channels] scheduled by admin" completed during last minute, refreshing the page
+
+  Scenario: Check direct connection
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see a "This system connects directly and not through a Proxy" text
+
+  Scenario: Change connection back to a proxy via SSM
+    # be sure that the old events are older than 1 minute
+    Given I wait for "120" seconds
+    When I follow the left menu "Systems > Overview"
+    And I follow "Clear"
+    And I check the "sle_minion" client
+    And I should see "1" systems selected for SSM
+    And I follow the left menu "Systems > System Set Manager > Overview"
+    And I follow "proxy server" in the content area
+    And I select the hostname of "proxy" from "proxies"
+    And I click on "Change Proxy"
+    And I wait until I see "scheduled" text
+
+  Scenario: Check events on the minion
+    Given I am on the Systems overview page of this "sle_minion"
+    And I follow "Events"
+    And I follow "History"
+    And I wait until I see the event "Apply states [bootstrap.set_proxy] scheduled by admin" completed during last minute, refreshing the page
+    And I wait until I see the event "Apply states [channels] scheduled by admin" completed during last minute, refreshing the page
+
+  Scenario: Check registration on proxy of minion
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Details" in the content area
+    And I follow "Proxy" in the content area
+    Then I should see "sle_minion" hostname
+
+  Scenario: Check connection from minion to proxy
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see "proxy" short hostname
+
+  Scenario: Check events history for failures on the minion
+    Given I am on the Systems overview page of this "sle_minion"
+    Then I check for failed events on history event page

--- a/testsuite/features/secondary/minssh_move_from_and_to_proxy.feature
+++ b/testsuite/features/secondary/minssh_move_from_and_to_proxy.feature
@@ -1,0 +1,91 @@
+# Copyright (c) 2021 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@ssh_minion
+@scope_salt_ssh
+@proxy
+Feature: Move a ssh minion from a proxy to direct connection
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Delete minion system profile before bootstrap
+    Given I am on the Systems overview page of this "ssh_minion"
+    When I follow "Delete System"
+    Then I should see a "Confirm System Profile Deletion" text
+    When I click on "Delete Profile"
+    And I wait until I see "has been deleted" text
+    Then "ssh_minion" should not be registered
+
+  Scenario: Bootstrap a minion
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I check "manageWithSSH"
+    And I enter the hostname of "ssh_minion" as "hostname"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I select "1-SUSE-SSH-KEY-x86_64" from "activationKeys"
+    And I select the hostname of "proxy" from "proxies"
+    And I click on "Bootstrap"
+    And I wait until I see "Successfully bootstrapped host!" text
+    And I wait until onboarding is completed for "ssh_minion"
+
+  Scenario: Check initial connection from minion to proxy
+    Given I am on the Systems overview page of this "ssh_minion"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see "proxy" short hostname
+
+  Scenario: Check initial registration on proxy of minion
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Details" in the content area
+    And I follow "Proxy" in the content area
+    Then I should see "ssh_minion" hostname
+
+  Scenario: Change from proxy to direct connection
+    Given I am on the Systems overview page of this "ssh_minion"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    And I follow "Change" in the content area
+    And I select "None" from "proxies"
+    And I click on "Change Proxy"
+    And I wait until I see "scheduled" text
+    And I follow "Events"
+    And I follow "History"
+    And I wait until I see the event "Apply states [channels] scheduled by admin" completed during last minute, refreshing the page
+
+  Scenario: Check direct connection
+    Given I am on the Systems overview page of this "ssh_minion"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see a "This system connects directly and not through a Proxy" text
+
+  Scenario: Change connection to a proxy
+    # be sure that the old events are older than 1 minute
+    Given I wait for "120" seconds
+    Given I am on the Systems overview page of this "ssh_minion"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    And I follow "Change" in the content area
+    And I select the hostname of "proxy" from "proxies"
+    And I click on "Change Proxy"
+    And I wait until I see "scheduled" text
+    And I follow "Events"
+    And I follow "History"
+    And I wait until I see the event "Apply states [channels] scheduled by admin" completed during last minute, refreshing the page
+
+  Scenario: Check registration on proxy of minion
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Details" in the content area
+    And I follow "Proxy" in the content area
+    Then I should see "ssh_minion" hostname
+
+  Scenario: Check connection from minion to proxy
+    Given I am on the Systems overview page of this "ssh_minion"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see "proxy" short hostname
+
+  Scenario: Check events history for failures on the minion
+    Given I am on the Systems overview page of this "ssh_minion"
+    Then I check for failed events on history event page

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -65,4 +65,6 @@
 - features/secondary/proxy_cobbler_pxeboot.feature
 - features/secondary/srv_restart.feature
 - features/secondary/min_timezone.feature
+- features/secondary/min_move_from_and_to_proxy.feature
+- features/secondary/minssh_move_from_and_to_proxy.feature
 ## Secondary features END ##


### PR DESCRIPTION
## What does this PR change?

This is a test for moving minion and ssh minion between direct connection and a proxy.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only testsuite
- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Test for https://github.com/uyuni-project/uyuni/pull/4313

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
