### PR TITLE
QA: Disable IPv4 forwarding on branch formula

### DIFF
--- a/testsuite/features/build_validation/core/allcli_sanity.feature
+++ b/testsuite/features/build_validation/core/allcli_sanity.feature
@@ -34,285 +34,285 @@ Feature: Sanity checks
   Scenario: The proxy is healthy
     Then "proxy" should have a FQDN
     And reverse resolution should work for "proxy"
-    And "proxy" should communicate with the server
+    And "proxy" should communicate with the server using "eth0"
     And the clock from "proxy" should be exact
 
 @sle11sp4_client
   Scenario: The SLES 11 SP4 traditional client is healthy
     Then "sle11sp4_client" should have a FQDN
     And reverse resolution should work for "sle11sp4_client"
-    And "sle11sp4_client" should communicate with the server
+    And "sle11sp4_client" should communicate with the server using "eth0"
     And the clock from "sle11sp4_client" should be exact
 
 @sle11sp4_minion
   Scenario: The SLES 11 SP4 minion is healthy
     Then "sle11sp4_minion" should have a FQDN
     And reverse resolution should work for "sle11sp4_minion"
-    And "sle11sp4_minion" should communicate with the server
+    And "sle11sp4_minion" should communicate with the server using "eth0"
     And the clock from "sle11sp4_minion" should be exact
 
 @sle11sp4_ssh_minion
   Scenario: The SLES 11 SP4 Salt SSH minion is healthy
     Then "sle11sp4_ssh_minion" should have a FQDN
     And reverse resolution should work for "sle11sp4_ssh_minion"
-    And "sle11sp4_ssh_minion" should communicate with the server
+    And "sle11sp4_ssh_minion" should communicate with the server using "eth0"
     And the clock from "sle11sp4_ssh_minion" should be exact
 
 @sle12sp4_client
   Scenario: The SLES 12 SP4 traditional client is healthy
     Then "sle12sp4_client" should have a FQDN
     And reverse resolution should work for "sle12sp4_client"
-    And "sle12sp4_client" should communicate with the server
+    And "sle12sp4_client" should communicate with the server using "eth0"
     And the clock from "sle12sp4_client" should be exact
 
 @sle12sp4_minion
   Scenario: The SLES 12 SP4 minion is healthy
     Then "sle12sp4_minion" should have a FQDN
     And reverse resolution should work for "sle12sp4_minion"
-    And "sle12sp4_minion" should communicate with the server
+    And "sle12sp4_minion" should communicate with the server using "eth0"
     And the clock from "sle12sp4_minion" should be exact
 
 @sle12sp4_ssh_minion
   Scenario: The SLES 12 SP4 Salt SSH minion is healthy
     Then "sle12sp4_minion" should have a FQDN
     And reverse resolution should work for "sle12sp4_minion"
-    And "sle12sp4_minion" should communicate with the server
+    And "sle12sp4_minion" should communicate with the server using "eth0"
     And the clock from "sle12sp4_minion" should be exact
 
 @sle12sp5_client
   Scenario: The SLES 12 SP5 traditional client is healthy
     Then "sle12sp5_client" should have a FQDN
     And reverse resolution should work for "sle12sp5_client"
-    And "sle12sp5_client" should communicate with the server
+    And "sle12sp5_client" should communicate with the server using "eth0"
     And the clock from "sle12sp5_client" should be exact
 
 @sle12sp5_minion
   Scenario: The SLES 12 SP5 minion is healthy
     Then "sle12sp5_minion" should have a FQDN
     And reverse resolution should work for "sle12sp5_minion"
-    And "sle12sp5_minion" should communicate with the server
+    And "sle12sp5_minion" should communicate with the server using "eth0"
     And the clock from "sle12sp5_minion" should be exact
 
 @sle12sp5_ssh_minion
   Scenario: The SLES 12 SP5 Salt SSH minion is healthy
     Then "sle12sp5_minion" should have a FQDN
     And reverse resolution should work for "sle12sp5_minion"
-    And "sle12sp5_minion" should communicate with the server
+    And "sle12sp5_minion" should communicate with the server using "eth0"
     And the clock from "sle12sp5_minion" should be exact
 
 @sle15_client
   Scenario: The SLES 15 traditional client is healthy
     Then "sle15_client" should have a FQDN
     And reverse resolution should work for "sle15_client"
-    And "sle15_client" should communicate with the server
+    And "sle15_client" should communicate with the server using "eth0"
     And the clock from "sle15_client" should be exact
 
 @sle15_minion
   Scenario: The SLES 15 minion is healthy
     Then "sle15_minion" should have a FQDN
     And reverse resolution should work for "sle15_minion"
-    And "sle15_minion" should communicate with the server
+    And "sle15_minion" should communicate with the server using "eth0"
     And the clock from "sle15_minion" should be exact
 
 @sle15_ssh_minion
   Scenario: The SLES 15 Salt SSH minion is healthy
     Then "sle15_ssh_minion" should have a FQDN
     And reverse resolution should work for "sle15_ssh_minion"
-    And "sle15_ssh_minion" should communicate with the server
+    And "sle15_ssh_minion" should communicate with the server using "eth0"
     And the clock from "sle15_ssh_minion" should be exact
 
 @sle15sp1_client
   Scenario: The SLES 15 SP1 traditional client is healthy
     Then "sle15sp1_client" should have a FQDN
     And reverse resolution should work for "sle15sp1_client"
-    And "sle15sp1_client" should communicate with the server
+    And "sle15sp1_client" should communicate with the server using "eth0"
     And the clock from "sle15sp1_client" should be exact
 
 @sle15sp1_minion
   Scenario: The SLES 15 SP1 minion is healthy
     Then "sle15sp1_minion" should have a FQDN
     And reverse resolution should work for "sle15sp1_minion"
-    And "sle15sp1_minion" should communicate with the server
+    And "sle15sp1_minion" should communicate with the server using "eth0"
     And the clock from "sle15sp1_minion" should be exact
 
 @sle15sp1_ssh_minion
   Scenario: The SLES 15 SP1 Salt SSH minion is healthy
     Then "sle15sp1_ssh_minion" should have a FQDN
     And reverse resolution should work for "sle15sp1_ssh_minion"
-    And "sle15sp1_ssh_minion" should communicate with the server
+    And "sle15sp1_ssh_minion" should communicate with the server using "eth0"
     And the clock from "sle15sp1_ssh_minion" should be exact
 
 @sle15sp2_client
   Scenario: The SLES 15 SP2 traditional client is healthy
     Then "sle15sp2_client" should have a FQDN
     And reverse resolution should work for "sle15sp2_client"
-    And "sle15sp2_client" should communicate with the server
+    And "sle15sp2_client" should communicate with the server using "eth0"
     And the clock from "sle15sp2_client" should be exact
 
 @sle15sp2_minion
   Scenario: The SLES 15 SP2 minion is healthy
     Then "sle15sp2_minion" should have a FQDN
     And reverse resolution should work for "sle15sp2_minion"
-    And "sle15sp2_minion" should communicate with the server
+    And "sle15sp2_minion" should communicate with the server using "eth0"
     And the clock from "sle15sp2_minion" should be exact
 
 @sle15sp2_ssh_minion
   Scenario: The SLES 15 SP2 Salt SSH minion is healthy
     Then "sle15sp2_ssh_minion" should have a FQDN
     And reverse resolution should work for "sle15sp2_ssh_minion"
-    And "sle15sp2_ssh_minion" should communicate with the server
+    And "sle15sp2_ssh_minion" should communicate with the server using "eth0"
     And the clock from "sle15sp2_ssh_minion" should be exact
 
 @sle15sp3_client
   Scenario: The SLES 15 SP3 traditional client is healthy
     Then "sle15sp3_client" should have a FQDN
     And reverse resolution should work for "sle15sp3_client"
-    And "sle15sp3_client" should communicate with the server
+    And "sle15sp3_client" should communicate with the server using "eth0"
     And the clock from "sle15sp3_client" should be exact
 
 @sle15sp3_minion
   Scenario: The SLES 15 SP3 minion is healthy
     Then "sle15sp3_minion" should have a FQDN
     And reverse resolution should work for "sle15sp3_minion"
-    And "sle15sp3_minion" should communicate with the server
+    And "sle15sp3_minion" should communicate with the server using "eth0"
     And the clock from "sle15sp3_minion" should be exact
 
 @sle15sp3_ssh_minion
   Scenario: The SLES 15 SP3 Salt SSH minion is healthy
     Then "sle15sp3_ssh_minion" should have a FQDN
     And reverse resolution should work for "sle15sp3_ssh_minion"
-    And "sle15sp3_ssh_minion" should communicate with the server
+    And "sle15sp3_ssh_minion" should communicate with the server using "eth0"
     And the clock from "sle15sp3_ssh_minion" should be exact
 
 @ceos7_client
   Scenario: The CentOS 7 traditional client is healthy
     Then "ceos7_client" should have a FQDN
     And reverse resolution should work for "ceos7_client"
-    And "ceos7_client" should communicate with the server
+    And "ceos7_client" should communicate with the server using "eth0"
     And the clock from "ceos7_client" should be exact
 
 @ceos7_minion
   Scenario: The CentOS 7 Salt minion is healthy
     Then "ceos7_minion" should have a FQDN
     And reverse resolution should work for "ceos7_minion"
-    And "ceos7_minion" should communicate with the server
+    And "ceos7_minion" should communicate with the server using "eth0"
     And the clock from "ceos7_minion" should be exact
 
 @ceos7_ssh_minion
   Scenario: The CentOS 7 Salt SSH minion is healthy
     Then "ceos7_ssh_minion" should have a FQDN
     And reverse resolution should work for "ceos7_ssh_minion"
-    And "ceos7_ssh_minion" should communicate with the server
+    And "ceos7_ssh_minion" should communicate with the server using "eth0"
     And the clock from "ceos7_ssh_minion" should be exact
 
 @ceos8_minion
   Scenario: The CentOS 8 Salt minion is healthy
     Then "ceos8_minion" should have a FQDN
     And reverse resolution should work for "ceos8_minion"
-    And "ceos8_minion" should communicate with the server
+    And "ceos8_minion" should communicate with the server using "eth0"
     And the clock from "ceos8_minion" should be exact
 
 @ceos8_ssh_minion
   Scenario: The CentOS 8 Salt SSH minion is healthy
     Then "ceos8_ssh_minion" should have a FQDN
     And reverse resolution should work for "ceos8_ssh_minion"
-    And "ceos8_ssh_minion" should communicate with the server
+    And "ceos8_ssh_minion" should communicate with the server using "eth0"
     And the clock from "ceos8_ssh_minion" should be exact
 
 @ubuntu1804_minion
   Scenario: The Ubuntu 18.04 Salt minion is healthy
     Then "ubuntu1804_minion" should have a FQDN
     And reverse resolution should work for "ubuntu1804_minion"
-    And "ubuntu1804_minion" should communicate with the server
+    And "ubuntu1804_minion" should communicate with the server using "eth0"
     And the clock from "ubuntu1804_minion" should be exact
 
 @ubuntu1804_ssh_minion
   Scenario: The Ubuntu 18.04 Salt SSH minion is healthy
     Then "ubuntu1804_ssh_minion" should have a FQDN
     And reverse resolution should work for "ubuntu1804_ssh_minion"
-    And "ubuntu1804_ssh_minion" should communicate with the server
+    And "ubuntu1804_ssh_minion" should communicate with the server using "eth0"
     And the clock from "ubuntu1804_ssh_minion" should be exact
 
 @ubuntu2004_minion
   Scenario: The Ubuntu 20.04 minion is healthy
     Then "ubuntu2004_minion" should have a FQDN
     And reverse resolution should work for "ubuntu2004_minion"
-    And "ubuntu2004_minion" should communicate with the server
+    And "ubuntu2004_minion" should communicate with the server using "eth0"
     And the clock from "ubuntu2004_minion" should be exact
 
 @ubuntu2004_ssh_minion
   Scenario: The Ubuntu 20.04 Salt SSH minion is healthy
     Then "ubuntu2004_ssh_minion" should have a FQDN
     And reverse resolution should work for "ubuntu2004_ssh_minion"
-    And "ubuntu2004_ssh_minion" should communicate with the server
+    And "ubuntu2004_ssh_minion" should communicate with the server using "eth0"
     And the clock from "ubuntu2004_ssh_minion" should be exact
 
 @debian9_minion
   Scenario: The Debian 9 minion is healthy
     Then "debian9_minion" should have a FQDN
     And reverse resolution should work for "debian9_minion"
-    And "debian9_minion" should communicate with the server
+    And "debian9_minion" should communicate with the server using "eth0"
     And the clock from "debian9_minion" should be exact
 
 @debian9_ssh_minion
   Scenario: The Debian 9 Salt SSH minion is healthy
     Then "debian9_ssh_minion" should have a FQDN
     And reverse resolution should work for "debian9_ssh_minion"
-    And "debian9_ssh_minion" should communicate with the server
+    And "debian9_ssh_minion" should communicate with the server using "eth0"
     And the clock from "debian9_ssh_minion" should be exact
 
 @debian10_minion
   Scenario: The Debian 10 minion is healthy
     Then "debian10_minion" should have a FQDN
     And reverse resolution should work for "debian10_minion"
-    And "debian10_minion" should communicate with the server
+    And "debian10_minion" should communicate with the server using "eth0"
     And the clock from "debian10_minion" should be exact
 
 @debian10_ssh_minion
   Scenario: The Debian 10 Salt SSH minion is healthy
     Then "debian10_ssh_minion" should have a FQDN
     And reverse resolution should work for "debian10_ssh_minion"
-    And "debian10_ssh_minion" should communicate with the server
+    And "debian10_ssh_minion" should communicate with the server using "eth0"
     And the clock from "debian10_ssh_minion" should be exact
 
 @debian11_minion
   Scenario: The Debian 11 minion is healthy
     Then "debian11_minion" should have a FQDN
     And reverse resolution should work for "debian11_minion"
-    And "debian11_minion" should communicate with the server
+    And "debian11_minion" should communicate with the server using "eth0"
     And the clock from "debian11_minion" should be exact
 
 @debian11_ssh_minion
   Scenario: The Debian 11 Salt SSH minion is healthy
     Then "debian11_ssh_minion" should have a FQDN
     And reverse resolution should work for "debian11_ssh_minion"
-    And "debian11_ssh_minion" should communicate with the server
+    And "debian11_ssh_minion" should communicate with the server using "eth0"
     And the clock from "debian11_ssh_minion" should be exact
 
 @sle11sp4_buildhost
   Scenario: The SLES 11 SP4 build host is healthy
     Then "sle11sp4_buildhost" should have a FQDN
     And reverse resolution should work for "sle11sp4_buildhost"
-    And "sle11sp4_buildhost" should communicate with the server
+    And "sle11sp4_buildhost" should communicate with the server using "eth0"
     And the clock from "sle11sp4_buildhost" should be exact
 
 @sle12sp5_buildhost
   Scenario: The SLES 12 SP5 build host is healthy
     Then "sle12sp5_buildhost" should have a FQDN
     And reverse resolution should work for "sle12sp5_buildhost"
-    And "sle12sp5_buildhost" should communicate with the server
+    And "sle12sp5_buildhost" should communicate with the server using "eth0"
     And the clock from "sle12sp5_buildhost" should be exact
 
 @sle15sp3_buildhost
   Scenario: The SLES 15 SP3 build host is healthy
     Then "sle15sp3_buildhost" should have a FQDN
     And reverse resolution should work for "sle15sp3_buildhost"
-    And "sle15sp3_buildhost" should communicate with the server
+    And "sle15sp3_buildhost" should communicate with the server using "eth0"
     And the clock from "sle15sp3_buildhost" should be exact
 
 @opensuse153arm_minion
   Scenario: The openSUSE 15.3 ARM minion is healthy
     Then "opensuse153arm_minion" should have a FQDN
     And reverse resolution should work for "opensuse153arm_minion"
-    And "opensuse153arm_minion" should communicate with the server
+    And "opensuse153arm_minion" should communicate with the server using "eth0"
     And the clock from "opensuse153arm_minion" should be exact

--- a/testsuite/features/core/allcli_sanity.feature
+++ b/testsuite/features/core/allcli_sanity.feature
@@ -34,63 +34,63 @@ Feature: Sanity checks
   Scenario: The proxy is healthy
     Then "proxy" should have a FQDN
     And reverse resolution should work for "proxy"
-    And "proxy" should communicate with the server
+    And "proxy" should communicate with the server using "eth0"
     And the clock from "proxy" should be exact
 
 @sle_client
   Scenario: The traditional client is healthy
     Then "sle_client" should have a FQDN
     And reverse resolution should work for "sle_client"
-    And "sle_client" should communicate with the server
+    And "sle_client" should communicate with the server using "eth0"
     And the clock from "sle_client" should be exact
 
 @sle_minion
   Scenario: The minion is healthy
     Then "sle_minion" should have a FQDN
     And reverse resolution should work for "sle_minion"
-    And "sle_minion" should communicate with the server
+    And "sle_minion" should communicate with the server using "eth0"
     And the clock from "sle_minion" should be exact
 
 @buildhost
   Scenario: The build host is healthy
     Then "build_host" should have a FQDN
     And reverse resolution should work for "build_host"
-    And "build_host" should communicate with the server
+    And "build_host" should communicate with the server using "eth0"
     And the clock from "build_host" should be exact
 
 @ssh_minion
   Scenario: The SSH minion is healthy
     Then "ssh_minion" should have a FQDN
     And reverse resolution should work for "ssh_minion"
-    And "ssh_minion" should communicate with the server
+    And "ssh_minion" should communicate with the server using "eth0"
     And the clock from "ssh_minion" should be exact
 
 @centos_minion
   Scenario: The CentOS minion is healthy
     Then "ceos_minion" should have a FQDN
     And reverse resolution should work for "ceos_minion"
-    And "ceos_minion" should communicate with the server
+    And "ceos_minion" should communicate with the server using "eth0"
     And the clock from "ceos_minion" should be exact
 
 @ubuntu_minion
   Scenario: The Ubuntu minion is healthy
     Then "ubuntu_minion" should have a FQDN
     And reverse resolution should work for "ubuntu_minion"
-    And "ubuntu_minion" should communicate with the server
+    And "ubuntu_minion" should communicate with the server using "eth0"
     And the clock from "ubuntu_minion" should be exact
 
 @virthost_kvm
   Scenario: The KVM host is healthy
     Then "kvm_server" should have a FQDN
     And reverse resolution should work for "kvm_server"
-    And "kvm_server" should communicate with the server
+    And "kvm_server" should communicate with the server using "eth0"
     And the clock from "kvm_server" should be exact
 
 @virthost_xen
   Scenario: The Xen host is healthy
     Then "xen_server" should have a FQDN
     And reverse resolution should work for "xen_server"
-    And "xen_server" should communicate with the server
+    And "xen_server" should communicate with the server using "eth0"
     And the clock from "xen_server" should be exact
 
   Scenario: The external resources can be reached

--- a/testsuite/features/core/proxy_branch_network.feature
+++ b/testsuite/features/core/proxy_branch_network.feature
@@ -200,3 +200,9 @@ Feature: Setup Uyuni for Retail branch network
     And name resolution should work on terminal "sle_client"
     And terminal "sle_minion" should have got a retail network IP address
     And name resolution should work on terminal "sle_minion"
+
+@proxy
+@private_net
+  Scenario: The terminals should not reach the server
+    Then "sle_client" should not communicate with the server using "eth1"
+    And "sle_minion" should not communicate with the server using "eth1"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -23,10 +23,16 @@ Then(/^reverse resolution should work for "([^"]*)"$/) do |host|
   raise "reverse resolution for #{node.ip} returned #{result}, expected to see #{node.full_hostname}" unless result.include? node.full_hostname
 end
 
-Then(/^"([^"]*)" should communicate with the server$/) do |host|
+Then(/^"([^"]*)" should communicate with the server using "([^"]*)"/) do |host, ethernet|
   node = get_target(host)
-  node.run("ping -c1 #{$server.full_hostname}")
-  $server.run("ping -c1 #{node.full_hostname}")
+  node.run("ping -4 -c 1 -I #{ethernet} #{$server.ip}")
+  $server.run("ping -4 -c 1 #{node.ip}")
+end
+
+Then(/^"([^"]*)" should not communicate with the server using "([^"]*)"/) do |host, ethernet|
+  node = get_target(host)
+  node.run_until_fail("ping -4 -c 1 -I #{ethernet} #{$server.ip}")
+  $server.run_until_fail("ping -4 -c 1 #{node.ip}")
 end
 
 Then(/^the clock from "([^"]*)" should be exact$/) do |host|

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -165,6 +165,14 @@ When(/^I check "([^"]*)" if not checked$/) do |arg1|
   check(arg1) unless has_checked_field?(arg1)
 end
 
+When(/^I check (.*) box$/) do |checkbox_name|
+  check BOX_IDS[checkbox_name]
+end
+
+When(/^I uncheck (.*) box$/) do |checkbox_name|
+  uncheck BOX_IDS[checkbox_name]
+end
+
 When(/^I select "([^"]*)" from "([^"]*)"$/) do |option, field|
   xpath_option = ".//*[contains(@class, 'class-#{field}__option') and contains(text(),'#{option}')]"
   xpath_field = "//*[contains(@class, 'class-#{field}__control')]/../*[@name='#{field}']/.."

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -335,10 +335,14 @@ $nodes.each do |node|
   next if node.nil?
   next if node.is_a?(String) && node.empty?
 
-  node.init_ip(node.full_hostname)
-
   host = $host_by_node[node]
   raise "Cannot resolve host for node: '#{node.hostname}'" if host.nil? || host == ''
+
+  if ADDRESSES.key? host
+    node.init_ip(net_prefix + ADDRESSES[host])
+  else
+    node.init_ip(node.full_hostname)
+  end
 
   ip = client_public_ip host
   node.init_public_ip ip


### PR DESCRIPTION
## What does this PR change?

Related card: https://github.com/SUSE/spacewalk/issues/16486

We want to make the systems in the private network to not have access to any external server outside the private network. This way catch this kind of issues earlier.

For now, this PR prevents this communication if the systems are configured with IPv4.

Notes:
- The "ip" attribute in our twopence nodes was not including the private IP, but the domain name.
- We need to specify the use of a concrete network when we do our ping, otherwise, it tries to use the other IP.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
