### PR TITLE
BV: Allow all SSL Protocols in Proxy's Apache

### DIFF
--- a/testsuite/features/build_validation/init_clients/proxy.feature
+++ b/testsuite/features/build_validation/init_clients/proxy.feature
@@ -17,6 +17,7 @@ Feature: Setup SUSE Manager proxy
     # uncomment when product is out:
     # When I install "SUSE-Manager-Proxy" product on the proxy
     And I install proxy pattern on the proxy
+    And I allow all SSL protocols on the proxy's apache
     And I let squid use avahi on the proxy
 
   Scenario: Log in as admin user

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1744,3 +1744,11 @@ When(/^I regenerate the boot RAM disk on "([^"]*)" if necessary$/) do |host|
     node.run('mkinitrd')
   end
 end
+
+When(/^I allow all SSL protocols on the proxy's apache$/) do
+  file = '/etc/apache2/ssl-global.conf'
+  key = 'SSLProtocol'
+  val = 'all -SSLv2 -SSLv3'
+  $proxy.run("grep '#{key}' #{file} && sed -i -e 's/#{key}.*$/#{key} #{val}/' #{file}")
+  $proxy.run("systemctl reload apache2.service")
+end


### PR DESCRIPTION
## What does this PR change?

Allow all SSL Protocols in Proxy's Apache.

Explanation:
This one is very concrete for BV, as for CI we don't have a SLE11 and we don't plan to have it.
In BV, due to another issue during the cleaning process of salt packages, we handle ourselves the installation of suma_proxy pattern, so, it's not installed during salt states made by sumaform. That implies that we will not have apache installed at the moment we run salt states in sumaform. Therefore, we need to also handle ourselves from the test suite the change of config in Proxy's Apache.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
