### PR TITLE
Activation Keys: Only show the warning for SUMA Default, when the default channel is selected

### DIFF
--- a/web/html/src/manager/systems/activation-key/activation-key-channels.tsx
+++ b/web/html/src/manager/systems/activation-key/activation-key-channels.tsx
@@ -128,15 +128,16 @@ class ActivationKeyChannels extends React.Component<ActivationKeyChannelsProps, 
                         `is not compatible then the fall back will be the "${defaultChannelName}" channel.`
                     )}
                   </span>
-                  <Messages
-                    items={MessagesUtils.warning(
-                      t(
-                        `When "${this.getDefaultBase().name}" is selected and the installed ` +
-                          "product is not detected, no channel will be added even if children " +
-                          "channels are selected."
-                      )
-                    )}
-                  />
+                  {this.state.currentSelectedBaseId === -1 &&
+                    <Messages
+                      items={MessagesUtils.warning(
+                        t(
+                          `When "${this.getDefaultBase().name}" is selected and the installed ` +
+                            "product is not detected, no channel will be added even if children " +
+                            "channels are selected."
+                        )
+                      )}
+                    />}
                 </div>
               </div>
               <div className="form-group">

--- a/web/html/src/manager/systems/activation-key/activation-key-channels.tsx
+++ b/web/html/src/manager/systems/activation-key/activation-key-channels.tsx
@@ -128,7 +128,7 @@ class ActivationKeyChannels extends React.Component<ActivationKeyChannelsProps, 
                         `is not compatible then the fall back will be the "${defaultChannelName}" channel.`
                     )}
                   </span>
-                  {this.state.currentSelectedBaseId === -1 &&
+                  {this.state.currentSelectedBaseId === -1 && (
                     <Messages
                       items={MessagesUtils.warning(
                         t(
@@ -137,7 +137,8 @@ class ActivationKeyChannels extends React.Component<ActivationKeyChannelsProps, 
                             "channels are selected."
                         )
                       )}
-                    />}
+                    />
+                  )}
                 </div>
               </div>
               <div className="form-group">


### PR DESCRIPTION
## GUI diff

![ss-before](https://user-images.githubusercontent.com/1412268/146341088-4d2f7f97-0539-42fd-82ec-41847c9cf0b9.png)

![ss-after](https://user-images.githubusercontent.com/1412268/146341099-2b021bca-81ff-4b69-9626-10678bb9cdfd.png)


- [x] **DONE**

## Documentation
- No documentation needed: cosmetic issue

- [x] **DONE**

## Test coverage
- No tests: cosmetic issue

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/16415

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
