### PR TITLE
QA: We are wronly using eth0 in some steps

### DIFF
--- a/testsuite/features/build_validation/core/allcli_sanity.feature
+++ b/testsuite/features/build_validation/core/allcli_sanity.feature
@@ -223,28 +223,28 @@ Feature: Sanity checks
   Scenario: The Ubuntu 18.04 Salt minion is healthy
     Then "ubuntu1804_minion" should have a FQDN
     And reverse resolution should work for "ubuntu1804_minion"
-    And "ubuntu1804_minion" should communicate with the server using "eth0"
+    And "ubuntu1804_minion" should communicate with the server using "ens3"
     And the clock from "ubuntu1804_minion" should be exact
 
 @ubuntu1804_ssh_minion
   Scenario: The Ubuntu 18.04 Salt SSH minion is healthy
     Then "ubuntu1804_ssh_minion" should have a FQDN
     And reverse resolution should work for "ubuntu1804_ssh_minion"
-    And "ubuntu1804_ssh_minion" should communicate with the server using "eth0"
+    And "ubuntu1804_ssh_minion" should communicate with the server using "ens3"
     And the clock from "ubuntu1804_ssh_minion" should be exact
 
 @ubuntu2004_minion
   Scenario: The Ubuntu 20.04 minion is healthy
     Then "ubuntu2004_minion" should have a FQDN
     And reverse resolution should work for "ubuntu2004_minion"
-    And "ubuntu2004_minion" should communicate with the server using "eth0"
+    And "ubuntu2004_minion" should communicate with the server using "ens3"
     And the clock from "ubuntu2004_minion" should be exact
 
 @ubuntu2004_ssh_minion
   Scenario: The Ubuntu 20.04 Salt SSH minion is healthy
     Then "ubuntu2004_ssh_minion" should have a FQDN
     And reverse resolution should work for "ubuntu2004_ssh_minion"
-    And "ubuntu2004_ssh_minion" should communicate with the server using "eth0"
+    And "ubuntu2004_ssh_minion" should communicate with the server using "ens3"
     And the clock from "ubuntu2004_ssh_minion" should be exact
 
 @debian9_minion
@@ -279,14 +279,14 @@ Feature: Sanity checks
   Scenario: The Debian 11 minion is healthy
     Then "debian11_minion" should have a FQDN
     And reverse resolution should work for "debian11_minion"
-    And "debian11_minion" should communicate with the server using "eth0"
+    And "debian11_minion" should communicate with the server using "ens3"
     And the clock from "debian11_minion" should be exact
 
 @debian11_ssh_minion
   Scenario: The Debian 11 Salt SSH minion is healthy
     Then "debian11_ssh_minion" should have a FQDN
     And reverse resolution should work for "debian11_ssh_minion"
-    And "debian11_ssh_minion" should communicate with the server using "eth0"
+    And "debian11_ssh_minion" should communicate with the server using "ens3"
     And the clock from "debian11_ssh_minion" should be exact
 
 @sle11sp4_buildhost

--- a/testsuite/features/core/allcli_sanity.feature
+++ b/testsuite/features/core/allcli_sanity.feature
@@ -76,21 +76,21 @@ Feature: Sanity checks
   Scenario: The Ubuntu minion is healthy
     Then "ubuntu_minion" should have a FQDN
     And reverse resolution should work for "ubuntu_minion"
-    And "ubuntu_minion" should communicate with the server using "eth0"
+    And "ubuntu_minion" should communicate with the server using "ens3"
     And the clock from "ubuntu_minion" should be exact
 
 @virthost_kvm
   Scenario: The KVM host is healthy
     Then "kvm_server" should have a FQDN
     And reverse resolution should work for "kvm_server"
-    And "kvm_server" should communicate with the server using "eth0"
+    And "kvm_server" should communicate with the server using "br0"
     And the clock from "kvm_server" should be exact
 
 @virthost_xen
   Scenario: The Xen host is healthy
     Then "xen_server" should have a FQDN
     And reverse resolution should work for "xen_server"
-    And "xen_server" should communicate with the server using "eth0"
+    And "xen_server" should communicate with the server using "br0"
     And the clock from "xen_server" should be exact
 
   Scenario: The external resources can be reached


### PR DESCRIPTION
## What does this PR change?

We are wrongly using eth0 in some steps

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
