### PR TITLE
Generalised repo2solv usage

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriter.java
@@ -68,7 +68,7 @@ public class RpmRepositoryWriter extends RepositoryWriter {
     private static final String SUSEDATA_FILE = "susedata.xml.gz.new";
     private static final String NOREPO_FILE = "noyumrepo.txt";
     private static final String SOLV_FILE = "solv.new";
-    private static final String REPO2SOLV = "/usr/bin/repo2solv.sh";
+    private static final String REPO2SOLV = "/usr/bin/repo2solv";
 
     private static final String GROUP = "groups";
     private static final String MODULES = "modules";

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -215,6 +215,7 @@ Requires:       jboss-logging
 Requires:       joda-time
 Requires:       jose4j
 Requires:       jpa-api
+Requires:       libsolv-tools
 Requires:       mgr-libmod
 Requires:       netty
 Requires:       objectweb-asm


### PR DESCRIPTION
## What does this PR change?

Added libsolv-tools dependency.
Call repo2solv instead of repo2solv.sh.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

Not tested.

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
