### PR TITLE
Virt list fix

### DIFF
--- a/java/code/src/com/suse/manager/webui/websocket/Notification.java
+++ b/java/code/src/com/suse/manager/webui/websocket/Notification.java
@@ -189,6 +189,9 @@ public class Notification {
      * @param property which property to spread to all sessions
      */
     public static void spreadUpdate(String property) {
+        // Check for closed sessions before notifying them
+        clearBrokenSessions();
+
         synchronized (LOCK) {
             // if there are unread messages, notify it to all attached WebSocket sessions
             wsSessions.forEach((session, watched) -> {

--- a/testsuite/features/secondary/srv_menu.feature
+++ b/testsuite/features/secondary/srv_menu.feature
@@ -203,7 +203,7 @@ Feature: Web UI - Main landing page menu, texts and links
   Scenario: Sidebar link destination for Systems => Virtual Systems
     When I follow the left menu "Systems > System List > Virtual Systems"
     Then I should see a "Virtual Systems" text
-    And the current path is "/rhn/systems/VirtualList.do"
+    And the current path is "/rhn/manager/systems/list/virtual"
 
   Scenario: Sidebar link destination for Systems => Out of Date
     When I follow the left menu "Systems > System List > Out of Date"


### PR DESCRIPTION
## What does this PR change?

Fixes the SSM websocket errors and the virtual list menu link check in the testsuite.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links


- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
