### PR TITLE
QA: Add tests for details overview page

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -21,7 +21,16 @@ Feature: Smoke tests for <client>
 
   Scenario: Client <client> grains are displayed correctly on the details page
     Given I am on the Systems overview page of this "<client>"
-    Then I can see all system information for "<client>"
+    Then the hostname for "<client>" should be correct
+    And the kernel for "<client>" should be correct
+    And the OS version for "<client>" should be correct
+    And the IPv4 address for "<client>" should be correct
+    # disabled for the moment due to a possible bug (#bsc1193858)
+    # And the IPv6 address for "<client>" should be correct
+    And the system ID for "<client>" should be correct
+    And the system name for "<client>" should be correct
+    And the uptime for "<client>" should be correct
+    And I can see several text fields for "<client>"
 
 @skip_for_debianlike
   Scenario: Install a patch on the <client>

--- a/testsuite/features/secondary/allcli_overview_systems_details.feature
+++ b/testsuite/features/secondary/allcli_overview_systems_details.feature
@@ -9,24 +9,64 @@ Feature: The system details of each minion and client provides an overview of th
 
   Scenario: Traditional client grains are displayed correctly on the details page
     Given I am on the Systems overview page of this "sle_client"
-    Then I can see all system information for "sle_client"
+    Then the hostname for "sle_client" should be correct
+    And the kernel for "sle_client" should be correct
+    And the OS version for "sle_client" should be correct
+    And the IPv4 address for "sle_client" should be correct
+    # disabled for the moment due to a possible bug (#bsc1193858)
+    # And the IPv6 address for "sle_client" should be correct
+    And the system ID for "sle_client" should be correct
+    And the system name for "sle_client" should be correct
+    And the uptime for "sle_client" should be correct
+    And I can see several text fields for "sle_client"
 
   Scenario: Minion grains are displayed correctly on the details page
     Given I am on the Systems overview page of this "sle_minion"
-    Then I can see all system information for "sle_minion"
+    Then the hostname for "sle_minion" should be correct
+    And the kernel for "sle_minion" should be correct
+    And the OS version for "sle_minion" should be correct
+    And the IPv4 address for "sle_minion" should be correct
+    And the IPv6 address for "sle_minion" should be correct
+    And the system ID for "sle_minion" should be correct
+    And the system name for "sle_minion" should be correct
+    And the uptime for "sle_minion" should be correct
+    And I can see several text fields for "sle_minion"
 
 @centos_minion
   Scenario: CentOS minion grains are displayed correctly on the details page
     Given I am on the Systems overview page of this "ceos_minion"
-    Then I can see all system information for "ceos_minion"
+    Then the hostname for "ceos_minion" should be correct
+    And the kernel for "ceos_minion" should be correct
+    And the OS version for "ceos_minion" should be correct
+    And the IPv4 address for "ceos_minion" should be correct
+    And the IPv6 address for "ceos_minion" should be correct
+    And the system ID for "ceos_minion" should be correct
+    And the system name for "ceos_minion" should be correct
+    And the uptime for "ceos_minion" should be correct
+    And I can see several text fields for "ceos_minion"
 
 @ubuntu_minion
   Scenario: Ubuntu minion grains are displayed correctly on the details page
     Given I am on the Systems overview page of this "ubuntu_minion"
-    Then I can see all system information for "ubuntu_minion"
+    Then the hostname for "ubuntu_minion" should be correct
+    And the kernel for "ubuntu_minion" should be correct
+    And the OS version for "ubuntu_minion" should be correct
+    And the IPv4 address for "ubuntu_minion" should be correct
+    And the IPv6 address for "ubuntu_minion" should be correct
+    And the system ID for "ubuntu_minion" should be correct
+    And the system name for "ubuntu_minion" should be correct
+    And the uptime for "ubuntu_minion" should be correct
+    And I can see several text fields for "ubuntu_minion"
 
 @ssh_minion
   Scenario: SSH-managed minion grains are displayed correctly on the details page
     Given I am on the Systems overview page of this "ssh_minion"
-    Then I can see all system information for "ssh_minion"
-
+    Then the hostname for "ssh_minion" should be correct
+    And the kernel for "ssh_minion" should be correct
+    And the OS version for "ssh_minion" should be correct
+    And the IPv4 address for "ssh_minion" should be correct
+    And the IPv6 address for "ssh_minion" should be correct
+    And the system ID for "ssh_minion" should be correct
+    And the system name for "ssh_minion" should be correct
+    And the uptime for "ssh_minion" should be correct
+    And I can see several text fields for "ssh_minion"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -22,15 +22,76 @@ When(/^I mount as "([^"]+)" the ISO from "([^"]+)" in the server$/) do |name, ur
   $server.run("umount #{iso_path}; mount #{iso_path}")
 end
 
-Then(/^I can see all system information for "([^"]*)"$/) do |host|
+Then(/^the hostname for "([^"]*)" should be correct$/) do |host|
   node = get_target(host)
   step %(I should see a "#{node.hostname}" text)
+end
+
+Then(/^the kernel for "([^"]*)" should be correct$/) do |host|
+  node = get_target(host)
   kernel_version, _code = node.run('uname -r')
-  puts 'I should see kernel version: ' + kernel_version
   step %(I should see a "#{kernel_version.strip}" text)
+end
+
+Then(/^the OS version for "([^"]*)" should be correct$/) do |host|
+  node = get_target(host)
   os_version, os_family = get_os_version(node)
   # skip this test for centos and ubuntu systems
   step %(I should see a "#{os_version.gsub!('-SP', ' SP')}" text) if os_family.include? 'sles'
+end
+
+Then(/^the IPv4 address for "([^"]*)" should be correct$/) do |host|
+  node = get_target(host)
+  step %(I should see a "#{node.public_ip}" text)
+end
+
+Then(/^the IPv6 address for "([^"]*)" should be correct$/) do |host|
+  node = get_target(host)
+  # query and modify OS ID string.
+  os_family_raw, code = node.run('grep "^ID=" /etc/os-release', check_errors: false)
+  os_family = os_family_raw.strip.split('=')[1]
+  os_family.delete! '"'
+  # ubuntu has a different default interface name
+  if os_family == 'ubuntu'
+    ipv6, _code = node.run('ip -6 addr show ens3 | sed -e"s/^.*inet6 \(2620[^ ]*\)\/64 scope global dynamic.*$/\1/;t;d"|tr -d "\n"')
+  else
+    ipv6, _code = node.run('ip -6 addr show eth0 | sed -e"s/^.*inet6 \(2620[^ ]*\)\/64 scope global dynamic.*$/\1/;t;d"|tr -d "\n"')
+  end
+  step %(I should see a "#{ipv6}" text)
+end
+
+Then(/^the system ID for "([^"]*)" should be correct$/) do |host|
+  node = get_target(host)
+  step %(I am logged in via XML\-RPC actionchain as user "admin" and password "admin")
+  client_id = @system_api.search_by_name(get_system_name(host)).first['id']
+  step %(I should see a "#{client_id.to_s}" text)
+end
+
+Then(/^the system name for "([^"]*)" should be correct$/) do |host|
+  node = get_target(host)
+  system_name = get_system_name(host)
+  step %(I should see a "#{system_name}" text)
+end
+
+Then(/^the uptime for "([^"]*)" should be correct$/) do |host|
+  node = get_target(host)
+  uptime_days, _code = node.run("awk '{print $1/86400}' /proc/uptime")
+  step %(I should see a "#{uptime_days.to_f.round} days ago" text)
+end
+
+Then(/^I can see several text fields for "([^"]*)"$/) do |host|
+  node = get_target(host)
+  steps %(Then I should see a "UUID" text
+    And I should see a "Virtualization" text
+    And I should see a "Installed Products" text
+    And I should see a "Checked In" text
+    And I should see a "Registered" text
+    And I should see a "Contact Method" text
+    And I should see a "Auto Patch Update" text
+    And I should see a "Maintenance Schedule" text
+    And I should see a "Description" text
+    And I should see a "Location" text
+  )
 end
 
 Then(/^I should see the terminals imported from the configuration file$/) do


### PR DESCRIPTION
## What does this PR change?

This will add more tests for the system details overview page, e.g. uptime, IP addresses, SUSE Manager system ID, etc.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:

Manager-4.1

Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
