### PR TITLE
Report the latest built package on "rhnChannelNewestPackageView" when duplicates (bsc#1193612)

### DIFF
--- a/schema/spacewalk/common/views/rhnChannelNewestPackageView.sql
+++ b/schema/spacewalk/common/views/rhnChannelNewestPackageView.sql
@@ -24,35 +24,43 @@ SELECT channel_id,
        name_id,
        evr_id,
        package_arch_id,
-       max(package_id) as package_id
+       package_id
 FROM (
-       SELECT m.channel_id          as channel_id,
-              p.name_id             as name_id,
-              p.evr_id              as evr_id,
-              m.package_arch_id     as package_arch_id,
-              p.id                  as package_id
-         FROM
-              (select max(pe.evr) AS max_evr,
-                      cp.channel_id,
-                      p.name_id,
-                      p.package_arch_id
-                 from rhnPackageEVR                           pe,
-                      rhnPackage                              p,
-                      suseChannelPackageRetractedStatusView   cp
-                where p.evr_id = pe.id
-                  and cp.package_id = p.id
-                  and NOT cp.is_retracted
-                group by cp.channel_id, p.name_id, p.package_arch_id) m,
-              rhnPackageEVR       pe,
-              rhnPackage          p,
-              rhnChannelPackage   chp
-        WHERE m.max_evr = pe.evr
-          AND m.name_id = p.name_id
-          AND m.package_arch_id = p.package_arch_id
-          AND p.evr_id = pe.id
-          AND chp.package_id = p.id
-          AND chp.channel_id = m.channel_id
-) latest_packages
-group by channel_id, name_id, evr_id, package_arch_id
-;
-
+      SELECT channel_id,
+             name_id,
+             evr_id,
+             package_arch_id,
+             build_time,
+             max(package_id) as package_id,
+             ROW_NUMBER() OVER(PARTITION BY name_id, channel_id, package_arch_id ORDER BY build_time DESC) rn
+      FROM (
+            SELECT m.channel_id          as channel_id,
+                   p.name_id             as name_id,
+                   p.evr_id              as evr_id,
+                   m.package_arch_id     as package_arch_id,
+                   p.id                  as package_id,
+                   p.build_time          as build_time
+            FROM (select max(pe.evr) AS max_evr,
+                         cp.channel_id,
+                         p.name_id,
+                         p.package_arch_id
+                    from rhnPackageEVR                           pe,
+                         rhnPackage                              p,
+                         suseChannelPackageRetractedStatusView   cp
+                   where p.evr_id = pe.id
+                     and cp.package_id = p.id
+                     and NOT cp.is_retracted
+                   group by cp.channel_id, p.name_id, p.package_arch_id) m,
+                 rhnPackageEVR       pe,
+                 rhnPackage          p,
+                 rhnChannelPackage   chp
+            WHERE m.max_evr = pe.evr
+                AND m.name_id = p.name_id
+                AND m.package_arch_id = p.package_arch_id
+                AND p.evr_id = pe.id
+                AND chp.package_id = p.id
+                AND chp.channel_id = m.channel_id
+      ) latest_packages
+      group by channel_id, name_id, evr_id, package_arch_id, build_time
+) n
+WHERE rn = 1

--- a/schema/spacewalk/common/views/rhnChannelNewestPackageView.sql
+++ b/schema/spacewalk/common/views/rhnChannelNewestPackageView.sql
@@ -63,4 +63,4 @@ FROM (
       ) latest_packages
       group by channel_id, name_id, evr_id, package_arch_id, build_time
 ) n
-WHERE rn = 1
+WHERE rn = 1;

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Fix rhnChannelNewestPackageView in case there are duplicates (bsc#1193612)
 - Change rhnPackageCapability name data type to TEXT
 - Add support for custom SSH port for SSH minions
 - Fix changing of existing proxy path

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.4-to-susemanager-schema-4.3.5/030-rhnChannelNewestPackageView-fix-duplicates.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.4-to-susemanager-schema-4.3.5/030-rhnChannelNewestPackageView-fix-duplicates.sql
@@ -44,4 +44,4 @@ FROM (
       ) latest_packages
       group by channel_id, name_id, evr_id, package_arch_id, build_time
 ) n
-WHERE rn = 1
+WHERE rn = 1;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.4-to-susemanager-schema-4.3.5/030-rhnChannelNewestPackageView-fix-duplicates.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.4-to-susemanager-schema-4.3.5/030-rhnChannelNewestPackageView-fix-duplicates.sql
@@ -1,0 +1,47 @@
+create or replace view
+rhnChannelNewestPackageView
+as
+SELECT channel_id,
+       name_id,
+       evr_id,
+       package_arch_id,
+       package_id
+FROM (
+      SELECT channel_id,
+             name_id,
+             evr_id,
+             package_arch_id,
+             build_time,
+             max(package_id) as package_id,
+             ROW_NUMBER() OVER(PARTITION BY name_id, channel_id, package_arch_id ORDER BY build_time DESC) rn
+      FROM (
+            SELECT m.channel_id          as channel_id,
+                   p.name_id             as name_id,
+                   p.evr_id              as evr_id,
+                   m.package_arch_id     as package_arch_id,
+                   p.id                  as package_id,
+                   p.build_time          as build_time
+            FROM (select max(pe.evr) AS max_evr,
+                         cp.channel_id,
+                         p.name_id,
+                         p.package_arch_id
+                    from rhnPackageEVR                           pe,
+                         rhnPackage                              p,
+                         suseChannelPackageRetractedStatusView   cp
+                   where p.evr_id = pe.id
+                     and cp.package_id = p.id
+                     and NOT cp.is_retracted
+                   group by cp.channel_id, p.name_id, p.package_arch_id) m,
+                 rhnPackageEVR       pe,
+                 rhnPackage          p,
+                 rhnChannelPackage   chp
+            WHERE m.max_evr = pe.evr
+                AND m.name_id = p.name_id
+                AND m.package_arch_id = p.package_arch_id
+                AND p.evr_id = pe.id
+                AND chp.package_id = p.id
+                AND chp.channel_id = m.channel_id
+      ) latest_packages
+      group by channel_id, name_id, evr_id, package_arch_id, build_time
+) n
+WHERE rn = 1


### PR DESCRIPTION
## What does this PR change?

This PR fixes a nasty corner case that is caused when a repository provides two packages with the same nvra, where one of them has `epoch = 0` and the other one has no `epoch` defined.

The `epoch` is an optional attribute for a RPM package [1]. When this attribute is missing, it epoch is considered as "0".

For example, this repo: https://rpm.releases.hashicorp.com/RHEL/8/x86_64/stable/ provides twice the package `consul-1.10.4-1.x86_64` as we described.

The problem for Uyuni appears in `spacewalk-repo-sync` in case we are syncing a repository that provides these "conflictive" packages, but only when those packages are the latest versions for this particular package name inside the channel where we are syncing those packages. When this situation happens, it makes `spacewalk-repo-sync` to crash without syncing the packages:

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/spacewalk/server/importlib/backend.py", line 2085, in update_newest_package_cache
    refresh_newest_package(channel_id, caller, None)
  File "/usr/lib/python3.6/site-packages/spacewalk/server/rhnSQL/driver_postgresql.py", line 116, in __call__
    result = Function.__call__(self, *args)
  File "/usr/lib/python3.6/site-packages/spacewalk/server/rhnSQL/driver_postgresql.py", line 92, in __call__
    raise sql_base.SQLSchemaError(error_code, e.pgerror, e)
spacewalk.server.rhnSQL.sql_base.SQLSchemaError: (99999, 'ERROR:  duplicate key value violates unique constraint "rhn_cnp_cid_nid_uq"', 'DETAIL:  Key (channel_id, name_id, package_arch_id)=(203, 11803, 120) already exists.\nCONTEXT:  SQL statement "insert into rhnChannelNewestPackage\n                (channel_id, name_id, evr_id, package_id, package_arch_id)\n                (select channel_id,\n                        name_id, evr_id,\n                        package_id, package_arch_id\n                   from rhnChannelNewestPackageView\n                  where channel_id = channel_id_in\n                    and (package_name_id_in is null\n                         or name_id = package_name_id_in)\n                )"\nPL/pgSQL function rhn_channel.refresh_newest_package(numeric,character varying,numeric) line 9 at SQL statement\n', UniqueViolation('duplicate key value violates unique constraint "rhn_cnp_cid_nid_uq"\nDETAIL:  Key (channel_id, name_id, package_arch_id)=(203, 11803, 120) already exists.\nCONTEXT:  SQL statement "insert into rhnChannelNewestPackage\n                (channel_id, name_id, evr_id, package_id, package_arch_id)\n                (select channel_id,\n                        name_id, evr_id,\n                        package_id, package_arch_id\n                   from rhnChannelNewestPackageView\n                  where channel_id = channel_id_in\n                    and (package_name_id_in is null\n                         or name_id = package_name_id_in)\n                )"\nPL/pgSQL function rhn_channel.refresh_newest_package(numeric,character varying,numeric) line 9 at SQL statement\n',))
```

What is happening here is that the Uyuni DB considers the two conflictive packages as with the same nevra, so same evr, and therefore the `rhnChannelNewestPackageView` is returning a duplicate for this package as the SQL code does not have this possible case into account. 

The proposed solution here is to make the `rhnChannelNewestPackageView` to return the one package that was built more recently, based on the package "build time" attribute.

[1] https://docs.fedoraproject.org/en-US/packaging-guidelines/#_use_of_epochs

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **bugfix**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/16527

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
