### PR TITLE
Improve ssm channel change and fix tftpsync IP replacement

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -202,7 +202,7 @@ When(/^I select the contact method for the "([^"]*)" from "([^"]*)"$/) do |clien
 end
 
 When(/^I select "([^"]*)" from drop-down in table line with "([^"]*)"$/) do |value, line|
-  select = find(:xpath, ".//div[@class='table-responsive']/table/tbody/tr[contains(td,'#{line}')]//select")
+  select = find(:xpath, ".//div[@class='table-responsive']/table/tbody/tr[contains(td/a,'#{line}')]//select")
   select(value, from: select[:id])
 end
 

--- a/tftpsync/susemanager-tftpsync-recv/add.wsgi
+++ b/tftpsync/susemanager-tftpsync-recv/add.wsgi
@@ -100,6 +100,8 @@ def application(environ, start_response):
                 file_content = form.getvalue('file')
                 file_content = file_content.replace(CFG.SERVER_IP.encode(), CFG.PROXY_IP.encode())
                 file_content = file_content.replace(CFG.SERVER_FQDN.encode(), CFG.PROXY_FQDN.encode())
+                if CFG.SERVER_IP6 and CFG.PROXY_IP6:
+                    file_content = file_content.replace(CFG.SERVER_IP6.encode(), CFG.PROXY_IP6.encode())
                 tf.write(file_content)
                 tf.close()
                 os.rename(tfname, rfname)

--- a/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
+++ b/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
@@ -1,3 +1,6 @@
+- fix IPv4/IPv6 address handling when replacing PXE files from
+  the Server (bsc#1189401)
+
 -------------------------------------------------------------------
 Tue Dec 07 10:38:04 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

- fix detection of base channel selection box in SSM channel management
- fix IPv4/IPv6 address handling when replacing PXE files from the Server (bsc#1189401)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
