### PR TITLE
QA: Proxy not anymore a router

### DIFF
--- a/testsuite/features/core/proxy_branch_network.feature
+++ b/testsuite/features/core/proxy_branch_network.feature
@@ -92,7 +92,6 @@ Feature: Setup Uyuni for Retail branch network
     And I enter the local IP address of "range begin" in dynamic IP range begin field
     And I enter the local IP address of "range end" in dynamic IP range end field
     And I enter the local IP address of "broadcast" in broadcast address field
-    And I enter the local IP address of "proxy" in routers field
     And I press "Add Item" in host reservations section
     And I enter "client" in first reserved hostname field
     And I enter the local IP address of "sle_client" in first reserved IP field


### PR DESCRIPTION
## What does this PR change?

We don't want the proxy to be a router anymore

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
