### PR TITLE
Old CentOSes don't support Recommends tag

### DIFF
--- a/uyuni/common-libs/uyuni-common-libs.spec
+++ b/uyuni/common-libs/uyuni-common-libs.spec
@@ -67,7 +67,9 @@ BuildRequires:  python-devel
 %else
 BuildRequires:  python2-devel
 %endif
+%if 0%{?suse_version} || 0%{?rhel} >= 8
 Recommends:     zchunk
+%endif
 
 %description -n python2-%{name}
 Python 2 libraries required by both Uyuni server and client tools.
@@ -85,7 +87,9 @@ Requires:       python3-base
 %else
 Requires:       python3-libs
 %endif
+%if 0%{?suse_version} || 0%{?rhel} >= 8
 Recommends:     zchunk
+%endif
 
 Obsoletes:      python3-spacewalk-backend-libs
 Obsoletes:      python3-spacewalk-usix


### PR DESCRIPTION
## What does this PR change?

Fix CentOS 6 and 7 builds

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
