### PR TITLE
Formulas show hide all sections and searchbox

### DIFF
--- a/testsuite/features/build_validation/init_clients/proxy.feature
+++ b/testsuite/features/build_validation/init_clients/proxy.feature
@@ -76,6 +76,7 @@ Feature: Setup SUSE Manager proxy
     Given I am on the Systems overview page of this "proxy"
     When I follow "Formulas" in the content area
     And I follow first "Bind" in the content area
+    And I click on "Expand All Sections"
     And I check include forwarders box
     And I press "Add Item" in config options section
     And I enter "empty-zones-enable" in first option field

--- a/testsuite/features/core/proxy_branch_network.feature
+++ b/testsuite/features/core/proxy_branch_network.feature
@@ -71,6 +71,7 @@ Feature: Setup Uyuni for Retail branch network
   Scenario: Parametrize the branch network
     When I follow "Formulas" in the content area
     And I follow first "Branch Network" in the content area
+    And I click on "Expand All Sections"
     And I enter "eth1" in NIC field
     And I enter the local IP address of "proxy" in IP field
     # bsc#1132908 - Branch network formula closes IPv6 default route, potentially making further networking fail
@@ -86,6 +87,7 @@ Feature: Setup Uyuni for Retail branch network
   Scenario: Parametrize DHCP on the branch server
     When I follow "Formulas" in the content area
     And I follow first "Dhcpd" in the content area
+    And I click on "Expand All Sections"
     And I enter "example.org" in domain name field
     And I enter the local IP address of "proxy" in domain name server field
     And I enter "eth1" in listen interfaces field
@@ -111,6 +113,7 @@ Feature: Setup Uyuni for Retail branch network
   Scenario: Parametrize DNS on the branch server
     When I follow "Formulas" in the content area
     And I follow first "Bind" in the content area
+    And I click on "Expand All Sections"
     # general information:
     And I check include forwarders box
     And I press "Add Item" in config options section
@@ -162,6 +165,7 @@ Feature: Setup Uyuni for Retail branch network
     # dhcpd:
     When I follow "Formulas" in the content area
     And I follow first "Dhcpd" in the content area
+    And I click on "Expand All Sections"
     And I press "Add Item" in host reservations section
     And I enter "pxeboot" in third reserved hostname field
     And I enter the local IP address of "pxeboot_minion" in third reserved IP field
@@ -170,6 +174,7 @@ Feature: Setup Uyuni for Retail branch network
     Then I should see a "Formula saved" text
     # bind:
     When I follow first "Bind" in the content area
+    And I click on "Expand All Sections"
     And I press "Add Item" in A section of example.org zone
     And I enter "pxeboot" in fourth A name field of example.org zone
     And I enter the local IP address of "pxeboot_minion" in fourth A address field of example.org zone

--- a/testsuite/features/secondary/min_centos_monitoring.feature
+++ b/testsuite/features/secondary/min_centos_monitoring.feature
@@ -30,6 +30,7 @@ Feature: Monitor SUMA environment with Prometheus on a CentOS Salt minion
   Scenario: Configure Prometheus exporter formula on the CentOS minion
     When I follow "Formulas" in the content area
     And I follow "Prometheus Exporters" in the content area
+    And I click on "Expand All Sections"
     And I should see a "Enable and configure Prometheus exporters for managed systems." text
     And I check "node" exporter
     And I check "apache" exporter

--- a/testsuite/features/secondary/min_monitoring.feature
+++ b/testsuite/features/secondary/min_monitoring.feature
@@ -31,6 +31,7 @@ Feature: Monitor SUMA environment with Prometheus on a SLE Salt minion
   Scenario: Configure Prometheus formula
     When I follow "Formulas" in the content area
     And I follow "Prometheus" in the content area
+    And I click on "Expand All Sections"
     And I enter "admin" as "Username"
     And I enter "admin" as "Password"
     And I click on "Save Formula"
@@ -39,6 +40,7 @@ Feature: Monitor SUMA environment with Prometheus on a SLE Salt minion
   Scenario: Configure Prometheus exporter formula
     When I follow "Formulas" in the content area
     And I follow "Prometheus Exporters" in the content area
+    And I click on "Expand All Sections"
     And I should see a "Enable and configure Prometheus exporters for managed systems." text
     And I check "node" exporter
     And I check "apache" exporter

--- a/testsuite/features/secondary/min_salt_formulas.feature
+++ b/testsuite/features/secondary/min_salt_formulas.feature
@@ -32,6 +32,7 @@ Feature: Use salt formulas
   Scenario: Parametrize the formula on the minion
      When I follow "Formulas" in the content area
      And I follow first "Locale" in the content area
+     And I click on "Expand All Sections"
      And I select "Etc/GMT-5" in timezone name field
      And I select "French" in language field
      And I select "French (Canada)" in keyboard layout field

--- a/testsuite/features/secondary/min_salt_formulas_advanced.feature
+++ b/testsuite/features/secondary/min_salt_formulas_advanced.feature
@@ -69,6 +69,7 @@ Feature: Use advanced features of Salt formulas
      When I follow "test-formula-group" in the content area
      And I follow "Formulas" in the content area
      And I follow first "Testform" in the content area
+     And I click on "Expand All Sections"
      And I enter "text1" as "testing#str"
      And I enter "text2" as "testing#str_def"
      And I enter "text3" as "testing#str_or_null"
@@ -132,6 +133,7 @@ Feature: Use advanced features of Salt formulas
      When I follow "test-formula-group" in the content area
      And I follow "Formulas" in the content area
      And I follow first "Testform" in the content area
+     And I click on "Expand All Sections"
      And I enter "text1" as "testing#str"
      And I enter "1" as "testing#num"
      And I enter "2" as "testing#num_def"
@@ -171,6 +173,7 @@ Feature: Use advanced features of Salt formulas
   Scenario: Fill in and verify non-default values in minion formula
      When I follow "Formulas" in the content area
      And I follow first "Testform" in the content area
+     And I click on "Expand All Sections"
      And I enter "min_text1" as "testing#str"
      And I enter "min_text2" as "testing#str_def"
      And I enter "min_text3" as "testing#str_or_null"

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -43,6 +43,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
   Scenario: Parametrize the KVM virtualization host
     When I follow "Formulas" in the content area
     And I follow first "Virtualization Host" in the content area
+    And I click on "Expand All Sections"
     And I select "NAT" in virtual network mode field
     And I enter "192.168.124.1" in virtual network IPv4 address field
     And I enter "192.168.124.2" in first IPv4 address for DHCP field

--- a/testsuite/features/secondary/minxen_guests.feature
+++ b/testsuite/features/secondary/minxen_guests.feature
@@ -43,6 +43,7 @@ Feature: Be able to manage XEN virtual machines via the GUI
   Scenario: Parametrize the Xen virtualization host
     When I follow "Formulas" in the content area
     And I follow first "Virtualization Host" in the content area
+    And I click on "Expand All Sections"
     And I select "Xen" from "hypervisor"
     And I select "NAT" in virtual network mode field
     And I enter "192.168.124.1" in virtual network IPv4 address field

--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -18,6 +18,7 @@ Feature: PXE boot a terminal with Cobbler
     Given I am on the Systems overview page of this "proxy"
     When I follow "Formulas" in the content area
     And I follow first "Dhcpd" in the content area
+    And I click on "Expand All Sections"
     And I enter the local IP address of "proxy" in pxeboot next server field
     And I enter "pxelinux.0" in pxeboot filename field
     And I click on "Save Formula"
@@ -135,6 +136,7 @@ Feature: PXE boot a terminal with Cobbler
     Given I am on the Systems overview page of this "proxy"
     When I follow "Formulas" in the content area
     And I follow first "Dhcpd" in the content area
+    And I click on "Expand All Sections"
     And I enter "boot/pxelinux.0" in pxeboot filename field
     And I click on "Save Formula"
     Then I should see a "Formula saved" text

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -51,6 +51,7 @@ Feature: PXE boot a Retail terminal
     Given I am on the Systems overview page of this "proxy"
     When I follow "Formulas" in the content area
     And I follow first "Bind" in the content area
+    And I click on "Expand All Sections"
     And I press "Add Item" in CNAME section of example.org zone
     And I enter "ftp" in first CNAME alias field of example.org zone
     And I enter "proxy" in first CNAME name field of example.org zone
@@ -68,6 +69,7 @@ Feature: PXE boot a Retail terminal
     Given I am on the Systems overview page of this "proxy"
     When I follow "Formulas" in the content area
     And I follow first "Dhcpd" in the content area
+    And I click on "Expand All Sections"
     And I enter the local IP address of "proxy" in next server field
     And I enter "boot/pxelinux.0" in filename field
     And I click on "Save Formula"
@@ -77,6 +79,7 @@ Feature: PXE boot a Retail terminal
     Given I am on the Systems overview page of this "proxy"
     When I follow "Formulas" in the content area
     And I follow first "Tftpd" in the content area
+    And I click on "Expand All Sections"
     And I enter the local IP address of "proxy" in internal network address field
     And I enter "/srv/saltboot" in TFTP base directory field
     And I click on "Save Formula"
@@ -86,6 +89,7 @@ Feature: PXE boot a Retail terminal
     Given I am on the Systems overview page of this "proxy"
     When I follow "Formulas" in the content area
     And I follow first "Vsftpd" in the content area
+    And I click on "Expand All Sections"
     And I enter the local IP address of "proxy" in vsftpd internal network address field
     And I enter "/srv/saltboot" in FTP server directory field
     And I click on "Save Formula"
@@ -158,6 +162,7 @@ Feature: PXE boot a Retail terminal
     When I follow "HWTYPE:Intel-Genuine" in the content area
     When I follow "Formulas" in the content area
     And I follow first "Saltboot" in the content area
+    And I click on "Expand All Sections"
     And I enter "disk1" in disk id field
     And I enter "/dev/vda" in disk device field
     And I select "msdos" in disk label field
@@ -243,6 +248,7 @@ Feature: PXE boot a Retail terminal
     Given I am on the Systems overview page of this "proxy"
     When I follow "Formulas" in the content area
     And I follow first "Bind" in the content area
+    And I click on "Expand All Sections"
     And I press "Remove Item" in salt CNAME of example.org zone section
     And I press "Remove Item" in tftp CNAME of example.org zone section
     And I press "Remove Item" in ftp CNAME of example.org zone section
@@ -373,6 +379,7 @@ Feature: PXE boot a Retail terminal
     Given I am on the Systems overview page of this "proxy"
     When I follow "Formulas" in the content area
     And I follow first "Bind" in the content area
+    And I click on "Expand All Sections"
     # direct zone example.org:
     And I press "Remove Item" in salt CNAME of example.org zone section
     And I press "Remove Item" in tftp CNAME of example.org zone section
@@ -401,6 +408,7 @@ Feature: PXE boot a Retail terminal
     Given I am on the Systems overview page of this "proxy"
     When I follow "Formulas" in the content area
     And I follow first "Branch Network" in the content area
+    And I click on "Expand All Sections"
     And I enter "example" in branch id field
     And I click on "Save Formula"
     Then I should see a "Formula saved" text

--- a/web/html/src/components/FormulaForm.tsx
+++ b/web/html/src/components/FormulaForm.tsx
@@ -339,7 +339,7 @@ class FormulaForm extends React.Component<Props, State> {
                   <SearchField
                       placeholder={t("Search by formula's group name")}
                       criteria={this.state.searchCriteria}
-                      onSearch={(v) => this.setState({ searchCriteria: v }) } />
+                      onSearch={(v) => this.setState({ searchCriteria: v, sectionsExpanded: "expanded"}) } />
                   <hr />
                   <p>{text(this.state.formulaMetadata.description)}</p>
                   <hr />

--- a/web/html/src/components/FormulaForm.tsx
+++ b/web/html/src/components/FormulaForm.tsx
@@ -337,9 +337,10 @@ class FormulaForm extends React.Component<Props, State> {
               >
                 <div className="formula-content">
                   <SearchField
-                      placeholder={t("Search by formula's group name")}
-                      criteria={this.state.searchCriteria}
-                      onSearch={(v) => this.setState({ searchCriteria: v, sectionsExpanded: "expanded"}) } />
+                    placeholder={t("Search by formula's group name")}
+                    criteria={this.state.searchCriteria}
+                    onSearch={(v) => this.setState({ searchCriteria: v, sectionsExpanded: "expanded" })}
+                  />
                   <hr />
                   <p>{text(this.state.formulaMetadata.description)}</p>
                   <hr />

--- a/web/html/src/components/FormulaForm.tsx
+++ b/web/html/src/components/FormulaForm.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import { Button } from "components/buttons";
 import { Messages, MessageType } from "components/messages";
+import { BootstrapPanel } from "components/panels/BootstrapPanel";
 import { SectionToolbar } from "components/section-toolbar/section-toolbar";
 
 import { Utils } from "utils/functions";
@@ -62,6 +63,7 @@ type State = {
   messages: string[];
   warnings: string[];
   errors: string[];
+  sectionsExpanded: string;
 };
 
 class FormulaForm extends React.Component<Props, State> {
@@ -78,6 +80,7 @@ class FormulaForm extends React.Component<Props, State> {
       messages: [],
       warnings: [],
       errors: [],
+      sectionsExpanded: "collapsed",
     };
 
     window.addEventListener(
@@ -247,12 +250,28 @@ class FormulaForm extends React.Component<Props, State> {
       }
       const nextHref = this.props.getFormulaUrl(this.props.formulaId + 1);
       const prevHref = this.props.getFormulaUrl(this.props.formulaId - 1);
+      const showAllButton = (
+        <Button
+          handler={() => this.setState({ sectionsExpanded: "expanded" })}
+          text={t("Expand All Sections")}
+          className="btn-link"
+        />
+      );
+      const hideAllButton = (
+        <Button
+          handler={() => this.setState({ sectionsExpanded: "collapsed" })}
+          text={t("Collapse All Sections")}
+          className="btn-link"
+        />
+      );
       return (
         <FormulaFormContextProvider
           layout={this.state.formulaRawLayout}
           systemData={this.state.systemData}
           groupData={this.state.groupData}
           scope={this.props.scope}
+          sectionsExpanded={this.state.sectionsExpanded}
+          setSectionsExpanded={(status) => this.setState({ sectionsExpanded: status })}
         >
           <div>
             {defaultMessage}
@@ -304,18 +323,20 @@ class FormulaForm extends React.Component<Props, State> {
                   </FormulaFormContext.Consumer>
                 </div>
               </SectionToolbar>
-              <div className="panel panel-default">
-                <div className="panel-heading">
-                  <h3>{capitalize(get(this.state.formulaName, "Unnamed"))}</h3>
-                </div>
-                <div className="panel-body">
-                  <div className="formula-content">
-                    <p>{text(this.state.formulaMetadata.description)}</p>
-                    <hr />
-                    <FormulaFormRenderer />
+              <BootstrapPanel
+                title={capitalize(get(this.state.formulaName, "Unnamed"))}
+                buttons={
+                  <div>
+                    {showAllButton} | {hideAllButton}
                   </div>
+                }
+              >
+                <div className="formula-content">
+                  <p>{text(this.state.formulaMetadata.description)}</p>
+                  <hr />
+                  <FormulaFormRenderer />
                 </div>
-              </div>
+              </BootstrapPanel>
             </div>
           </div>
         </FormulaFormContextProvider>

--- a/web/html/src/components/FormulaForm.tsx
+++ b/web/html/src/components/FormulaForm.tsx
@@ -24,6 +24,12 @@ const defaultMessageTexts = {
   pillar_only_formula_saved: <p>{t("Formula saved. Applying the highstate is not needed for this formula.")}</p>,
 };
 
+export enum SectionState {
+  Expanded,
+  Mixed,
+  Collapsed,
+}
+
 type Props = {
   /** URL to get the server data */
   dataUrl: string;
@@ -64,7 +70,7 @@ type State = {
   messages: string[];
   warnings: string[];
   errors: string[];
-  sectionsExpanded: string;
+  sectionsExpanded: SectionState;
   searchCriteria: string;
 };
 
@@ -82,7 +88,7 @@ class FormulaForm extends React.Component<Props, State> {
       messages: [],
       warnings: [],
       errors: [],
-      sectionsExpanded: "collapsed",
+      sectionsExpanded: SectionState.Collapsed,
       searchCriteria: "",
     };
 
@@ -255,14 +261,14 @@ class FormulaForm extends React.Component<Props, State> {
       const prevHref = this.props.getFormulaUrl(this.props.formulaId - 1);
       const showAllButton = (
         <Button
-          handler={() => this.setState({ sectionsExpanded: "expanded" })}
+          handler={() => this.setState({ sectionsExpanded: SectionState.Expanded })}
           text={t("Expand All Sections")}
           className="btn-link"
         />
       );
       const hideAllButton = (
         <Button
-          handler={() => this.setState({ sectionsExpanded: "collapsed" })}
+          handler={() => this.setState({ sectionsExpanded: SectionState.Collapsed })}
           text={t("Collapse All Sections")}
           className="btn-link"
         />
@@ -328,7 +334,7 @@ class FormulaForm extends React.Component<Props, State> {
                 </div>
               </SectionToolbar>
               <BootstrapPanel
-                title={capitalize(get(this.state.formulaName, "Unnamed"))}
+                title={capitalize(get(this.state.formulaName, t("Unnamed")))}
                 buttons={
                   <div>
                     {showAllButton} | {hideAllButton}
@@ -339,7 +345,7 @@ class FormulaForm extends React.Component<Props, State> {
                   <SearchField
                     placeholder={t("Search by formula's group name")}
                     criteria={this.state.searchCriteria}
-                    onSearch={(v) => this.setState({ searchCriteria: v, sectionsExpanded: "expanded" })}
+                    onSearch={(v) => this.setState({ searchCriteria: v, sectionsExpanded: SectionState.Expanded })}
                   />
                   <hr />
                   <p>{text(this.state.formulaMetadata.description)}</p>

--- a/web/html/src/components/FormulaForm.tsx
+++ b/web/html/src/components/FormulaForm.tsx
@@ -16,6 +16,7 @@ import {
   get,
   text,
 } from "./formulas/FormulaComponentGenerator";
+import { SearchField } from "./table/SearchField";
 
 const capitalize = Utils.capitalize;
 
@@ -64,6 +65,7 @@ type State = {
   warnings: string[];
   errors: string[];
   sectionsExpanded: string;
+  searchCriteria: string;
 };
 
 class FormulaForm extends React.Component<Props, State> {
@@ -81,6 +83,7 @@ class FormulaForm extends React.Component<Props, State> {
       warnings: [],
       errors: [],
       sectionsExpanded: "collapsed",
+      searchCriteria: "",
     };
 
     window.addEventListener(
@@ -272,6 +275,7 @@ class FormulaForm extends React.Component<Props, State> {
           scope={this.props.scope}
           sectionsExpanded={this.state.sectionsExpanded}
           setSectionsExpanded={(status) => this.setState({ sectionsExpanded: status })}
+          searchCriteria={this.state.searchCriteria}
         >
           <div>
             {defaultMessage}
@@ -332,6 +336,11 @@ class FormulaForm extends React.Component<Props, State> {
                 }
               >
                 <div className="formula-content">
+                  <SearchField
+                      placeholder={t("Search by formula's group name")}
+                      criteria={this.state.searchCriteria}
+                      onSearch={(v) => this.setState({ searchCriteria: v }) } />
+                  <hr />
                   <p>{text(this.state.formulaMetadata.description)}</p>
                   <hr />
                   <FormulaFormRenderer />

--- a/web/html/src/components/formulas/EditGroup.tsx
+++ b/web/html/src/components/formulas/EditGroup.tsx
@@ -113,50 +113,52 @@ class EditGroup extends React.Component<EditGroupProps, EditGroupState> {
       Component = EditDictionaryGroup;
     }
 
-    return (
-      this.props.isVisibleByCriteria?.() ?
-        <div
-          id={this.props.id}
-          className={this.isVisible() ? "formula-content-section-open" : "formula-content-section-closed"}
-        >
-          <div className="group-heading">
-            <SectionToggle setVisible={this.setVisible} isVisible={this.isVisible}>
-              <h4>
-                <Highlight enabled={isFiltered(this.props.criteria)} text={this.props.element.$name} highlight={this.props.criteria} />
-              </h4>
-            </SectionToggle>
-            <i
-              className="fa fa-plus"
-              id={this.props.id + "#add_item"}
-              title={
-                this.props.element.$maxItems! <= this.props.value.length ? "Max number of items reached" : "Add Item"
-              }
-              onClick={this.handleAddItem}
-              /* @ts-expect-error: The property `disabled` doesn't exist on the `<i>` tag, but this was here historically */
-              disabled={this.props.element.$maxItems! <= this.props.value.length || this.props.disabled}
-            ></i>
-          </div>
-          <div>
-            {this.state.visible ? (
-              <React.Fragment>
-                {"$help" in this.props.element ? <p>{this.props.element.$help}</p> : null}
-                <Component
-                  handleRemoveItem={this.handleRemoveItem}
-                  isDisabled={this.isDisabled()}
-                  id={this.props.id}
-                  key={this.props.key}
-                  element={this.props.element}
-                  value={this.props.value}
-                  sectionsExpanded={this.props.sectionsExpanded}
-                  setSectionsExpanded={this.props.setSectionsExpanded}
-                  formulaForm={this.props.formulaForm}
-                />
-              </React.Fragment>
-            ) : null}
-          </div>
+    return this.props.isVisibleByCriteria?.() ? (
+      <div
+        id={this.props.id}
+        className={this.isVisible() ? "formula-content-section-open" : "formula-content-section-closed"}
+      >
+        <div className="group-heading">
+          <SectionToggle setVisible={this.setVisible} isVisible={this.isVisible}>
+            <h4>
+              <Highlight
+                enabled={isFiltered(this.props.criteria)}
+                text={this.props.element.$name}
+                highlight={this.props.criteria}
+              />
+            </h4>
+          </SectionToggle>
+          <i
+            className="fa fa-plus"
+            id={this.props.id + "#add_item"}
+            title={
+              this.props.element.$maxItems! <= this.props.value.length ? "Max number of items reached" : "Add Item"
+            }
+            onClick={this.handleAddItem}
+            /* @ts-expect-error: The property `disabled` doesn't exist on the `<i>` tag, but this was here historically */
+            disabled={this.props.element.$maxItems! <= this.props.value.length || this.props.disabled}
+          ></i>
         </div>
-        : null
-    );
+        <div>
+          {this.state.visible ? (
+            <React.Fragment>
+              {"$help" in this.props.element ? <p>{this.props.element.$help}</p> : null}
+              <Component
+                handleRemoveItem={this.handleRemoveItem}
+                isDisabled={this.isDisabled()}
+                id={this.props.id}
+                key={this.props.key}
+                element={this.props.element}
+                value={this.props.value}
+                sectionsExpanded={this.props.sectionsExpanded}
+                setSectionsExpanded={this.props.setSectionsExpanded}
+                formulaForm={this.props.formulaForm}
+              />
+            </React.Fragment>
+          ) : null}
+        </div>
+      </div>
+    ) : null;
   }
 }
 

--- a/web/html/src/components/formulas/EditGroup.tsx
+++ b/web/html/src/components/formulas/EditGroup.tsx
@@ -27,6 +27,8 @@ type EditGroupProps = {
   value: any;
   formulaForm: any;
   element: ElementDefinition;
+  sectionsExpanded: string;
+  setSectionsExpanded: (string) => void;
 };
 
 type EditGroupState = {
@@ -41,8 +43,14 @@ class EditGroup extends React.Component<EditGroupProps, EditGroupState> {
   constructor(props: EditGroupProps) {
     super(props);
     this.state = {
-      visible: true,
+      visible: props.sectionsExpanded === "expanded",
     };
+  }
+
+  componentDidUpdate(prevProps: Readonly<EditGroupProps>) {
+    if (this.props.sectionsExpanded !== "mixed" && this.props.sectionsExpanded !== prevProps.sectionsExpanded) {
+      this.setState({ visible: this.props.sectionsExpanded === "expanded" });
+    }
   }
 
   isDisabled = () => {
@@ -56,6 +64,7 @@ class EditGroup extends React.Component<EditGroupProps, EditGroupState> {
   handleAddItem = (event) => {
     if (this.props.element.$maxItems! <= this.props.value.length || this.isDisabled()) return;
 
+    this.props.setSectionsExpanded("mixed");
     let newValueProps = this.props.value;
     let newValue = deepCopy(this.props.element.$newItemValue);
 
@@ -84,6 +93,7 @@ class EditGroup extends React.Component<EditGroupProps, EditGroupState> {
   setVisible = (index, visible) => {
     // index not needed here
     this.setState({ visible: visible });
+    this.props.setSectionsExpanded("mixed");
   };
 
   render() {
@@ -130,6 +140,8 @@ class EditGroup extends React.Component<EditGroupProps, EditGroupState> {
                 key={this.props.key}
                 element={this.props.element}
                 value={this.props.value}
+                sectionsExpanded={this.props.sectionsExpanded}
+                setSectionsExpanded={this.props.setSectionsExpanded}
                 formulaForm={this.props.formulaForm}
               />
             </React.Fragment>
@@ -145,6 +157,8 @@ type EditPrimitiveGroupProps = {
   value: any;
   element: ElementDefinition;
   formulaForm: any;
+  sectionsExpanded: string;
+  setSectionsExpanded: (string) => void;
   isDisabled?: boolean;
   handleRemoveItem: (...args: any[]) => any;
 };
@@ -202,6 +216,8 @@ type EditPrimitiveDictionaryGroupProps = {
   value: any;
   element: ElementDefinition;
   formulaForm: any;
+  sectionsExpanded: string;
+  setSectionsExpanded: (string) => void;
   isDisabled?: boolean;
   handleRemoveItem: (...args: any[]) => any;
 };
@@ -289,6 +305,8 @@ type EditDictionaryGroupProps = {
   value: any;
   isDisabled?: boolean;
   formulaForm: any;
+  sectionsExpanded: string;
+  setSectionsExpanded: (string) => void;
   handleRemoveItem: (...args: any[]) => any;
 };
 
@@ -306,6 +324,15 @@ class EditDictionaryGroup extends React.Component<EditDictionaryGroupProps, Edit
     this.state = {
       visibility: new Map(),
     };
+    for (let i in props.value) {
+      this.state.visibility.set(i, props.sectionsExpanded === "expanded");
+    }
+  }
+
+  componentDidUpdate(prevProps: Readonly<EditDictionaryGroupProps>) {
+    if (this.props.sectionsExpanded !== "mixed" && this.props.sectionsExpanded !== prevProps.sectionsExpanded) {
+      this.setAllVisible(this.props.sectionsExpanded === "expanded");
+    }
   }
 
   wrapKeyGroup(element_name, required, innerHTML) {
@@ -333,14 +360,23 @@ class EditDictionaryGroup extends React.Component<EditDictionaryGroupProps, Edit
   }
 
   isVisible = (index) => {
-    return this.state.visibility.get(index) === undefined || this.state.visibility.get(index) === true;
+    return !(this.state.visibility.get(index) === undefined || this.state.visibility.get(index) === false);
   };
 
   setVisible = (index, visible) => {
     const { visibility } = this.state;
     visibility.set(index, visible);
+    this.props.setSectionsExpanded("mixed");
     this.setState({ visibility });
   };
+
+  setAllVisible(visible) {
+    const { visibility } = this.state;
+    for (let i in this.props.value) {
+      visibility.set(i, visible);
+      this.setState({ visibility });
+    }
+  }
 
   render() {
     let elements: React.ReactNode[] = [];
@@ -386,7 +422,9 @@ class EditDictionaryGroup extends React.Component<EditDictionaryGroupProps, Edit
             />
           </div>
           <div>
-            {this.state.visibility.get(i) === undefined || this.state.visibility.get(i) === true ? item_elements : null}
+            {!(this.state.visibility.get(i) === undefined || this.state.visibility.get(i) === false)
+              ? item_elements
+              : null}
           </div>
         </div>
       );

--- a/web/html/src/components/formulas/EditGroup.tsx
+++ b/web/html/src/components/formulas/EditGroup.tsx
@@ -2,6 +2,7 @@ import "./formula-form.css";
 
 import * as React from "react";
 
+import { SectionState } from "components/FormulaForm";
 import { Highlight } from "components/table/Highlight";
 import HelpIcon from "components/utils/HelpIcon";
 
@@ -29,9 +30,9 @@ type EditGroupProps = {
   value: any;
   formulaForm: any;
   element: ElementDefinition;
-  sectionsExpanded: string;
-  setSectionsExpanded: (string) => void;
-  isVisibleByCriteria?: any;
+  sectionsExpanded: SectionState;
+  setSectionsExpanded: (SectionState) => void;
+  isVisibleByCriteria?: () => boolean;
   criteria: string;
 };
 
@@ -47,13 +48,16 @@ class EditGroup extends React.Component<EditGroupProps, EditGroupState> {
   constructor(props: EditGroupProps) {
     super(props);
     this.state = {
-      visible: props.sectionsExpanded !== "collapsed",
+      visible: props.sectionsExpanded !== SectionState.Collapsed,
     };
   }
 
   componentDidUpdate(prevProps: Readonly<EditGroupProps>) {
-    if (this.props.sectionsExpanded !== "mixed" && this.props.sectionsExpanded !== prevProps.sectionsExpanded) {
-      this.setState({ visible: this.props.sectionsExpanded === "expanded" });
+    if (
+      this.props.sectionsExpanded !== SectionState.Mixed &&
+      this.props.sectionsExpanded !== prevProps.sectionsExpanded
+    ) {
+      this.setState({ visible: this.props.sectionsExpanded === SectionState.Expanded });
     }
   }
 
@@ -68,7 +72,7 @@ class EditGroup extends React.Component<EditGroupProps, EditGroupState> {
   handleAddItem = (event) => {
     if (this.props.element.$maxItems! <= this.props.value.length || this.isDisabled()) return;
 
-    this.props.setSectionsExpanded("mixed");
+    this.props.setSectionsExpanded(SectionState.Mixed);
     let newValueProps = this.props.value;
     let newValue = deepCopy(this.props.element.$newItemValue);
 
@@ -97,7 +101,7 @@ class EditGroup extends React.Component<EditGroupProps, EditGroupState> {
   setVisible = (index, visible) => {
     // index not needed here
     this.setState({ visible: visible });
-    this.props.setSectionsExpanded("mixed");
+    this.props.setSectionsExpanded(SectionState.Mixed);
   };
 
   render() {
@@ -224,7 +228,6 @@ type EditPrimitiveDictionaryGroupProps = {
   value: any;
   element: ElementDefinition;
   formulaForm: any;
-  sectionsExpanded: string;
   isDisabled?: boolean;
   handleRemoveItem: (...args: any[]) => any;
 };
@@ -312,8 +315,8 @@ type EditDictionaryGroupProps = {
   value: any;
   isDisabled?: boolean;
   formulaForm: any;
-  sectionsExpanded: string;
-  setSectionsExpanded: (string) => void;
+  sectionsExpanded: SectionState;
+  setSectionsExpanded: (SectionState) => void;
   handleRemoveItem: (...args: any[]) => any;
 };
 
@@ -334,8 +337,11 @@ class EditDictionaryGroup extends React.Component<EditDictionaryGroupProps, Edit
   }
 
   componentDidUpdate(prevProps: Readonly<EditDictionaryGroupProps>) {
-    if (this.props.sectionsExpanded !== "mixed" && this.props.sectionsExpanded !== prevProps.sectionsExpanded) {
-      this.setAllVisible(this.props.sectionsExpanded === "expanded");
+    if (
+      this.props.sectionsExpanded !== SectionState.Mixed &&
+      this.props.sectionsExpanded !== prevProps.sectionsExpanded
+    ) {
+      this.setAllVisible(this.props.sectionsExpanded === SectionState.Expanded);
     }
   }
 
@@ -370,7 +376,7 @@ class EditDictionaryGroup extends React.Component<EditDictionaryGroupProps, Edit
   setVisible = (index, visible) => {
     const { visibility } = this.state;
     visibility.set(index, visible);
-    this.props.setSectionsExpanded("mixed");
+    this.props.setSectionsExpanded(SectionState.Mixed);
     this.setState({ visibility });
   };
 

--- a/web/html/src/components/formulas/EditGroup.tsx
+++ b/web/html/src/components/formulas/EditGroup.tsx
@@ -47,7 +47,7 @@ class EditGroup extends React.Component<EditGroupProps, EditGroupState> {
   constructor(props: EditGroupProps) {
     super(props);
     this.state = {
-      visible: props.sectionsExpanded === "expanded",
+      visible: props.sectionsExpanded !== "collapsed",
     };
   }
 
@@ -167,8 +167,6 @@ type EditPrimitiveGroupProps = {
   value: any;
   element: ElementDefinition;
   formulaForm: any;
-  sectionsExpanded: string;
-  setSectionsExpanded: (string) => void;
   isDisabled?: boolean;
   handleRemoveItem: (...args: any[]) => any;
 };
@@ -227,7 +225,6 @@ type EditPrimitiveDictionaryGroupProps = {
   element: ElementDefinition;
   formulaForm: any;
   sectionsExpanded: string;
-  setSectionsExpanded: (string) => void;
   isDisabled?: boolean;
   handleRemoveItem: (...args: any[]) => any;
 };
@@ -334,9 +331,6 @@ class EditDictionaryGroup extends React.Component<EditDictionaryGroupProps, Edit
     this.state = {
       visibility: new Map(),
     };
-    for (let i in props.value) {
-      this.state.visibility.set(i, props.sectionsExpanded === "expanded");
-    }
   }
 
   componentDidUpdate(prevProps: Readonly<EditDictionaryGroupProps>) {
@@ -370,7 +364,7 @@ class EditDictionaryGroup extends React.Component<EditDictionaryGroupProps, Edit
   }
 
   isVisible = (index) => {
-    return !(this.state.visibility.get(index) === undefined || this.state.visibility.get(index) === false);
+    return this.state.visibility.get(index) === undefined || this.state.visibility.get(index) !== false;
   };
 
   setVisible = (index, visible) => {
@@ -431,11 +425,7 @@ class EditDictionaryGroup extends React.Component<EditDictionaryGroupProps, Edit
               disabled={this.props.element.$minItems! >= this.props.value.length || this.props.isDisabled}
             />
           </div>
-          <div>
-            {!(this.state.visibility.get(i) === undefined || this.state.visibility.get(i) === false)
-              ? item_elements
-              : null}
-          </div>
+          <div>{this.state.visibility.get(i) !== false ? item_elements : null}</div>
         </div>
       );
     }

--- a/web/html/src/components/formulas/EditGroup.tsx
+++ b/web/html/src/components/formulas/EditGroup.tsx
@@ -29,6 +29,7 @@ type EditGroupProps = {
   element: ElementDefinition;
   sectionsExpanded: string;
   setSectionsExpanded: (string) => void;
+  isVisibleByCriteria?: any;
 };
 
 type EditGroupState = {
@@ -110,44 +111,46 @@ class EditGroup extends React.Component<EditGroupProps, EditGroupState> {
     }
 
     return (
-      <div
-        id={this.props.id}
-        className={this.isVisible() ? "formula-content-section-open" : "formula-content-section-closed"}
-      >
-        <div className="group-heading">
-          <SectionToggle setVisible={this.setVisible} isVisible={this.isVisible}>
-            <h4>{this.props.element.$name}</h4>
-          </SectionToggle>
-          <i
-            className="fa fa-plus"
-            id={this.props.id + "#add_item"}
-            title={
-              this.props.element.$maxItems! <= this.props.value.length ? "Max number of items reached" : "Add Item"
-            }
-            onClick={this.handleAddItem}
-            /* @ts-expect-error: The property `disabled` doesn't exist on the `<i>` tag, but this was here historically */
-            disabled={this.props.element.$maxItems! <= this.props.value.length || this.props.disabled}
-          ></i>
+      this.props.isVisibleByCriteria?.() ?
+        <div
+          id={this.props.id}
+          className={this.isVisible() ? "formula-content-section-open" : "formula-content-section-closed"}
+        >
+          <div className="group-heading">
+            <SectionToggle setVisible={this.setVisible} isVisible={this.isVisible}>
+              <h4>{this.props.element.$name}</h4>
+            </SectionToggle>
+            <i
+              className="fa fa-plus"
+              id={this.props.id + "#add_item"}
+              title={
+                this.props.element.$maxItems! <= this.props.value.length ? "Max number of items reached" : "Add Item"
+              }
+              onClick={this.handleAddItem}
+              /* @ts-expect-error: The property `disabled` doesn't exist on the `<i>` tag, but this was here historically */
+              disabled={this.props.element.$maxItems! <= this.props.value.length || this.props.disabled}
+            ></i>
+          </div>
+          <div>
+            {this.state.visible ? (
+              <React.Fragment>
+                {"$help" in this.props.element ? <p>{this.props.element.$help}</p> : null}
+                <Component
+                  handleRemoveItem={this.handleRemoveItem}
+                  isDisabled={this.isDisabled()}
+                  id={this.props.id}
+                  key={this.props.key}
+                  element={this.props.element}
+                  value={this.props.value}
+                  sectionsExpanded={this.props.sectionsExpanded}
+                  setSectionsExpanded={this.props.setSectionsExpanded}
+                  formulaForm={this.props.formulaForm}
+                />
+              </React.Fragment>
+            ) : null}
+          </div>
         </div>
-        <div>
-          {this.state.visible ? (
-            <React.Fragment>
-              {"$help" in this.props.element ? <p>{this.props.element.$help}</p> : null}
-              <Component
-                handleRemoveItem={this.handleRemoveItem}
-                isDisabled={this.isDisabled()}
-                id={this.props.id}
-                key={this.props.key}
-                element={this.props.element}
-                value={this.props.value}
-                sectionsExpanded={this.props.sectionsExpanded}
-                setSectionsExpanded={this.props.setSectionsExpanded}
-                formulaForm={this.props.formulaForm}
-              />
-            </React.Fragment>
-          ) : null}
-        </div>
-      </div>
+        : null
     );
   }
 }

--- a/web/html/src/components/formulas/EditGroup.tsx
+++ b/web/html/src/components/formulas/EditGroup.tsx
@@ -2,6 +2,7 @@ import "./formula-form.css";
 
 import * as React from "react";
 
+import { Highlight } from "components/table/Highlight";
 import HelpIcon from "components/utils/HelpIcon";
 
 import { Formulas, Utils } from "utils/functions";
@@ -10,6 +11,7 @@ import {
   ElementDefinition,
   generateFormulaComponent,
   generateFormulaComponentForId,
+  isFiltered,
 } from "./FormulaComponentGenerator";
 import SectionToggle from "./SectionToggle";
 
@@ -30,6 +32,7 @@ type EditGroupProps = {
   sectionsExpanded: string;
   setSectionsExpanded: (string) => void;
   isVisibleByCriteria?: any;
+  criteria: string;
 };
 
 type EditGroupState = {
@@ -118,7 +121,9 @@ class EditGroup extends React.Component<EditGroupProps, EditGroupState> {
         >
           <div className="group-heading">
             <SectionToggle setVisible={this.setVisible} isVisible={this.isVisible}>
-              <h4>{this.props.element.$name}</h4>
+              <h4>
+                <Highlight enabled={isFiltered(this.props.criteria)} text={this.props.element.$name} highlight={this.props.criteria} />
+              </h4>
             </SectionToggle>
             <i
               className="fa fa-plus"

--- a/web/html/src/components/formulas/FormulaComponentGenerator.tsx
+++ b/web/html/src/components/formulas/FormulaComponentGenerator.tsx
@@ -45,6 +45,8 @@ type Context = {
   getCleanValues?: any | null;
   clearValues: any | null;
   validate: any | null;
+  sectionsExpanded: any | null;
+  setSectionsExpanded: any | null;
 };
 
 export const FormulaFormContext = React.createContext<Context>({
@@ -55,6 +57,8 @@ export const FormulaFormContext = React.createContext<Context>({
   getCleanValues: null,
   clearValues: null,
   validate: null,
+  sectionsExpanded: null,
+  setSectionsExpanded: null,
 });
 
 export function generateFormulaComponent(
@@ -196,7 +200,14 @@ export function generateFormulaComponentForId(
     );
   else if (element.$type === "group") {
     return (
-      <Group id={id} key={id} header={element.$name} help={element.$help}>
+      <Group
+        id={id}
+        key={id}
+        header={element.$name}
+        help={element.$help}
+        sectionsExpanded={formulaForm.props.sectionsExpanded}
+        setSectionsExpanded={formulaForm.props.setSectionsExpanded}
+      >
         {generateChildrenFormItems(element, value, formulaForm, id, isDisabled)}
       </Group>
     );
@@ -210,6 +221,8 @@ export function generateFormulaComponentForId(
         value={value}
         formulaForm={formulaForm}
         disabled={isDisabled}
+        sectionsExpanded={formulaForm.props.sectionsExpanded}
+        setSectionsExpanded={formulaForm.props.setSectionsExpanded}
       />
     );
   } else if (element.$type === "select")
@@ -419,6 +432,8 @@ export const FormulaFormRenderer = () => (
 type UnwrappedFormulaFormRendererProps = {
   scope: string | null;
   values: any;
+  sectionsExpanded: string;
+  setSectionsExpanded: (string) => void;
   layout?: any;
   onChange?: (id: string, value: string) => any;
   registerValidationTrigger?: (...args: any[]) => any;
@@ -594,6 +609,8 @@ type FormulaFormContextProviderProps = {
   systemData?: any;
   groupData?: any;
   scope?: any;
+  sectionsExpanded?: string | undefined;
+  setSectionsExpanded?: (status: string) => void | undefined;
 };
 
 type FormulaFormContextProviderState = {
@@ -636,6 +653,8 @@ export class FormulaFormContextProvider extends React.Component<
       clearValues: this.clearValues,
       validate: this.validate,
       registerValidationTrigger: this.registerValidationTrigger,
+      sectionsExpanded: this.props.sectionsExpanded,
+      setSectionsExpanded: this.props.setSectionsExpanded,
     };
 
     return <FormulaFormContext.Provider value={contextValue}>{this.props.children}</FormulaFormContext.Provider>;

--- a/web/html/src/components/formulas/FormulaComponentGenerator.tsx
+++ b/web/html/src/components/formulas/FormulaComponentGenerator.tsx
@@ -210,6 +210,7 @@ export function generateFormulaComponentForId(
         sectionsExpanded={formulaForm.props.sectionsExpanded}
         setSectionsExpanded={formulaForm.props.setSectionsExpanded}
         isVisibleByCriteria={() => isVisibleByCriteria(element, formulaForm.props.searchCriteria)}
+        criteria={formulaForm.props.searchCriteria}
       >
         {generateChildrenFormItems(element, value, formulaForm, id, isDisabled)}
       </Group>
@@ -227,6 +228,7 @@ export function generateFormulaComponentForId(
         sectionsExpanded={formulaForm.props.sectionsExpanded}
         setSectionsExpanded={formulaForm.props.setSectionsExpanded}
         isVisibleByCriteria={() => isVisibleByCriteria(element, formulaForm.props.searchCriteria)}
+        criteria={formulaForm.props.searchCriteria}
       />
     );
   } else if (element.$type === "select")
@@ -348,8 +350,12 @@ function checkVisibilityCondition(id, condition, formulaForm) {
   return false;
 }
 
+export function isFiltered(criteria) {
+  return criteria && criteria.length > 0;
+}
+
 // return the element content visibility conditionally based on the element name by the criteria
-function isVisibleByCriteria(element, criteria) {
+function isVisibleByCriteria(element: any, criteria: string) {
   let visibilityForcedByChildren = false;
   // check if all children are not visible by criteria so we can hide the parent (this element) as well
   for (var child_name in element) {

--- a/web/html/src/components/formulas/FormulaComponentGenerator.tsx
+++ b/web/html/src/components/formulas/FormulaComponentGenerator.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import { default as Jexl } from "jexl";
 
+import { SectionState } from "components/FormulaForm";
 import HelpIcon from "components/utils/HelpIcon";
 
 import { Formulas, Utils } from "utils/functions";
@@ -45,9 +46,9 @@ type Context = {
   getCleanValues?: any | null;
   clearValues: any | null;
   validate: any | null;
-  sectionsExpanded: any | null;
-  setSectionsExpanded: any | null;
-  searchCriteria: any | null;
+  sectionsExpanded: SectionState | null | undefined;
+  setSectionsExpanded: ((SectionState) => void) | null | undefined;
+  searchCriteria: string | null | undefined;
 };
 
 export const FormulaFormContext = React.createContext<Context>({
@@ -359,6 +360,8 @@ function isVisibleByCriteria(element: any, criteria: string) {
   let visibilityForcedByChildren = false;
   // check if all children are not visible by criteria so we can hide the parent (this element) as well
   for (var child_name in element) {
+    // We want to apply the search and filter only on top of nested components the child elements that start
+    // with '$' are normal labels or other values so we skip them.
     if (child_name.startsWith("$")) continue;
     visibilityForcedByChildren = isVisibleByCriteria(element[child_name], criteria);
     if (visibilityForcedByChildren) break;
@@ -461,12 +464,12 @@ export const FormulaFormRenderer = () => (
 type UnwrappedFormulaFormRendererProps = {
   scope: string | null;
   values: any;
-  sectionsExpanded: string;
-  setSectionsExpanded: (string) => void;
+  sectionsExpanded: SectionState | null | undefined;
+  setSectionsExpanded: ((SectionState) => void) | null | undefined;
   layout?: any;
   onChange?: (id: string, value: string) => any;
   registerValidationTrigger?: (...args: any[]) => any;
-  searchCriteria: string | null;
+  searchCriteria: string | null | undefined;
 };
 
 // layout
@@ -639,8 +642,8 @@ type FormulaFormContextProviderProps = {
   systemData?: any;
   groupData?: any;
   scope?: any;
-  sectionsExpanded?: string | undefined;
-  setSectionsExpanded?: (status: string) => void | undefined;
+  sectionsExpanded?: SectionState;
+  setSectionsExpanded?: (status: SectionState) => void;
   searchCriteria?: string;
 };
 

--- a/web/html/src/components/formulas/FormulaComponentGenerator.tsx
+++ b/web/html/src/components/formulas/FormulaComponentGenerator.tsx
@@ -47,6 +47,7 @@ type Context = {
   validate: any | null;
   sectionsExpanded: any | null;
   setSectionsExpanded: any | null;
+  searchCriteria: any | null;
 };
 
 export const FormulaFormContext = React.createContext<Context>({
@@ -59,6 +60,7 @@ export const FormulaFormContext = React.createContext<Context>({
   validate: null,
   sectionsExpanded: null,
   setSectionsExpanded: null,
+  searchCriteria: null,
 });
 
 export function generateFormulaComponent(
@@ -344,6 +346,18 @@ function checkVisibilityCondition(id, condition, formulaForm) {
   return false;
 }
 
+// return the element content visibility conditionally based on the element name by the criteria
+const collapsedByCriteria = (element, criteria) => {
+  return (
+      criteria ||
+      (
+        element.$name &&
+        criteria.length > 0 &&
+        element.$name.toLowerCase().includes(criteria.toLowerCase())
+      )
+  );
+}
+
 function generateChildrenFormItems(element, value, formulaForm, id, disabled = false) {
   var child_items: React.ReactNode[] = [];
   for (var child_name in element) {
@@ -437,6 +451,7 @@ type UnwrappedFormulaFormRendererProps = {
   layout?: any;
   onChange?: (id: string, value: string) => any;
   registerValidationTrigger?: (...args: any[]) => any;
+  searchCriteria: string | null;
 };
 
 // layout
@@ -611,6 +626,7 @@ type FormulaFormContextProviderProps = {
   scope?: any;
   sectionsExpanded?: string | undefined;
   setSectionsExpanded?: (status: string) => void | undefined;
+  searchCriteria?: string;
 };
 
 type FormulaFormContextProviderState = {
@@ -624,6 +640,7 @@ type FormulaFormContextProviderState = {
 // systemData
 // groupData
 // scope
+// searchCriteria
 export class FormulaFormContextProvider extends React.Component<
   FormulaFormContextProviderProps,
   FormulaFormContextProviderState
@@ -655,6 +672,7 @@ export class FormulaFormContextProvider extends React.Component<
       registerValidationTrigger: this.registerValidationTrigger,
       sectionsExpanded: this.props.sectionsExpanded,
       setSectionsExpanded: this.props.setSectionsExpanded,
+      searchCriteria: this.props.searchCriteria,
     };
 
     return <FormulaFormContext.Provider value={contextValue}>{this.props.children}</FormulaFormContext.Provider>;

--- a/web/html/src/components/formulas/FormulaComponentGenerator.tsx
+++ b/web/html/src/components/formulas/FormulaComponentGenerator.tsx
@@ -209,6 +209,7 @@ export function generateFormulaComponentForId(
         help={element.$help}
         sectionsExpanded={formulaForm.props.sectionsExpanded}
         setSectionsExpanded={formulaForm.props.setSectionsExpanded}
+        isVisibleByCriteria={() => isVisibleByCriteria(element, formulaForm.props.searchCriteria)}
       >
         {generateChildrenFormItems(element, value, formulaForm, id, isDisabled)}
       </Group>
@@ -225,6 +226,7 @@ export function generateFormulaComponentForId(
         disabled={isDisabled}
         sectionsExpanded={formulaForm.props.sectionsExpanded}
         setSectionsExpanded={formulaForm.props.setSectionsExpanded}
+        isVisibleByCriteria={() => isVisibleByCriteria(element, formulaForm.props.searchCriteria)}
       />
     );
   } else if (element.$type === "select")
@@ -347,14 +349,21 @@ function checkVisibilityCondition(id, condition, formulaForm) {
 }
 
 // return the element content visibility conditionally based on the element name by the criteria
-const collapsedByCriteria = (element, criteria) => {
+function isVisibleByCriteria(element, criteria) {
+  let visibilityForcedByChildren = false;
+  // check if all children are not visible by criteria so we can hide the parent (this element) as well
+  for (var child_name in element) {
+    if (child_name.startsWith("$")) continue;
+    visibilityForcedByChildren = isVisibleByCriteria(element[child_name], criteria);
+    if (visibilityForcedByChildren) break;
+  }
+
+  // return conditions result whether the element can be hided or not
   return (
-      criteria ||
-      (
-        element.$name &&
-        criteria.length > 0 &&
-        element.$name.toLowerCase().includes(criteria.toLowerCase())
-      )
+      criteria == null ||
+      criteria === "" ||
+      element.$name.toLowerCase().includes(criteria.toLowerCase()) ||
+      visibilityForcedByChildren
   );
 }
 

--- a/web/html/src/components/formulas/FormulaComponentGenerator.tsx
+++ b/web/html/src/components/formulas/FormulaComponentGenerator.tsx
@@ -366,10 +366,10 @@ function isVisibleByCriteria(element: any, criteria: string) {
 
   // return conditions result whether the element can be hided or not
   return (
-      criteria == null ||
-      criteria === "" ||
-      element.$name.toLowerCase().includes(criteria.toLowerCase()) ||
-      visibilityForcedByChildren
+    criteria == null ||
+    criteria === "" ||
+    element.$name.toLowerCase().includes(criteria.toLowerCase()) ||
+    visibilityForcedByChildren
   );
 }
 

--- a/web/html/src/components/formulas/Group.tsx
+++ b/web/html/src/components/formulas/Group.tsx
@@ -10,6 +10,7 @@ type Props = {
   header?: React.ReactNode;
   help?: React.ReactNode;
   children?: React.ReactNode;
+  isVisibleByCriteria?: any;
 };
 
 const Group = (props: Props) => {
@@ -31,25 +32,28 @@ const Group = (props: Props) => {
   };
 
   return (
-    <div
-      className={
-        visible ? "formula-content-section-open group-heading" : "formula-content-section-closed group-heading"
-      }
-    >
-      <SectionToggle setVisible={setVisibility} isVisible={isVisible}>
-        <h4 id={props.id} key={props.id}>
-          {props.header}
-        </h4>
-      </SectionToggle>
-      <div>
-        {visible ? (
-          <React.Fragment>
-            {props.help ? <p>{props.help}</p> : null}
-            {props.children}
-          </React.Fragment>
-        ) : null}
+    props.isVisibleByCriteria?.() ?
+      <div
+        className={
+          visible ? "formula-content-section-open group-heading" : "formula-content-section-closed group-heading"
+        }
+      >
+        <SectionToggle setVisible={setVisibility} isVisible={isVisible}>
+          <h4 id={props.id} key={props.id}>
+            {props.header}
+          </h4>
+        </SectionToggle>
+        <div>
+          {visible ? (
+            <React.Fragment>
+              {props.help ? <p>{props.help}</p> : null}
+              {props.children}
+            </React.Fragment>
+          ) : null}
+
+        </div>
       </div>
-    </div>
+      : null
   );
 };
 

--- a/web/html/src/components/formulas/Group.tsx
+++ b/web/html/src/components/formulas/Group.tsx
@@ -1,17 +1,34 @@
 import * as React from "react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import SectionToggle from "./SectionToggle";
 
 type Props = {
   id: string;
+  sectionsExpanded: string;
+  setSectionsExpanded: (string) => void;
   header?: React.ReactNode;
   help?: React.ReactNode;
   children?: React.ReactNode;
 };
 
 const Group = (props: Props) => {
-  const [visible, setVisible] = useState(true);
+  const [visible, setVisible] = useState(props.sectionsExpanded === "expanded");
+
+  useEffect(() => {
+    if (props.sectionsExpanded !== "mixed") {
+      setVisible(props.sectionsExpanded === "expanded");
+    }
+  }, [props.sectionsExpanded]);
+
+  const isVisible = () => {
+    return visible;
+  };
+
+  const setVisibility = (index, visible) => {
+    setVisible(visible);
+    props.setSectionsExpanded("mixed");
+  };
 
   return (
     <div
@@ -19,7 +36,7 @@ const Group = (props: Props) => {
         visible ? "formula-content-section-open group-heading" : "formula-content-section-closed group-heading"
       }
     >
-      <SectionToggle setVisible={() => setVisible(!visible)} isVisible={(index) => visible}>
+      <SectionToggle setVisible={setVisibility} isVisible={isVisible}>
         <h4 id={props.id} key={props.id}>
           {props.header}
         </h4>

--- a/web/html/src/components/formulas/Group.tsx
+++ b/web/html/src/components/formulas/Group.tsx
@@ -35,34 +35,35 @@ const Group = (props: Props) => {
     props.setSectionsExpanded("mixed");
   };
 
-  return (
-    props.isVisibleByCriteria?.() ?
-      <div
-        className={
-          visible ? "formula-content-section-open group-heading" : "formula-content-section-closed group-heading"
-        }
-      >
-        <SectionToggle setVisible={setVisibility} isVisible={isVisible}>
-          <h4 id={props.id} key={props.id}>
-            {
-              isFiltered(props.criteria) ?
-                <Highlight enabled={isFiltered(props.criteria)} text={props.header ? props.header.toString() : ""} highlight={props.criteria} />
-                : props.header
-            }
-          </h4>
-        </SectionToggle>
-        <div>
-          {visible ? (
-            <React.Fragment>
-              {props.help ? <p>{props.help}</p> : null}
-              {props.children}
-            </React.Fragment>
-          ) : null}
-
-        </div>
+  return props.isVisibleByCriteria?.() ? (
+    <div
+      className={
+        visible ? "formula-content-section-open group-heading" : "formula-content-section-closed group-heading"
+      }
+    >
+      <SectionToggle setVisible={setVisibility} isVisible={isVisible}>
+        <h4 id={props.id} key={props.id}>
+          {isFiltered(props.criteria) ? (
+            <Highlight
+              enabled={isFiltered(props.criteria)}
+              text={props.header ? props.header.toString() : ""}
+              highlight={props.criteria}
+            />
+          ) : (
+            props.header
+          )}
+        </h4>
+      </SectionToggle>
+      <div>
+        {visible ? (
+          <React.Fragment>
+            {props.help ? <p>{props.help}</p> : null}
+            {props.children}
+          </React.Fragment>
+        ) : null}
       </div>
-      : null
-  );
+    </div>
+  ) : null;
 };
 
 export default Group;

--- a/web/html/src/components/formulas/Group.tsx
+++ b/web/html/src/components/formulas/Group.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { useEffect, useState } from "react";
 
+import { SectionState } from "components/FormulaForm";
 import { Highlight } from "components/table/Highlight";
 
 import { isFiltered } from "./FormulaComponentGenerator";
@@ -8,21 +9,21 @@ import SectionToggle from "./SectionToggle";
 
 type Props = {
   id: string;
-  sectionsExpanded: string;
-  setSectionsExpanded: (string) => void;
+  sectionsExpanded: SectionState;
+  setSectionsExpanded: (SectionState) => void;
   header?: React.ReactNode;
   help?: React.ReactNode;
   children?: React.ReactNode;
-  isVisibleByCriteria?: any;
+  isVisibleByCriteria?: () => boolean;
   criteria: string;
 };
 
 const Group = (props: Props) => {
-  const [visible, setVisible] = useState(props.sectionsExpanded !== "collapsed");
+  const [visible, setVisible] = useState(props.sectionsExpanded !== SectionState.Collapsed);
 
   useEffect(() => {
-    if (props.sectionsExpanded !== "mixed") {
-      setVisible(props.sectionsExpanded !== "collapsed");
+    if (props.sectionsExpanded !== SectionState.Mixed) {
+      setVisible(props.sectionsExpanded !== SectionState.Collapsed);
     }
   }, [props.sectionsExpanded]);
 
@@ -32,7 +33,7 @@ const Group = (props: Props) => {
 
   const setVisibility = (index, visible) => {
     setVisible(visible);
-    props.setSectionsExpanded("mixed");
+    props.setSectionsExpanded(SectionState.Mixed);
   };
 
   return props.isVisibleByCriteria?.() ? (

--- a/web/html/src/components/formulas/Group.tsx
+++ b/web/html/src/components/formulas/Group.tsx
@@ -18,11 +18,11 @@ type Props = {
 };
 
 const Group = (props: Props) => {
-  const [visible, setVisible] = useState(props.sectionsExpanded === "expanded");
+  const [visible, setVisible] = useState(props.sectionsExpanded !== "collapsed");
 
   useEffect(() => {
     if (props.sectionsExpanded !== "mixed") {
-      setVisible(props.sectionsExpanded === "expanded");
+      setVisible(props.sectionsExpanded !== "collapsed");
     }
   }, [props.sectionsExpanded]);
 

--- a/web/html/src/components/formulas/Group.tsx
+++ b/web/html/src/components/formulas/Group.tsx
@@ -1,6 +1,9 @@
 import * as React from "react";
 import { useEffect, useState } from "react";
 
+import { Highlight } from "components/table/Highlight";
+
+import { isFiltered } from "./FormulaComponentGenerator";
 import SectionToggle from "./SectionToggle";
 
 type Props = {
@@ -11,6 +14,7 @@ type Props = {
   help?: React.ReactNode;
   children?: React.ReactNode;
   isVisibleByCriteria?: any;
+  criteria: string;
 };
 
 const Group = (props: Props) => {
@@ -40,7 +44,11 @@ const Group = (props: Props) => {
       >
         <SectionToggle setVisible={setVisibility} isVisible={isVisible}>
           <h4 id={props.id} key={props.id}>
-            {props.header}
+            {
+              isFiltered(props.criteria) ?
+                <Highlight enabled={isFiltered(props.criteria)} text={props.header ? props.header.toString() : ""} highlight={props.criteria} />
+                : props.header
+            }
           </h4>
         </SectionToggle>
         <div>

--- a/web/html/src/components/formulas/SectionToggle.tsx
+++ b/web/html/src/components/formulas/SectionToggle.tsx
@@ -11,7 +11,7 @@ const SectionToggle = (props: Props) => {
   const toggleSection = () => {
     let visible = props.isVisible(props.index);
     if (visible === undefined) {
-      visible = true; // initially is open
+      visible = false; // initially is closed
     }
     props.setVisible(props.index, !visible);
   };

--- a/web/html/src/components/formulas/SectionToggle.tsx
+++ b/web/html/src/components/formulas/SectionToggle.tsx
@@ -11,7 +11,7 @@ const SectionToggle = (props: Props) => {
   const toggleSection = () => {
     let visible = props.isVisible(props.index);
     if (visible === undefined) {
-      visible = false; // initially is closed
+      visible = true; // initially is open
     }
     props.setVisible(props.index, !visible);
   };

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Provide a search box on section name for Formulas content
 - Add expand/collapse all button for formula sections
 - Add ssh_salt_pre_flight_script and ssh_use_salt_thin parameters
   to default rhn_web.conf

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Add expand/collapse all button for formula sections
 - Add ssh_salt_pre_flight_script and ssh_use_salt_thin parameters
   to default rhn_web.conf
 - Improved large data support in channel selection


### PR DESCRIPTION
## What does this PR change?

This is a reopen of https://github.com/uyuni-project/uyuni/pull/4278 which has accidentally been merged and needed to be reverted due to breaking the testsuite

Add buttons to expand/collapse all formula sections.
And provide a search box in the Formulas context. **Note:** the search box is capable to filter in/out by the section name whether the section is a `group` or an `edit group` type **only**.

**Previous PR has already been reviewed**

## GUI diff

See: https://github.com/parlt91/uyuni/pull/2

- [x] **DONE**

## Documentation

- No documentation needed: 

- [x] **DONE**

## Test coverage

- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/13404

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
