### PR TITLE
Mix of 4580 and 4590

### DIFF
--- a/testsuite/features/core/proxy_branch_network.feature
+++ b/testsuite/features/core/proxy_branch_network.feature
@@ -94,11 +94,11 @@ Feature: Setup Uyuni for Retail branch network
     And I enter the local IP address of "broadcast" in broadcast address field
     And I press "Add Item" in host reservations section
     And I enter "client" in first reserved hostname field
-    And I enter the local IP address of "client" in first reserved IP field
+    And I enter the local IP address of "sle_client" in first reserved IP field
     And I enter the MAC address of "sle_client" in first reserved MAC field
     And I press "Add Item" in host reservations section
     And I enter "minion" in second reserved hostname field
-    And I enter the local IP address of "minion" in second reserved IP field
+    And I enter the local IP address of "sle_minion" in second reserved IP field
     And I enter the MAC address of "sle_minion" in second reserved MAC field
     And I click on "Save Formula"
     Then I should see a "Formula saved" text
@@ -123,10 +123,10 @@ Feature: Setup Uyuni for Retail branch network
     And I enter "admin@example.org." in first contact field
     And I press "Add Item" in first A section
     And I enter "client" in first A name field
-    And I enter the local IP address of "client" in first A address field
+    And I enter the local IP address of "sle_client" in first A address field
     And I press "Add Item" in first A section
     And I enter "minion" in second A name field
-    And I enter the local IP address of "minion" in second A address field
+    And I enter the local IP address of "sle_minion" in second A address field
     And I press "Add Item" in first A section
     And I enter "proxy" in third A name field
     And I enter the local IP address of "proxy" in third A address field
@@ -161,7 +161,7 @@ Feature: Setup Uyuni for Retail branch network
     And I follow first "Dhcpd" in the content area
     And I press "Add Item" in host reservations section
     And I enter "pxeboot" in third reserved hostname field
-    And I enter the local IP address of "pxeboot" in third reserved IP field
+    And I enter the local IP address of "pxeboot_minion" in third reserved IP field
     And I enter the MAC address of "pxeboot_minion" in third reserved MAC field
     And I click on "Save Formula"
     Then I should see a "Formula saved" text
@@ -169,7 +169,7 @@ Feature: Setup Uyuni for Retail branch network
     When I follow first "Bind" in the content area
     And I press "Add Item" in first A section
     And I enter "pxeboot" in fourth A name field
-    And I enter the local IP address of "pxeboot" in fourth A address field
+    And I enter the local IP address of "pxeboot_minion" in fourth A address field
     And I click on "Save Formula"
     Then I should see a "Formula saved" text
 

--- a/testsuite/features/core/proxy_branch_network.feature
+++ b/testsuite/features/core/proxy_branch_network.feature
@@ -92,7 +92,6 @@ Feature: Setup Uyuni for Retail branch network
     And I enter the local IP address of "range begin" in dynamic IP range begin field
     And I enter the local IP address of "range end" in dynamic IP range end field
     And I enter the local IP address of "broadcast" in broadcast address field
-    And I enter the local IP address of "proxy" in routers field
     And I press "Add Item" in host reservations section
     And I enter "client" in first reserved hostname field
     And I enter the local IP address of "client" in first reserved IP field

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -518,7 +518,7 @@ When(/^I stop salt-minion on the PXE boot minion$/) do
   dest = "/tmp/" + file
   return_code = file_inject($proxy, source, dest)
   raise 'File injection failed' unless return_code.zero?
-  ipv4 = net_prefix + ADDRESSES['pxeboot']
+  ipv4 = net_prefix + ADDRESSES['pxeboot_minion']
   $proxy.run("expect -f /tmp/#{file} #{ipv4}")
 end
 
@@ -1151,7 +1151,6 @@ Then(/^name resolution should work on terminal "([^"]*)"$/) do |host|
     STDOUT.puts "#{output}"
   end
   # reverse name resolution
-  net_prefix = $private_net.sub(%r{\.0+/24$}, ".")
   client = net_prefix + "2"
   [client, "8.8.8.8"].each do |dest|
     output, return_code = node.run("host #{dest}", check_errors: false)
@@ -1624,11 +1623,11 @@ When(/^I prepare the retail configuration file on server$/) do
   sed_values << "s/<PROXY>/#{ADDRESSES['proxy']}/; "
   sed_values << "s/<RANGE_BEGIN>/#{ADDRESSES['range begin']}/; "
   sed_values << "s/<RANGE_END>/#{ADDRESSES['range end']}/; "
-  sed_values << "s/<PXEBOOT>/#{ADDRESSES['pxeboot']}/; "
+  sed_values << "s/<PXEBOOT>/#{ADDRESSES['pxeboot_minion']}/; "
   sed_values << "s/<PXEBOOT_MAC>/#{$pxeboot_mac}/; "
-  sed_values << "s/<MINION>/#{ADDRESSES['minion']}/; "
+  sed_values << "s/<MINION>/#{ADDRESSES['sle_minion']}/; "
   sed_values << "s/<MINION_MAC>/#{get_mac_address('sle_minion')}/; "
-  sed_values << "s/<CLIENT>/#{ADDRESSES['client']}/; "
+  sed_values << "s/<CLIENT>/#{ADDRESSES['sle_client']}/; "
   sed_values << "s/<CLIENT_MAC>/#{get_mac_address('sle_client')}/; "
   sed_values << "s/<IMAGE>/#{compute_image_name}/"
   $server.run("sed -i '#{sed_values}' #{dest}")

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -625,7 +625,7 @@ When(/^I bootstrap pxeboot minion via bootstrap script on the proxy$/) do
   dest = "/tmp/" + file
   return_code = file_inject($proxy, source, dest)
   raise 'File injection failed' unless return_code.zero?
-  ipv4 = net_prefix + ADDRESSES['pxeboot']
+  ipv4 = net_prefix + ADDRESSES['pxeboot_minion']
   $proxy.run("expect -f /tmp/#{file} #{ipv4}")
 end
 

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -300,16 +300,7 @@ When(/^I enter the local IP address of "([^"]*)" in (.*) field$/) do |host, fiel
                'fourth A address'         => 'bind#available_zones#0#records#A#3#1',
                'internal network address' => 'tftpd#listen_ip',
                'vsftpd internal network address' => 'vsftpd_config#listen_address' }
-  addresses = { 'network'     => '0',
-                'client'      => '2',
-                'minion'      => '3',
-                'pxeboot'     => '4',
-                'range begin' => '128',
-                'range end'   => '253',
-                'proxy'       => '254',
-                'broadcast'   => '255' }
-  net_prefix = $private_net.sub(%r{\.0+/24$}, ".")
-  fill_in fieldids[field], with: net_prefix + addresses[host]
+  fill_in fieldids[field], with: net_prefix + ADDRESSES[host]
 end
 
 When(/^I enter the local IP address of "([^"]*)" in (.*) field for vsftpd$/) do |host, field|
@@ -329,16 +320,7 @@ When(/^I enter the local IP address of "([^"]*)" in (.*) field for vsftpd$/) do 
                'third A address'          => 'bind#available_zones#0#records#A#2#1',
                'fourth A address'         => 'bind#available_zones#0#records#A#3#1',
                'internal network address' => 'vsftpd_config#listen_address' }
-  addresses = { 'network'     => '0',
-                'client'      => '2',
-                'minion'      => '3',
-                'pxeboot'     => '4',
-                'range begin' => '128',
-                'range end'   => '253',
-                'proxy'       => '254',
-                'broadcast'   => '255' }
-  net_prefix = $private_net.sub(%r{\.0+/24$}, ".")
-  fill_in fieldids[field], with: net_prefix + addresses[host]
+  fill_in fieldids[field], with: net_prefix + ADDRESSES[host]
 end
 
 When(/^I enter "([^"]*)" in (.*) field$/) do |value, field|
@@ -766,7 +748,6 @@ When(/^I kill remaining Salt jobs on "([^"]*)"$/) do |minion|
 end
 
 When(/^I set "([^"]*)" as NIC, "([^"]*)" as prefix, "([^"]*)" as branch server name and "([^"]*)" as domain$/) do |nic, prefix, server_name, domain|
-  net_prefix = $private_net.sub(%r{\.0+/24$}, ".")
   cred = "--api-user admin --api-pass admin"
   dhcp = "--dedicated-nic #{nic} --branch-ip #{net_prefix}#{ADDRESSES['proxy']} --netmask 255.255.255.0 --dyn-range #{net_prefix}#{ADDRESSES['range begin']} #{net_prefix}#{ADDRESSES['range end']}"
   names = "--server-name #{server_name} --server-domain #{domain} --branch-prefix #{prefix}"

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -1,14 +1,14 @@
 # Copyright (c) 2019-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-ADDRESSES = { 'network'     => '0',
-              'client'      => '2',
-              'minion'      => '3',
-              'pxeboot'     => '4',
-              'range begin' => '128',
-              'range end'   => '253',
-              'proxy'       => '254',
-              'broadcast'   => '255' }.freeze
+ADDRESSES = { 'network'        => '0',
+              'sle_client'     => '2',
+              'sle_minion'     => '3',
+              'pxeboot_minion' => '4',
+              'range begin'    => '128',
+              'range end'      => '253',
+              'proxy'          => '254',
+              'broadcast'      => '255' }.freeze
 
 FIELD_IDS = { 'NIC'                             => 'branch_network#nic',
               'IP'                              => 'branch_network#ip',

--- a/testsuite/features/support/lavanda.rb
+++ b/testsuite/features/support/lavanda.rb
@@ -45,6 +45,7 @@ module LavandaBasic
   end
 
   def private_ip
+    raise 'empty private_ip, something wrong' if @in_private_ip.empty?
     @in_private_ip
   end
 
@@ -54,6 +55,7 @@ module LavandaBasic
   end
 
   def private_interface
+    raise 'empty private_interface, something wrong' if @in_private_interface.empty?
     @in_private_interface
   end
 


### PR DESCRIPTION
## What does this PR change?

**add description**

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
