### PR TITLE
Add checking for libvirtd binary to grains.virt

### DIFF
--- a/susemanager-utils/susemanager-sls/src/grains/virt.py
+++ b/susemanager-utils/susemanager-sls/src/grains/virt.py
@@ -7,7 +7,11 @@ import re
 import subprocess
 import salt.modules.virt
 
-from salt.utils.path import which_bin as _which_bin
+try:
+    from salt.utils.path import which_bin as _which_bin
+except ImportError:
+    from salt.utils import which_bin as _which_bin
+
 from xml.etree import ElementTree
 
 
@@ -15,7 +19,7 @@ log = logging.getLogger(__name__)
 
 
 def __virtual__():
-    return salt.modules.virt.__virtual__() and _which_bin("libvirtd") is not None
+    return salt.modules.virt.__virtual__() and _which_bin(["libvirtd"]) is not None
 
 
 def features():

--- a/susemanager-utils/susemanager-sls/src/grains/virt.py
+++ b/susemanager-utils/susemanager-sls/src/grains/virt.py
@@ -5,14 +5,17 @@ Grains for virtualization hosts
 import logging
 import re
 import subprocess
-from xml.etree import ElementTree
 import salt.modules.virt
+
+from salt.utils.path import which_bin as _which_bin
+from xml.etree import ElementTree
+
 
 log = logging.getLogger(__name__)
 
 
 def __virtual__():
-    return salt.modules.virt.__virtual__()
+    return salt.modules.virt.__virtual__() and _which_bin("libvirtd") is not None
 
 
 def features():

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Add checking for libvirtd binary to grains.virt module
 - Fix errors on calling sed -E ... by force_restart_minion
   with action chains
 - Fix problem installing/removing packages using action chains


### PR DESCRIPTION
## What does this PR change?

In case of using Salt Bundle, `libvirt` python module is present in the salt bundle virtual environment, but `libvirt` could be not installed on the system. In this case any call for `grains` leads to writing the following message to the log or console:
```
[salt.loaded.ext.grains.virt:47  ][ERROR   ][2215] libvirtd is not installed or is not in the PATH
```

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Changelogs

- Add checking for libvirtd binary to grains.virt module

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
