### PR TITLE
Fix test_module_sumautil

### DIFF
--- a/susemanager-utils/susemanager-sls/src/tests/test_module_sumautil.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_sumautil.py
@@ -17,7 +17,7 @@ def test_livepatching_kernelliveversion():
     '''
 
     sumautil.log = MagicMock()
-    with patch('src.modules.udevdb._which_bin', MagicMock(return_value="/bogus/path")):
+    with patch('salt.utils.path.which_bin', MagicMock(return_value="/bogus/path")):
         mock = MagicMock(side_effect=[{ 'retcode': 0, 'stdout': 'ready' },
                                     { 'retcode': 0, 'stdout': mockery.get_test_data('livepatching-1.sample')}
                                     ]);
@@ -36,6 +36,6 @@ def test_livepatching_kernelliveversion():
             assert 'mgr_kernel_live_version' in out
             assert out['mgr_kernel_live_version'] == 'kgraft_patch_2_2_1'
 
-    with patch('src.modules.udevdb._which_bin', MagicMock(return_value=None)):
+    with patch('salt.utils.path.which_bin', MagicMock(return_value=None)):
         out = sumautil.get_kernel_live_version()
         assert out is None


### PR DESCRIPTION
## What does this PR change?

Just a fix for a test.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- Unit tests were fixed

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
