### PR TITLE
Disallow unused variables in production

### DIFF
--- a/web/html/src/.eslintrc.production.js
+++ b/web/html/src/.eslintrc.production.js
@@ -3,5 +3,6 @@ module.exports = {
   rules: {
     // Make stylistic issues fail production lint
     "prettier/prettier": "error",
+    "@typescript-eslint/no-unused-vars": "error",
   },
 };

--- a/web/html/src/build/fill-spec-file.js
+++ b/web/html/src/build/fill-spec-file.js
@@ -18,7 +18,7 @@ function fillSpecFile() {
     fs.readFile(specFileLocation, "utf8", function (err, specFile) {
       if (err) {
         reject(err);
-        return;
+        throw err;
       }
       var specFileEdited = specFile.replace(
         /(?<=%package -n susemanager-web-libs[\s\S]*?)License:.*/m,
@@ -28,7 +28,7 @@ function fillSpecFile() {
       fs.writeFile(specFileLocation, specFileEdited, "utf8", function (err) {
         if (err) {
           reject(err);
-          return;
+          throw err;
         }
 
         resolve({ mappedProcessedLicenses });

--- a/web/html/src/build/fill-spec-file.js
+++ b/web/html/src/build/fill-spec-file.js
@@ -17,7 +17,8 @@ function fillSpecFile() {
   return new Promise(function (resolve, reject) {
     fs.readFile(specFileLocation, "utf8", function (err, specFile) {
       if (err) {
-        throw err;
+        reject(err);
+        return;
       }
       var specFileEdited = specFile.replace(
         /(?<=%package -n susemanager-web-libs[\s\S]*?)License:.*/m,
@@ -26,7 +27,8 @@ function fillSpecFile() {
 
       fs.writeFile(specFileLocation, specFileEdited, "utf8", function (err) {
         if (err) {
-          throw err;
+          reject(err);
+          return;
         }
 
         resolve({ mappedProcessedLicenses });

--- a/web/html/src/manager/systems/proxy.tsx
+++ b/web/html/src/manager/systems/proxy.tsx
@@ -49,8 +49,6 @@ class Proxy extends React.Component<Props, State> {
   }
 
   proxyChanged = (event) => {
-    var proxyId = event.target.value;
-    var proxy = this.props.proxies.find((p) => p.id === proxyId);
     this.setState({
       proxy: event.target.value,
     });


### PR DESCRIPTION
## What does this PR change?

Currently, production lint allows unused variables which means cleaning them up later if someone forgets something. This PR disallows them.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: Internal changes only.

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
