### PR TITLE
Fix cobbler snippets xml

### DIFF
--- a/java/conf/cobbler/snippets/minion_script
+++ b/java/conf/cobbler/snippets/minion_script
@@ -1,4 +1,4 @@
-# begin SUSE Manager registration
+<!-- begin Uyuni/SUSE Manager registration -->
 <script>
     <filename>uyuni-minion.sh</filename>
     <source>
@@ -74,5 +74,5 @@ zypper mr -e --medium-type plugin
         ]]>
     </source>
 </script>
-# end SUSE Manager registration
+<!-- end Uyuni/SUSE Manager registration -->
 

--- a/java/conf/cobbler/snippets/sles_register_script
+++ b/java/conf/cobbler/snippets/sles_register_script
@@ -1,4 +1,4 @@
-# begin SUSE Manager registration
+<!-- begin Uyuni/SUSE Manager registration -->
 <script>
     <filename>spacewalk-sles_register.sh</filename>
     <source>
@@ -102,5 +102,5 @@ zypper mr -e --medium-type plugin
         ]]>
     </source>
 </script>
-# end SUSE Manager registration
+<!-- end Uyuni/SUSE Manager registration -->
 

--- a/java/conf/cobbler/snippets/wait_for_networkmanager_script
+++ b/java/conf/cobbler/snippets/wait_for_networkmanager_script
@@ -1,4 +1,4 @@
-# begin waiting for NetworkManager
+<!-- begin waiting for NetworkManager -->
     <source>
         <![CDATA[
 if systemctl is-enabled NetworkManager.service ; then
@@ -15,5 +15,5 @@ if systemctl is-enabled NetworkManager.service ; then
 fi
         ]]>
     </source>
-# end waiting for NetworkManager
+<!-- end waiting for NetworkManager -->
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix XML syntax in cobbler snippets (bsc#1193694)
 - Migrate the displaying of the date/time to rhn:formatDate
 - Suggest Product Migration when patch for CVE is in a successor Product (bsc#1191360)
 - Add route for virtual systems ReactJS page


### PR DESCRIPTION
## What does this PR change?

In autoyast snipptes better use official XML comments and not `#` sign.
This produce XML parsing errors in yast.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/16590

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
