### PR TITLE
Update tomcat connector timeouts to new default value

### DIFF
--- a/spacewalk/setup/share/server_update.xml.xsl
+++ b/spacewalk/setup/share/server_update.xml.xsl
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml" indent="no" omit-xml-declaration="yes" />
+<xsl:preserve-space elements="Connector"/>
+
+<xsl:template match="@*|node()">
+  <xsl:copy>
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:copy>
+</xsl:template>
+
+<xsl:template match="/Server/Service[@name='Catalina']/Connector[@connectionTimeout='20000']">
+  <xsl:element name="Connector">
+    <xsl:copy-of select="@*" />
+    <xsl:attribute name="connectionTimeout">900000</xsl:attribute>
+  </xsl:element>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,5 @@
+- During upgrade, set tomcat connector connectionTimeout
+  to 900000 if the previous values is the old default (20000)
 - Increase "max_event_size" value for the Salt master (bsc#1191340)
 
 -------------------------------------------------------------------

--- a/spacewalk/setup/spacewalk-setup.spec
+++ b/spacewalk/setup/spacewalk-setup.spec
@@ -251,7 +251,7 @@ fi
 
 if [ $1 == 2 -a -e /etc/tomcat/server.xml ]; then
     cp /etc/tomcat/server.xml /etc/tomcat/server.xml.post-script-backup
-    xsltproc %{_datadir}/spacewalk/setup/server_update.xml.xsl /etc/tomcat/server.xml > /etc/tomcat/server.xml
+    xsltproc %{_datadir}/spacewalk/setup/server_update.xml.xsl /etc/tomcat/server.xml.post-script-backup -o /etc/tomcat/server.xml
 fi
 
 

--- a/spacewalk/setup/spacewalk-setup.spec
+++ b/spacewalk/setup/spacewalk-setup.spec
@@ -251,7 +251,7 @@ fi
 
 if [ $1 == 2 -a -e /etc/tomcat/server.xml ]; then
     cp /etc/tomcat/server.xml /etc/tomcat/server.xml.post-script-backup
-    xsltproc %{_datadir}/server.xml.xsl /etc/tomcat/server.xml > /etc/tomcat/server.xml
+    xsltproc %{_datadir}/spacewalk/setup/server_update.xml.xsl /etc/tomcat/server.xml > /etc/tomcat/server.xml
 fi
 
 

--- a/spacewalk/setup/spacewalk-setup.spec
+++ b/spacewalk/setup/spacewalk-setup.spec
@@ -113,7 +113,7 @@ Requires:       spacewalk-base-minimal
 Requires:       spacewalk-base-minimal-config
 Requires:       spacewalk-java-lib >= 2.4.5
 Requires:       spacewalk-setup-jabberd
-
+Requires(post): libxslt-tools
 Provides:       salt-formulas-configuration
 Conflicts:      otherproviders(salt-formulas-configuration)
 
@@ -176,6 +176,7 @@ install -m 0644 share/mod_ssl.conf.* %{buildroot}/%{_datadir}/spacewalk/setup/
 install -m 0644 share/tomcat.* %{buildroot}/%{_datadir}/spacewalk/setup/
 install -m 0644 share/tomcat6.* %{buildroot}/%{_datadir}/spacewalk/setup/
 install -m 0644 share/server.xml.xsl %{buildroot}/%{_datadir}/spacewalk/setup/
+install -m 0644 share/server_update.xml.xsl %{buildroot}/%{_datadir}/spacewalk/setup/
 install -m 0644 share/context.xml.xsl %{buildroot}/%{_datadir}/spacewalk/setup/
 install -m 0644 share/server-external-authentication.xml.xsl %{buildroot}/%{_datadir}/spacewalk/setup/
 install -m 0644 share/web.xml.patch %{buildroot}/%{_datadir}/spacewalk/setup/
@@ -247,6 +248,12 @@ if [ $1 = 2 -a -e /etc/tomcat6/tomcat6.conf ]; then
         echo 'module = manage_in_tftpd'                     >> /etc/cobbler/modules.conf
     fi
 fi
+
+if [ $1 == 2 -a -e /etc/tomcat/server.xml ]; then
+    cp /etc/tomcat/server.xml /etc/tomcat/server.xml.post-script-backup
+    xsltproc %{_datadir}/server.xml.xsl /etc/tomcat/server.xml > /etc/tomcat/server.xml
+fi
+
 
 %if 0%{?suse_version}
 if [ $1 = 2 -a -e /etc/sysconfig/tomcat ]; then

--- a/spacewalk/setup/spacewalk-setup.spec
+++ b/spacewalk/setup/spacewalk-setup.spec
@@ -251,7 +251,7 @@ fi
 
 if [ $1 == 2 -a -e /etc/tomcat/server.xml ]; then
     cp /etc/tomcat/server.xml /etc/tomcat/server.xml.post-script-backup
-    xsltproc %{_datadir}/spacewalk/setup/server_update.xml.xsl /etc/tomcat/server.xml.post-script-backup -o /etc/tomcat/server.xml
+    xsltproc %{_datadir}/spacewalk/setup/server_update.xml.xsl /etc/tomcat/server.xml.post-script-backup > /etc/tomcat/server.xml
 fi
 
 

--- a/spacewalk/setup/spacewalk-setup.spec
+++ b/spacewalk/setup/spacewalk-setup.spec
@@ -114,6 +114,7 @@ Requires:       spacewalk-base-minimal-config
 Requires:       spacewalk-java-lib >= 2.4.5
 Requires:       spacewalk-setup-jabberd
 Requires(post): libxslt-tools
+
 Provides:       salt-formulas-configuration
 Conflicts:      otherproviders(salt-formulas-configuration)
 

--- a/spacewalk/setup/spacewalk-setup.spec
+++ b/spacewalk/setup/spacewalk-setup.spec
@@ -250,11 +250,11 @@ if [ $1 = 2 -a -e /etc/tomcat6/tomcat6.conf ]; then
     fi
 fi
 
-if [ $1 == 2 -a -e /etc/tomcat/server.xml ]; then
+if [ $1 == 2 -a -e /etc/tomcat/server.xml ]; then 
+#during upgrade, setup new connectionTimeout if the user didn't change it
     cp /etc/tomcat/server.xml /etc/tomcat/server.xml.post-script-backup
     xsltproc %{_datadir}/spacewalk/setup/server_update.xml.xsl /etc/tomcat/server.xml.post-script-backup > /etc/tomcat/server.xml
 fi
-
 
 %if 0%{?suse_version}
 if [ $1 = 2 -a -e /etc/sysconfig/tomcat ]; then


### PR DESCRIPTION
## What does this PR change?

update tomcat connection timeouts only if it has the previous (and now obsolete) default values.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15719

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
