### PR TITLE
Remove constructor context binding

### DIFF
--- a/web/html/src/components/buttons.tsx
+++ b/web/html/src/components/buttons.tsx
@@ -75,13 +75,12 @@ type AsyncState = {
 export class AsyncButton extends _ButtonBase<AsyncProps, AsyncState> {
   constructor(props: AsyncProps) {
     super(props);
-    ["trigger"].forEach((method) => (this[method] = this[method].bind(this)));
     this.state = {
       value: props.initialValue ? props.initialValue : "initial",
     };
   }
 
-  trigger() {
+  trigger = () => {
     this.setState({
       value: "waiting",
     });
@@ -104,7 +103,7 @@ export class AsyncButton extends _ButtonBase<AsyncProps, AsyncState> {
         });
       }
     );
-  }
+  };
 
   render() {
     let style = "btn ";

--- a/web/html/src/components/config-channels.tsx
+++ b/web/html/src/components/config-channels.tsx
@@ -51,27 +51,10 @@ class ConfigChannels extends React.Component<ConfigChannelsProps, ConfigChannels
 
   constructor(props: ConfigChannelsProps) {
     super(props);
-
-    [
-      "init",
-      "tableBody",
-      "handleSelectionChange",
-      "onSearchChange",
-      "search",
-      "save",
-      "applySaltState",
-      "addChanged",
-      "showPopUp",
-      "onClosePopUp",
-      "showRanking",
-      "hideRanking",
-      "onUpdateRanking",
-      "getCurrentAssignment",
-    ].forEach((method) => (this[method] = this[method].bind(this)));
     this.init();
   }
 
-  init() {
+  init = () => {
     Network.get(this.props.matchUrl()).then((data) => {
       this.setState({
         channels: data,
@@ -81,9 +64,9 @@ class ConfigChannels extends React.Component<ConfigChannelsProps, ConfigChannels
         },
       });
     });
-  }
+  };
 
-  applySaltState() {
+  applySaltState = () => {
     if (this.state.changed.size > 0) {
       const response = window.confirm(t("There are unsaved changes. Do you want to proceed?"));
       if (DEPRECATED_unsafeEquals(response, false)) {
@@ -94,13 +77,13 @@ class ConfigChannels extends React.Component<ConfigChannelsProps, ConfigChannels
     const request = this.props.applyRequest(this);
 
     return request;
-  }
+  };
 
-  onUpdateRanking(channels) {
+  onUpdateRanking = (channels) => {
     this.setState({ assigned: channels });
-  }
+  };
 
-  save() {
+  save = () => {
     const channels = this.state.assigned;
     const request = this.props.saveRequest(channels).then(
       (data, textStatus, jqXHR) => {
@@ -132,15 +115,15 @@ class ConfigChannels extends React.Component<ConfigChannelsProps, ConfigChannels
       }
     );
     return request;
-  }
+  };
 
-  onSearchChange(event) {
+  onSearchChange = (event) => {
     this.setState({
       filter: event.target.value,
     });
-  }
+  };
 
-  search() {
+  search = () => {
     return Promise.resolve().then(() => {
       if (this.state.filter !== this.state.search.filter) {
         Network.get(this.props.matchUrl(this.state.filter)).then((data) => {
@@ -154,9 +137,9 @@ class ConfigChannels extends React.Component<ConfigChannelsProps, ConfigChannels
         });
       }
     });
-  }
+  };
 
-  addChanged(original, key, selected) {
+  addChanged = (original, key, selected) => {
     const currentChannel = this.state.changed.get(key);
     if (
       !DEPRECATED_unsafeEquals(currentChannel, undefined) &&
@@ -172,15 +155,15 @@ class ConfigChannels extends React.Component<ConfigChannelsProps, ConfigChannels
     this.setState({
       changed: this.state.changed,
     });
-  }
+  };
 
-  handleSelectionChange(original) {
+  handleSelectionChange = (original) => {
     return (event) => {
       this.addChanged(original, event.target.value, event.target.checked);
     };
-  }
+  };
 
-  tableBody() {
+  tableBody = () => {
     const elements: React.ReactNode[] = [];
     let rows: any[] = [];
     rows = this.state.search.results.map((channel) => {
@@ -247,30 +230,30 @@ class ConfigChannels extends React.Component<ConfigChannelsProps, ConfigChannels
         )}
       </tbody>
     );
-  }
+  };
 
-  showPopUp(channel) {
+  showPopUp = (channel) => {
     Network.get("/rhn/manager/api/states/" + channel.id + "/content").then((data) => {
       this.setState({
         showSaltState: Object.assign({}, channel, { content: data }),
       });
     });
-  }
+  };
 
-  showRanking() {
+  showRanking = () => {
     this.clearMessages();
     this.setState({ rank: true });
-  }
+  };
 
-  hideRanking() {
+  hideRanking = () => {
     this.setState({ rank: false });
-  }
+  };
 
-  onClosePopUp() {
+  onClosePopUp = () => {
     this.setState({
       showSaltState: null,
     });
-  }
+  };
 
   clearMessages() {
     this.setState({
@@ -278,12 +261,12 @@ class ConfigChannels extends React.Component<ConfigChannelsProps, ConfigChannels
     });
   }
 
-  getCurrentAssignment() {
+  getCurrentAssignment = () => {
     const unchanged = this.state.channels.filter((c) => !this.state.changed.has(channelKey(c)));
     const changed = Array.from(this.state.changed.values()).map((c) => c.value);
 
     return unchanged.concat(changed).filter((c) => c.assigned);
-  }
+  };
 
   render() {
     const currentAssignment = this.getCurrentAssignment();

--- a/web/html/src/components/datetime/DateTimePicker.tsx
+++ b/web/html/src/components/datetime/DateTimePicker.tsx
@@ -53,11 +53,6 @@ type DatePickerProps = {
 class DatePicker extends React.PureComponent<DatePickerProps> {
   _input: JQuery | null = null;
 
-  constructor(props: DatePickerProps) {
-    super(props);
-    this.setVisible.bind(this);
-  }
-
   componentDidMount() {
     this._input?.datepicker({});
     this.setVisible(this.props.open);
@@ -109,13 +104,13 @@ class DatePicker extends React.PureComponent<DatePickerProps> {
     return date;
   }
 
-  setVisible(visible?: boolean) {
+  setVisible = (visible?: boolean) => {
     if (visible) {
       this._input?.datepicker("show");
     } else {
       this._input?.datepicker("hide");
     }
-  }
+  };
 
   render() {
     return (

--- a/web/html/src/components/fields.tsx
+++ b/web/html/src/components/fields.tsx
@@ -5,16 +5,11 @@ type Props = React.InputHTMLAttributes<HTMLInputElement> & {
 };
 
 class TextField extends React.Component<Props> {
-  constructor(props: Props) {
-    super(props);
-    ["onKeyPress"].forEach((method) => (this[method] = this[method].bind(this)));
-  }
-
-  onKeyPress(event: React.KeyboardEvent<HTMLInputElement>) {
+  onKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === "Enter" && this.props.onPressEnter) {
       this.props.onPressEnter(event);
     }
-  }
+  };
 
   render() {
     const defaultClassName = this.props.className ? this.props.className : "form-control";

--- a/web/html/src/components/formula-selection.tsx
+++ b/web/html/src/components/formula-selection.tsx
@@ -30,19 +30,6 @@ class FormulaSelection extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
 
-    [
-      "init",
-      "saveRequest",
-      "resetChanges",
-      "removeAllFormulas",
-      "getGroupItemState",
-      "getListIcon",
-      "getListStyle",
-      "generateList",
-      "onGroupItemClick",
-      "onListItemClick",
-    ].forEach((method) => (this[method] = this[method].bind(this)));
-
     this.state = {
       formulas: {},
       groups: { groupless: [] },
@@ -54,7 +41,7 @@ class FormulaSelection extends React.Component<Props, State> {
     this.init();
   }
 
-  init() {
+  init = () => {
     Network.get(this.props.dataUrl).then((data) => {
       const groupDict = { groupless: [] };
       const formulaDict: any = {};
@@ -72,9 +59,9 @@ class FormulaSelection extends React.Component<Props, State> {
         groups: groupDict,
       });
     });
-  }
+  };
 
-  saveRequest() {
+  saveRequest = () => {
     const selectedFormulas: unknown[] = [];
     jQuery.each(this.state.formulas, function (name, formula) {
       if (formula.selected) selectedFormulas.push(name);
@@ -89,24 +76,24 @@ class FormulaSelection extends React.Component<Props, State> {
       this.init();
       window.scrollTo(0, 0);
     });
-  }
+  };
 
-  resetChanges() {
+  resetChanges = () => {
     const selectedFormulas = this.state.activeSelectedFormulas;
     jQuery.each(this.state.formulas, function (name, formula) {
       formula.selected = selectedFormulas.indexOf(name) >= 0;
     });
     this.forceUpdate();
-  }
+  };
 
-  removeAllFormulas() {
+  removeAllFormulas = () => {
     jQuery.each(this.state.formulas, function (name, formula) {
       formula.selected = false;
     });
     this.forceUpdate();
-  }
+  };
 
-  getGroupItemState(group) {
+  getGroupItemState = (group) => {
     let selectedCount = 0;
     group.forEach(function (formula) {
       if (formula.selected) selectedCount++;
@@ -114,18 +101,18 @@ class FormulaSelection extends React.Component<Props, State> {
     if (selectedCount === 0) return 0;
     else if (selectedCount === group.length) return 1;
     else return 2;
-  }
+  };
 
-  getListIcon(state) {
+  getListIcon = (state) => {
     if (!state) return "fa fa-lg fa-square-o";
     else if (DEPRECATED_unsafeEquals(state, 1)) return "fa fa-lg fa-check-square-o";
     else return "fa fa-lg fa-minus-square-o";
-  }
+  };
 
-  getListStyle(state) {
+  getListStyle = (state) => {
     if (state) return "list-group-item list-group-item-info";
     else return "list-group-item";
-  }
+  };
 
   getDescription(formula) {
     if (this.state.showDescription === formula.name)
@@ -133,7 +120,7 @@ class FormulaSelection extends React.Component<Props, State> {
     else return null;
   }
 
-  generateList() {
+  generateList = () => {
     var list: React.ReactNode[] = [];
     const groups = this.state.groups;
 
@@ -210,9 +197,9 @@ class FormulaSelection extends React.Component<Props, State> {
       }, this);
     }
     return list;
-  }
+  };
 
-  onListItemClick(e) {
+  onListItemClick = (e) => {
     e.preventDefault();
     const formula =
       this.state.formulas[DEPRECATED_unsafeEquals(e.target.href, undefined) ? e.target.parentElement.id : e.target.id];
@@ -227,9 +214,9 @@ class FormulaSelection extends React.Component<Props, State> {
       formula.selected = !formula.selected;
     }
     this.forceUpdate();
-  }
+  };
 
-  onGroupItemClick(e) {
+  onGroupItemClick = (e) => {
     e.preventDefault();
 
     var group = e.target;
@@ -250,7 +237,7 @@ class FormulaSelection extends React.Component<Props, State> {
         break;
     }
     this.forceUpdate();
-  }
+  };
 
   render() {
     var items: MessageType[] = [];

--- a/web/html/src/components/formulas/EditGroup.tsx
+++ b/web/html/src/components/formulas/EditGroup.tsx
@@ -39,20 +39,17 @@ class EditGroup extends React.Component<EditGroupProps, EditGroupState> {
     this.state = {
       visible: true,
     };
-    ["handleAddItem", "handleRemoveItem", "isDisabled", "setVisible", "isVisible"].forEach(
-      (method) => (this[method] = this[method].bind(this))
-    );
   }
 
-  isDisabled() {
+  isDisabled = () => {
     const formScope = this.props.formulaForm.props.scope;
     const elementScope = this.props.element.$scope;
     return (
       elementScope === "readonly" || (formScope !== elementScope && elementScope !== "system") || this.props.disabled
     );
-  }
+  };
 
-  handleAddItem(event) {
+  handleAddItem = (event) => {
     if (this.props.element.$maxItems! <= this.props.value.length || this.isDisabled()) return;
 
     let newValueProps = this.props.value;
@@ -64,9 +61,9 @@ class EditGroup extends React.Component<EditGroupProps, EditGroupState> {
       id: this.props.id,
       value: newValueProps,
     });
-  }
+  };
 
-  handleRemoveItem(index: number) {
+  handleRemoveItem = (index: number) => {
     if (this.props.element.$minItems! >= this.props.value.length || this.isDisabled()) return;
 
     this.props.value.splice(index, 1);
@@ -74,16 +71,16 @@ class EditGroup extends React.Component<EditGroupProps, EditGroupState> {
       id: this.props.id,
       value: this.props.value,
     });
-  }
+  };
 
-  isVisible(index?: number) {
+  isVisible = (index?: number) => {
     return this.state.visible;
-  }
+  };
 
-  setVisible(index, visible) {
+  setVisible = (index, visible) => {
     // index not needed here
     this.setState({ visible: visible });
-  }
+  };
 
   render() {
     const element = this.props.element;
@@ -153,12 +150,7 @@ type EditPrimitiveGroupProps = {
  * to be rendered as a list of simple form elements in the UI.
  */
 class EditPrimitiveGroup extends React.Component<EditPrimitiveGroupProps> {
-  constructor(props) {
-    super(props);
-    ["simpleWrapper"].forEach((method) => (this[method] = this[method].bind(this)));
-  }
-
-  simpleWrapper(name, required, element, help = null) {
+  simpleWrapper = (name, required, element, help = null) => {
     return (
       <React.Fragment>
         <div className="col-lg-3">{element}</div>
@@ -170,7 +162,7 @@ class EditPrimitiveGroup extends React.Component<EditPrimitiveGroupProps> {
         <HelpIcon text={this.props.element["$help"]} />
       </React.Fragment>
     );
-  }
+  };
 
   render() {
     let elements: React.ReactNode[] = [];
@@ -310,7 +302,6 @@ class EditDictionaryGroup extends React.Component<EditDictionaryGroupProps, Edit
     this.state = {
       visibility: new Map(),
     };
-    ["isVisible", "setVisible"].forEach((method) => (this[method] = this[method].bind(this)));
   }
 
   wrapKeyGroup(element_name, required, innerHTML) {
@@ -337,15 +328,15 @@ class EditDictionaryGroup extends React.Component<EditDictionaryGroupProps, Edit
     return name;
   }
 
-  isVisible(index) {
+  isVisible = (index) => {
     return this.state.visibility.get(index) === undefined || this.state.visibility.get(index) === true;
-  }
+  };
 
-  setVisible(index, visible) {
+  setVisible = (index, visible) => {
     const { visibility } = this.state;
     visibility.set(index, visible);
     this.setState({ visibility });
-  }
+  };
 
   render() {
     let elements: React.ReactNode[] = [];

--- a/web/html/src/components/formulas/PasswordInput.tsx
+++ b/web/html/src/components/formulas/PasswordInput.tsx
@@ -24,25 +24,22 @@ class PasswordInput extends React.Component<Props, State> {
     this.state = {
       showPassword: false,
     };
-
-    this.handleGeneratePassword = this.handleGeneratePassword.bind(this);
-    this.handleToggleShowPassword = this.handleToggleShowPassword.bind(this);
   }
 
-  handleGeneratePassword(event) {
+  handleGeneratePassword = (event) => {
     event.preventDefault();
     this.props.onChange({
       value: generatePassword(),
       id: this.props.id,
     });
-  }
+  };
 
-  handleToggleShowPassword(event) {
+  handleToggleShowPassword = (event) => {
     event.preventDefault();
     this.setState((state, props) => {
       return { showPassword: !state.showPassword };
     });
-  }
+  };
 
   render() {
     // empty password is always rendered as text to prevent problems with browser autocompletion

--- a/web/html/src/manager/audit/cveaudit/cveaudit.tsx
+++ b/web/html/src/manager/audit/cveaudit/cveaudit.tsx
@@ -83,9 +83,6 @@ class CVEAudit extends React.Component<Props, State> {
   constructor(props) {
     super(props);
 
-    ["onCVEChange", "searchData", "handleSelectItems", "audit", "onCVEYearChange", "onTargetChange"].forEach(
-      (method) => (this[method] = this[method].bind(this))
-    );
     this.state = {
       cveNumber: "",
       cveYear: CURRENT_YEAR,
@@ -97,14 +94,14 @@ class CVEAudit extends React.Component<Props, State> {
     };
   }
 
-  searchData(datum, criteria) {
+  searchData = (datum, criteria) => {
     if (criteria) {
       return datum.name.toLocaleLowerCase().includes(criteria.toLocaleLowerCase());
     }
     return true;
-  }
+  };
 
-  handleSelectItems(items) {
+  handleSelectItems = (items) => {
     const removed = this.state.selectedItems.filter((i) => !items.includes(i));
     const isAdd = removed.length === 0;
     const list = isAdd ? items : removed;
@@ -116,23 +113,23 @@ class CVEAudit extends React.Component<Props, State> {
         dwr.util.setValue("header_selcount", eval(res).header, { escapeHtml: false });
       });
     });
-  }
+  };
 
-  onTargetChange(e) {
+  onTargetChange = (e) => {
     const value = e.target.value;
     this.setState({
       target: value,
     });
-  }
+  };
 
-  onCVEYearChange(e) {
+  onCVEYearChange = (e) => {
     const value = e.target.value;
     this.setState({
       cveYear: value,
     });
-  }
+  };
 
-  onCVEChange(e) {
+  onCVEChange = (e) => {
     const value = e.target.value;
     const parts = CVE_REGEX.exec(value);
     if (parts != null && DEPRECATED_unsafeEquals(parts.length, 3)) {
@@ -149,13 +146,13 @@ class CVEAudit extends React.Component<Props, State> {
         cveNumber: value,
       });
     }
-  }
+  };
 
   isFiltered(criteria) {
     return criteria && criteria.length > 0;
   }
 
-  audit(target) {
+  audit = (target) => {
     cveAudit("CVE-" + this.state.cveYear + "-" + this.state.cveNumber, target, this.state.statuses).then((data) => {
       if (data.success) {
         this.setState({
@@ -172,7 +169,7 @@ class CVEAudit extends React.Component<Props, State> {
         });
       }
     });
-  }
+  };
 
   render() {
     return (

--- a/web/html/src/manager/images/image-build.tsx
+++ b/web/html/src/manager/images/image-build.tsx
@@ -71,15 +71,6 @@ class BuildImage extends React.Component<Props, State> {
       messages: [],
     };
 
-    [
-      "handleProfileChange",
-      "onFormChange",
-      "onValidate",
-      "onBuild",
-      "onDateTimeChanged",
-      "onActionChainChanged",
-    ].forEach((method) => (this[method] = this[method].bind(this)));
-
     this.getProfiles();
   }
 
@@ -138,9 +129,9 @@ class BuildImage extends React.Component<Props, State> {
     });
   }
 
-  handleProfileChange(name, value) {
+  handleProfileChange = (name, value) => {
     this.changeProfile(value);
-  }
+  };
 
   changeProfile(id) {
     const model = Object.assign({}, this.state.model);
@@ -169,19 +160,19 @@ class BuildImage extends React.Component<Props, State> {
     return encodeURIComponent("/rhn/manager/cm/build" + (qstr ? "?" + qstr : ""));
   }
 
-  onFormChange(model) {
+  onFormChange = (model) => {
     this.setState({
       model: model,
     });
-  }
+  };
 
-  onValidate(isValid) {
+  onValidate = (isValid) => {
     this.setState({
       isInvalid: !isValid,
     });
-  }
+  };
 
-  onDateTimeChanged(value: moment.Moment) {
+  onDateTimeChanged = (value: moment.Moment) => {
     const model: State["model"] = Object.assign({}, this.state.model, {
       earliest: value,
       actionChain: null,
@@ -190,9 +181,9 @@ class BuildImage extends React.Component<Props, State> {
       actionChain: null,
       model,
     });
-  }
+  };
 
-  onActionChainChanged(actionChain: ActionChain | null) {
+  onActionChainChanged = (actionChain: ActionChain | null) => {
     const model: State["model"] = Object.assign({}, this.state.model, {
       actionChain: actionChain?.text,
     });
@@ -200,9 +191,9 @@ class BuildImage extends React.Component<Props, State> {
       actionChain,
       model,
     });
-  }
+  };
 
-  onBuild(model) {
+  onBuild = (model) => {
     Network.post("/rhn/manager/api/cm/build/" + this.state.model.profileId, model).then((data) => {
       if (data.success) {
         const msg = MessagesUtils.info(
@@ -235,7 +226,7 @@ class BuildImage extends React.Component<Props, State> {
         });
       }
     });
-  }
+  };
 
   renderProfileSummary() {
     var p = this.state.profile;

--- a/web/html/src/manager/images/image-import.tsx
+++ b/web/html/src/manager/images/image-import.tsx
@@ -69,17 +69,6 @@ class ImageImport extends React.Component {
   constructor(props) {
     super(props);
 
-    this.getImageStores = this.getImageStores.bind(this);
-    this.getBounceUrl = this.getBounceUrl.bind(this);
-    this.onFormChange = this.onFormChange.bind(this);
-    this.onValidate = this.onValidate.bind(this);
-    this.getBuildHosts = this.getBuildHosts.bind(this);
-    this.getActivationKeys = this.getActivationKeys.bind(this);
-    this.onImport = this.onImport.bind(this);
-    this.handleActivationKeyChange = this.handleActivationKeyChange.bind(this);
-    this.clearFields = this.clearFields.bind(this);
-    this.handleResponseError = this.handleResponseError.bind(this);
-
     this.state = {
       imageStores: null,
       messages: [],
@@ -96,7 +85,7 @@ class ImageImport extends React.Component {
     this.getActivationKeys();
   }
 
-  getImageStores() {
+  getImageStores = () => {
     const type = "registry";
     Network.get("/rhn/manager/api/cm/imagestores/type/" + type)
       .then((data) => {
@@ -105,9 +94,9 @@ class ImageImport extends React.Component {
         });
       })
       .catch(this.handleResponseError);
-  }
+  };
 
-  getBuildHosts() {
+  getBuildHosts = () => {
     Network.get("/rhn/manager/api/cm/build/hosts/container_build_host")
       .then((data) => {
         this.setState({
@@ -115,9 +104,9 @@ class ImageImport extends React.Component {
         });
       })
       .catch(this.handleResponseError);
-  }
+  };
 
-  getActivationKeys() {
+  getActivationKeys = () => {
     Network.get("/rhn/manager/api/cm/activationkeys")
       .then((data) => {
         this.setState({
@@ -125,7 +114,7 @@ class ImageImport extends React.Component {
         });
       })
       .catch(this.handleResponseError);
-  }
+  };
 
   getChannels(token) {
     if (!token) {
@@ -145,35 +134,35 @@ class ImageImport extends React.Component {
     });
   }
 
-  handleResponseError(jqXHR) {
+  handleResponseError = (jqXHR) => {
     this.setState({
       messages: Network.responseErrorMessage(jqXHR),
     });
-  }
+  };
 
-  getBounceUrl() {
+  getBounceUrl = () => {
     return encodeURIComponent("/rhn/manager/cm/import");
-  }
+  };
 
-  onFormChange(model) {
+  onFormChange = (model) => {
     this.setState({
       model: model,
     });
-  }
+  };
 
-  onValidate(isValid) {
+  onValidate = (isValid) => {
     this.setState({
       isInvalid: !isValid,
     });
-  }
+  };
 
-  clearFields() {
+  clearFields = () => {
     this.setState({
       model: emptyModel(),
     });
-  }
+  };
 
-  onImport() {
+  onImport = () => {
     const storeId: number = parseInt(this.state.model.storeId || "", 10);
     const buildHostId: number = parseInt(this.state.model.buildHostId || "", 10);
     if (
@@ -209,11 +198,11 @@ class ImageImport extends React.Component {
         messages: MessagesUtils.error("Not all required values present."),
       });
     }
-  }
+  };
 
-  handleActivationKeyChange(name, value) {
+  handleActivationKeyChange = (name, value) => {
     this.getChannels(value);
-  }
+  };
 
   renderActivationKeySelect() {
     const hint =

--- a/web/html/src/manager/images/image-profile-edit.tsx
+++ b/web/html/src/manager/images/image-profile-edit.tsx
@@ -66,18 +66,6 @@ class CreateImageProfile extends React.Component<Props, State> {
       customData: {},
     };
 
-    [
-      "handleTokenChange",
-      "handleImageTypeChange",
-      "handleImageStoreChange",
-      "isLabelValid",
-      "onUpdate",
-      "onCreate",
-      "onFormChange",
-      "onValidate",
-      "clearFields",
-    ].forEach((method) => (this[method] = this[method].bind(this)));
-
     this.getImageStores(typeMap[this.state.model.imageType].storeType);
     if (this.isEdit()) {
       this.setValues(window.profileId);
@@ -137,22 +125,22 @@ class CreateImageProfile extends React.Component<Props, State> {
     });
   }
 
-  handleTokenChange(name, value) {
+  handleTokenChange = (name, value) => {
     this.getChannels(value);
-  }
+  };
 
-  handleImageTypeChange(name, value) {
+  handleImageTypeChange = (name, value) => {
     const storeType = typeMap[value].storeType;
     this.getImageStores(storeType);
-  }
+  };
 
-  handleImageStoreChange(name, storeLabel) {
+  handleImageStoreChange = (name, storeLabel) => {
     Network.get("/rhn/manager/api/cm/imagestores/find/" + storeLabel).then((res) => {
       this.setState({
         storeUri: res.success && res.data.uri,
       });
     });
-  }
+  };
 
   addCustomData(label) {
     if (label) {
@@ -176,7 +164,7 @@ class CreateImageProfile extends React.Component<Props, State> {
     }
   }
 
-  isLabelValid(label) {
+  isLabelValid = (label) => {
     if (this.state.initLabel && this.state.initLabel === label) {
       // Initial state (on edit), always valid.
       return true;
@@ -189,9 +177,9 @@ class CreateImageProfile extends React.Component<Props, State> {
     return Network.get("/rhn/manager/api/cm/imageprofiles/find/" + label)
       .then((res) => !res.success && isValid)
       .catch(() => false);
-  }
+  };
 
-  onUpdate(model) {
+  onUpdate = (model) => {
     if (!this.isEdit()) {
       return false;
     }
@@ -215,9 +203,9 @@ class CreateImageProfile extends React.Component<Props, State> {
         });
       }
     });
-  }
+  };
 
-  onCreate(model) {
+  onCreate = (model) => {
     if (this.isEdit()) {
       return false;
     }
@@ -241,25 +229,25 @@ class CreateImageProfile extends React.Component<Props, State> {
         });
       }
     });
-  }
+  };
 
-  onFormChange(model) {
+  onFormChange = (model) => {
     this.setState({
       model: model,
     });
-  }
+  };
 
-  onValidate(isValid) {
+  onValidate = (isValid) => {
     this.setState({
       isInvalid: !isValid,
     });
-  }
+  };
 
-  clearFields() {
+  clearFields = () => {
     this.setState({
       model: Object.assign({}, this.defaultModel),
     });
-  }
+  };
 
   getImageStores(type) {
     return Network.get("/rhn/manager/api/cm/imagestores/type/" + type).then((data) => {

--- a/web/html/src/manager/images/image-profiles.tsx
+++ b/web/html/src/manager/images/image-profiles.tsx
@@ -42,9 +42,6 @@ type State = {
 class ImageProfiles extends React.Component<Props, State> {
   constructor(props) {
     super(props);
-    ["reloadData", "handleSelectItems", "selectProfile", "deleteProfiles"].forEach(
-      (method) => (this[method] = this[method].bind(this))
-    );
     this.state = {
       messages: [],
       imageprofiles: [],
@@ -63,26 +60,26 @@ class ImageProfiles extends React.Component<Props, State> {
     return true;
   }
 
-  reloadData() {
+  reloadData = () => {
     Network.get("/rhn/manager/api/cm/imageprofiles").then((data) => {
       this.setState({
         imageprofiles: data,
       });
     });
     this.clearMessages();
-  }
+  };
 
-  handleSelectItems(items) {
+  handleSelectItems = (items) => {
     this.setState({
       selectedItems: items,
     });
-  }
+  };
 
-  selectProfile(row) {
+  selectProfile = (row) => {
     this.setState({
       selected: row,
     });
-  }
+  };
 
   clearMessages() {
     this.setState({
@@ -90,7 +87,7 @@ class ImageProfiles extends React.Component<Props, State> {
     });
   }
 
-  deleteProfiles(idList) {
+  deleteProfiles = (idList) => {
     return Network.post("/rhn/manager/api/cm/imageprofiles/delete", idList).then((data) => {
       if (data.success) {
         this.setState({
@@ -119,7 +116,7 @@ class ImageProfiles extends React.Component<Props, State> {
         });
       }
     });
-  }
+  };
 
   isFiltered(criteria) {
     return criteria && criteria.length > 0;

--- a/web/html/src/manager/images/image-store-edit.tsx
+++ b/web/html/src/manager/images/image-store-edit.tsx
@@ -53,10 +53,6 @@ class CreateImageStore extends React.Component<Props, State> {
       messages: [],
     };
 
-    ["setValues", "isLabelUnique", "onUpdate", "onCreate", "onFormChange", "onValidate", "clearFields"].forEach(
-      (method) => (this[method] = this[method].bind(this))
-    );
-
     if (this.isEdit()) {
       this.setValues(window.storeId);
     }
@@ -66,7 +62,7 @@ class CreateImageStore extends React.Component<Props, State> {
     return window.storeId ? true : false;
   }
 
-  setValues(id) {
+  setValues = (id) => {
     Network.get("/rhn/manager/api/cm/imagestores/" + id).then((res) => {
       if (res.success) {
         var data = res.data;
@@ -78,9 +74,9 @@ class CreateImageStore extends React.Component<Props, State> {
         window.location.href = "/rhn/manager/cm/imagestores/create";
       }
     });
-  }
+  };
 
-  isLabelUnique(label) {
+  isLabelUnique = (label) => {
     if (this.state.initLabel && this.state.initLabel === label) {
       return true;
     }
@@ -88,9 +84,9 @@ class CreateImageStore extends React.Component<Props, State> {
     return Network.get("/rhn/manager/api/cm/imagestores/find/" + label)
       .then((res) => !res.success)
       .catch(() => false);
-  }
+  };
 
-  onUpdate(model) {
+  onUpdate = (model) => {
     if (!this.isEdit()) {
       return false;
     }
@@ -112,9 +108,9 @@ class CreateImageStore extends React.Component<Props, State> {
         });
       }
     });
-  }
+  };
 
-  onCreate(model) {
+  onCreate = (model) => {
     if (this.isEdit()) {
       return false;
     }
@@ -136,25 +132,25 @@ class CreateImageStore extends React.Component<Props, State> {
         });
       }
     });
-  }
+  };
 
-  onFormChange(model) {
+  onFormChange = (model) => {
     this.setState({
       model: model,
     });
-  }
+  };
 
-  onValidate(isValid) {
+  onValidate = (isValid) => {
     this.setState({
       isInvalid: !isValid,
     });
-  }
+  };
 
-  clearFields() {
+  clearFields = () => {
     this.setState({
       model: Object.assign({}, this.defaultModel),
     });
-  }
+  };
 
   renderTypeInputs(type) {
     switch (type) {

--- a/web/html/src/manager/images/image-stores.tsx
+++ b/web/html/src/manager/images/image-stores.tsx
@@ -42,9 +42,6 @@ type State = {
 class ImageStores extends React.Component<Props, State> {
   constructor(props) {
     super(props);
-    ["reloadData", "handleSelectItems", "selectStore", "deleteStores"].forEach(
-      (method) => (this[method] = this[method].bind(this))
-    );
     this.state = {
       messages: [],
       imagestores: [],
@@ -63,14 +60,14 @@ class ImageStores extends React.Component<Props, State> {
     return true;
   }
 
-  reloadData() {
+  reloadData = () => {
     Network.get("/rhn/manager/api/cm/imagestores").then((data) => {
       this.setState({
         imagestores: data,
       });
     });
     this.clearMessages();
-  }
+  };
 
   clearMessages() {
     this.setState({
@@ -78,19 +75,19 @@ class ImageStores extends React.Component<Props, State> {
     });
   }
 
-  handleSelectItems(items) {
+  handleSelectItems = (items) => {
     this.setState({
       selectedItems: items,
     });
-  }
+  };
 
-  selectStore(row) {
+  selectStore = (row) => {
     this.setState({
       selected: row,
     });
-  }
+  };
 
-  deleteStores(idList) {
+  deleteStores = (idList) => {
     return Network.post("/rhn/manager/api/cm/imagestores/delete", idList).then((data) => {
       if (data.success) {
         this.setState({
@@ -119,7 +116,7 @@ class ImageStores extends React.Component<Props, State> {
         });
       }
     });
-  }
+  };
 
   isFiltered(criteria) {
     return criteria && criteria.length > 0;

--- a/web/html/src/manager/images/image-view-patches.tsx
+++ b/web/html/src/manager/images/image-view-patches.tsx
@@ -37,12 +37,6 @@ type ImageViewPatchesProps = {
 };
 
 class ImageViewPatches extends React.Component<ImageViewPatchesProps> {
-  constructor(props) {
-    super(props);
-
-    ["renderType"].forEach((method) => (this[method] = this[method].bind(this)));
-  }
-
   searchData(row, criteria) {
     if (criteria) {
       return (
@@ -57,7 +51,7 @@ class ImageViewPatches extends React.Component<ImageViewPatchesProps> {
     return criteria && criteria.length > 0;
   }
 
-  renderType(row) {
+  renderType = (row) => {
     let icon = [<i key={row.type} className={typeIcons[row.type]} title={typeTitles[row.type]} />];
 
     for (let k of row.keywords) {
@@ -65,7 +59,7 @@ class ImageViewPatches extends React.Component<ImageViewPatchesProps> {
     }
 
     return icon;
-  }
+  };
 
   render() {
     const data = this.props.data;

--- a/web/html/src/manager/images/image-view.tsx
+++ b/web/html/src/manager/images/image-view.tsx
@@ -74,15 +74,6 @@ type ImageViewState = {
 class ImageView extends React.Component<ImageViewProps, ImageViewState> {
   constructor(props) {
     super(props);
-    [
-      "reloadData",
-      "handleBackAction",
-      "handleDetailsAction",
-      "deleteImages",
-      "inspectImage",
-      "buildImage",
-      "handleImportImage",
-    ].forEach((method) => (this[method] = this[method].bind(this)));
     this.state = {
       messages: [],
       images: [],
@@ -123,9 +114,9 @@ class ImageView extends React.Component<ImageViewProps, ImageViewState> {
     this.clearMessages();
   }
 
-  reloadData() {
+  reloadData = () => {
     this.updateView(this.state.selected ? this.state.selected.id : undefined, getHashTab());
-  }
+  };
 
   clearMessages() {
     this.setState({
@@ -133,15 +124,15 @@ class ImageView extends React.Component<ImageViewProps, ImageViewState> {
     });
   }
 
-  handleBackAction() {
+  handleBackAction = () => {
     return this.getImageInfoList().then(() => {
       const loc = window.location;
       window.history.pushState(null, "", loc.pathname + loc.search);
       this.clearMessages();
     });
-  }
+  };
 
-  handleDetailsAction(row) {
+  handleDetailsAction = (row) => {
     const tab = getHashTab() || "overview";
     this.getImageInfoDetails(row.id, tab).then(() => {
       window.history.pushState(null, "", "#/" + tab + "/" + row.id);
@@ -149,11 +140,11 @@ class ImageView extends React.Component<ImageViewProps, ImageViewState> {
     });
 
     this.setState({ selectedRuntime: undefined });
-  }
+  };
 
-  handleImportImage() {
+  handleImportImage = () => {
     Utils.urlBounce("/rhn/manager/cm/import");
-  }
+  };
 
   handleResponseError(jqXHR, arg = "") {
     const msg = Network.responseErrorMessage(jqXHR, (status, msg) => (msgMap[msg] ? t(msgMap[msg], arg) : null));
@@ -298,7 +289,7 @@ class ImageView extends React.Component<ImageViewProps, ImageViewState> {
     return detailsPromise;
   }
 
-  deleteImages(idList) {
+  deleteImages = (idList) => {
     return Network.post("/rhn/manager/api/cm/images/delete", idList)
       .then(() => {
         // Waits for the 'Back' action if not in the list page
@@ -312,9 +303,9 @@ class ImageView extends React.Component<ImageViewProps, ImageViewState> {
         );
       })
       .catch(this.handleResponseError);
-  }
+  };
 
-  inspectImage(id: unknown, earliest: moment.Moment) {
+  inspectImage = (id: unknown, earliest: moment.Moment) => {
     return Network.post("/rhn/manager/api/cm/images/inspect/" + id, { imageId: id, earliest })
       .then(() => {
         this.reloadData();
@@ -323,9 +314,9 @@ class ImageView extends React.Component<ImageViewProps, ImageViewState> {
         });
       })
       .catch(this.handleResponseError);
-  }
+  };
 
-  buildImage(profile, version, host, earliest) {
+  buildImage = (profile, version, host, earliest) => {
     return Network.post("/rhn/manager/api/cm/build/" + profile, {
       version: version,
       buildHostId: host,
@@ -339,7 +330,7 @@ class ImageView extends React.Component<ImageViewProps, ImageViewState> {
         });
       })
       .catch(this.handleResponseError);
-  }
+  };
 
   render() {
     const panelButtons = (
@@ -434,10 +425,6 @@ type ImageViewListState = {
 class ImageViewList extends React.Component<ImageViewListProps, ImageViewListState> {
   constructor(props) {
     super(props);
-
-    ["selectImage", "handleSelectItems", "renderRuntimeIcon", "renderInstances"].forEach(
-      (method) => (this[method] = this[method].bind(this))
-    );
     this.state = {
       selectedItems: [],
       instancePopupContent: {},
@@ -459,18 +446,18 @@ class ImageViewList extends React.Component<ImageViewListProps, ImageViewListSta
     return criteria && criteria.length > 0;
   }
 
-  selectImage(row) {
+  selectImage = (row) => {
     this.setState({
       selected: row,
     });
-  }
+  };
 
-  handleSelectItems(items) {
+  handleSelectItems = (items) => {
     this.setState({
       selectedItems: items,
     });
     this.props.onSelectCount(items.length);
-  }
+  };
 
   renderUpdatesIcon(row) {
     let icon;
@@ -511,7 +498,7 @@ class ImageViewList extends React.Component<ImageViewListProps, ImageViewListSta
     return icon;
   }
 
-  renderRuntimeIcon(row) {
+  renderRuntimeIcon = (row) => {
     if (!this.props.gotRuntimeInfo) {
       return <i className="fa fa-circle-o-notch fa-spin fa-1-5x" title={t("Waiting for update ...")} />;
     }
@@ -531,7 +518,7 @@ class ImageViewList extends React.Component<ImageViewListProps, ImageViewListSta
     }
 
     return icon;
-  }
+  };
 
   renderInstanceDetails(row) {
     if (!this.props.gotRuntimeInfo) {
@@ -560,7 +547,7 @@ class ImageViewList extends React.Component<ImageViewListProps, ImageViewListSta
     );
   }
 
-  renderInstances(row) {
+  renderInstances = (row) => {
     if (!this.props.gotRuntimeInfo) {
       return <i className="fa fa-circle-o-notch fa-spin fa-1-5x" title={t("Waiting for update ...")} />;
     }
@@ -593,7 +580,7 @@ class ImageViewList extends React.Component<ImageViewListProps, ImageViewListSta
         />
       </span>
     );
-  }
+  };
 
   render() {
     let runtimeColumns: React.ReactNode[] = [];
@@ -753,22 +740,17 @@ type ImageViewDetailsProps = {
 };
 
 class ImageViewDetails extends React.Component<ImageViewDetailsProps> {
-  constructor(props) {
-    super(props);
-    ["onTabChange"].forEach((method) => (this[method] = this[method].bind(this)));
-  }
-
   getHashUrls(tabs) {
     const id = this.props.data.id;
     return tabs.map((t) => "#/" + t + "/" + id);
   }
 
-  onTabChange(hash) {
+  onTabChange = (hash) => {
     window.history.pushState(null, "", hash);
     if (this.props.onTabChange) {
       this.props.onTabChange(hash);
     }
-  }
+  };
 
   render() {
     const data = this.props.data;

--- a/web/html/src/manager/salt/cmd/remote-commands.tsx
+++ b/web/html/src/manager/salt/cmd/remote-commands.tsx
@@ -135,10 +135,6 @@ type RemoteCommandState = {
 class RemoteCommand extends React.Component<RemoteCommandProps, RemoteCommandState> {
   constructor(props) {
     super(props);
-    ["onPreview", "onRun", "onStop", "commandChanged", "targetChanged", "commandResult", "onBeforeUnload"].forEach(
-      (method) => (this[method] = this[method].bind(this))
-    );
-
     this.state = {
       command: "ls -lha",
       target: "*",
@@ -273,7 +269,7 @@ class RemoteCommand extends React.Component<RemoteCommandProps, RemoteCommandSta
     );
   }
 
-  onPreview() {
+  onPreview = () => {
     const deferred = jQuery.Deferred();
     this.state.websocket.send(
       JSON.stringify({
@@ -290,9 +286,9 @@ class RemoteCommand extends React.Component<RemoteCommandProps, RemoteCommandSta
       },
     });
     return deferred;
-  }
+  };
 
-  onRun() {
+  onRun = () => {
     const deferred = jQuery.Deferred();
     this.state.websocket.send(
       JSON.stringify({
@@ -307,21 +303,21 @@ class RemoteCommand extends React.Component<RemoteCommandProps, RemoteCommandSta
       ran: deferred,
     });
     return deferred;
-  }
+  };
 
-  onStop() {
+  onStop = () => {
     this.state.websocket.send(
       JSON.stringify({
         cancel: true,
       })
     );
-  }
+  };
 
-  onBeforeUnload(event) {
+  onBeforeUnload = (event) => {
     this.setState({
       pageUnloading: true,
     });
-  }
+  };
 
   componentDidMount() {
     var port = window.location.port;
@@ -531,21 +527,21 @@ class RemoteCommand extends React.Component<RemoteCommandProps, RemoteCommandSta
     window.removeEventListener("beforeunload", this.onBeforeUnload);
   }
 
-  targetChanged(event) {
+  targetChanged = (event) => {
     this.setState({
       target: event.target.value,
       previewed: jQuery.Deferred(),
       ran: jQuery.Deferred().resolve(),
     });
-  }
+  };
 
-  commandChanged(event) {
+  commandChanged = (event) => {
     this.setState({
       command: event.target.value,
     });
-  }
+  };
 
-  commandResult(result) {
+  commandResult = (result) => {
     const elements: React.ReactNode[] = [];
     for (var kv of result.minions) {
       const id = kv[0];
@@ -572,7 +568,7 @@ class RemoteCommand extends React.Component<RemoteCommandProps, RemoteCommandSta
       );
     }
     return <div>{elements}</div>;
-  }
+  };
 }
 
 export const renderer = (id) => SpaRenderer.renderNavigationReact(<RemoteCommand />, document.getElementById(id));

--- a/web/html/src/manager/salt/cmd/remote-commands.tsx
+++ b/web/html/src/manager/salt/cmd/remote-commands.tsx
@@ -19,10 +19,9 @@ class MinionResultView extends React.Component<MinionResultViewProps, MinionResu
     this.state = {
       open: false,
     };
-    ["onClick"].forEach((method) => (this[method] = this[method].bind(this)));
   }
 
-  onClick() {
+  onClick = () => {
     if (
       this.props.result !== "pending" &&
       this.props.result !== "timedOut" &&
@@ -31,7 +30,7 @@ class MinionResultView extends React.Component<MinionResultViewProps, MinionResu
     ) {
       this.setState({ open: !this.state.open });
     }
-  }
+  };
 
   render() {
     const id = this.props.id;

--- a/web/html/src/manager/salt/keys/key-management.tsx
+++ b/web/html/src/manager/salt/keys/key-management.tsx
@@ -97,7 +97,6 @@ type State = {
 class KeyManagement extends React.Component<Props, State> {
   constructor(props) {
     super(props);
-    ["searchData", "rowKey", "reloadKeys"].forEach((method) => (this[method] = this[method].bind(this)));
     this.state = {
       keys: [],
       isOrgAdmin: false,
@@ -106,7 +105,7 @@ class KeyManagement extends React.Component<Props, State> {
     this.reloadKeys();
   }
 
-  reloadKeys() {
+  reloadKeys = () => {
     this.setState({ loading: true });
     return listKeys().then((data) => {
       this.setState({
@@ -115,13 +114,13 @@ class KeyManagement extends React.Component<Props, State> {
         loading: false,
       });
     });
-  }
+  };
 
-  rowKey(rowData) {
+  rowKey = (rowData) => {
     return rowData.id;
-  }
+  };
 
-  searchData(datum, criteria) {
+  searchData = (datum, criteria) => {
     if (criteria) {
       return (
         datum.id.toLocaleLowerCase().includes(criteria.toLocaleLowerCase()) ||
@@ -129,7 +128,7 @@ class KeyManagement extends React.Component<Props, State> {
       );
     }
     return true;
-  }
+  };
 
   isFiltered(criteria) {
     return criteria && criteria.length > 0;

--- a/web/html/src/manager/state/recurring-states.tsx
+++ b/web/html/src/manager/state/recurring-states.tsx
@@ -66,16 +66,6 @@ type State = {
 class RecurringStates extends React.Component<Props, State> {
   constructor(props) {
     super(props);
-
-    [
-      "deleteSchedule",
-      "handleForwardAction",
-      "handleDetailsAction",
-      "handleEditAction",
-      "handleResponseError",
-      "updateSchedule",
-      "toggleActive",
-    ].forEach((method) => (this[method] = this[method].bind(this)));
     this.state = {
       messages: [],
       schedules: [],
@@ -124,24 +114,24 @@ class RecurringStates extends React.Component<Props, State> {
     this.setState({ selected: row, action: action });
   }
 
-  handleDetailsAction(row) {
+  handleDetailsAction = (row) => {
     this.getScheduleDetails(row, "details");
     window.history.pushState(null, "", "#/details/" + row.recurringActionId);
-  }
+  };
 
-  handleEditAction(row) {
+  handleEditAction = (row) => {
     this.getScheduleDetails(row, "edit");
     window.history.pushState(null, "", "#/edit/" + row.recurringActionId);
-  }
+  };
 
-  toggleActive(schedule) {
+  toggleActive = (schedule) => {
     Object.assign(schedule, {
       active: !schedule.active,
     });
     this.updateSchedule(schedule);
-  }
+  };
 
-  updateSchedule(schedule) {
+  updateSchedule = (schedule) => {
     return Network.post("/rhn/manager/api/recurringactions/save", schedule)
       .then((_) => {
         const successMsg = (
@@ -160,9 +150,9 @@ class RecurringStates extends React.Component<Props, State> {
         this.handleForwardAction();
       })
       .catch(this.handleResponseError);
-  }
+  };
 
-  deleteSchedule(item) {
+  deleteSchedule = (item) => {
     return Network.del("/rhn/manager/api/recurringactions/" + item.recurringActionId + "/delete")
       .then((_) => {
         this.setState({
@@ -177,7 +167,7 @@ class RecurringStates extends React.Component<Props, State> {
           messages: messages,
         });
       });
-  }
+  };
 
   handleForwardAction = (action?: string) => {
     const loc = window.location;

--- a/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
+++ b/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
@@ -64,104 +64,86 @@ class BootstrapMinions extends React.Component<Props, State> {
     };
 
     this.state = this.initState;
-
-    [
-      "hostChanged",
-      "portChanged",
-      "userChanged",
-      "authMethodChanged",
-      "passwordChanged",
-      "privKeyPwdChanged",
-      "privKeyFileChanged",
-      "privKeyLoaded",
-      "onBootstrap",
-      "ignoreHostKeysChanged",
-      "manageWithSSHChanged",
-      "activationKeyChanged",
-      "reactivationKeyChanged",
-      "clearFields",
-      "proxyChanged",
-    ].forEach((method) => (this[method] = this[method].bind(this)));
   }
 
-  hostChanged(event) {
+  hostChanged = (event) => {
     this.setState({
       host: event.target.value,
     });
-  }
+  };
 
-  portChanged(event) {
+  portChanged = (event) => {
     this.setState({
       port: event.target.value,
     });
-  }
+  };
 
-  userChanged(event) {
+  userChanged = (event) => {
     this.setState({
       user: event.target.value,
     });
-  }
+  };
 
-  authMethodChanged(event) {
+  authMethodChanged = (event) => {
     this.setState({
       authMethod: event.target.value,
     });
-  }
+  };
 
-  passwordChanged(event) {
+  passwordChanged = (event) => {
     this.setState({
       password: event.target.value,
     });
-  }
+  };
 
-  privKeyFileChanged(event) {
+  privKeyFileChanged = (event) => {
     this.setState({
       privKeyLoading: true,
     });
     const reader = new FileReader();
     reader.onload = (e) => this.privKeyLoaded(e.target?.result);
     reader.readAsText(event.target.files[0]);
-  }
+  };
 
-  privKeyLoaded(keyString) {
+  privKeyLoaded = (keyString) => {
     this.setState({
       // replace CRLF from Windows
       privKey: keyString.replace(/\r\n/g, "\n"),
       privKeyLoading: false,
     });
-  }
+  };
 
-  privKeyPwdChanged(event) {
+  privKeyPwdChanged = (event) => {
     this.setState({
       privKeyPwd: event.target.value,
     });
-  }
+  };
 
-  ignoreHostKeysChanged(event) {
+  ignoreHostKeysChanged = (event) => {
     this.setState({
       ignoreHostKeys: event.target.checked,
     });
-  }
+  };
 
-  manageWithSSHChanged(event) {
+  manageWithSSHChanged = (event) => {
     this.setState({
       manageWithSSH: event.target.checked,
     });
-  }
+  };
 
-  activationKeyChanged(event) {
+  activationKeyChanged = (event) => {
     this.setState({
       activationKey: event.target.value,
     });
-  }
+  };
 
-  reactivationKeyChanged(event) {
+  reactivationKeyChanged = (event) => {
     this.setState({
       reactivationKey: event.target.value,
     });
-  }
+  };
 
-  proxyChanged(event) {
+  proxyChanged = (event) => {
     var proxyId = event.target.value;
     var proxy = this.props.proxies.find((p) => DEPRECATED_unsafeEquals(p.id, proxyId));
     var showWarn = proxy && proxy.hostname.indexOf(".") < 0;
@@ -169,9 +151,9 @@ class BootstrapMinions extends React.Component<Props, State> {
       proxy: event.target.value,
       showProxyHostnameWarn: showWarn,
     });
-  }
+  };
 
-  onBootstrap() {
+  onBootstrap = () => {
     this.setState({ messages: [], loading: true });
     var formData: any = {};
     formData["host"] = this.state.host.trim();
@@ -229,11 +211,11 @@ class BootstrapMinions extends React.Component<Props, State> {
       }
     );
     return request;
-  }
+  };
 
-  clearFields() {
+  clearFields = () => {
     this.setState(this.initState);
-  }
+  };
 
   render() {
     var messages: React.ReactNode = null;

--- a/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-details.tsx
+++ b/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-details.tsx
@@ -25,18 +25,16 @@ type State = {
 class VirtualHostManagerDetails extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
-
-    ["onRefresh", "handleResponseError"].forEach((method) => (this[method] = this[method].bind(this)));
     this.state = {
       messages: [],
     };
   }
 
-  handleResponseError(jqXHR) {
+  handleResponseError = (jqXHR) => {
     this.setState({
       messages: Network.responseErrorMessage(jqXHR),
     });
-  }
+  };
 
   UNSAFE_componentWillMount() {
     Network.get("/rhn/manager/api/vhms/" + this.props.data.id + "/nodes")
@@ -46,7 +44,7 @@ class VirtualHostManagerDetails extends React.Component<Props, State> {
       .catch(this.handleResponseError);
   }
 
-  onRefresh() {
+  onRefresh = () => {
     return Network.post("/rhn/manager/api/vhms/" + this.props.data.id + "/refresh", this.props.data.id)
       .then((data) => {
         if (data.success) {
@@ -60,7 +58,7 @@ class VirtualHostManagerDetails extends React.Component<Props, State> {
         }
       })
       .catch(this.handleResponseError);
-  }
+  };
 
   render() {
     return (

--- a/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-edit.tsx
+++ b/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-edit.tsx
@@ -37,21 +37,6 @@ class VirtualHostManagerEdit extends React.Component<Props, State> {
       messages: [],
     };
 
-    [
-      "onFormChange",
-      "onValidate",
-      "clearFields",
-      "renderForm",
-      "onCreate",
-      "onUpdate",
-      "renderKubernetesForm",
-      "renderModuleParamsForm",
-      "handleKubeconfigUpload",
-      "bindForm",
-      "setKubeconfigContexts",
-      "handleResponseError",
-    ].forEach((method) => (this[method] = this[method].bind(this)));
-
     if (this.isEdit()) {
       this.setValues(this.props.item);
     }
@@ -65,11 +50,11 @@ class VirtualHostManagerEdit extends React.Component<Props, State> {
       .catch(this.handleResponseError);
   }
 
-  handleResponseError(jqXHR) {
+  handleResponseError = (jqXHR) => {
     this.setState({
       messages: Network.responseErrorMessage(jqXHR),
     });
-  }
+  };
 
   setValues(item) {
     var m: any = {};
@@ -89,7 +74,7 @@ class VirtualHostManagerEdit extends React.Component<Props, State> {
     Object.assign(this.state, { model: m });
   }
 
-  setKubeconfigContexts(id) {
+  setKubeconfigContexts = (id) => {
     Network.get("/rhn/manager/api/vhms/kubeconfig/" + id + "/contexts")
       .then((data) => {
         this.setState({
@@ -97,13 +82,13 @@ class VirtualHostManagerEdit extends React.Component<Props, State> {
         });
       })
       .catch(this.handleResponseError);
-  }
+  };
 
   isEdit() {
     return this.props.item ? true : false;
   }
 
-  onUpdate(model) {
+  onUpdate = (model) => {
     if (!this.isEdit()) {
       return false;
     }
@@ -133,9 +118,9 @@ class VirtualHostManagerEdit extends React.Component<Props, State> {
         Utils.urlBounce("/rhn/manager/vhms");
       })
       .catch(this.handleResponseError);
-  }
+  };
 
-  onCreate(model) {
+  onCreate = (model) => {
     if (this.isEdit()) {
       return false;
     }
@@ -165,15 +150,15 @@ class VirtualHostManagerEdit extends React.Component<Props, State> {
         Utils.urlBounce("/rhn/manager/vhms");
       })
       .catch(this.handleResponseError);
-  }
+  };
 
-  onFormChange(model) {
+  onFormChange = (model) => {
     this.setState({
       model: model,
     });
-  }
+  };
 
-  onValidate(isValid) {
+  onValidate = (isValid) => {
     if (this.props.type.toLowerCase() === "kubernetes" && !this.isEdit()) {
       this.setState({
         isInvalid: !isValid || !this.state.validKubeconfig,
@@ -183,13 +168,13 @@ class VirtualHostManagerEdit extends React.Component<Props, State> {
         isInvalid: !isValid,
       });
     }
-  }
+  };
 
-  clearFields() {
+  clearFields = () => {
     this.setState({
       model: {},
     });
-  }
+  };
 
   renderButtons() {
     var buttons = [
@@ -273,7 +258,7 @@ class VirtualHostManagerEdit extends React.Component<Props, State> {
     }
   }
 
-  renderModuleParamsForm() {
+  renderModuleParamsForm = () => {
     if (!this.state.vhmParams) {
       return null;
     }
@@ -285,9 +270,9 @@ class VirtualHostManagerEdit extends React.Component<Props, State> {
       <Text name="gathererModule" label={t("Gatherer module")} disabled labelClass="col-md-3" divClass="col-md-6" />
     );
     return <div>{fields}</div>;
-  }
+  };
 
-  handleKubeconfigUpload(event) {
+  handleKubeconfigUpload = (event) => {
     let kubeconfig = event.target.files[0];
     let formData = new FormData();
     formData.append("kubeconfig", kubeconfig);
@@ -315,9 +300,9 @@ class VirtualHostManagerEdit extends React.Component<Props, State> {
         });
         this.handleResponseError(jqXHR);
       });
-  }
+  };
 
-  renderKubernetesForm() {
+  renderKubernetesForm = () => {
     var contextSelect;
     if (this.state.model.contexts) {
       contextSelect = (
@@ -345,19 +330,19 @@ class VirtualHostManagerEdit extends React.Component<Props, State> {
         {contextSelect}
       </div>
     );
-  }
+  };
 
-  renderForm() {
+  renderForm = () => {
     if (this.props.type.toLowerCase() === "kubernetes") {
       return this.renderKubernetesForm();
     } else if (this.props.type) {
       return this.renderModuleParamsForm();
     }
-  }
+  };
 
-  bindForm(form: HTMLFormElement) {
+  bindForm = (form: HTMLFormElement) => {
     this.form = form;
-  }
+  };
 
   render() {
     return (

--- a/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager.tsx
+++ b/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager.tsx
@@ -45,16 +45,6 @@ type State = {
 class VirtualHostManager extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
-
-    [
-      "deleteSelected",
-      "deleteVhm",
-      "handleBackAction",
-      "handleDetailsAction",
-      "handleEditAction",
-      "handleResponseError",
-      "getAvailableModules",
-    ].forEach((method) => (this[method] = this[method].bind(this)));
     this.state = {
       vhms: [],
       messages: [],
@@ -81,11 +71,11 @@ class VirtualHostManager extends React.Component<Props, State> {
     this.clearMessages();
   }
 
-  handleResponseError(jqXHR) {
+  handleResponseError = (jqXHR) => {
     this.setState({
       messages: Network.responseErrorMessage(jqXHR),
     });
-  }
+  };
 
   clearMessages() {
     this.setState({
@@ -103,17 +93,17 @@ class VirtualHostManager extends React.Component<Props, State> {
       .catch(this.handleResponseError);
   }
 
-  getAvailableModules() {
+  getAvailableModules = () => {
     return Network.get("/rhn/manager/api/vhms/modules")
       .then((data) => this.setState({ availableModules: data }))
       .catch(this.handleResponseError);
-  }
+  };
 
-  deleteSelected() {
+  deleteSelected = () => {
     this.deleteVhm(this.state.selected);
-  }
+  };
 
-  deleteVhm(item) {
+  deleteVhm = (item) => {
     if (!item) return false;
     return Network.del("/rhn/manager/api/vhms/delete/" + item.id)
       .then((data) => {
@@ -123,34 +113,34 @@ class VirtualHostManager extends React.Component<Props, State> {
         });
       })
       .catch(this.handleResponseError);
-  }
+  };
 
   getCreateType() {
     const types = ["file", "vmware", "kubernetes", "amazonec2", "googlece", "azure", "nutanixahv"];
     return types.includes(this.state.id) ? this.state.id : types[0];
   }
 
-  handleBackAction() {
+  handleBackAction = () => {
     this.getVhmList().then((data) => {
       const loc = window.location;
       window.history.pushState(null, "", loc.pathname + loc.search);
     });
     this.getAvailableModules();
-  }
+  };
 
-  handleDetailsAction(row) {
+  handleDetailsAction = (row) => {
     this.getVhmDetails(row.id).then((data) => {
       this.setState({ selected: data.data, action: "details" });
       window.history.pushState(null, "", "#/details/" + row.id);
     });
-  }
+  };
 
-  handleEditAction(row) {
+  handleEditAction = (row) => {
     this.getVhmDetails(row.id).then((data) => {
       this.setState({ selected: data.data, action: "edit" });
       window.history.pushState(null, "", "#/edit/" + row.id);
     });
-  }
+  };
 
   getPanelTitle() {
     const action = this.state.action;


### PR DESCRIPTION
## What does this PR change?

A common anti-pattern that we have is a string-based method binding loop in constructors. This is unnecessary and only makes the constructor very verbose. Most of these methods don't actually even need to be bound, but currently I went for the functionally equivalent option so I don't have to manually test every method that's affected.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
