### PR TITLE
Fix stripping module metadata when cloning channels in CLM (bsc#1193008)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/channel/CloneChannelCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/CloneChannelCommand.java
@@ -15,6 +15,7 @@
 
 package com.redhat.rhn.manager.channel;
 
+import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelArch;
 import com.redhat.rhn.domain.channel.ChannelFactory;
@@ -117,6 +118,9 @@ public class CloneChannelCommand extends CreateChannelCommand {
         c = ChannelFactory.reload(c);
 
         if (stripModularMetadata) {
+            if (c.getModules() != null) {
+                HibernateFactory.getSession().delete(c.getModules());
+            }
             c.setModules(null);
         }
         else {

--- a/java/code/src/com/redhat/rhn/manager/channel/test/CloneChannelCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/CloneChannelCommandTest.java
@@ -80,6 +80,27 @@ public class CloneChannelCommandTest extends BaseTestCaseWithUser {
         assertFalse(originalModules.getId().equals(cloneModules.getId()));
     }
 
+    /**
+     * Test cloning a modular channel as a regular channel, stripping modular metadata
+     */
+    public void testStripModularMetadata() throws Exception {
+        Channel original = createBaseChannel();
+        Modules modules = new Modules();
+        modules.setChannel(original);
+        modules.setRelativeFilename("blablafilename");
+        original.setModules(modules);
+        assertTrue(original.isModular());
+
+        CloneChannelCommand ccc = new CloneChannelCommand(CloneChannelCommand.CloneBehavior.ORIGINAL_STATE, original);
+        ccc.setUser(user);
+        ccc.setStripModularMetadata(true);
+        Channel c = ccc.create();
+        c = ChannelFactory.reload(c);
+
+        assertFalse(c.isModular());
+    }
+
+
     private Channel createBaseChannel() throws Exception {
         Channel channel = ChannelTestUtils.createBaseChannel(user);
         channel.setChecksumType(ChannelFactory.findChecksumTypeByLabel("sha256"));

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix stripping module metadata when cloning channels in CLM (bsc#1193008)
 - Migrate the displaying of the date/time to rhn:formatDate
 - Suggest Product Migration when patch for CVE is in a successor Product (bsc#1191360)
 - Add route for virtual systems ReactJS page


### PR DESCRIPTION
When cloning a channel via CLM, a DB trigger copies comps entries on insert. This PR removes the `modules.yaml` entry correctly when it should be removed.

https://bugzilla.suse.com/show_bug.cgi?id=1193008

Port of https://github.com/SUSE/spacewalk/pull/16447

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
