### PR TITLE
Fix issues to work with latest "urlgrabber" version 4.1.0

### DIFF
--- a/backend/satellite_tools/download.py
+++ b/backend/satellite_tools/download.py
@@ -115,7 +115,7 @@ class PyCurlFileObjectThread(PyCurlFileObject):
         (url, parts) = opts.urlparser.parse(url, opts)
         (scheme, host, path, parm, query, frag) = parts
         opts.find_proxy(url, scheme)
-        super().__init__(str(url), filename, opts)
+        super().__init__(url, filename, opts)
 
     def _do_open(self):
         self.curl_obj = self.curl_cache

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Fix issues to work with latest urlgrabber version 4.1
 - Retrieve and store copyright information about patches
 - Unify decompression of metadata with uyuni.common.fileutils
 - Fix yum reposync plugin for Fedora 33-35 repos

--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -234,7 +234,7 @@ BuildRequires:  systemd-rpm-macros
 
 Requires:       python3-rhn-client-tools
 Requires:       python3-solv
-Requires:       python3-urlgrabber < 4
+Requires:       python3-urlgrabber >= 4
 Requires:       spacewalk-admin >= 0.1.1-0
 Requires:       spacewalk-certs-tools
 Requires:       susemanager-tools


### PR DESCRIPTION
## What does this PR change?

This PR fixes a small issue that prevents "spacewalk-repo-sync" to properly work with latest `urlgrabber` version 4.1.0.

This PR requires:

- https://build.opensuse.org/request/show/942105 (Uyuni)
- https://build.suse.de/request/show/261056 (SUMA Head)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/10749

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
