### PR TITLE
Avoid using RPM tags when filtering modular packages in CLM (bsc#1192487)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
@@ -27,7 +27,6 @@ import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.CONTAINS_
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.CONTAINS_PKG_NAME;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.CONTAINS_PROVIDES_NAME;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.EQUALS;
-import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.EXISTS;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.GREATER;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.GREATEREQ;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.LOWER;
@@ -100,7 +99,6 @@ public class FilterCriteria {
         validCombinations.add(Triple.of(ERRATUM, CONTAINS_PKG_GE_EVR, "package_nevr"));
         validCombinations.add(Triple.of(ERRATUM, CONTAINS_PKG_GT_EVR, "package_nevr"));
         validCombinations.add(Triple.of(MODULE, EQUALS, "module_stream"));
-        validCombinations.add(Triple.of(PACKAGE, EXISTS, "module_stream"));
         validCombinations.add(Triple.of(PACKAGE, PROVIDES_NAME, "provides_name"));
         validCombinations.add(Triple.of(ERRATUM, CONTAINS_PROVIDES_NAME, "package_provides_name"));
     }
@@ -123,7 +121,6 @@ public class FilterCriteria {
         GREATER("greater"),
         GREATEREQ("greatereq"),
         MATCHES("matches"),
-        EXISTS("exists"),
         PROVIDES_NAME("provides_name"),
         CONTAINS_PROVIDES_NAME("contains_provides_name");
 

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
@@ -18,8 +18,6 @@ package com.redhat.rhn.domain.contentmgmt;
 import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.rhnpackage.PackageEvr;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.Optional;
 import java.util.regex.Pattern;
 
@@ -64,8 +62,6 @@ public class PackageFilter extends ContentFilter<Package> {
                     pattern = Pattern.compile(value);
                 }
                 return pattern.matcher(getField(pack, field, String.class)).matches();
-            case EXISTS:
-                return StringUtils.isNotEmpty(getField(pack, field, String.class));
             case PROVIDES_NAME:
                 return pack.getProvides().stream()
                         .map(p -> p.getCapability().getName())
@@ -85,8 +81,6 @@ public class PackageFilter extends ContentFilter<Package> {
                 //Case for null epoch: Module metadata reports epoch as '0' even if there's none. We need to match it.
                 // pack.getNameEvra() omits the epoch if null so instead, pack.getNevraWithEpoch() is used here.
                 return type.cast(pack.getNevraWithEpoch());
-            case "module_stream":
-                return type.cast(pack.getExtraTag("modularitylabel"));
             default:
                 throw new UnsupportedOperationException("Field " + field + " not supported");
         }

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/DependencyResolver.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/DependencyResolver.java
@@ -50,7 +50,7 @@ import java.util.stream.Stream;
  * current module selection. In return, all module filters are translated into a collection of package filters by the
  * following rules:
  *
- * 1. All modular packages are denied (deny by existence of 'modularitylabel' rpm header)
+ * 1. All modular packages are denied (deny by nevra)
  * 2. For each package publicly provided by a module, all the packages from other sources with the same package name
  *    are denied. As a result, a specific package is only provided exclusively by the module to prevent any conflicts
  *    (deny by name).
@@ -135,10 +135,15 @@ public class DependencyResolver {
 
         List<Module> resolvedModules = modPkgList.getSelected().stream().map(Module::new).collect(Collectors.toList());
 
-        List<ContentFilter> outFilters = new ArrayList<>();
-
         // 1. Modular packages to be denied
-        outFilters.add(initFilter(FilterCriteria.Matcher.EXISTS, ContentFilter.Rule.DENY, "module_stream", null));
+        Stream<PackageFilter> pkgDenyFilters;
+        try {
+            pkgDenyFilters = modulemdApi.getAllPackages(sources).stream()
+                    .map(nevra -> initFilterFromPackageNevra(nevra, ContentFilter.Rule.DENY));
+        }
+        catch (ModulemdApiException e) {
+            throw new DependencyResolutionException("Failed to resolve modular dependencies.", e);
+        }
 
         // 2. Non-modular packages to be denied by name
         Stream<PackageFilter> providedRpmApiFilters = modPkgList.getRpmApis().stream()
@@ -146,16 +151,15 @@ public class DependencyResolver {
 
         // 3. Modular packages to be allowed
         Stream<PackageFilter> pkgAllowFilters = modPkgList.getRpmPackages().stream()
-                .map(DependencyResolver::initFilterFromPackageNevra);
+                .map(nevra -> initFilterFromPackageNevra(nevra, ContentFilter.Rule.ALLOW));
 
         // Concatenate filter streams into the list
-        outFilters.addAll(Stream.of(providedRpmApiFilters, pkgAllowFilters).flatMap(s -> s).collect(toList()));
-
-        return new DependencyResolutionResult(outFilters, resolvedModules);
+        return new DependencyResolutionResult(Stream.of(pkgDenyFilters, providedRpmApiFilters, pkgAllowFilters)
+                .flatMap(s -> s).collect(toList()), resolvedModules);
     }
 
-    private static PackageFilter initFilterFromPackageNevra(String nevra) {
-        return initFilter(FilterCriteria.Matcher.EQUALS, ContentFilter.Rule.ALLOW, "nevra", nevra);
+    private static PackageFilter initFilterFromPackageNevra(String nevra, ContentFilter.Rule rule) {
+        return initFilter(FilterCriteria.Matcher.EQUALS, rule, "nevra", nevra);
     }
 
     private static PackageFilter initFilterFromPackageName(String name) {

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/DependencyResolverTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/DependencyResolverTest.java
@@ -41,7 +41,6 @@ import com.redhat.rhn.testing.BaseTestCaseWithUser;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 public class DependencyResolverTest extends BaseTestCaseWithUser {
@@ -141,7 +140,7 @@ public class DependencyResolverTest extends BaseTestCaseWithUser {
      * Expected result from the sample data in MockModulemdApi:
      * 5 ALLOW nevra filters for modular packages of the selected modules (postgresql:10, perl:5.24)
      * 3 DENY name filters for postgresql:10 provided apis (postgresql, postgresql-server, perl)
-     * 1 DENY RPM header filter for all modular packages
+     * 7 DENY nevra filters for all modular packages
      *
      * @see DependencyResolver#resolveModularDependencies
      */
@@ -159,7 +158,7 @@ public class DependencyResolverTest extends BaseTestCaseWithUser {
 
         // The original module filters must be absent
         List<ContentFilter> filters = result.getFilters();
-        assertEquals(9, filters.size());
+        assertEquals(15, filters.size());
         assertTrue(filters.stream().noneMatch(filter1::equals));
         assertTrue(filters.stream().noneMatch(filter2::equals));
 
@@ -178,9 +177,10 @@ public class DependencyResolverTest extends BaseTestCaseWithUser {
         // For the enabled module, all other packages with the same name should be filtered out from different sources
         moduleData.getRpmApis().forEach(a -> assertTrue(filters.stream().anyMatch(f -> isDenyNameMatches(f, a))));
 
-        // DENY filter for all modular packages
+        // DENY filters for all modular packages
         // Deny-all rule for all modular packages (are overridden by ALLOW filters for the selected modules)
-        assertTrue(filters.stream().anyMatch(this::isDenyModuleStreamExists));
+        api.getAllPackages(singletonList(modularChannel))
+                .forEach(p -> assertTrue(filters.stream().anyMatch(f -> isDenyNevraEquals(f, p))));
     }
 
     /**
@@ -194,7 +194,7 @@ public class DependencyResolverTest extends BaseTestCaseWithUser {
 
         List<ContentFilter> result = resolver.resolveFilters(singletonList(filter)).getFilters();
 
-        assertEquals(4, result.size());
+        assertEquals(10, result.size());
         // There should be one and only one "perl" api filter
         assertEquals(1, result.stream().filter(f -> isDenyNameMatches(f, "perl")).count());
         // There should be allow filters for both versions
@@ -266,8 +266,8 @@ public class DependencyResolverTest extends BaseTestCaseWithUser {
         return isFilterOfType(f, ALLOW, FilterCriteria.Matcher.EQUALS, "nevra", value);
     }
 
-    private boolean isDenyModuleStreamExists(ContentFilter f) {
-        return isFilterOfType(f, DENY, FilterCriteria.Matcher.EXISTS, "module_stream", null);
+    private boolean isDenyNevraEquals(ContentFilter f, String value) {
+        return isFilterOfType(f, DENY, FilterCriteria.Matcher.EQUALS, "nevra", value);
     }
 
     private boolean isDenyNameMatches(ContentFilter f, String value) {
@@ -277,6 +277,6 @@ public class DependencyResolverTest extends BaseTestCaseWithUser {
     private boolean isFilterOfType(ContentFilter f, ContentFilter.Rule rule, FilterCriteria.Matcher matcher,
             String field, String value) {
         return rule.equals(f.getRule()) && matcher.equals(f.getCriteria().getMatcher()) && field
-                .equals(f.getCriteria().getField()) && Objects.equals(value, f.getCriteria().getValue());
+                .equals(f.getCriteria().getField()) && value.equals(f.getCriteria().getValue());
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/MockModulemdApi.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/MockModulemdApi.java
@@ -34,19 +34,16 @@ import com.redhat.rhn.domain.contentmgmt.modulemd.ModulemdApi;
 import com.redhat.rhn.domain.contentmgmt.modulemd.RepositoryNotModularException;
 import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.rhnpackage.PackageArch;
-import com.redhat.rhn.domain.rhnpackage.PackageExtraTagsKeys;
 import com.redhat.rhn.domain.rhnpackage.PackageFactory;
 import com.redhat.rhn.domain.rhnpackage.test.PackageEvrFactoryTest;
 import com.redhat.rhn.domain.rhnpackage.test.PackageNameTest;
 import com.redhat.rhn.domain.rhnpackage.test.PackageTest;
 import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.manager.rhnpackage.test.PackageManagerTest;
 import com.redhat.rhn.testing.TestUtils;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -74,13 +71,6 @@ public class MockModulemdApi extends ModulemdApi {
         return moduleStreamsMap;
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated this endpoint is not currently used by the
-     * {@link com.redhat.rhn.manager.contentmgmt.DependencyResolver} logic.
-     */
-    @Deprecated
     @Override
     public List<String> getAllPackages(List<Channel> sources) {
         // Dummy call to trigger RepositoryNotModular exception:
@@ -146,11 +136,7 @@ public class MockModulemdApi extends ModulemdApi {
         List<String> nevras = doGetAllPackages();
         // perl 5.26 is a special package which is included in the module definition even though it's not served as a
         // modular package. We need it in the channel to be able to test this case.
-        String perlNevra = "perl-5.26.3-416.el8:4.x86_64";
-        nevras.add(perlNevra);
-
-        // 'modularitylabel' rpm tag determines that a package belongs to a module
-        PackageExtraTagsKeys modularityHeader = PackageManagerTest.createExtraTagKey("modularitylabel");
+        nevras.add("perl-5.26.3-416.el8:4.x86_64");
 
         Pattern nevraPattern = Pattern.compile("^(.*)-(\\d+):(.*)-(.*)\\.(.*)$");
         for (String nevra : nevras) {
@@ -163,12 +149,6 @@ public class MockModulemdApi extends ModulemdApi {
                                 packageArch.getArchType().getPackageType()),
                                 packageArch
                         );
-
-                if (!perlNevra.equals(nevra)) {
-                    // Exclude non-modular Perl package mentioned above
-                    pkg.setExtraTags(Collections.singletonMap(modularityHeader, "my:nsvc"));
-                }
-
                 channel.addPackage(pkg);
             }
         }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Avoid using RPM tags when filtering modular packages in CLM (bsc#1192487)
 - Store formula pillar data in database
 - Add new endpoints to packages API: schedulePackageLockChange, listPackagesLockStatus
 - Generate flat repositories metadata for Debian based systems

--- a/uyuni/common-libs/common/rhn_rpm.py
+++ b/uyuni/common-libs/common/rhn_rpm.py
@@ -120,10 +120,19 @@ class RPM_Header:
         """
         Get modularity label tag.
         Returns string of modularity label or None if tag is not there.
+
+        Fix: Some distributions use the DISTTAG (1155) tag instead of
+        MODULARITYLABEL (5096) to label modular packages in the format:
+        `module(n:s:v:c:a)`. We need to check this tag as a fallback
+        (bsc#1192487).
         """
         mtag = None
         if rpm.RPMTAG_MODULARITYLABEL in self.hdr.keys():
             mtag = self.hdr[rpm.RPMTAG_MODULARITYLABEL]
+        elif rpm.RPMTAG_DISTTAG in self.hdr.keys() \
+                and self.hdr[rpm.RPMTAG_DISTTAG].startswith(b"module("):
+            # Strip away 'module(...)' wrap
+            mtag = self.hdr[rpm.RPMTAG_DISTTAG][7:-1]
         return mtag
 
     def checksum_type(self):

--- a/uyuni/common-libs/uyuni-common-libs.changes
+++ b/uyuni/common-libs/uyuni-common-libs.changes
@@ -1,3 +1,4 @@
+- Read modularity data from DISTTAG tag as fallback (bsc#1192487)
 - Add decompression of zck files to fileutils
 - require python macros for building
 


### PR DESCRIPTION
During reposync, we look for a special RPM header tag called MODULARITYLABEL to find out if a package is modular and do the filtering for AppStream modules accordingly.

However, I've been checking out the actual metadata from various distributions (centos8, oraclelinux, almalinux, etc.) and found out that some maintainers use a different approach to label modular metadata in packages.

Some distributions use different tags, and some don't specify any tag at all. To make sure CLM works with all variants, we need to revert to filtering all the modular packages regardless of their tags, while still writing modularity tags into the DB for future use and debugging.

https://bugzilla.suse.com/show_bug.cgi?id=1192487

Port of https://github.com/SUSE/spacewalk/pull/16409

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
