### PR TITLE
Get rid of new.instance from rhnAuthCacheClient

### DIFF
--- a/proxy/proxy/rhnAuthCacheClient.py
+++ b/proxy/proxy/rhnAuthCacheClient.py
@@ -145,32 +145,7 @@ class Shelf:
         except Fault as e:
             rfile.close()
             sock.close()
-            # If e.faultCode is 0, it's another exception
-            if e.faultCode != 0:
-                # Treat is as a regular xmlrpc fault
-                raise
-
-            _dict = e.faultString
-            if not isinstance(_dict, type({})):
-                # Not the expected type
-                raise
-
-            if 'name' not in _dict:
-                # Doesn't look like a marshalled exception
-                raise
-
-            name = _dict['name']
-            args = _dict.get('args')
-            # Look up the exception
-            if not hasattr(__builtins__, name):
-                # Unknown exception name
-                raise
-
-            # Instantiate the exception object
-            import new
-            _dict = {'args': args}
-            # pylint: disable=bad-option-value,nonstandard-exception
-            raise_with_tb(new.instance(getattr(__builtins__, name), _dict), sys.exc_info()[2])
+            raise
 
         return params[0]
 

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,4 @@
+- Remove old Python 2 dependency on module new from rhnAuthCacheClient
 - remove unnecessary package dependencies
 - add an option to send salt-broker logs to standard output/error instead of files
 - Update the token in case a channel can't be found in the cache.


### PR DESCRIPTION
## What does this PR change?

Gets rid of `new` Python 2 module used by `rhnAuthCacheClient.py` for `new.instance` call for exception handling.

This call is not really required there as it was used to handle very specific cases which shouldn't really happen and it's safe to handle the exception without it.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: no any unit tests for this part

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/4126
Tracks https://github.com/SUSE/spacewalk/issues/16248

## Changelogs

- Remove old Python 2 dependency on module new from rhnAuthCacheClient

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
