### PR TITLE
Kill a few global instance holder uses

### DIFF
--- a/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
+++ b/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
@@ -56,7 +56,7 @@ public class GlobalInstanceHolder {
     private static final SaltService SALT_SERVICE = new SaltService();
     public static final SystemQuery SYSTEM_QUERY = SALT_SERVICE;
     public static final SaltApi SALT_API = SALT_SERVICE;
-    public static final ServerGroupManager SERVER_GROUP_MANAGER = new ServerGroupManager();
+    public static final ServerGroupManager SERVER_GROUP_MANAGER = new ServerGroupManager(SALT_API);
     public static final FormulaManager FORMULA_MANAGER = new FormulaManager(SALT_API);
     public static final ClusterManager CLUSTER_MANAGER = new ClusterManager(
             SALT_API, SYSTEM_QUERY, SERVER_GROUP_MANAGER, FORMULA_MANAGER

--- a/java/code/src/com/redhat/rhn/common/messaging/MessageQueue.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/MessageQueue.java
@@ -15,6 +15,8 @@
 
 package com.redhat.rhn.common.messaging;
 
+import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.frontend.events.AlignSoftwareTargetAction;
 import com.redhat.rhn.frontend.events.AlignSoftwareTargetMsg;
 import com.redhat.rhn.frontend.events.CloneErrataAction;
@@ -53,6 +55,7 @@ import com.redhat.rhn.frontend.events.TraceBackAction;
 import com.redhat.rhn.frontend.events.TraceBackEvent;
 import com.redhat.rhn.frontend.events.UpdateErrataCacheAction;
 import com.redhat.rhn.frontend.events.UpdateErrataCacheEvent;
+import com.redhat.rhn.manager.system.SystemManager;
 
 import com.suse.manager.reactor.messaging.ChannelsChangedEventMessage;
 import com.suse.manager.reactor.messaging.ChannelsChangedEventMessageAction;
@@ -297,7 +300,8 @@ public class MessageQueue {
         MessageQueue.registerAction(new SsmChangeChannelSubscriptionsAction(),
                                     SsmChangeChannelSubscriptionsEvent.class);
 
-        MessageQueue.registerAction(new SsmDeleteServersAction(),
+        SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON, saltApi);
+        MessageQueue.registerAction(new SsmDeleteServersAction(systemManager),
                                     SsmDeleteServersEvent.class);
 
         // Used to allow SSM package installs to be run asynchronously

--- a/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
@@ -63,7 +63,7 @@ public class AccessTest extends BaseTestCaseWithUser {
     private Acl acl;
     private final SystemQuery systemQuery = new TestSystemQuery();
     private final SaltApi saltApi = new TestSaltApi();
-    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final FormulaManager formulaManager = new FormulaManager(saltApi);
     private final ClusterManager clusterManager = new ClusterManager(
             saltApi, systemQuery, serverGroupManager, formulaManager);

--- a/java/code/src/com/redhat/rhn/common/security/acl/test/AclFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/test/AclFactoryTest.java
@@ -35,7 +35,7 @@ public class AclFactoryTest extends RhnBaseTestCase {
     public void testGetAcl() {
         SystemQuery systemQuery = new TestSystemQuery();
         SaltApi saltApi = new TestSaltApi();
-        ServerGroupManager serverGroupManager = new ServerGroupManager();
+        ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
         AclFactory aclFactory = new AclFactory(new Access(clusterManager));

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/BaseEntitlementTestCase.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/BaseEntitlementTestCase.java
@@ -42,7 +42,7 @@ public abstract class BaseEntitlementTestCase extends BaseTestCaseWithUser {
 
     private final SystemQuery systemQuery = new TestSystemQuery();
     private final SaltApi saltApi = new TestSaltApi();
-    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/ContainerBuildHostEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/ContainerBuildHostEntitlementTest.java
@@ -39,7 +39,7 @@ import java.util.Map;
 public class ContainerBuildHostEntitlementTest extends BaseEntitlementTestCase {
 
     private final SaltApi saltApi = new TestSaltApi();
-    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/OSImageBuildHostEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/OSImageBuildHostEntitlementTest.java
@@ -39,7 +39,7 @@ public class OSImageBuildHostEntitlementTest extends BaseEntitlementTestCase {
 
     private final SystemQuery systemQuery = new TestSystemQuery();
     private final SaltApi saltApi = new TestSaltApi();
-    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/VirtualizationEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/VirtualizationEntitlementTest.java
@@ -42,7 +42,7 @@ public class VirtualizationEntitlementTest extends BaseEntitlementTestCase {
 
     private final SystemQuery systemQuery = new TestSystemQuery();
     private final SaltApi saltApi = new TestSaltApi();
-    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(

--- a/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
@@ -283,26 +283,10 @@ public class FormulaFactory {
                     }
                 }
                 else {
-                    grantMonitoringEntitlement(minion);
+                    systemEntitlementManager.grantMonitoringEntitlement(minion);
                 }
             });
         }
-    }
-
-    /**
-     * Entitle server if it doesn't already have the monitoring entitlement and if it's allowed.
-     * @param server the server to entitle
-     */
-    public static void grantMonitoringEntitlement(Server server) {
-        boolean hasEntitlement = SystemManager.hasEntitlement(server.getId(), EntitlementManager.MONITORING);
-        if (!hasEntitlement && systemEntitlementManager.canEntitleServer(server, EntitlementManager.MONITORING)) {
-            systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.MONITORING);
-            return;
-        }
-        if (LOG.isDebugEnabled() && hasEntitlement) {
-            LOG.debug("Server " + server.getName() + " already has monitoring entitlement.");
-        }
-
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
@@ -89,7 +89,7 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
     private static TaskomaticApi taskomaticApi;
     private final SystemQuery systemQuery = new TestSystemQuery();
     private final SaltApi saltApi = new TestSaltApi();
-    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -137,7 +137,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
 
     private static final SystemQuery SYSTEM_QUERY = new TestSystemQuery();
     private static final SaltApi SALT_API = new TestSaltApi();
-    private static final ServerGroupManager SERVER_GROUP_MANAGER = new ServerGroupManager();
+    private static final ServerGroupManager SERVER_GROUP_MANAGER = new ServerGroupManager(SALT_API);
     private static final FormulaManager FORMULA_MANAGER = new FormulaManager(SALT_API);
     private static final ClusterManager CLUSTER_MANAGER = new ClusterManager(
             SALT_API, SYSTEM_QUERY, SERVER_GROUP_MANAGER, FORMULA_MANAGER);

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
@@ -57,7 +57,7 @@ import java.util.Optional;
 public class ServerTest extends BaseTestCaseWithUser {
 
     private final SaltApi saltApi = new TestSaltApi();
-    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemUnentitler systemUnentitler = new SystemUnentitler(
@@ -325,12 +325,11 @@ public class ServerTest extends BaseTestCaseWithUser {
     private class VirtEntitledServer extends Server {
         VirtEntitledServer(User user) {
             setOrg(user.getOrg());
-            ServerGroupManager manager = new ServerGroupManager();
-            EntitlementServerGroup group = manager.
+            EntitlementServerGroup group = serverGroupManager.
                         lookupEntitled(EntitlementManager.VIRTUALIZATION, user);
             List servers = new ArrayList();
             servers.add(this);
-            manager.addServers(group, servers, user);
+            serverGroupManager.addServers(group, servers, user);
         }
     }
 

--- a/java/code/src/com/redhat/rhn/domain/server/test/VirtualInstanceFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/VirtualInstanceFactoryTest.java
@@ -31,6 +31,7 @@ import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
 import com.suse.manager.virtualization.test.TestVirtManager;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.test.TestSaltApi;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -58,11 +59,11 @@ public class VirtualInstanceFactoryTest extends RhnBaseTestCase {
         user = UserTestUtils.findNewUser("testUser",
                 "testOrg" + this.getClass().getSimpleName());
         builder = new GuestBuilder(user);
-        ServerGroupManager serverGroupManager = new ServerGroupManager();
+        SaltApi saltApi = new TestSaltApi();
+        ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
         systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(new TestVirtManager(), new FormulaMonitoringManager(), serverGroupManager),
-                new SystemEntitler(new TestSaltApi(), new TestVirtManager(), new FormulaMonitoringManager(),
-                        serverGroupManager)
+                new SystemEntitler(saltApi, new TestVirtManager(), new FormulaMonitoringManager(), serverGroupManager)
         );
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/ssm/MigrateSystemsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/ssm/MigrateSystemsAction.java
@@ -46,6 +46,18 @@ import javax.servlet.http.HttpServletResponse;
  * MigrateSystemsAction
  */
 public class MigrateSystemsAction extends RhnAction implements Listable {
+
+    private final MigrationManager migrationManager;
+
+    /**
+     * Constructor
+     *
+     * @param migrationManagerIn the migration manager
+     */
+    public MigrateSystemsAction(MigrationManager migrationManagerIn) {
+        migrationManager = migrationManagerIn;
+    }
+
     /**
      *
      * {@inheritDoc}
@@ -78,7 +90,7 @@ public class MigrateSystemsAction extends RhnAction implements Listable {
             }
             else {
                 Org toOrg = OrgFactory.lookupByName(daForm.getString("org"));
-                MigrationManager.migrateServers(user, toOrg, serverList);
+                migrationManager.migrateServers(user, toOrg, serverList);
 
                 // Empty the set as we no longer have access to these systems
                 RhnSetDecl.SYSTEMS.clear(user);

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/duplicate/DuplicateSystemsCompareAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/duplicate/DuplicateSystemsCompareAction.java
@@ -50,6 +50,17 @@ public class DuplicateSystemsCompareAction extends RhnAction implements Listable
     public static final String KEY_TYPE = "key_type";
     private static final int MAX_LIMIT = 3;
 
+    private final SystemManager systemManager;
+
+    /**
+     * Constructor
+     *
+     * @param systemManagerIn the system manager
+     */
+    public DuplicateSystemsCompareAction(SystemManager systemManagerIn) {
+        systemManager = systemManagerIn;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -85,7 +96,7 @@ public class DuplicateSystemsCompareAction extends RhnAction implements Listable
                                                     context.getCurrentUser());
                     String name = server.getName();
                     server = null;
-                    SystemManager.deleteServer(context.getCurrentUser(), id);
+                    systemManager.deleteServer(context.getCurrentUser(), id);
                     getStrutsDelegate().saveMessage("message.serverdeleted.param",
                                                     new String[] {name}, request);
                     itr.remove();

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSetupActionTest.java
@@ -69,7 +69,7 @@ public class SystemEntitlementsSetupActionTest extends RhnMockStrutsTestCase {
         Config.get().setBoolean(ConfigDefaults.KIWI_OS_IMAGE_BUILDING_ENABLED, "true");
         context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         saltServiceMock = context.mock(SaltService.class);
-        ServerGroupManager serverGroupManager = new ServerGroupManager();
+        ServerGroupManager serverGroupManager = new ServerGroupManager(saltServiceMock);
         systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(new VirtManagerSalt(saltServiceMock),
                         new FormulaMonitoringManager(), serverGroupManager),

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSubmitActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSubmitActionTest.java
@@ -58,7 +58,7 @@ public class SystemEntitlementsSubmitActionTest extends RhnPostMockStrutsTestCas
 
     private final SystemQuery systemQuery = new TestSystemQuery();
     private final SaltApi saltApi = new TestSaltApi();
-    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemDeleteConfirmAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemDeleteConfirmAction.java
@@ -45,6 +45,17 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class SystemDeleteConfirmAction extends RhnAction {
 
+    private final SystemManager systemManager;
+
+    /**
+     * Constructor
+     *
+     * @param systemManagerIn the system manager
+     */
+    public SystemDeleteConfirmAction(SystemManager systemManagerIn) {
+        systemManager = systemManagerIn;
+    }
+
     /** {@inheritDoc} */
     public ActionForward execute(ActionMapping mapping,
             ActionForm form,
@@ -87,7 +98,7 @@ public class SystemDeleteConfirmAction extends RhnAction {
 
             try {
                 // Now we can remove the system
-                SystemManager.deleteServer(loggedInUser, sid);
+                systemManager.deleteServer(loggedInUser, sid);
                 createSuccessMessage(request, "message.serverdeleted.param",
                         sid.toString());
             }

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemMigrateAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemMigrateAction.java
@@ -52,6 +52,16 @@ public class SystemMigrateAction extends RhnAction {
     public static final String SID = "sid";
     public static final String ORG = "to_org";
 
+    private final MigrationManager migrationManager;
+
+    /**
+     * Constructor
+     *
+     * @param migrationManagerIn the migration manager
+     */
+    public SystemMigrateAction(MigrationManager migrationManagerIn) {
+        migrationManager = migrationManagerIn;
+    }
 
     /** {@inheritDoc} */
     public ActionForward execute(ActionMapping mapping, ActionForm form,
@@ -170,7 +180,7 @@ public class SystemMigrateAction extends RhnAction {
         List<Server> serverList = new ArrayList<Server>();
         serverList.add(s);
 
-        List<Long> serversMigrated = MigrationManager.migrateServers(user,
+        List<Long> serversMigrated = migrationManager.migrateServers(user,
                 toOrg, serverList);
 
         Iterator it = serversMigrated.iterator();

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemDetailsEditActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemDetailsEditActionTest.java
@@ -55,7 +55,7 @@ public class SystemDetailsEditActionTest extends RhnPostMockStrutsTestCase {
     protected Server s;
     private final SystemQuery systemQuery = new TestSystemQuery();
     private final SaltApi saltApi = new TestSaltApi();
-    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemOverviewActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemOverviewActionTest.java
@@ -57,7 +57,7 @@ public class SystemOverviewActionTest extends RhnMockStrutsTestCase {
 
     protected Server s;
     private final SaltApi saltApi = new TestSaltApi();
-    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/test/RegisteredSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/test/RegisteredSetupActionTest.java
@@ -20,6 +20,7 @@ import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerConstants;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.ServerGroup;
+import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.domain.server.test.ServerFactoryTest;
 import com.redhat.rhn.domain.server.test.ServerGroupTest;
 import com.redhat.rhn.frontend.action.systems.RegisteredSetupAction;
@@ -27,6 +28,9 @@ import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.testing.RhnPostMockStrutsTestCase;
+
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.test.TestSaltApi;
 
 /**
  * RegisteredSetupActionTest
@@ -44,7 +48,9 @@ public class RegisteredSetupActionTest extends RhnPostMockStrutsTestCase {
                 ServerConstants.getServerGroupTypeEnterpriseEntitled());
         ServerGroup group = ServerGroupTest
                 .createTestServerGroup(user.getOrg(), null);
-        SystemManager.addServerToServerGroup(server, group);
+        SaltApi saltApi = new TestSaltApi();
+        SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON, saltApi);
+        systemManager.addServerToServerGroup(server, group);
         ServerFactory.save(server);
 
         for (int j = 0; j < RegisteredSetupAction.OPTIONS.length; ++j) {

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/virtualization/test/ProvisionVirtualizationWizardActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/virtualization/test/ProvisionVirtualizationWizardActionTest.java
@@ -67,7 +67,7 @@ public class ProvisionVirtualizationWizardActionTest extends RhnMockStrutsTestCa
 
     private Server s;
     private final SaltApi saltApi = new TestSaltApi();
-    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(

--- a/java/code/src/com/redhat/rhn/frontend/events/SsmDeleteServersAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/SsmDeleteServersAction.java
@@ -38,6 +38,17 @@ public class SsmDeleteServersAction implements MessageAction {
     /** Logger instance. */
     private static Log log = LogFactory.getLog(SsmDeleteServersAction.class);
 
+    private final SystemManager systemManager;
+
+    /**
+     * Constructor
+     *
+     * @param systemManagerIn the system manager
+     */
+    public SsmDeleteServersAction(SystemManager systemManagerIn) {
+        systemManager = systemManagerIn;
+    }
+
     /** {@inheritDoc} */
     public void execute(EventMessage msg) {
         SsmDeleteServersEvent event = (SsmDeleteServersEvent) msg;
@@ -53,7 +64,7 @@ public class SsmDeleteServersAction implements MessageAction {
         try {
             for (Long sid : sids) {
                 try {
-                    SystemManager.deleteServerAndCleanup(user,
+                    systemManager.deleteServerAndCleanup(user,
                             sid,
                             event.getServerCleanupType()
                     );

--- a/java/code/src/com/redhat/rhn/frontend/nav/test/AclGuardTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/nav/test/AclGuardTest.java
@@ -38,7 +38,7 @@ public class AclGuardTest extends RhnBaseTestCase {
 
     private final SystemQuery systemQuery = new TestSystemQuery();
     private final SaltApi saltApi = new TestSaltApi();
-    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final FormulaManager formulaManager = new FormulaManager(saltApi);
     private final ClusterManager clusterManager = new ClusterManager(
             saltApi, systemQuery, serverGroupManager, formulaManager);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
@@ -77,6 +77,7 @@ import com.redhat.rhn.frontend.xmlrpc.user.UserHandler;
 import com.redhat.rhn.frontend.xmlrpc.user.external.UserExternalHandler;
 import com.redhat.rhn.frontend.xmlrpc.virtualhostmanager.VirtualHostManagerHandler;
 import com.redhat.rhn.manager.formula.FormulaManager;
+import com.redhat.rhn.manager.org.MigrationManager;
 import com.redhat.rhn.manager.system.AnsibleManager;
 import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
@@ -132,6 +133,7 @@ public class HandlerFactory {
         ClusterManager clusterManager = GlobalInstanceHolder.CLUSTER_MANAGER;
         SaltKeyUtils saltKeyUtils = GlobalInstanceHolder.SALT_KEY_UTILS;
         ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+        MigrationManager migrationManager = new MigrationManager(serverGroupManager);
 
         RegularMinionBootstrapper regularMinionBootstrapper = GlobalInstanceHolder.REGULAR_MINION_BOOTSTRAPPER;
         SSHMinionBootstrapper sshMinionBootstrapper = GlobalInstanceHolder.SSH_MINION_BOOTSTRAPPER;
@@ -174,7 +176,7 @@ public class HandlerFactory {
         factory.addHandler("kickstart.snippet", new SnippetHandler());
         factory.addHandler("kickstart.tree", new KickstartTreeHandler());
         factory.addHandler("maintenance", new MaintenanceHandler());
-        factory.addHandler("org", new OrgHandler());
+        factory.addHandler("org", new OrgHandler(migrationManager));
         factory.addHandler("org.trusts", new OrgTrustHandler());
         factory.addHandler("packages", new PackagesHandler());
         factory.addHandler("packages.provider", new PackagesProviderHandler());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
@@ -77,6 +77,7 @@ import com.redhat.rhn.frontend.xmlrpc.user.UserHandler;
 import com.redhat.rhn.frontend.xmlrpc.user.external.UserExternalHandler;
 import com.redhat.rhn.frontend.xmlrpc.virtualhostmanager.VirtualHostManagerHandler;
 import com.redhat.rhn.manager.formula.FormulaManager;
+import com.redhat.rhn.manager.system.AnsibleManager;
 import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
@@ -145,7 +146,7 @@ public class HandlerFactory {
         factory.addHandler("actionchain", new ActionChainHandler());
         factory.addHandler("activationkey", new ActivationKeyHandler(serverGroupManager));
         factory.addHandler("admin.monitoring", new AdminMonitoringHandler());
-        factory.addHandler("ansible", new AnsibleHandler());
+        factory.addHandler("ansible", new AnsibleHandler(new AnsibleManager(GlobalInstanceHolder.SALT_API)));
         factory.addHandler("api", new ApiHandler(factory));
         factory.addHandler("audit", new CVEAuditHandler());
         factory.addHandler("auth", new AuthHandler());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
@@ -125,7 +125,8 @@ public class HandlerFactory {
         HandlerFactory factory = new HandlerFactory();
         TaskomaticApi taskomaticApi = new TaskomaticApi();
         SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
-        SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON);
+        SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON,
+                GlobalInstanceHolder.SALT_API);
         FormulaManager formulaManager = GlobalInstanceHolder.FORMULA_MANAGER;
         ClusterManager clusterManager = GlobalInstanceHolder.CLUSTER_MANAGER;
         SaltKeyUtils saltKeyUtils = GlobalInstanceHolder.SALT_KEY_UTILS;

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/activationkey/test/ActivationKeyHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/activationkey/test/ActivationKeyHandlerTest.java
@@ -52,6 +52,7 @@ import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
 import com.suse.manager.utils.MachinePasswordUtils;
+import com.suse.manager.webui.services.test.TestSaltApi;
 
 import org.apache.commons.codec.digest.DigestUtils;
 
@@ -70,7 +71,7 @@ import redstone.xmlrpc.XmlRpcSerializer;
 
 public class ActivationKeyHandlerTest extends BaseHandlerTestCase {
 
-    private ActivationKeyHandler keyHandler = new ActivationKeyHandler(new ServerGroupManager());
+    private ActivationKeyHandler keyHandler = new ActivationKeyHandler(new ServerGroupManager(new TestSaltApi()));
     private static final String KEY = "myexplicitkey";
     private static final String KEY_DESCRIPTION = "Test Key";
     private static final Integer KEY_USAGE_LIMIT = 0;

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandler.java
@@ -48,6 +48,17 @@ public class AnsibleHandler extends BaseHandler {
     // Keys to pass to schedulePlaybook endpoint as additional args for Ansible
     public static final String ANSIBLE_FLUSH_CACHE = "flushCache";
 
+    private final AnsibleManager ansibleManager;
+
+    /**
+     * Constructor
+     *
+     * @param managerIn the ansible manager
+     */
+    public AnsibleHandler(AnsibleManager managerIn) {
+        ansibleManager = managerIn;
+    }
+
     /**
      * Schedule a playbook execution
      *
@@ -342,7 +353,7 @@ public class AnsibleHandler extends BaseHandler {
      */
     public String fetchPlaybookContents(User loggedInUser, Integer pathId, String playbookRelPath) {
         try {
-            return AnsibleManager.fetchPlaybookContents(pathId, playbookRelPath, loggedInUser)
+            return ansibleManager.fetchPlaybookContents(pathId, playbookRelPath, loggedInUser)
                     .orElseThrow(() -> new SaltFaultException("Minion not responding"));
         }
         catch (LookupException e) {
@@ -375,7 +386,7 @@ public class AnsibleHandler extends BaseHandler {
      */
     public Map<String, Map<String, AnsiblePlaybookSlsResult>> discoverPlaybooks(User loggedInUser, Integer pathId) {
         try {
-            return AnsibleManager.discoverPlaybooks(pathId, loggedInUser)
+            return ansibleManager.discoverPlaybooks(pathId, loggedInUser)
                     .orElseThrow(() -> new SaltFaultException("Minion not responding"));
         }
         catch (LookupException e) {
@@ -406,7 +417,7 @@ public class AnsibleHandler extends BaseHandler {
      */
     public Map<String, Map<String, Object>> introspectInventory(User loggedInUser, Integer pathId) {
         try {
-            return AnsibleManager.introspectInventory(pathId, loggedInUser)
+            return ansibleManager.introspectInventory(pathId, loggedInUser)
                     .orElseThrow(() -> new SaltFaultException("Minion not responding"));
         }
         catch (LookupException e) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/test/AnsibleHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/test/AnsibleHandlerTest.java
@@ -15,7 +15,6 @@
 
 package com.redhat.rhn.frontend.xmlrpc.ansible.test;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
@@ -36,13 +35,20 @@ import com.redhat.rhn.frontend.xmlrpc.test.BaseHandlerTestCase;
 import com.redhat.rhn.manager.action.ActionChainManager;
 import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
+import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
 import com.redhat.rhn.manager.system.AnsibleManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
+import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 import com.redhat.rhn.testing.TestUtils;
 
+import com.suse.manager.virtualization.VirtManagerSalt;
+import com.suse.manager.webui.services.iface.MonitoringManager;
 import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.salt.netapi.calls.LocalCall;
 import com.suse.salt.netapi.utils.Xor;
 
@@ -292,7 +298,13 @@ public class AnsibleHandlerTest extends BaseHandlerTestCase {
     }
 
     private MinionServer createAnsibleControlNode(User user) throws Exception {
-        SystemEntitlementManager entitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
+        VirtManager virtManager = new VirtManagerSalt(saltApi);
+        MonitoringManager monitoringManager = new FormulaMonitoringManager();
+        ServerGroupManager groupManager = new ServerGroupManager(saltApi);
+        SystemEntitlementManager entitlementManager = new SystemEntitlementManager(
+                new SystemUnentitler(virtManager, monitoringManager, groupManager),
+                new SystemEntitler(saltApi, virtManager, monitoringManager, groupManager)
+        );
 
         MinionServer server = MinionServerFactoryTest.createTestMinionServer(user);
         ServerArch a = ServerFactory.lookupServerArchByName("x86_64");

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/org/test/ChannelOrgHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/org/test/ChannelOrgHandlerTest.java
@@ -23,7 +23,11 @@ import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.frontend.xmlrpc.channel.org.ChannelOrgHandler;
 import com.redhat.rhn.frontend.xmlrpc.org.OrgHandler;
 import com.redhat.rhn.frontend.xmlrpc.test.BaseHandlerTestCase;
+import com.redhat.rhn.manager.org.MigrationManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.testing.TestUtils;
+
+import com.suse.manager.webui.services.test.TestSaltApi;
 
 import java.util.List;
 import java.util.Map;
@@ -34,7 +38,7 @@ import java.util.Map;
 public class ChannelOrgHandlerTest extends BaseHandlerTestCase {
 
     private ChannelOrgHandler handler = new ChannelOrgHandler();
-    private OrgHandler orgHandler = new OrgHandler();
+    private OrgHandler orgHandler = new OrgHandler(new MigrationManager(new ServerGroupManager(new TestSaltApi())));
 
     public void setUp() throws Exception {
         super.setUp();

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
@@ -100,7 +100,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     private TaskomaticApi taskomaticApi = new TaskomaticApi();
     private final SystemQuery systemQuery = new TestSystemQuery();
     private final SaltApi saltApi = new TestSaltApi();
-    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery, saltApi);
     private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery, saltApi);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
@@ -116,7 +116,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     private SystemManager systemManager =
             new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON, saltApi);
     private SystemHandler systemHandler = new SystemHandler(taskomaticApi, xmlRpcSystemHelper, systemEntitlementManager,
-            systemManager, new ServerGroupManager());
+            systemManager, serverGroupManager);
     private ChannelSoftwareHandler handler = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper,
             systemHandler);
     private ErrataHandler errataHandler = new ErrataHandler();

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
@@ -113,7 +113,8 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
             new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
             new SystemEntitler(saltApi, virtManager, monitoringManager, serverGroupManager)
     );
-    private SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON);
+    private SystemManager systemManager =
+            new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON, saltApi);
     private SystemHandler systemHandler = new SystemHandler(taskomaticApi, xmlRpcSystemHelper, systemEntitlementManager,
             systemManager, new ServerGroupManager());
     private ChannelSoftwareHandler handler = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper,

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
@@ -111,7 +111,7 @@ public class ImageInfoHandlerTest extends BaseHandlerTestCase {
     public final void testImportImage() throws Exception {
         ImageInfoFactory.setTaskomaticApi(getTaskomaticApi());
 
-        MinionServer server = ImageTestUtils.createBuildHost(admin);
+        MinionServer server = ImageTestUtils.createBuildHost(systemEntitlementManager, admin);
         ImageStore store = createImageStore("registry.reg", admin);
         ActivationKey ak = createActivationKey(admin);
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
@@ -93,7 +93,7 @@ public class ImageInfoHandlerTest extends BaseHandlerTestCase {
 
     private static TaskomaticApi taskomaticApi;
     private final SaltApi saltApi = new TestSaltApi();
-    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
@@ -175,12 +175,11 @@ public class ImageInfoHandlerTest extends BaseHandlerTestCase {
                 will(returnValue(Optional.of(mockResult)));
         }});
 
-        ServerGroupManager serverGroupMgr = new ServerGroupManager();
         SystemEntitlementManager sem = new SystemEntitlementManager(
                 new SystemUnentitler(new VirtManagerSalt(saltServiceMock), new FormulaMonitoringManager(),
-                        serverGroupMgr),
+                        serverGroupManager),
                 new SystemEntitler(saltServiceMock, new VirtManagerSalt(saltServiceMock),
-                        new FormulaMonitoringManager(), serverGroupMgr)
+                        new FormulaMonitoringManager(), serverGroupManager)
         );
 
         MinionServer server = MinionServerFactoryTest.createTestMinionServer(admin);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
@@ -64,12 +64,10 @@ import com.redhat.rhn.testing.TestUtils;
 
 import com.suse.manager.virtualization.VirtManagerSalt;
 import com.suse.manager.webui.services.iface.MonitoringManager;
-import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.services.impl.SaltSSHService;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
-import com.suse.manager.webui.services.test.TestSaltApi;
 
 import org.jmock.Expectations;
 import org.jmock.Mockery;
@@ -87,25 +85,27 @@ public class ImageInfoHandlerTest extends BaseHandlerTestCase {
 
     private ImageInfoHandler handler = new ImageInfoHandler();
 
-    private static final Mockery CONTEXT = new JUnit3Mockery() {{
+    private Mockery context = new JUnit3Mockery() {{
         setThreadingPolicy(new Synchroniser());
     }};
 
     private static TaskomaticApi taskomaticApi;
-    private final SaltApi saltApi = new TestSaltApi();
-    private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
-    private final VirtManager virtManager = new VirtManagerSalt(saltApi);
-    private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
-    private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-            new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
-            new SystemEntitler(saltApi, virtManager, monitoringManager, serverGroupManager)
-    );
+    private SaltService saltServiceMock;
+    private SystemEntitlementManager systemEntitlementManager;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        CONTEXT.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+        context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         Config.get().setBoolean(ConfigDefaults.KIWI_OS_IMAGE_BUILDING_ENABLED, "true");
+        saltServiceMock = context.mock(SaltService.class);
+        ServerGroupManager serverGroupManager = new ServerGroupManager(saltServiceMock);
+        VirtManager virtManager = new VirtManagerSalt(saltServiceMock);
+        MonitoringManager monitoringManager = new FormulaMonitoringManager();
+        systemEntitlementManager = new SystemEntitlementManager(
+                new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
+                new SystemEntitler(saltServiceMock, virtManager, monitoringManager, serverGroupManager)
+        );
     }
 
     public final void testImportImage() throws Exception {
@@ -168,24 +168,16 @@ public class ImageInfoHandlerTest extends BaseHandlerTestCase {
 
     public final void testScheduleOSImageBuild() throws Exception {
         ImageInfoFactory.setTaskomaticApi(getTaskomaticApi());
-        SaltService saltServiceMock = CONTEXT.mock(SaltService.class);
         MgrUtilRunner.ExecResult mockResult = new MgrUtilRunner.ExecResult();
-        CONTEXT.checking(new Expectations() {{
+        context.checking(new Expectations() {{
                 allowing(saltServiceMock).generateSSHKey(with(equal(SaltSSHService.SSH_KEY_PATH)));
                 will(returnValue(Optional.of(mockResult)));
         }});
 
-        SystemEntitlementManager sem = new SystemEntitlementManager(
-                new SystemUnentitler(new VirtManagerSalt(saltServiceMock), new FormulaMonitoringManager(),
-                        serverGroupManager),
-                new SystemEntitler(saltServiceMock, new VirtManagerSalt(saltServiceMock),
-                        new FormulaMonitoringManager(), serverGroupManager)
-        );
-
         MinionServer server = MinionServerFactoryTest.createTestMinionServer(admin);
         server.setServerArch(ServerFactory.lookupServerArchByLabel("x86_64-redhat-linux"));
         ServerFactory.save(server);
-        sem.addEntitlementToServer(server, EntitlementManager.OSIMAGE_BUILD_HOST);
+        systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.OSIMAGE_BUILD_HOST);
         ActivationKey ak = createActivationKey(admin);
         ImageProfile prof = createKiwiImageProfile("myprofile", ak, admin);
 
@@ -280,8 +272,8 @@ public class ImageInfoHandlerTest extends BaseHandlerTestCase {
 
     private TaskomaticApi getTaskomaticApi() throws TaskomaticApiException {
         if (taskomaticApi == null) {
-            taskomaticApi = CONTEXT.mock(TaskomaticApi.class);
-            CONTEXT.checking(new Expectations() {
+            taskomaticApi = context.mock(TaskomaticApi.class);
+            context.checking(new Expectations() {
                 {
                     allowing(taskomaticApi)
                             .scheduleActionExecution(with(any(Action.class)));

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/org/OrgHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/org/OrgHandler.java
@@ -70,6 +70,17 @@ public class OrgHandler extends BaseHandler {
     private static final String USED_KEY = "used";
     private static Logger log = Logger.getLogger(OrgHandler.class);
 
+    private final MigrationManager migrationManager;
+
+    /**
+     * Constructor
+     *
+     * @param migrationManagerIn the migration manager
+     */
+    public OrgHandler(MigrationManager migrationManagerIn) {
+        migrationManager = migrationManagerIn;
+    }
+
     /**
      * Create a new organization.
      * @param loggedInUser The current user
@@ -447,7 +458,7 @@ public class OrgHandler extends BaseHandler {
             }
         }
 
-        List<Long> serversMigrated = MigrationManager.migrateServers(loggedInUser,
+        List<Long> serversMigrated = migrationManager.migrateServers(loggedInUser,
                 toOrg, servers);
         return serversMigrated.toArray();
     }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/org/test/OrgHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/org/test/OrgHandlerTest.java
@@ -32,17 +32,21 @@ import com.redhat.rhn.frontend.xmlrpc.PermissionCheckFailureException;
 import com.redhat.rhn.frontend.xmlrpc.ValidationException;
 import com.redhat.rhn.frontend.xmlrpc.org.OrgHandler;
 import com.redhat.rhn.frontend.xmlrpc.test.BaseHandlerTestCase;
+import com.redhat.rhn.manager.org.MigrationManager;
 import com.redhat.rhn.manager.org.OrgManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
+
+import com.suse.manager.webui.services.test.TestSaltApi;
 
 import java.util.LinkedList;
 import java.util.List;
 
 public class OrgHandlerTest extends BaseHandlerTestCase {
 
-    private OrgHandler handler = new OrgHandler();
+    private OrgHandler handler = new OrgHandler(new MigrationManager(new ServerGroupManager(new TestSaltApi())));
 
     private static final String LOGIN = "fakeadmin";
     private static final String PASSWORD = "fakeadmin";

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/org/trusts/test/OrgTrustHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/org/trusts/test/OrgTrustHandlerTest.java
@@ -31,9 +31,13 @@ import com.redhat.rhn.frontend.dto.TrustedOrgDto;
 import com.redhat.rhn.frontend.xmlrpc.org.OrgHandler;
 import com.redhat.rhn.frontend.xmlrpc.org.trusts.OrgTrustHandler;
 import com.redhat.rhn.frontend.xmlrpc.test.BaseHandlerTestCase;
+import com.redhat.rhn.manager.org.MigrationManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
+
+import com.suse.manager.webui.services.test.TestSaltApi;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,7 +49,7 @@ import java.util.Map;
 public class OrgTrustHandlerTest extends BaseHandlerTestCase {
 
     private OrgTrustHandler handler = new OrgTrustHandler();
-    private OrgHandler orgHandler = new OrgHandler();
+    private OrgHandler orgHandler = new OrgHandler(new MigrationManager(new ServerGroupManager(new TestSaltApi())));
 
     public void setUp() throws Exception {
         super.setUp();

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -1763,7 +1763,7 @@ public class SystemHandler extends BaseHandler {
 
     public int deleteSystem(String clientCert) throws FaultException {
         Server server = validateClientCertificate(clientCert);
-        SystemManager.deleteServerAndCleanup(server.getOrg().getActiveOrgAdmins().get(0),
+        systemManager.deleteServerAndCleanup(server.getOrg().getActiveOrgAdmins().get(0),
                 server.getId(),
                 SystemManager.ServerCleanupType.NO_CLEANUP
                 );
@@ -1808,7 +1808,7 @@ public class SystemHandler extends BaseHandler {
             throws FaultException {
 
         Server server = lookupServer(loggedInUser, serverId);
-        SystemManager.deleteServerAndCleanup(loggedInUser,
+        systemManager.deleteServerAndCleanup(loggedInUser,
                 server.getId(),
                 SystemManager.ServerCleanupType.fromString(cleanupType).orElseThrow(() ->
                                     new IllegalArgumentException(

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -6585,7 +6585,7 @@ public class SystemHandler extends BaseHandler {
      */
     public int createSystemProfile(User loggedInUser, String systemName, Map<String, Object> data) {
         try {
-            return SystemManager.createSystemProfile(loggedInUser, systemName, data).getId().intValue();
+            return systemManager.createSystemProfile(loggedInUser, systemName, data).getId().intValue();
         }
         catch (SystemsExistException e) {
             throw new SystemsExistFaultException(e.getSystemIds());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/ServerGroupHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/ServerGroupHandlerTest.java
@@ -61,7 +61,7 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
             regularMinionBootstrapper,
             sshMinionBootstrapper
     );
-    private ServerGroupManager manager = new ServerGroupManager();
+    private ServerGroupManager manager = new ServerGroupManager(saltApi);
     private ServerGroupHandler handler = new ServerGroupHandler(xmlRpcSystemHelper, manager);
     private static final String NAME = "HAHAHA" + TestUtils.randomString();
     private static final String DESCRIPTION =  TestUtils.randomString();

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -204,7 +204,8 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
             new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
             new SystemEntitler(saltApi, virtManager, monitoringManager, serverGroupManager)
     );
-    private SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON);
+    private SystemManager systemManager =
+            new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON, saltApi);
     private SystemHandler handler =
             new SystemHandler(taskomaticApi, xmlRpcSystemHelper, systemEntitlementManager, systemManager,
                     new ServerGroupManager());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -197,7 +197,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
             regularMinionBootstrapper,
             sshMinionBootstrapper
     );
-    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
@@ -208,7 +208,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
             new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON, saltApi);
     private SystemHandler handler =
             new SystemHandler(taskomaticApi, xmlRpcSystemHelper, systemEntitlementManager, systemManager,
-                    new ServerGroupManager());
+                    serverGroupManager);
 
     private final Mockery MOCK_CONTEXT = new JUnit3Mockery() {{
         setThreadingPolicy(new Synchroniser());
@@ -1372,12 +1372,11 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         Server server = ServerFactoryTest.createTestServer(admin, true);
         Set servers = new HashSet();
         servers.add(server);
-        ServerGroupManager manager = new ServerGroupManager();
-        manager.addServers(group, servers, admin);
+        serverGroupManager.addServers(group, servers, admin);
 
         Set admins = new HashSet();
         admins.add(regular);
-        manager.associateAdmins(group, admins, admin);
+        serverGroupManager.associateAdmins(group, admins, admin);
 
 
         User nonGroupAdminUser = UserTestUtils.createUser(
@@ -3254,7 +3253,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
     private SystemHandler getMockedHandler() throws Exception {
         TaskomaticApi taskomaticMock = MOCK_CONTEXT.mock(TaskomaticApi.class);
         SystemHandler systemHandler = new SystemHandler(taskomaticMock, xmlRpcSystemHelper, systemEntitlementManager,
-                systemManager, new ServerGroupManager());
+                systemManager, serverGroupManager);
 
         MOCK_CONTEXT.checking(new Expectations() {{
             allowing(taskomaticMock).scheduleActionExecution(with(any(Action.class)));

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/external/test/UserExternalHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/external/test/UserExternalHandlerTest.java
@@ -127,7 +127,7 @@ public class UserExternalHandlerTest extends BaseHandlerTestCase {
                 regularMinionBootstrapper,
                 sshMinionBootstrapper
         );
-        ServerGroupHandler sghandler = new ServerGroupHandler(xmlRpcSystemHelper, new ServerGroupManager());
+        ServerGroupHandler sghandler = new ServerGroupHandler(xmlRpcSystemHelper, new ServerGroupManager(saltApi));
         sghandler.create(admin, systemGroupName, desc);
 
         //admin should be able to call list users, regular should not

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/test/UserHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/test/UserHandlerTest.java
@@ -32,6 +32,8 @@ import com.redhat.rhn.testing.ServerGroupTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
+import com.suse.manager.webui.services.test.TestSaltApi;
+
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -40,7 +42,7 @@ import java.util.Set;
 
 public class UserHandlerTest extends BaseHandlerTestCase {
 
-    private UserHandler handler = new UserHandler(new ServerGroupManager());
+    private UserHandler handler = new UserHandler(new ServerGroupManager(new TestSaltApi()));
 
     public void testListUsers() throws Exception {
         //admin should be able to call list users, regular should not

--- a/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
@@ -139,7 +139,7 @@ public class ActionManagerTest extends JMockBaseTestCaseWithUser {
     private static TaskomaticApi taskomaticApi;
     private final SystemQuery systemQuery = new TestSystemQuery();
     private final SaltApi saltApi = new TestSaltApi();
-    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(

--- a/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
@@ -60,6 +60,7 @@ import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.domain.server.test.ServerFactoryTest;
 import com.redhat.rhn.domain.token.ActivationKey;
@@ -145,6 +146,8 @@ public class ActionManagerTest extends JMockBaseTestCaseWithUser {
             new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
             new SystemEntitler(saltApi, virtManager, monitoringManager, serverGroupManager)
     );
+    private final SystemManager systemManager =
+            new SystemManager(ServerFactory.SINGLETON, new ServerGroupFactory(), saltApi);
 
     private final Mockery MOCK_CONTEXT = new JUnit3Mockery() {{
         setThreadingPolicy(new Synchroniser());
@@ -199,7 +202,7 @@ public class ActionManagerTest extends JMockBaseTestCaseWithUser {
         Action result = ActionManager.lookupAction(user, action.getId());
         assertNotNull(result);
 
-        SystemManager.deleteServer(user, server.getId());
+        systemManager.deleteServer(user, server.getId());
 
         try {
             // Regular users cannot see orphan actions
@@ -223,7 +226,7 @@ public class ActionManagerTest extends JMockBaseTestCaseWithUser {
         Action result = ActionManager.lookupAction(user, action.getId());
         assertNotNull(result);
 
-        SystemManager.deleteServer(user, server.getId());
+        systemManager.deleteServer(user, server.getId());
         // Admins should see orphan actions
         result = ActionManager.lookupAction(user, action.getId());
         assertNotNull(result);

--- a/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
@@ -107,7 +107,8 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
             regularMinionBootstrapper,
             sshMinionBootstrapper
     );
-    private SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON);
+    private SystemManager systemManager =
+            new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON, saltApi);
 
     @Override
     public void setUp() throws Exception {

--- a/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
@@ -94,7 +94,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
 
     private final SystemQuery systemQuery = new TestSystemQuery();
     private final SaltApi saltApi = new TestSaltApi();
-    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
@@ -143,7 +143,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         MinionActionManager.setTaskomaticApi(taskomaticMock);
 
         SystemHandler handler = new SystemHandler(taskomaticMock, xmlRpcSystemHelper, systemEntitlementManager,
-                systemManager, new ServerGroupManager());
+                systemManager, serverGroupManager);
         context().checking(new Expectations() { {
             Matcher<Map<Long, ZonedDateTime>> minionMatcher =
                     AllOf.allOf(IsMapContaining.hasKey(minion1.getId()));
@@ -193,7 +193,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
 
 
         SystemHandler handler = new SystemHandler(taskomaticMock, xmlRpcSystemHelper, systemEntitlementManager,
-                systemManager, new ServerGroupManager());
+                systemManager, serverGroupManager);
 
         context().checking(new Expectations() { {
             Matcher<Map<Long, ZonedDateTime>> minionMatcher =
@@ -244,7 +244,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         MinionActionManager.setTaskomaticApi(taskomaticMock);
 
         SystemHandler handler = new SystemHandler(taskomaticMock, xmlRpcSystemHelper, systemEntitlementManager,
-                systemManager, new ServerGroupManager());
+                systemManager, serverGroupManager);
 
         context().checking(new Expectations() { {
             exactly(1).of(taskomaticMock)
@@ -294,7 +294,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         MinionActionManager.setTaskomaticApi(taskomaticMock);
 
         SystemHandler handler = new SystemHandler(taskomaticMock, xmlRpcSystemHelper, systemEntitlementManager,
-                systemManager, new ServerGroupManager());
+                systemManager, serverGroupManager);
         context().checking(new Expectations() {{
             Matcher<Map<Long, ZonedDateTime>> minionMatcher =
                     AllOf.allOf(IsMapContaining.hasKey(minion1.getId()));
@@ -344,7 +344,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         MinionActionManager.setTaskomaticApi(taskomaticMock);
 
         SystemHandler handler = new SystemHandler(taskomaticMock, xmlRpcSystemHelper, systemEntitlementManager,
-                systemManager, new ServerGroupManager());
+                systemManager, serverGroupManager);
 
         context().checking(new Expectations() { {
             exactly(1).of(taskomaticMock)

--- a/java/code/src/com/redhat/rhn/manager/formula/test/FormulaManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/formula/test/FormulaManagerTest.java
@@ -24,6 +24,7 @@ import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.ServerGroup;
+import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.domain.server.test.ServerGroupTest;
 import com.redhat.rhn.domain.user.User;
@@ -236,7 +237,9 @@ public class FormulaManagerTest extends JMockBaseTestCaseWithUser {
         FormulaFactory.saveGroupFormulaData(formulaData, group.getId(), user.getOrg(), PROMETHEUS_EXPORTERS);
 
         // Server should have a monitoring entitlement after being added to the group
-        SystemManager.addServerToServerGroup(minion, group);
+        SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON,
+                saltServiceMock);
+        systemManager.addServerToServerGroup(minion, group);
         assertTrue(SystemManager.hasEntitlement(minion.getId(), EntitlementManager.MONITORING));
 
         List<FormulaData> combinedPrometheusExportersFormulas = this.manager

--- a/java/code/src/com/redhat/rhn/manager/formula/test/FormulaMonitoringManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/formula/test/FormulaMonitoringManagerTest.java
@@ -18,12 +18,17 @@ import static com.redhat.rhn.domain.formula.FormulaFactory.PROMETHEUS_EXPORTERS;
 
 import com.redhat.rhn.domain.formula.FormulaFactory;
 import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.ServerGroup;
+import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.domain.server.test.ServerGroupTest;
 import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
+
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.test.TestSaltApi;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -81,7 +86,9 @@ public class FormulaMonitoringManagerTest extends BaseTestCaseWithUser {
 
         // Create a group level assignment of the Formula
         ServerGroup group = ServerGroupTest.createTestServerGroup(user.getOrg(), null);
-        SystemManager.addServerToServerGroup(minion, group);
+        SaltApi saltApi = new TestSaltApi();
+        SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON, saltApi);
+        systemManager.addServerToServerGroup(minion, group);
         FormulaFactory.saveGroupFormulas(group.getId(), Arrays.asList(PROMETHEUS_EXPORTERS), user.getOrg());
 
         // Save data that enables monitoring

--- a/java/code/src/com/redhat/rhn/manager/org/MigrationManager.java
+++ b/java/code/src/com/redhat/rhn/manager/org/MigrationManager.java
@@ -14,7 +14,6 @@
  */
 package com.redhat.rhn.manager.org;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.domain.entitlement.Entitlement;
 import com.redhat.rhn.domain.org.Org;
@@ -57,7 +56,16 @@ import java.util.Set;
  */
 public class MigrationManager extends BaseManager {
 
-    private static final ServerGroupManager SERVER_GROUP_MANAGER = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+    private final ServerGroupManager groupManager;
+
+    /**
+     * Constructor
+     *
+     * @param groupManagerIn the server group manager
+     */
+    public MigrationManager(ServerGroupManager groupManagerIn) {
+        groupManager = groupManagerIn;
+    }
 
     /**
      * Migrate a set of servers to the organization specified
@@ -66,7 +74,7 @@ public class MigrationManager extends BaseManager {
      * @param servers List of servers to be migrated
      * @return the list of server ids successfully migrated.
      */
-    public static List<Long> migrateServers(User user, Org toOrg, List<Server> servers) {
+    public List<Long> migrateServers(User user, Org toOrg, List<Server> servers) {
 
         List<Long> serversMigrated = new ArrayList<Long>();
 
@@ -75,7 +83,7 @@ public class MigrationManager extends BaseManager {
             Org fromOrg = server.getOrg();
             Set<Entitlement> entitlements = server.getEntitlements();
 
-            MigrationManager.removeOrgRelationships(user, server);
+            removeOrgRelationships(user, server);
             MigrationManager.updateAdminRelationships(fromOrg, toOrg, server);
             MigrationManager.moveServerToOrg(toOrg, server);
             MigrationManager.updateServerEntitlements(toOrg, server, entitlements);
@@ -121,7 +129,7 @@ public class MigrationManager extends BaseManager {
      * @param user Org admin performing the migration.
      * @param server Server to be migrated.
      */
-    public static void removeOrgRelationships(User user, Server server) {
+    public void removeOrgRelationships(User user, Server server) {
 
         if (!user.hasRole(RoleFactory.ORG_ADMIN)) {
             throw new PermissionException(RoleFactory.ORG_ADMIN);
@@ -142,7 +150,7 @@ public class MigrationManager extends BaseManager {
         for (ManagedServerGroup group : server.getManagedGroups()) {
             List<Server> tempList = new LinkedList<Server>();
             tempList.add(server);
-            SERVER_GROUP_MANAGER.removeServers(group, tempList);
+            groupManager.removeServers(group, tempList);
         }
 
         // Remove from entitlement groups

--- a/java/code/src/com/redhat/rhn/manager/org/test/MigrationManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/org/test/MigrationManagerTest.java
@@ -72,6 +72,7 @@ public class MigrationManagerTest extends BaseTestCaseWithUser {
             new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
             new SystemEntitler(saltApi, virtManager, monitoringManager, serverGroupManager)
     );
+    private final MigrationManager migrationManager = new MigrationManager(serverGroupManager);
 
     @Override
     public void setUp() throws Exception {
@@ -111,7 +112,7 @@ public class MigrationManagerTest extends BaseTestCaseWithUser {
         User user = UserTestUtils.findNewUser("testUser",
                 "testOrg" + this.getClass().getSimpleName());
         try {
-            MigrationManager.removeOrgRelationships(user, server);
+            migrationManager.removeOrgRelationships(user, server);
             fail();
         }
         catch (PermissionException e) {
@@ -122,7 +123,7 @@ public class MigrationManagerTest extends BaseTestCaseWithUser {
     public void testRemoveEntitlements() throws Exception {
         assertTrue(server.getEntitlements().size() > 0);
 
-        MigrationManager.removeOrgRelationships(origOrgAdmins.iterator().next(), server);
+        migrationManager.removeOrgRelationships(origOrgAdmins.iterator().next(), server);
         server = ServerFactory.lookupById(server.getId());
 
         assertTrue(server.getEntitlements().size() == 0);
@@ -133,7 +134,7 @@ public class MigrationManagerTest extends BaseTestCaseWithUser {
         assertEquals(1, server.getManagedGroups().size());
         ManagedServerGroup serverGroup1 = server.getManagedGroups().get(0);
 
-        MigrationManager.removeOrgRelationships(origOrgAdmins.iterator().next(), server);
+        migrationManager.removeOrgRelationships(origOrgAdmins.iterator().next(), server);
         server = ServerFactory.lookupById(server.getId());
 
         //serverGroup1 = (ManagedServerGroup) reload(serverGroup1);
@@ -147,7 +148,7 @@ public class MigrationManagerTest extends BaseTestCaseWithUser {
         // verify that server was initially created w/channels
         assertTrue(server.getChannels().size() > 0);
 
-        MigrationManager.removeOrgRelationships(origOrgAdmins.iterator().next(), server);
+        migrationManager.removeOrgRelationships(origOrgAdmins.iterator().next(), server);
 
         assertEquals(0, server.getChannels().size());
     }
@@ -162,7 +163,7 @@ public class MigrationManagerTest extends BaseTestCaseWithUser {
 
         assertEquals(2, server2.getConfigChannelCount());
 
-        MigrationManager.removeOrgRelationships(origOrgAdmins.iterator().next(), server2);
+        migrationManager.removeOrgRelationships(origOrgAdmins.iterator().next(), server2);
 
         assertEquals(0, server2.getConfigChannelCount());
     }
@@ -206,7 +207,7 @@ public class MigrationManagerTest extends BaseTestCaseWithUser {
         servers.add(server);
         servers.add(server2);
         User origOrgAdmin = origOrgAdmins.iterator().next();
-        MigrationManager.migrateServers(origOrgAdmin, destOrg, servers);
+        migrationManager.migrateServers(origOrgAdmin, destOrg, servers);
 
         assertEquals(server.getOrg(), destOrg);
         assertEquals(server2.getOrg(), destOrg);
@@ -254,7 +255,7 @@ public class MigrationManagerTest extends BaseTestCaseWithUser {
 
         List<Server> servers = new ArrayList<Server>();
         servers.add(bootstrapServer);
-        MigrationManager.migrateServers(origOrgAdmin, destOrg, servers);
+        migrationManager.migrateServers(origOrgAdmin, destOrg, servers);
 
         assertEquals(bootstrapServer.getOrg(), destOrg);
 

--- a/java/code/src/com/redhat/rhn/manager/org/test/MigrationManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/org/test/MigrationManagerTest.java
@@ -65,7 +65,7 @@ public class MigrationManagerTest extends BaseTestCaseWithUser {
     private Server server2; // server w/provisioning ent
 
     private final SaltApi saltApi = new TestSaltApi();
-    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(

--- a/java/code/src/com/redhat/rhn/manager/recurringactions/test/RecurringActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/recurringactions/test/RecurringActionManagerTest.java
@@ -39,6 +39,8 @@ import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ServerGroupTestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
+import com.suse.manager.webui.services.test.TestSaltApi;
+
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.imposters.ByteBuddyClassImposteriser;
@@ -208,7 +210,7 @@ public class RecurringActionManagerTest extends BaseTestCaseWithUser {
     }
 
     public void testListGroupRecurringActions() {
-        ServerGroupManager manager = new ServerGroupManager();
+        ServerGroupManager manager = new ServerGroupManager(new TestSaltApi());
         ManagedServerGroup group = ServerGroupTestUtils.createManaged(user);
 
         var action = new GroupRecurringAction();

--- a/java/code/src/com/redhat/rhn/manager/system/AnsibleManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/AnsibleManager.java
@@ -18,7 +18,6 @@ package com.redhat.rhn.manager.system;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.common.validator.ValidatorException;
 import com.redhat.rhn.common.validator.ValidatorResult;
@@ -54,7 +53,16 @@ import java.util.Optional;
 
 public class AnsibleManager extends BaseManager {
 
-    private static SaltApi saltApi = GlobalInstanceHolder.SALT_API;
+    private final SaltApi saltApi;
+
+    /**
+     * Constructor
+     *
+     * @param saltApiIn the Salt API
+     */
+    public AnsibleManager(SaltApi saltApiIn) {
+        saltApi = saltApiIn;
+    }
 
     /**
      * Lookup ansible path by id
@@ -239,7 +247,7 @@ public class AnsibleManager extends BaseManager {
      * @throws LookupException when playbook path not found or accessible
      * @throws IllegalArgumentException when the specified relative path is absolute
      */
-    public static Optional<String> fetchPlaybookContents(long pathId, String playbookRelPathStr, User user) {
+    public Optional<String> fetchPlaybookContents(long pathId, String playbookRelPathStr, User user) {
         AnsiblePath path = lookupAnsiblePathById(pathId, user)
                 .orElseThrow(() -> new LookupException("Ansible playbook path id " + pathId + " not found."));
         if (!(path instanceof PlaybookPath)) {
@@ -309,7 +317,7 @@ public class AnsibleManager extends BaseManager {
      * @throws LookupException if the user does not have permissions to the minion associated with the path
      * @throws IllegalStateException if there is an error during the salt call
      */
-    public static Optional<Map<String, Map<String, AnsiblePlaybookSlsResult>>> discoverPlaybooks(long pathId,
+    public Optional<Map<String, Map<String, AnsiblePlaybookSlsResult>>> discoverPlaybooks(long pathId,
             User user) {
         AnsiblePath path = lookupAnsiblePathById(pathId, user)
                 .orElseThrow(() -> new LookupException(String.format("Path id %d not found", pathId)));
@@ -344,7 +352,7 @@ public class AnsibleManager extends BaseManager {
      * @throws LookupException if the user does not have permissions to the minion associated with the path
      * @throws IllegalStateException if there is an error during the salt call
      */
-    public static Optional<Map<String, Map<String, Object>>> introspectInventory(long pathId, User user) {
+    public Optional<Map<String, Map<String, Object>>> introspectInventory(long pathId, User user) {
         AnsiblePath path = lookupAnsiblePathById(pathId, user)
                 .orElseThrow(() -> new LookupException(String.format("Path id %d not found", pathId)));
 
@@ -376,23 +384,5 @@ public class AnsibleManager extends BaseManager {
         }
 
         return controlNode.asMinionServer().orElseThrow(() -> new LookupException(controlNode + " is not a minion"));
-    }
-
-    /**
-     * Sets the saltApi for testing
-     *
-     * @param saltApiIn the saltApi
-     */
-    public static void setSaltApi(SaltApi saltApiIn) {
-        AnsibleManager.saltApi = saltApiIn;
-    }
-
-    /**
-     * Gets the saltApi.
-     *
-     * @return saltApi
-     */
-    public static SaltApi getSaltApi() {
-        return saltApi;
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/system/ServerGroupManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/ServerGroupManager.java
@@ -340,7 +340,8 @@ public class ServerGroupManager {
         validateAccessCredentials(loggedInUser, sg, sg.getName());
         validateAdminCredentials(loggedInUser);
 
-        SystemManager.addServersToServerGroup(servers, sg);
+        SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON, saltApi);
+        systemManager.addServersToServerGroup(servers, sg);
         updatePillarAfterGroupUpdateForServers(servers);
     }
 

--- a/java/code/src/com/redhat/rhn/manager/system/ServerGroupManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/ServerGroupManager.java
@@ -364,7 +364,9 @@ public class ServerGroupManager {
      */
     public void removeServers(ServerGroup sg, Collection<Server> servers) {
         if (!servers.isEmpty()) {
-            SystemManager.removeServersFromServerGroup(servers, sg);
+            SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON,
+                    saltApi);
+            systemManager.removeServersFromServerGroup(servers, sg);
             updatePillarAfterGroupUpdateForServers(servers);
         }
     }

--- a/java/code/src/com/redhat/rhn/manager/system/ServerGroupManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/ServerGroupManager.java
@@ -25,12 +25,14 @@ import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.EntitlementServerGroup;
 import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.ServerGroup;
 import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.domain.user.UserFactory;
 
 import com.suse.manager.webui.services.SaltStateGeneratorService;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.utils.Opt;
 
@@ -52,6 +54,17 @@ public class ServerGroupManager {
 
     /** Logger */
     private static final Logger LOG = Logger.getLogger(ServerGroupManager.class);
+
+    private final SaltApi saltApi;
+
+    /**
+     * Constructor.
+     *
+     * @param saltApiIn the Salt API
+     */
+    public ServerGroupManager(SaltApi saltApiIn) {
+        saltApi = saltApiIn;
+    }
 
     /**
      * Lookup a ServerGroup by ID and organization.

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -777,14 +777,14 @@ public class SystemManager extends BaseManager {
      * @param servers The servers to add
      * @param serverGroup The group to add the server to
      */
-    public static void addServersToServerGroup(Collection<Server> servers,
+    public void addServersToServerGroup(Collection<Server> servers,
             ServerGroup serverGroup) {
         ServerFactory.addServersToGroup(servers, serverGroup);
         snapshotServers(servers, "Group membership alteration");
 
         if (FormulaFactory.hasMonitoringDataEnabled(serverGroup)) {
             for (Server server : servers) {
-                FormulaFactory.grantMonitoringEntitlement(server);
+                systemEntitlementManager.grantMonitoringEntitlement(server);
             }
         }
     }
@@ -794,7 +794,7 @@ public class SystemManager extends BaseManager {
      * @param server The server to add
      * @param serverGroup The group to add the server to
      */
-    public static void addServerToServerGroup(Server server, ServerGroup serverGroup) {
+    public void addServerToServerGroup(Server server, ServerGroup serverGroup) {
         addServersToServerGroup(Arrays.asList(server), serverGroup);
     }
 

--- a/java/code/src/com/redhat/rhn/manager/system/entitling/SystemEntitlementManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/entitling/SystemEntitlementManager.java
@@ -17,12 +17,18 @@ package com.redhat.rhn.manager.system.entitling;
 import com.redhat.rhn.common.validator.ValidatorResult;
 import com.redhat.rhn.domain.entitlement.Entitlement;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.manager.entitlement.EntitlementManager;
+import com.redhat.rhn.manager.system.SystemManager;
+
+import org.apache.log4j.Logger;
 
 
 /**
  * Manager class for adding/removing entitlements to/from servers
  */
 public class SystemEntitlementManager {
+
+    private static final Logger LOG = Logger.getLogger(SystemEntitlementManager.class);
 
     private SystemUnentitler systemUnentitler;
     private SystemEntitler systemEntitler;
@@ -95,5 +101,20 @@ public class SystemEntitlementManager {
             this.systemUnentitler.removeServerEntitlement(server, baseEntitlement);
         }
         this.systemEntitler.addEntitlementToServer(server, baseIn);
+    }
+
+    /**
+     * Entitle server if it doesn't already have the monitoring entitlement and if it's allowed.
+     * @param server the server to entitle
+     */
+    public void grantMonitoringEntitlement(Server server) {
+        boolean hasEntitlement = SystemManager.hasEntitlement(server.getId(), EntitlementManager.MONITORING);
+        if (!hasEntitlement && canEntitleServer(server, EntitlementManager.MONITORING)) {
+            addEntitlementToServer(server, EntitlementManager.MONITORING);
+            return;
+        }
+        if (LOG.isDebugEnabled() && hasEntitlement) {
+            LOG.debug("Server " + server.getName() + " already has monitoring entitlement.");
+        }
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/system/entitling/test/SystemEntitlementManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/entitling/test/SystemEntitlementManagerTest.java
@@ -54,7 +54,7 @@ public class SystemEntitlementManagerTest extends JMockBaseTestCaseWithUser {
         super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         saltServiceMock = mock(SaltService.class);
-        ServerGroupManager serverGroupManager = new ServerGroupManager();
+        ServerGroupManager serverGroupManager = new ServerGroupManager(saltServiceMock);
         systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(new VirtManagerSalt(saltServiceMock), new FormulaMonitoringManager(),
                         serverGroupManager),

--- a/java/code/src/com/redhat/rhn/manager/system/test/ServerGroupManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/ServerGroupManagerTest.java
@@ -24,6 +24,8 @@ import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
+import com.suse.manager.webui.services.test.TestSaltApi;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -42,7 +44,7 @@ public class ServerGroupManagerTest extends BaseTestCaseWithUser {
 
     public void setUp() throws Exception {
         super.setUp();
-        manager = new ServerGroupManager();
+        manager = new ServerGroupManager(new TestSaltApi());
     }
 
     public void testCreate() {

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerMockTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerMockTest.java
@@ -21,6 +21,8 @@ import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.kickstart.cobbler.CobblerXMLRPCHelper;
@@ -88,8 +90,9 @@ public class SystemManagerMockTest extends JMockBaseTestCaseWithUser {
             will(returnValue(Optional.of(new MgrUtilRunner.RemoveKnowHostResult("removed", ""))));
         }});
 
-        SystemManager.mockSaltService(saltServiceMock);
-        SystemManager.deleteServer(server.getOrg().getActiveOrgAdmins().get(0), server.getId());
+        SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON,
+                saltServiceMock);
+        systemManager.deleteServer(server.getOrg().getActiveOrgAdmins().get(0), server.getId());
 
         assertFalse(tokenBase.getValid());
         assertFalse(tokenChild.getValid());

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -195,7 +195,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         });
         SaltApi saltApi = new TestSaltApi();
         VirtManager virtManager = new TestVirtManager();
-        ServerGroupManager serverGroupManager = new ServerGroupManager();
+        ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
         systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(virtManager, new FormulaMonitoringManager(),
                         serverGroupManager),

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -1387,7 +1387,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
     public void testCreateSystemProfile() {
         String hwAddr = "be:b0:bc:a3:a7:ad";
         Map<String, Object> data = singletonMap("hwAddress", hwAddr);
-        MinionServer minion = SystemManager.createSystemProfile(user, "test system", data);
+        MinionServer minion = systemManager.createSystemProfile(user, "test system", data);
         Server minionFromDb = SystemManager.lookupByIdAndOrg(minion.getId(), user.getOrg());
 
         // flush & refresh iface because generated="insert"
@@ -1421,7 +1421,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
     public void testListSystemProfile() throws Exception {
         UserTestUtils.addUserRole(user, RoleFactory.ORG_ADMIN);
         String hwAddr = "be:b0:bc:a3:a7:ad";
-        MinionServer emptyProfileMinion = SystemManager.createSystemProfile(user, "test system",
+        MinionServer emptyProfileMinion = systemManager.createSystemProfile(user, "test system",
                 singletonMap("hwAddress", hwAddr));
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().evict(emptyProfileMinion);
@@ -1449,7 +1449,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
     public void testListSystemProfileTradSystem() {
         UserTestUtils.addUserRole(user, RoleFactory.ORG_ADMIN);
         String hwAddr = "be:b0:bc:a3:a7:ad";
-        MinionServer emptyProfileMinion = SystemManager.createSystemProfile(user, "test system",
+        MinionServer emptyProfileMinion = systemManager.createSystemProfile(user, "test system",
                 singletonMap("hwAddress", hwAddr));
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().createNativeQuery("DELETE FROM suseMinionInfo").executeUpdate();
@@ -1467,7 +1467,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         UserTestUtils.addUserRole(foreignUser, RoleFactory.ORG_ADMIN);
         UserTestUtils.addUserRole(user, RoleFactory.ORG_ADMIN);
         String hwAddr = "be:b0:bc:a3:a7:ad";
-        SystemManager.createSystemProfile(user, "test system", singletonMap("hwAddress", hwAddr));
+        systemManager.createSystemProfile(user, "test system", singletonMap("hwAddress", hwAddr));
 
         assertEquals(1, SystemManager.listEmptySystemProfiles(user, null).getTotalSize());
         assertEquals(0, SystemManager.listEmptySystemProfiles(foreignUser, null).getTotalSize());
@@ -1480,9 +1480,9 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
     public void testCreateSystemProfileExistingHwAddress() {
         String hwAddr = "be:b0:bc:a3:a7:ad";
         Map<String, Object> data = singletonMap("hwAddress", hwAddr);
-        MinionServer profile = SystemManager.createSystemProfile(user, "test system", data);
+        MinionServer profile = systemManager.createSystemProfile(user, "test system", data);
         try {
-            SystemManager.createSystemProfile(user, "test system 2", data);
+            systemManager.createSystemProfile(user, "test system 2", data);
             fail("System creation should have failed!");
         }
         catch (SystemsExistException e) {
@@ -1611,7 +1611,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         Map<String, Object> data = new HashMap<>();
         hostName.ifPresent(n -> data.put("hostname", n));
         hwAddr.ifPresent(a -> data.put("hwAddress", a));
-        return SystemManager.createSystemProfile(user, hostName.orElse("test system"), data);
+        return systemManager.createSystemProfile(user, hostName.orElse("test system"), data);
     }
 
     /**
@@ -1641,7 +1641,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         assertTrue(SystemManager.hasEntitlement(server.getId(), EntitlementManager.MONITORING));
 
         // Remove server from group, entitlement should be removed
-        SystemManager.removeServersFromServerGroup(Arrays.asList(server), group);
+        systemManager.removeServersFromServerGroup(Arrays.asList(server), group);
         assertFalse(SystemManager.hasEntitlement(server.getId(), EntitlementManager.MONITORING));
     }
 

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -411,7 +411,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         assertTrue(serverInList(s, systems));
 
 
-        SystemManager.addServerToServerGroup(s, sg);
+        systemManager.addServerToServerGroup(s, sg);
         systems = SystemManager.systemsNotInGroup(user, sg, null);
         assertFalse(serverInList(s, systems));
     }
@@ -729,7 +729,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
                 ServerConstants.getServerGroupTypeEnterpriseEntitled());
         ServerGroup group = ServerGroupTest
                 .createTestServerGroup(user.getOrg(), null);
-        SystemManager.addServerToServerGroup(server, group);
+        systemManager.addServerToServerGroup(server, group);
         ServerFactory.save(server);
 
         DataResult<SystemOverview> dr = SystemManager.registeredList(user, null, 0);
@@ -1637,7 +1637,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         FormulaFactory.saveGroupFormulaData(formulaData, group.getId(), user.getOrg(), PROMETHEUS_EXPORTERS);
 
         // Server should have a monitoring entitlement after being added to the group
-        SystemManager.addServerToServerGroup(server, group);
+        systemManager.addServerToServerGroup(server, group);
         assertTrue(SystemManager.hasEntitlement(server.getId(), EntitlementManager.MONITORING));
 
         // Remove server from group, entitlement should be removed
@@ -1652,7 +1652,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         MinionServer server = MinionServerFactoryTest.createTestMinionServer(user);
 
         ServerGroup group = ServerGroupTest.createTestServerGroup(user.getOrg(), null);
-        SystemManager.addServerToServerGroup(server, group);
+        systemManager.addServerToServerGroup(server, group);
 
         List<SystemGroupsDTO> systemGroupsDTOs = this.systemManager
                 .retrieveSystemGroupsForSystemsWithEntitlementAndUser(user, EntitlementManager.SALT.getLabel());

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -187,7 +187,6 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         metadataDirOfficial = Files.createTempDirectory("meta");
         FormulaFactory.setDataDir(tmpSaltRoot.toString());
         FormulaFactory.setMetadataDirOfficial(metadataDirOfficial.toString());
-        SystemManager.mockSaltService(saltServiceMock);
         context().checking(new Expectations() {
             {
                 allowing(taskomaticMock)
@@ -203,7 +202,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
                 new SystemEntitler(saltApi, virtManager, new FormulaMonitoringManager(),
                         serverGroupManager)
         );
-        this.systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON);
+        this.systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON, saltServiceMock);
         createMetadataFiles();
     }
 
@@ -275,7 +274,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         Server test = SystemManager.lookupByIdAndUser(id, user);
         assertNotNull(test);
 
-        SystemManager.deleteServer(user, id);
+        systemManager.deleteServer(user, id);
 
         try {
             test = SystemManager.lookupByIdAndUser(id, user);
@@ -309,7 +308,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
             allowing(saltServiceMock).removeSaltSSHKnownHost(minion.getHostname());
             will(returnValue(Optional.of(new MgrUtilRunner.RemoveKnowHostResult("removed", ""))));
         }});
-        SystemManager.deleteServer(user, minion.getId());
+        systemManager.deleteServer(user, minion.getId());
 
         assertTrue(FormulaFactory.getFormulasByMinionId(minionId).isEmpty());
         assertFalse(FormulaFactory.getFormulaValuesByNameAndMinionId(formulaName, minionId).isPresent());
@@ -333,7 +332,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
             allowing(saltServiceMock).removeSaltSSHKnownHost(minion.getHostname());
             will(returnValue(Optional.of(new MgrUtilRunner.RemoveKnowHostResult("removed", ""))));
         }});
-        SystemManager.deleteServer(user, minion.getId());
+        systemManager.deleteServer(user, minion.getId());
 
         assertTrue(FormulaFactory.getFormulasByMinionId(minionId).isEmpty());
         assertFalse(FormulaFactory.getFormulaValuesByNameAndMinionId(formulaName, minionId).isPresent());
@@ -353,7 +352,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         Server test = SystemManager.lookupByIdAndUser(sid, user);
         assertNotNull(test);
 
-        SystemManager.deleteServer(user, sid);
+        systemManager.deleteServer(user, sid);
 
         try {
             test = SystemManager.lookupByIdAndUser(sid, user);
@@ -380,10 +379,10 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         assertNotNull(test);
 
         // Delete the host first:
-        SystemManager.deleteServer(user, host.getId());
+        systemManager.deleteServer(user, host.getId());
         TestUtils.flushAndEvict(host);
 
-        SystemManager.deleteServer(user, sid);
+        systemManager.deleteServer(user, sid);
         TestUtils.flushAndEvict(guest);
 
         try {

--- a/java/code/src/com/redhat/rhn/manager/user/test/UserManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/user/test/UserManagerTest.java
@@ -55,6 +55,9 @@ import com.redhat.rhn.testing.TestStatics;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.test.TestSaltApi;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -69,6 +72,7 @@ import java.util.Set;
  */
 public class UserManagerTest extends RhnBaseTestCase {
 
+    private SystemManager systemManager;
     private Set<User> users;
     private boolean committed = false;
 
@@ -79,6 +83,8 @@ public class UserManagerTest extends RhnBaseTestCase {
     public void setUp() throws Exception {
         super.setUp();
         this.users = new HashSet<User>();
+        SaltApi saltApi = new TestSaltApi();
+        systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON, saltApi);
     }
 
     /**
@@ -113,7 +119,7 @@ public class UserManagerTest extends RhnBaseTestCase {
         ServerGroup group = ServerGroupTest
                 .createTestServerGroup(user.getOrg(), null);
 
-        SystemManager.addServerToServerGroup(server, group);
+        systemManager.addServerToServerGroup(server, group);
         ServerFactory.save(server);
 
         ServerGroup foundGroup = ServerGroupFactory.lookupByIdAndOrg(group.getId(),
@@ -176,7 +182,7 @@ public class UserManagerTest extends RhnBaseTestCase {
         ServerGroup group2 = ServerGroupTest
                 .createTestServerGroup(foundUser2.getOrg(), null);
 
-        SystemManager.addServerToServerGroup(server2, group2);
+        systemManager.addServerToServerGroup(server2, group2);
         ServerFactory.save(server2);
 
         ManagedServerGroup foundGroup2 = ServerGroupFactory.lookupByIdAndOrg(group2.getId(),
@@ -217,7 +223,7 @@ public class UserManagerTest extends RhnBaseTestCase {
         ServerGroup group = ServerGroupTest
                 .createTestServerGroup(user.getOrg(), null);
 
-        SystemManager.addServerToServerGroup(server, group);
+        systemManager.addServerToServerGroup(server, group);
         ServerFactory.save(server);
 
         ServerGroup foundGroup = ServerGroupFactory.lookupByIdAndOrg(group.getId(),

--- a/java/code/src/com/redhat/rhn/manager/visualization/test/VisualizationManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/visualization/test/VisualizationManagerTest.java
@@ -44,6 +44,8 @@ import com.redhat.rhn.manager.visualization.json.VirtualHostManager;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ChannelTestUtils;
 
+import com.suse.manager.webui.services.test.TestSaltApi;
+
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -225,7 +227,7 @@ public class VisualizationManagerTest extends BaseTestCaseWithUser {
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         Server server = ServerFactoryTest.createTestServer(user, false);
 
-        ServerGroupManager manager = new ServerGroupManager();
+        ServerGroupManager manager = new ServerGroupManager(new TestSaltApi());
         ManagedServerGroup sg1 = manager.create(user, "FooFooFOO", "Foo Description");
         manager.addServers(sg1, Collections.singleton(server), user);
 
@@ -260,7 +262,7 @@ public class VisualizationManagerTest extends BaseTestCaseWithUser {
         // information as we rely on errata cache in our query
         ErrataCacheManager.insertNeededErrataCache(server.getId(), e.getId(), p.getId());
 
-        ServerGroupManager manager = new ServerGroupManager();
+        ServerGroupManager manager = new ServerGroupManager(new TestSaltApi());
         ManagedServerGroup sg1 = manager.create(user, "FooFooFOO", "Foo Description");
         manager.addServers(sg1, Collections.singleton(server), user);
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
@@ -307,7 +307,7 @@ public class SSHPushWorkerSaltTest extends JMockBaseTestCaseWithUser {
     }
 
     private SSHPushWorkerSalt successWorker(SystemQuery systemQuery, SaltApi saltApi) {
-        ServerGroupManager serverGroupManager = new ServerGroupManager();
+        ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
         SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager, serverGroupManager);

--- a/java/code/src/com/redhat/rhn/testing/ImageTestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/ImageTestUtils.java
@@ -15,7 +15,6 @@
 
 package com.redhat.rhn.testing;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.credentials.Credentials;
 import com.redhat.rhn.domain.credentials.CredentialsFactory;
@@ -47,8 +46,6 @@ import java.util.Set;
  * Utility methods for testing of the image features.
  */
 public class ImageTestUtils {
-
-    private static SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
 
     private ImageTestUtils() { }
 
@@ -388,26 +385,15 @@ public class ImageTestUtils {
     /**
      * Create a {@link MinionServer} with Container Build Host entitlement.
      *
+     * @param entitlementManager system entitlement manager
      * @param user the user
      * @return the minion server
      * @throws Exception the exception
      */
-    public static MinionServer createBuildHost(User user) throws Exception {
+    public static MinionServer createBuildHost(SystemEntitlementManager entitlementManager, User user)
+            throws Exception {
         MinionServer server = MinionServerFactoryTest.createTestMinionServer(user);
-        systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.CONTAINER_BUILD_HOST);
-        return server;
-    }
-
-    /**
-     * Create a {@link MinionServer} with OSImage Build Host entitlement.
-     *
-     * @param user the user
-     * @return the minion server
-     * @throws Exception the exception
-     */
-    public static MinionServer createOSImageBuildHost(User user) throws Exception {
-        MinionServer server = MinionServerFactoryTest.createTestMinionServer(user);
-        systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.OSIMAGE_BUILD_HOST);
+        entitlementManager.addEntitlementToServer(server, EntitlementManager.CONTAINER_BUILD_HOST);
         return server;
     }
 }

--- a/java/code/src/com/suse/manager/clusters/test/ClusterManagerTest.java
+++ b/java/code/src/com/suse/manager/clusters/test/ClusterManagerTest.java
@@ -83,7 +83,7 @@ public class ClusterManagerTest extends JMockBaseTestCaseWithUser {
 
         ClusterManager clusterManager = new ClusterManager(saltServiceMock,
                 saltServiceMock,
-                new ServerGroupManager(),
+                new ServerGroupManager(saltServiceMock),
                 formulaManagerMock);
         Optional<String> plan = clusterManager.getUpgradePlan(cluster);
         assertTrue(plan.isPresent());

--- a/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
+++ b/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
@@ -47,6 +47,7 @@ import com.redhat.rhn.testing.TestUtils;
 
 import com.suse.manager.matcher.MatcherJsonIO;
 import com.suse.manager.virtualization.test.TestVirtManager;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.matcher.json.MatchJson;
@@ -100,12 +101,11 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
             public void updateLibvirtEngine(MinionServer minion) {
             }
         };
-        ServerGroupManager serverGroupManager = new ServerGroupManager();
+        SaltApi saltApi = new TestSaltApi();
+        ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(virtManager, new FormulaMonitoringManager(),
-                        serverGroupManager),
-                new SystemEntitler(new TestSaltApi(), virtManager, new FormulaMonitoringManager(),
-                        serverGroupManager)
+                new SystemUnentitler(virtManager, new FormulaMonitoringManager(), serverGroupManager),
+                new SystemEntitler(saltApi, virtManager, new FormulaMonitoringManager(), serverGroupManager)
         );
     }
 

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -653,8 +653,9 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                     branchIdGroupName + "\")! Aborting registration.");
         }
 
-        SystemManager.addServerToServerGroup(minion, terminalsGroup);
-        SystemManager.addServerToServerGroup(minion, branchIdGroup);
+        SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON, saltApi);
+        systemManager.addServerToServerGroup(minion, terminalsGroup);
+        systemManager.addServerToServerGroup(minion, branchIdGroup);
         if (hwGroup != null) {
             // if the system is already assigned to some HWTYPE group, skip assignment and log this only
             if (minion.getManagedGroups().stream().anyMatch(g -> g.getName().startsWith(hwTypeGroupPrefix))) {
@@ -662,7 +663,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                         ". The minion is already in a HW group.");
             }
             else {
-                SystemManager.addServerToServerGroup(minion, hwGroup);
+                systemManager.addServerToServerGroup(minion, hwGroup);
             }
         }
 

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -159,7 +159,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         Config.get().setString("server.secret_key",
                 DigestUtils.sha256Hex(TestUtils.randomString()));
         saltServiceMock = context().mock(SaltService.class);
-        ServerGroupManager serverGroupManager = new ServerGroupManager();
+        ServerGroupManager serverGroupManager = new ServerGroupManager(saltServiceMock);
         systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(new VirtManagerSalt(saltServiceMock), new FormulaMonitoringManager(),
                         serverGroupManager),

--- a/java/code/src/com/suse/manager/reactor/messaging/test/LibvirtEngineDomainLifecycleMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/LibvirtEngineDomainLifecycleMessageActionTest.java
@@ -88,7 +88,7 @@ public class LibvirtEngineDomainLifecycleMessageActionTest extends JMockBaseTest
             allowing(virtManager).updateLibvirtEngine(with(any(MinionServer.class)));
         }});
 
-        ServerGroupManager serverGroupManager = new ServerGroupManager();
+        ServerGroupManager serverGroupManager = new ServerGroupManager(new TestSaltApi());
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(virtManager, new FormulaMonitoringManager(), serverGroupManager),
                 new SystemEntitler(new TestSaltApi(), virtManager, new FormulaMonitoringManager(),

--- a/java/code/src/com/suse/manager/reactor/messaging/test/MinionActionCleanupTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/MinionActionCleanupTest.java
@@ -124,7 +124,7 @@ public class MinionActionCleanupTest extends JMockBaseTestCaseWithUser {
             }
         } });
 
-        ServerGroupManager serverGroupManager = new ServerGroupManager();
+        ServerGroupManager serverGroupManager = new ServerGroupManager(saltServiceMock);
         FormulaManager formulaManager = new FormulaManager(saltServiceMock);
         ClusterManager clusterManager = new ClusterManager(
                 saltServiceMock, saltServiceMock, serverGroupManager, formulaManager);
@@ -278,7 +278,7 @@ public class MinionActionCleanupTest extends JMockBaseTestCaseWithUser {
 
         ActionChainFactory.delete(actionChain);
 
-        ServerGroupManager serverGroupManager = new ServerGroupManager();
+        ServerGroupManager serverGroupManager = new ServerGroupManager(saltServiceMock);
         FormulaManager formulaManager = new FormulaManager(saltServiceMock);
         ClusterManager clusterManager =  new ClusterManager(saltServiceMock, saltServiceMock, serverGroupManager,
                 formulaManager);

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -516,7 +516,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         server.getManagedGroups().add(terminalsGroup);
         server.setMinionId(MINION_ID);
         server.setMachineId(MACHINE_ID);
-        SystemManager.addServerToServerGroup(server, terminalsGroup);
+        systemManager.addServerToServerGroup(server, terminalsGroup);
         MinionStartupGrains minionStartUpGrains =  new MinionStartupGrains.MinionStartupGrainsBuilder()
                 .machineId(MACHINE_ID).saltbootInitrd(true)
                 .createMinionStartUpGrains();

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -315,7 +315,6 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         if (expectations != null) {
             Expectations exp = expectations.apply(saltServiceMock, key);
             context().checking(exp);
-            SystemManager.mockSaltService(saltServiceMock);
 
             TaskomaticApi taskomaticMock = mock(TaskomaticApi.class);
             ActionManager.setTaskomaticApi(taskomaticMock);

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -561,10 +561,10 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
 
         ChannelFamily channelFamily = createTestChannelFamily();
         SUSEProduct product = SUSEProductTestUtils.createTestSUSEProduct(channelFamily);
-        SaltService saltService = setupStubs(product);
+        setupStubs(product);
 
         // Verify the resulting system entry
-        String machineId = saltService.getMachineId(MINION_ID).get();
+        String machineId = saltServiceMock.getMachineId(MINION_ID).get();
         Optional<MinionServer> optMinion = MinionServerFactory.findByMachineId(machineId);
         assertTrue(optMinion.isPresent());
         MinionServer minion = optMinion.get();
@@ -2317,9 +2317,8 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
     }
 
     @SuppressWarnings("unchecked")
-    private SaltService setupStubs(SUSEProduct product)
+    private void setupStubs(SUSEProduct product)
         throws ClassNotFoundException, IOException {
-        SaltService saltService = mock(SaltService.class);
 
         TaskomaticApi taskomaticMock = mock(TaskomaticApi.class);
         ActionManager.setTaskomaticApi(taskomaticMock);
@@ -2328,17 +2327,17 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 .createMinionStartUpGrains();
         MinionServerFactory.findByMachineId(MACHINE_ID).ifPresent(ServerFactory::delete);
         context().checking(new Expectations() { {
-            allowing(saltService).getMasterHostname(MINION_ID);
+            allowing(saltServiceMock).getMasterHostname(MINION_ID);
             will(returnValue(Optional.of(MINION_ID)));
-            allowing(saltService).getMachineId(MINION_ID);
+            allowing(saltServiceMock).getMachineId(MINION_ID);
             will(returnValue(Optional.of(MACHINE_ID)));
-            allowing(saltService).getGrains(
+            allowing(saltServiceMock).getGrains(
                     with(any(String.class)), with(any(TypeToken.class)), with(any(String[].class)));
             will(returnValue(Optional.of(minionStartUpGrains)));
-            allowing(saltService).getGrains(MINION_ID);
+            allowing(saltServiceMock).getGrains(MINION_ID);
             will(returnValue(getGrains(MINION_ID, null, "foo")));
-            allowing(saltService).syncGrains(with(any(MinionList.class)));
-            allowing(saltService).syncModules(with(any(MinionList.class)));
+            allowing(saltServiceMock).syncGrains(with(any(MinionList.class)));
+            allowing(saltServiceMock).syncModules(with(any(MinionList.class)));
             List<ProductInfo> pil = new ArrayList<>();
             ProductInfo pi = new ProductInfo(
                         product.getName(),
@@ -2347,7 +2346,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                         "test", "repo", "shortname", "summary", "vendor",
                         product.getVersion());
             pil.add(pi);
-            allowing(saltService).callSync(
+            allowing(saltServiceMock).callSync(
                      with(any(LocalCall.class)),
                      with(any(String.class)));
             will(returnValue(Optional.of(pil)));
@@ -2360,9 +2359,8 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         } });
 
         RegisterMinionEventMessageAction action =
-                new RegisterMinionEventMessageAction(saltService, saltService);
+                new RegisterMinionEventMessageAction(saltServiceMock, saltServiceMock);
         action.execute(new RegisterMinionEventMessage(MINION_ID, Optional.empty()));
-        return saltService;
     }
 
     private Optional<Map<String, Object>> getGrains(String minionId, String sufix, String akey)

--- a/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
@@ -25,6 +25,7 @@ import static com.suse.manager.webui.utils.gson.ResultJson.success;
 import static spark.Spark.get;
 import static spark.Spark.post;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.validator.ValidatorException;
@@ -273,7 +274,7 @@ public class AnsibleController {
     public static String fetchPlaybookContents(Request req, Response res, User user) {
         try {
             AnsiblePlaybookIdJson params = GSON.fromJson(req.body(), AnsiblePlaybookIdJson.class);
-            return AnsibleManager.fetchPlaybookContents(params.getPathId(), params.getPlaybookRelPathStr(), user)
+            return getAnsibleManager().fetchPlaybookContents(params.getPathId(), params.getPlaybookRelPathStr(), user)
                     .map(contents -> json(res, success(contents)))
                     .orElseGet(() -> json(res,
                             error(LOCAL.getMessage("ansible.control_node_not_responding"))));
@@ -336,7 +337,7 @@ public class AnsibleController {
         long pathId = Long.parseLong(req.params("pathId"));
 
         try {
-            return AnsibleManager.introspectInventory(pathId, user)
+            return getAnsibleManager().introspectInventory(pathId, user)
                     .map(inventory -> {
                         Map<String, Object> data = new HashMap<>();
 
@@ -399,7 +400,7 @@ public class AnsibleController {
         long pathId = Long.parseLong(req.params("pathId"));
 
         try {
-            return AnsibleManager.discoverPlaybooks(pathId, user)
+            return getAnsibleManager().discoverPlaybooks(pathId, user)
                     .map(playbook -> json(res, success(playbook)))
                     .orElseGet(() -> json(res,
                             error(LOCAL.getMessage("ansible.control_node_not_responding"))));
@@ -411,5 +412,9 @@ public class AnsibleController {
         catch (LookupException e) {
             return json(res, error(LOCAL.getMessage("ansible.entity_not_found")));
         }
+    }
+
+    private static AnsibleManager getAnsibleManager() {
+        return new AnsibleManager(GlobalInstanceHolder.SALT_API);
     }
 }

--- a/java/code/src/com/suse/manager/webui/controllers/SystemsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/SystemsController.java
@@ -33,6 +33,7 @@ import com.redhat.rhn.domain.rhnset.RhnSet;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.context.Context;
 import com.redhat.rhn.frontend.dto.EssentialChannelDto;
@@ -212,7 +213,9 @@ public class SystemsController {
 
         try {
             // Now we can remove the system
-            SystemManager.deleteServer(user, sid);
+            SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON,
+                    saltApi);
+            systemManager.deleteServer(user, sid);
             createSuccessMessage(request.raw(), "message.serverdeleted.param",
                     Long.toString(sid));
         }

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualGuestsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualGuestsControllerTest.java
@@ -43,6 +43,7 @@ import com.suse.manager.virtualization.VmInfoJson;
 import com.suse.manager.virtualization.test.TestVirtManager;
 import com.suse.manager.webui.controllers.test.BaseControllerTestCase;
 import com.suse.manager.webui.controllers.virtualization.VirtualGuestsController;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.services.test.TestSaltApi;
 
@@ -136,12 +137,11 @@ public class VirtualGuestsControllerTest extends BaseControllerTestCase {
             }
         };
 
-        ServerGroupManager serverGroupManager = new ServerGroupManager();
+        SaltApi saltApi = new TestSaltApi();
+        ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(virtManager, new FormulaMonitoringManager(),
-                        serverGroupManager),
-                new SystemEntitler(new TestSaltApi(), virtManager, new FormulaMonitoringManager(),
-                        serverGroupManager)
+                new SystemUnentitler(virtManager, new FormulaMonitoringManager(), serverGroupManager),
+                new SystemEntitler(saltApi, virtManager, new FormulaMonitoringManager(), serverGroupManager)
         );
 
         host = ServerTestUtils.createVirtHostWithGuests(user, 2, true, systemEntitlementManager);

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualNetsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualNetsControllerTest.java
@@ -101,7 +101,7 @@ public class VirtualNetsControllerTest extends BaseControllerTestCase {
             }
         };
 
-        ServerGroupManager serverGroupManager = new ServerGroupManager();
+        ServerGroupManager serverGroupManager = new ServerGroupManager(new TestSaltApi());
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(virtManager, new FormulaMonitoringManager(), serverGroupManager),
                 new SystemEntitler(new TestSaltApi(), virtManager, new FormulaMonitoringManager(), serverGroupManager)

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualPoolsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualPoolsControllerTest.java
@@ -45,6 +45,7 @@ import com.suse.manager.virtualization.test.TestVirtManager;
 import com.suse.manager.webui.controllers.test.BaseControllerTestCase;
 import com.suse.manager.webui.controllers.virtualization.VirtualPoolsController;
 import com.suse.manager.webui.controllers.virtualization.gson.VirtualStoragePoolInfoJson;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.services.test.TestSaltApi;
 
@@ -115,11 +116,12 @@ public class VirtualPoolsControllerTest extends BaseControllerTestCase {
                         new TypeToken<PoolCapabilitiesJson>() { });
             }
         };
-        ServerGroupManager serverGroupManager = new ServerGroupManager();
+        SaltApi saltApi = new TestSaltApi();
+        ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
         systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(virtManager, new FormulaMonitoringManager(),
                         serverGroupManager),
-                new SystemEntitler(new TestSaltApi(), virtManager, new FormulaMonitoringManager(),
+                new SystemEntitler(saltApi, virtManager, new FormulaMonitoringManager(),
                         serverGroupManager)
         );
 

--- a/java/code/src/com/suse/manager/webui/menu/test/MenuTreeTest.java
+++ b/java/code/src/com/suse/manager/webui/menu/test/MenuTreeTest.java
@@ -90,7 +90,7 @@ public class MenuTreeTest extends TestCase {
         SystemQuery systemQuery = new TestSystemQuery();
         SaltApi saltApi = new TestSaltApi();
         MenuTree menuTree = new MenuTree(new AclFactory(new Access(new ClusterManager(
-                saltApi, systemQuery, new ServerGroupManager(), new FormulaManager(saltApi)
+                saltApi, systemQuery, new ServerGroupManager(saltApi), new FormulaManager(saltApi)
         ))));
 
         // the TESTED method

--- a/java/code/src/com/suse/manager/webui/services/pillar/test/MinionVirtualizationPillarGeneratorTest.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/test/MinionVirtualizationPillarGeneratorTest.java
@@ -57,7 +57,7 @@ public class MinionVirtualizationPillarGeneratorTest extends BaseTestCaseWithUse
             }
         };
 
-        ServerGroupManager serverGroupManager =  new ServerGroupManager();
+        ServerGroupManager serverGroupManager =  new ServerGroupManager(new TestSaltApi());
         systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(virtManager, new FormulaMonitoringManager(),
                         serverGroupManager),

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -119,6 +119,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
     private MinionServer minion;
     private SaltServerActionService saltServerActionService;
     private SystemEntitlementManager systemEntitlementManager;
+    private ServerGroupManager serverGroupManager;
     private TaskomaticApi taskomaticMock;
 
     @Override
@@ -139,7 +140,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         };
         minion = MinionServerFactoryTest.createTestMinionServer(user);
         saltServerActionService = createSaltServerActionService(saltService, saltService);
-        ServerGroupManager serverGroupManager = new ServerGroupManager();
+        serverGroupManager = new ServerGroupManager(saltService);
         systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(virtManager, new FormulaMonitoringManager(),
                         serverGroupManager),
@@ -152,7 +153,6 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
     }
 
     private SaltServerActionService createSaltServerActionService(SystemQuery systemQuery, SaltApi saltApi) {
-        ServerGroupManager serverGroupManager = new ServerGroupManager();
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ClusterManager clusterManager = new ClusterManager(
                 saltApi, systemQuery, serverGroupManager, formulaManager
@@ -475,7 +475,6 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
     public void testExecuteActionChain() throws Exception {
         SystemQuery systemQuery = new TestSystemQuery();
         SaltApi saltApi = new TestSaltApi();
-        ServerGroupManager serverGroupManager = new ServerGroupManager();
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ClusterManager clusterManager = new ClusterManager(
                 saltApi, systemQuery, serverGroupManager, formulaManager
@@ -964,7 +963,6 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         SystemQuery systemQuery = new TestSystemQuery();
         SaltApi saltApi = new TestSaltApi();
         FormulaManager formulaManager = new FormulaManager(saltApi);
-        ServerGroupManager serverGroupManager = new ServerGroupManager();
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
         SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager, serverGroupManager) {
             @Override

--- a/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
+++ b/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
@@ -44,23 +44,34 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
 
     private final SystemQuery systemQuery = new TestSystemQuery();
     private final SaltApi saltApi = new TestSaltApi();
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
+    private final FormulaManager formulaManager = new FormulaManager(saltApi);
+    private final ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager,
+            formulaManager);
+    private final SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager,
+            serverGroupManager);
+    private final SaltKeyUtils saltKeyUtils = new SaltKeyUtils(saltApi);
+    private final SaltServerActionService saltServerActionService = new SaltServerActionService(saltApi, saltUtils,
+            clusterManager, formulaManager, saltKeyUtils);
+    private final MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, saltApi,
+            saltUtils);
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        saltUtils.setScriptsDir(Files.createTempDirectory("scripts"));
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        Files.delete(saltUtils.getScriptsDir());
+    }
 
     /**
      * Verify script is deleted in case all servers are finished (COMPLETED or FAILED).
      */
     public void testCleanupScriptActions() throws Exception {
-
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ServerGroupManager serverGroupManager = new ServerGroupManager();
-        ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
-        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager, serverGroupManager);
-        SaltKeyUtils saltKeyUtils = new SaltKeyUtils(saltApi);
-        SaltServerActionService saltServerActionService = new SaltServerActionService(saltApi, saltUtils,
-                clusterManager, formulaManager, saltKeyUtils);
-        MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, saltApi,
-                saltUtils);
-
-        saltUtils.setScriptsDir(Files.createTempDirectory("scripts"));
         Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_SCRIPT_RUN);
         ServerAction sa = ActionFactoryTest.createServerAction(ServerFactoryTest.createTestServer(user), action);
         sa.setStatus(ActionFactory.STATUS_COMPLETED);
@@ -73,49 +84,23 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
         // Testing
         minionActionUtils.cleanupScriptActions();
         assertFalse(Files.exists(scriptFile));
-
-        // Cleanup
-        Files.delete(saltUtils.getScriptsDir());
     }
 
     /**
      * Verify script is deleted in case no Action is there at all.
      */
     public void testCleanupScriptWithoutAction() throws Exception {
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ServerGroupManager serverGroupManager = new ServerGroupManager();
-        ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
-        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager, serverGroupManager);
-        SaltKeyUtils saltKeyUtils = new SaltKeyUtils(saltApi);
-        SaltServerActionService saltServerActionService = new SaltServerActionService(saltApi, saltUtils,
-                clusterManager, formulaManager, saltKeyUtils);
-        MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, saltApi,
-                saltUtils);
-        saltUtils.setScriptsDir(Files.createTempDirectory("scripts"));
         Path scriptFile = Files.createFile(saltUtils.getScriptPath(123456L));
 
         // Testing
         minionActionUtils.cleanupScriptActions();
         assertFalse(Files.exists(scriptFile));
-
-        // Cleanup
-        Files.delete(saltUtils.getScriptsDir());
     }
 
     /**
      * Verify script is not deleted as long as not all servers have finished (e.g. PICKED_UP).
      */
     public void testCleanupScriptActionsPickedUp() throws Exception {
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ServerGroupManager serverGroupManager = new ServerGroupManager();
-        ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
-        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager, serverGroupManager);
-        SaltKeyUtils saltKeyUtils = new SaltKeyUtils(saltApi);
-        SaltServerActionService saltServerActionService = new SaltServerActionService(saltApi, saltUtils,
-                clusterManager, formulaManager, saltKeyUtils);
-        MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, saltApi,
-                saltUtils);
-        saltUtils.setScriptsDir(Files.createTempDirectory("scripts"));
         Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_SCRIPT_RUN);
         ServerAction sa = ActionFactoryTest.createServerAction(ServerFactoryTest.createTestServer(user), action);
         sa.setStatus(ActionFactory.STATUS_PICKED_UP);
@@ -131,6 +116,5 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
 
         // Cleanup
         FileUtils.deleteFile(scriptFile);
-        Files.delete(saltUtils.getScriptsDir());
     }
 }


### PR DESCRIPTION
## What does this PR change?

Refactor some of the Java classes to make them more easily testable.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: already covered

## Links

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
