### PR TITLE
Make page size usage more consistent

### DIFF
--- a/web/html/src/components/table/TableDataHandler.tsx
+++ b/web/html/src/components/table/TableDataHandler.tsx
@@ -6,6 +6,7 @@ import { SearchPanel } from "./SearchPanel";
 import { SearchField } from "./SearchField";
 import { PageControl, SimpleDataProvider, AsyncDataProvider } from "utils/data-providers";
 import { Utils } from "utils/functions";
+import { pageSize } from "core/user-preferences";
 
 import { PagedData, Comparator } from "utils/data-providers";
 
@@ -112,7 +113,7 @@ export class TableDataHandler extends React.Component<Props, State> {
       data: [],
       provider: this.getProvider(),
       currentPage: 1,
-      itemsPerPage: this.props.initialItemsPerPage || window.userPrefPageSize || 15,
+      itemsPerPage: this.props.initialItemsPerPage || pageSize,
       totalItems: 0,
       criteria: undefined,
       sortColumnKey: this.props.initialSortColumnKey || null,

--- a/web/html/src/core/user-preferences/index.ts
+++ b/web/html/src/core/user-preferences/index.ts
@@ -1,0 +1,1 @@
+export const pageSize: number = window.userPrefPageSize || 15;

--- a/web/html/src/manager/admin/setup/products/products.tsx
+++ b/web/html/src/manager/admin/setup/products/products.tsx
@@ -539,7 +539,6 @@ class Products extends React.Component<ProductsProps> {
         <CustomDataHandler
           data={this.buildRows(this.filterDataByArch([...this.props.data]).sort(this.compareProducts))}
           identifier={(raw) => raw.identifier}
-          initialItemsPerPage={window.userPrefPageSize}
           loading={this.props.loading}
           additionalFilters={[archFilter]}
           searchField={

--- a/web/html/src/manager/admin/task-engine-status/taskotop.tsx
+++ b/web/html/src/manager/admin/task-engine-status/taskotop.tsx
@@ -191,7 +191,6 @@ class TaskoTop extends React.Component<Props> {
               identifier={(row) => row["id"]}
               cssClassFunction={(row) => (row["status"] === "skipped" ? "text-muted" : null)}
               initialSortColumnKey="status"
-              initialItemsPerPage={window.userPrefPageSize}
               searchField={<SearchField filter={this.searchData} placeholder={t("Filter by name")} />}
             >
               <Column columnKey="id" comparator={Utils.sortById} header={t("Task Id")} cell={(row) => row["id"]} />

--- a/web/html/src/manager/audit/cveaudit/cveaudit.tsx
+++ b/web/html/src/manager/audit/cveaudit/cveaudit.tsx
@@ -255,7 +255,6 @@ class CVEAudit extends React.Component<Props, State> {
             data={this.state.results}
             identifier={(row) => row.id}
             initialSortColumnKey="id"
-            initialItemsPerPage={window.userPrefPageSize}
             selectable={this.state.resultType === TARGET_SERVER && this.state.results.length > 0}
             onSelect={this.handleSelectItems}
             selectedItems={this.state.selectedItems}

--- a/web/html/src/manager/audit/subscription-matching/subscription-matching-messages.tsx
+++ b/web/html/src/manager/audit/subscription-matching/subscription-matching-messages.tsx
@@ -79,7 +79,6 @@ class Messages extends React.Component<Props> {
             data={this.buildRows(this.props.messages, this.props.systems, this.props.subscriptions)}
             identifier={(row) => row.id}
             initialSortColumnKey="message"
-            initialItemsPerPage={window.userPrefPageSize}
           >
             <Column
               columnKey="message"

--- a/web/html/src/manager/audit/subscription-matching/subscription-matching-pins.tsx
+++ b/web/html/src/manager/audit/subscription-matching/subscription-matching-pins.tsx
@@ -105,7 +105,6 @@ class Pins extends React.Component<PinsProps> {
             key="table"
             data={this.buildRows(this.props)}
             identifier={(row) => row.id}
-            initialItemsPerPage={window.userPrefPageSize}
             initialSortColumnKey="systemName"
           >
             <Column
@@ -274,7 +273,6 @@ class AddPinPopUp extends React.Component<AddPinPopUpProps> {
             data={this.buildRows()}
             identifier={(row) => row.id}
             initialSortColumnKey="name"
-            initialItemsPerPage={window.userPrefPageSize}
             searchField={<SearchField filter={this.searchData} placeholder={t("Filter by name")} />}
           >
             <Column
@@ -363,12 +361,7 @@ class PinSubscriptionSelector extends React.Component<PinSubscriptionSelectorPro
   render() {
     if (this.props.subscriptions.length > 0) {
       return (
-        <Table
-          key="table"
-          data={this.props.subscriptions}
-          identifier={(row) => row.id}
-          initialItemsPerPage={window.userPrefPageSize}
-        >
+        <Table key="table" data={this.props.subscriptions} identifier={(row) => row.id}>
           <Column columnKey="partNumber" header={t("Part number")} cell={(s) => s.partNumber} />
           <Column columnKey="description" header={t("Description")} cell={(s) => s.description} />
           <Column columnKey="policy" header={t("Policy")} cell={(s) => humanReadablePolicy(s.policy)} />

--- a/web/html/src/manager/audit/subscription-matching/subscription-matching-subscriptions.tsx
+++ b/web/html/src/manager/audit/subscription-matching/subscription-matching-subscriptions.tsx
@@ -59,7 +59,6 @@ class Subscriptions extends React.Component<SubscriptionsProps> {
                 : null;
             }}
             initialSortColumnKey="partNumber"
-            initialItemsPerPage={window.userPrefPageSize}
             searchField={<SearchField filter={this.searchData} placeholder={t("Filter by description")} />}
           >
             <Column

--- a/web/html/src/manager/audit/subscription-matching/subscription-matching-unmatched-products.tsx
+++ b/web/html/src/manager/audit/subscription-matching/subscription-matching-unmatched-products.tsx
@@ -49,12 +49,7 @@ class UnmatchedProducts extends React.Component<UnmatchedProductsProps> {
     if (this.props.unmatchedProductIds.length > 0) {
       body = (
         <div>
-          <Table
-            data={this.buildData(this.props)}
-            identifier={(row) => row.id}
-            initialSortColumnKey="productName"
-            initialItemsPerPage={window.userPrefPageSize}
-          >
+          <Table data={this.buildData(this.props)} identifier={(row) => row.id} initialSortColumnKey="productName">
             <Column
               columnKey="productName"
               comparator={Utils.sortByText}
@@ -139,7 +134,6 @@ class UnmatchedSystemPopUp extends React.Component<UnmatchedSystemPopUpProps> {
         data={this.buildTableData(this.props)}
         identifier={(row) => row.id}
         initialSortColumnKey="systemName"
-        initialItemsPerPage={window.userPrefPageSize}
         searchField={<SearchField filter={this.searchData} placeholder={t("Filter by name")} />}
       >
         <Column

--- a/web/html/src/manager/content-management/list-filters/list-filters.tsx
+++ b/web/html/src/manager/content-management/list-filters/list-filters.tsx
@@ -151,7 +151,6 @@ const ListFilters = (props: Props) => {
         data={displayedFilters}
         identifier={identifier}
         initialSortColumnKey="filter_name"
-        initialItemsPerPage={window.userPrefPageSize}
         searchField={<SearchField filter={searchData} placeholder={t("Filter by name or project")} />}
         selectable={true}
         onSelect={onSelect}

--- a/web/html/src/manager/content-management/list-projects/list-projects.tsx
+++ b/web/html/src/manager/content-management/list-projects/list-projects.tsx
@@ -88,7 +88,6 @@ const ListProjects = (props: Props) => {
         data={normalizedProjects}
         identifier={(row) => row.label}
         initialSortColumnKey="name"
-        initialItemsPerPage={window.userPrefPageSize}
         searchField={<SearchField filter={searchData} placeholder={t("Filter by any value")} />}
       >
         <Column

--- a/web/html/src/manager/images/image-profiles.tsx
+++ b/web/html/src/manager/images/image-profiles.tsx
@@ -165,7 +165,6 @@ class ImageProfiles extends React.Component<Props, State> {
             data={this.state.imageprofiles}
             identifier={(profile) => profile.profileId}
             initialSortColumnKey="profileId"
-            initialItemsPerPage={window.userPrefPageSize}
             searchField={<SearchField filter={this.searchData} />}
             selectable
             selectedItems={this.state.selectedItems}

--- a/web/html/src/manager/images/image-stores.tsx
+++ b/web/html/src/manager/images/image-stores.tsx
@@ -165,7 +165,6 @@ class ImageStores extends React.Component<Props, State> {
             data={this.state.imagestores}
             identifier={(imagestore) => imagestore.id}
             initialSortColumnKey="id"
-            initialItemsPerPage={window.userPrefPageSize}
             searchField={<SearchField filter={this.searchData} />}
             selectable
             selectedItems={this.state.selectedItems}

--- a/web/html/src/manager/images/image-view-packages.tsx
+++ b/web/html/src/manager/images/image-view-packages.tsx
@@ -42,7 +42,6 @@ class ImageViewPackages extends React.Component<Props> {
         data={data.packagelist ? data.packagelist : []}
         identifier={(p) => p.name + p.arch}
         initialSortColumnKey="name"
-        initialItemsPerPage={window.userPrefPageSize}
         searchField={<SearchField filter={this.searchData} />}
       >
         <Column columnKey="name" comparator={Utils.sortByText} header={t("Package Name")} cell={(row) => row.name} />

--- a/web/html/src/manager/images/image-view-patches.tsx
+++ b/web/html/src/manager/images/image-view-patches.tsx
@@ -74,7 +74,6 @@ class ImageViewPatches extends React.Component<ImageViewPatchesProps> {
         data={data.patchlist ? data.patchlist : []}
         identifier={(p) => p.id}
         initialSortColumnKey="name"
-        initialItemsPerPage={window.userPrefPageSize}
         searchField={<SearchField filter={this.searchData} />}
       >
         <Column

--- a/web/html/src/manager/images/image-view.tsx
+++ b/web/html/src/manager/images/image-view.tsx
@@ -618,7 +618,6 @@ class ImageViewList extends React.Component<ImageViewListProps, ImageViewListSta
           identifier={(img) => img.id}
           initialSortColumnKey="modified"
           initialSortDirection={-1}
-          initialItemsPerPage={window.userPrefPageSize}
           searchField={<SearchField filter={this.searchData} />}
           selectable
           selectedItems={this.state.selectedItems}

--- a/web/html/src/manager/maintenance/list/calendar-list.tsx
+++ b/web/html/src/manager/maintenance/list/calendar-list.tsx
@@ -41,7 +41,6 @@ const MaintenanceCalendarList = (props: CalendarListProps) => {
       <Table
         data={props.data}
         identifier={(row) => row.name}
-        initialItemsPerPage={window.userPrefPageSize}
         emptyText={t("No calendars created. Use Create to add a calendar.")}
       >
         <Column columnKey="calendarName" header={t("Calendar Name")} cell={(row) => row.name} />

--- a/web/html/src/manager/maintenance/list/schedule-list.tsx
+++ b/web/html/src/manager/maintenance/list/schedule-list.tsx
@@ -26,7 +26,6 @@ const MaintenanceScheduleList = (props: ScheduleListProps) => {
       <Table
         data={props.data}
         identifier={(row) => row.id}
-        initialItemsPerPage={window.userPrefPageSize}
         emptyText={t("No schedules created. Use Create to add a schedule.")}
       >
         <Column columnKey="scheduleName" header={t("Schedule Name")} cell={(row) => row.name} />

--- a/web/html/src/manager/notifications/notification-messages.tsx
+++ b/web/html/src/manager/notifications/notification-messages.tsx
@@ -479,7 +479,6 @@ class NotificationMessages extends React.Component<Props, State> {
             cssClassFunction={(row) => (DEPRECATED_unsafeEquals(row["isRead"], true) ? "text-muted" : "")}
             initialSortColumnKey="created"
             initialSortDirection={-1}
-            initialItemsPerPage={window.userPrefPageSize}
             loading={this.state.loading}
             selectable
             selectedItems={this.state.selectedItems}

--- a/web/html/src/manager/salt/formula-catalog/org-formula-catalog.tsx
+++ b/web/html/src/manager/salt/formula-catalog/org-formula-catalog.tsx
@@ -95,7 +95,6 @@ class FormulaCatalog extends React.Component<Props, State> {
             data={this.state.serverData}
             identifier={this.rowKey}
             initialSortColumnKey="name"
-            initialItemsPerPage={window.userPrefPageSize}
             searchField={<SearchField filter={this.searchData} placeholder={t("Filter by formula name")} />}
           >
             <Column

--- a/web/html/src/manager/salt/keys/key-management.tsx
+++ b/web/html/src/manager/salt/keys/key-management.tsx
@@ -148,7 +148,6 @@ class KeyManagement extends React.Component<Props, State> {
             data={this.state.keys}
             identifier={this.rowKey}
             initialSortColumnKey="id"
-            initialItemsPerPage={window.userPrefPageSize}
             loading={this.state.loading}
             searchField={<SearchField filter={this.searchData} />}
           >

--- a/web/html/src/manager/state/recurring-states-list.tsx
+++ b/web/html/src/manager/state/recurring-states-list.tsx
@@ -7,6 +7,7 @@ import { DeleteDialog } from "components/dialog/DeleteDialog";
 import { Column } from "components/table/Column";
 import { Table } from "components/table/Table";
 import { targetTypeToString } from "./recurring-states-utils";
+import { pageSize } from "core/user-preferences";
 
 type Props = {
   data?: any;
@@ -68,7 +69,7 @@ class RecurringStatesList extends React.Component<Props, State> {
               data={this.props.data}
               identifier={(action) => action.recurringActionId}
               /* Using 0 to hide table header/footer */
-              initialItemsPerPage={this.props.disableCreate ? window.userPrefPageSize : 0}
+              initialItemsPerPage={this.props.disableCreate ? pageSize : 0}
               emptyText={t(
                 "No schedules created." + (this.props.disableCreate ? "" : " Use Create to add a schedule.")
               )}

--- a/web/html/src/manager/systems/ssm/ssm-subscribe-channels.tsx
+++ b/web/html/src/manager/systems/ssm/ssm-subscribe-channels.tsx
@@ -72,7 +72,6 @@ class ServersListPopup extends React.Component<ServersListPopupProps> {
             identifier={(srv) => srv.id}
             initialSortColumnKey="modified"
             initialSortDirection={-1}
-            initialItemsPerPage={window.userPrefPageSize}
           >
             <Column
               columnKey="name"
@@ -165,7 +164,6 @@ class BaseChannelPage extends React.Component<BaseChannelProps, BaseChannelState
           identifier={(channel) => channel.base.id}
           initialSortColumnKey="modified"
           initialSortDirection={-1}
-          initialItemsPerPage={window.userPrefPageSize}
         >
           <Column
             columnKey="name"
@@ -763,7 +761,6 @@ class ResultPage extends React.Component<ResultPageProps> {
           identifier={(dto) => dto.server.id}
           initialSortColumnKey="modified"
           initialSortDirection={-1}
-          initialItemsPerPage={window.userPrefPageSize}
         >
           <Column
             columnKey="server"

--- a/web/html/src/manager/systems/virtual-list.tsx
+++ b/web/html/src/manager/systems/virtual-list.tsx
@@ -54,7 +54,6 @@ export function VirtualSystems(props: Props) {
         selectable={(item) => item.hasOwnProperty("virtualSystemId")}
         selectedItems={selectedSystems}
         onSelect={handleSelectedSystems}
-        initialItemsPerPage={window.userPrefPageSize}
         searchField={<SearchField filter={searchData} placeholder={t("Filter by name")} />}
         emptyText={t("No Virtual Systems.")}
       >

--- a/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-details.tsx
+++ b/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-details.tsx
@@ -71,12 +71,7 @@ class VirtualHostManagerDetails extends React.Component<Props, State> {
         </BootstrapPanel>
         {this.state.nodes && this.state.nodes.length > 0 && (
           <BootstrapPanel title={t("Nodes")}>
-            <Table
-              data={this.state.nodes}
-              identifier={(node) => node.type + "_" + node.id}
-              initialSortColumnKey="name"
-              initialItemsPerPage={window.userPrefPageSize}
-            >
+            <Table data={this.state.nodes} identifier={(node) => node.type + "_" + node.id} initialSortColumnKey="name">
               <Column
                 columnKey="name"
                 comparator={Utils.sortByText}

--- a/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-list.tsx
+++ b/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-list.tsx
@@ -36,7 +36,6 @@ class VirtualHostManagerList extends React.Component<Props, State> {
           data={this.props.data}
           identifier={(vhm) => vhm.id}
           initialSortColumnKey="label"
-          initialItemsPerPage={window.userPrefPageSize}
           emptyText={t("No Virtual Host Managers.")}
         >
           <Column


### PR DESCRIPTION
## What does this PR change?

Move page size into a shared module for user prefs and remove unnecessary page size configs on tables. `Table` simply passes the `initialItemsPerPage` prop through to `TableDataHandler` which already internally uses the user's pref by default so all of those are unnecesary.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
