### PR TITLE
Fix cfg_component in setup_repo of yum_dnf_src

### DIFF
--- a/backend/satellite_tools/repo_plugins/yum_dnf_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_dnf_src.py
@@ -179,7 +179,8 @@ class ContentSource(zypper_ContentSource):
         repo.metadata_expire=0
         repo.mirrorlist = self.url
         repo.baseurl = [self.url]
-        pkgdir = os.path.join(CFG.MOUNT_POINT, CFG.PREPENDED_DIR, self.org, 'stage')
+        with cfg_component('server.satellite') as CFG:
+            pkgdir = os.path.join(CFG.MOUNT_POINT, CFG.PREPENDED_DIR, self.org, 'stage')
         if not os.path.isdir(pkgdir):
             fileutils.makedirs(pkgdir, user=APACHE_USER, group=APACHE_GROUP)
         repo.pkgdir = pkgdir


### PR DESCRIPTION
## What does this PR change?

Fix using `CFG` with `cfg_component` context manager.

`CFG` was not defined in `setup_repo` of `yum_dnf_src` plugin.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: already covered

## Links

Tracks https://github.com/uyuni-project/uyuni/pull/4264/files

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
