### PR TITLE
Fix channels state path calculation for dnf plugin with bundle

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/init.sls
@@ -5,7 +5,7 @@
 {%- set is_dnf = salt['pkg.version']("dnf") %}
 
 {%- if is_dnf %}
-{%- set dnf_plugins = salt['cmd.run']("find /usr/lib -type d -name dnf-plugins -printf "%T@ %p\n" | sort -nr | cut -d " " -s -f 2- | head -n 1", python_shell=True) %}
+{%- set dnf_plugins = salt['cmd.run']("find /usr/lib -type d -name dnf-plugins -printf '%T@ %p\n' | sort -nr | cut -d ' ' -s -f 2- | head -n 1", python_shell=True) %}
 {%- if dnf_plugins %}
 mgrchannels_susemanagerplugin_dnf:
   file.managed:

--- a/susemanager-utils/susemanager-sls/salt/channels/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/init.sls
@@ -5,9 +5,11 @@
 {%- set is_dnf = salt['pkg.version']("dnf") %}
 
 {%- if is_dnf %}
+{%- set dnf_plugins = salt['cmd.run']("find /usr/lib -type d -name dnf-plugins -printf "%T@ %p\n" | sort -nr | cut -d " " -s -f 2- | head -n 1", python_shell=True) %}
+{%- if dnf_plugins %}
 mgrchannels_susemanagerplugin_dnf:
   file.managed:
-    - name: /usr/lib/python{{ grains['pythonversion'][0] }}.{{ grains['pythonversion'][1] }}/site-packages/dnf-plugins/susemanagerplugin.py
+    - name: {{ dnf_plugins }}/susemanagerplugin.py
     - source:
       - salt://channels/dnf-susemanager-plugin/susemanagerplugin.py
     - user: root
@@ -30,6 +32,7 @@ mgrchannels_enable_dnf_plugins:
     - repl: plugins=1
 {#- default is '1' when option is not specififed #}
     - onlyif: grep -e 'plugins=0' -e 'plugins=False' -e 'plugins=no' /etc/dnf/dnf.conf
+{%- endif %}
 {%- endif %}
 
 {%- if is_yum %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix dnf plugin path calculation when using Salt Bundle
 - Use global import for which_bin in sumautil module
 - Get the formula pillar data from the database
 - Use flat repositories format for Debian based systems


### PR DESCRIPTION
## What does this PR change?

Fixes dnf plugin path calculation in `channels` state while using Salt Bundle. As Salt Bundle is running with python version other than used for dnf plugins.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Links

Fixes https://github.com/uyuni-project/uyuni/pull/4626

## Changelogs

- Fix dnf plugin path calculation when using Salt Bundle

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
