### PR TITLE
Drop `spacewalk-login.js`

### DIFF
--- a/web/html/javascript/spacewalk-essentials.js
+++ b/web/html/javascript/spacewalk-essentials.js
@@ -253,14 +253,6 @@ function onDocumentReadyAutoBootstrapGrid() {
   });
 }
 
-// Put the focus on a given form element
-function formFocus(form, name) {
-  var focusControl = document.forms[form].elements[name];
-  if (focusControl.type != "hidden" && !focusControl.disabled) {
-     focusControl.focus();
-  }
-}
-
 // Humanizes all the time elements with the human class
 function humanizeDates() {
   // should be consistent with UserPreferencesUtils.java

--- a/web/html/javascript/spacewalk-login.js
+++ b/web/html/javascript/spacewalk-login.js
@@ -1,9 +1,0 @@
-jQuery(document).ready(function() {
-  jQuery("aside").remove();
-  var me = jQuery("section");
-  var newMe = jQuery("<div class='login-page'>");
-  newMe.html(me.html());
-  me.replaceWith(newMe);
-  formFocus('loginForm', 'username');
-});
-


### PR DESCRIPTION
## What does this PR change?

As far as I could see, `spacewalk-login.js` is not actually used anywhere anymore given the login page is now in React. This also means the `formFocus` function is not used anywhere.  

Tagging Michael for a review just in case there's some arcane knowledge background that I'm missing here.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: Unused code.

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
