### PR TITLE
server migrator to 15.4

### DIFF
--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -111,13 +111,13 @@ Requires:       postgresql14-contrib
 # we do not support postgresql versions > 14.x yet
 Conflicts:      postgresql-implementation >= 15
 Conflicts:      postgresql-contrib-implementation >= 15
-%else # not sle_version >= 150300
+%else # not sle_version >= 150400
 Requires:       postgresql13
 Requires:       postgresql13-contrib
 # we do not support postgresql versions > 13.x yet
 Conflicts:      postgresql-implementation >= 14
 Conflicts:      postgresql-contrib-implementation >= 14
-%endif # if sle_version >= 150300
+%endif # if sle_version >= 150400
 %else # not suse_version
 Requires:       postgresql >= 12
 Requires:       postgresql-contrib >= 12

--- a/susemanager/bin/server-migrator.sh
+++ b/susemanager/bin/server-migrator.sh
@@ -19,27 +19,44 @@ echo
 read -n 1 -s -r -p "Press any key to start the migration or CTRL+C to cancel...";
 echo
 
+NEW_VERSION_ID=15.4
+
+CHECK_OS=$(cat /etc/os-release  | grep PRETTY_NAME)
+
+if [[ ${CHECK_OS} != *"openSUSE Leap"* ]]; then
+  echo "Please check your OS. openSUSE Leap is needed "
+  exit -1
+fi
+
 spacewalk-service stop
 rm -rf /etc/zypp/repos.d.old
 mv /etc/zypp/repos.d /etc/zypp/repos.d.old
 mkdir /etc/zypp/repos.d
-zypper ar -n "Main Repository" http://download.opensuse.org/distribution/leap/15.3/repo/oss repo-oss
-zypper ar -n "Main Update Repository" http://download.opensuse.org/update/leap/15.3/oss repo-update
-zypper ar -n "Non-OSS Repository" http://download.opensuse.org/distribution/leap/15.3/repo/non-oss repo-non-oss
-zypper ar -n "Update Repository (Non-Oss)" http://download.opensuse.org/update/leap/15.3/non-oss/ repo-update-non-oss
+zypper ar -n "Main Repository" http://download.opensuse.org/distribution/leap/${NEW_VERSION_ID}/repo/oss repo-oss
+zypper ar -n "Main Update Repository" http://download.opensuse.org/update/leap/${NEW_VERSION_ID}/oss repo-update
+zypper ar -n "Non-OSS Repository" http://download.opensuse.org/distribution/leap/${NEW_VERSION_ID}/repo/non-oss repo-non-oss
+zypper ar -n "Update Repository (Non-Oss)" http://download.opensuse.org/update/leap/${NEW_VERSION_ID}/non-oss/ repo-update-non-oss
 zypper ar -n "Uyuni Server Stable" https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/ uyuni-server-stable
-zypper ar -n "Update repository wiht updates from SUSE Linux Enterprise 15" http://download.opensuse.org/update/leap/15.3/sle repo-sle-update
-zypper ar -n "Update repository of openSUSE Backports" http://download.opensuse.org/update/leap/15.3/backports/ repo-backports-update
+zypper ar -n "Update repository wiht updates from SUSE Linux Enterprise" http://download.opensuse.org/update/leap/${NEW_VERSION_ID}/sle repo-sle-update
+zypper ar -n "Update repository of openSUSE Backports" http://download.opensuse.org/update/leap/${NEW_VERSION_ID}/backports/ repo-backports-update
 zypper ref
 zypper -n dup --allow-vendor-change
-if [ $? -ne 0 ];then
-    echo "Migration went wrong. Please fix the issues and try again."
+ret=$?
+if [[ $ret -ne 0 ]];then
+    echo "Migration went wrong. Please fix the issues and try again. return code is $ret"
     exit -1
 fi
 
-echo
+CURRENT_VERSION_ID=$(cat /etc/os-release  | grep VERSION_ID | cut -f2 -d=)
+
+if [[ "${CURRENT_VERSION_ID}" != "\"${NEW_VERSION_ID}\"" ]]; then
+    echo "Migration went wrong. Expected version is ${NEW_VERSION_ID} instead is ${CURRENT_VERSION_ID}"
+    echo "Please try to re-run this script"
+    exit -1
+fi
+
 echo "==================================================================="
-echo "If you did not yet migrate the database to postgresql13, do so now"
+echo "If you did not yet migrate the database to the new postgres version, do so now"
 echo "by running /usr/lib/susemanager/bin/pg-migrate-x-to-y.sh"
 echo
 echo "Reboot system afterwards."

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Update server-migrator to dist-upgrade to openSUSE 15.4
 - Bootstrap repo configureable.
 - Added installation on Rocky Linux 8.
 - fix pg-migrate to check version of postgresql??-server (bsc#1192368)


### PR DESCRIPTION
## What does this PR change?

Upgrade server migrator to upgrade to 15.4.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Documentation required, issue will be created

- [ ] **DONE**

## Test coverage
- No tests

- [ ] **DONE**

## Links

Partial fix https://github.com/SUSE/spacewalk/issues/16348
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
