### PR TITLE
Fix lock secondary test

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -140,7 +140,7 @@ When(/^I wait until I see the event "([^"]*)" completed during last minute, refr
     current_minute = now.strftime('%H:%M')
     previous_minute = (now - 60).strftime('%H:%M')
     begin
-      break if find(:xpath, "//a[contains(text(),'#{event}')]/../..//td[4][contains(text(),'#{current_minute}') or contains(text(),'#{previous_minute}')]/../td[3]/a[1]", wait: 1)
+      break if find(:xpath, "//a[contains(text(),'#{event}')]/../..//td[4]/time[contains(text(),'#{current_minute}') or contains(text(),'#{previous_minute}')]/../../td[3]/a[1]", wait: 1)
     rescue Capybara::ElementNotFound
       # ignored - pending actions cannot be found
     end
@@ -158,7 +158,7 @@ When(/^I follow the event "([^"]*)" completed during last minute$/) do |event|
   now = Time.now
   current_minute = now.strftime('%H:%M')
   previous_minute = (now - 60).strftime('%H:%M')
-  xpath_query = "//a[contains(text(), '#{event}')]/../..//td[4][contains(text(),'#{current_minute}') or contains(text(),'#{previous_minute}')]/../td[3]/a[1]"
+  xpath_query = "//a[contains(text(), '#{event}')]/../..//td[4]/time[contains(text(),'#{current_minute}') or contains(text(),'#{previous_minute}')]/../../td[3]/a[1]"
   element = find_and_wait_click(:xpath, xpath_query)
   element.click
 end


### PR DESCRIPTION
## What does this PR change?

Currently the following cucumber secondary tests are failing in Uyuni (not in Manager-4.2) 
- Lock packages on SLES salt minion.Attempt to install a locked package on the client
- Lock packages on traditional client.Attempt to install a locked package on the client

The issue is caused by a new HTML time format in UI: 
4.2: `<td>2022-01-03 15:09:02 CET </td>`
Uyuni: `<time data-reference-date="2022-01-03T15:59:46.765+01:00" datetime="2022-01-03T15:57:30.115+01:00">2022-01-03 15:57:30 CET  </time>`

The PR adapts the cucumber function in order to parse correctly the new format.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
