### PR TITLE
Use global instance holder from JSP actions

### DIFF
--- a/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
+++ b/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
@@ -16,10 +16,14 @@ package com.redhat.rhn;
 
 import com.redhat.rhn.common.security.acl.Access;
 import com.redhat.rhn.common.security.acl.AclFactory;
+import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.frontend.taglibs.helpers.RenderUtils;
 import com.redhat.rhn.manager.formula.FormulaManager;
 import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
+import com.redhat.rhn.manager.org.MigrationManager;
 import com.redhat.rhn.manager.system.ServerGroupManager;
+import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
@@ -86,6 +90,9 @@ public class GlobalInstanceHolder {
             new SystemEntitler(SALT_API, VIRT_MANAGER, MONITORING_MANAGER,
                     SERVER_GROUP_MANAGER)
     );
+    public static final SystemManager SYSTEM_MANAGER = new SystemManager(ServerFactory.SINGLETON,
+            ServerGroupFactory.SINGLETON, SALT_API);
+    public static final MigrationManager MIGRATION_MANAGER = new MigrationManager(SERVER_GROUP_MANAGER);
 
     public static final ViewHelper VIEW_HELPER = ViewHelper.getInstance();
 }

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemDeleteConfirmAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemDeleteConfirmAction.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.frontend.action.systems.sdc;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.rhnset.RhnSet;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
@@ -45,16 +46,8 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class SystemDeleteConfirmAction extends RhnAction {
 
-    private final SystemManager systemManager;
+    private final SystemManager systemManager = GlobalInstanceHolder.SYSTEM_MANAGER;
 
-    /**
-     * Constructor
-     *
-     * @param systemManagerIn the system manager
-     */
-    public SystemDeleteConfirmAction(SystemManager systemManagerIn) {
-        systemManager = systemManagerIn;
-    }
 
     /** {@inheritDoc} */
     public ActionForward execute(ActionMapping mapping,

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemMigrateAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemMigrateAction.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.frontend.action.systems.sdc;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.validator.ValidatorError;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.org.OrgFactory;
@@ -52,16 +53,8 @@ public class SystemMigrateAction extends RhnAction {
     public static final String SID = "sid";
     public static final String ORG = "to_org";
 
-    private final MigrationManager migrationManager;
+    private final MigrationManager migrationManager = GlobalInstanceHolder.MIGRATION_MANAGER;
 
-    /**
-     * Constructor
-     *
-     * @param migrationManagerIn the migration manager
-     */
-    public SystemMigrateAction(MigrationManager migrationManagerIn) {
-        migrationManager = migrationManagerIn;
-    }
 
     /** {@inheritDoc} */
     public ActionForward execute(ActionMapping mapping, ActionForm form,


### PR DESCRIPTION
## What does this PR change?

JSP actions constructors are expected to have no parameter. Use the
global instance holder to retrieve service managers in them.

This fixes a lot of the ISE in the cucumber runs after the merge of https://github.com/uyuni-project/uyuni/pull/4616

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
