### PR TITLE
Don't send empty objects with GET requests

### DIFF
--- a/web/html/src/utils/network.ts
+++ b/web/html/src/utils/network.ts
@@ -31,7 +31,7 @@ type DataType<T> = T & (T extends CommonMimeTypes ? never : T);
 function request<Returns>(
   url: string,
   type: "GET" | "POST" | "DELETE" | "PUT",
-  headers: Record<string, string>,
+  headers: Record<string, string> | undefined,
   data: any,
   contentType: string,
   processData: boolean = true
@@ -87,7 +87,7 @@ function put<Returns = any, Payload = any>(
 }
 
 function get<Returns = any>(url: string, contentType: string = "application/json"): Cancelable<Returns> {
-  return request<Returns>(url, "GET", {}, {}, contentType);
+  return request<Returns>(url, "GET", undefined, undefined, contentType);
 }
 
 function errorMessageByStatus(status: number): Array<string> {

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix virtual systems list request error (bsc#1194397)
 - Fix header search autofocus
 - Migrate the displaying of the date/time to rhn:formatDate, get rid of the legacy fmt:formatDate glue
 - Suggest Product Migration when patch for CVE is in a successor Product (bsc#1191360)


### PR DESCRIPTION
## What does this PR change?

Michael found a bug where GET requests are sending an unnecessary empty object as their data. This PR fixes the issue, but needs a testsuite run first.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1194397

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
