### PR TITLE
Make it more obvious that we are using log4j12

### DIFF
--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -49,7 +49,6 @@
 %define apache_commons_discovery   (apache-commons-discovery or jakarta-commons-discovery)
 %define apache_commons_fileupload  (apache-commons-fileupload or jakarta-commons-fileupload)
 %define apache_commons_validator   (apache-commons-validator or jakarta-commons-validator)
-%define log4j                      (log4j or log4j12)
 
 %if 0%{?is_opensuse}
 %define supported_locales bn_IN,ca,de,en_US,es,fr,gu,hi,it,ja,ko,pa,pt,pt_BR,ru,ta,zh_CN,zh_TW
@@ -138,7 +137,7 @@ BuildRequires:  libxml2-devel
 %else
 BuildRequires:  libxml2-tools
 %endif
-BuildRequires:  %{log4j}
+BuildRequires:  log4j12
 BuildRequires:  slf4j-log4j12
 BuildRequires:  netty
 BuildRequires:  objectweb-asm
@@ -234,7 +233,7 @@ Requires:       uyuni-cluster-provider-caasp
 Requires(pre):  uyuni-base-server
 Requires:       %{apache_commons_discovery}
 Requires:       %{apache_commons_fileupload}
-Requires:       %{log4j}
+Requires:       log4j12
 Requires:       apache-commons-el
 Requires:       jcommon
 Requires:       jdom
@@ -378,7 +377,7 @@ Requires:       java-11-openjdk
 %else
 Requires:       java >= %{java_version}
 %endif
-Requires:       %{log4j}
+Requires:       log4j12
 Requires:       javassist
 Requires:       jboss-logging
 Requires:       jcommon

--- a/search-server/spacewalk-search/spacewalk-search.spec
+++ b/search-server/spacewalk-search/spacewalk-search.spec
@@ -91,8 +91,8 @@ Requires:       quartz >= 2.0
 Requires:       redstone-xmlrpc
 Requires:       simple-core
 Obsoletes:      rhn-search < 5.3.0
-Requires:       (log4j or log4j12)
-BuildRequires:  (log4j or log4j12)
+Requires:       log4j12
+BuildRequires:  log4j12
 
 %description
 This package contains the code for the Full Text Search Server for


### PR DESCRIPTION
## What does this PR change?

This patch is changing our spec files to just make it more obvious that we are using log4j12 vs. log4j 2.x. It was already the case before, but previously the log4j12 package was named just log4j (in centos?), therefore this patch is just cleaning up leftovers.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed: no visible or behavioral changes.

- [X] **DONE**

## Test coverage

- No tests needed: no visible or behavioral changes.

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
