### PR TITLE
Uyuni 10544 jakart packages

### DIFF
--- a/search-server/spacewalk-search/spacewalk-search.spec
+++ b/search-server/spacewalk-search/spacewalk-search.spec
@@ -25,6 +25,9 @@
 %global apache_group apache
 %endif
 
+%define apache_commons_httpclient (apache-commons-httpclient or jakarta-commons-httpclient)
+%define oro (oro or jakarta-oro)
+
 Name:           spacewalk-search
 Summary:        Spacewalk Full Text Search Server
 License:        GPL-2.0-only AND Apache-2.0
@@ -51,8 +54,8 @@ BuildRequires:  c3p0 >= 0.9.1
 BuildRequires:  cglib
 BuildRequires:  doc-indexes
 BuildRequires:  hadoop
-BuildRequires:  jakarta-commons-httpclient
-BuildRequires:  jakarta-oro
+BuildRequires:  %{apache_commons_httpclient}
+BuildRequires:  %{oro}
 BuildRequires:  javapackages-tools
 BuildRequires:  junit
 BuildRequires:  lucene == 2.4.1
@@ -80,8 +83,8 @@ Requires:       apache-mybatis
 Requires:       c3p0 >= 0.9.1
 Requires:       cglib
 Requires:       hadoop
-Requires:       jakarta-commons-httpclient
-Requires:       jakarta-oro
+Requires:       %{apache_commons_httpclient}
+Requires:       %{oro}
 Requires:       javapackages-tools
 Requires:       lucene == 2.4.1
 Requires:       nutch-core


### PR DESCRIPTION
## What does this PR change?

This PR changes the spec file for seach package to not refer jakarta packages anymore.
I use the or option to keep compatibility with centos release like it was made in [1]

I think spacewalk java is already compatible with the package renaming.
There are only a couple of places I'm not completely sure [2] [3] [4].

I think I will need some guidance on how I can test these changes. I search the build server and the available packages on opensuse leap product. 

[1] https://github.com/uyuni-project/uyuni/pull/2953/files#diff-2de3ee26fbb18696208de9203d6937cc7551c86324f208e4dee716f4d43cf874R47-R52
[2] https://github.com/uyuni-project/uyuni/blob/master/java/spacewalk-java.spec#L645
[3] https://github.com/uyuni-project/uyuni/blob/master/java/spacewalk-java.spec#L649
[4] https://github.com/uyuni-project/uyuni/blob/master/java/spacewalk-java.spec#L791

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10544
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
