### PR TITLE
susemanager-branding-oss: Dynamic html docroot

### DIFF
--- a/susemanager-branding-oss/susemanager-branding-oss.spec
+++ b/susemanager-branding-oss/susemanager-branding-oss.spec
@@ -15,6 +15,12 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
+%if 0%{?suse_version}
+%global wwwdocroot /srv/www/htdocs
+%else
+%global wwwdocroot %{_localstatedir}/www/html
+%endif
+
 
 Name:           susemanager-branding-oss
 Version:        4.3.2
@@ -52,10 +58,10 @@ cat license.txt | sed 's/^$/<\/p><p>/' >> eula.html
 echo "</p>" >> eula.html
 
 %install
-mkdir -p $RPM_BUILD_ROOT/srv/www/htdocs/help/
+mkdir -p $RPM_BUILD_ROOT/%{wwwdocroot}/help/
 mkdir -p $RPM_BUILD_ROOT/%_defaultdocdir/susemanager/
 # final license
-install -m 644 eula.html $RPM_BUILD_ROOT/srv/www/htdocs/help/
+install -m 644 eula.html $RPM_BUILD_ROOT/%{wwwdocroot}/help/
 install -m 644 license.txt $RPM_BUILD_ROOT/%_defaultdocdir/susemanager/
 
 %files
@@ -63,7 +69,7 @@ install -m 644 license.txt $RPM_BUILD_ROOT/%_defaultdocdir/susemanager/
 %docdir %_defaultdocdir/susemanager
 %dir %_defaultdocdir/susemanager
 %_defaultdocdir/susemanager/license.txt
-%dir /srv/www/htdocs/help
-/srv/www/htdocs/help/eula.html
+%dir %{wwwdocroot}/help
+%[wwwdocroot}/help/eula.html
 
 %changelog


### PR DESCRIPTION
## What does this PR change?

Dynamic html docroot location for SUSE and non-suse systems

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered
not specifically tested

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
