### PR TITLE
spacewalk-backend: Removed static links

### DIFF
--- a/backend/satellite_tools/mgr-sign-metadata-ctl
+++ b/backend/satellite_tools/mgr-sign-metadata-ctl
@@ -94,7 +94,7 @@ fi
 
 RHN_CONF="/etc/rhn/rhn.conf"
 GPG_SALT_EXPORT_FILE="/srv/susemanager/salt/gpg/mgr-keyring.gpg"
-GPG_PUB_EXPORT_FILE="/srv/www/htdocs/pub/mgr-gpg-pub.key"
+GPG_PUB_EXPORT_FILE="$(spacewalk-cfg-get documentroot)/pub/mgr-gpg-pub.key"
 SIGNING_CONF="/etc/rhn/signing.conf"
 
 if [[ ! -f $SIGNING_CONF ]]; then

--- a/backend/satellite_tools/spacewalk-debug
+++ b/backend/satellite_tools/spacewalk-debug
@@ -423,7 +423,7 @@ if [ $IS_SUSE -eq 1 ]; then
         /usr/bin/spacewalk-report activation-keys > $DIR/activation-keys-report.csv
     fi
 
-    ls -laR /srv/www/htdocs/pub > $DIR/ls-laR-htdocs
+    ls -laR $(spacewalk-cfg-get documentroot)/pub > $DIR/ls-laR-htdocs
 fi
 
 echo "    * timestamping"

--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -32,7 +32,7 @@
 %global apache_user root
 %global apache_group root
 %global apache_pkg httpd
-%global documentroot /var/www/html 
+%global documentroot %{_localstatedir}/www/html 
 %global m2crypto python3-m2crypto
 %endif
 


### PR DESCRIPTION
## What does this PR change?

Replaced static html document root links with `spacewalk-cfg-get`

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

No testing

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
