### PR TITLE
Replaced static tftpboot folder creation

### DIFF
--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -28,7 +28,8 @@
 %global tftp_group root
 %global salt_user root
 %global salt_group root
-%global wwwroot %{_var}/www
+%global serverdir %{_sharedstatedir}
+%global wwwroot %{_localstatedir}/www
 %global wwwdocroot %{wwwroot}/html
 %endif
 
@@ -38,7 +39,8 @@
 %global tftp_group tftp
 %global salt_user salt
 %global salt_group salt
-%global wwwroot /srv/www
+%global serverdir /srv
+%global wwwroot %{serverdir}/www
 %global wwwdocroot %{wwwroot}/htdocs
 %endif
 
@@ -241,13 +243,13 @@ if [ -f /etc/sysconfig/atftpd ]; then
   . /etc/sysconfig/atftpd
   if [ $ATFTPD_DIRECTORY = "/tftpboot" ]; then
     sysconf_addword -r /etc/sysconfig/atftpd ATFTPD_DIRECTORY "/tftpboot"
-    sysconf_addword /etc/sysconfig/atftpd ATFTPD_DIRECTORY "/srv/tftpboot"
+    sysconf_addword /etc/sysconfig/atftpd ATFTPD_DIRECTORY "%{serverdir}/tftpboot"
   fi
 fi
-if [ ! -d /srv/tftpboot ]; then
-  mkdir -p /srv/tftpboot
-  chmod 750 /srv/tftpboot
-  chown %{apache_user}:%{tftp_group} /srv/tftpboot
+if [ ! -d %{serverdir}/tftpboot ]; then
+  mkdir -p %{serverdir}/tftpboot
+  chmod 750 %{serverdir}/tftpboot
+  chown %{apache_user}:%{tftp_group} %{serverdir}/tftpboot
 fi
 # XE appliance overlay file created this with different user
 chown root.root /etc/sysconfig


### PR DESCRIPTION
## What does this PR change?

Replaced static tftpboot folder creation during package installation.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered
Not tested

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
