### PR TITLE
Fix external Documents' link

### DIFF
--- a/java/code/src/com/suse/manager/webui/menu/MenuTree.java
+++ b/java/code/src/com/suse/manager/webui/menu/MenuTree.java
@@ -524,7 +524,7 @@ public class MenuTree {
                     .withTarget("_blank"))
             .addChild(new MenuItem("header.jsp.documentation")
                     .withPrimaryUrl(ConfigDefaults.get().isUyuni() ?
-                            "https://www.uyuni-project.org/uyuni-docs/uyuni/index.html" :
+                            "https://www.uyuni-project.org/uyuni-docs/en/uyuni/index.html" :
                             "https://documentation.suse.com/suma/")
                     .withTarget("_blank"));
     }


### PR DESCRIPTION
Signed-off-by: Li Zhijian <lizhijian@fujitsu.com>

## What does this PR change?

Fix an external Documents link that was not available.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
It's most likely a typo fix

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**


- [x] **DONE**



- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
