### PR TITLE
fix: Uptime in details overview page II

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -79,24 +79,24 @@ Then(/^the uptime for "([^"]*)" should be correct$/) do |host|
   uptime_hours, _code = node.run("awk '{print $1/3600}' /proc/uptime")
   uptime_minutes, _code = node.run("awk '{print $1/60}' /proc/uptime")
   uptime_seconds, _code = node.run("awk '{print $1}' /proc/uptime")
-  uptime_days = uptime_days.to_f
-  uptime_hours = uptime_hours.to_f
-  uptime_minutes = uptime_minutes.to_f
-  uptime_seconds = uptime_seconds.to_f
+  uptime_days = uptime_days.to_f.round
+  uptime_hours = uptime_hours.to_f.round
+  uptime_minutes = uptime_minutes.to_f.round
+  uptime_seconds = uptime_seconds.to_f.round
 
-  if uptime_days < 2.0 and uptime_days > 0.9
+  if uptime_days < 2 and uptime_days >= 1
     step %(I should see a "#{uptime_days.round} day ago" text)
-  elsif uptime_days < 1.0 and uptime_hours >= 2.0
+  elsif uptime_days < 1 and uptime_hours >= 2
     step %(I should see a "#{uptime_hours.round} hours ago" text)
-  elsif uptime_days < 1.0 and uptime_hours < 2.0
+  elsif uptime_days < 1 and uptime_hours < 2
     step %(I should see a "#{uptime_hours.round} hour ago" text)
-  elsif uptime_hours < 1.0 and uptime_minutes >= 2.0
+  elsif uptime_hours < 1 and uptime_minutes >= 2
     step %(I should see a "#{uptime_minutes.round} minutes ago" text)
-  elsif uptime_hours < 1.0 and uptime_minutes < 2.0
+  elsif uptime_hours < 1 and uptime_minutes < 2
     step %(I should see a "#{uptime_minutes.round} minute ago" text)
-  elsif uptime_minutes < 1.0 and uptime_seconds >= 2.0
+  elsif uptime_minutes < 1 and uptime_seconds >= 2
     step %(I should see a "#{uptime_seconds.round} seconds ago" text)
-  elsif uptime_minutes < 1.0 and uptime_seconds < 2.0
+  elsif uptime_minutes < 1 and uptime_seconds < 2
     step %(I should see a "#{uptime_seconds.round} second ago" text)
   else
     step %(I should see a "#{uptime_days.round} days ago" text)


### PR DESCRIPTION
## What does this PR change?

This is a fixup PR for #4582. The uptime is now rounded upfront.


## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
- Cucumber tests were edited

- [x] **DONE**

## Links

Ports:

Manager-4.1

Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
