### PR TITLE
Revert "Cleanup of motd msg after uninstall"

### DIFF
--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -281,8 +281,6 @@ sed -i 's/su wwwrun www/su apache apache/' /etc/logrotate.d/susemanager-tools
 %if 0%{?suse_version}
 %{insserv_cleanup}
 %endif
-# Cleanup
-sed -i '/You can access .* via https:\/\//d' /etc/motd
 
 %files -f susemanager.lang
 %defattr(-,root,root,-)


### PR DESCRIPTION
Reverts uyuni-project/uyuni#4641

See https://build.opensuse.org/package/live_build_log/systemsmanagement:Uyuni:Master/susemanager/openSUSE_Leap_15.3/x86_64