### PR TITLE
Cleanup of motd msg after uninstall

### DIFF
--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -280,7 +280,8 @@ sed -i 's/su wwwrun www/su apache apache/' /etc/logrotate.d/susemanager-tools
 %{insserv_cleanup}
 %endif
 # Cleanup
-sed -i '/You can access .* via https:\/\//d' /etc/motd
+sed -i '/You can access .* via https:\/\//d' /tmp/motd 2> /dev/null ||:
+
 
 %files -f susemanager.lang
 %defattr(-,root,root,-)

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -279,6 +279,8 @@ sed -i 's/su wwwrun www/su apache apache/' /etc/logrotate.d/susemanager-tools
 %if 0%{?suse_version}
 %{insserv_cleanup}
 %endif
+# Cleanup
+sed -i '/You can access .* via https:\/\//d' /etc/motd
 
 %files -f susemanager.lang
 %defattr(-,root,root,-)


### PR DESCRIPTION
## What does this PR change?

This change removes the message `You can access <PRODUCTNAME> via https://<HOSTNAME>` on login when the susemanager package has been removed.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: none done. Low impact.

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
