### PR TITLE
Fix header padding bug

### DIFF
--- a/branding/css/buttons.less
+++ b/branding/css/buttons.less
@@ -3,6 +3,7 @@ button.is-plain {
   -moz-appearance: none;
   appearance: none;
   border: none;
+  border-radius: 0;
   box-sizing: border-box;
   cursor: pointer;
   display: inline;
@@ -11,4 +12,5 @@ button.is-plain {
   outline: none;
   text-decoration: none;
   user-select: text;
+  padding: 0;
 }

--- a/web/html/src/manager/header/search/search.tsx
+++ b/web/html/src/manager/header/search/search.tsx
@@ -54,7 +54,7 @@ export class HeaderSearch extends React.PureComponent {
       <FocusGroup onFocusOut={() => this.setState({ isOpen: false })}>
         <button
           aria-label={t("Open search")}
-          className={`is-plain manual-toggle-box ${this.state.isOpen ? "open" : ""}`}
+          className={`is-plain header-non-link manual-toggle-box ${this.state.isOpen ? "open" : ""}`}
           onClick={() => this.setState({ isOpen: !this.state.isOpen })}
         >
           <i className="fa fa-search" aria-hidden="true" />


### PR DESCRIPTION
## What does this PR change?

I introduced a small padding difference with the latest header update, this fixes the bug.

## GUI diff

Few pixels of padding.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfix.

- [x] **DONE**

## Test coverage
- No tests: Visual change only.

- [x] **DONE**

## Links

Followup to https://github.com/uyuni-project/uyuni/pull/4612

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
