### PR TITLE
run on master-weblate only when weblate pushes

### DIFF
--- a/.github/workflows/update_translations.yml
+++ b/.github/workflows/update_translations.yml
@@ -3,7 +3,25 @@ name: Update translation files
 on:
   push:
     branches:
-      - master
+      - master-weblate
+    paths:
+      - 'web/po/*.po'
+      - 'backend/po/*.po'
+      - 'susemanager/po/*.po'
+      - 'spacecmd/po/*.po'
+      - 'java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_*.xml'
+      - '!java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_en_US.xml'
+      - 'java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_*.xml'
+      - '!java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml'
+      - 'java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_*.xml'
+      - '!java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml'
+      - 'java/code/src/com/redhat/rhn/frontend/strings/nav/StringResource_*.xml'
+      - '!java/code/src/com/redhat/rhn/frontend/strings/nav/StringResource_en_US.xml'
+      - 'java/code/src/com/redhat/rhn/frontend/strings/template/StringResource_*.xml'
+      - '!java/code/src/com/redhat/rhn/frontend/strings/template/StringResource_en_US.xml'
+      - 'client/rhel/yum-rhn-plugin/po/*.po'
+      - 'client/rhel/mgr-daemon/po/*.po'
+      - 'client/rhel/spacewalk-client-tools/po/*.po'
 
 jobs:
  run:


### PR DESCRIPTION
## What does this PR change?

run the update translation script on weblate branch when weblate is pushing

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
