### PR TITLE
Print more clear errors for spacewalk-remove-channel (bsc#1190564)

### DIFF
--- a/backend/satellite_tools/contentRemove.py
+++ b/backend/satellite_tools/contentRemove.py
@@ -270,7 +270,10 @@ def delete_channels(channelLabels, force=0, justdb=0, skip_packages=0, skip_chan
         _delete_rpms(rpms_ids)
 
     if not skip_kickstart_trees and not justdb:
-        _delete_ks_files(channelLabels)
+        try:
+            _delete_ks_files(channelLabels)
+        except OSError:
+            return
 
     if not justdb and not skip_packages and not just_kickstart_trees:
         _delete_files(rpms_paths + srpms_paths)
@@ -359,14 +362,22 @@ def delete_channels(channelLabels, force=0, justdb=0, skip_packages=0, skip_chan
         h.executemany(channel_id=channel_ids)
 
     if not justdb and not just_kickstart_trees:
-        __deleteRepoData(channelLabels)
+        try:
+            __deleteRepoData(channelLabels)
+        except OSError:
+            return
+
+
+def __rmtree_error(op, name, exc):
+    print("Error calling %s for %s: %s" % (op.__name__, name, exc[1]))
+    raise exc[1]
 
 
 def __deleteRepoData(labels):
     directory = '/var/cache/' + CFG.repomd_path_prefix
     for label in labels:
         if os.path.isdir(directory + '/' + label):
-            shutil.rmtree(directory + '/' + label)
+            shutil.rmtree(directory + '/' + label, onerror=__rmtree_error)
 
 
 def list_packages_without_channels(org_id, sources=0):
@@ -598,7 +609,9 @@ def _delete_ks_files(channel_labels):
         if not os.path.exists(path):
             log_debug(1, "Not removing %s: no such file" % path)
             continue
-        shutil.rmtree(path)
+        shutil.rmtree(path, onerror=__rmtree_error)
+
+
 class UserError(Exception):
 
     def __init__(self, msg):

--- a/backend/satellite_tools/contentRemove.py
+++ b/backend/satellite_tools/contentRemove.py
@@ -369,7 +369,7 @@ def delete_channels(channelLabels, force=0, justdb=0, skip_packages=0, skip_chan
 
 
 def __rmtree_error(op, name, exc):
-    print("Error calling %s for %s: %s" % (op.__name__, name, exc[1]))
+    sys.stderr.write("Error calling %s for %s: %s\n" % (op.__name__, name, exc[1]))
     raise exc[1]
 
 

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Print more clear errors for spacewalk-remove-channel (bsc#1190564)
 - Fix issues to work with latest urlgrabber version 4.1
 - Retrieve and store copyright information about patches
 - Unify decompression of metadata with uyuni.common.fileutils


### PR DESCRIPTION
## What does this PR change?

Print more clear errors on calling `spacewalk-remove-channel` if `shutil.rmtree` raises an exception.

Before the change we can get the following output:
```
ERROR: unhandled exception occurred: ([Errno 30] Read-only file system: 'ARCHIVES.gz').
Traceback (most recent call last):
  File "/usr/bin/spacewalk-remove-channel", line 220, in <module>
    sys.exit(main() or 0)
  File "/usr/bin/spacewalk-remove-channel", line 194, in main
    just_kickstart_trees=options.just_kickstart_trees)
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/contentRemove.py", line 273, in delete_channels
    _delete_ks_files(channelLabels)
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/contentRemove.py", line 606, in _delete_ks_files
    shutil.rmtree(path, onerror=rm_error)
  File "/usr/lib64/python3.6/shutil.py", line 486, in rmtree
    _rmtree_safe_fd(fd, path, onerror)
  File "/usr/lib64/python3.6/shutil.py", line 444, in _rmtree_safe_fd
    onerror(os.unlink, fullname, sys.exc_info())
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/contentRemove.py", line 598, in rm_error
    raise exc[1]
  File "/usr/lib64/python3.6/shutil.py", line 442, in _rmtree_safe_fd
    os.unlink(name, dir_fd=topfd)
OSError: [Errno 30] Read-only file system: 'ARCHIVES.gz'
```

After this change the output will be the following:
```
Error calling unlink for `/srv/www/htdocs/pub/distr/sles12sp5/ARCHIVES.gz`: [Errno 30] Read-only file system: 'ARCHIVES.gz'
```

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15906

## Changelogs

```
- Print more clear errors for spacewalk-remove-channel (bsc#1190564)
```

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
