### PR TITLE
BV various fixes

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -6,8 +6,8 @@ reviewers:
       - maximenoel8
       - srbarrios
       - Bischoff
-      - nodeg
       - orestis87
+      - vandabarata
 
 files:
   # Keys are glob expressions.

--- a/testsuite/features/core/proxy_branch_network.feature
+++ b/testsuite/features/core/proxy_branch_network.feature
@@ -46,19 +46,13 @@ Feature: Setup Uyuni for Retail branch network
 
 @proxy
 @private_net
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
-
-@proxy
-@private_net
   Scenario: Show the overview page of the proxy
-    Given I am on the Systems overview page of this "proxy"
-
+    Given I am authorized for the "Admin" section
+    And I am on the Systems overview page of this "proxy"
 
 @proxy
 @private_net
   Scenario: Enable the branch network formulas on the branch server
-    Given I am on the Systems overview page of this "proxy"
     When I follow "Formulas" in the content area
     Then I should see a "Choose formulas" text
     And I should see a "Suse Manager For Retail" text

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -25,14 +25,14 @@ end
 
 Then(/^"([^"]*)" should communicate with the server using public interface/) do |host|
   node = get_target(host)
-  node.run("ping -4 -c 1 -I #{node.public_interface} #{$server.full_hostname}")
-  $server.run("ping -4 -c 1 #{node.public_ip}")
+  node.run("ping -c 1 -I #{node.public_interface} #{$server.public_ip}")
+  $server.run("ping -c 1 #{node.public_ip}")
 end
 
 Then(/^"([^"]*)" should not communicate with the server using private interface/) do |host|
   node = get_target(host)
-  node.run_until_fail("ping -4 -c 1 -I #{node.private_interface} #{$server.full_hostname}")
-  $server.run_until_fail("ping -4 -c 1 #{node.private_ip}")
+  node.run_until_fail("ping -c 1 -I #{node.private_interface} #{$server.public_ip}")
+  $server.run_until_fail("ping -c 1 #{node.private_ip}")
 end
 
 Then(/^the clock from "([^"]*)" should be exact$/) do |host|


### PR DESCRIPTION
## What does this PR change?

Various BV fixes:
* `ip -4` is not supported on older systems like SLE 11 and SLE 12
   force using IPv4 for ping tests by not using the FQDN
* remove useless lines in `proxy_branch_network.feature`
* add Vanda to the reviewers


## Links

Ports:
* 4.1: SUSE/spacewalk#16663
* 4.2: SUSE/spacewalk#16661


## Changelogs

- [x] No changelog needed
