### PR TITLE
Do not build python2 subpackages for SLE15SP4 and higher

### DIFF
--- a/client/tools/mgr-cfg/mgr-cfg.changes
+++ b/client/tools/mgr-cfg/mgr-cfg.changes
@@ -1,5 +1,5 @@
 - Fix python selinux package name depending on build target (bsc#1193600)
-- do not build python 2 package for SLE15
+- Do not build python 2 package for SLE15SP4 and higher
 
 -------------------------------------------------------------------
 Fri Nov 05 13:33:47 CET 2021 - jgonzalez@suse.com

--- a/client/tools/mgr-cfg/mgr-cfg.spec
+++ b/client/tools/mgr-cfg/mgr-cfg.spec
@@ -36,7 +36,7 @@
 %global __python /usr/bin/python2 
 %endif
 
-%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || (0%{?suse_version} && 0%{?suse_version} < 1500) || 0%{?ubuntu} || 0%{?debian}
+%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || (0%{?suse_version} && 0%{?sle_version} < 150400) || 0%{?ubuntu} || 0%{?debian}
 %global build_py2   1
 %endif
 
@@ -95,7 +95,7 @@ Requires:       %{pythonX}-%{name} = %{version}-%{release}
 %if 0%{?suse_version}
 # provide rhn directories and no selinux on suse
 BuildRequires:  spacewalk-client-tools
-%if 0%{?suse_version} >= 1110 && 0%{?suse_version} < 1500
+%if 0%{?suse_version} >= 1110 && 0%{?sle_version} < 150400
 Requires:       python-selinux
 %endif
 %if 0%{?suse_version} >= 1500

--- a/client/tools/mgr-osad/mgr-osad.changes
+++ b/client/tools/mgr-osad/mgr-osad.changes
@@ -1,5 +1,5 @@
 - require python macros for building
-- do not build python 2 package for SLE15
+- Do not build python 2 package for SLE15SP4 and higher
 
 -------------------------------------------------------------------
 Fri Nov 05 13:34:38 CET 2021 - jgonzalez@suse.com

--- a/client/tools/mgr-osad/mgr-osad.spec
+++ b/client/tools/mgr-osad/mgr-osad.spec
@@ -39,7 +39,7 @@
 %global default_py3 1
 %endif
 
-%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || (0%{?suse_version} && 0%{?suse_version} < 1500)
+%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || (0%{?suse_version} && 0%{?sle_version} < 150400)
 %global build_py2   1
 %endif
 

--- a/client/tools/mgr-virtualization/mgr-virtualization.changes
+++ b/client/tools/mgr-virtualization/mgr-virtualization.changes
@@ -1,5 +1,5 @@
 - require python macros for building
-- do not build python 2 package for SLE15
+- Do not build python 2 package for SLE15SP4 and higher
 
 -------------------------------------------------------------------
 Mon Aug 09 10:51:53 CEST 2021 - jgonzalez@suse.com

--- a/client/tools/mgr-virtualization/mgr-virtualization.spec
+++ b/client/tools/mgr-virtualization/mgr-virtualization.spec
@@ -35,7 +35,7 @@
 %global default_py3 1
 %endif
 
-%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || (0%{?suse_version} && 0%{?suse_version} < 1500)
+%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || (0%{?suse_version} && 0%{?sle_version} < 150400)
 %global build_py2   1
 %endif
 

--- a/client/tools/spacewalk-koan/spacewalk-koan.changes
+++ b/client/tools/spacewalk-koan/spacewalk-koan.changes
@@ -1,4 +1,4 @@
-- do not build python 2 package for SLE15
+- Do not build python 2 package for SLE15SP4 and higher
 
 -------------------------------------------------------------------
 Mon Aug 09 11:01:18 CEST 2021 - jgonzalez@suse.com

--- a/client/tools/spacewalk-koan/spacewalk-koan.spec
+++ b/client/tools/spacewalk-koan/spacewalk-koan.spec
@@ -25,7 +25,7 @@
 %global default_py3 1
 %endif
 
-%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || (0%{?suse_version} && 0%{?suse_version} < 1500)
+%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || (0%{?suse_version} && 0%{?sle_version} < 150400)
 %global build_py2   1
 %endif
 

--- a/client/tools/spacewalk-oscap/spacewalk-oscap.changes
+++ b/client/tools/spacewalk-oscap/spacewalk-oscap.changes
@@ -1,5 +1,5 @@
 - require python macros for building
-- do not build python 2 package for SLE15
+- Do not build python 2 package for SLE15SP4 and higher
 
 -------------------------------------------------------------------
 Mon Aug 09 11:01:49 CEST 2021 - jgonzalez@suse.com

--- a/client/tools/spacewalk-oscap/spacewalk-oscap.spec
+++ b/client/tools/spacewalk-oscap/spacewalk-oscap.spec
@@ -22,7 +22,7 @@
 %global default_py3 1
 %endif
 
-%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || (0%{?suse_version} && 0%{?suse_version} < 1500)
+%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || (0%{?suse_version} && 0%{?sle_version} < 150400)
 %global build_py2   1
 %endif
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes some of the changes introduced in https://github.com/uyuni-project/uyuni/pull/4537/ in order to disable the python2 builds only for SLE15SP4 and higher, to avoid problems with latest released python2 subpackages.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- Tracks: https://github.com/SUSE/spacewalk/issues/16508
- 
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
