### PR TITLE
Restore waiting after base channels reposync

### DIFF
--- a/testsuite/run_sets/build_validation_reposync.yml
+++ b/testsuite/run_sets/build_validation_reposync.yml
@@ -3,6 +3,6 @@
 ## Product synchronization features BEGIN ###
 
 - features/build_validation/reposync/srv_sync_all_products.feature
+- features/build_validation/reposync/srv_wait_for_product_reposync.feature
 
 ## Product synchronization features END ###
-


### PR DESCRIPTION
## What does this PR change?

More various BV test suite fixes
* simplify the reposyncs (related PR: SUSE/susemanager-ci)
* revert the workaround for the formula (4.1 only)


## Links

Ports:
* 4.1: SUSE/spacewalk#16670
* 4.2:


## Changelogs

- [x] No changelog needed
