### PR TITLE
Fix restart text

### DIFF
--- a/testsuite/features/secondary/srv_restart.feature
+++ b/testsuite/features/secondary/srv_restart.feature
@@ -12,7 +12,7 @@ Feature: Restart the spacewalk services via UI
     When I follow the left menu "Admin > Manager Configuration > Restart"
     And I check "restart"
     And I click on "Restart"
-    And I wait until I see "SUSE Manager restarting" text
-    And I wait at most "300" seconds until I do not see "SUSE Manager restarting" text
+    And I wait until I see "restarting. If this page" text
+    And I wait at most "300" seconds until I do not see "restarting. If this page" text
     And I refresh the page
     Then I follow the left menu "Admin > Manager Configuration > Restart"


### PR DESCRIPTION
## What does this PR change?

Changes the text we check in this feature so that it works with uyuni also.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes I didn't create an issue this is directly from testsuite review.
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
