### PR TITLE
Fix cobbler pxe feature

### DIFF
--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -92,6 +92,8 @@ Feature: PXE boot a terminal with Cobbler
     When I configure tftp on the "server"
     And I start tftp on the proxy
     And I configure tftp on the "proxy"
+    And I restart the cobbler service in the server
+    And I wait for "5" seconds
     And I synchronize the tftp configuration on the proxy with the server
 
   Scenario: PXE boot the PXE boot minion

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -412,6 +412,10 @@ Then(/^the tomcat logs should not contain errors$/) do
   end
 end
 
+When(/^I restart the cobbler service in the server$/) do
+  $server.run('systemctl restart cobblerd.service')
+end
+
 When(/^I restart the spacewalk service$/) do
   $server.run('spacewalk-service restart')
 end
@@ -650,7 +654,7 @@ When(/^I configure tftp on the "([^"]*)"$/) do |host|
   when 'proxy'
     cmd = "configure-tftpsync.sh --non-interactive --tftpbootdir=/srv/tftpboot \
 --server-fqdn=#{ENV['SERVER']} \
---proxy-fqdn=#{ENV['PROXY']}"
+--proxy-fqdn='proxy.example.org'"
     $proxy.run(cmd)
   end
 end


### PR DESCRIPTION
## What does this PR change?

Should fix the PXE boot feature to change the url from the proxy hostname to the proxy.example.org.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
