### PR TITLE
Backend deb importlib - less strict packages-list parsing 

### DIFF
--- a/python/spacewalk/server/importlib/debPackage.py
+++ b/python/spacewalk/server/importlib/debPackage.py
@@ -123,7 +123,7 @@ class debBinaryPackage(headerSource.rpmBinaryPackage):
             l = []
             values = header[k]
             if values is not None:
-                val = values.split(', ')  # split packages
+                val = [ elem.strip() for elem in values.split(',') ]  # split packages
                 i = 0
                 for v in val:
                     relation = 0

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Less strict package-list parsing in debPackage importlib
 - implement more decompression algorithms for reposync (bsc#1196704)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

This PR is regarding #4481 

Before this PR, package-lists in the repository of debian packages are expected to be separated by comma-space (`', '`)
With this change, the package list is splitted by the comma only, and any leading and trailing whitespaces are striped from the elements of the package list.

The debian src-control spec does not explicitly state that package-lists have to be comma-space-separated.
It only is states (quoting the [manual](https://www.man7.org/linux/man-pages/man5/deb-control.5.html))

>       The syntax of Depends, Pre-Depends, Recommends and Suggests
>        fields is a list of groups of alternative packages. Each group is
>        a list of packages separated by vertical bar (or “pipe”) symbols,
>        ‘|’.  The groups are separated by commas.  Commas are to be read
>        as “AND”, and pipes as “OR”, with pipes binding more tightly.
>        Each package name is optionally followed by an architecture
>        qualifier appended after a colon ‘:’, optionally followed by a
>        version number specification in parentheses.

My tests show a now tolerant behavior to deal with more unconventional meta data in third-party repositories.


## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [X] **DONE**

## Test coverage
- No tests: How would you propose this to be tested?
The current tests for the backend (in docker) do not return any errors with this change.
However, there is no complex test which would test debian repositories in the first place.


- [ ] **DONE**

## Links

Fixes #4481

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
