### PR TITLE
continue migration when indexes do not exist

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,5 @@
+- Continue with index migration when the expected indexes do not exist
+  (bsc#1192566)
 - Add upgrade script to migrate pillar and formula data to database
 - Remove minion_pillars PL/SQL function
 - Force metadata files regeneration for Debian based repos

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.4-to-susemanager-schema-4.2.5/702-debvercmp.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.4-to-susemanager-schema-4.2.5/702-debvercmp.sql
@@ -13,12 +13,12 @@ BEGIN
     END IF;
 END $$;
 
-drop index rhn_pe_v_r_e_uq;
+drop index if exists rhn_pe_v_r_e_uq;
 create unique index rhn_pe_v_r_e_uq
     on rhnpackageevr (version, release, epoch, ((evr).type))
  where epoch is not null;
 
-drop index rhn_pe_v_r_uq;
+drop index if exists rhn_pe_v_r_uq;
 create unique index rhn_pe_v_r_uq
     on rhnpackageevr (version, release, ((evr).type))
  where epoch is null;


### PR DESCRIPTION
## What does this PR change?

Continue with index migration when the expected indexes do not exist.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/16423

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
