### PR TITLE
Drop IE detection hacks

### DIFF
--- a/web/html/javascript/channel_tree.js
+++ b/web/html/javascript/channel_tree.js
@@ -3,15 +3,7 @@ IMAGE_EXPANDED_PATH  = '/img/list-collapse.gif';
 IMAGE_CHILDLESS_PATH  = '/img/rhn-bullet-parentchannel.gif';
 
 var rowHash = new Array();
-var browserType;
 var columnsPerRow;
-
-// tip of the Red Hat to Mar Orlygsson for this little IE detection script
-var is_ie/*@cc_on = {
-   quirksmode : (document.compatMode=="BackCompat"),
-   version : parseFloat(navigator.appVersion.match(/MSIE (.+?);/)[1])
-}@*/;
-browserType = is_ie;
 
 function onLoadStuff(columns) {
   columnsPerRow = columns;

--- a/web/html/javascript/tree.js
+++ b/web/html/javascript/tree.js
@@ -2,16 +2,6 @@ IMAGE_COLLAPSED_PATH = '/img/list-expand.gif';
 IMAGE_EXPANDED_PATH  = '/img/list-collapse.gif';
 IMAGE_CHILDLESS_PATH  = '/img/rhn-bullet-parentchannel.gif';
 
-
-var browserType;
-
-// tip of the Red Hat to Mar Orlygsson for this little IE detection script
-var is_ie/*@cc_on = {
-   quirksmode : (document.compatMode=="BackCompat"),
-   version : parseFloat(navigator.appVersion.match(/MSIE (.+?);/)[1])
-}@*/;
-browserType = is_ie;
-
 function onLoadStuff(columns, tableId, rowHash)  {
   var channelTable = document.getElementById(tableId);
   createParentRows(channelTable, rowHash, columns);


### PR DESCRIPTION
## What does this PR change?

Stumbled upon these while working on https://github.com/uyuni-project/uyuni/pull/4676. This PR removes IE detection hacks since they're picked up as license comments by the license extractor.  

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
