### PR TITLE
workaround for bug 1192195 - change zypp conf to install docs

### DIFF
--- a/testsuite/features/core/proxy_register_as_minion_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_script.feature
@@ -15,6 +15,8 @@ Feature: Setup Uyuni proxy
 
   Scenario: Install proxy software
     When I refresh the metadata for "proxy"
+    # workaround for bug 1192195, remove when fixed
+    And I adapt zyppconfig
     # uncomment when product is out:
     # When I install "SUSE-Manager-Proxy" product on the proxy
     And I install proxy pattern on the proxy

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1063,6 +1063,11 @@ When(/^I install "([^"]*)" product on the proxy$/) do |product|
   STDOUT.puts "Installed #{product} product: #{out}"
 end
 
+When(/^I adapt zyppconfig$/) do
+   cmd = "sed -i 's/^rpm.install.excludedocs =.*$/rpm.install.excludedocs = no/' /etc/zypp/zypp.conf"
+   $proxy.run(cmd)
+end
+
 When(/^I install proxy pattern on the proxy$/) do
   pattern = $product == 'Uyuni' ? 'uyuni_proxy' : 'suma_proxy'
   cmd = "zypper --non-interactive install -t pattern #{pattern}"


### PR DESCRIPTION
## What does this PR change?

workaround for groff-full install bug.
Remove as soon as the bug is fixed in SP4 Beta

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

https://bugzilla.suse.com/show_bug.cgi?id=1192195

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
