### PR TITLE
Configure minion correct

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/util/mgr_disable_fqdns_grain.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/mgr_disable_fqdns_grain.sls
@@ -9,6 +9,7 @@ mgr_disable_fqdns_grains:
   file.append:
     - name: {{ susemanager_minion_config }}
     - text: "enable_fqdns_grains: False"
+    - unless: grep 'enable_fqdns_grains:' {{ susemanager_minion_config }}
 
 mgr_salt_minion:
   service.running:

--- a/susemanager-utils/susemanager-sls/salt/util/mgr_mine_config_clean_up.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/mgr_mine_config_clean_up.sls
@@ -10,6 +10,7 @@ mgr_disable_mine:
   file.managed:
     - name: {{ susemanager_minion_config }}
     - contents: "mine_enabled: False"
+    - unless: grep 'mine_enabled:' {{ susemanager_minion_config }}
 
 mgr_salt_minion:
   service.running:

--- a/susemanager-utils/susemanager-sls/salt/util/mgr_start_event_grains.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/mgr_start_event_grains.sls
@@ -8,3 +8,4 @@ mgr_start_event_grains:
     - name: {{ susemanager_minion_config }}
     - text: |
         start_event_grains: [machine_id, saltboot_initrd, susemanager]
+    - unless: grep 'start_event_grains:' {{ susemanager_minion_config }}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- enforce correct minion configuration similar to bootstrapping
+  (bsc#1192510)
 - Fix issues running mgr_events on Salt 3004
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Having problems with minions configured wrong where changes we did in the past were not applied.
We better use the template during highstate for minions `susemanager.conf` we also use during bootstrapping time.
We do **not** watch the config file changes to prevent restarting the minion during bootstrapping.
This could result into lost actions like the package or hardware refresh when the minion gets restarted when these actions are currently waiting in the queue.

Port of https://github.com/SUSE/spacewalk/pull/16620
Adapted for venv usage

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
