### PR TITLE
Fix salt job race

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/RebootActionCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/RebootActionCleanup.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 
 /**
@@ -67,6 +68,11 @@ public class RebootActionCleanup extends RhnJavaJob {
         if (failedRebootActions.size() > 0) {
             log.info("Set " + failedRebootActions.size() +
                     " reboot action(s) to failed. Running longer than 6 hours.");
+            if (log.isDebugEnabled()) {
+                log.debug("failed (server,action) ids" + failedRebootActions.stream()
+                    .map(a -> "(" + a.get("server_id") + ", " + a.get("action_id") + ")")
+                    .collect(Collectors.joining(", ")));
+            }
         }
     }
 

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -1875,23 +1875,35 @@ public class SaltUtils {
 
     private boolean shouldCleanupAction(Date bootTime, ServerAction sa) {
         Action action = sa.getParentAction();
+        boolean result = false;
         if (action.getActionType().equals(ActionFactory.TYPE_REBOOT)) {
             if (sa.getStatus().equals(ActionFactory.STATUS_PICKED_UP) && sa.getPickupTime() != null) {
-                return bootTime.after(sa.getPickupTime());
+                result = bootTime.after(sa.getPickupTime());
             }
             else if (sa.getStatus().equals(ActionFactory.STATUS_PICKED_UP) && sa.getPickupTime() == null) {
-                return bootTime.after(action.getEarliestAction());
+                result = bootTime.after(action.getEarliestAction());
             }
             else if (sa.getStatus().equals(ActionFactory.STATUS_QUEUED)) {
                 if (action.getPrerequisite() != null) {
                     // queued reboot actions that do not complete in 12 hours will
                     // be cleaned up by MinionActionUtils.cleanupMinionActions()
-                    return false;
+                    result = false;
                 }
-                return bootTime.after(sa.getParentAction().getEarliestAction());
+                else {
+                    result = bootTime.after(sa.getParentAction().getEarliestAction());
+                }
+            }
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("shouldCleanupAction" +
+                        " Server:" + sa.getServer().getId() +
+                        " Action: " + sa.getParentAction().getId() +
+                        " BootTime: " + bootTime +
+                        " PickupTime: " + sa.getPickupTime() +
+                        " EarliestAction " + action.getEarliestAction() +
+                        " Result: " + result);
             }
         }
-        return false;
+        return result;
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix possible race condition in job handling (bsc#1192510)
 - Remove verbose token log
 - FIX errors when an image profile / store is deleted
   during build / inspect action (bsc#1191597, bsc#1192150)


### PR DESCRIPTION
## What does this PR change?

A race condition seems to happen again.

Change the code to switch an action to state "Picked Up" only when the current state is "Queued"
and add debug looging for cleanup action.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/16408

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
