### PR TITLE
Force tftp to use proxy instead of server

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -653,7 +653,7 @@ When(/^I configure tftp on the "([^"]*)"$/) do |host|
     $server.run("configure-tftpsync.sh #{ENV['PROXY']}")
   when 'proxy'
     cmd = "configure-tftpsync.sh --non-interactive --tftpbootdir=/srv/tftpboot \
---server-fqdn=#{ENV['SERVER']} \
+--server-fqdn='proxy.example.org' \
 --proxy-fqdn='proxy.example.org'"
     $proxy.run(cmd)
   end

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -653,7 +653,7 @@ When(/^I configure tftp on the "([^"]*)"$/) do |host|
     $server.run("configure-tftpsync.sh #{ENV['PROXY']}")
   when 'proxy'
     cmd = "configure-tftpsync.sh --non-interactive --tftpbootdir=/srv/tftpboot \
---server-fqdn='proxy.example.org' \
+--server-fqdn=#{ENV['SERVER']} \
 --proxy-fqdn='proxy.example.org'"
     $proxy.run(cmd)
   end

--- a/testsuite/features/upload_files/sle-15-sp2-autoyast.xml
+++ b/testsuite/features/upload_files/sle-15-sp2-autoyast.xml
@@ -3,21 +3,21 @@
     <add_on_products config:type="list">
       <listentry>
         <ask_on_error config:type="boolean">true</ask_on_error>
-        <media_url>http://$redhat_management_server/ks/dist/child/sle-product-sles15-sp2-updates-x86_64/$distrotree</media_url>
+        <media_url>http://proxy.example.org/ks/dist/child/sle-product-sles15-sp2-updates-x86_64/$distrotree</media_url>
         <name>sle-product-sles15-updates-x86_64</name>
         <product>SLES15</product>
         <product_dir>/</product_dir>
       </listentry>
       <listentry>
         <ask_on_error config:type="boolean">true</ask_on_error>
-        <media_url>http://$redhat_management_server/ks/dist/child/sle-module-basesystem15-sp2-pool-x86_64/$distrotree</media_url>
+        <media_url>http://proxy.example.org/ks/dist/child/sle-module-basesystem15-sp2-pool-x86_64/$distrotree</media_url>
         <name>basesystem pool</name>
         <product>Basesystem Module</product>
         <product_dir>/</product_dir>
       </listentry>
       <listentry>
         <ask_on_error config:type="boolean">true</ask_on_error>
-        <media_url>http://$redhat_management_server/ks/dist/child/sle-module-basesystem15-sp2-updates-x86_64/$distrotree</media_url>
+        <media_url>http://proxy.example.org/ks/dist/child/sle-module-basesystem15-sp2-updates-x86_64/$distrotree</media_url>
         <name>basesystem updates</name>
         <product>Basesystem Module</product>
         <product_dir>/</product_dir>


### PR DESCRIPTION
## What does this PR change?

Force tftp to use proxy instead of server

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes no issue, was created directly from testsuite review
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
