### PR TITLE
Add cucumber tags for build validation clients

### DIFF
--- a/testsuite/features/build_validation/add_custom_repositories/srv_common_channels.feature
+++ b/testsuite/features/build_validation/add_custom_repositories/srv_common_channels.feature
@@ -1,12 +1,15 @@
-# Copyright 2021 SUSE LLC
+# Copyright 2021-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Add common channels and schedule their synchronization
-  # needed for external repositories that are not in SCC
+  In order to use external repositories that are not in SCC
+  As an authorized user
+  I want to declare channels with these repositories and synchronize them
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
+@ubuntu1804_minion
   Scenario: Add common channels for Ubuntu 18.04 main
     When I use spacewalk-common-channel to add channel "ubuntu-1804-amd64-main" with arch "amd64-deb"
     And I follow the left menu "Software > Manage > Channels"
@@ -19,6 +22,7 @@ Feature: Add common channels and schedule their synchronization
     And I click on "Sync Now"
     Then I should see a "Repository sync scheduled for Ubuntu 18.04 LTS AMD64 Main." text
 
+@ubuntu1804_minion
   Scenario: Add common channels for Ubuntu 18.04 updates
     When I use spacewalk-common-channel to add channel "ubuntu-1804-amd64-main-updates" with arch "amd64-deb"
     And I follow the left menu "Software > Manage > Channels"
@@ -31,6 +35,7 @@ Feature: Add common channels and schedule their synchronization
     And I click on "Sync Now"
     Then I should see a "Repository sync scheduled for Ubuntu 18.04 LTS AMD64 Main Updates." text
 
+@ubuntu1804_minion
   Scenario: Add common channels for Ubuntu 18.04 security
     When I use spacewalk-common-channel to add channel "ubuntu-1804-amd64-main-security" with arch "amd64-deb"
     And I follow the left menu "Software > Manage > Channels"
@@ -45,6 +50,7 @@ Feature: Add common channels and schedule their synchronization
 
   # No common channels for Ubuntu 20.04
 
+@opensuse153arm_minion
   Scenario: Add common channels for openSUSE 15.3 ARM
     When I use spacewalk-common-channel to add channel "opensuse_leap15_3" with arch "aarch64"
     And I follow the left menu "Software > Manage > Channels"

--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 SUSE LLC
+# Copyright 2017-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Synchronize products in the products page of the Setup Wizard
@@ -9,6 +9,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
+@sle11sp3_terminal
   Scenario: Add SUSE Linux Enterprise Server 11 SP3
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
@@ -19,6 +20,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I see "SUSE Linux Enterprise Server 11 SP3 i586" product has been added
     And I add "sles11-sp3-ltss-updates-i586" channel
 
+@sle11sp4_minion
   Scenario: Add SUSE Linux Enterprise Server 11 SP4
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
@@ -32,6 +34,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I see "SUSE Linux Enterprise Server 11 SP4 x86_64" product has been added
     And I add "sles11-sp4-ltss-updates-x86_64" channel
 
+@sle12sp4_minion
   Scenario: Add SUSE Linux Enterprise Server 12 SP4
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
@@ -44,6 +47,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 12 SP4 x86_64" product has been added
 
+@sle12sp5_minion
   Scenario: Add SUSE Linux Enterprise Server 12 SP5
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
@@ -53,6 +57,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 12 SP5 x86_64" product has been added
 
+@sle15_minion
   Scenario: Add SUSE Linux Enterprise Server 15
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
@@ -66,6 +71,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 15 x86_64" product has been added
 
+@sle15sp1_minion
   Scenario: Add SUSE Linux Enterprise Server 15 SP1
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
@@ -75,6 +81,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 15 SP1 x86_64" product has been added
 
+@sle15sp2_minion
   Scenario: Add SUSE Linux Enterprise Server 15 SP2
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
@@ -91,6 +98,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 15 SP2 x86_64" product has been added
 
+@sle15sp3_minion
   Scenario: Add SUSE Linux Enterprise Server 15 SP3
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
@@ -108,6 +116,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
     And I wait until I see "SUSE Linux Enterprise Server 15 SP3 x86_64" product has been added
 
+@ceos7_minion
   Scenario: Add SUSE Linux Enterprise Server with Expanded Support 7
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
@@ -117,6 +126,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server with Expanded Support 7" product has been added
 
+@ceos8_minion
   Scenario: Add SUSE Linux Enterprise Server with Expanded Support 8
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
@@ -129,6 +139,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I click the Add Product button
     And I wait until I see "RHEL or SLES ES or CentOS 8 Base" product has been added
 
+@ubuntu1804_minion
   Scenario: Add Ubuntu 18.04
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
@@ -138,6 +149,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I click the Add Product button
     And I wait until I see "Ubuntu 18.04" product has been added
 
+@ubuntu2004_minion
   Scenario: Add Ubuntu 20.04
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
@@ -147,6 +159,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I click the Add Product button
     And I wait until I see "Ubuntu 20.04" product has been added
 
+@debian9_minion
   Scenario: Add Debian 9
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
@@ -156,6 +169,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I click the Add Product button
     And I wait until I see "Debian 9" product has been added
 
+@debian10_minion
   Scenario: Add Debian 10
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
@@ -165,6 +179,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I click the Add Product button
     And I wait until I see "Debian 10" product has been added
 
+@debian11_minion
   Scenario: Add Debian 11
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -172,14 +172,6 @@ When(/^I check "([^"]*)" if not checked$/) do |arg1|
   check(arg1) unless has_checked_field?(arg1)
 end
 
-When(/^I check (.*) box$/) do |checkbox_name|
-  check BOX_IDS[checkbox_name]
-end
-
-When(/^I uncheck (.*) box$/) do |checkbox_name|
-  uncheck BOX_IDS[checkbox_name]
-end
-
 When(/^I select "([^"]*)" from "([^"]*)"$/) do |option, field|
   xpath_option = ".//*[contains(@class, 'class-#{field}__option') and contains(text(),'#{option}')]"
   xpath_field = "//*[contains(@class, 'class-#{field}__control')]/../*[@name='#{field}']/.."

--- a/testsuite/features/step_definitions/retail_steps.rb
+++ b/testsuite/features/step_definitions/retail_steps.rb
@@ -540,10 +540,12 @@ When(/^I press minus sign in (.*) section$/) do |section|
   find(:xpath, "#{sectionids[section]}/div[1]/i[@class='fa fa-minus']").click
 end
 
-When(/^I check (.*) box$/) do |box|
-  boxids = { 'enable SLAAC with routing' => 'branch_network#firewall#enable_SLAAC_with_routing',
-             'include forwarders'        => 'bind#config#include_forwarders' }
-  check boxids[box]
+When(/^I check (.*) box$/) do |checkbox_name|
+  check BOX_IDS[checkbox_name]
+end
+
+When(/^I uncheck (.*) box$/) do |checkbox_name|
+  uncheck BOX_IDS[checkbox_name]
 end
 
 # OS image build


### PR DESCRIPTION
## What does this PR change?

This PR is specific to build validation.

It is possible that some VMs like Debian 11 or openSUSE 15.3 are not supported in some branches.

Furthermore, it might be we don't want to test with all supported clients.

This PR adds cucumber tags for declaring channels and synchronizing them, according to which clients we have.

Caveat: `@debian9_minion or @debian9_ssh_minion` does not work. Therefore we are examining the minion only, assuming we will never have the ssh minion without the base minion.

Alternative: SUSE/spacewalk#16697

** Also piggybacking a fix to Retail preparation PR. **


## Links

Ports:
* 4.1: SUSE/spacewalk#16712
* 4.2: SUSE/spacewalk#16711

## Changelogs

- [x] No changelog needed
