### PR TITLE
CI: set only one maintainer for obs proxy

### DIFF
--- a/susemanager-utils/testing/automation/obs-project.py
+++ b/susemanager-utils/testing/automation/obs-project.py
@@ -66,7 +66,11 @@ def add(args):
     root.find("title").text = new_title 
 
     if (maintainer!=""):
-        print("DEBUG: Adding user {} as maintainer".format(auth_user))
+        print("DEBUG: Adding user {} as the only maintainer".format(auth_user))
+        for user in root.findall("person"):
+            root.remove(user)
+        for group in root.finall("group"):
+            root.remove(group)
         new_person = ET.fromstring("<person userid=\"{}\" role=\"maintainer\"/>".format(auth_user))
         root.append(new_person)
 
@@ -180,7 +184,7 @@ parser_add = subparser.add_parser("add", help="add project")
 parser_add.add_argument('--project', help="Project from which to \"branch\" from, defaults to systemsmanagement:Uyuni:Master", default="systemsmanagement:Uyuni:Master")
 parser_add.add_argument('--repo', help="Repo to build for, defaults to openSUSE.*|SLE.*", default="openSUSE.*|SLE.*")
 parser_add.add_argument('pullnumber', help="Pull Request number, for example 1")
-parser_add.add_argument('--setmaintainer', help="Set maintainer", default="")
+parser_add.add_argument('--setmaintainer', help="Set this user as the only maintainer", default="")
 parser_add.add_argument('--disablepublish', help="Disable the publish", action="store_true", default=False)
 parser_add.set_defaults(func=add)
 


### PR DESCRIPTION
## What does this PR change?

CI: to avoid getting "noisy" emails to other users from obs

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests
- [X] **DONE**

## Links

N/A

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
