### PR TITLE
Revert server migrator to 15.4

### DIFF
--- a/susemanager/bin/server-migrator.sh
+++ b/susemanager/bin/server-migrator.sh
@@ -19,44 +19,27 @@ echo
 read -n 1 -s -r -p "Press any key to start the migration or CTRL+C to cancel...";
 echo
 
-NEW_VERSION_ID=15.4
-
-CHECK_OS=$(cat /etc/os-release  | grep PRETTY_NAME)
-
-if [[ ${CHECK_OS} != *"openSUSE Leap"* ]]; then
-  echo "Please check your OS. openSUSE Leap is needed "
-  exit -1
-fi
-
 spacewalk-service stop
 rm -rf /etc/zypp/repos.d.old
 mv /etc/zypp/repos.d /etc/zypp/repos.d.old
 mkdir /etc/zypp/repos.d
-zypper ar -n "Main Repository" http://download.opensuse.org/distribution/leap/${NEW_VERSION_ID}/repo/oss repo-oss
-zypper ar -n "Main Update Repository" http://download.opensuse.org/update/leap/${NEW_VERSION_ID}/oss repo-update
-zypper ar -n "Non-OSS Repository" http://download.opensuse.org/distribution/leap/${NEW_VERSION_ID}/repo/non-oss repo-non-oss
-zypper ar -n "Update Repository (Non-Oss)" http://download.opensuse.org/update/leap/${NEW_VERSION_ID}/non-oss/ repo-update-non-oss
+zypper ar -n "Main Repository" http://download.opensuse.org/distribution/leap/15.3/repo/oss repo-oss
+zypper ar -n "Main Update Repository" http://download.opensuse.org/update/leap/15.3/oss repo-update
+zypper ar -n "Non-OSS Repository" http://download.opensuse.org/distribution/leap/15.3/repo/non-oss repo-non-oss
+zypper ar -n "Update Repository (Non-Oss)" http://download.opensuse.org/update/leap/15.3/non-oss/ repo-update-non-oss
 zypper ar -n "Uyuni Server Stable" https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/ uyuni-server-stable
-zypper ar -n "Update repository wiht updates from SUSE Linux Enterprise" http://download.opensuse.org/update/leap/${NEW_VERSION_ID}/sle repo-sle-update
-zypper ar -n "Update repository of openSUSE Backports" http://download.opensuse.org/update/leap/${NEW_VERSION_ID}/backports/ repo-backports-update
+zypper ar -n "Update repository wiht updates from SUSE Linux Enterprise 15" http://download.opensuse.org/update/leap/15.3/sle repo-sle-update
+zypper ar -n "Update repository of openSUSE Backports" http://download.opensuse.org/update/leap/15.3/backports/ repo-backports-update
 zypper ref
 zypper -n dup --allow-vendor-change
-ret=$?
-if [[ $ret -ne 0 ]];then
-    echo "Migration went wrong. Please fix the issues and try again. return code is $ret"
+if [ $? -ne 0 ];then
+    echo "Migration went wrong. Please fix the issues and try again."
     exit -1
 fi
 
-CURRENT_VERSION_ID=$(cat /etc/os-release  | grep VERSION_ID | cut -f2 -d=)
-
-if [[ "${CURRENT_VERSION_ID}" != "\"${NEW_VERSION_ID}\"" ]]; then
-    echo "Migration went wrong. Expected version is ${NEW_VERSION_ID} instead is ${CURRENT_VERSION_ID}"
-    echo "Please try to re-run this script"
-    exit -1
-fi
-
+echo
 echo "==================================================================="
-echo "If you did not yet migrate the database to the new postgres version, do so now"
+echo "If you did not yet migrate the database to postgresql13, do so now"
 echo "by running /usr/lib/susemanager/bin/pg-migrate-x-to-y.sh"
 echo
 echo "Reboot system afterwards."

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,4 +1,3 @@
-- Update server-migrator to dist-upgrade to openSUSE 15.4
 - Bootstrap repo configureable.
 - Added installation on Rocky Linux 8.
 - fix pg-migrate to check version of postgresql??-server (bsc#1192368)


### PR DESCRIPTION
## What does this PR change?

We should have not merged this yet because of 2 reasons:

1- we do not support 15.4 yet
2- users can't migrate to 15.3 if we do not revert


## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

N/A
- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
