### PR TITLE
Some MUs have a different URL prefix

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -181,6 +181,7 @@ end
 def generate_repository_name(repo_url)
   repo_name = repo_url.strip
   repo_name.delete_prefix! 'http://download.suse.de/ibs/SUSE:/Maintenance:/'
+  repo_name.delete_prefix! 'http://download.suse.de/download/ibs/SUSE:/Maintenance:/'
   repo_name.delete_prefix! 'http://minima-mirror-qam.mgr.prv.suse.net/ibs/SUSE:/Maintenance:/'
   repo_name.gsub!('/', '_')
   repo_name[0...64] # HACK: Due to the 64 characters size limit of a repository label


### PR DESCRIPTION
## What does this PR change?

```
https://download.suse.de/ibs/SUSE:/Maintenance:/22379/
https://download.suse.de/download/ibs/SUSE:/Maintenance:/22379/ 
```
are both valid. Let's remove both prefixes, so we can use both forms on the `.json` file.


## Links

Ports:
* 4.1:
* 4.2: SUSE/spacewalk#16750

## Changelogs

- [x] No changelog needed
