### PR TITLE
Filter actions to cancel by selected servers

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -389,6 +389,7 @@ public class ActionManager extends BaseManager {
                         a.getServerActions().stream()
                             .filter(sa -> isMinionServer(sa.getServer()))
                             .filter(sa -> ActionFactory.STATUS_QUEUED.equals(sa.getStatus()))
+                            .filter(sa -> servers.contains(sa.getServer()))
                             .map(sa -> sa.getServer())
                             .collect(toSet())
                         )

--- a/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
@@ -18,6 +18,8 @@ package com.redhat.rhn.manager.action.test;
 import static com.redhat.rhn.testing.ImageTestUtils.createActivationKey;
 import static com.redhat.rhn.testing.ImageTestUtils.createImageProfile;
 import static com.redhat.rhn.testing.ImageTestUtils.createImageStore;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
 
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.db.datasource.DataResult;
@@ -107,6 +109,8 @@ import com.suse.salt.netapi.results.Result;
 import com.suse.salt.netapi.utils.Xor;
 
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.log4j.Logger;
 import org.hibernate.Session;
 import org.hibernate.query.Query;
@@ -530,6 +534,46 @@ public class ActionManagerTest extends JMockBaseTestCaseWithUser {
         ActionManager.cancelActions(user, actionList);
         assertServerActionCount(parent, 0);
         assertActionsForUser(user, 1); // shouldn't have been deleted
+    }
+
+    public void testCancelActionForSubsetOfServerWithMultipleServerActions() throws Exception {
+        Action parent = createActionWithServerActions(user, 2);
+        List<Action> actionList = Collections.singletonList(parent);
+        TaskomaticApi taskomaticMock = mock(TaskomaticApi.class);
+        ActionManager.setTaskomaticApi(taskomaticMock);
+
+        List<Server> servers = actionList.stream()
+                .flatMap(a -> a.getServerActions().stream())
+                .map(ServerAction::getServer)
+                .collect(Collectors.toList());
+
+        Server ignoreFirst = servers.remove(0);
+        Collection<Long> activeServers = servers.stream().map(Server::getId).collect(Collectors.toList());
+
+        Map<Action, Set<Server>> actionMap = actionList.stream()
+                .map(a -> new ImmutablePair<>(
+                                a,
+                                a.getServerActions().stream()
+                                        .map(sa -> sa.getServer())
+                                        .collect(toSet())
+                        )
+                )
+                .collect(toMap(
+                        Pair::getLeft,
+                        Pair::getRight
+                ));
+
+        context().checking(new Expectations() { {
+            never(taskomaticMock).deleteScheduledActions(with(same(actionMap)));
+        } });
+
+        assertServerActionCount(parent, 2);
+        assertActionsForUser(user, 1);
+        ActionManager.cancelActions(user, actionList, Optional.of(activeServers));
+        assertServerActionCount(parent, 1);
+        assertActionsForUser(user, 1); // shouldn't have been deleted
+        // check that action was indeed not canceled on taskomatic side
+        context().assertIsSatisfied();
     }
 
     public void testCancelActionWithParentFails() throws Exception {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Pass only selected servers to taskomatic for cancelation (bsc#1194044)
+
 -------------------------------------------------------------------
 Tue Jan 18 13:52:58 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

When multi server action is canceled for just one of the servers we cannot unschedule the action on taskomatic side, only remove it from server actions. This filtering was missing when constructing options for taskomatic call and this PR adds it.

Port of https://github.com/SUSE/spacewalk/pull/16693

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/16608
Tracks https://github.com/SUSE/spacewalk/pull/16693

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
