### PR TITLE
Don't tune SSL before the proxy is configured

### DIFF
--- a/testsuite/features/build_validation/init_clients/proxy.feature
+++ b/testsuite/features/build_validation/init_clients/proxy.feature
@@ -13,11 +13,10 @@ Feature: Setup SUSE Manager proxy
   Scenario: Clean up sumaform leftovers on a SUSE Manager proxy
     When I perform a full salt minion cleanup on "proxy"
 
-  Scenario: Install proxy software
+  Scenario: Install proxy software for build validation
     # uncomment when product is out:
     # When I install "SUSE-Manager-Proxy" product on the proxy
     And I install proxy pattern on the proxy
-    And I allow all SSL protocols on the proxy's apache
     And I let squid use avahi on the proxy
 
   Scenario: Log in as admin user
@@ -45,6 +44,7 @@ Feature: Setup SUSE Manager proxy
   Scenario: Copy the keys and configure the proxy
     When I copy server's keys to the proxy
     And I configure the proxy
+    And I allow all SSL protocols on the proxy's apache
     Then I should see "proxy" via spacecmd
     And service "salt-broker" is active on "proxy"
 


### PR DESCRIPTION
## What does this PR change?

We can't reload apache if it's not running yet.

In any case, it's safer to modify its configuration only after SUSE Manager's configuration script has run.


## Links

Ports:
* 4.1: SUSE/spacewalk#16752
* 4.2: SUSE/spacewalk#16753


## Changelogs

- [x] No changelog needed
