### PR TITLE
Fix uptime display tests to follow moment.js library rules

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -6,6 +6,7 @@ Feature: Smoke tests for <client>
   In order to test <client>
   As an authorized user
   I want to :
+  - View the details of the system
   - Install a package via Web UI
   - Install a patch via Web UI
   - Remove a package via Web UI

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -75,31 +75,33 @@ end
 
 Then(/^the uptime for "([^"]*)" should be correct$/) do |host|
   node = get_target(host)
-  uptime_days, _code = node.run("awk '{print $1/86400}' /proc/uptime")
-  uptime_hours, _code = node.run("awk '{print $1/3600}' /proc/uptime")
-  uptime_minutes, _code = node.run("awk '{print $1/60}' /proc/uptime")
-  uptime_seconds, _code = node.run("awk '{print $1}' /proc/uptime")
-  uptime_days = uptime_days.to_f.round
-  uptime_hours = uptime_hours.to_f.round
-  uptime_minutes = uptime_minutes.to_f.round
-  uptime_seconds = uptime_seconds.to_f.round
+  uptime_seconds, _return_code = node.run("awk '{print $1}' /proc/uptime") # run code on node only once, to get uptime in seconds
+  uptime_days = (uptime_seconds / 86400.0) # 60 seconds * 60 minutes * 24 hours; the .0 forces a float division
+  uptime_hours = (uptime_seconds / 3600.0) # 60 seconds * 60 minutes
+  uptime_minutes = (uptime_seconds / 60.0) # 60 seconds
 
-  if uptime_days < 2 and uptime_days >= 1
-    step %(I should see a "#{uptime_days.round} day ago" text)
-  elsif uptime_days < 1 and uptime_hours >= 2
-    step %(I should see a "#{uptime_hours.round} hours ago" text)
-  elsif uptime_days < 1 and uptime_hours < 2
-    step %(I should see a "#{uptime_hours.round} hour ago" text)
-  elsif uptime_hours < 1 and uptime_minutes >= 2
-    step %(I should see a "#{uptime_minutes.round} minutes ago" text)
-  elsif uptime_hours < 1 and uptime_minutes < 2
-    step %(I should see a "#{uptime_minutes.round} minute ago" text)
-  elsif uptime_minutes < 1 and uptime_seconds >= 2
-    step %(I should see a "#{uptime_seconds.round} seconds ago" text)
-  elsif uptime_minutes < 1 and uptime_seconds < 2
-    step %(I should see a "#{uptime_seconds.round} second ago" text)
+  # rounded values to nearest integer number
+  rounded_uptime_minutes = uptime_minutes.round
+  rounded_uptime_hours = uptime_hours.round
+  rounded_uptime_days = uptime_days.round
+
+  # the moment.js library being used has some weird rules, which these conditionals follow
+  if (uptime_days >= 1 && rounded_uptime_days < 2) || (uptime_days < 1 && rounded_uptime_hours >= 22) # shows "a day ago" after 22 hours and before it's been 1.5 days
+    step %(I should see a "a day ago" text)
+  elsif rounded_uptime_hours > 1 && rounded_uptime_hours <= 21
+    step %(I should see a "#{rounded_uptime_hours} hours ago" text)
+  elsif rounded_uptime_minutes >= 45 && rounded_uptime_hours == 1 # shows "an hour ago" from 45 minutes onwards up to 1,5 hours
+    step %(I should see a "an hour ago" text)
+  elsif rounded_uptime_minutes > 1 && rounded_uptime_hours < 1
+    step %(I should see a "#{rounded_uptime_minutes} minutes ago" text)
+  elsif uptime_seconds >= 45 && rounded_uptime_minutes == 1
+    step %(I should see a "a minute ago" text)
+  elsif uptime_seconds < 45
+    step %(I should see a "a few seconds ago" text)
+  elsif rounded_uptime_days < 25
+    step %(I should see a "#{rounded_uptime_days} days ago" text) # shows "a month ago" from 25 days onwards
   else
-    step %(I should see a "#{uptime_days.round} days ago" text)
+    step %(I should see a "a month ago" text)
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

- Adds a specific message for special cases (1 day uptime shows "a day ago", 1 minute is "a minute ago" and so on)
- Fixes the uptime rules, according to the moment.js library: 
  - <1min is "a few seconds ago"
  - \>=45min is "an hour ago"
  - \>=22 hours is "a day ago"
  - \>=25 days is "a month ago"
- Run the uptime command only once, for getting the different uptime time units

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were modified

- [x] **DONE**

## Links

- [4.1](https://github.com/SUSE/spacewalk/pull/16710)
- [4.2](https://github.com/SUSE/spacewalk/pull/16755)

## Changelogs

- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
