### PR TITLE
HUB-ISS: XML-RPC endpoint to restore config channel files on disk

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/configchannel/ConfigChannelHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/configchannel/ConfigChannelHandler.java
@@ -56,6 +56,8 @@ import com.redhat.rhn.manager.configuration.ConfigurationManager;
 import com.redhat.rhn.manager.configuration.file.SLSFileData;
 import com.redhat.rhn.manager.system.SystemManager;
 
+import com.suse.manager.webui.services.ConfigChannelSaltManager;
+
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Date;
@@ -277,6 +279,33 @@ public class ConfigChannelHandler extends BaseHandler {
         }
 
         return cm.lookupConfigRevisionByRevId(loggedInUser, cf, revision.longValue());
+    }
+
+    /**
+     * Synchronize all files on the disk to the current state of the database.
+     * @param loggedInUser The current user
+     * @param channelLabels the list of global channels to synchronize files from.
+     * @return 1 if successful with the operation, errors out otherwise.
+     *
+     * @xmlrpc.doc Synchronize all files on the disk to the current state of the database.
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param
+     * #array_single("string","configuration channel labels to synchronize files from.")
+     * @xmlrpc.returntype #return_int_success()
+     */
+    public int syncSaltFilesOnDisk(User loggedInUser, List<String> channelLabels) {
+        var manager = ConfigurationManager.getInstance();
+        var saltManager = ConfigChannelSaltManager.getInstance();
+        for (var label : channelLabels) {
+            try {
+                var channel = manager.lookupGlobalConfigChannel(loggedInUser, label);
+                saltManager.generateConfigChannelFiles(channel);
+            }
+            catch (Exception e) {
+                throw new ConfigFileErrorException(e.getMessage());
+            }
+        }
+        return 1;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/configchannel/test/ConfigChannelHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/configchannel/test/ConfigChannelHandlerTest.java
@@ -59,6 +59,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * ConfigChannelHandlerTest
@@ -214,6 +215,58 @@ public class ConfigChannelHandlerTest extends BaseHandlerTestCase {
         handler.updateInitSls(admin, cc.getLabel(), data);
         assertEquals(newContents, initSls.getLatestConfigRevision().getConfigContent().getContentsString());
 
+    }
+
+    public void testSyncSaltFiles() throws Exception {
+
+        // Remove all channels
+        var deleted = removeAllGlobals();
+        assertEquals(1, deleted);
+
+        // Create a normal channel with a file attached
+        ConfigChannel channel = handler.create(admin, LABEL, NAME, DESCRIPTION, "normal");
+        ConfigFile file = ConfigTestUtils.createConfigFile(channel);
+        ConfigTestUtils.createConfigRevision(file);
+
+        assertEquals(LABEL, channel.getLabel());
+        assertEquals(NAME, channel.getName());
+        assertEquals(DESCRIPTION, channel.getDescription());
+        assertEquals(admin.getOrg(), channel.getOrg());
+        assertEquals(ConfigChannelType.normal(), channel.getConfigChannelType());
+        assertEquals(1, channel.getConfigFiles().size());
+        assertNotNull(file.getLatestConfigRevision());
+
+        // Remove files from the disk only
+        ConfigTestUtils.removeChannelFiles(channel);
+        assertFalse(ConfigTestUtils.lookUpChannelFiles(channel));
+
+        // Sync files on the disk.
+        handler.syncSaltFilesOnDisk(admin, List.of(channel.getLabel()));
+        assertTrue(ConfigTestUtils.lookUpChannelFiles(channel));
+
+    }
+
+    public void testSyncSaltFilesNoChannels() throws Exception {
+
+        // Remove all channels.
+        var deleted = removeAllGlobals();
+        assertEquals(1, deleted);
+
+        // Attempt restoring files on the disk while there are no channels.
+        var synced = handler.syncSaltFilesOnDisk(admin, List.of());
+        assertEquals(1, synced);
+
+    }
+
+    /**
+     * Deletes a list of  global channels.
+     *
+     * @return 1 if successful with the operation errors out otherwise.
+     */
+    private int removeAllGlobals() {
+        var channels = handler.listGlobals(admin);
+        var labels = channels.stream().map(ConfigChannelDto::getLabel).collect(Collectors.toList());
+        return handler.deleteChannels(admin, labels);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/testing/ConfigTestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/ConfigTestUtils.java
@@ -31,6 +31,8 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.test.SystemManagerTest;
 
+import com.suse.manager.webui.services.ConfigChannelSaltManager;
+
 import java.util.Date;
 
 import junit.framework.Assert;
@@ -386,5 +388,24 @@ public class ConfigTestUtils extends Assert {
         SystemManagerTest.giveCapability(server.getId(),
                 SystemManager.CAP_CONFIGFILES_MTIME_UPLOAD, 1L);
 
+    }
+
+    /**
+     * Removes all the files associated with a config channel.
+     * @param channel The channel for which to remove files from the disk.
+     */
+    public static void removeChannelFiles(ConfigChannel channel) {
+        ConfigChannelSaltManager saltManager = ConfigChannelSaltManager.getInstance();
+        saltManager.removeConfigChannelFiles(channel);
+    }
+
+    /**
+     * Looks up if channel files are generated on the disk.
+     * @param channel The channel for which to look up the generated files.
+     * @return True if files were generated on the disk, false otherwise.
+     */
+    public static boolean lookUpChannelFiles(ConfigChannel channel) {
+        ConfigChannelSaltManager saltManager = ConfigChannelSaltManager.getInstance();
+        return saltManager.areFilesGenerated(channel);
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Added new XML-RPC mathod: configchannel.syncSaltFilesOnDisk
 - Fix virtualization list rendering for foreign systems (bsc#1195712)
 - Change order of 'Relevant' and 'All' in patches menu
 - When adding a product, check if the new vendor channels conflicts


### PR DESCRIPTION
## What does this PR change?

In the ISS v2, after we synchronize the state of the database, we need to be able to recreate certain salt files on the disk under the `/srv/susemanager/salt` folder, so that they can be later deployed to target systems. For this reason, we create a new XML-RPC endpoint on the uyuni side, so that the ISS agent can call it and trigger the generation of the salt files upon import operation.

**How to test manually**
1. Create a normal config channel.
2. Create a new file in the channel.
3. Export config channels and re-import on your target system.
4. On the target system, call `spacecmd`, then in the prompt call `api configchannel.syncSaltFilesOnDisk -A '[["<you_chanel_label>"]]'`. Be careful with parents as well as the quotes, since we want to pass a list of arguments, where the first argument is a list itself. 
5. In case of a successful restore, you'll get a `[1]` as a response. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation

No documentation needed as discussed. 

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

closes https://github.com/SUSE/spacewalk/issues/16754

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
