### PR TITLE
WIP: HUB-ISS add cucumber tests for config channels import

### DIFF
--- a/testsuite/features/secondary/srv_handle_config_channels_with_ISS_v2.feature
+++ b/testsuite/features/secondary/srv_handle_config_channels_with_ISS_v2.feature
@@ -1,0 +1,68 @@
+# Copyright (c) 2021 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Export and import configuration channels with new ISS implementation
+  Distribute configuration between servers
+  Run export and import with ISS v2
+
+  Scenario: Install inter server sync package
+    When I install packages "inter-server-sync" on this "server"
+    Then "inter-server-sync" should be installed on "server"
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Create a configuration channel
+    When I follow the left menu "Configuration > Channels"
+    And I follow "Create Config Channel"
+    And I enter "Test Config Channel" as "cofName"
+    And I enter "testconfigchannel" as "cofLabel"
+    And I enter "This is a test configuration channel" as "cofDescription"
+    And I click on "Create Config Channel"
+    Then I should see a "Test Config Channel" text
+
+  Scenario: Add a configuration file to the test configuration channel
+    When I follow the left menu "Configuration > Channels"
+    And I follow "Test Config Channel"
+    And I follow "Create Configuration File or Directory"
+    And I enter "/etc/s-mgr/config" as "cffPath"
+    And I enter "COLOR=white" in the editor
+    And I click on "Create Configuration File"
+    Then I should see a "Revision 1 of /etc/s-mgr/config from channel Test Config Channel" text
+    And file "/srv/susemanager/salt/manager_org_1/testconfigchannel/init.sls" should exist on server
+    And file "/srv/susemanager/salt/manager_org_1/testconfigchannel/etc/s-mgr/config" should exist on server
+
+  Scenario: Export data with ISS v2
+    When I ensure folder "/tmp/export_iss_v2" doesn't exist
+    Then export folder "/tmp/export_iss_v2" shouldn't exist on server
+    When I export config channels "testconfigchannel" with ISS v2 to "/tmp/export_iss_v2"
+    Then "/tmp/export_iss_v2" folder on server is ISS v2 export directory
+
+  Scenario: Cleanup: remove the test configuration channel
+    When I follow the left menu "Configuration > Channels"
+    And I follow "Test Config Channel"
+    And I follow "Delete Channel"
+    And I click on "Delete Config Channel"
+    Then file "/srv/susemanager/salt/manager_org_1/testconfigchannel/init.sls" should not exist on server
+
+  Scenario: Import data with ISS v2
+    When I import data with ISS v2 from "/tmp/export_iss_v2"
+
+  Scenario: Check that the config channel was imported
+    When I follow the left menu "Configuration > Channels"
+    Then I should see a "Test Config Channel" link
+  
+  Scenario: Check that file has been created on server
+    When I run "rhn_check -vvv" on "server"
+    Then file "/etc/s-mgr/config" should contain "COLOR=white" on "server"
+
+  Scenario: Cleanup: remove the test configuration channel
+    When I follow the left menu "Configuration > Channels"
+    And I follow "Test Config Channel"
+    And I follow "Delete Channel"
+    And I click on "Delete Config Channel"
+    Then file "/srv/susemanager/salt/manager_org_1/testconfigchannel/init.sls" should not exist on server
+
+  Scenario: Cleanup: remove ISS v2 export folder
+    When I ensure folder "/tmp/export_iss_v2" doesn't exist
+    Then export folder "/tmp/export_iss_v2" shouldn't exist on server

--- a/testsuite/features/secondary/srv_handle_software_channels_with_ISS_v2.feature
+++ b/testsuite/features/secondary/srv_handle_software_channels_with_ISS_v2.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Export and import channels with new ISS implementation
+Feature: Export and import software channels with new ISS implementation
   Distribute software between servers
   Run export and import with ISS v2
 
@@ -36,7 +36,7 @@ Feature: Export and import channels with new ISS implementation
   Scenario: Export data with ISS v2
     When I ensure folder "/tmp/export_iss_v2" doesn't exist
     Then export folder "/tmp/export_iss_v2" shouldn't exist on server
-    When I export "clone-test-channel-x86_64" with ISS v2 to "/tmp/export_iss_v2"
+    When I export software channels "clone-test-channel-x86_64" with ISS v2 to "/tmp/export_iss_v2"
     Then "/tmp/export_iss_v2" folder on server is ISS v2 export directory
 
   Scenario: Cleanup: remove cloned channels

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1553,7 +1553,7 @@ When(/^I export software channels "([^"]*)" with ISS v2 to "([^"]*)"$/) do |chan
 end
 
 When(/^I export config channels "([^"]*)" with ISS v2 to "([^"]*)"$/) do |channel, path|
-  $server.run("inter-server-sync exportconfig --labels=#{channel} --outputDir=#{path}")
+  $server.run("inter-server-sync export --configChannels=#{channel} --outputDir=#{path}")
 end
 
 When(/^I import data with ISS v2 from "([^"]*)"$/) do |path|

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1548,8 +1548,12 @@ And(/^I copy vCenter configuration file on server$/) do
   raise 'File injection failed' unless return_code.zero?
 end
 
-When(/^I export "([^"]*)" with ISS v2 to "([^"]*)"$/) do |channel, path|
+When(/^I export software channels "([^"]*)" with ISS v2 to "([^"]*)"$/) do |channel, path|
   $server.run("inter-server-sync export --channels=#{channel} --outputDir=#{path}")
+end
+
+When(/^I export config channels "([^"]*)" with ISS v2 to "([^"]*)"$/) do |channel, path|
+  $server.run("inter-server-sync exportconfig --labels=#{channel} --outputDir=#{path}")
 end
 
 When(/^I import data with ISS v2 from "([^"]*)"$/) do |path|


### PR DESCRIPTION
## What does this PR change?

Add integration tests for the new ISS v2 tool.

The steps of this test are:

install inter-server-sync package on server
Clone an existing channel with packages and patches
Export it with ISS v2
Remove the cloned channel
Import with ISS v2
Check if the imported channel has the data

## GUI diff

No difference.
It's a command-line tool for now.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

closes https://github.com/SUSE/spacewalk/issues/16757

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
