### PR TITLE
Fix Chinese timezone display

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_en_US.xml
@@ -378,7 +378,7 @@
           <context context-type="sourcefile">/rhn/account/UserDetails</context>
         </context-group>
       </trans-unit>
-       <trans-unit id="Asia/Beijing" xml:space="preserve">
+       <trans-unit id="Asia/Shanghai" xml:space="preserve">
         <source>(GMT+0800) China</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/account/UserDetails</context>

--- a/java/code/src/com/redhat/rhn/manager/user/test/UserManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/user/test/UserManagerTest.java
@@ -58,6 +58,7 @@ import com.redhat.rhn.testing.UserTestUtils;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.test.TestSaltApi;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -66,6 +67,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /** JUnit test case for the User
  *  class.
@@ -602,13 +604,21 @@ public class UserManagerTest extends RhnBaseTestCase {
         assertTrue(lst.get(5) instanceof RhnTimeZone);
         assertTrue(lst.get(29) instanceof RhnTimeZone);
 
+        // Check if all configured timezones are valid
+        Set<String> validTimezones = ZoneId.getAvailableZoneIds();
+        assertTrue(lst.stream().filter(timezone ->
+                !validTimezones.contains(timezone.getOlsonName()))
+                .collect(Collectors.toList())
+                .isEmpty());
+
         assertEquals(UserManager.getTimeZone("GMT"), lst.get(0));
         assertEquals("GMT", lst.get(0).getOlsonName());
-        assertEquals("Atlantic/South_Georgia", lst.get(5).getOlsonName());
-        assertEquals(UserManager.getTimeZone("Atlantic/South_Georgia"), lst.get(5));
+        assertEquals("America/Sao_Paulo", lst.get(5).getOlsonName());
+        assertEquals(UserManager.getTimeZone("America/Sao_Paulo"), lst.get(5));
 
         assertEquals("Europe/Paris", lst.get(lst.size() - 1).getOlsonName());
         assertEquals(UserManager.getTimeZone("Europe/Paris"), lst.get(lst.size() - 1));
+
     }
 
    public void testUsersInSet() throws Exception {

--- a/schema/spacewalk/common/data/rhnTimezone.sql
+++ b/schema/spacewalk/common/data/rhnTimezone.sql
@@ -327,6 +327,6 @@ insert into rhnTimezone
   (id, olson_name, display_name)
 values
   (sequence_nextval('rhn_timezone_id_seq'),
-   'Asia/Beijing', 'China');
+   'Asia/Shanghai', 'China');
 
 commit;

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Replace not existing Asia/Beijing timezone with Asia/Shanghai (bsc#1194862)
 - Add created and modified fields to suseMinionInfo to make
   uyuni roster module cache validation more accurate
 - add ubuntu errata data and install handling

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.0-to-susemanager-schema-4.3.1/002-new-timezones.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.0-to-susemanager-schema-4.3.1/002-new-timezones.sql
@@ -2,6 +2,6 @@ insert into rhnTimezone(id, olson_name, display_name) (
   select sequence_nextval('rhn_timezone_id_seq'), 'Asia/Beijing', 'China'
     from dual
    where not exists (
-	select 1 from rhnTimezone where olson_name = 'Asia/Beijing'
+	select 1 from rhnTimezone where display_name = 'China'
    )
 );

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.7-to-susemanager-schema-4.3.8/002-fix-china-timezone.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.7-to-susemanager-schema-4.3.8/002-fix-china-timezone.sql
@@ -1,0 +1,15 @@
+-- Copyright (c) 2022 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+UPDATE rhnTimezone SET olson_name='Asia/Shanghai' WHERE olson_name='Asia/Beijing';


### PR DESCRIPTION
## What does this PR change?

Replace the not existing `Asia/Beijing` timezone with `Asia/Shanghai`

## GUI diff

No difference.

- [x] **DONE**

## Test coverage

- No tests: 

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/16743

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
