### PR TITLE
spacecmd: fix interactive mode for "system_applyerrata" and "errata_apply" commands (bsc#1194363)

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,5 @@
+- Detect interactive mode for system_applyerrata (bsc#1194363)
+
 -------------------------------------------------------------------
 Tue Jan 18 13:37:17 CET 2022 - jgonzalez@suse.com
 

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,4 +1,4 @@
-- Detect interactive mode for system_applyerrata (bsc#1194363)
+- Fix interactive mode for "system_applyerrata" and "errata_apply" (bsc#1194363)
 
 -------------------------------------------------------------------
 Tue Jan 18 13:37:17 CET 2022 - jgonzalez@suse.com

--- a/spacecmd/src/spacecmd/errata.py
+++ b/spacecmd/src/spacecmd/errata.py
@@ -168,7 +168,10 @@ def do_errata_apply(self, args, errata=None, only_systems=None):
     print('')
     print(_('Start Time: %s') % start_time)
 
-    if (is_interactive(options) and not self.user_confirm(_('Apply these patches [y/N]:'))) or not self.options.yes:
+    if not is_interactive(options) and not self.options.yes:
+        return 1
+
+    if is_interactive(options) and not self.user_confirm(_('Apply these patches [y/N]:')):
         return 1
 
     # if the API supports it, try to schedule multiple systems for one erratum

--- a/spacecmd/src/spacecmd/errata.py
+++ b/spacecmd/src/spacecmd/errata.py
@@ -92,19 +92,23 @@ def complete_errata_apply(self, text, line, beg, end):
     return self.tab_complete_errata(text)
 
 
-def do_errata_apply(self, args, errata=None, only_systems=None):
+def do_errata_apply(self, args, errata_list=None, only_systems=None):
     arg_parser = get_argument_parser()
     arg_parser.add_argument('errata', nargs="*")
     arg_parser.add_argument('-s', '--start-time')
 
     args, options = parse_command_arguments(args, arg_parser)
     only_systems = only_systems or []
-    errata = options.errata or errata
-    del options.errata
 
-    if not args and not errata:
+    if not options.errata and not errata_list:
         self.help_errata_apply()
         return 1
+
+    if not errata_list:
+        # allow globbing and searching via arguments
+        errata_list = self.expand_errata(options.errata)
+        # Do not assume non-interactive mode
+        del options.errata
 
     # get the start time option
     # skip the prompt if we are running with --yes
@@ -117,9 +121,8 @@ def do_errata_apply(self, args, errata=None, only_systems=None):
             start_time = parse_time_input('now')
         else:
             start_time = parse_time_input(options.start_time)
-
-    # allow globbing and searching via arguments
-    errata_list = self.expand_errata(errata)
+            # Do not assume non-interactive mode
+            del options.start_time
 
     systems = []
     summary = []

--- a/spacecmd/src/spacecmd/system.py
+++ b/spacecmd/src/spacecmd/system.py
@@ -3223,7 +3223,7 @@ def do_system_applyerrata(self, args):
     if options.start_time:
         opts.append('-s ' + options.start_time)
 
-    return self.do_errata_apply(' '.join(opts + errata_list), systems)
+    return self.do_errata_apply(' '.join(opts), errata_list, systems)
 
 ####################
 

--- a/spacecmd/tests/test_errata.py
+++ b/spacecmd/tests/test_errata.py
@@ -956,7 +956,7 @@ class TestSCErrata:
         assert not shell.help_errata_apply.called
         assert not logger.warning.called
         assert not logger.debug.called
-        assert not shell.user_confirm.called
+        assert shell.user_confirm.called
         assert shell.client.system.scheduleApplyErrata.called
         assert shell.check_api_version.called
         assert shell.client.system.getUnscheduledErrata.called
@@ -1026,7 +1026,7 @@ class TestSCErrata:
         assert not shell.help_errata_apply.called
         assert logger.warning.called
         assert not logger.debug.called
-        assert not shell.user_confirm.called
+        assert shell.user_confirm.called
         assert shell.client.system.scheduleApplyErrata.called
         assert shell.check_api_version.called
         assert shell.client.system.getUnscheduledErrata.called


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue in `spacecmd`, which is not properly detecting interactive/non-interactive mode when running `system_applyerrata` and `errata_apply` commands:

```console
suma-42-srv.tf.local:~ # spacecmd 
Welcome to spacecmd, a command-line interface to Spacewalk.

Type: 'help' for a list of commands
      'help <cmd>' for command-specific help
      'quit' to quit

INFO: Connected to https://suma-42-srv.tf.local/rpc/api as admin
spacecmd {SSM:0}> system_applyerrata suma-42-min-sles15sp3.tf.local SUSE-15-SP3-2021-2858
Errata             Systems
--------------     -------
SUSE-15-SP3-2021-2858          1

Start Time: 20220120T17:46:52
spacecmd {SSM:0}> 
```

As you see, the command exited, didn't ask for user confirmation and directly existed without scheduling any action as it was expected.

With this PR is applied, "spacecmd" is asking the expected questions when running in interactive mode:

```console
suma-42-srv.tf.local:~ # spacecmd system_applyerrata suma-42-min-sles15sp3.tf.local SUSE-15-SP3-2021-2858
INFO: Connected to https://suma-42-srv.tf.local/rpc/api as admin
Start Time [now]: now
Errata             Systems
--------------     -------
SUSE-15-SP3-2021-2858          1

Start Time: 20220121T11:55:23

Apply these patches [y/N]: y
INFO: Scheduled 1 system(s) for SUSE-15-SP3-2021-2858
```

If running in non-interactive mode, using `--yes` will directly schedule the action as it is expected.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/16628

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
