### PR TITLE
Allow link-local fe80: ipv6 addresses

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -42,6 +42,7 @@ end
 
 Then(/^the IPv4 address for "([^"]*)" should be correct$/) do |host|
   node = get_target(host)
+  puts node.public_ip
   step %(I should see a "#{node.public_ip}" text)
 end
 
@@ -49,8 +50,10 @@ Then(/^the IPv6 address for "([^"]*)" should be correct$/) do |host|
   node = get_target(host)
   interface, code = node.run("ip -6 address show #{node.public_interface}")
   raise unless code.zero?
-  ipv6 = interface.lines.grep(/inet6 .* global/).last.scan(/2620[:0-9a-f]*/).first
-  step %(I should see a "#{ipv6}" text)
+  last_ipv6_line = interface.lines.grep(/inet6 /).last
+  ipv6_address = last_ipv6_line.scan(/2620:[:0-9a-f]*|fe80:[:0-9a-f]*/).first
+  puts ipv6_address
+  step %(I should see a "#{ipv6_address}" text)
 end
 
 Then(/^the system ID for "([^"]*)" should be correct$/) do |host|


### PR DESCRIPTION
## What does this PR change?

Allow `fe80:` addresses when there are no `2620:` addresses.

This assumes SUSE Manager always displays the last IPv6 address, but according to my tests it is true.


## Links

Ports:
* 4.1: SUSE/spacewalk#16775
* 4.2: SUSE/spacewalk#16774


## Changelogs

- [x] No changelog needed
