### PR TITLE
Fix "mgr-cfg" installation problem on SLE15SP4

### DIFF
--- a/client/tools/mgr-cfg/mgr-cfg.changes
+++ b/client/tools/mgr-cfg/mgr-cfg.changes
@@ -1,3 +1,5 @@
+- Fix installation problem for SLE15SP4 due missing python-selinux
+
 -------------------------------------------------------------------
 Tue Jan 18 13:30:50 CET 2022 - jgonzalez@suse.com
 

--- a/client/tools/mgr-cfg/mgr-cfg.spec
+++ b/client/tools/mgr-cfg/mgr-cfg.spec
@@ -95,7 +95,7 @@ Requires:       %{pythonX}-%{name} = %{version}-%{release}
 %if 0%{?suse_version}
 # provide rhn directories and no selinux on suse
 BuildRequires:  spacewalk-client-tools
-%if 0%{?suse_version} >= 1110 && 0%{?sle_version} < 150400
+%if 0%{?suse_version} >= 1110 && 0%{?suse_version} < 1500
 Requires:       python-selinux
 %endif
 %if 0%{?suse_version} >= 1500


### PR DESCRIPTION
## What does this PR change?

This PR fixes a situation when installation `mgr-cfg` from the SLE15 clients tools. The packages on this channels are built based on SLE15SP0 and this means the logic we have in the spec file for the require of `python-selinux` is not working as expected for SLE15SP4.

Since we do not ship any `python2-mgr-cfg` as part of the SLE15 client tools, it is safe to fix the spec logic to simply do not require `python-selinux` for any SLE15 SP.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
