### PR TITLE
add ubuntu errata data and install handling

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -667,7 +667,7 @@ select {ra.*}
 
     <query name="Action.findMinionSummaries">
     <![CDATA[
-        SELECT sa.server.id, s.minionId, s.digitalServerId, s.machineId, c.label
+        SELECT sa.server.id, s.minionId, s.digitalServerId, s.machineId, c.label, s.os
             FROM ServerAction AS sa
                 JOIN sa.server AS s
                 JOIN s.contactMethod AS c

--- a/java/code/src/com/redhat/rhn/domain/errata/CveFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/CveFactory.java
@@ -55,6 +55,24 @@ public class CveFactory extends HibernateFactory {
     }
 
     /**
+     *  Looks up a CVE or inserts it if it does not exist.
+     * @param name CVE
+     * @return the CVE
+     */
+    public static Cve lookupOrInsertByName(String name) {
+        Cve cve = lookupByName(name);
+        if (cve != null) {
+            return cve;
+        }
+        else {
+            Cve newCve = new Cve();
+            newCve.setName(name);
+            save(newCve);
+            return newCve;
+        }
+    }
+
+    /**
      * Insert or Update a CVE.
      * @param cve CVE to be stored in database.
      */

--- a/java/code/src/com/redhat/rhn/domain/server/MinionServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServerFactory.java
@@ -207,8 +207,13 @@ public class MinionServerFactory extends HibernateFactory {
                 .getNamedQuery("Action.findMinionSummaries")
                 .setParameter("id", actionId)
                 .getResultList()).stream()
-                .map(row -> new MinionSummary((Long)row[0], row[1].toString(), row[2].toString(), row[3].toString(),
-                        Optional.ofNullable(row[4].toString())))
+                .map(row -> new MinionSummary(
+                        (Long)row[0],
+                        row[1].toString(),
+                        row[2].toString(),
+                        row[3].toString(),
+                        Optional.ofNullable(row[4].toString()),
+                        row[5].toString()))
                 .collect(toList());
     }
 

--- a/java/code/src/com/redhat/rhn/domain/server/MinionSummary.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionSummary.java
@@ -31,6 +31,7 @@ public class MinionSummary {
     private String minionId;
     private String digitalServerId;
     private String machineId;
+    private String os;
     private Optional<String> contactMethodLabel;
 
     /**
@@ -39,8 +40,8 @@ public class MinionSummary {
      * @param minion the minion
      */
     public MinionSummary(MinionServer minion) {
-        this(minion.getId(), minion.getMinionId(), minion.getDigitalServerId(), minion.getMachineId(),
-                minion.getContactMethodLabel());
+        this(minion.getId(), minion.getMinionId(), minion.getDigitalServerId(),
+                minion.getMachineId(), minion.getContactMethodLabel(), minion.getOs());
     }
 
     /**
@@ -51,14 +52,23 @@ public class MinionSummary {
      * @param digitalServerIdIn the digital server id
      * @param machineIdIn the machine id
      * @param contactMethodLabelIn the contact method label
+     * @param osIn the minion os
      */
     public MinionSummary(Long serverIdIn, String minionIdIn, String digitalServerIdIn, String machineIdIn,
-            Optional<String> contactMethodLabelIn) {
+            Optional<String> contactMethodLabelIn, String osIn) {
         this.serverId = serverIdIn;
         this.minionId = minionIdIn;
         this.digitalServerId = digitalServerIdIn;
         this.machineId = machineIdIn;
         this.contactMethodLabel = contactMethodLabelIn;
+        this.os = osIn;
+    }
+
+    /**
+     * @return the minion os
+     */
+    public String getOs() {
+        return os;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -30,6 +30,7 @@ import com.redhat.rhn.domain.dto.SystemIDInfo;
 import com.redhat.rhn.domain.entitlement.Entitlement;
 import com.redhat.rhn.domain.org.CustomDataKey;
 import com.redhat.rhn.domain.org.Org;
+import com.redhat.rhn.domain.product.Tuple2;
 import com.redhat.rhn.domain.rhnpackage.PackageEvr;
 import com.redhat.rhn.domain.rhnpackage.PackageEvrFactory;
 import com.redhat.rhn.domain.user.User;
@@ -1369,7 +1370,7 @@ public class ServerFactory extends HibernateFactory {
      * @return map from server id to map of package name to package version in evr format
      */
     @SuppressWarnings("unchecked")
-    public static Map<Long, Map<String, String>> listNewestPkgsForServerErrata(
+    public static Map<Long, Map<String, Tuple2<String, String>>> listNewestPkgsForServerErrata(
             Set<Long> serverIds, Set<Long> errataIds) {
         if (serverIds.isEmpty() || errataIds.isEmpty()) {
             return new HashMap<>();
@@ -1385,7 +1386,7 @@ public class ServerFactory extends HibernateFactory {
                 Collectors.groupingBy(row -> (Long) row[0],
                         // Map from package name to version (requires package names
                         // to be unique which is guaranteed by the sql query
-                        toMap(row -> (String)row[1], row -> (String)row[2])
+                        toMap(row -> (String)row[1], row -> new Tuple2<>((String)row[2], (String)row[3]))
                 )
         );
     }

--- a/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
@@ -540,19 +540,21 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     <sql-query name="Server.listNewestPkgsForServerErrata">
         <return-scalar column="serverId" type="long"/>
         <return-scalar column="packageName" type="string"/>
+        <return-scalar column="packageArch" type="string"/>
         <return-scalar column="packageVersion" type="string"/>
-        <![CDATA[select X.server_id as serverId, X.name as packageName,
+        <![CDATA[select X.server_id as serverId, X.name as packageName, X.package_arch as packageArch,
             case when (X.evr).epoch is null
                 then (X.evr).version || '-' || (X.evr).release
                 else (X.evr).epoch || ':' || (X.evr).version || '-' || (X.evr).release
             end  as packageVersion
-            FROM ( select distinct sc.server_id, pn.name, max(pevr.evr) evr
+            FROM ( select distinct sc.server_id, pn.name, max(pevr.evr) evr, pa.label as package_arch
                  FROM rhnErrata e,
                       rhnServerChannel sc,
                       rhnChannelErrata ce,
                       rhnErrataPackage ep,
                       rhnServerPackage sp,
                       rhnPackage p,
+                      rhnPackageArch pa,
                       rhnPackageEVR pevr,
                       rhnPackageEVR spevr,
                       rhnPackageName pn
@@ -568,8 +570,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                       (pevr.evr).type = (spevr.evr).type AND
                       pevr.evr > spevr.evr AND
                       p.package_arch_id = sp.package_arch_id AND
+                      p.package_arch_id = pa.id AND
                       p.name_id = pn.id
-                 GROUP BY sc.server_id, pn.name) X]]>
+                 GROUP BY sc.server_id, pn.name, pa.label) X]]>
     </sql-query>
 
     <sql-query name="Server.findServerInSSMByChannel">

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -32,6 +32,7 @@ import com.redhat.rhn.domain.errata.test.ErrataFactoryTest;
 import com.redhat.rhn.domain.org.CustomDataKey;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.org.test.CustomDataKeyTest;
+import com.redhat.rhn.domain.product.Tuple2;
 import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.rhnpackage.PackageArch;
 import com.redhat.rhn.domain.rhnpackage.PackageEvr;
@@ -1250,10 +1251,11 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
         TestUtils.saveAndFlush(e4);
         TestUtils.saveAndFlush(e5);
 
-        Map<Long, Map<String, String>> out = ServerFactory.listNewestPkgsForServerErrata(serverIds, errataIds);
-        Map<String, String> packages = out.get(srv.getId());
+        Map<Long, Map<String, Tuple2<String, String>>> out =
+                ServerFactory.listNewestPkgsForServerErrata(serverIds, errataIds);
+        Map<String, Tuple2<String, String>> packages = out.get(srv.getId());
         assertEquals(1, packages.size());
-        assertEquals(p1v3.getPackageEvr().toString(), packages.get(p1v3.getPackageName().getName()));
+        assertEquals(p1v3.getPackageEvr().toString(), packages.get(p1v3.getPackageName().getName()).getB());
     }
 
     public void testListErrataNamesForServer() throws Exception {

--- a/java/code/src/com/redhat/rhn/manager/content/ubuntu/Binary.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ubuntu/Binary.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.manager.content.ubuntu;
+
+import java.util.Optional;
+
+public class Binary {
+    private String pocket;
+    private String version;
+    private Optional<String> source = Optional.empty();
+
+    public Optional<String> getSource() {
+        return source;
+    }
+
+    public String getPocket() {
+        return pocket;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/content/ubuntu/Entry.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ubuntu/Entry.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.manager.content.ubuntu;
+
+import com.redhat.rhn.domain.product.Tuple3;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Entry containing all ubuntu errata information needed to create an errata for susemanager.
+ */
+public class Entry {
+
+    private final String id;
+    private final List<String> cves;
+    private final String summary;
+    private final String isummary;
+    private final Instant date;
+    private final String description;
+    private final boolean reboot;
+    private final List<Tuple3<String, String, List<String>>> packages;
+
+    /**
+     * Default constructor.
+     * @param idIn errata id
+     * @param cvesIn list of CVEs
+     * @param summaryIn errata summary
+     * @param isummaryIn
+     * @param dateIn issue date
+     * @param descriptionIn errata description
+     * @param rebootIn reboot required flag
+     * @param packagesIn list of errata package information
+     */
+    public Entry(String idIn, List<String> cvesIn, String summaryIn, String isummaryIn,
+          Instant dateIn, String descriptionIn, boolean rebootIn,
+          List<Tuple3<String, String, List<String>>> packagesIn) {
+        this.id = idIn;
+        this.cves = cvesIn;
+        this.summary = summaryIn;
+        this.date = dateIn;
+        this.description = descriptionIn;
+        this.reboot = rebootIn;
+        this.packages = packagesIn;
+        this.isummary = isummaryIn;
+    }
+
+    /**
+     * @return summary
+     */
+    public String getSummary() {
+        return summary;
+    }
+
+    /**
+     * @return id
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * @return description
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * @return CVEs
+     */
+    public List<String> getCves() {
+        return cves;
+    }
+
+    /**
+     * @return issue date
+     */
+    public Instant getDate() {
+        return date;
+    }
+
+    /**
+     * @return package information
+     */
+    public List<Tuple3<String, String, List<String>>> getPackages() {
+        return packages;
+    }
+
+    /**
+     * @return isummary
+     */
+    public String getIsummary() {
+        return isummary;
+    }
+
+    /**
+     * @return reboot flag
+     */
+    public boolean isReboot() {
+        return reboot;
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/content/ubuntu/PackageInfo.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ubuntu/PackageInfo.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.manager.content.ubuntu;
+
+import java.util.Optional;
+
+public class PackageInfo {
+    private String version;
+    private Optional<String> description = Optional.empty();
+
+    public String getVersion() {
+        return version;
+    }
+
+    public Optional<String> getDescription() {
+        return description;
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/content/ubuntu/Release.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ubuntu/Release.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.manager.content.ubuntu;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class Release {
+    private Map<String, Urls> archs;
+    private Map<String, PackageInfo> binaries;
+    private Map<String, PackageInfo> sources;
+    private Map<String, Binary> allbinaries;
+
+    /**
+     * Default constructor
+     */
+    public Release() {
+    }
+
+    public Map<String, PackageInfo> getBinaries() {
+        return binaries;
+    }
+
+    public Map<String, Binary> getAllbinaries() {
+        return allbinaries;
+    }
+
+    public Map<String, PackageInfo> getSources() {
+        return sources;
+    }
+
+    public Optional<Map<String, Urls>> getArchs() {
+        return Optional.ofNullable(archs);
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataInfo.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataInfo.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.manager.content.ubuntu;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class UbuntuErrataInfo {
+    private String action;
+    private List<String> cves;
+    private String description;
+    private String id;
+    private String isummary;
+    private Map<String, Release> releases;
+    private String summary;
+    private Instant timestamp;
+    private String title;
+
+    public Optional<String> getAction() {
+        return Optional.ofNullable(action);
+    }
+
+    public Optional<String> getIsummary() {
+        return Optional.ofNullable(isummary);
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public List<String> getCves() {
+        return cves;
+    }
+
+    public Map<String, Release> getReleases() {
+        return releases;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+}

--- a/java/code/src/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManager.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.manager.content.ubuntu;
+
+import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.util.TimeUtils;
+import com.redhat.rhn.common.util.http.HttpClientAdapter;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.ChannelFactory;
+import com.redhat.rhn.domain.errata.AdvisoryStatus;
+import com.redhat.rhn.domain.errata.Cve;
+import com.redhat.rhn.domain.errata.CveFactory;
+import com.redhat.rhn.domain.errata.Errata;
+import com.redhat.rhn.domain.errata.ErrataFactory;
+import com.redhat.rhn.domain.org.Org;
+import com.redhat.rhn.domain.product.Tuple3;
+import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.PackageEvr;
+import com.redhat.rhn.manager.content.ContentSyncManager;
+import com.redhat.rhn.manager.content.MgrSyncUtils;
+
+import com.suse.manager.reactor.utils.OptionalTypeAdapterFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapter;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class UbuntuErrataManager {
+
+    private static final Logger LOG = Logger.getLogger(UbuntuErrataManager.class);
+
+    private UbuntuErrataManager() {
+    }
+
+    private static boolean isFromDir() {
+        return Config.get().getString(ContentSyncManager.RESOURCE_PATH, null) != null;
+    }
+
+    private static final Gson GSON = new GsonBuilder()
+            .registerTypeAdapterFactory(new OptionalTypeAdapterFactory())
+            .registerTypeAdapter(Instant.class, new TypeAdapter<Instant>() {
+                @Override
+                public void write(JsonWriter jsonWriter, Instant instant) throws IOException {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public Instant read(JsonReader jsonReader) throws IOException {
+                    double d = jsonReader.nextDouble();
+                    long seconds = (long)d;
+                    long n = (long)((d - seconds) * 1e9);
+                    return Instant.ofEpochSecond(seconds, n);
+                }
+            })
+            .create();
+
+    private static Optional<String> archToPackageArchLabel(String arch) {
+        switch (arch) {
+            case "all": return Optional.of("all-deb");
+            case "source": return Optional.of("src-deb");
+            case "amd64": return Optional.of("amd64-deb");
+            case "arm64": return Optional.of("arm64-deb");
+            case "armel": return Optional.of("armel-deb");
+            case "armhf": return Optional.of("armhf-deb");
+            case "sparc": return Optional.of("sparc-deb");
+            case "i386": return Optional.of("i386-deb");
+            case "riscv64": return Optional.of("riscv64-deb");
+            case "ppc64el": return Optional.of("ppc64el-deb");
+            case "s390x": return Optional.of("s390x-deb");
+            case "powerpc": return Optional.of("powerpc-deb");
+            default: return Optional.empty();
+        }
+    }
+
+    private static Map<String, UbuntuErrataInfo> downloadUbuntuErrataInfo(String jsonDBUrl) throws IOException {
+        HttpClientAdapter httpClient = new HttpClientAdapter();
+        HttpGet httpGet = new HttpGet(jsonDBUrl);
+        LOG.info("download ubuntu errata start");
+        HttpResponse httpResponse = httpClient.executeRequest(httpGet);
+        if (httpResponse.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+            Map<String, UbuntuErrataInfo> errataInfo = GSON.fromJson(
+                    new InputStreamReader(httpResponse.getEntity().getContent()),
+                    new TypeToken<Map<String, UbuntuErrataInfo>>() { } .getType());
+            LOG.info("download ubuntu errata end");
+            return errataInfo;
+        }
+        else {
+            throw new IOException("error downloading " + jsonDBUrl + " status code " +
+                   httpResponse.getStatusLine().getStatusCode());
+        }
+    }
+
+    private static List<Entry> parseUbuntuErrata(Map<String, UbuntuErrataInfo> errataInfo) {
+        return errataInfo.values().stream().map(ubuntuErrataInfo -> {
+            String description = ubuntuErrataInfo.getDescription().length() > 4000 ?
+                    ubuntuErrataInfo.getDescription().substring(0, 4000) :
+                    ubuntuErrataInfo.getDescription();
+            boolean reboot = ubuntuErrataInfo.getAction().map(a -> a.contains("you need to reboot")).orElse(false);
+            List<Tuple3<String, String, List<String>>> packageData = ubuntuErrataInfo.getReleases().entrySet().stream()
+                    .flatMap(release ->
+                            release.getValue().getBinaries().entrySet().stream().flatMap(binary -> {
+                                String name = binary.getKey();
+                                String version = binary.getValue().getVersion();
+
+                                List<String> archs = release.getValue().getArchs()
+                                        .stream()
+                                        .flatMap(m -> m.entrySet().stream())
+                                        .flatMap(a -> {
+                                            String arch = a.getKey();
+                                            boolean hasArchPkg = a.getValue().getUrls().entrySet().stream()
+                                                    .anyMatch(b -> {
+                                                        String url = b.getKey();
+                                                        return url.endsWith("/" + name + "_" + version + "_" + arch +
+                                                                ".deb");
+                                                    });
+                                                    if (hasArchPkg) {
+                                                        return Stream.of(arch);
+                                                    }
+                                                    else {
+                                                        return Stream.empty();
+                                                    }
+                                                }).collect(Collectors.toList());
+                                return Stream.of(new Tuple3<>(name, version, archs));
+                            })
+                    ).collect(Collectors.toList());
+
+            return new Entry(
+                    ubuntuErrataInfo.getId(),
+                    ubuntuErrataInfo.getCves(),
+                    ubuntuErrataInfo.getSummary(),
+                    ubuntuErrataInfo.getIsummary().orElse("-"),
+                    ubuntuErrataInfo.getTimestamp(),
+                    description,
+                    reboot,
+                    packageData);
+        }).collect(Collectors.toList());
+    }
+
+    private static Map<String, UbuntuErrataInfo> getUbuntuErrataInfo() throws IOException {
+        String jsonDBUrl = "https://usn.ubuntu.com/usn-db/database.json";
+        if (isFromDir()) {
+            URI uri = MgrSyncUtils.urlToFSPath(jsonDBUrl, "");
+            InputStream inputStream = Files.newInputStream(Paths.get(uri));
+            return GSON.fromJson(new InputStreamReader(inputStream),
+                    new TypeToken<Map<String, UbuntuErrataInfo>>() { }.getType());
+        }
+        else {
+            return downloadUbuntuErrataInfo(jsonDBUrl);
+        }
+    }
+
+    /**
+     * Syncs ubuntu errata information and matches it against the given channels
+     * @param channelIds ids of channels to match erratas against
+     * @throws IOException in case of download issues
+     */
+    public static void sync(Set<Long> channelIds) throws IOException {
+        List<Entry> ubuntuErrataInfo = parseUbuntuErrata(getUbuntuErrataInfo());
+        processUbuntuErrataByIds(channelIds, ubuntuErrataInfo);
+    }
+
+    /**
+     * Processes ubuntu errata and tries to associate them to the given channels
+     * @param channelIds list of channel ids to match errata against
+     * @param ubuntuErrataInfo list of ubuntu errata entries
+     */
+    public static void processUbuntuErrataByIds(Set<Long> channelIds, List<Entry> ubuntuErrataInfo) {
+        processUbuntuErrata(channelIds.stream()
+                .map(cid -> ChannelFactory.lookupById(cid))
+                .collect(Collectors.toSet()), ubuntuErrataInfo);
+    }
+
+    /**
+     * Processes ubuntu errata and tries to associate them to the given channels
+     * @param channels list of channels to match errata against
+     * @param ubuntuErrataInfo list of ubuntu errata entries
+     */
+    public static void processUbuntuErrata(Set<Channel> channels, List<Entry> ubuntuErrataInfo) {
+
+        Map<Channel, Set<Package>> ubuntuChannels = channels.stream()
+                .filter(c -> c.isTypeDeb() && !c.isCloned())
+                .collect(Collectors.toMap(c -> c, c -> c.getPackages()));
+
+        List<String> uniqueCVEs = ubuntuErrataInfo.stream()
+                .flatMap(e -> e.getCves().stream().filter(c -> c.startsWith("CVE-")))
+                .distinct()
+                .collect(Collectors.toList());
+
+        Map<String, Cve> cveByName = TimeUtils.logTime(LOG, "looking up " +  uniqueCVEs.size() + " CVEs",
+                () -> uniqueCVEs.stream()
+                        .map(e -> CveFactory.lookupOrInsertByName(e))
+                        .collect(Collectors.toMap(e -> e.getName(), e -> e)));
+
+        TimeUtils.logTime(LOG, "writing " + ubuntuErrataInfo.size() + " erratas to db", () -> {
+            ubuntuErrataInfo.stream().flatMap(entry -> {
+
+
+                Map<Channel, Set<Package>> matchingPackagesByChannel =
+                        TimeUtils.logTime(LOG, "matching packages for " + entry.getId(), () -> {
+                            return ubuntuChannels.entrySet().stream().collect(Collectors.toMap(e -> e.getKey(), c -> {
+
+                                return c.getValue().stream().filter(p -> {
+
+                                    return entry.getPackages().stream().anyMatch(e -> {
+
+                                        PackageEvr packageEvr = PackageEvr.parseDebian(e.getB());
+                                        return e.getC().stream().anyMatch(arch -> {
+                                            return p.getPackageName().getName().equals(e.getA()) &&
+                                                    archToPackageArchLabel(arch)
+                                                            .map(a -> p.getPackageArch().getLabel().equals(a))
+                                                            .orElse(false) &&
+                                                    p.getPackageEvr().getVersion().equals(packageEvr.getVersion()) &&
+                                                    p.getPackageEvr().getRelease().equals(packageEvr.getRelease()) &&
+                                                    Optional.ofNullable(p.getPackageEvr().getEpoch())
+                                                            .equals(Optional.ofNullable(packageEvr.getEpoch())) &&
+                                                    p.getPackageEvr().getPackageType()
+                                                            .equals(packageEvr.getPackageType());
+                                        });
+
+                                    });
+
+                                }).collect(Collectors.toSet());
+                            }));
+                        });
+
+                Map<Optional<Org>, Map<Channel, Set<Package>>> collect = matchingPackagesByChannel.entrySet().stream()
+                        .collect(Collectors.groupingBy(e -> Optional.ofNullable(e.getKey().getOrg()),
+                                Collectors.toMap(e -> e.getKey(), e -> e.getValue())));
+
+                return collect.entrySet().stream().map(e -> {
+                    Optional<Org> org = e.getKey();
+                    Errata errata = Optional.ofNullable(ErrataFactory.lookupByAdvisoryAndOrg(
+                                entry.getId(), org.orElse(null)
+                            )).orElseGet(() -> {
+                                Errata newErrata = new Errata();
+                                newErrata.setOrg(org.orElse(null));
+                                return newErrata;
+                            });
+
+                    errata.setAdvisory(entry.getId());
+                    errata.setAdvisoryName(entry.getId());
+                    errata.setAdvisoryStatus(AdvisoryStatus.STABLE);
+                    errata.setAdvisoryType(ErrataFactory.ERRATA_TYPE_SECURITY);
+                    errata.setIssueDate(Date.from(entry.getDate()));
+                    errata.setUpdateDate(Date.from(entry.getDate()));
+                    String[] split = entry.getId().split("-", 2);
+                    errata.setAdvisoryRel(Long.parseLong(split[1]));
+                    errata.setProduct("Ubuntu");
+                    errata.setSolution("-");
+                    errata.setSynopsis(entry.getIsummary());
+                    Set<Cve> cves = entry.getCves().stream()
+                            .filter(c -> c.startsWith("CVE-"))
+                            .map(cveByName::get)
+                            .collect(Collectors.toSet());
+                    errata.setCves(cves);
+                    errata.setDescription(entry.getDescription());
+
+                    Set<Package> packages = e.getValue().entrySet().stream()
+                            .flatMap(x -> x.getValue().stream())
+                            .collect(Collectors.toSet());
+                    errata.getPackages().addAll(packages);
+
+                    Set<Channel> matchingChannels = e.getValue().entrySet().stream()
+                            .filter(c -> !c.getValue().isEmpty())
+                            .map(c -> c.getKey())
+                            .collect(Collectors.toSet());
+
+                    errata.getChannels().addAll(matchingChannels);
+
+                    return errata;
+                });
+            }).forEach(ErrataFactory::save);
+        });
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/content/ubuntu/UrlData.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ubuntu/UrlData.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.manager.content.ubuntu;
+
+public class UrlData {
+    private String md5;
+    private Long size;
+
+    public Long getSize() {
+        return size;
+    }
+
+    public String getMd5() {
+        return md5;
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/content/ubuntu/Urls.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ubuntu/Urls.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.manager.content.ubuntu;
+
+import java.util.Map;
+
+public class Urls {
+    private Map<String, UrlData> urls;
+
+    public Map<String, UrlData> getUrls() {
+        return urls;
+    }
+}

--- a/java/code/src/com/redhat/rhn/taskomatic/task/RepoSyncTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/RepoSyncTask.java
@@ -24,13 +24,16 @@ import com.redhat.rhn.domain.notification.UserNotificationFactory;
 import com.redhat.rhn.domain.notification.types.ChannelSyncFailed;
 import com.redhat.rhn.domain.notification.types.ChannelSyncFinished;
 import com.redhat.rhn.domain.role.RoleFactory;
+import com.redhat.rhn.manager.content.ubuntu.UbuntuErrataManager;
 
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -110,6 +113,12 @@ public class RepoSyncTask extends RhnJavaJob {
             else {
                 log.error("No such channel with channel_id " + channelId);
             }
+        }
+        try {
+            UbuntuErrataManager.sync(new HashSet<>(channelIds));
+        }
+        catch (IOException e) {
+            log.error(e);
         }
     }
 

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -26,6 +26,7 @@ import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.partitioningBy;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
@@ -1031,14 +1032,21 @@ public class SaltServerActionService {
      */
     public Map<LocalCall<?>, List<MinionSummary>> errataAction(List<MinionSummary> minionSummaries,
             Set<Long> errataIds, boolean allowVendorChange) {
-        Set<Long> minionServerIds = minionSummaries.stream().map(MinionSummary::getServerId)
+        Map<Boolean, List<MinionSummary>> byUbuntu = minionSummaries.stream()
+                .collect(partitioningBy(m -> m.getOs().equals("Ubuntu")));
+
+        Map<LocalCall<Map<String, ApplyResult>>, List<MinionSummary>> ubuntuErrataInstallCalls =
+                errataToPackageInstallCalls(byUbuntu.get(true), errataIds);
+
+        Set<Long> minionServerIds = byUbuntu.get(false).stream()
+                .map(MinionSummary::getServerId)
                 .collect(Collectors.toSet());
 
         Map<Long, Map<Long, Set<ErrataInfo>>> errataInfos = ServerFactory
                 .listErrataNamesForServers(minionServerIds, errataIds);
 
         // Group targeted minions by errata names
-        Map<Set<ErrataInfo>, List<MinionSummary>> collect = minionSummaries.stream()
+        Map<Set<ErrataInfo>, List<MinionSummary>> collect = byUbuntu.get(false).stream()
                 .collect(Collectors.groupingBy(minionId -> errataInfos.get(minionId.getServerId())
                         .entrySet().stream()
                         .map(Map.Entry::getValue)
@@ -1047,7 +1055,7 @@ public class SaltServerActionService {
         ));
 
         // Convert errata names to LocalCall objects of type State.apply
-        return collect.entrySet().stream()
+        Map<LocalCall<?>, List<MinionSummary>> patchableCalls = collect.entrySet().stream()
             .collect(Collectors.toMap(entry -> {
                 Map<String, Object> params = new HashMap<>();
                 params.put(PARAM_REGULAR_PATCHES,
@@ -1055,7 +1063,7 @@ public class SaltServerActionService {
                         .filter(e -> !e.isUpdateStack())
                         .map(e -> e.getName())
                         .sorted()
-                        .collect(Collectors.toList())
+                        .collect(toList())
                 );
                 params.put(ALLOW_VENDOR_CHANGE, allowVendorChange);
                 params.put(PARAM_UPDATE_STACK_PATCHES,
@@ -1063,11 +1071,11 @@ public class SaltServerActionService {
                         .filter(e -> e.isUpdateStack())
                         .map(e -> e.getName())
                         .sorted()
-                        .collect(Collectors.toList())
+                        .collect(toList())
                 );
                 if (!entry.getKey().stream()
                         .filter(e -> e.includeSalt())
-                        .collect(Collectors.toList()).isEmpty()) {
+                        .collect(toList()).isEmpty()) {
                     params.put("include_salt_upgrade", true);
                 }
                 return State.apply(
@@ -1076,6 +1084,8 @@ public class SaltServerActionService {
                 );
             },
             Map.Entry::getValue));
+        patchableCalls.putAll(ubuntuErrataInstallCalls);
+        return patchableCalls;
     }
 
     private Map<LocalCall<?>, List<MinionSummary>> packagesLockAction(
@@ -1095,6 +1105,38 @@ public class SaltServerActionService {
             ret.put(localCall, mSums);
         }
         return ret;
+    }
+
+    private Map<LocalCall<Map<String, ApplyResult>>, List<MinionSummary>> errataToPackageInstallCalls(
+            List<MinionSummary> minions,
+            Set<Long> errataIds) {
+        Set<Long> minionIds = minions.stream()
+                .map(MinionSummary::getServerId).collect(Collectors.toSet());
+        Map<Long, Map<String, Tuple2<String, String>>> longMapMap =
+                ServerFactory.listNewestPkgsForServerErrata(minionIds, errataIds);
+
+        // group minions by packages that need to be updated
+        Map<Map<String, Tuple2<String, String>>, List<MinionSummary>> nameArchVersionToMinions =
+                minions.stream().collect(
+                        Collectors.groupingBy(minion -> longMapMap.get(minion.getServerId()))
+                );
+
+        return nameArchVersionToMinions.entrySet().stream().collect(toMap(
+                entry -> State.apply(
+                        singletonList(PACKAGES_PKGINSTALL),
+                        Optional.of(singletonMap(PARAM_PKGS,
+                                entry.getKey().entrySet()
+                                        .stream()
+                                        .map(e -> List.of(
+                                                e.getKey(),
+                                                e.getValue().getA().replaceAll("-deb$", ""),
+                                                e.getValue().getB().endsWith("-X") ?
+                                                    e.getValue().getB().substring(0, e.getValue().getB().length() - 2) :
+                                                    e.getValue().getB()))
+                                        .collect(Collectors.toList())))
+                ),
+                Map.Entry::getValue
+        ));
     }
 
     private Map<LocalCall<?>, List<MinionSummary>> packagesUpdateAction(

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- add ubuntu errata data and install handling
 - fix possible race condition in job handling (bsc#1192510)
 - Remove verbose token log
 - FIX errors when an image profile / store is deleted

--- a/schema/spacewalk/common/data/rhnPackageArch.sql
+++ b/schema/spacewalk/common/data/rhnPackageArch.sql
@@ -110,6 +110,14 @@ insert into rhnPackageArch (id, label, name, arch_type_id) values
 (sequence_nextval('rhn_package_arch_id_seq'), 'amd64-deb', 'AMD64-deb', lookup_arch_type('deb'));
 insert into rhnPackageArch (id, label, name, arch_type_id) values
 (sequence_nextval('rhn_package_arch_id_seq'), 'arm64-deb', 'ARM64-deb', lookup_arch_type('deb'));
+insert into rhnPackageArch (id, label, name, arch_type_id) values
+(sequence_nextval('rhn_package_arch_id_seq'), 'armel-deb', 'armel-deb', lookup_arch_type('deb'));
+insert into rhnPackageArch (id, label, name, arch_type_id) values
+(sequence_nextval('rhn_package_arch_id_seq'), 'riscv64-deb', 'riscv64-deb', lookup_arch_type('deb'));
+insert into rhnPackageArch (id, label, name, arch_type_id) values
+(sequence_nextval('rhn_package_arch_id_seq'), 'ppc64el-deb', 'ppc64el-deb', lookup_arch_type('deb'));
+insert into rhnPackageArch (id, label, name, arch_type_id) values
+(sequence_nextval('rhn_package_arch_id_seq'), 's390x-deb', 's390x-deb', lookup_arch_type('deb'));
 
 commit;
 

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- add ubuntu errata data and install handling
 - FIX error when an image profile / store is deleted
   during build / inspect action (bsc#1191597, bsc#1192150)
 - SLES PAYG client support on cloud

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.6-to-susemanager-schema-4.3.7/050-add-additional-packagearchs.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.6-to-susemanager-schema-4.3.7/050-add-additional-packagearchs.sql
@@ -1,0 +1,15 @@
+insert into rhnChannelArch (id, label, name, arch_type_id) select
+  sequence_nextval('rhn_channel_arch_id_seq'), 'armel-deb', 'armel-deb', lookup_arch_type('deb') from dual
+where not exists (select 1 from rhnChannelArch where label = 'armel-deb');
+
+insert into rhnChannelArch (id, label, name, arch_type_id) select
+  sequence_nextval('rhn_channel_arch_id_seq'), 'riscv64-deb', 'riscv64-deb', lookup_arch_type('deb') from dual
+where not exists (select 1 from rhnChannelArch where label = 'riscv64-deb');
+
+insert into rhnChannelArch (id, label, name, arch_type_id) select
+  sequence_nextval('rhn_channel_arch_id_seq'), 'ppc64el-deb', 'ppc64el-deb', lookup_arch_type('deb') from dual
+where not exists (select 1 from rhnChannelArch where label = 'ppc64el-deb');
+
+insert into rhnChannelArch (id, label, name, arch_type_id) select
+  sequence_nextval('rhn_channel_arch_id_seq'), 's390x-deb', 's390x-deb', lookup_arch_type('deb') from dual
+where not exists (select 1 from rhnChannelArch where label = 's390x-deb');


### PR DESCRIPTION
## What does this PR change?


This adds basic ubuntu errata support by downloading errata information from https://usn.ubuntu.com/usn-db/database.json and matching it after the syncing of Ubuntu channels. It also adds support for installing errata on ubuntu systems by mapping them to package installs.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- Documentation issue was created: https://github.com/SUSE/spacewalk/issues/16807

- [x] **DONE**

## Test coverage
- No tests: manually tested

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11634

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
