### PR TITLE
Fix uptime failing tests and re-enable IPV6 tests for clients

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -26,8 +26,7 @@ Feature: Smoke tests for <client>
     And the kernel for "<client>" should be correct
     And the OS version for "<client>" should be correct
     And the IPv4 address for "<client>" should be correct
-    # WORKAROUND: disabled for the moment due to a possible bug (#bsc1193858)
-    # And the IPv6 address for "<client>" should be correct
+    And the IPv6 address for "<client>" should be correct
     And the system ID for "<client>" should be correct
     And the system name for "<client>" should be correct
     And the uptime for "<client>" should be correct

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -82,7 +82,7 @@ Then(/^the uptime for "([^"]*)" should be correct$/) do |host|
 
   # needed for the library's conversion of 24h multiples plus 11 hours to consider the next day
   eleven_hours_in_seconds = 39600 # 11 hours * 60 minutes * 60 seconds
-  rounded_uptime_days = ((uptime_seconds + eleven_hours_in_seconds) / 86400.0).round # 60 seconds * 60 minutes * 24 hours
+  rounded_uptime_days = ((uptime_seconds.to_f + eleven_hours_in_seconds) / 86400.0).round # 60 seconds * 60 minutes * 24 hours
 
   # the moment.js library being used has some weird rules, which these conditionals follow
   if (uptime_days >= 1 && rounded_uptime_days < 2) || (uptime_days < 1 && rounded_uptime_hours >= 22) # shows "a day ago" after 22 hours and before it's been 1.5 days


### PR DESCRIPTION
## What does this PR change?
Fixes Ruby casting error on line 85 of common steps and uncomments no longer needed workaround for IPV6 on clients

## GUI diff
No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were modified

- [x] **DONE**

## Ports
- Fixes [#16720](https://github.com/SUSE/spacewalk/issues/16720)
- [4.1](https://github.com/SUSE/spacewalk/pull/16817)
- [4.2](https://github.com/SUSE/spacewalk/pull/16818)

- [ ] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
