### PR TITLE
mgr-setup: do not concatenate groups 

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -724,7 +724,7 @@ do_migration() {
     cp /etc/rhn/rhn.conf-$FROMVERSION /etc/rhn/rhn.conf
     chmod 640 /etc/rhn/rhn.conf
     # Detect the Apache group name (SUSE/RHEL differences)
-    APACHE_GROUP=`cut -d: -f3 < <((getent group www);(getent group apache))`
+    APACHE_GROUP=`cut -d: -f3 < <((getent group www)||(getent group apache))`
     chown root:${APACHE_GROUP} /etc/rhn/rhn.conf
 }
 

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- mgr-setup: do not concanate www and apache groups (bsc#1195171)
+
 -------------------------------------------------------------------
 Tue Jan 18 15:06:14 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

port of https://github.com/SUSE/spacewalk/pull/16820

## GUI diff

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
- [x] **DONE**

## Links

Fixes # https://bugzilla.suse.com/show_bug.cgi?id=1195171
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
