### PR TITLE
QA: Get rid of long_tests tag

### DIFF
--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -10,7 +10,6 @@
 # which means "Enable Kiwi OS Image building"
 
 @buildhost
-@long_test
 @scope_retail
 @scope_building_container_images
 Feature: Build OS images

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -368,7 +368,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
 # Start provisioning scenarios
 
-@long_test
 @scc_credentials
   Scenario: Create auto installation distribution
     And I install package tftpboot-installation on the server
@@ -384,7 +383,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     Then I should see a "Autoinstallable Distributions" text
     And I should see a "SLE-15-SP2-TFTP" link
 
-@long_test
 @scc_credentials
   Scenario: Create auto installation profile
     And I follow the left menu "Systems > Autoinstallation > Profiles"
@@ -397,7 +395,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     Then I should see a "Autoinstallation: 15-sp2-kvm" text
     And I should see a "Autoinstallation Details" text
 
-@long_test
 @scc_credentials
   Scenario: Configure auto installation profile
     When I enter "self_update=0" as "kernel_options"
@@ -408,7 +405,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I follow "Autoinstallation File"
     Then I should see a "SLE-15-SP2-TFTP" text
 
-@long_test
 @scc_credentials
   Scenario: Create an auto installing KVM virtual machine
     Given I am on the "Virtualization" page of this "kvm_server"
@@ -433,7 +429,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I wait at most 1000 seconds until Salt master sees "test-vm2" as "unaccepted"
     When I close the last opened window
 
-@long_test
 @scc_credentials
   Scenario: Cleanup: remove the auto installation profile
     And I follow the left menu "Systems > Autoinstallation > Profiles"
@@ -442,7 +437,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I click on "Delete Autoinstallation"
     Then I should not see a "15-sp2-kvm" text
 
-@long_test
 @scc_credentials
   Scenario: Cleanup: remove the auto installation distribution
     When I follow the left menu "Systems > Autoinstallation > Distributions"

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -12,7 +12,6 @@
 # * if there is no PXE boot minion ($pxeboot_mac is nil)
 
 @buildhost
-@long_test
 @proxy
 @private_net
 @pxeboot_minion

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -28,7 +28,7 @@ end
 # This is a safety net only, the best thing to do is to not start the reposync at all.
 def compute_list_to_leave_running
   # keep the repos needed for the auto-installation tests
-  do_not_kill = $long_tests_enabled ? CHANNEL_TO_SYNCH_BY_OS_VERSION['default'] : []
+  do_not_kill = CHANNEL_TO_SYNCH_BY_OS_VERSION['default']
   [$minion, $build_host, $sshminion].each do |node|
     next unless node
     os_version, os_family = get_os_version(node)

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -18,8 +18,6 @@ require 'multi_test'
 
 server = ENV['SERVER']
 $debug_mode = true if ENV['DEBUG']
-$long_tests_enabled = true if ENV['LONG_TESTS'] == 'true'
-puts "Executing long running tests" if $long_tests_enabled
 
 # maximal wait before giving up
 # the tests return much before that delay in case of success
@@ -378,11 +376,6 @@ end
 # do test only if the registry with authentication is available
 Before('@auth_registry') do
   skip_this_scenario unless $auth_registry
-end
-
-# do test only if we want to run long tests
-Before('@long_test') do
-  skip_this_scenario unless $long_tests_enabled
 end
 
 # have more infos about the errors


### PR DESCRIPTION
## What does this PR change?

Related card: https://github.com/SUSE/spacewalk/issues/13530

Get rid of long_tests tag.
In addition, we want to also remove this parameter from our pipeline https://github.com/SUSE/susemanager-ci/pull/449

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were modified

- [x] **DONE**

## Links

Ports:
- Manager-4.1 https://github.com/SUSE/spacewalk/pull/16837
- Manager-4.2 https://github.com/SUSE/spacewalk/pull/16838

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
