### PR TITLE
QA: Reinforce the cleanup of min_salt_install_package.feature

### DIFF
--- a/testsuite/features/secondary/min_salt_install_package.feature
+++ b/testsuite/features/secondary/min_salt_install_package.feature
@@ -46,3 +46,5 @@ Feature: Install a patch on the client via Salt through the UI
     When I disable repository "test_repo_rpm_pool" on this "sle_minion"
     And I remove package "virgo-dummy" from this "sle_minion" without error control
     And I run "zypper -n ref" on "sle_minion"
+    And I refresh packages list via spacecmd on "sle_minion"
+    And I wait until refresh package list on "sle_minion" is finished


### PR DESCRIPTION
## What does this PR change?

Related PR https://github.com/SUSE/spacewalk/issues/14248

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- [Manager-4.1](https://github.com/SUSE/spacewalk/pull/16833)
- [Manager-4.2](https://github.com/SUSE/spacewalk/pull/16834) 

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
