### PR TITLE
Spacecmd bootstrap

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/utils/test/AbstractMinionBootstrapperTestBase.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/test/AbstractMinionBootstrapperTestBase.java
@@ -25,8 +25,10 @@ import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 
 import com.suse.manager.webui.controllers.utils.AbstractMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.AbstractMinionBootstrapper.BootstrapResult;
+import com.suse.manager.webui.services.impl.SaltSSHService;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.impl.SaltService.KeyStatus;
+import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
 import com.suse.manager.webui.utils.gson.BootstrapHostsJson;
 import com.suse.manager.webui.utils.gson.BootstrapParameters;
 import com.suse.salt.netapi.calls.modules.State;
@@ -159,6 +161,10 @@ public abstract class AbstractMinionBootstrapperTestBase extends JMockBaseTestCa
             allowing(saltServiceMock).generateKeysAndAccept("myhost", false);
             will(returnValue(keyPair));
 
+            MgrUtilRunner.ExecResult mockResult = new MgrUtilRunner.ExecResult();
+            allowing(saltServiceMock).generateSSHKey(SaltSSHService.SSH_KEY_PATH);
+            will(returnValue(of(mockResult)));
+
             List<String> bootstrapMods = bootstrapMods();
             Map<String, Object> pillarData = createPillarData(Optional.empty(), Optional.empty());
             // return success when calling low-level bootstrap
@@ -223,6 +229,10 @@ public abstract class AbstractMinionBootstrapperTestBase extends JMockBaseTestCa
             Key.Pair keyPair = mockKeyPair();
             allowing(saltServiceMock).generateKeysAndAccept("myhost", false);
             will(returnValue(keyPair));
+
+            MgrUtilRunner.ExecResult mockResult = new MgrUtilRunner.ExecResult();
+            allowing(saltServiceMock).generateSSHKey(SaltSSHService.SSH_KEY_PATH);
+            will(returnValue(of(mockResult)));
 
             List<String> bootstrapMods = bootstrapMods();
             Map<String, Object> pillarData = createPillarData(Optional.of(key), Optional.empty());

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- generate the system ssh key when bootstrapping a salt-ssh client
+  (bsc#1194909)
 - Fix disappearing metadata key files after channel change (bsc#1192822)
 - New endpoint 'createFirst' added to 'org' xmlrpc api to allow initial organization and user creation
 - Corrected source URLs in spec file.

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- implement system.bootstrap (bsc#1194909)
 - Option 'org_createfirst' added to perform initial organization and user creation
 - Added gettext build requirement for RHEL.
 - Removed RHEL 5 references.

--- a/spacecmd/src/spacecmd/api.py
+++ b/spacecmd/src/spacecmd/api.py
@@ -92,7 +92,10 @@ def do_api(self, args):
         return
 
     try:
-        res = api(self.session, *api_args)
+        if api_name in ['api.getVersion', 'api.systemVersion']:
+            res = api(*api_args)
+        else:
+            res = api(self.session, *api_args)
 
         if not isinstance(res, list):
             res = [res]

--- a/spacecmd/src/spacecmd/system.py
+++ b/spacecmd/src/spacecmd/system.py
@@ -37,6 +37,7 @@ try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
     import xmlrpclib
+from getpass import getpass
 from operator import itemgetter
 from xml.parsers.expat import ExpatError
 from spacecmd.i18n import _N
@@ -4637,3 +4638,102 @@ def do_system_scheduleproductmigration(self, args):
     return
 
 ####################
+
+
+def help_system_bootstrap(self):
+    print(_("system_bootstrap: Bootstrap a system for management via either Salt or Salt SSH."))
+    print(_('''usage: bootstrap [options]
+
+    options:
+        -H HOSTNAME
+        -p SSH_PORT
+        -u SSH_USERNAME
+        -P SSH_PASSWORD
+        -k SSH_PRIVATEKEY_PATH
+        -S SSH_PRIVATEKEY_PASSWORD
+        -a ACTIVATION_KEY
+        -r REACTIVATION_KEY
+        --proxyid PROXY_SYSID
+        --saltssh
+        '''))
+    print('')
+
+
+def do_system_bootstrap(self, args):
+
+    arg_parser = get_argument_parser()
+    arg_parser.add_argument('-H', '--hostname')
+    arg_parser.add_argument('-p', '--port', default=22)
+    arg_parser.add_argument('-u', '--ssh-user', default="root")
+    arg_parser.add_argument('-P', '--ssh-password')
+    arg_parser.add_argument('-k', '--ssh-privatekey-file')
+    arg_parser.add_argument('-S', '--ssh-privatekey-password', default="")
+    arg_parser.add_argument('-a', '--activation-key', default="")
+    arg_parser.add_argument('-r', '--reactivation-key')
+    arg_parser.add_argument('--proxyid')
+    arg_parser.add_argument('--saltssh', action='store_true', default=False)
+
+    (args, options) = parse_command_arguments(args, arg_parser)
+
+    if not (options.hostname or options.ssh_password or options.ssh_privatekey_file):
+        options.hostname = prompt_user(_('Hostname:'))
+        options.port = prompt_user(_('Port [22]:'))
+        if not options.port:
+            options.port = 22
+        options.ssh_user = prompt_user(_('SSH User [root]:'))
+        if not options.ssh_user:
+            options.ssh_user = "root"
+        options.ssh_password = getpass(_('SSH Password:'))
+        if not options.ssh_password:
+            options.ssh_privatekey_file = prompt_user(_('SSH Private Key File:'))
+            options.ssh_privatekey_password = getpass(_('SSH Private Key Password:'))
+            if not options.ssh_privatekey_password:
+                options.ssh_privatekey_password = ""
+        options.activation_key = prompt_user(_('Activation Key:'))
+        if not options.activation_key:
+            options.activation_key = ""
+        options.reactivation_key = prompt_user(_('Reactivation Key:'))
+        options.proxyid = prompt_user(_('Proxy System ID:'))
+        options.saltssh = False
+        answer = prompt_user(_('Manage with Salt SSH') + ' [y/N]:')
+        if answer in ['y', 'Y']:
+            options.saltssh = True
+
+    if not options.hostname:
+        logging.error(_N("Hostname must be provided"))
+        return 1
+    if not (options.ssh_password or options.ssh_privatekey_file):
+        logging.error(_N("Either a SSH Password or a private key must be provided"))
+        return 1
+
+    args = []
+    if self.check_api_version('25.0'):
+        if options.reactivation_key:
+            args.append(options.reactivation_key)
+    elif options.reactivation_key:
+        logging.error(_N("Server is not supporting reactivation keys at bootstrap time"))
+        return 1
+
+    if options.proxyid:
+        args.append(int(options.proxyid))
+    args.append(options.saltssh)
+
+    print(_("Bootstrapping '{}'. This may take a while.".format(options.hostname)))
+    if options.ssh_password:
+        self.client.system.bootstrap(self.session, options.hostname, options.port,
+                options.ssh_user, options.ssh_password, options.activation_key,
+                *args)
+    else:
+        with open(options.ssh_privatekey_file, "r") as key:
+            pkey = key.read()
+
+            # use ssh key
+            self.client.system.bootstrapWithPrivateSshKey(self.session,
+                    options.hostname, options.port, options.ssh_user,
+                    pkey, options.ssh_privatekey_password, options.activation_key,
+                    *args)
+    print(_("Initial phase successfully finished. Check event history for actions still running"))
+    return 0
+
+####################
+

--- a/susemanager-utils/susemanager-sls/modules/runners/mgrutil.py
+++ b/susemanager-utils/susemanager-sls/modules/runners/mgrutil.py
@@ -16,26 +16,26 @@ def delete_rejected_key(minion):
     '''
     Delete a previously rejected minion key from minions_rejected
     :param minion: the minion id to look for
-    :return: map containing returncode and stdout/stderr
+    :return: map containing retcode and stdout/stderr
     '''
     path_rejected = "/etc/salt/pki/master/minions_rejected/"
     path = os.path.normpath(path_rejected + minion)
     if not path.startswith(path_rejected):
-        return {"returncode": -1, "stderr": "Unexpected path: " + path}
+        return {"retcode": -1, "stderr": "Unexpected path: " + path}
     if os.path.isfile(path):
         cmd = ['rm', path]
         return _cmd(cmd)
-    return {"returncode": 0}
+    return {"retcode": 0}
 
 
 def ssh_keygen(path):
     '''
     Generate SSH keys using the given path.
     :param path: the path
-    :return: map containing returncode and stdout/stderr
+    :return: map containing retcode and stdout/stderr
     '''
     if os.path.isfile(path):
-        return {"returncode": -1, "stderr": "Key file already exists"}
+        return {"retcode": -1, "stderr": "Key file already exists"}
     cmd = ['ssh-keygen', '-N', '', '-f', path, '-t', 'rsa', '-q']
     # if not os.path.isdir(os.path.dirname(path)):
     #     os.makedirs(os.path.dirname(path))
@@ -75,7 +75,7 @@ def remove_ssh_known_host(user, hostname):
 def _cmd(cmd):
     p = Popen(cmd, stdout=PIPE, stderr=PIPE)
     stdout, stderr = p.communicate()
-    return {"returncode": p.returncode, "stdout": salt.utils.stringutils.to_unicode(stdout), "stderr": salt.utils.stringutils.to_unicode(stderr)}
+    return {"retcode": p.returncode, "stdout": salt.utils.stringutils.to_unicode(stdout), "stderr": salt.utils.stringutils.to_unicode(stderr)}
 
 
 def move_minion_uploaded_files(minion=None, dirtomove=None, basepath=None, actionpath=None):

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- fixing how the return code is returned in mgrutil runner (bsc#1194909)
 - Use /var/lib/susemanager/formula_data if /srv/susemanager/formula_data is missing.
 - Avoid using lscpu -J option in grains (bsc#1195920)
 


### PR DESCRIPTION
## What does this PR change?

Implement `system_bootstrap` in spacecmd

Port of https://github.com/SUSE/spacewalk/pull/16800

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- modules/reference/pages/spacecmd/system.adoc needs refreshing
  https://github.com/SUSE/spacewalk/issues/16801

- [ ] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/4737

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
