### PR TITLE
Call event.unpack correctly

### DIFF
--- a/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
+++ b/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
@@ -70,6 +70,7 @@ except ImportError:
     HAS_PSYCOPG2 = False
 
 # Import salt libs
+import salt.version
 import salt.ext.tornado
 import salt.utils.event
 import json
@@ -166,7 +167,12 @@ class Responder:
 
     @salt.ext.tornado.gen.coroutine
     def add_event_to_queue(self, raw):
-        tag, data = self.event_bus.unpack(raw, self.event_bus.serial)
+        # FIXME: Drop once we only use Salt >= 3004
+        major, _ = salt.version.__version_info__
+        if major < 3004:
+            tag, data = self.event_bus.unpack(raw, self.event_bus.serial)
+        else:
+            tag, data = self.event_bus.unpack(raw)
         self._insert(tag, data)
 
     def db_keepalive(self):


### PR DESCRIPTION
## What does this PR change?

Depending on the Salt version, event.unpack has a different API.
Once we only use Salt 3004, we can fully switch to the new syntax.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage
- No tests: already covered


- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
