### PR TITLE
Fix disappearing metadata key files after channel change (bsc#1192822)

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebRepositoryWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebRepositoryWriter.java
@@ -21,6 +21,7 @@ import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.frontend.dto.PackageDto;
 import com.redhat.rhn.manager.rhnpackage.PackageManager;
+import com.redhat.rhn.manager.satellite.Executor;
 import com.redhat.rhn.manager.satellite.SystemCommandExecutor;
 import com.redhat.rhn.manager.task.TaskManager;
 
@@ -48,7 +49,17 @@ public class DebRepositoryWriter extends RepositoryWriter {
      * @param mountPointIn mount point package resides
      */
     public DebRepositoryWriter(String pathPrefixIn, String mountPointIn) {
-        super(pathPrefixIn, mountPointIn);
+        this(pathPrefixIn, mountPointIn, new SystemCommandExecutor());
+    }
+
+    /**
+     * Constructor takes in pathprefix and mountpoint
+     * @param pathPrefixIn prefix to package path
+     * @param mountPointIn mount point package resides
+     * @param cmdExecutorIn {@link Executor} instance to run system commands
+     */
+    public DebRepositoryWriter(String pathPrefixIn, String mountPointIn, Executor cmdExecutorIn) {
+        super(pathPrefixIn, mountPointIn, cmdExecutorIn);
     }
 
     /**
@@ -131,8 +142,7 @@ public class DebRepositoryWriter extends RepositoryWriter {
         releaseWriter.generateRelease();
 
         if (ConfigDefaults.get().isMetadataSigningEnabled()) {
-            SystemCommandExecutor sce = new SystemCommandExecutor();
-            int exitCode = sce.execute(
+            int exitCode = cmdExecutor.execute(
                     new String[] {"/usr/bin/mgr-sign-metadata", prefix + "Release", prefix + "Release.gpg",
                             prefix + "InRelease"});
             if (exitCode != 0) {

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RepositoryWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RepositoryWriter.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.taskomatic.task.repomd;
 
 import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.manager.satellite.Executor;
 
 import org.apache.log4j.Logger;
 
@@ -28,17 +29,20 @@ import java.io.File;
 public abstract class RepositoryWriter {
 
     protected Logger log = Logger.getLogger(RepositoryWriter.class);
-    protected String pathPrefix;
-    protected String mountPoint;
+    protected final String pathPrefix;
+    protected final String mountPoint;
+    protected final Executor cmdExecutor;
 
     /**
      * Constructor takes in pathprefix and mountpoint
      * @param pathPrefixIn prefix to package path
      * @param mountPointIn mount point package resides
+     * @param cmdExecutorIn {@link Executor} instance to run system commands
      */
-    public RepositoryWriter(String pathPrefixIn, String mountPointIn) {
+    public RepositoryWriter(String pathPrefixIn, String mountPointIn, Executor cmdExecutorIn) {
         this.pathPrefix = pathPrefixIn;
         this.mountPoint = mountPointIn;
+        this.cmdExecutor = cmdExecutorIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriter.java
@@ -26,6 +26,7 @@ import com.redhat.rhn.domain.channel.RepoMetadata;
 import com.redhat.rhn.frontend.dto.PackageDto;
 import com.redhat.rhn.manager.channel.ChannelManager;
 import com.redhat.rhn.manager.rhnpackage.PackageManager;
+import com.redhat.rhn.manager.satellite.Executor;
 import com.redhat.rhn.manager.satellite.SystemCommandExecutor;
 import com.redhat.rhn.manager.task.TaskManager;
 
@@ -154,7 +155,17 @@ public class RpmRepositoryWriter extends RepositoryWriter {
      * @param mountPointIn mount point package resides
      */
     public RpmRepositoryWriter(String pathPrefixIn, String mountPointIn) {
-        super(pathPrefixIn, mountPointIn);
+        this(pathPrefixIn, mountPointIn, new SystemCommandExecutor());
+    }
+
+    /**
+     * Constructor takes in pathprefix and mountpoint
+     * @param pathPrefixIn prefix to package path
+     * @param mountPointIn mount point package resides
+     * @param cmdExecutorIn {@link Executor} instance to run system commands
+     */
+    public RpmRepositoryWriter(String pathPrefixIn, String mountPointIn, Executor cmdExecutorIn) {
+        super(pathPrefixIn, mountPointIn, cmdExecutorIn);
     }
 
     /**
@@ -408,11 +419,12 @@ public class RpmRepositoryWriter extends RepositoryWriter {
         createdFiles.add(organizer.move(REPOMD_FILE, "repomd.xml"));
 
         if (ConfigDefaults.get().isMetadataSigningEnabled()) {
-            SystemCommandExecutor sce = new SystemCommandExecutor();
             String[] signCommand = new String[2];
             signCommand[0] = "mgr-sign-metadata";
             signCommand[1] = prefix + "repomd.xml";
-            sce.execute(signCommand);
+            cmdExecutor.execute(signCommand);
+            createdFiles.add(new File(prefix, "repomd.xml.asc"));
+            createdFiles.add(new File(prefix, "repomd.xml.key"));
         }
         log.info("Repository metadata generation for '" +
                 channel.getLabel() + "' finished in " +
@@ -600,11 +612,10 @@ public class RpmRepositoryWriter extends RepositoryWriter {
     /**
      * Generates product info for given channel
      * @param channel channel info
-     * @param checksumtype checksum type
+     * @param checksumtypeIn checksum type
      * @return repodata index
      */
-    private RepomdIndexData generateProducts(Channel channel, String prefix,
-            String checksumtypeIn) {
+    private RepomdIndexData generateProducts(Channel channel, String prefix, String checksumtypeIn) {
 
         DigestOutputStream productsFile;
         try {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix disappearing metadata key files after channel change (bsc#1192822)
 - New endpoint 'createFirst' added to 'org' xmlrpc api to allow initial organization and user creation
 - Corrected source URLs in spec file.
 - RHEL certificate compatibility.


### PR DESCRIPTION
This is the fix for a regression introduced with https://github.com/SUSE/spacewalk/pull/15664.

For channels with signed metadata, the fix adds the `repomd.xml.asc` and `repomd.xml.key` files to the list of created files so they won't be removed during metadata generation cleanup.

https://bugzilla.suse.com/show_bug.cgi?id=1192822

Port of: https://github.com/SUSE/spacewalk/pull/16439

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
