### PR TITLE
Fix unpack issue getting Salt major version from "mgr_events"

### DIFF
--- a/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
+++ b/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
@@ -168,8 +168,7 @@ class Responder:
     @salt.ext.tornado.gen.coroutine
     def add_event_to_queue(self, raw):
         # FIXME: Drop once we only use Salt >= 3004
-        major, _ = salt.version.__version_info__
-        if major < 3004:
+        if salt.version.SaltStackVersion(*salt.version.__version_info__).major < 3004:
             tag, data = self.event_bus.unpack(raw, self.event_bus.serial)
         else:
             tag, data = self.event_bus.unpack(raw)

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Fix issues running mgr_events on Salt 3004
+
 -------------------------------------------------------------------
 Tue Jan 18 14:08:20 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes a problem when getting the major Salt version on 3004:

```
2022-02-01 09:35:05,202 [tornado.application:640 ][ERROR   ][29129] Exception in callback functools.partial(<function wrap.<locals>.null_wrapper at 0x7f028f5496a8>, <salt.ext.tornado.concurrent.Future object at 0x7f02833ac550>)
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/salt/ext/tornado/ioloop.py", line 606, in _run_callback
    ret = callback()
  File "/usr/lib/python3.6/site-packages/salt/ext/tornado/stack_context.py", line 278, in null_wrapper
    return fn(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/ext/tornado/ioloop.py", line 628, in _discard_future_result
    future.result()
  File "/usr/lib/python3.6/site-packages/salt/ext/tornado/concurrent.py", line 249, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 4, in raise_exc_info
  File "/usr/lib/python3.6/site-packages/salt/ext/tornado/gen.py", line 294, in wrapper
    result = func(*args, **kwargs)
  File "/usr/lib64/python3.6/types.py", line 248, in wrapped
    coro = func(*args, **kwargs)
  File "/usr/share/susemanager/modules/engines/mgr_events.py", line 171, in add_event_to_queue
    major, _ = salt.version.__version_info__
ValueError: not enough values to unpack (expected 2, got 1)
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
