### PR TITLE
Fix Debian 11 repo name in spacewalk-common-channels

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -2766,7 +2766,7 @@ repo_url = http://security-cdn.debian.org/debian-security/dists/bullseye-securit
 
 [debian-11-amd64-uyuni-client-devel]
 label    = debian-11-amd64-uyuni-client-devel
-name     = Uyuni Client Tools for Debian 10 Buster AMD64 (Development)
+name     = Uyuni Client Tools for Debian 11 Bullseye AMD64 (Development)
 archs    = amd64-deb
 repo_type = deb
 checksum = sha256
@@ -2775,7 +2775,7 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 
 [debian-11-amd64-uyuni-client]
 label    = debian-11-amd64-uyuni-client
-name     = Uyuni Client Tools for Debian 10 Buster AMD64
+name     = Uyuni Client Tools for Debian 11 Bullseye AMD64
 archs    = amd64-deb
 repo_type = deb
 checksum = sha256

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,4 +1,4 @@
-- Fix Debian 11 repo name in spacewalk-common-channels
+- Fix Debian 11 client tools repository name in spacewalk-common-channels
 
 -------------------------------------------------------------------
 Tue Jan 18 14:01:26 CET 2022 - jgonzalez@suse.com

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- Fix Debian 11 repo name in spacewalk-common-channels
+
 -------------------------------------------------------------------
 Tue Jan 18 14:01:26 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fix Debian 11 repo name

## GUI diff
- [x] **DONE**

## Documentation
- [x] **DONE**

## Test coverage

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/4748 
Fixes https://github.com/uyuni-project/uyuni/issues/4755

- [x] **DONE**

## Changelogs

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
