### PR TITLE
add ongres-scram to ivy dependencies

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -10,6 +10,8 @@
         <dependency org="suse" name="cglib" rev="3.2.4" />
         <dependency org="suse" name="classmate" rev="1.3.4" />
         <dependency org="suse" name="classpathx-mail-1.3.1-monolithic" rev="1.1.2" />
+        <dependency org="suse" name="client" rev="1.0.0~beta.2" />
+        <dependency org="suse" name="common" rev="1.0.0~beta.2" />
         <dependency org="suse" name="commons-beanutils" rev="1.9.4" />
         <dependency org="suse" name="commons-cli" rev="1.4" />
         <dependency org="suse" name="commons-codec" rev="1.11" />

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -175,6 +175,12 @@ artifacts:
   - artifact: netty-transport-native-unix-common
     package: netty
     repository: Uyuni_Other
+  - artifact: client
+    package: ongres-scram-client
+    repository: Leap
+  - artifact: common
+    package: ongres-scram
+    repository: Leap
   - artifact: oro
     repository: Leap
   - artifact: pgjdbc-ng


### PR DESCRIPTION
## What does this PR change?

ongres-scram is required to authenticate against a postgres DB which is configured scram-sha256 auth method.
Since Pg14 this is the default.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **development tools only**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
