### PR TITLE
Check session is valid during websocket handshake (bsc#1195428)

### DIFF
--- a/java/code/src/com/suse/manager/webui/websocket/WebsocketSessionConfigurator.java
+++ b/java/code/src/com/suse/manager/webui/websocket/WebsocketSessionConfigurator.java
@@ -15,6 +15,8 @@
 
 package com.suse.manager.webui.websocket;
 
+import org.apache.log4j.Logger;
+
 import javax.servlet.http.HttpSession;
 import javax.websocket.HandshakeResponse;
 import javax.websocket.server.HandshakeRequest;
@@ -26,11 +28,20 @@ import javax.websocket.server.ServerEndpointConfig;
  * WebsocketSessionConfigurator
  */
 public class WebsocketSessionConfigurator extends ServerEndpointConfig.Configurator {
+
+    private static final Logger LOG = Logger.getLogger(WebsocketSessionConfigurator.class);
+
     @Override
     public void modifyHandshake(ServerEndpointConfig config,
             HandshakeRequest request,
             HandshakeResponse response) {
         HttpSession httpSession = (HttpSession)request.getHttpSession();
-        config.getUserProperties().put("webUserID", httpSession.getAttribute("webUserID"));
+        if (httpSession.getAttribute("webUserID") != null) {
+            config.getUserProperties().put("webUserID", httpSession.getAttribute("webUserID"));
+        }
+        else {
+            LOG.info("session field 'webUserID' was null during websocket handshake");
+            config.getUserProperties().remove("webUserID");
+        }
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+  * Check session is valid during websocket handshake (bsc#1195428)
+
 -------------------------------------------------------------------
 Mon Jan 24 11:17:28 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

Solution for: https://github.com/SUSE/spacewalk/issues/16852

The Notifications code that uses this field from the session is already protected against null values.
With this code change, we are making sure the configurator doesn't return NPE if the sessions don't have the user id field.

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
