### PR TITLE
Finish separation of private network

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -2,11 +2,12 @@ reviewers:
   # Reviewer groups each of which has a list of GitHub usernames
   groups:
     qa:
+      - Bischoff
       - ktsamis
       - maximenoel8
-      - srbarrios
-      - Bischoff
+      - nodeg
       - orestis87
+      - srbarrios
       - vandabarata
 
 files:

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -563,8 +563,8 @@ When(/^I configure tftp on the "([^"]*)"$/) do |host|
   when 'server'
     $server.run("configure-tftpsync.sh #{ENV['PROXY']}")
   when 'proxy'
-    cmd = "configure-tftpsync.sh --non-interactive --tftpbootdir=/srv/tftpboot " +
-      "--server-fqdn=#{ENV['SERVER']} " +
+    cmd = "configure-tftpsync.sh --non-interactive --tftpbootdir=/srv/tftpboot " \
+      "--server-fqdn=#{ENV['SERVER']} " \
       "--proxy-fqdn='proxy.example.org'"
     $proxy.run(cmd)
   end
@@ -1029,7 +1029,7 @@ When(/^I configure the proxy$/) do
              "SSL_STATE=Bayern\n" \
              "SSL_COUNTRY=DE\n" \
              "SSL_EMAIL=galaxy-noise@suse.de\n" \
-             "SSL_CNAME_ASK=''\n" \
+             "SSL_CNAME_ASK=proxy.example.org\n" \
              "POPULATE_CONFIG_CHANNEL=y\n" \
              "RHN_USER=admin\n" \
              "ACTIVATE_SLP=y\n"


### PR DESCRIPTION
## What does this PR change?

This PR provides a CNAME for `proxy.example.org` on the branch network, so we don't get a `503` when PXE booting from cobbler or Retail.

(also adding back Dominik to the reviewers).


## Links

Ports:
* 4.1:
* 4.2:

## Changelogs

- [x] No changelog needed
