### PR TITLE
QA: Strip a text containing the amount of items

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -55,7 +55,7 @@ def count_table_items
   # count table items using the table counter component
   items_label_xpath = "//span[contains(text(), 'Items ')]"
   raise unless (items_label = find(:xpath, items_label_xpath).text)
-  items_label.split('of ')[1]
+  items_label.split('of ')[1].strip
 end
 
 def product


### PR DESCRIPTION
## What does this PR change?

This small change fix this issue:
```
Unable to find xpath "//i[contains(@class, 'fa-bell')]/following-sibling::*[text()='30  ']" (Capybara::ElementNotFound)
./features/step_definitions/common_steps.rb:1088:in `/^the notification badge and the table should count the same amount of messages$/'
features/secondary/srv_notifications.feature:14:in `the notification badge and the table should count the same amount of messages'
```
Note the '30  ' text.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were modified

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
