### PR TITLE
fix ClassCastException when casting potential hibernate proxies (bsc#…

### DIFF
--- a/java/code/src/com/redhat/rhn/common/hibernate/HibernateFactory.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/HibernateFactory.java
@@ -861,4 +861,15 @@ public abstract class HibernateFactory {
                 .reduce(identity, accumulator::apply);
     }
 
+    /**
+     * Loads the full hibernate object in case the object is currently just a proxy
+     * @param proxy object to unproxy
+     * @param <T> type of the object to unproxy
+     * @return the unproxied hibernate object
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T unproxy(T proxy) {
+        return (T) Hibernate.unproxy(proxy);
+    }
+
 }

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -502,7 +502,7 @@ public class SaltUtils {
             serverAction.setStatus(ActionFactory.STATUS_COMPLETED);
         }
 
-        Action action = serverAction.getParentAction();
+        Action action = HibernateFactory.unproxy(serverAction.getParentAction());
 
         if (action.getActionType().equals(ActionFactory.TYPE_APPLY_STATES)) {
             handleStateApplyData(serverAction, jsonResult, retcode, success);

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -14,6 +14,7 @@
  */
 package com.suse.manager.webui.services;
 
+import static com.redhat.rhn.common.hibernate.HibernateFactory.unproxy;
 import static com.redhat.rhn.domain.action.ActionFactory.STATUS_COMPLETED;
 import static com.redhat.rhn.domain.action.ActionFactory.STATUS_FAILED;
 import static com.suse.manager.webui.services.SaltConstants.SALT_FS_PREFIX;
@@ -281,6 +282,7 @@ public class SaltServerActionService {
         }
 
         ActionType actionType = actionIn.getActionType();
+        actionIn = unproxy(actionIn);
         if (ActionFactory.TYPE_ERRATA.equals(actionType)) {
             ErrataAction errataAction = (ErrataAction) actionIn;
             Set<Long> errataIds = errataAction.getErrata().stream()
@@ -329,8 +331,7 @@ public class SaltServerActionService {
         else if (ActionFactory.TYPE_IMAGE_BUILD.equals(actionType)) {
             ImageBuildAction imageBuildAction = (ImageBuildAction) actionIn;
             ImageBuildActionDetails details = imageBuildAction.getDetails();
-            return ImageProfileFactory.lookupById(details.getImageProfileId()).map(
-                    ip -> imageBuildAction(
+            return ImageProfileFactory.lookupById(details.getImageProfileId()).map(ip -> imageBuildAction(
                             minions,
                             Optional.ofNullable(details.getVersion()),
                             ip,

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,6 +1,10 @@
+- fix ClassCastException during action processing (bsc#1195043)
 - Install product by default after a channel is subscribed
 - Improve token validation logs
 - Pass only selected servers to taskomatic for cancelation (bsc#1194044)
+
+-------------------------------------------------------------------
+Wed Feb 02 13:50:23 CET 2022 - jmassaguerpla@suse.de
 
 -------------------------------------------------------------------
 Mon Jan 24 11:17:28 CET 2022 - jgonzalez@suse.com


### PR DESCRIPTION
## What does this PR change?

This makes sure we always have the real Action object instead of just a HibernateProxy before we try to cast it so we avoid a ClassCastExceltion.

## GUI diff

No difference.


- [ ] **DONE**

## Documentation
- No documentation needed

- [ ] **DONE**

## Test coverage
- No tests

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
