### PR TITLE
Add certificate-fetch snippet for autoyast migrations

### DIFF
--- a/java/conf/cobbler/snippets/certificate-fetch
+++ b/java/conf/cobbler/snippets/certificate-fetch
@@ -1,0 +1,10 @@
+<!-- Fetch certificate from server to be able to validate https repositories -->
+<script>
+    <filename>certificate-fetch.sh</filename>
+    <source>
+        <![CDATA[
+        curl --insecure -o /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT  http://$redhat_management_server/pub/RHN-ORG-TRUSTED-SSL-CERT
+        /usr/sbin/update-ca-certificates
+        ]]>
+    </source>
+</script>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add certificate-fetch snippet for autoyast migrations (bsc#1194792)
 - fix ClassCastException during action processing (bsc#1195043)
 - Install product by default after a channel is subscribed
 - Improve token validation logs


### PR DESCRIPTION
## What does this PR change?

Autoyast during upgrade may try to use https repositories and then fail validating it because of missing CA certificate for SUMA server.
This snipped when added in `<pre-scripts>` to the autoyast file will download CA from server and update ca settings in initrd.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/16723
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
