### PR TITLE
Restart squid so proxy.example.org is recognized

### DIFF
--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2021-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 
@@ -93,6 +93,9 @@ Feature: PXE boot a terminal with Cobbler
     And I start tftp on the proxy
     And I configure tftp on the "proxy"
     And I synchronize the tftp configuration on the proxy with the server
+
+  Scenario: Restart squid so proxy.example.org is recognized
+    When I restart squid service on the proxy
 
   Scenario: PXE boot the PXE boot minion
     Given I set the default PXE menu entry to the "target profile" on the "proxy"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1043,6 +1043,19 @@ When(/^I configure the proxy$/) do
   $proxy.run(cmd, timeout: proxy_timeout)
 end
 
+When(/^I allow all SSL protocols on the proxy's apache$/) do
+  file = '/etc/apache2/ssl-global.conf'
+  key = 'SSLProtocol'
+  val = 'all -SSLv2 -SSLv3'
+  $proxy.run("grep '#{key}' #{file} && sed -i -e 's/#{key}.*$/#{key} #{val}/' #{file}")
+  $proxy.run("systemctl reload apache2.service")
+end
+
+When(/^I restart squid service on the proxy$/) do
+  # We need to restart squid when we add a CNAME to the certificate
+  $proxy.run("systemctl restart squid.service")
+end
+
 Then(/^The metadata buildtime from package "(.*?)" match the one in the rpm on "(.*?)"$/) do |pkg, host|
   # for testing buildtime of generated metadata - See bsc#1078056
   node = get_target(host)
@@ -1548,12 +1561,4 @@ When(/^I regenerate the boot RAM disk on "([^"]*)" if necessary$/) do |host|
   if os_family =~ /^sles/ && os_version =~ /^11/
     node.run('mkinitrd')
   end
-end
-
-When(/^I allow all SSL protocols on the proxy's apache$/) do
-  file = '/etc/apache2/ssl-global.conf'
-  key = 'SSLProtocol'
-  val = 'all -SSLv2 -SSLv3'
-  $proxy.run("grep '#{key}' #{file} && sed -i -e 's/#{key}.*$/#{key} #{val}/' #{file}")
-  $proxy.run("systemctl reload apache2.service")
 end


### PR DESCRIPTION
## What does this PR change?

Cobbler tests: squid needs being restarted so that the CNAME in the SSL certificate for proxy.example.org is recognized.


## Changelogs

- [x] No changelog needed
