### PR TITLE
hibernate was updated to 5.3.25

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -32,10 +32,10 @@
         <dependency org="suse" name="ehcache-core" rev="2.10.1" />
         <dependency org="suse" name="geronimo-jta-1.1-api" rev="1.2" />
         <dependency org="suse" name="google-gson" rev="2.8.5" />
-        <dependency org="suse" name="hibernate-c3p0" rev="5.3.7" />
+        <dependency org="suse" name="hibernate-c3p0" rev="5.3.25" />
         <dependency org="suse" name="hibernate-commons-annotations" rev="5.0.4" />
-        <dependency org="suse" name="hibernate-core" rev="5.3.7" />
-        <dependency org="suse" name="hibernate-ehcache" rev="5.3.7" />
+        <dependency org="suse" name="hibernate-core" rev="5.3.25" />
+        <dependency org="suse" name="hibernate-ehcache" rev="5.3.25" />
         <dependency org="suse" name="hibernate-types" rev="2.12.1" />
         <dependency org="suse" name="httpasyncclient" rev="4.1.4" />
         <dependency org="suse" name="httpclient" rev="4.5.6" />


### PR DESCRIPTION
## What does this PR change?

Hibernate package was updated. Align ivy repo to new version to fix the test runs.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
