### PR TITLE
wait for onboarding completed before cleaning up again

### DIFF
--- a/testsuite/features/secondary/min_bootstrap_reactivation.feature
+++ b/testsuite/features/secondary/min_bootstrap_reactivation.feature
@@ -60,6 +60,7 @@ Feature: bootstrapping with reactivation key
     When I follow "Events" in the content area
     And I follow "History" in the content area
     And I wait until I see "Server reactivated as Salt minion" text, refreshing the page
+    And I wait until event "Apply states [certs, channels, channels.disablelocalrepos, packages, services.salt-minion] scheduled by admin" is completed
 
   Scenario: Cleanup: delete SLES minion after reactivation tests
     Given I am on the Systems overview page of this "sle_minion"


### PR DESCRIPTION
## What does this PR change?

After the re-activation we need to wait for the bootstrapping really finished before we start to cleanup the system again.
It happened that we removed the system before the state apply finished. This cause state files requested which were already removed and in the database the system not yet fully exist while we already try to remove it again.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
