### PR TITLE
Test Jest performance throttling

### DIFF
--- a/web/html/src/jest.config.js
+++ b/web/html/src/jest.config.js
@@ -20,6 +20,7 @@ module.exports = {
   modulePaths: ["<rootDir>"],
   moduleDirectories: ["node_modules"],
   setupFiles: ["./utils/test-utils/setup/index.ts"],
+  maxWorkers: 1,
   globals: {
     // These are simply sufficiently different so it's easy to check outputs
     serverTimeZone: "Asia/Tokyo", // GMT+9

--- a/web/html/src/package.json
+++ b/web/html/src/package.json
@@ -16,7 +16,7 @@
     "build:novalidate": "BUILD_VALIDATION=false node build",
     "lint": "eslint . -f codeframe --fix",
     "lint:production": "NODE_ENV=production eslint . -f codeframe",
-    "test": "BABEL_ENV=test jest",
+    "test": "NODE_OPTIONS=\"--max-old-space-size=2048\" BABEL_ENV=test jest",
     "test:watch": "BABEL_ENV=test jest --watch",
     "storybook": "start-storybook -s ./.storybook/public",
     "tsc": "tsc",


### PR DESCRIPTION
## What does this PR change?

Limit the amount of CPU threads and memory available to Jest to see if that's the source of CI issues as seen [here](https://ci.suse.de/view/Manager/view/Manager-Head/job/manager-Head-dev-javascript-lint/4970/console).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
