### PR TITLE
DownloadController log: add bugnumber  (bsc#1195666)

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,5 +1,5 @@
 - fix possible race condition in job handling (bsc#1192510)
-- Remove verbose token log
+- Remove verbose token log (bsc#1195666)
 - FIX errors when an image profile / store is deleted
   during build / inspect action (bsc#1191597, bsc#1192150)
 - SLES PAYG client support on cloud


### PR DESCRIPTION
## What does this PR change?

DownloadController log: add bugnumber to changelog

## GUI diff
- [x] **DONE**

## Documentation
- [x] **DONE**

## Test coverage

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/16906
bsc: https://bugzilla.suse.com/show_bug.cgi?id=1195666

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
