### PR TITLE
Add javascript licenses back into the bundle

### DIFF
--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -260,6 +260,7 @@ cp -r html/src/dist/javascript/manager %{buildroot}/%{www_path}/javascript
 %{www_path}/robots.txt
 %{www_path}/pub
 %{www_path}/javascript/manager/*.js
+%{www_path}/javascript/manager/*.js.LICENSE.txt
 %{www_path}/javascript/*.js
 %license LICENSE
 


### PR DESCRIPTION
## What does this PR change?

Fix [licenses missing from the bundle](https://build.opensuse.org/package/live_build_log/systemsmanagement:Uyuni:Master/spacewalk-web/openSUSE_Leap_15.3/x86_64) after https://github.com/uyuni-project/uyuni/pull/4676.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Followup to https://github.com/uyuni-project/uyuni/pull/4676

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
