### PR TITLE
QA: Wait until the SCC delete user modal dialog is not shown

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -938,13 +938,19 @@ When(/^I click on "([^"]*)" in "([^"]*)" modal$/) do |btn, title|
     '/ancestor::div[contains(@class, "modal-dialog")]'
 
   # We wait until the element becomes visible, because
-  # the fade out animation might still be in progress
-  repeat_until_timeout(message: "Couldn't find the #{title} modal") do
-    break if find(:xpath, path)
+  # the fade in animation might still be in progress
+  repeat_until_timeout(message: "It couldn't find the #{title} modal dialog") do
+    break if has_xpath?(path, wait: 1)
   end
 
   within(:xpath, path) do
     click_button(btn, wait: 5)
+  end
+
+  # We wait until the element is not shown, because
+  # the fade out animation might still be in progress
+  repeat_until_timeout(message: "The #{title} modal dialog is still present") do
+    break if has_no_xpath?(path, wait: 1)
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

This will prevent this issue, where our next step tries to look for a text but it has on top a modal dialog that took a bit more time than expected to be closed.
![image](https://user-images.githubusercontent.com/2827771/153017373-01c77fd7-61aa-4509-98b6-bc5a85be9774.png)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were modified

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
