### PR TITLE
Fix `susemanager-web-libs` references

### DIFF
--- a/web/html/src/build/fill-spec-file.js
+++ b/web/html/src/build/fill-spec-file.js
@@ -1,8 +1,15 @@
 const fs = require("fs");
+const path = require("path");
 
 function fillSpecFile() {
   delete require.cache[require.resolve("../vendors/npm.licenses.structured")];
   const { npmLicensesArray } = require("../vendors/npm.licenses.structured");
+
+  // Keep the original base license
+  npmLicensesArray.push("GPL-2.0-only");
+  // Files under `web/html/javascript` are MIT licensed but won't be inferred from the automatic list
+  npmLicensesArray.push("MIT");
+
   //https://github.com/metal/metal.js/issues/411
   const processedLicenses = npmLicensesArray.map((item) => {
     if (item === "BSD") {
@@ -21,7 +28,7 @@ function fillSpecFile() {
         throw err;
       }
       var specFileEdited = specFile.replace(
-        /(?<=%package -n susemanager-web-libs[\s\S]*?)License:.*/m,
+        /(?<=%package -n susemanager-html[\s\S]*?)License:.*/m,
         `License:        ${mappedProcessedLicenses}`
       );
 
@@ -33,7 +40,9 @@ function fillSpecFile() {
 
         resolve({ mappedProcessedLicenses });
         console.log(
-          `susemanager-web-libs.spec was generated successfully with the following licenses: ${mappedProcessedLicenses}`
+          `${path.basename(
+            specFileLocation
+          )} was updated successfully with the following licenses for susemanager-html: ${mappedProcessedLicenses}`
         );
       });
     });

--- a/web/html/src/build/fill-spec-file.js
+++ b/web/html/src/build/fill-spec-file.js
@@ -28,7 +28,7 @@ function fillSpecFile() {
         throw err;
       }
       var specFileEdited = specFile.replace(
-        /(?<=%package -n susemanager-html[\s\S]*?)License:.*/m,
+        /(?<=%package -n spacewalk-html[\s\S]*?)License:.*/m,
         `License:        ${mappedProcessedLicenses}`
       );
 
@@ -42,7 +42,7 @@ function fillSpecFile() {
         console.log(
           `${path.basename(
             specFileLocation
-          )} was updated successfully with the following licenses for susemanager-html: ${mappedProcessedLicenses}`
+          )} was updated successfully with the following licenses for spacewalk-html: ${mappedProcessedLicenses}`
         );
       });
     });

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- susemanager-web-libs is now packaged as a part of spacewalk-html
 - Improved error handling in the product setup page
 - SLES PAYG client support on cloud
 

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -63,7 +63,7 @@ but it does generate a number of sub-packages.
 
 %package -n spacewalk-html
 Summary:        HTML document files for Spacewalk
-License:        GPL-2.0-only AND MIT
+License:        0BSD AND BSD-3-Clause AND GPL-2.0-only AND LGPL-3.0-or-later AND MIT AND MPL-2.0
 Group:          Applications/Internet
 Requires:       httpd
 Requires:       spacewalk-branding

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -61,38 +61,12 @@ This package contains the code for the Spacewalk Web Site.
 Normally this source RPM does not generate a %{name} binary package,
 but it does generate a number of sub-packages.
 
-%package -n susemanager-web-libs
-Summary:        Vendor bundles for spacewalk-web
-License:        0BSD AND BSD-3-Clause AND LGPL-3.0-or-later AND MIT AND MPL-2.0
-Group:          Applications/Internet
-
-BuildArch:      noarch
-BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-BuildRequires:  nodejs-packaging
-BuildRequires:  susemanager-nodejs-sdk-devel
-
-%description -n susemanager-web-libs
-This package contains Vendor bundles needed for spacewalk-web
-
-%package -n susemanager-web-libs-debug
-Summary:        Vendor bundles for spacewalk-web debug files
-License:        0BSD AND BSD-3-Clause AND LGPL-3.0-or-later AND MIT AND MPL-2.0
-Group:          Applications/Internet
-
-BuildArch:      noarch
-BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-Requires:       susemanager-web-libs
-
-%description -n susemanager-web-libs-debug
-This package contains debug files for spacewalk-web-libs
-
 %package -n spacewalk-html
 Summary:        HTML document files for Spacewalk
 License:        GPL-2.0-only AND MIT
 Group:          Applications/Internet
 Requires:       httpd
 Requires:       spacewalk-branding
-Requires:       susemanager-web-libs
 Obsoletes:      rhn-help < 5.3.0
 Provides:       rhn-help = 5.3.0
 Obsoletes:      rhn-html < 5.3.0


### PR DESCRIPTION
## What does this PR change?

Followup to https://github.com/uyuni-project/uyuni/pull/4676, cleans up dangling references to `susemanager-web-libs`.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Followup to https://github.com/uyuni-project/uyuni/pull/4676

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
