### PR TITLE
Fix the virtualization list for foreign systems

### DIFF
--- a/java/code/src/com/suse/manager/virtualization/HostInfo.java
+++ b/java/code/src/com/suse/manager/virtualization/HostInfo.java
@@ -26,7 +26,7 @@ public class HostInfo {
     private String hypervisor;
 
     @SerializedName("cluster_other_nodes")
-    private List<String> clusterOtherNodes;
+    private List<String> clusterOtherNodes = List.of();
 
     /**
      * @return value of hypervisor

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualGuestsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualGuestsController.java
@@ -173,8 +173,8 @@ public class VirtualGuestsController extends AbstractVirtualizationController {
         data.put("foreign_entitled", server.hasEntitlement(EntitlementManager.FOREIGN));
         data.put("is_admin", user.hasRole(RoleFactory.ORG_ADMIN));
         data.put("hostInfo", server.hasVirtualizationEntitlement() && server.asMinionServer().isPresent() ?
-                GSON.toJson(virtManager.getHostInfo(server.getMinionId()).orElse(null)) :
-                null);
+                virtManager.getHostInfo(server.getMinionId()).map(GSON::toJson).orElse("{}") :
+                "{}");
 
         return renderPage("show", () -> data);
     }

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualGuestsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualGuestsControllerTest.java
@@ -38,6 +38,7 @@ import com.redhat.rhn.testing.ServerTestUtils;
 import com.suse.manager.reactor.messaging.test.SaltTestUtils;
 import com.suse.manager.virtualization.DomainCapabilitiesJson;
 import com.suse.manager.virtualization.GuestDefinition;
+import com.suse.manager.virtualization.HostInfo;
 import com.suse.manager.virtualization.VirtualizationActionHelper;
 import com.suse.manager.virtualization.VmInfoJson;
 import com.suse.manager.virtualization.test.TestVirtManager;
@@ -65,6 +66,7 @@ import java.util.Optional;
 import java.util.TimeZone;
 
 import spark.HaltException;
+import spark.ModelAndView;
 
 /**
  * Tests for VirtualGuestsController
@@ -135,6 +137,13 @@ public class VirtualGuestsControllerTest extends BaseControllerTestCase {
                         "/com/suse/manager/webui/controllers/virtualization/test/virt_utils.vm.info.json",
                         Collections.emptyMap(),
                         new TypeToken<Map<String, Map<String, JsonElement>>>() { });
+            }
+
+            @Override
+            public Optional<HostInfo> getHostInfo(String minionId) {
+                HostInfo info = new HostInfo();
+                info.setHypervisor("kvm");
+                return Optional.of(info);
             }
         };
 
@@ -400,6 +409,23 @@ public class VirtualGuestsControllerTest extends BaseControllerTestCase {
         assertEquals("kvm", caps.getDomainsCaps().get(0).getDomain());
         assertTrue(caps.getDomainsCaps().get(0).getDevices().get("disk").get("bus").contains("virtio"));
         assertFalse(caps.getDomainsCaps().get(1).getDevices().get("disk").get("bus").contains("virtio"));
+    }
+
+    public void testShow() {
+        ModelAndView page = virtualGuestsController.show(
+                getRequestWithCsrf("/manager/systems/details/virtualization/guests/:sid",
+                        host.getId()), response, user, host);
+        Map<String, Object> model = (Map<String, Object>) page.getModel();
+        assertEquals("{\"hypervisor\":\"kvm\",\"cluster_other_nodes\":[]}", model.get("hostInfo"));
+    }
+
+    public void testShowVHM() throws Exception {
+        Server vhmHost = ServerTestUtils.createForeignSystem(user, "server_digital_id");
+        ModelAndView page = virtualGuestsController.show(
+                getRequestWithCsrf("/manager/systems/details/virtualization/guests/:sid",
+                        vhmHost.getId()), response, user, vhmHost);
+        Map<String, Object> model = (Map<String, Object>) page.getModel();
+        assertEquals("{}", model.get("hostInfo"));
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix virtualization list rendering for foreign systems (bsc#1195712)
 - Change order of 'Relevant' and 'All' in patches menu
 - When adding a product, check if the new vendor channels conflicts
   with any of the existing custom channel (bsc#1193448)


### PR DESCRIPTION
## What does this PR change?

VHM report no hostInfo, leading to the following error:

    SyntaxError: Unexpected token ','

Now return to an empty dictionary when hostInfo is not available.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Unit tests were added
- [X] **DONE**

## Links

- Issue: https://github.com/SUSE/spacewalk/issues/16929
- 4.2: https://github.com/SUSE/spacewalk/pull/16932

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
