### PR TITLE
Add new feature testing the timezone

### DIFF
--- a/testsuite/features/secondary/min_timezone.feature
+++ b/testsuite/features/secondary/min_timezone.feature
@@ -4,7 +4,7 @@
 @sle_minion
 Feature: Correct timezone display 
 #  1) create a user and assign him a timezone different than the server's timezone
-#  2) test that the popups in some scheduling actions appear in users prefered timezone 
+#  2) test that the popups in some scheduling actions appear in user's prefered timezone 
 #  3) some scheduler tests based on previous bugs are unavoidable
 
   Scenario: Log in as admin user
@@ -38,9 +38,8 @@ Feature: Correct timezone display
     Given I am authorized as "MalaysianUser" with password "MalaysianUser"
     Then I should see a "MalaysianUser" link
 
-#bsc#1195455, a P3 bug not fixed yet, 
   Scenario: Schedule a remote script in the future and see the correct timezone as a pop up
-		Given I am on the Systems overview page of this "sle_minion"
+    Given I am on the Systems overview page of this "sle_minion"
     When I follow "Remote Command" in the content area
     And I enter as remote command this script in
       """
@@ -49,15 +48,14 @@ Feature: Correct timezone display
       """
     And I enter "00:00" as "date_timepicker_widget_input"
     And I click on "Schedule"
-    #WORKAROUND If the below line gets red, they probably fixed the bug, then remove AM from the text
+    # WORKAROUND for bsc #1195455, If the below line gets red, they probably fixed the bug, then we should remove AM from the below text
     Then I should see a "12:00:00 AM MYT" text
     
   Scenario: Login as the new Malaysian user if the previous scenario failed
     Given I am authorized as "MalaysianUser" with password "MalaysianUser"
     Then I should see a "MalaysianUser" link
 
-#bsc#1195191, a P3 bug not fixed yet 
-  Scenario: Schuedule a remote script to run now  and see the correct timezone details in history
+  Scenario: Schedule a remote script to run now  and see the correct timezone details in history
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Remote Command" in the content area
     And I enter as remote command this script in
@@ -66,12 +64,12 @@ Feature: Correct timezone display
       ls
       """
     And I click on "Schedule"
-    When I follow "Events" in the content area
+    And I follow "Events" in the content area
     And I follow "History" in the content area
-    When I follow first "scheduled by MalaysianUser"
+    And I follow first "scheduled by MalaysianUser"
     Then I should see a "MYT" text
-    #WORKAROUND remove the comment from the below line if its fixed
-    #And I should not see a "PM" text
+    # WORKAROUND for bsc #1195191, the below line is commented out but if the bug is fixed we should enable it. 
+    # And I should not see a "PM" text
     
   Scenario: Login as the new Malaysian user if the previous scenario failed
     Given I am authorized as "MalaysianUser" with password "MalaysianUser"

--- a/testsuite/features/secondary/srv_timezone.feature
+++ b/testsuite/features/secondary/srv_timezone.feature
@@ -1,0 +1,138 @@
+# Copyright (c) 2022 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+#@sle_minion
+Feature: Correct timezone display 
+#  1) create a user and assing him a timezone different than the server's timezone
+#  2) test that the popups in some scheduling actions appear in users prefered timezone 
+#  3) some scheduler tests based on previous bugs are unavoidable
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Create a new user in a timezone different than server's timezone
+    When I follow the left menu "Users > User List > Active"
+    And I follow "Create User"
+    And I enter "user1" as "login"
+    And I enter "user1" as "desiredpassword"
+    And I enter "user1" as "desiredpasswordConfirm"
+    And I select "Mr." from "prefix"
+    And I enter "Test" as "firstNames"
+    And I enter "User" as "lastName"
+    And I enter "galaxy-noise@suse.de" as "email"
+    And I select "(GMT+0800) Malaysia" from "timezone"
+    And I click on "Create Login"
+
+  Scenario: Add roles
+    When I follow the left menu "Users > User List > Active"
+    And I follow "user1"
+    And the "role_satellite_admin" checkbox should be disabled
+    And I check "role_org_admin"
+    And I check "role_system_group_admin"
+    And I check "role_channel_admin"
+    And I check "role_activation_key_admin"
+    And I check "role_config_admin"
+    And I click on "Update"
+
+  Scenario: Login as the new user
+    Given I am authorized as "user1" with password "user1"
+    Then I should see a "user1" link
+
+# bsc 1195455, a P3 bug not fixed yet, 
+  Scenario: Schedule a remote script in the future and see the correct timezone as a pop up
+    Given I am on the Systems overview page of this "onalmpantis-min-sles15sp3-1.tf.local"
+    When I follow "Remote Command" in the content area
+    And I enter as remote command this script in
+      """
+      #!/bin/bash
+      ls
+      """
+    And I enter "00:00" as "date_timepicker_widget_input"
+    And I click on "Schedule"
+    Then I should see a "12:00:00 AM MYT" text
+    #WORKAROUND If the above line gets red, they probably fixed the bug, then remove AM from the text
+    
+#  Scenario: Login as the new user if the previous scenario failed
+#    Given I am authorized as "user1" with password "user1"
+#    Then I should see a "user1" link
+
+#WORKAROUND
+# bsc 1195190, a P3 bug not fixed yet, this scenario is disabled as it is a minor bug, if they fix it we will re-enable
+#  Scenario: Cancel the event and see the correct timezone 
+#    Given I am on the Systems overview page of this "onalmpantis-min-sles15sp3-1.tf.local"
+#    When I follow "Events" in the content area
+#    Then I should see a "00:00:00 MYT" text
+#    And I check "list_1697531469_sel"
+#    And I click on "Cancel Selected Events"
+#    Then I should see a "MYT" text  
+
+#  Scenario: Login as the new user if the previous scenario failed
+#    Given I am authorized as "user1" with password "user1"
+#    Then I should see a "user1" link
+
+# bsc 1195191, a P3 bug not fixed yet 
+  Scenario: Schuedule a remote script to run now  and see the correct timezone details in history
+    Given I am on the Systems overview page of this "onalmpantis-min-sles15sp3-1.tf.local"
+    When I follow "Remote Command" in the content area
+    And I enter as remote command this script in
+      """
+      #!/bin/bash
+      ls
+      """
+    And I click on "Schedule"
+    When I follow "Events" in the content area
+    And I follow "History" in the content area
+    When I follow first "Remote Command on onalmpantis-min-sles15sp3-1.tf.local. scheduled by user1"
+    Then I should see a "MYT" text
+    #And I should not see a "PM" text
+    #WORKAROUND remove the comment from the above line if its fixed
+    
+#  Scenario: Login as the new user if the previous scenario failed
+#    Given I am authorized as "user1" with password "user1"
+#    Then I should see a "user1" link
+
+#WORKAROUND
+# bsc 1195189, a P3 bug not fixed yet
+#  Scenario: Schedule a minion reboot and check the pop up timezone 
+#    Given I am on the Systems overview page of this "onalmpantis-min-sles15sp3-1.tf.local"
+#    When I follow first "Schedule System Reboot"
+#    And I enter "00:00" as "date_timepicker_widget_input"
+#    When I click on "Reboot system"
+#    Then I should see a "MYT" text
+#    And I should not see a "CET" text
+
+#  Scenario: Login as the new user if the previous scenario failed
+#    Given I am authorized as "user1" with password "user1"
+#    Then I should see a "user1" link
+
+#bsc 1195452, a scheduler P3 bug not fixed yet
+  Scenario: Clean up - Cancel minion reboot 
+    Given I am on the Systems overview page of this "onalmpantis-min-sles15sp3-1.tf.local"
+    When I follow "Events" in the content area
+    And I check "list_1697531469_sel"
+    And I click on "Cancel Selected Events"
+    And I click on "Cancel Selected Events"
+
+  Scenario: Clean up - Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Clean up - Remove role
+    When I follow the left menu "Users > User List > Active"
+    And I follow "user1"
+    And I uncheck "role_org_admin"
+    And I click on "Update"
+    Then I should see "role_org_admin" as unchecked
+    And I should see "role_system_group_admin" as checked
+    And I should see "role_channel_admin" as checked
+    And I should see "role_activation_key_admin" as checked
+    And I should see "role_config_admin" as checked
+
+  Scenario: Clean up - Delete user
+    When I follow the left menu "Users > User List > Active"
+    And I follow "user1"
+    When I follow "Delete User"
+    Then I should see a "Confirm User Deletion" text
+    And I should see a "This will delete this user permanently." text
+    When I click on "Delete User"
+    Then I should see a "Active Users" text
+    And I should not see a "user1" link

--- a/testsuite/features/secondary/srv_timezone.feature
+++ b/testsuite/features/secondary/srv_timezone.feature
@@ -13,9 +13,9 @@ Feature: Correct timezone display
   Scenario: Create a new user in a timezone different than server's timezone
     When I follow the left menu "Users > User List > Active"
     And I follow "Create User"
-    And I enter "user1" as "login"
-    And I enter "user1" as "desiredpassword"
-    And I enter "user1" as "desiredpasswordConfirm"
+    And I enter "MalaysianUser" as "login"
+    And I enter "MalaysianUser" as "desiredpassword"
+    And I enter "MalaysianUser" as "desiredpasswordConfirm"
     And I select "Mr." from "prefix"
     And I enter "Test" as "firstNames"
     And I enter "User" as "lastName"
@@ -23,9 +23,9 @@ Feature: Correct timezone display
     And I select "(GMT+0800) Malaysia" from "timezone"
     And I click on "Create Login"
 
-  Scenario: Add roles
+  Scenario: Add roles for the Malaysian user
     When I follow the left menu "Users > User List > Active"
-    And I follow "user1"
+    And I follow "MalaysianUser"
     And the "role_satellite_admin" checkbox should be disabled
     And I check "role_org_admin"
     And I check "role_system_group_admin"
@@ -34,9 +34,9 @@ Feature: Correct timezone display
     And I check "role_config_admin"
     And I click on "Update"
 
-  Scenario: Login as the new user
-    Given I am authorized as "user1" with password "user1"
-    Then I should see a "user1" link
+  Scenario: Login as the new Malaysian user
+    Given I am authorized as "MalaysianUser" with password "MalaysianUser"
+    Then I should see a "MalaysianUser" link
 
 # bsc 1195455, a P3 bug not fixed yet, 
   Scenario: Schedule a remote script in the future and see the correct timezone as a pop up
@@ -52,9 +52,9 @@ Feature: Correct timezone display
     Then I should see a "12:00:00 AM MYT" text
     #WORKAROUND If the above line gets red, they probably fixed the bug, then remove AM from the text
     
-  Scenario: Login as the new user if the previous scenario failed
-    Given I am authorized as "user1" with password "user1"
-    Then I should see a "user1" link
+  Scenario: Login as the new Malaysian user if the previous scenario failed
+    Given I am authorized as "MalaysianUser" with password "MalaysianUser"
+    Then I should see a "MalaysianUser" link
 
 #WORKAROUND
 # bsc 1195190, a P3 bug not fixed yet, this scenario is disabled as it is a minor bug, if they fix it we will re-enable
@@ -66,9 +66,9 @@ Feature: Correct timezone display
 #    And I click on "Cancel Selected Events"
 #    Then I should see a "MYT" text  
 
-#  Scenario: Login as the new user if the previous scenario failed
-#    Given I am authorized as "user1" with password "user1"
-#    Then I should see a "user1" link
+#  Scenario: Login as the new Malaysian user if the previous scenario failed
+#    Given I am authorized as "MalaysianUser" with password "MalaysianUser"
+#    Then I should see a "MalaysianUser" link
 
 # bsc 1195191, a P3 bug not fixed yet 
   Scenario: Schuedule a remote script to run now  and see the correct timezone details in history
@@ -82,14 +82,14 @@ Feature: Correct timezone display
     And I click on "Schedule"
     When I follow "Events" in the content area
     And I follow "History" in the content area
-    When I follow first "Remote Command on onalmpantis-min-sles15sp3-1.tf.local. scheduled by user1"
+    When I follow first "Remote Command on onalmpantis-min-sles15sp3-1.tf.local. scheduled by MalaysianUser"
     Then I should see a "MYT" text
+    #WORKAROUND remove the comment from the below line if its fixed
     #And I should not see a "PM" text
-    #WORKAROUND remove the comment from the above line if its fixed
     
-  Scenario: Login as the new user if the previous scenario failed
-    Given I am authorized as "user1" with password "user1"
-    Then I should see a "user1" link
+  Scenario: Login as the new Malaysian user if the previous scenario failed
+    Given I am authorized as "MalaysianUser" with password "MalaysianUser"
+    Then I should see a "MalaysianUser" link
 
 #WORKAROUND
 # bsc 1195189, a P3 bug not fixed yet
@@ -101,24 +101,24 @@ Feature: Correct timezone display
 #    Then I should see a "MYT" text
 #    And I should not see a "CET" text
 
-#  Scenario: Login as the new user if the previous scenario failed
-#    Given I am authorized as "user1" with password "user1"
-#    Then I should see a "user1" link
+#  Scenario: Login as the new Malaysian user if the previous scenario failed
+#    Given I am authorized as "MalaysianUser" with password "MalaysianUser"
+#    Then I should see a "MalaysianUser" link
 
 #bsc 1195452, a scheduler P3 bug not fixed yet
-  Scenario: Clean up - Cancel minion reboot 
+  Scenario: Cleanup: Cancel minion reboot 
     Given I am on the Systems overview page of this "onalmpantis-min-sles15sp3-1.tf.local"
     When I follow "Events" in the content area
     And I check "list_1697531469_sel"
     And I click on "Cancel Selected Events"
     And I click on "Cancel Selected Events"
 
-  Scenario: Clean up - Log in as admin user
+  Scenario: Cleanup: Log in as admin user again
     Given I am authorized for the "Admin" section
 
-  Scenario: Clean up - Remove role
+  Scenario: Cleanup: Remove role
     When I follow the left menu "Users > User List > Active"
-    And I follow "user1"
+    And I follow "MalaysianUser"
     And I uncheck "role_org_admin"
     And I click on "Update"
     Then I should see "role_org_admin" as unchecked
@@ -127,12 +127,12 @@ Feature: Correct timezone display
     And I should see "role_activation_key_admin" as checked
     And I should see "role_config_admin" as checked
 
-  Scenario: Clean up - Delete user
+  Scenario: Cleanup: Delete user
     When I follow the left menu "Users > User List > Active"
-    And I follow "user1"
-    When I follow "Delete User"
+    And I follow "MalaysianUser"
+    And I follow "Delete User"
     Then I should see a "Confirm User Deletion" text
     And I should see a "This will delete this user permanently." text
     When I click on "Delete User"
     Then I should see a "Active Users" text
-    And I should not see a "user1" link
+    And I should not see a "MalaysianUser" link

--- a/testsuite/features/secondary/srv_timezone.feature
+++ b/testsuite/features/secondary/srv_timezone.feature
@@ -3,7 +3,7 @@
 
 #@sle_minion
 Feature: Correct timezone display 
-#  1) create a user and assing him a timezone different than the server's timezone
+#  1) create a user and assign him a timezone different than the server's timezone
 #  2) test that the popups in some scheduling actions appear in users prefered timezone 
 #  3) some scheduler tests based on previous bugs are unavoidable
 
@@ -52,9 +52,9 @@ Feature: Correct timezone display
     Then I should see a "12:00:00 AM MYT" text
     #WORKAROUND If the above line gets red, they probably fixed the bug, then remove AM from the text
     
-#  Scenario: Login as the new user if the previous scenario failed
-#    Given I am authorized as "user1" with password "user1"
-#    Then I should see a "user1" link
+  Scenario: Login as the new user if the previous scenario failed
+    Given I am authorized as "user1" with password "user1"
+    Then I should see a "user1" link
 
 #WORKAROUND
 # bsc 1195190, a P3 bug not fixed yet, this scenario is disabled as it is a minor bug, if they fix it we will re-enable
@@ -87,9 +87,9 @@ Feature: Correct timezone display
     #And I should not see a "PM" text
     #WORKAROUND remove the comment from the above line if its fixed
     
-#  Scenario: Login as the new user if the previous scenario failed
-#    Given I am authorized as "user1" with password "user1"
-#    Then I should see a "user1" link
+  Scenario: Login as the new user if the previous scenario failed
+    Given I am authorized as "user1" with password "user1"
+    Then I should see a "user1" link
 
 #WORKAROUND
 # bsc 1195189, a P3 bug not fixed yet

--- a/testsuite/features/secondary/srv_timezone.feature
+++ b/testsuite/features/secondary/srv_timezone.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 SUSE LLC
 # Licensed under the terms of the MIT license.
-
-#@sle_minion
+@scope_visualization
+@sle_minion
 Feature: Correct timezone display 
 #  1) create a user and assign him a timezone different than the server's timezone
 #  2) test that the popups in some scheduling actions appear in users prefered timezone 
@@ -38,9 +38,9 @@ Feature: Correct timezone display
     Given I am authorized as "MalaysianUser" with password "MalaysianUser"
     Then I should see a "MalaysianUser" link
 
-# bsc 1195455, a P3 bug not fixed yet, 
+#bsc#1195455, a P3 bug not fixed yet, 
   Scenario: Schedule a remote script in the future and see the correct timezone as a pop up
-    Given I am on the Systems overview page of this "onalmpantis-min-sles15sp3-1.tf.local"
+		Given I am on the Systems overview page of this "sle_minion"
     When I follow "Remote Command" in the content area
     And I enter as remote command this script in
       """
@@ -49,30 +49,16 @@ Feature: Correct timezone display
       """
     And I enter "00:00" as "date_timepicker_widget_input"
     And I click on "Schedule"
+    #WORKAROUND If the below line gets red, they probably fixed the bug, then remove AM from the text
     Then I should see a "12:00:00 AM MYT" text
-    #WORKAROUND If the above line gets red, they probably fixed the bug, then remove AM from the text
     
   Scenario: Login as the new Malaysian user if the previous scenario failed
     Given I am authorized as "MalaysianUser" with password "MalaysianUser"
     Then I should see a "MalaysianUser" link
 
-#WORKAROUND
-# bsc 1195190, a P3 bug not fixed yet, this scenario is disabled as it is a minor bug, if they fix it we will re-enable
-#  Scenario: Cancel the event and see the correct timezone 
-#    Given I am on the Systems overview page of this "onalmpantis-min-sles15sp3-1.tf.local"
-#    When I follow "Events" in the content area
-#    Then I should see a "00:00:00 MYT" text
-#    And I check "list_1697531469_sel"
-#    And I click on "Cancel Selected Events"
-#    Then I should see a "MYT" text  
-
-#  Scenario: Login as the new Malaysian user if the previous scenario failed
-#    Given I am authorized as "MalaysianUser" with password "MalaysianUser"
-#    Then I should see a "MalaysianUser" link
-
-# bsc 1195191, a P3 bug not fixed yet 
+#bsc#1195191, a P3 bug not fixed yet 
   Scenario: Schuedule a remote script to run now  and see the correct timezone details in history
-    Given I am on the Systems overview page of this "onalmpantis-min-sles15sp3-1.tf.local"
+    Given I am on the Systems overview page of this "sle_minion"
     When I follow "Remote Command" in the content area
     And I enter as remote command this script in
       """
@@ -82,7 +68,7 @@ Feature: Correct timezone display
     And I click on "Schedule"
     When I follow "Events" in the content area
     And I follow "History" in the content area
-    When I follow first "Remote Command on onalmpantis-min-sles15sp3-1.tf.local. scheduled by MalaysianUser"
+    When I follow first "scheduled by MalaysianUser"
     Then I should see a "MYT" text
     #WORKAROUND remove the comment from the below line if its fixed
     #And I should not see a "PM" text
@@ -90,28 +76,6 @@ Feature: Correct timezone display
   Scenario: Login as the new Malaysian user if the previous scenario failed
     Given I am authorized as "MalaysianUser" with password "MalaysianUser"
     Then I should see a "MalaysianUser" link
-
-#WORKAROUND
-# bsc 1195189, a P3 bug not fixed yet
-#  Scenario: Schedule a minion reboot and check the pop up timezone 
-#    Given I am on the Systems overview page of this "onalmpantis-min-sles15sp3-1.tf.local"
-#    When I follow first "Schedule System Reboot"
-#    And I enter "00:00" as "date_timepicker_widget_input"
-#    When I click on "Reboot system"
-#    Then I should see a "MYT" text
-#    And I should not see a "CET" text
-
-#  Scenario: Login as the new Malaysian user if the previous scenario failed
-#    Given I am authorized as "MalaysianUser" with password "MalaysianUser"
-#    Then I should see a "MalaysianUser" link
-
-#bsc 1195452, a scheduler P3 bug not fixed yet
-  Scenario: Cleanup: Cancel minion reboot 
-    Given I am on the Systems overview page of this "onalmpantis-min-sles15sp3-1.tf.local"
-    When I follow "Events" in the content area
-    And I check "list_1697531469_sel"
-    And I click on "Cancel Selected Events"
-    And I click on "Cancel Selected Events"
 
   Scenario: Cleanup: Log in as admin user again
     Given I am authorized for the "Admin" section

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -63,5 +63,5 @@
 - features/secondary/min_retracted_patches.feature
 - features/secondary/proxy_cobbler_pxeboot.feature
 - features/secondary/srv_restart.feature
-- features/secondary/srv_timezone.feature
+- features/secondary/min_timezone.feature
 ## Secondary features END ##

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -63,5 +63,5 @@
 - features/secondary/min_retracted_patches.feature
 - features/secondary/proxy_cobbler_pxeboot.feature
 - features/secondary/srv_restart.feature
-
+- features/secondary/srv_timezone.feature
 ## Secondary features END ##


### PR DESCRIPTION
## What does this PR change?

This PR adds a feature that tests different timezone functions. Here is the related ticket https://github.com/SUSE/spacewalk/issues/15864 with a lot of information on the bugs found during manual testing before writing the automation for this test.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Fixes https://github.com/SUSE/spacewalk/issues/15864 

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
