### PR TITLE
Add provides and obsoletes for `susemanager-web-libs`

### DIFF
--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -71,6 +71,8 @@ Obsoletes:      rhn-help < 5.3.0
 Provides:       rhn-help = 5.3.0
 Obsoletes:      rhn-html < 5.3.0
 Provides:       rhn-html = 5.3.0
+Obsoletes:      susemanager-web-libs < %{version}
+Provides:       susemanager-web-libs = %{version}
 # files html/javascript/{builder.js,controls.js,dragdrop.js,effects.js,
 # prototype-1.6.0.js,scriptaculous.js,slider.js,sound.js,unittest.js}
 # are licensed under MIT license


### PR DESCRIPTION
## What does this PR change?

Properly deprecates `susemanager-web-libs` in the specfile.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Followup for https://github.com/uyuni-project/uyuni/pull/4807

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
