### PR TITLE
fix advisory status migration

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,4 +1,5 @@
-  * Corrected source URLs in spec file.
+- fix advisory status migration (bsc#1195765)
+- Corrected source URLs in spec file.
 
 -------------------------------------------------------------------
 Tue Feb 15 10:07:07 CET 2022 - jgonzalez@suse.com

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.9-to-susemanager-schema-4.2.10/010-errata-status.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.9-to-susemanager-schema-4.2.10/010-errata-status.sql
@@ -3,4 +3,4 @@ ALTER TABLE rhnErrata ADD COLUMN IF NOT EXISTS
     advisory_status   VARCHAR(32) NOT NULL DEFAULT('final');
 ALTER TABLE rhnErrata ADD
     CONSTRAINT rhn_errata_adv_status_ck
-    CHECK (advisory_status in ('final', 'stable', 'testing', 'retracted'));
+    CHECK (advisory_status in ('final', 'stable', 'testing', 'pending', 'retracted'));


### PR DESCRIPTION

## What does this PR change?

Latest 4.1 schema already support "pending".
When a patch with status pending is synced and a migration from 4.1 to 4.2 happens, a check constraint violation happens.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/16943

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
