### PR TITLE
QA: Wait until I see wrong encoded packages in the list

### DIFF
--- a/testsuite/features/core/srv_create_repository.feature
+++ b/testsuite/features/core/srv_create_repository.feature
@@ -124,11 +124,11 @@ Feature: Add a repository to a channel
     When I follow the left menu "Software > Channel List"
     And I follow "Test-Channel-x86_64"
     And I follow "Packages" in the content area
-    Then I should see a "blackhole-dummy" text
+    And I wait until I see "blackhole-dummy" text, refreshing the page
 
 @ubuntu_minion
   Scenario: Reposync handles wrong encoding on DEB attributes
     When I follow the left menu "Software > Channel List"
     And I follow "Test-Channel-Deb-AMD64"
     And I follow "Packages" in the content area
-    Then I should see a "blackhole-dummy" text
+    And I wait until I see "blackhole-dummy" text, refreshing the page


### PR DESCRIPTION
## What does this PR change?

We are started to have this issue, not directly finding a package we are looking for.
It seems now we will need to wait a bit.

![image](https://user-images.githubusercontent.com/2827771/153393260-58d96ce6-7f25-4ff3-ab07-1dfe7d2bb4d2.png)

Warning: This issue shows a possible problem of degradation of our system, as before, this wait was not required.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
