### PR TITLE
QA: Add test for migrating a deleted client into a Salt minion

### DIFF
--- a/testsuite/features/secondary/min_migrate_to_trad.feature
+++ b/testsuite/features/secondary/min_migrate_to_trad.feature
@@ -1,0 +1,111 @@
+# Copyright (c) 2022 SUSE LLC
+# Licensed under the terms of the MIT license.
+#
+# This test case does not test a valid scenario. In SUMA you normally do not
+# delete a traditional client and then register it again as Salt minion. You
+# would always just bootstrap the traditional client as a Salt minion again
+# and Salt would recognize that it is a traditional client and will take the
+# the necessary steps to migrate it
+
+Feature: Migrate a Salt minion into a traditional client
+  As an authorized user
+  I want to migrate these Salt minions to traditional clients and have everything as before
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Migrate a SLES client into a Salt minion
+    When I follow the left menu "Systems > Bootstrapping"
+    And I enter the hostname of "sle_client" as "hostname"
+    And I enter "22" as "port"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I select "1-SUSE-KEY-x86_64" from "activationKeys"
+    And I select the hostname of "proxy" from "proxies"
+    And I click on "Bootstrap"
+    And I wait until I see "Successfully bootstrapped host!" text
+
+  Scenario: Wait until the Salt minion appears
+    When I wait until onboarding is completed for "sle_client" salt minion
+
+  Scenario: Check that the migrated system is now a minion
+    Given I am on the Systems overview page of this "sle_client"
+    When I follow "Properties" in the content area
+    Then I wait until I see "Base System Type:.*Salt" regex, refreshing the page
+
+  @proxy
+  Scenario: Check connection from migrated minion to proxy
+    Given I am on the Systems overview page of this "sle_client"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see "proxy" short hostname
+
+  @proxy
+  Scenario: Check registration on proxy of migrated minion
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Details" in the content area
+    And I follow "Proxy" in the content area
+    Then I should see "sle_client" hostname
+
+  Scenario: Unregister migrated client
+    Given I am on the Systems overview page of this "sle_client"
+    When I follow "Delete System"
+    Then I should see a "Confirm System Profile Deletion" text
+    When I click on "Delete Profile"
+    And I wait until I see "has been deleted" text
+    Then "sle_client" should not be registered
+
+  @susemanager
+  Scenario: Register minion again as traditional client
+    When I enable client tools repositories on "sle_client"
+    And I install the traditional stack utils on "sle_client"
+    And I remove package "salt-minion" from this "sle_client"
+    And I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-KEY-x86_64" from the proxy
+    Then I should see "sle_client" via spacecmd
+
+  @uyuni
+  Scenario: Register minion again as traditional client
+    When I enable client tools repositories on "sle_client"
+    And I install the traditional stack utils on "sle_client"
+    And I remove package "venv-salt-minion" from this "sle_client"
+    And I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-KEY-x86_64" from the proxy
+    Then I should see "sle_client" via spacecmd
+
+  Scenario: Wait until the traditional client appears
+    When I wait until onboarding is completed for "sle_client"
+
+  Scenario: Check that the migrated minion is again a traditional client
+    Given I am on the Systems overview page of this "sle_client"
+    When I follow "Properties" in the content area
+    Then I wait until I see "Base System Type:.*Management" regex, refreshing the page
+
+  Scenario: Unregister traditional client
+    Given I am on the Systems overview page of this "sle_client"
+    When I follow "Delete System"
+    Then I should see a "Confirm System Profile Deletion" text
+    When I click on "Delete Profile"
+    And I wait until I see "has been deleted" text
+    Then "sle_client" should not be registered
+
+  Scenario: Cleanup: remove leftover package of traditional client
+    When I remove package "zypp-plugin-spacewalk" from this "sle_client"
+
+  Scenario: Migrate a SLES client into a Salt minion
+    When I enable client tools repositories on "sle_client"
+    When I follow the left menu "Systems > Bootstrapping"
+    And I enter the hostname of "sle_client" as "hostname"
+    And I enter "22" as "port"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I select "1-SUSE-KEY-x86_64" from "activationKeys"
+    And I select the hostname of "proxy" from "proxies"
+    And I click on "Bootstrap"
+    And I wait until I see "Successfully bootstrapped host!" text
+
+  Scenario: Wait until the Salt minion appears
+    When I wait until onboarding is completed for "sle_client" salt minion
+
+  Scenario: Check that the migrated system is now a minion
+    Given I am on the Systems overview page of this "sle_client"
+    When I follow "Properties" in the content area
+    Then I wait until I see "Base System Type:.*Salt" regex, refreshing the page

--- a/testsuite/features/secondary/trad_deleted_migrate_to_minion.feature
+++ b/testsuite/features/secondary/trad_deleted_migrate_to_minion.feature
@@ -5,16 +5,16 @@
 # delete a traditional client and then register it again as Salt minion. You
 # would always just bootstrap the traditional client as a Salt minion again
 # and Salt would recognize that it is a traditional client and will take the
-# the necessary steps to migrate it
+# the necessary steps to migrate it.
 
-Feature: Migrate a Salt minion into a traditional client
+@sle_client
+@scope_traditional_client
+Feature: Migrate a unregistered traditional client into a Salt minion
   As an authorized user
-  I want to migrate these Salt minions to traditional clients and have everything as before
-
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  I want to bootstrap a Salt minion after unregistering a traditional client
 
   Scenario: Migrate a SLES client into a Salt minion
+    Given I am authorized for the "Admin" section
     When I follow the left menu "Systems > Bootstrapping"
     And I enter the hostname of "sle_client" as "hostname"
     And I enter "22" as "port"
@@ -88,6 +88,9 @@ Feature: Migrate a Salt minion into a traditional client
     Then "sle_client" should not be registered
 
   Scenario: Cleanup: remove leftover package of traditional client
+    # workaround for bsc#1195977
+    # will not be fixed since traditional clients will be deprecated in future versions
+    # this is the minimal clean up that has to be done to successfully register a Salt minion afterwards
     When I remove package "zypp-plugin-spacewalk" from this "sle_client"
 
   Scenario: Migrate a SLES client into a Salt minion

--- a/testsuite/features/secondary/trad_deleted_migrate_to_minion.feature
+++ b/testsuite/features/secondary/trad_deleted_migrate_to_minion.feature
@@ -13,7 +13,7 @@ Feature: Migrate a unregistered traditional client into a Salt minion
   As an authorized user
   I want to bootstrap a Salt minion after unregistering a traditional client
 
-  Scenario: Migrate a SLES client into a Salt minion
+  Scenario: Migrate a SLES client into a Salt minion in a deleted client context
     Given I am authorized for the "Admin" section
     When I follow the left menu "Systems > Bootstrapping"
     And I enter the hostname of "sle_client" as "hostname"
@@ -28,26 +28,26 @@ Feature: Migrate a unregistered traditional client into a Salt minion
   Scenario: Wait until the Salt minion appears
     When I wait until onboarding is completed for "sle_client" salt minion
 
-  Scenario: Check that the migrated system is now a minion
+  Scenario: Check that the migrated system is now a minion in a deleted client context
     Given I am on the Systems overview page of this "sle_client"
     When I follow "Properties" in the content area
     Then I wait until I see "Base System Type:.*Salt" regex, refreshing the page
 
   @proxy
-  Scenario: Check connection from migrated minion to proxy
+  Scenario: Check connection from migrated minion to proxy in a deleted client context
     Given I am on the Systems overview page of this "sle_client"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
     Then I should see "proxy" short hostname
 
   @proxy
-  Scenario: Check registration on proxy of migrated minion
+  Scenario: Check registration on proxy of migrated minion in a deleted client context
     Given I am on the Systems overview page of this "proxy"
     When I follow "Details" in the content area
     And I follow "Proxy" in the content area
     Then I should see "sle_client" hostname
 
-  Scenario: Unregister migrated client
+  Scenario: Unregister migrated client in a deleted client context
     Given I am on the Systems overview page of this "sle_client"
     When I follow "Delete System"
     Then I should see a "Confirm System Profile Deletion" text
@@ -56,7 +56,7 @@ Feature: Migrate a unregistered traditional client into a Salt minion
     Then "sle_client" should not be registered
 
   @susemanager
-  Scenario: Register minion again as traditional client
+  Scenario: Register minion again as traditional client in a deleted client context
     When I enable client tools repositories on "sle_client"
     And I install the traditional stack utils on "sle_client"
     And I remove package "salt-minion" from this "sle_client"
@@ -64,22 +64,22 @@ Feature: Migrate a unregistered traditional client into a Salt minion
     Then I should see "sle_client" via spacecmd
 
   @uyuni
-  Scenario: Register minion again as traditional client
+  Scenario: Register minion again as traditional client in a deleted client context
     When I enable client tools repositories on "sle_client"
     And I install the traditional stack utils on "sle_client"
     And I remove package "venv-salt-minion" from this "sle_client"
     And I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-KEY-x86_64" from the proxy
     Then I should see "sle_client" via spacecmd
 
-  Scenario: Wait until the traditional client appears
+  Scenario: Wait until the traditional client appears in a deleted client context
     When I wait until onboarding is completed for "sle_client"
 
-  Scenario: Check that the migrated minion is again a traditional client
+  Scenario: Check that the migrated minion is again a traditional client in a deleted client context
     Given I am on the Systems overview page of this "sle_client"
     When I follow "Properties" in the content area
     Then I wait until I see "Base System Type:.*Management" regex, refreshing the page
 
-  Scenario: Unregister traditional client
+  Scenario: Unregister traditional client in a deleted client context
     Given I am on the Systems overview page of this "sle_client"
     When I follow "Delete System"
     Then I should see a "Confirm System Profile Deletion" text
@@ -87,13 +87,13 @@ Feature: Migrate a unregistered traditional client into a Salt minion
     And I wait until I see "has been deleted" text
     Then "sle_client" should not be registered
 
-  Scenario: Cleanup: remove leftover package of traditional client
+  Scenario: Cleanup: remove leftover package of traditional client in a deleted client context
     # workaround for bsc#1195977
     # will not be fixed since traditional clients will be deprecated in future versions
     # this is the minimal clean up that has to be done to successfully register a Salt minion afterwards
     When I remove package "zypp-plugin-spacewalk" from this "sle_client"
 
-  Scenario: Migrate a SLES client into a Salt minion
+  Scenario: Migrate a SLES client into a Salt minion in a deleted client context
     When I enable client tools repositories on "sle_client"
     When I follow the left menu "Systems > Bootstrapping"
     And I enter the hostname of "sle_client" as "hostname"
@@ -105,10 +105,10 @@ Feature: Migrate a unregistered traditional client into a Salt minion
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
 
-  Scenario: Wait until the Salt minion appears
+  Scenario: Wait until the Salt minion appears in a deleted client context
     When I wait until onboarding is completed for "sle_client" salt minion
 
-  Scenario: Check that the migrated system is now a minion
+  Scenario: Check that the migrated system is now a minion in a deleted client context
     Given I am on the Systems overview page of this "sle_client"
     When I follow "Properties" in the content area
     Then I wait until I see "Base System Type:.*Salt" regex, refreshing the page

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -888,13 +888,13 @@ And(/^I register "([^*]*)" as traditional client with activation key "([^*]*)"$/
   log node.run(command2, timeout: 500).to_s.gsub(/(\\x\h+){1,}/, '?')
 end
 
-When(/^I wait until onboarding is completed for "([^"]*)"$/) do |host|
+When(/^I wait until onboarding is completed for "([^"]*)"((?: salt minion)?)$/) do |host, is_salt|
   steps %(
     When I follow the left menu "Systems > Overview"
     And I wait until I see the name of "#{host}", refreshing the page
     And I follow this "#{host}" link
   )
-  if get_client_type(host) == 'traditional'
+  if get_client_type(host) == 'traditional' and is_salt.empty?
     get_target(host).run('rhn_check -vvv')
   else
     steps %(

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -36,7 +36,6 @@
 - features/secondary/min_bootstrap_script.feature
 - features/secondary/min_ssh_tunnel.feature
 - features/secondary/min_activationkey.feature
-- features/secondary/min_migrate_to_trad.feature
 - features/secondary/trad_migrate_to_minion.feature
 - features/secondary/trad_migrate_to_sshminion.feature
 - features/secondary/trad_ssh_tunnel.feature
@@ -49,6 +48,7 @@
 - features/secondary/min_empty_system_profiles.feature
 - features/secondary/trad_need_reboot.feature
 - features/secondary/trad_action_chain.feature
+- features/secondary/trad_deleted_migrate_to_minion.feature
 - features/secondary/min_action_chain.feature
 - features/secondary/minssh_action_chain.feature
 - features/secondary/allcli_action_chain.feature

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -36,6 +36,7 @@
 - features/secondary/min_bootstrap_script.feature
 - features/secondary/min_ssh_tunnel.feature
 - features/secondary/min_activationkey.feature
+- features/secondary/min_migrate_to_trad.feature
 - features/secondary/trad_migrate_to_minion.feature
 - features/secondary/trad_migrate_to_sshminion.feature
 - features/secondary/trad_ssh_tunnel.feature


### PR DESCRIPTION
## What does this PR change?

This PR adds a new migration test. It migrates a beforehand deleted traditional client into a Salt minion. The exact steps are

- register trad. client as Minion
- unregister Minion
- register as trad. client again
- unregister trad. client
- register trad. client as Minion again

This test case does not test a valid scenario. In SUMA you normally do not delete a traditional client and then register it again as Salt minion. You would always just bootstrap the traditional client as a Salt minion again and Salt would recognize that it is a traditional client and will take the the necessary steps to migrate it.

## GUI diff

No difference.



- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/6781

[Manager 4.2](https://github.com/SUSE/spacewalk/pull/17030)
[Manager 4.1](https://github.com/SUSE/spacewalk/pull/17029)

- [x] **DONE**

## Changelogs

- [x] No changelog needed


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
