### PR TITLE
Handle multiple Kiwi bundles (bsc#1194905)

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/test/image.build.kiwi.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/image.build.kiwi.json
@@ -42,14 +42,14 @@
                             "type": "pxe",
                             "size": 1490026496
                         },
-                        "bundle": {
+                        "bundles": [{
                             "hash": "sha256:a46cbaad0679e40ea53d0907ed42e00030142b0b9372c9ebc0ba6b9dde5df6b",
                             "suffix": "tgz",
                             "filepath": "/var/lib/Kiwi/build06/images/POS_Image_JeOS6.x86_64-6.0.0-build06.tgz",
                             "basename": "POS_Image_JeOS6.x86_64-6.0.0",
                             "filename": "POS_Image_JeOS6.x86_64-6.0.0-build06.tgz",
                             "id": "build06"
-                        }
+                        }]
                     }
                 },
                 "__id__": "mgr_buildimage_info"

--- a/java/code/src/com/suse/manager/reactor/messaging/test/image.inspect.kiwi.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/image.inspect.kiwi.json
@@ -2360,14 +2360,14 @@
                                 "size": 101571905
                             }
                         },
-                        "bundle": {
+                        "bundles": [{
                             "hash": "sha256:a46cbaad0679e40ea53d0907ed42e00030142b0b9372c9ebc0ba6b9dde5df6b",
                             "suffix": "tgz",
                             "filepath": "/var/lib/Kiwi/build24/images/POS_Image_JeOS6.x86_64-6.0.0-build24.tgz",
                             "basename": "POS_Image_JeOS6.x86_64-6.0.0",
                             "filename": "POS_Image_JeOS6.x86_64-6.0.0-build24.tgz",
                             "id": "build24"
-                        }
+                        }]
                     }
                 },
                 "__id__": "mgr_inspect_kiwi_image"

--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/OSImageBuildImageInfoResult.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/OSImageBuildImageInfoResult.java
@@ -14,17 +14,23 @@
  */
 package com.suse.manager.webui.utils.salt.custom;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
 /**
  * The resulting image info from kiwi-image-build
  */
 public class OSImageBuildImageInfoResult {
 
     private OSImageInspectSlsResult.Bundle bundle;
+    private List<OSImageInspectSlsResult.Bundle> bundles;
+    private OSImageInspectSlsResult.Image image;
 
     /**
      * @return the bundle info
      */
-    public OSImageInspectSlsResult.Bundle getBundle() {
-        return bundle;
+    public List<OSImageInspectSlsResult.Bundle> getBundles() {
+        return Optional.ofNullable(bundles).orElseGet(() -> Collections.singletonList(bundle));
     }
 }

--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/OSImageInspectSlsResult.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/OSImageInspectSlsResult.java
@@ -18,7 +18,9 @@ import com.suse.manager.webui.utils.salt.custom.ImageChecksum.Checksum;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Object representation of the results of a call to state.apply
@@ -311,6 +313,7 @@ public class OSImageInspectSlsResult {
     @SerializedName("boot_image")
     private BootImage bootImage;
     private Bundle bundle;
+    private List<Bundle> bundles;
     private List<Package> packages;
 
     /**
@@ -391,7 +394,7 @@ public class OSImageInspectSlsResult {
     /**
      * @return the bundle
      */
-    public Bundle getBundle() {
-        return bundle;
+    public List<Bundle> getBundles() {
+        return Optional.ofNullable(bundles).orElseGet(() -> Collections.singletonList(bundle));
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Handle multiple Kiwi bundles (bsc#1194905)
 - Added new XML-RPC mathod: configchannel.syncSaltFilesOnDisk
 - Fix virtualization list rendering for foreign systems (bsc#1195712)
 - Change order of 'Relevant' and 'All' in patches menu

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Handle multiple Kiwi bundles (bsc#1194905)
 - fix deprecation warnings
 - Implement uyuni roster module for Salt
 - enforce correct minion configuration similar to bootstrapping


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/16765

Kiwi can create multiple results from bundle build.
This patch uploads all of them, before only one bundle file was handled.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed:  only a bugfix
- [x] **DONE**

## Test coverage

- covered by unit tests and by cucumber tests
- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/16747
Tracks  https://github.com/SUSE/spacewalk/pull/16765

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
