### PR TITLE
Replace FK reference on image profile to activation key

### DIFF
--- a/schema/spacewalk/common/tables/rhnActivationKey.sql
+++ b/schema/spacewalk/common/tables/rhnActivationKey.sql
@@ -22,6 +22,7 @@ CREATE TABLE rhnActivationKey
                        CONSTRAINT rhn_act_key_reg_tid_fk
                            REFERENCES rhnRegToken (id)
                            ON DELETE CASCADE,
+                       CONSTRAINT rhn_act_key_reg_tid_uq UNIQUE,
     ks_session_id  NUMERIC
                        CONSTRAINT rhn_act_key_ks_sid_fk
                            REFERENCES rhnKickstartSession (id)

--- a/schema/spacewalk/common/tables/suseImageProfile.sql
+++ b/schema/spacewalk/common/tables/suseImageProfile.sql
@@ -24,7 +24,7 @@ CREATE TABLE suseImageProfile
                        ON DELETE CASCADE,
     token_id       NUMERIC
                      CONSTRAINT suse_imgprof_tk_fk
-                       REFERENCES rhnRegToken (id)
+                       REFERENCES rhnActivationKey (reg_token_id)
                        ON DELETE SET NULL,
     image_type     VARCHAR(32) NOT NULL,
     target_store_id NUMERIC NOT NULL

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Replace FK reference on image profile to activation key
 - Replace not existing Asia/Beijing timezone with Asia/Shanghai (bsc#1194862)
 - Add created and modified fields to suseMinionInfo to make
   uyuni roster module cache validation more accurate

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.6-to-susemanager-schema-4.3.7/003-change-imageprofile-fk-reference.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.6-to-susemanager-schema-4.3.7/003-change-imageprofile-fk-reference.sql
@@ -1,0 +1,2 @@
+ALTER TABLE rhnactivationkey ADD CONSTRAINT rhn_act_key_reg_tid_uq UNIQUE (reg_token_id);
+ALTER TABLE suseimageprofile DROP CONSTRAINT suse_imgprof_tk_fk, ADD CONSTRAINT suse_imgprof_tk_fk FOREIGN KEY (token_id) REFERENCES rhnActivationKey (reg_token_id) ON DELETE SET NULL;


### PR DESCRIPTION
## What does this PR change?

- instead of referencing rhnRegToken from suseImageProfiles, reference the same id in rhnActivationKey table

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
