### PR TITLE
Fix pkgset beacon test for AlmaLinux

### DIFF
--- a/susemanager-utils/susemanager-sls/src/tests/test_beacon_pkgset.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_beacon_pkgset.py
@@ -8,7 +8,10 @@ from . import mockery
 
 mockery.setup_environment()
 
-from ..beacons import pkgset
+with patch(
+    "salt.config.minion_config", return_value={"cachedir": "/var/cache/salt/minion"}
+):
+    from ..beacons import pkgset
 
 
 pkgset.__context__ = dict()


### PR DESCRIPTION
## What does this PR change?

Fixes failing test on building `susemanager-sls` for AlmaLinux

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: already covered

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
