### PR TITLE
Provide link for CVEs

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -8997,6 +8997,9 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
       <trans-unit id="cveaudit.nav.title" xml:space="preserve">
         <source>CVE Audit</source>
       </trans-unit>
+      <trans-unit id="cveaudit.notfound" xml:space="preserve">
+        <source>The specified CVE number was not found in our database. You can get more information about this CVE from the links given below.</source>
+      </trans-unit>
       <trans-unit id="cobbler.powermanagement.ipmitool" xml:space="preserve">
         <source>IPMI</source>
       </trans-unit>

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/IconTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/IconTag.java
@@ -55,6 +55,7 @@ public class IconTag extends TagSupport {
         icons.put("errata-security-important", "fa fa-shield fa-1-1-5x errata-important");
         icons.put("errata-security-critical", "fa fa-shield fa-1-1-5x errata-critical");
         icons.put("errata-retracted", "fa fa-1-5x fa-times-circle errata-retracted");
+        icons.put("external-link", "fa fa-external-link");
         icons.put("event-type-errata", "fa spacewalk-icon-patches");
         icons.put("event-type-package", "fa spacewalk-icon-packages");
         icons.put("event-type-preferences", "fa fa-cog");

--- a/java/code/src/com/suse/manager/webui/controllers/CVEAuditController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/CVEAuditController.java
@@ -154,8 +154,8 @@ public class CVEAuditController {
             }
         }
         catch (UnknownCVEIdentifierException e) {
-            return json(res, ResultJson.error("According to our records, your systems/images are not affected by " +
-                    "this CVE. Please follow the provided links for more information."));
+            return json(res, ResultJson.error("The specified CVE number was not found in our database. " +
+                    "You can get more information about this CVE from the links given below"));
         }
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/CVEAuditController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/CVEAuditController.java
@@ -22,6 +22,7 @@ import static com.suse.manager.webui.utils.SparkApplicationHelper.withUserPrefer
 import static spark.Spark.get;
 import static spark.Spark.post;
 
+import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.audit.CVEAuditImage;
 import com.redhat.rhn.manager.audit.CVEAuditManager;
@@ -56,6 +57,7 @@ import spark.template.jade.JadeTemplateEngine;
  * Spark controller class the CVE Audit page.
  */
 public class CVEAuditController {
+    private static final LocalizationService LOC = LocalizationService.getInstance();
 
     private static final Gson GSON = new GsonBuilder().create();
 
@@ -154,8 +156,7 @@ public class CVEAuditController {
             }
         }
         catch (UnknownCVEIdentifierException e) {
-            return json(res, ResultJson.error("The specified CVE number was not found in our database. " +
-                    "You can get more information about this CVE from the links given below"));
+            return json(res, ResultJson.error(LOC.getMessage("cveaudit.notfound")));
         }
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/CVEAuditController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/CVEAuditController.java
@@ -23,6 +23,7 @@ import static spark.Spark.get;
 import static spark.Spark.post;
 
 import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.dto.CVE;
 import com.redhat.rhn.manager.audit.CVEAuditImage;
 import com.redhat.rhn.manager.audit.CVEAuditManager;
 import com.redhat.rhn.manager.audit.CVEAuditServer;
@@ -154,9 +155,8 @@ public class CVEAuditController {
             }
         }
         catch (UnknownCVEIdentifierException e) {
-            return json(res, ResultJson.error("The specified CVE number was not" +
-                    " found. This can happen for very old or yet-unknown numbers, please" +
-                    " also check it for possible typing errors."));
+            return json(res, ResultJson.error("According to our records, your systems/images are not affected by " +
+                    "this CVE. Please follow the provided links for more information."));
         }
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/CVEAuditController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/CVEAuditController.java
@@ -23,7 +23,6 @@ import static spark.Spark.get;
 import static spark.Spark.post;
 
 import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.frontend.dto.CVE;
 import com.redhat.rhn.manager.audit.CVEAuditImage;
 import com.redhat.rhn.manager.audit.CVEAuditManager;
 import com.redhat.rhn.manager.audit.CVEAuditServer;

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Provide link for CVEs
+
 -------------------------------------------------------------------
 Tue Feb 15 10:03:14 CET 2022 - jgonzalez@suse.com
 

--- a/web/html/src/components/icontag.tsx
+++ b/web/html/src/components/icontag.tsx
@@ -17,6 +17,7 @@ function IconTag(props: Props) {
     "errata-security": "fa fa-shield fa-1-5x",
     "errata-reboot": "fa fa-1-5x fa-refresh",
     "errata-restart": "fa fa-1-5x fa-archive",
+    "external-link": "fa fa-external-link",
     "event-type-errata": "fa spacewalk-icon-patches",
     "event-type-package": "fa spacewalk-icon-packages",
     "event-type-preferences": "fa fa-cog",

--- a/web/html/src/manager/audit/cveaudit/cveaudit.tsx
+++ b/web/html/src/manager/audit/cveaudit/cveaudit.tsx
@@ -256,7 +256,7 @@ class CVEAudit extends React.Component<Props, State> {
               />
             </div>
           </p>
-          {this.state.auditExecuted === true && (
+          {this.state.auditExecuted && (
             <div>
               <p>
                 <a

--- a/web/html/src/manager/audit/cveaudit/cveaudit.tsx
+++ b/web/html/src/manager/audit/cveaudit/cveaudit.tsx
@@ -260,6 +260,7 @@ class CVEAudit extends React.Component<Props, State> {
             <div>
               <p>
                 <a
+                  className="btn btn-link"
                   target="_blank"
                   rel="noopener noreferrer"
                   href={
@@ -270,8 +271,8 @@ class CVEAudit extends React.Component<Props, State> {
                   <IconTag type="external-link" />
                   {t("MITRE CVE link")}
                 </a>
-                &nbsp;&nbsp;&nbsp;&nbsp;
                 <a
+                  className="btn btn-link"
                   target="_blank"
                   rel="noopener noreferrer"
                   href={

--- a/web/html/src/manager/audit/cveaudit/cveaudit.tsx
+++ b/web/html/src/manager/audit/cveaudit/cveaudit.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import { IconTag } from "components/icontag";
 import SpaRenderer from "core/spa/spa-renderer";
 
 import { AsyncButton, LinkButton } from "components/buttons";
@@ -378,28 +379,32 @@ class CVEAudit extends React.Component<Props, State> {
             />
           </Table>
           <p>
-          <AsyncButton
-            id="bootstrap-btn"
-            defaultType="btn-link"
-            icon="fa-external-link"
-            text={t("SUSE Security CVE link")}
-            action={() => window.open("https://www.suse.com/security/cve/CVE-" +
-                          this.state.cveYear  +
-                          "-" + 
-                          this.state.cveNumber +
-                          ".html", '_blank','noopener')}
-          />
-          <AsyncButton
-            id="bootstrap-btn"
-            defaultType="btn-link"
-            icon="fa-external-link"
-            text={t("MITRE CVE link")}
-            action={() => window.open("https://cve.mitre.org/cgi-bin/cvename.cgi?name=" +
-                                       this.state.cveYear +
-                                       "-" +
-                                       this.state.cveNumber, '_blank','noopener')}
-          />
-          </p>
+            <a className="btn btn-link" target="_blank" rel="noopener noreferrer"
+              href={
+                "https://www.suse.com/security/cve/CVE-" +
+                this.state.cveYear  +
+                "-" + 
+                this.state.cveNumber +
+                ".html"
+              } 
+              data-senna-off="true"
+            >
+              <IconTag type="external-link" />
+              {t("SUSE Security CVE link")}
+            </a>
+            <a className="btn btn-link" target="_blank" rel="noopener noreferrer"
+              href={
+                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=" +
+                this.state.cveYear +
+                "-" +
+                this.state.cveNumber
+              } 
+              data-senna-off="true"
+            >
+              <IconTag type="external-link" />
+              {t("MITRE CVE link")}
+            </a>
+          </p>      
           <a
             href={
               "/rhn/manager/api/audit/cve.csv?cveIdentifier=CVE-" +
@@ -413,6 +418,7 @@ class CVEAudit extends React.Component<Props, State> {
             }
             data-senna-off="true"
           >
+            <IconTag type="item-download-csv" />
             {t("Download CSV")}
           </a>
         </TopPanel>

--- a/web/html/src/manager/audit/cveaudit/cveaudit.tsx
+++ b/web/html/src/manager/audit/cveaudit/cveaudit.tsx
@@ -205,7 +205,7 @@ class CVEAudit extends React.Component<Props, State> {
             />
           </div>
           <div>
-          <br />
+            <br />
             <p>
               <a
                 target="_blank"
@@ -214,7 +214,7 @@ class CVEAudit extends React.Component<Props, State> {
                   "https://cve.mitre.org/cgi-bin/cvename.cgi?name=" + this.state.cveYear + "-" + this.state.cveNumber
                 }
                 data-senna-off="true"
-                >
+              >
                 <IconTag type="external-link" />
                 {t("MITRE CVE link")}
               </a>
@@ -227,8 +227,8 @@ class CVEAudit extends React.Component<Props, State> {
                 }
                 data-senna-off="true"
               >
-              <IconTag type="external-link" />
-              {t("SUSE Security CVE link")}
+                <IconTag type="external-link" />
+                {t("SUSE Security CVE link")}
               </a>
             </p>
           </div>

--- a/web/html/src/manager/audit/cveaudit/cveaudit.tsx
+++ b/web/html/src/manager/audit/cveaudit/cveaudit.tsx
@@ -258,7 +258,7 @@ class CVEAudit extends React.Component<Props, State> {
                 defaultType="btn-default"
                 icon="fa-external-link"
                 text={t("SUSE Security CVE Info")}
-                onClick={() => window.open("someLink", "_blank")}
+                onClick={() => window.open("https://www.suse.com/security/cve/CVE-", this.state.cveYear, "-", this.state.cveNumber,".html")}
               />
               <AsyncButton
                 id="bootstrap-btn"

--- a/web/html/src/manager/audit/cveaudit/cveaudit.tsx
+++ b/web/html/src/manager/audit/cveaudit/cveaudit.tsx
@@ -205,18 +205,20 @@ class CVEAudit extends React.Component<Props, State> {
             />
           </div>
           <div>
-          <br/>
+          <br />
             <p>
               <a
                 target="_blank"
                 rel="noopener noreferrer"
-                href={"https://cve.mitre.org/cgi-bin/cvename.cgi?name=" + this.state.cveYear + "-" + this.state.cveNumber}
+                href={
+                  "https://cve.mitre.org/cgi-bin/cvename.cgi?name=" + this.state.cveYear + "-" + this.state.cveNumber
+                }
                 data-senna-off="true"
                 >
-                  <IconTag type="external-link" />
-                  {t("MITRE CVE link")}
+                <IconTag type="external-link" />
+                {t("MITRE CVE link")}
               </a>
-              <br/>
+              <br />
               <a
                 target="_blank"
                 rel="noopener noreferrer"
@@ -225,8 +227,8 @@ class CVEAudit extends React.Component<Props, State> {
                 }
                 data-senna-off="true"
               >
-                <IconTag type="external-link" />
-                {t("SUSE Security CVE link")}
+              <IconTag type="external-link" />
+              {t("SUSE Security CVE link")}
               </a>
             </p>
           </div>

--- a/web/html/src/manager/audit/cveaudit/cveaudit.tsx
+++ b/web/html/src/manager/audit/cveaudit/cveaudit.tsx
@@ -81,6 +81,7 @@ type State = {
   messages: any[];
   selectedItems: any[];
   target?: any;
+  auditExecuted?: boolean;
 };
 
 class CVEAudit extends React.Component<Props, State> {
@@ -95,7 +96,7 @@ class CVEAudit extends React.Component<Props, State> {
       results: [],
       messages: [],
       selectedItems: [],
-      auditExecuted: false
+      auditExecuted: false,
     };
   }
 
@@ -255,7 +256,7 @@ class CVEAudit extends React.Component<Props, State> {
               />
             </div>
           </p>
-          {this.state.auditExecuted === true &&
+          {this.state.auditExecuted === true && (
             <div>
               <p>
                 <a
@@ -269,7 +270,7 @@ class CVEAudit extends React.Component<Props, State> {
                   <IconTag type="external-link" />
                   {t("MITRE CVE link")}
                 </a>
-                  &nbsp;&nbsp;&nbsp;&nbsp;
+                &nbsp;&nbsp;&nbsp;&nbsp;
                 <a
                   target="_blank"
                   rel="noopener noreferrer"
@@ -283,7 +284,7 @@ class CVEAudit extends React.Component<Props, State> {
                 </a>
               </p>
             </div>
-          }
+          )}
           <Table
             data={this.state.results}
             identifier={(row) => row.id}

--- a/web/html/src/manager/audit/cveaudit/cveaudit.tsx
+++ b/web/html/src/manager/audit/cveaudit/cveaudit.tsx
@@ -205,6 +205,32 @@ class CVEAudit extends React.Component<Props, State> {
             />
           </div>
           <div>
+          <br/>
+            <p>
+              <a
+                target="_blank"
+                rel="noopener noreferrer"
+                href={"https://cve.mitre.org/cgi-bin/cvename.cgi?name=" + this.state.cveYear + "-" + this.state.cveNumber}
+                data-senna-off="true"
+                >
+                  <IconTag type="external-link" />
+                  {t("MITRE CVE link")}
+              </a>
+              <br/>
+              <a
+                target="_blank"
+                rel="noopener noreferrer"
+                href={
+                  "https://www.suse.com/security/cve/CVE-" + this.state.cveYear + "-" + this.state.cveNumber + ".html"
+                }
+                data-senna-off="true"
+              >
+                <IconTag type="external-link" />
+                {t("SUSE Security CVE link")}
+              </a>
+            </p>
+          </div>
+          <div>
             {ALL.map((status) => {
               return (
                 <div className="checkbox">
@@ -378,30 +404,6 @@ class CVEAudit extends React.Component<Props, State> {
               }}
             />
           </Table>
-          <p>
-            <a
-              className="btn btn-link"
-              target="_blank"
-              rel="noopener noreferrer"
-              href={
-                "https://www.suse.com/security/cve/CVE-" + this.state.cveYear + "-" + this.state.cveNumber + ".html"
-              }
-              data-senna-off="true"
-            >
-              <IconTag type="external-link" />
-              {t("SUSE Security CVE link")}
-            </a>
-            <a
-              className="btn btn-link"
-              target="_blank"
-              rel="noopener noreferrer"
-              href={"https://cve.mitre.org/cgi-bin/cvename.cgi?name=" + this.state.cveYear + "-" + this.state.cveNumber}
-              data-senna-off="true"
-            >
-              <IconTag type="external-link" />
-              {t("MITRE CVE link")}
-            </a>
-          </p>
           <a
             href={
               "/rhn/manager/api/audit/cve.csv?cveIdentifier=CVE-" +

--- a/web/html/src/manager/audit/cveaudit/cveaudit.tsx
+++ b/web/html/src/manager/audit/cveaudit/cveaudit.tsx
@@ -251,24 +251,6 @@ class CVEAudit extends React.Component<Props, State> {
               />
             </div>
           </p>
-          <p>
-            <div className="btn-group">
-              <AsyncButton
-                id="bootstrap-btn"
-                defaultType="btn-default"
-                icon="fa-external-link"
-                text={t("SUSE Security CVE Info")}
-                onClick={() => window.open("https://www.suse.com/security/cve/CVE-", this.state.cveYear, "-", this.state.cveNumber,".html")}
-              />
-              <AsyncButton
-                id="bootstrap-btn"
-                defaultType="btn-default"
-                icon="fa-external-link"
-                text={t("MITRE CVE Info")}
-                onClick={() => window.open("https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-", this.state.cveYear, "-", this.state.cveNumber )}
-              />
-            </div>
-          </p>
           <Table
             data={this.state.results}
             identifier={(row) => row.id}
@@ -395,6 +377,29 @@ class CVEAudit extends React.Component<Props, State> {
               }}
             />
           </Table>
+          <p>
+          <AsyncButton
+            id="bootstrap-btn"
+            defaultType="btn-link"
+            icon="fa-external-link"
+            text={t("SUSE Security CVE link")}
+            action={() => window.open("https://www.suse.com/security/cve/" +
+                          this.state.cveYear  +
+                          "-" + 
+                          this.state.cveNumber +
+                          ".html", '_blank','noopener')}
+          />
+          <AsyncButton
+            id="bootstrap-btn"
+            defaultType="btn-link"
+            icon="fa-external-link"
+            text={t("MITRE CVE link")}
+            action={() => window.open("https://cve.mitre.org/cgi-bin/cvename.cgi?name=" +
+                                       this.state.cveYear +
+                                       "-" +
+                                       this.state.cveNumber, '_blank','noopener')}
+          />
+          </p>
           <a
             href={
               "/rhn/manager/api/audit/cve.csv?cveIdentifier=CVE-" +

--- a/web/html/src/manager/audit/cveaudit/cveaudit.tsx
+++ b/web/html/src/manager/audit/cveaudit/cveaudit.tsx
@@ -383,7 +383,7 @@ class CVEAudit extends React.Component<Props, State> {
             defaultType="btn-link"
             icon="fa-external-link"
             text={t("SUSE Security CVE link")}
-            action={() => window.open("https://www.suse.com/security/cve/" +
+            action={() => window.open("https://www.suse.com/security/cve/CVE-" +
                           this.state.cveYear  +
                           "-" + 
                           this.state.cveNumber +

--- a/web/html/src/manager/audit/cveaudit/cveaudit.tsx
+++ b/web/html/src/manager/audit/cveaudit/cveaudit.tsx
@@ -251,6 +251,24 @@ class CVEAudit extends React.Component<Props, State> {
               />
             </div>
           </p>
+          <p>
+            <div className="btn-group">
+              <AsyncButton
+                id="bootstrap-btn"
+                defaultType="btn-default"
+                icon="fa-external-link"
+                text={t("SUSE Security CVE Info")}
+                onClick={() => window.open("someLink", "_blank")}
+              />
+              <AsyncButton
+                id="bootstrap-btn"
+                defaultType="btn-default"
+                icon="fa-external-link"
+                text={t("MITRE CVE Info")}
+                onClick={() => window.open("https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-", this.state.cveYear, "-", this.state.cveNumber )}
+              />
+            </div>
+          </p>
           <Table
             data={this.state.results}
             identifier={(row) => row.id}

--- a/web/html/src/manager/audit/cveaudit/cveaudit.tsx
+++ b/web/html/src/manager/audit/cveaudit/cveaudit.tsx
@@ -95,6 +95,7 @@ class CVEAudit extends React.Component<Props, State> {
       results: [],
       messages: [],
       selectedItems: [],
+      auditExecuted: false
     };
   }
 
@@ -164,12 +165,14 @@ class CVEAudit extends React.Component<Props, State> {
           selectedItems: data.data.filter((i) => i.selected).map((i) => i.id),
           resultType: target,
           messages: [],
+          auditExecuted: true,
         });
       } else {
         this.setState({
           results: [],
           selectedItems: [],
           messages: data.messages,
+          auditExecuted: true,
         });
       }
     });
@@ -252,33 +255,35 @@ class CVEAudit extends React.Component<Props, State> {
               />
             </div>
           </p>
-          <div>
-            <p>
-              <a
-                target="_blank"
-                rel="noopener noreferrer"
-                href={
-                  "https://cve.mitre.org/cgi-bin/cvename.cgi?name=" + this.state.cveYear + "-" + this.state.cveNumber
-                }
-                data-senna-off="true"
-              >
-                <IconTag type="external-link" />
-                {t("MITRE CVE link")}
-              </a>
-              &nbsp;&nbsp;&nbsp;&nbsp;
-              <a
-                target="_blank"
-                rel="noopener noreferrer"
-                href={
-                  "https://www.suse.com/security/cve/CVE-" + this.state.cveYear + "-" + this.state.cveNumber + ".html"
-                }
-                data-senna-off="true"
-              >
-                <IconTag type="external-link" />
-                {t("SUSE Security CVE link")}
-              </a>
-            </p>
-          </div>
+          {this.state.auditExecuted === true &&
+            <div>
+              <p>
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={
+                    "https://cve.mitre.org/cgi-bin/cvename.cgi?name=" + this.state.cveYear + "-" + this.state.cveNumber
+                  }
+                  data-senna-off="true"
+                >
+                  <IconTag type="external-link" />
+                  {t("MITRE CVE link")}
+                </a>
+                  &nbsp;&nbsp;&nbsp;&nbsp;
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={
+                    "https://www.suse.com/security/cve/CVE-" + this.state.cveYear + "-" + this.state.cveNumber + ".html"
+                  }
+                  data-senna-off="true"
+                >
+                  <IconTag type="external-link" />
+                  {t("SUSE Security CVE link")}
+                </a>
+              </p>
+            </div>
+          }
           <Table
             data={this.state.results}
             identifier={(row) => row.id}

--- a/web/html/src/manager/audit/cveaudit/cveaudit.tsx
+++ b/web/html/src/manager/audit/cveaudit/cveaudit.tsx
@@ -205,34 +205,6 @@ class CVEAudit extends React.Component<Props, State> {
             />
           </div>
           <div>
-            <br />
-            <p>
-              <a
-                target="_blank"
-                rel="noopener noreferrer"
-                href={
-                  "https://cve.mitre.org/cgi-bin/cvename.cgi?name=" + this.state.cveYear + "-" + this.state.cveNumber
-                }
-                data-senna-off="true"
-              >
-                <IconTag type="external-link" />
-                {t("MITRE CVE link")}
-              </a>
-              <br />
-              <a
-                target="_blank"
-                rel="noopener noreferrer"
-                href={
-                  "https://www.suse.com/security/cve/CVE-" + this.state.cveYear + "-" + this.state.cveNumber + ".html"
-                }
-                data-senna-off="true"
-              >
-                <IconTag type="external-link" />
-                {t("SUSE Security CVE link")}
-              </a>
-            </p>
-          </div>
-          <div>
             {ALL.map((status) => {
               return (
                 <div className="checkbox">
@@ -280,6 +252,33 @@ class CVEAudit extends React.Component<Props, State> {
               />
             </div>
           </p>
+          <div>
+            <p>
+              <a
+                target="_blank"
+                rel="noopener noreferrer"
+                href={
+                  "https://cve.mitre.org/cgi-bin/cvename.cgi?name=" + this.state.cveYear + "-" + this.state.cveNumber
+                }
+                data-senna-off="true"
+              >
+                <IconTag type="external-link" />
+                {t("MITRE CVE link")}
+              </a>
+              &nbsp;&nbsp;&nbsp;&nbsp;
+              <a
+                target="_blank"
+                rel="noopener noreferrer"
+                href={
+                  "https://www.suse.com/security/cve/CVE-" + this.state.cveYear + "-" + this.state.cveNumber + ".html"
+                }
+                data-senna-off="true"
+              >
+                <IconTag type="external-link" />
+                {t("SUSE Security CVE link")}
+              </a>
+            </p>
+          </div>
           <Table
             data={this.state.results}
             identifier={(row) => row.id}

--- a/web/html/src/manager/audit/cveaudit/cveaudit.tsx
+++ b/web/html/src/manager/audit/cveaudit/cveaudit.tsx
@@ -395,8 +395,7 @@ class CVEAudit extends React.Component<Props, State> {
               className="btn btn-link"
               target="_blank"
               rel="noopener noreferrer"
-              href={ "https://cve.mitre.org/cgi-bin/cvename.cgi?name=" + this.state.cveYear + "-" + this.state.cveNumber
-              }
+              href={"https://cve.mitre.org/cgi-bin/cvename.cgi?name=" + this.state.cveYear + "-" + this.state.cveNumber}
               data-senna-off="true"
             >
               <IconTag type="external-link" />

--- a/web/html/src/manager/audit/cveaudit/cveaudit.tsx
+++ b/web/html/src/manager/audit/cveaudit/cveaudit.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 
-import { IconTag } from "components/icontag";
 import SpaRenderer from "core/spa/spa-renderer";
 
 import { AsyncButton, LinkButton } from "components/buttons";
+import { IconTag } from "components/icontag";
 import { Messages } from "components/messages";
 import { TopPanel } from "components/panels/TopPanel";
 import { Column } from "components/table/Column";
@@ -379,32 +379,30 @@ class CVEAudit extends React.Component<Props, State> {
             />
           </Table>
           <p>
-            <a className="btn btn-link" target="_blank" rel="noopener noreferrer"
+            <a
+              className="btn btn-link"
+              target="_blank"
+              rel="noopener noreferrer"
               href={
-                "https://www.suse.com/security/cve/CVE-" +
-                this.state.cveYear  +
-                "-" + 
-                this.state.cveNumber +
-                ".html"
-              } 
+                "https://www.suse.com/security/cve/CVE-" + this.state.cveYear + "-" + this.state.cveNumber + ".html"
+              }
               data-senna-off="true"
             >
               <IconTag type="external-link" />
               {t("SUSE Security CVE link")}
             </a>
-            <a className="btn btn-link" target="_blank" rel="noopener noreferrer"
-              href={
-                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=" +
-                this.state.cveYear +
-                "-" +
-                this.state.cveNumber
-              } 
+            <a
+              className="btn btn-link"
+              target="_blank"
+              rel="noopener noreferrer"
+              href={ "https://cve.mitre.org/cgi-bin/cvename.cgi?name=" + this.state.cveYear + "-" + this.state.cveNumber
+              }
               data-senna-off="true"
             >
               <IconTag type="external-link" />
               {t("MITRE CVE link")}
             </a>
-          </p>      
+          </p>
           <a
             href={
               "/rhn/manager/api/audit/cve.csv?cveIdentifier=CVE-" +

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Provide link for CVEs
+
 -------------------------------------------------------------------
 Tue Feb 15 10:05:28 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Provide link for CVEs 

## GUI diff

Before:
![now](https://user-images.githubusercontent.com/4320859/153591593-72d19a48-4ef4-4fa5-a84e-24b1e3b6a474.png)

After:
![Screenshot from 2022-02-15 17-13-04](https://user-images.githubusercontent.com/4320859/154102410-cbff5f1c-adfe-437c-93ea-5ffa11f5cd3d.png)

The links are shown only after a research
- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests
- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/16651

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_pgsql_tests"  
- [x] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "susemanager_unittests" (Test skipped, there are no changes to test)
- [x] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests" (Test skipped, there are no changes to test)
