### PR TITLE
Cobbler fixes

### DIFF
--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -39,10 +39,18 @@ Feature: PXE boot a terminal with Cobbler
     And I enter "/usr/share/tftpboot-installation/SLE-15-SP2-x86_64/" as "basepath"
     And I select "SLE-Product-SLES15-SP2-Pool for x86_64" from "channelid"
     And I select "SUSE Linux Enterprise 15" from "installtype"
-    And I enter "useonlinerepo insecure=1" as "kernelopts"
     And I click on "Create Autoinstallable Distribution"
     Then I should see a "Autoinstallable Distributions" text
     And I should see a "SLE-15-SP2-TFTP" link
+
+  # WORKAROUND bsc#1195842
+  # Default cobbler kernel parameters are wrong in case of proxy
+  Scenario: Fix kernel parameters
+    When I follow the left menu "Systems > Autoinstallation > Distributions"
+    And I follow "SLE-15-SP2-TFTP"
+    And I enter "useonlinerepo insecure=1 install=http://proxy.example.org/ks/dist/SLE-15-SP2-TFTP self_update=http://proxy.example.org/ks/dist/child/sle15-sp2-installer-updates-x86_64/SLE-15-SP2-TFTP" as "kernelopts"
+    And I click on "Update Autoinstallable Distribution"
+    Then I should see a "Autoinstallable Distribution Updated" text
 
   Scenario: Create auto installation profile
     When I follow the left menu "Systems > Autoinstallation > Profiles"

--- a/testsuite/features/upload_files/example.ks
+++ b/testsuite/features/upload_files/example.ks
@@ -19,9 +19,9 @@ keyboard us
 mouse none
 skipx
 
-# TODO pre script for eth1 and other complications?
+# root password is 'linux'
 network --device eth0 --bootproto dhcp
-#rootpw --iscrypted $1$mumble
+rootpw --iscrypted $6$LdF0Ddaf5q/wqYk6$x04erFOijr7U82EB2GL24Ko4yWvyVo4S91bg9Yp08PLDcLBwmxwJpfKox1vlZ/faFED.dbfAe5ofgoJtHCkia.
 authconfig --enableshadow --enablemd5
 
 firewall --enabled --ssh


### PR DESCRIPTION
## What does this PR change?

Various cobbler fixes:
* change the default values for kernel parameters when PXE booting a minion via cobbler. It's a work around for https://bugzilla.suse.com/show_bug.cgi?id=1195842 .
* avoid an error message about the encryption of root password when rendering the example cobbler profile
  (this error message was never detected by test suite, btw)


## Links

Ports:
* 4.1: SUSE/spacewalk#16970 SUSE/spacewalk#16973
* 4.2: SUSE/spacewalk#16969


## Changelogs

- [x] No changelog needed
