### PR TITLE
QA: Add CentOS 7 migration test

### DIFF
--- a/testsuite/features/secondary/trad_centos_migrate_to_min.feature
+++ b/testsuite/features/secondary/trad_centos_migrate_to_min.feature
@@ -1,0 +1,59 @@
+# Copyright (c) 2022 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@scope_traditional_client
+@centos_minion
+Feature: Migrate a CentOS 7 traditional client into a Salt minion
+  As an authorized user
+  I want to migrate this CentOS 7 traditional client to a Salt minion
+
+  Scenario: Prepare the CentOS 7 traditional client in the migration context
+    Given I am authorized for the "Admin" section
+    When I enable repository "CentOS-Base" on this "ceos_client"
+    And I enable client tools repositories on "ceos_client"
+    And I refresh the packages list via package manager on "ceos_client"
+    And I install the traditional stack utils on "ceos_client"
+    And I install OpenSCAP dependencies on "ceos_client"
+    And I register "ceos_client" as traditional client
+    And I run "rhn-actions-control --enable-all" on "ceos_client"
+
+  Scenario: Wait until the traditional client appears
+    When I wait until onboarding is completed for "ceos_client"
+
+  Scenario: Check that the traditional client is really one
+    Given I am on the Systems overview page of this "ceos_client"
+    When I follow "Properties" in the content area
+    Then I wait until I see "Base System Type:.*Management" regex, refreshing the page
+
+  @proxy
+  Scenario: Check connection from CentOS 7 traditional to proxy in the migration context
+    Given I am on the Systems overview page of this "ceos_client"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see "proxy" short hostname
+
+  @proxy
+  Scenario: Check registration on proxy of traditional CentOS 7 in the migration context
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Details" in the content area
+    And I follow "Proxy" in the content area
+    Then I should see "ceos_client" hostname
+
+  Scenario: Migrate a CentOS client into a Salt minion in the migration context
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I enter the hostname of "ceos_minion" as "hostname"
+    And I enter "22" as "port"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I select the hostname of "proxy" from "proxies"
+    And I click on "Bootstrap"
+    And I wait until I see "Successfully bootstrapped host!" text
+    And I follow the left menu "Systems > Overview"
+    And I wait until I see the name of "ceos_minion", refreshing the page
+    And I wait until onboarding is completed for "ceos_minion"
+
+  Scenario: Check that the migrated system is now a Salt minion in the migration context
+    Given I am on the Systems overview page of this "ceos_client"
+    When I follow "Properties" in the content area
+    Then I wait until I see "Base System Type:.*Salt" regex, refreshing the page

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1422,12 +1422,10 @@ end
 
 When(/^I refresh the packages list via package manager on "([^"]*)"$/) do |host|
   node = get_target(host)
-  if host.include? 'ceos'
-    cmd_clean = "yum -y clean all"
-    cmd_cache = "yum -y makecache"
-  end
-  node.run(cmd_clean)
-  node.run(cmd_cache)
+  next unless host.include? 'ceos'
+    
+  node.run('yum -y clean all')
+  node.run('yum -y makecache')
 end
 
 Then(/^I wait until refresh package list on "(.*?)" is finished$/) do |client|

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1423,7 +1423,7 @@ end
 When(/^I refresh the packages list via package manager on "([^"]*)"$/) do |host|
   node = get_target(host)
   next unless host.include? 'ceos'
-    
+
   node.run('yum -y clean all')
   node.run('yum -y makecache')
 end

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1420,6 +1420,16 @@ When(/^I refresh packages list via spacecmd on "([^"]*)"$/) do |client|
   $server.run(command)
 end
 
+When(/^I refresh the packages list via package manager on "([^"]*)"$/) do |host|
+  node = get_target(host)
+  if host.include? 'ceos'
+    cmd_clean = "yum -y clean all"
+    cmd_cache = "yum -y makecache"
+  end
+  node.run(cmd_clean)
+  node.run(cmd_cache)
+end
+
 Then(/^I wait until refresh package list on "(.*?)" is finished$/) do |client|
   round_minute = 60 # spacecmd uses timestamps with precision to minutes only
   long_wait_delay = 600

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -28,6 +28,7 @@
 - features/secondary/min_centos_remote-command.feature
 - features/secondary/min_centos_ssh.feature
 - features/secondary/trad_centos_client.feature
+- features/secondary/trad_centos_migrate_to_min.feature.feature
 - features/secondary/min_ubuntu_openscap_audit.feature
 - features/secondary/min_ubuntu_remote-command.feature
 - features/secondary/min_ubuntu_ssh.feature


### PR DESCRIPTION
## What does this PR change? 

This will add a test for migrating a CentOS 7 traditional client to a Salt minion.


## GUI diff

No difference.


- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/6782
[Manager 4.2](https://github.com/SUSE/spacewalk/pull/17031)
[Manager 4.1](https://github.com/SUSE/spacewalk/pull/17032)

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
