### PR TITLE
change owner of jabberd certificate file

### DIFF
--- a/spacewalk/certs-tools/mgr_ssl_cert_setup.py
+++ b/spacewalk/certs-tools/mgr_ssl_cert_setup.py
@@ -440,14 +440,17 @@ def deployApache(workdir):
 
 
 def deployJabberd(workdir):
-    if os.path.exists(JABBER_CRT_FILE):
-        os.remove(JABBER_CRT_FILE)
-    if os.path.exists(os.path.join(workdir, JABBER_CRT_NAME)):
-        shutil.copy(os.path.join(workdir, JABBER_CRT_NAME), JABBER_CRT_FILE)
-        os.chmod(JABBER_CRT_FILE, int("0600", 8))
-    else:
-        log_error("Certificate for Jabberd not found")
-        sys.exit(1)
+    j_uid, j_gid = getUidGid("jabber", "jabber")
+    if j_uid and j_gid:
+        if os.path.exists(JABBER_CRT_FILE):
+            os.remove(JABBER_CRT_FILE)
+        if os.path.exists(os.path.join(workdir, JABBER_CRT_NAME)):
+            shutil.copy(os.path.join(workdir, JABBER_CRT_NAME), JABBER_CRT_FILE)
+            os.chmod(JABBER_CRT_FILE, int("0600", 8))
+            os.chown(JABBER_CRT_FILE, j_uid, j_gid)
+        else:
+            log_error("Certificate for Jabberd not found")
+            sys.exit(1)
 
 
 def deployPg(workdir):


### PR DESCRIPTION
## What does this PR change?

Jabberd uses the user "jabber". Change the owner of the certificate file to jabber.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
