### PR TITLE
QA: In order to test the feature that builds an image we need pxe_minion deployed

### DIFF
--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -10,6 +10,7 @@
 # which means "Enable Kiwi OS Image building"
 
 @buildhost
+@pxeboot_minion
 @scope_retail
 @scope_building_container_images
 Feature: Build OS images


### PR DESCRIPTION
## What does this PR change?

In order to test the feature that builds an image we need pxe_minion deployed.
Otherwise a scenario in that feature will fail, as there is no PXEBOOT_IMAGE variable set up, where it can check the image to use.

**WARNING**: 
It needs discussion and maybe a refactor. (Here my proposal https://github.com/uyuni-project/uyuni/pull/4836)
The method `compute_image_filename` (used in `I enter the image filename relative to profiles as "path"`) shouldn't require that we have or not a pxe_minion deployed in order to provide an image to use for the building procedure.

**Ideally, we should be able to test the building image process, without being strong coupled with the process of pxebooting an image built.**

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were improved

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
