### PR TITLE
QA: Refactor to don't require pxeboot_minion deployed to have a pxeboot_image defined

### DIFF
--- a/testsuite/features/step_definitions/retail_steps.rb
+++ b/testsuite/features/step_definitions/retail_steps.rb
@@ -28,7 +28,7 @@ end
 
 # determine image for PXE boot tests
 def compute_image_filename
-  case ENV['PXEBOOT_IMAGE']
+  case $pxeboot_image
   when 'sles15sp3', 'sles15sp3o'
     # 'Kiwi/POS_Image-JeOS7_42' for 4.2 branch
     $product == 'Uyuni' ? 'Kiwi/POS_Image-JeOS7_uyuni' : 'Kiwi/POS_Image-JeOS7_head'
@@ -46,7 +46,7 @@ def compute_image_filename
 end
 
 def compute_image_name
-  case ENV['PXEBOOT_IMAGE']
+  case $pxeboot_image
   when 'sles15sp3', 'sles15sp3o'
     # 'POS_Image_JeOS7_42' for 4.2 branch
     $product == 'Uyuni' ? 'POS_Image_JeOS7_uyuni' : 'POS_Image_JeOS7_head'

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -226,6 +226,7 @@ end
 # Other global variables
 $product = product
 $pxeboot_mac = ENV['PXEBOOT_MAC']
+$pxeboot_image = ENV['PXEBOOT_IMAGE'] || 'sles15sp3o'
 $sle11sp3_terminal_mac = ENV['SLE11SP3_TERMINAL_MAC']
 $sle12sp5_terminal_mac = ENV['SLE12SP5_TERMINAL_MAC']
 $sle15sp3_terminal_mac = ENV['SLE15SP3_TERMINAL_MAC']


### PR DESCRIPTION
## What does this PR change?

This is an alternative PR for https://github.com/uyuni-project/uyuni/pull/4835

In this PR we define a default value for PXEBOOT_IMAGE if it's not defined in the controller.
This variable is only defined in the controller if during the sumaform deployment we included a pxeboot_minion.

With that PR we allow to validate building image procedure, without the requirement of having a pxeboot_minion deployed.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were refactored

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
