### PR TITLE
Comment out faulty JS tests until fixed

### DIFF
--- a/web/html/src/utils/data-providers/paged-data-endpoint.test.ts
+++ b/web/html/src/utils/data-providers/paged-data-endpoint.test.ts
@@ -108,30 +108,33 @@ describe("paged data endpoint", () => {
     endpoint.doGet(mockCallback, pageControl);
   });
 
-  test("Cancelling obsolete requests", (done) => {
-    const endpoint = new PagedDataEndpoint(new URL(PATH, ORIGIN));
-    const pageControl = new PageControl(1, 10, "mypagequery", "mycolumn");
+  // TODO: Fix the test to work with nodejs17
+  // See: https://github.com/SUSE/spacewalk/issues/16912#issuecomment-1033692446
+  //
+  // test("Cancelling obsolete requests", (done) => {
+  //   const endpoint = new PagedDataEndpoint(new URL(PATH, ORIGIN));
+  //   const pageControl = new PageControl(1, 10, "mypagequery", "mycolumn");
 
-    // Mock the 'Network.get' method
-    const mockPendingPromise = new Promise(() => {});
-    const mockCancelCallback = jest.fn();
-    MockedNetwork.get.mockReturnValue(Utils.cancelable(mockPendingPromise, mockCancelCallback));
+  //   // Mock the 'Network.get' method
+  //   const mockPendingPromise = new Promise(() => {});
+  //   const mockCancelCallback = jest.fn();
+  //   MockedNetwork.get.mockReturnValue(Utils.cancelable(mockPendingPromise, mockCancelCallback));
 
-    // Suppress rejections in the mock callback
-    // The test is done when the cancelled promise rejection is catched
-    const mockCallback = jest.fn((promise) =>
-      promise.catch((reason) => {
-        expect(reason).toBe("The request is cancelled due to subsequent calls");
-        // Cancel callback should've been called exactly once
-        expect(mockCancelCallback).toBeCalledTimes(1);
-        done();
-      })
-    );
-    endpoint.doGet(mockCallback, pageControl);
+  //   // Suppress rejections in the mock callback
+  //   // The test is done when the cancelled promise rejection is catched
+  //   const mockCallback = jest.fn((promise) =>
+  //     promise.catch((reason) => {
+  //       expect(reason).toBe("The request is cancelled due to subsequent calls");
+  //       // Cancel callback should've been called exactly once
+  //       expect(mockCancelCallback).toBeCalledTimes(1);
+  //       done();
+  //     })
+  //   );
+  //   endpoint.doGet(mockCallback, pageControl);
 
-    const mockPromise = Promise.resolve();
-    MockedNetwork.get.mockReturnValue(Utils.cancelable(mockPromise));
-    // The subsequent call should cancel the first promise
-    endpoint.doGet(mockCallback, pageControl);
-  });
+  //   const mockPromise = Promise.resolve();
+  //   MockedNetwork.get.mockReturnValue(Utils.cancelable(mockPromise));
+  //   // The subsequent call should cancel the first promise
+  //   endpoint.doGet(mockCallback, pageControl);
+  // });
 });

--- a/web/html/src/utils/functions.test.ts
+++ b/web/html/src/utils/functions.test.ts
@@ -87,15 +87,18 @@ describe("cancelable", () => {
     expect(onCancel).toBeCalledTimes(0);
   });
 
-  test("cancelling works", async (done) => {
-    const onSuccess = jest.fn();
-    const onCancel = () => {
-      expect(onSuccess).toBeCalledTimes(0);
-      done();
-    };
-    const promise = new Promise(() => undefined).then(() => onSuccess());
+  // TODO: Fix the test to work with nodejs17
+  // See: https://github.com/SUSE/spacewalk/issues/16912#issuecomment-1033692446
+  //
+  // test("cancelling works", async (done) => {
+  //   const onSuccess = jest.fn();
+  //   const onCancel = () => {
+  //     expect(onSuccess).toBeCalledTimes(0);
+  //     done();
+  //   };
+  //   const promise = new Promise(() => undefined).then(() => onSuccess());
 
-    const instance = cancelable(promise, onCancel);
-    setTimeout(() => instance.cancel(), 100);
-  });
+  //   const instance = cancelable(promise, onCancel);
+  //   setTimeout(() => instance.cancel(), 100);
+  // });
 });


### PR DESCRIPTION
A couple of async JS tests fail on some node versions. This PR disables those tests until we have a fix for them.

See: https://github.com/SUSE/spacewalk/issues/16912

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
