### PR TITLE
Restore salt CNAME alias

### DIFF
--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -58,6 +58,7 @@ Feature: PXE boot a Retail terminal
     And I enter "tftp" in second CNAME alias field of example.org zone
     And I enter "proxy" in second CNAME name field of example.org zone
     And I press "Add Item" in CNAME section of example.org zone
+    And I enter "salt" in third CNAME alias field of example.org zone
     And I enter the hostname of "proxy" in third CNAME name field of example.org zone
 
 @pxeboot_minion


### PR DESCRIPTION
## What does this PR change?

This PR restores a line that was removed by accident during a refactoring.

The "salt" CNAME alias for the proxy was missing.


## Links

Ports:
* 4.1: SUSE/spacewalk#16992
* 4.2: SUSE/spacewalk#16993


## Changelogs

- [x] No changelog needed
