### PR TITLE
Various Retail fixes

### DIFF
--- a/testsuite/features/core/proxy_branch_network.feature
+++ b/testsuite/features/core/proxy_branch_network.feature
@@ -187,13 +187,33 @@ Feature: Setup Uyuni for Retail branch network
     When I follow "States" in the content area
     And I click on "Apply Highstate"
     And I wait until event "Apply highstate scheduled by admin" is completed
-    And I disable repositories after installing branch server
     Then service "dhcpd" is enabled on "proxy"
     And service "dhcpd" is active on "proxy"
     And service "named" is enabled on "proxy"
     And service "named" is active on "proxy"
     And service "firewalld" is enabled on "proxy"
     And service "firewalld" is active on "proxy"
+
+@proxy
+@private_net
+  Scenario: Disable repositories after installing branch services
+    When I disable repositories after installing branch server
+    # WORKAROUND: the following event fails because the proxy needs 10 minutes to become responsive again
+    # And I wait until event "Package List Refresh scheduled by (none)" is completed
+    And I wait for "700" seconds
+
+@proxy
+@private_net
+  Scenario: Let the server know about the new FQDN of the proxy
+    When I follow "Details" in the content area
+    And I follow "Hardware" in the content area
+    And I click on "Schedule Hardware Refresh"
+    Then I should see a "You have successfully scheduled a hardware profile refresh" text
+    When I wait until event "Hardware List Refresh scheduled by admin" is completed
+    # WORKAROUND: needs to be investigated with Salt team
+    # And I follow "Details" in the content area
+    # And I follow "Hardware" in the content area
+    # Then I should see a "proxy.example.org" text
 
 @proxy
 @private_net

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -59,7 +59,9 @@ Feature: PXE boot a Retail terminal
     And I enter "proxy" in second CNAME name field of example.org zone
     And I press "Add Item" in CNAME section of example.org zone
     And I enter "salt" in third CNAME alias field of example.org zone
-    And I enter the hostname of "proxy" in third CNAME name field of example.org zone
+    And I enter "proxy" in third CNAME name field of example.org zone
+    And I click on "Save Formula"
+    Then I should see a "Formula saved" text
 
 @pxeboot_minion
   Scenario: Configure PXE part of DHCP on the branch server
@@ -137,6 +139,10 @@ Feature: PXE boot a Retail terminal
     And I enter "All branch servers" as "description"
     And I click on "Create Group"
     Then I should see a "System group SERVERS created." text
+    When I follow "Target Systems"
+    And I check the "proxy" client
+    And I click on "Add Systems"
+    Then I should see a "1 systems were added to SERVERS server group." text
 
   Scenario: Enable Saltboot formula for hardware type group
     When I follow the left menu "Systems > System Groups"

--- a/testsuite/features/step_definitions/retail_steps.rb
+++ b/testsuite/features/step_definitions/retail_steps.rb
@@ -425,11 +425,6 @@ When(/^I enter "([^"]*)" in (.*) field of (.*) zone$/) do |value, field, zone|
   find(:xpath, "#{zone_xpath}//input[contains(@id, '#{fieldids[field]}')]").set(value)
 end
 
-When(/^I enter the hostname of "([^"]*)" in (.*) field of (.*) zone$/) do |host, field, zone|
-  system_name = get_system_name(host)
-  step %(I enter "#{system_name}." in #{field} field of #{zone} zone)
-end
-
 When(/^I enter the IP address of "([^"]*)" in (.*) field of (.*) zone$/) do |host, field, zone|
   node = get_target(host)
   step %(I enter "#{node.public_ip}" in #{field} field of #{zone} zone)


### PR DESCRIPTION
## What does this PR change?

This PR:
* works around a problem with initial events on the branch server that has always been swept under the rug (and that would need real Salt debugging someday)
* does a "Hardware Refresh" on the proxy, so `proxy.example.org` is in SUSE Manager's database, and the pxeboot minion is seen behind the proxy
* avoids using a FQDN for the proxy (see technical details below)
* adds the proxy to the SERVERS group, so command-line tools like `retail_yaml` work


## Technical details

In Retail, don't do
```
    salt         CNAME   <fqdn of proxy>
```
as this will be replaced by
```
    salt         CNAME    my-proxy.tf.local
```
if you use avahi, and we removed avahi support.

Instead, just use:
```
    salt         CNAME    proxy
```

Using the FQDN was needed because it's the one that was in the SSL certificate. But now we have an alias for `proxy.example.org` in that certificate.


## Links

Ports:
* 4.1: SUSE/spacewalk#16994 SUSE/spacewalk#17002
* 4.2: SUSE/spacewalk#16995


## Changelogs

- [x] No changelog needed
