### PR TITLE
Fix NPE when accessing cancelled action via system history

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemHistoryEventAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemHistoryEventAction.java
@@ -72,9 +72,17 @@ public class SystemHistoryEventAction extends RhnAction {
         try {
             action = ActionManager.lookupAction(requestContext.getCurrentUser(), aid);
             serverAction = ActionFactory.getServerActionForServerAndAction(server, action);
+            if (serverAction == null) {
+                throw new LookupException("Could not find server action with id: " + action.getId());
+            }
         }
         catch (LookupException e) {
             ServerHistoryEvent event = ActionFactory.lookupHistoryEventById(aid);
+            // If there was no event found we assume the action details are no longer present
+            // and we forward to the system history
+            if (event == null) {
+                return mapping.findForward("continue");
+            }
             request.setAttribute("actionname", event.getSummary());
             request.setAttribute("actiontype", event.getSummary());
             request.setAttribute("earliestaction", event.getCreated());

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix NPE when accessing cancelled action via system history (bsc#1195762)
 - CVE Audit: Show patch as available in the currently installed product even if successor
   patch affects additional packages (bsc#1196455)
 - Added the server location information to reporting database


### PR DESCRIPTION
## What does this PR change?

Fix a NPE that occurs when navigating to the details of an action that is no longer present in the system history (e.g. because it got cancelled).

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- No tests: bugfix

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/16959

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
