### PR TITLE
cleanup server architecture detection and improve error handling

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -38,6 +38,7 @@ import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerArch;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.domain.server.ServerHistoryEvent;
@@ -473,17 +474,15 @@ public class RegisterMinionEventMessageAction implements MessageAction {
             minion.setContactMethod(getContactMethod(activationKey, isSaltSSH, minionId));
             minion.setHostname(grains.getOptionalAsString(FQDN).orElse(null));
 
-            minion.setServerArch(
-                    ServerFactory.lookupServerArchByLabel(osarch + "-redhat-linux"));
-            //ToDo Just a hacked version for ubuntu
-            if (osfamily.equals("Debian")) {
-                minion.setServerArch(
-                        ServerFactory.lookupServerArchByLabel(osarch + "-debian-linux"));
+            String serverArch = String.format("%s-%s", osarch,
+                    osfamily.equals("Debian") ? "debian-linux" : "redhat-linux");
+            ServerArch arch = ServerFactory.lookupServerArchByLabel(serverArch);
+            if (arch == null) {
+                LOG.error(String.format("Unable to find the server architecture for " +
+                        "osfamily: '%s' and osarch: '%s'", osfamily, osarch));
+                throw new IllegalArgumentException("Unable to get the server architecture");
             }
-            else {
-                minion.setServerArch(
-                        ServerFactory.lookupServerArchByLabel(osarch + "-redhat-linux"));
-            }
+            minion.setServerArch(arch);
 
             RegistrationUtils.subscribeMinionToChannels(systemQuery, minion, grains, activationKey,
                     activationKeyLabel);


### PR DESCRIPTION
## What does this PR change?

Check if the server architecture could be found.
Throw an exception and log an error if it could not be found.
Cleanup the code and remove duplicate setting of the architecture

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
