### PR TITLE
QA: Clear a field before fill in with text

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -223,22 +223,22 @@ end
 #
 # Enter a text into a textfield
 #
-When(/^I enter "([^"]*)" as "([^"]*)"$/) do |arg1, arg2|
-  fill_in arg2, with: arg1
+When(/^I enter "([^"]*)" as "([^"]*)"$/) do |text, field|
+  fill_in(field, with: text, fill_options: { clear: :backspace })
 end
 
 When(/^I enter "([^"]*)" as "([^"]*)" text area$/) do |arg1, arg2|
   execute_script("document.getElementsByName('#{arg2}')[0].value = '#{arg1}'")
 end
 
-When(/^I enter "(.*?)" as "(.*?)" in the content area$/) do |arg1, arg2|
+When(/^I enter "(.*?)" as "(.*?)" in the content area$/) do |text, field|
   within(:xpath, '//section') do
-    fill_in arg2, with: arg1
+    fill_in(field, with: text, fill_options: { clear: :backspace })
   end
 end
 
-When(/^I enter the URI of the registry as "([^"]*)"$/) do |arg1|
-  fill_in arg1, with: $no_auth_registry
+When(/^I enter the URI of the registry as "([^"]*)"$/) do |field|
+  fill_in(field, with: $no_auth_registry, fill_options: { clear: :backspace })
 end
 
 # Go back in the browser history
@@ -500,8 +500,8 @@ Given(/^I am authorized as "([^"]*)" with password "([^"]*)"$/) do |user, passwd
 
   find(:xpath, "//header//i[@class='fa fa-sign-out']").click if all(:xpath, "//header//i[@class='fa fa-sign-out']").any?
 
-  fill_in 'username', with: user
-  fill_in 'password', with: passwd
+  fill_in('username', with: user)
+  fill_in('password', with: passwd)
   click_button_and_wait('Sign In', match: :first)
 
   step %(I should be logged in)

--- a/testsuite/features/step_definitions/retail_steps.rb
+++ b/testsuite/features/step_definitions/retail_steps.rb
@@ -343,7 +343,7 @@ When(/^I enter the local IP address of "([^"]*)" in (.*) field$/) do |host, fiel
     'internal network address'        => 'tftpd#listen_ip',
     'vsftpd internal network address' => 'vsftpd_config#listen_address'
   }
-  fill_in fieldids[field], with: net_prefix + ADDRESSES[host]
+  fill_in(fieldids[field], with: net_prefix + ADDRESSES[host], fill_options: { clear: :backspace })
 end
 
 When(/^I enter "([^"]*)" in (.*) field$/) do |value, field|
@@ -394,7 +394,7 @@ When(/^I enter "([^"]*)" in (.*) field$/) do |value, field|
     'third partition password'     => 'partitioning#0#partitions#2#luks_pass',
     'FTP server directory'         => 'vsftpd_config#anon_root'
   }
-  fill_in fieldids[field], with: value
+  fill_in(fieldids[field], with: value, fill_options: { clear: :backspace })
 end
 
 When(/^I enter "([^"]*)" in (.*) field of (.*) zone$/) do |value, field, zone|
@@ -446,8 +446,7 @@ When(/^I enter the MAC address of "([^"]*)" in (.*) field$/) do |host, field|
     output, _code = node.run('ip link show dev eth1')
     mac = output.split("\n")[1].split[1]
   end
-
-  fill_in FIELD_IDS[field], with: 'ethernet ' + mac
+  fill_in(FIELD_IDS[field], with: 'ethernet ' + mac, fill_options: { clear: :backspace })
 end
 
 When(/^I enter the local zone name in (.*) field$/) do |field|
@@ -473,7 +472,7 @@ end
 
 When(/^I enter the image name in (.*) field$/) do |field|
   name = compute_image_name
-  fill_in FIELD_IDS[field], with: name
+  fill_in(FIELD_IDS[field], with: name, fill_options: { clear: :backspace })
 end
 
 When(/^I press "Add Item" in (.*) section$/) do |section|

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -199,11 +199,11 @@ When(/^I expand the results for "([^"]*)"$/) do |host|
 end
 
 When(/^I enter command "([^"]*)"$/) do |cmd|
-  fill_in 'command', with: cmd
+  fill_in('command', with: cmd, fill_options: { clear: :backspace })
 end
 
 When(/^I enter target "([^"]*)"$/) do |minion|
-  fill_in 'target', with: minion
+  fill_in('target', with: minion, fill_options: { clear: :backspace })
 end
 
 Then(/^I should see "([^"]*)" in the command output for "([^"]*)"$/) do |text, host|


### PR DESCRIPTION
## What does this PR change?

Clear a field before fill in with text.

Capybara `fill_in` method has a default behaviour which triggers native.clear, but for some UI frameworks this will not be enough. Adding the optional parameter `clear: :backspace` it will send backspaces to the field to clean it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were improved

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
