### PR TITLE
Add pg migration script from version 13 to 14

### DIFF
--- a/susemanager/bin/pg-migrate-13-to-14.sh
+++ b/susemanager/bin/pg-migrate-13-to-14.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+NEW_VERSION=14
+OLD_VERSION=13
+
+FAST_UPGRADE=""
+
+if [ $# -gt 1 ]; then
+    echo "`date +"%H:%M:%S"`   Usage: '$0' or '$0 fast'"
+    exit 1
+fi
+
+if [ $# == 1 ]; then
+    if [ $1 == "fast" ]; then
+        FAST_UPGRADE="-f"
+    else
+        echo "`date +"%H:%M:%S"`   Unknown option '$1'"
+        echo "`date +"%H:%M:%S"`   Usage: '$0' or '$0 fast'"
+        exit 1
+    fi
+fi
+
+$(dirname $0)/pg-migrate-x-to-y.sh -s $OLD_VERSION -d $NEW_VERSION $FAST_UPGRADE

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+* Add pg-migrate-13-to-14.sh script
+
 -------------------------------------------------------------------
 Tue Feb 15 10:05:55 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Add pg  migration script from version 13 to 14.
This script is a wrapper to pg-migrate-x-to-y.sh but it is convenient.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests
- [X] **DONE**

## Links

Partial fix for https://github.com/SUSE/spacewalk/issues/16348

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
