### PR TITLE
Scc forward last seen

### DIFF
--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -212,6 +212,7 @@ public class ConfigDefaults {
     public static final String SCC_URL = "server.susemanager.scc_url";
     public static final String FORWARD_REGISTRATION = "server.susemanager.forward_registration";
     public static final String REG_ERROR_EXPIRE_TIME = "server.susemanager.reg_error_expire_time";
+    public static final String REG_BATCH_SIZE = "server.susemanager.reg_batch_size";
     public static final String SCC_BACKUP_SRV_USR = "server.susemanager.scc_backup_srv_usr";
     public static final String PRODUCT_TREE_TAG = "java.product_tree_tag";
 

--- a/java/code/src/com/redhat/rhn/domain/scc/SCCCachingFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/scc/SCCCachingFactory.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -563,6 +564,33 @@ public class SCCCachingFactory extends HibernateFactory {
         return getSession().getNamedQuery("SCCRegCache.listRegItemsByCredentials")
                 .setParameter("creds", cred)
                 .getResultList();
+    }
+
+    /**
+     * Return list of data for last seen SCC update call
+     * @param cred SCC Org Crednetials
+     * @return a list of maps with the keys scc_login, scc_passwd, checkin
+     */
+    @SuppressWarnings("unchecked")
+    public static List<Map<String, Object>> listUpdateLastSeenCandidates(Credentials cred) {
+        List<Map<String, Object>> result = new ArrayList<Map<String, Object>>();
+        List<Object[]> rows = getSession().createQuery(
+                "SELECT reg.sccLogin, reg.sccPasswd, si.checkin " +
+                "FROM com.redhat.rhn.domain.scc.SCCRegCacheItem AS reg " +
+                "JOIN reg.server AS s " +
+                "JOIN s.serverInfo AS si " +
+                "WHERE reg.registrationErrorTime IS NULL " +
+                "AND reg.credentials = :cred")
+                .setParameter("cred", cred)
+                .list();
+        for (Object[] row : rows) {
+            Map<String, Object> entry = new HashMap<>();
+            entry.put("scc_login", row[0].toString());
+            entry.put("scc_passwd", row[1].toString());
+            entry.put("checkin", row[2]);
+            result.add(entry);
+        }
+        return result;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ForwardRegistrationTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ForwardRegistrationTask.java
@@ -32,11 +32,16 @@ import org.quartz.JobExecutionException;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 
 public class ForwardRegistrationTask extends RhnJavaJob {
+
+    // initialize first run between 30 minutes and 3 hours from now
+    private static LocalDateTime nextLastSeenUpdateRun = LocalDateTime.now().plusMinutes(
+            ThreadLocalRandom.current().nextInt(30, 3 * 60));
 
     @Override
     public String getConfigNamespace() {
@@ -51,6 +56,7 @@ public class ForwardRegistrationTask extends RhnJavaJob {
         }
         try {
             if (Config.get().getString(ContentSyncManager.RESOURCE_PATH) == null) {
+
                 int waitTime = ThreadLocalRandom.current().nextInt(0, 15 * 60);
                 if (log.isDebugEnabled()) {
                     // no waiting when debug is on
@@ -78,6 +84,12 @@ public class ForwardRegistrationTask extends RhnJavaJob {
                     .filter(Credentials::isPrimarySCCCredential)
                     .findFirst()
                     .ifPresent(primaryCredentials -> sccRegManager.register(forwardRegistration, primaryCredentials));
+                if (LocalDateTime.now().isAfter(nextLastSeenUpdateRun)) {
+                    sccRegManager.updateLastSeen();
+                    // next run in 22 - 26 hours
+                    nextLastSeenUpdateRun = nextLastSeenUpdateRun.plusMinutes(
+                            ThreadLocalRandom.current().nextInt(22 * 60, 26 * 60));
+                }
             }
         }
         catch (URISyntaxException e) {

--- a/java/code/src/com/suse/scc/SCCSystemRegistrationManager.java
+++ b/java/code/src/com/suse/scc/SCCSystemRegistrationManager.java
@@ -16,7 +16,10 @@ package com.suse.scc;
 
 import static java.util.Optional.ofNullable;
 
+import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.credentials.Credentials;
+import com.redhat.rhn.domain.credentials.CredentialsFactory;
 import com.redhat.rhn.domain.product.SUSEProduct;
 import com.redhat.rhn.domain.scc.SCCCachingFactory;
 import com.redhat.rhn.domain.scc.SCCRegCacheItem;
@@ -30,11 +33,13 @@ import com.suse.scc.client.SCCClientException;
 import com.suse.scc.model.SCCMinProductJson;
 import com.suse.scc.model.SCCRegisterSystemJson;
 import com.suse.scc.model.SCCSystemCredentialsJson;
+import com.suse.scc.model.SCCUpdateSystemJson;
 import com.suse.utils.Opt;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -43,6 +48,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class SCCSystemRegistrationManager {
 
@@ -56,6 +62,41 @@ public class SCCSystemRegistrationManager {
      */
     public SCCSystemRegistrationManager(SCCClient sccClientIn) {
         this.sccClient = sccClientIn;
+    }
+
+    /**
+     * Update last_seen field in SCC for all registered clients
+     */
+    public void updateLastSeen() {
+        List<Credentials> credentials = CredentialsFactory.lookupSCCCredentials();
+        Credentials primCred = credentials.stream()
+                .filter(c -> c.isPrimarySCCCredential())
+                .findFirst().orElseThrow();
+        List<Map<String, Object>> candidates = SCCCachingFactory.listUpdateLastSeenCandidates(primCred);
+
+        List<SCCUpdateSystemJson> sysList = candidates.stream()
+                .map(c -> new SCCUpdateSystemJson(
+                        c.get("scc_login").toString(),
+                        c.get("scc_passwd").toString(),
+                        (Date) c.get("checkin")))
+                .collect(Collectors.toList());
+
+        ArrayList<List<SCCUpdateSystemJson>> batches = new ArrayList<>(
+                IntStream.range(0, sysList.size()).boxed().collect(
+                        Collectors.groupingBy(e -> e / Config.get().getInt(ConfigDefaults.REG_BATCH_SIZE, 199),
+                                Collectors.mapping(e->sysList.get(e), Collectors.toList())
+                                )).values());
+        for (List<SCCUpdateSystemJson> batch: batches) {
+            try {
+                sccClient.updateBulkLastSeen(batch, primCred.getUsername(), primCred.getPassword());
+            }
+            catch (SCCClientException e) {
+                LOG.error("SCC error while updating systems", e);
+            }
+            catch (Exception e) {
+                LOG.error("Error updating systems", e);
+            }
+        }
     }
 
     /**

--- a/java/code/src/com/suse/scc/SCCSystemRegistrationManager.java
+++ b/java/code/src/com/suse/scc/SCCSystemRegistrationManager.java
@@ -207,6 +207,7 @@ public class SCCSystemRegistrationManager {
             return pw;
         });
 
-        return new SCCRegisterSystemJson(login, passwd, srv.getHostname(), hwinfo, products);
+        return new SCCRegisterSystemJson(login, passwd, srv.getHostname(), hwinfo, products,
+                srv.getServerInfo().getCheckin());
     }
 }

--- a/java/code/src/com/suse/scc/SCCSystemRegistrationManager.java
+++ b/java/code/src/com/suse/scc/SCCSystemRegistrationManager.java
@@ -83,7 +83,7 @@ public class SCCSystemRegistrationManager {
 
         ArrayList<List<SCCUpdateSystemJson>> batches = new ArrayList<>(
                 IntStream.range(0, sysList.size()).boxed().collect(
-                        Collectors.groupingBy(e -> e / Config.get().getInt(ConfigDefaults.REG_BATCH_SIZE, 199),
+                        Collectors.groupingBy(e -> e / Config.get().getInt(ConfigDefaults.REG_BATCH_SIZE, 200),
                                 Collectors.mapping(e->sysList.get(e), Collectors.toList())
                                 )).values());
         for (List<SCCUpdateSystemJson> batch: batches) {

--- a/java/code/src/com/suse/scc/client/SCCClient.java
+++ b/java/code/src/com/suse/scc/client/SCCClient.java
@@ -22,6 +22,7 @@ import com.suse.scc.model.SCCRegisterSystemJson;
 import com.suse.scc.model.SCCRepositoryJson;
 import com.suse.scc.model.SCCSubscriptionJson;
 import com.suse.scc.model.SCCSystemCredentialsJson;
+import com.suse.scc.model.SCCUpdateSystemJson;
 
 import java.util.List;
 
@@ -87,6 +88,16 @@ public interface SCCClient {
      * @throws SCCClientException
      */
     SCCSystemCredentialsJson createSystem(SCCRegisterSystemJson system, String username, String password)
+            throws SCCClientException;
+
+    /**
+     * Update multiple clients in SCC
+     * @param systems system data to update
+     * @param username the username
+     * @param password the password
+     * @throws SCCClientException
+     */
+    void updateBulkLastSeen(List<SCCUpdateSystemJson> systems, String username, String password)
             throws SCCClientException;
 
     /**

--- a/java/code/src/com/suse/scc/client/SCCFileClient.java
+++ b/java/code/src/com/suse/scc/client/SCCFileClient.java
@@ -23,6 +23,7 @@ import com.suse.scc.model.SCCRegisterSystemJson;
 import com.suse.scc.model.SCCRepositoryJson;
 import com.suse.scc.model.SCCSubscriptionJson;
 import com.suse.scc.model.SCCSystemCredentialsJson;
+import com.suse.scc.model.SCCUpdateSystemJson;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -103,6 +104,11 @@ public class SCCFileClient implements SCCClient {
     public SCCSystemCredentialsJson createSystem(SCCRegisterSystemJson system, String username, String password)
             throws SCCClientException {
         return null;
+    }
+
+    @Override
+    public void updateBulkLastSeen(List<SCCUpdateSystemJson> systems, String username, String password)
+            throws SCCClientException {
     }
 
     @Override

--- a/java/code/src/com/suse/scc/model/SCCRegisterSystemJson.java
+++ b/java/code/src/com/suse/scc/model/SCCRegisterSystemJson.java
@@ -14,6 +14,9 @@
  */
 package com.suse.scc.model;
 
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +32,8 @@ public class SCCRegisterSystemJson {
     private Map<String, String> hwinfo;
     private List<SCCMinProductJson> products;
     private List<String> regcodes = new LinkedList<>();
+    @SerializedName("last_seen_at")
+    private Date lastSeenAt;
 
     /**
      * Constructor
@@ -37,14 +42,16 @@ public class SCCRegisterSystemJson {
      * @param hostnameIn the hostname
      * @param hwinfoIn the hardware data
      * @param productsIn the products
+     * @param lastSeenIn the last seen date
      */
     public SCCRegisterSystemJson(String loginIn, String passwdIn, String hostnameIn,
-            Map<String, String> hwinfoIn, List<SCCMinProductJson> productsIn) {
+            Map<String, String> hwinfoIn, List<SCCMinProductJson> productsIn, Date lastSeenIn) {
         login = loginIn;
         password = passwdIn;
         hostname = hostnameIn;
         hwinfo = hwinfoIn;
         products = productsIn;
+        lastSeenAt = lastSeenIn;
     }
 
     /**
@@ -87,5 +94,11 @@ public class SCCRegisterSystemJson {
      */
     public List<String> getRegcodes() {
         return regcodes;
+    }
+    /**
+     * @return Returns the last seen date.
+     */
+    public Date getLastSeenAt() {
+        return lastSeenAt;
     }
 }

--- a/java/code/src/com/suse/scc/model/SCCUpdateSystemJson.java
+++ b/java/code/src/com/suse/scc/model/SCCUpdateSystemJson.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.scc.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Date;
+
+/**
+ * This is a System Item send to SCC for minimal update registration.
+ */
+public class SCCUpdateSystemJson {
+
+    private String login;
+    private String password;
+    @SerializedName("last_seen_at")
+    private Date lastSeenAt;
+
+    /**
+     * Constructor
+     * @param loginIn the login
+     * @param passwdIn the password
+     * @param lastSeenIn last seen date
+     */
+    public SCCUpdateSystemJson(String loginIn, String passwdIn, Date lastSeenIn) {
+        login = loginIn;
+        password = passwdIn;
+        lastSeenAt = lastSeenIn;
+    }
+
+    /**
+     * @return Returns the login.
+     */
+    public String getLogin() {
+        return login;
+    }
+
+    /**
+     * @return Returns the password.
+     */
+    public String getPassword() {
+        return password;
+    }
+
+    /**
+     * @return Returns lastSeenAt.
+     */
+    public Date getLastSeenAt() {
+        return lastSeenAt;
+    }
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- enhance SCC data with checkin time and submit the checkin times
+  for all clients, that they can be seen in SCC
 - generate the system ssh key when bootstrapping a salt-ssh client
   (bsc#1194909)
 - Fix disappearing metadata key files after channel change (bsc#1192822)

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,5 +1,4 @@
-- enhance SCC data with checkin time and submit the checkin times
-  for all clients, that they can be seen in SCC
+- allow SCC to display the last check-in time for registered systems
 - generate the system ssh key when bootstrapping a salt-ssh client
   (bsc#1194909)
 - Fix disappearing metadata key files after channel change (bsc#1192822)

--- a/susemanager/rhn-conf/rhn_server_susemanager.conf
+++ b/susemanager/rhn-conf/rhn_server_susemanager.conf
@@ -7,6 +7,9 @@ forward_registration = 1
 # hours until a failed registration will be send to SCC again
 reg_error_expire_time = 168
 
+# number of items which can be send to SCC in one call
+reg_batch_size = 200
+
 # load data from a directory and not from SCC
 fromdir =
 

--- a/susemanager/rhn-conf/rhn_server_susemanager.conf
+++ b/susemanager/rhn-conf/rhn_server_susemanager.conf
@@ -7,7 +7,7 @@ forward_registration = 1
 # hours until a failed registration will be send to SCC again
 reg_error_expire_time = 168
 
-# number of items which can be send to SCC in one call
+# number of systems which can be sent to SCC in batch as part of one call
 reg_batch_size = 200
 
 # load data from a directory and not from SCC

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- set default for registration batch size
   * Added gettext build requirement for RHEL.
   * Reuse existing certificate code.
 


### PR DESCRIPTION
## What does this PR change?

Send checkin time as "last_seen_at" to SCC.
Update all systems in SCC with this value in the first run after midnight.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

See https://github.com/SUSE/spacewalk/issues/16312
Tracks

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
