### PR TITLE
Revert "query elaborator when listing packages to install"

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
@@ -805,8 +805,10 @@ SELECT P.id, P.summary, PP.name as provider
 <mode name="system_available_packages"  class="com.redhat.rhn.frontend.dto.PackageListItem">
   <query params="sid">
     SELECT
-      DISTINCT rp.id AS id,
-      UPPER(pn.name) AS name
+      rp.id AS package_id,
+      pn.name || '-' || evr_t_as_vre_simple(latest.evr) AS NVRE,
+      latest.arch_label as arch,
+      pn.id || '|' || rp.evr_id || '|' || latest.arch_id AS ID_COMBO
     FROM
       (
             SELECT
@@ -843,19 +845,7 @@ SELECT P.id, P.summary, PP.name as provider
         )
         AND rsc.server_id = :sid
     ORDER BY UPPER(pn.name)
-
   </query>
-    <elaborator multiple="t" >
-        select p.id AS id, p.id AS package_id,
-        pn.name || '-' || evr_t_as_vre_simple(pe.evr) AS NVRE,
-        pa.label as arch,
-        pn.id || '|' || p.evr_id || '|' || p.package_arch_id AS ID_COMBO
-        from rhnpackage p
-        join rhnpackagename pn on p.name_id = pn.id
-        join rhnpackageevr pe on p.evr_id = pe.id
-        JOIN rhnPackageArch pa ON p.package_arch_id = pa.id
-        where p.id in (%s)
-    </elaborator>
 </mode>
 
 <mode name="system_set_locked_packages"  class="com.redhat.rhn.frontend.dto.PackageListItem">
@@ -899,7 +889,7 @@ SELECT p.package_id,
        p.name_id,
        p.evr_id,
        p.arch,
-       l.pending
+       l.pending 
   FROM rhnlockedpackages l
   LEFT JOIN (
 SELECT pkg.id AS package_id,

--- a/java/code/src/com/redhat/rhn/manager/rhnpackage/test/PackageManagerRetractedTest.java
+++ b/java/code/src/com/redhat/rhn/manager/rhnpackage/test/PackageManagerRetractedTest.java
@@ -139,14 +139,14 @@ public class PackageManagerRetractedTest extends BaseTestCaseWithUser {
         // the newest installable package should be the "newerPkg", since the "newestPkg" is retracted
         SystemManager.subscribeServerToChannel(user, server, channel);
         PackageListItem pkg = assertSingleAndGet(PackageManager.systemAvailablePackages(server.getId(), null));
-        assertEquals(newerPkg.getId(), pkg.getId());
+        assertEquals(newerPkg.getId(), pkg.getPackageId());
 
         // now subscribe to the clone, where the patch is not retracted
         // the newest package should be "newestPkg" now
         SystemManager.unsubscribeServerFromChannel(server, channel);
         SystemManager.subscribeServerToChannel(user, server, clonedChannel);
         pkg = assertSingleAndGet(PackageManager.systemAvailablePackages(server.getId(), null));
-        assertEquals(newestPkg.getId(), pkg.getId());
+        assertEquals(newestPkg.getId(), pkg.getPackageId());
     }
 
     public void testListPackagesInChannelForList() throws Exception {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,6 @@
+- Revert: Improvements on list packages query processing
+  by using query elaborator (bsc#1187333)
+
 -------------------------------------------------------------------
 Tue Feb 15 10:03:14 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
This reverts commit 89daf8a80be7eccc6c7992cb2537d70609da5401.

## What does this PR change?

Reverts commit: https://github.com/uyuni-project/uyuni/pull/4804
It causes problems in search feature for install package

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
