### PR TITLE
Supportconfig spacewalk-debug: report task schedule values

### DIFF
--- a/backend/satellite_tools/spacewalk-debug
+++ b/backend/satellite_tools/spacewalk-debug
@@ -450,6 +450,29 @@ if [ "$MAX_LOG_AGE" -eq "$MAX_LOG_AGE" 2>/dev/null ]; then
         done
 fi
 
+# task schedules
+if [ -f /usr/bin/spacewalk-sql ] ; then
+    # Extract task schedules from the database - only the default ones
+    TASK_SCHEDULE_DEFAULT_SQL="""
+        SELECT id, job_label, bunch_id, org_id,
+          active_from, active_till, cron_expr,
+          data, created, modified
+        FROM rhntaskoschedule
+        WHERE cron_expr is not null or job_label like '%default';
+    """
+    echo $TASK_SCHEDULE_DEFAULT_SQL | /usr/bin/spacewalk-sql --select-mode - > $DIR/tasko/task_schedule_default
+
+    # Extract task schedules from the database - only the modified ones
+    TASK_SCHEDULE_MODIFIED_SQL="""
+        SELECT id, job_label, bunch_id, org_id,
+          active_from, active_till, cron_expr,
+          data, created, modified
+        FROM rhntaskoschedule
+        WHERE created <> modified;
+    """
+    echo $TASK_SCHEDULE_MODIFIED_SQL | /usr/bin/spacewalk-sql --select-mode - > $DIR/tasko/task_schedule_modified
+fi
+
 # exclude private keys
 find $DIR -name "*PRIVATE*" -delete
 find $DIR -name "server.key*" -delete
@@ -474,3 +497,4 @@ else
   rm -Rf echo $DIR
   echo "Debug dump created, stored in $TARBALL"
 fi
+

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+  * supportconfig spacewalk-debug: extract task schedule data from db
   * Define report_db_sslroot default during package build.
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Additional information reported by the `spacewalk-debug` plugin: task schedules `defaults` and `modified`.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: it's about supportconfig grasping values
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: it's about supportconfig

- [x] **DONE**

## Links

Inspired by bsc#1187789

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
