### PR TITLE
Don't use lscpu -J in grains

### DIFF
--- a/susemanager-utils/susemanager-sls/src/tests/data/lscpu-json.aarch64.sample
+++ b/susemanager-utils/susemanager-sls/src/tests/data/lscpu-json.aarch64.sample
@@ -1,22 +1,18 @@
-{
-   "lscpu": [
-      {"field":"Architecture:", "data":"aarch64"},
-      {"field":"Byte Order:", "data":"Little Endian"},
-      {"field":"CPU(s):", "data":"64"},
-      {"field":"On-line CPU(s) list:", "data":"0-63"},
-      {"field":"Thread(s) per core:", "data":"1"},
-      {"field":"Core(s) per socket:", "data":"4"},
-      {"field":"Socket(s):", "data":"16"},
-      {"field":"NUMA node(s):", "data":"4"},
-      {"field":"Vendor ID:", "data":"ARM"},
-      {"field":"Model:", "data":"2"},
-      {"field":"Model name:", "data":"Cortex-A72"},
-      {"field":"Stepping:", "data":"r0p2"},
-      {"field":"BogoMIPS:", "data":"100.00"},
-      {"field":"NUMA node0 CPU(s):", "data":"0-15"},
-      {"field":"NUMA node1 CPU(s):", "data":"16-31"},
-      {"field":"NUMA node2 CPU(s):", "data":"32-47"},
-      {"field":"NUMA node3 CPU(s):", "data":"48-63"},
-      {"field":"Flags:", "data":"fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid"}
-   ]
-}
+Architecture:        aarch64
+Byte Order:          Little Endian
+CPU(s):              64
+On-line CPU(s) list: 0-63
+Thread(s) per core:  1
+Core(s) per socket:  4
+Socket(s):           16
+NUMA node(s):        4
+Vendor ID:           ARM
+Model:               2
+Model name:          Cortex-A72
+Stepping:            r0p2
+BogoMIPS:            100.00
+NUMA node0 CPU(s):   0-15
+NUMA node1 CPU(s):   16-31
+NUMA node2 CPU(s):   32-47
+NUMA node3 CPU(s):   48-63
+Flags:               fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid

--- a/susemanager-utils/susemanager-sls/src/tests/data/lscpu-json.ppc64.out
+++ b/susemanager-utils/susemanager-sls/src/tests/data/lscpu-json.ppc64.out
@@ -1,5 +1,5 @@
 {
     "cpu_model": "POWER9 (architected), altivec supported",
-    "cpu_numanodes": "2",
+    "cpu_numanodes": "1",
     "cpu_cores": "1"
 }

--- a/susemanager-utils/susemanager-sls/src/tests/data/lscpu-json.ppc64.sample
+++ b/susemanager-utils/susemanager-sls/src/tests/data/lscpu-json.ppc64.sample
@@ -1,23 +1,31 @@
-{
-   "lscpu": [
-      {"field":"Architecture:", "data":"ppc64le"},
-      {"field":"Byte Order:", "data":"Little Endian"},
-      {"field":"CPU(s):", "data":"8"},
-      {"field":"On-line CPU(s) list:", "data":"0-7"},
-      {"field":"Thread(s) per core:", "data":"8"},
-      {"field":"Core(s) per socket:", "data":"1"},
-      {"field":"Socket(s):", "data":"1"},
-      {"field":"NUMA node(s):", "data":"2"},
-      {"field":"Model:", "data":"2.2 (pvr 004e 0202)"},
-      {"field":"Model name:", "data":"POWER9 (architected), altivec supported"},
-      {"field":"Hypervisor vendor:", "data":"pHyp"},
-      {"field":"Virtualization type:", "data":"para"},
-      {"field":"L1d cache:", "data":"32K"},
-      {"field":"L1i cache:", "data":"32K"},
-      {"field":"NUMA node0 CPU(s):", "data":null},
-      {"field":"NUMA node1 CPU(s):", "data":"0-7"},
-      {"field":"Physical sockets:", "data":"2"},
-      {"field":"Physical chips:", "data":"1"},
-      {"field":"Physical cores/chip:", "data":"4"}
-   ]
-}
+Architecture:            ppc64le
+  Byte Order:            Little Endian
+CPU(s):                  8
+  On-line CPU(s) list:   0-7
+Model name:              POWER9 (architected), altivec supported
+  Model:                 2.2 (pvr 004e 0202)
+  Thread(s) per core:    8
+  Core(s) per socket:    1
+  Socket(s):             1
+  Physical sockets:      2
+  Physical chips:        1
+  Physical cores/chip:   4
+Virtualization features: 
+  Hypervisor vendor:     pHyp
+  Virtualization type:   para
+Caches (sum of all):     
+  L1d:                   64 KiB (2 instances)
+  L1i:                   64 KiB (2 instances)
+NUMA:                    
+  NUMA node(s):          1
+  NUMA node1 CPU(s):     0-7
+Vulnerabilities:         
+  Itlb multihit:         Not affected
+  L1tf:                  Mitigation; RFI Flush, L1D private per thread
+  Mds:                   Not affected
+  Meltdown:              Mitigation; RFI Flush, L1D private per thread
+  Spec store bypass:     Mitigation; Kernel entry/exit barrier (eieio)
+  Spectre v1:            Mitigation; __user pointer sanitization, ori31 speculation barrier enabled
+  Spectre v2:            Mitigation; Indirect branch cache disabled, Software link stack flush
+  Srbds:                 Not affected
+  Tsx async abort:       Not affected

--- a/susemanager-utils/susemanager-sls/src/tests/data/lscpu-json.s390.sample
+++ b/susemanager-utils/susemanager-sls/src/tests/data/lscpu-json.s390.sample
@@ -1,32 +1,37 @@
-{
-   "lscpu": [
-      {"field":"Architecture:", "data":"s390x"},
-      {"field":"CPU op-mode(s):", "data":"32-bit, 64-bit"},
-      {"field":"Byte Order:", "data":"Big Endian"},
-      {"field":"CPU(s):", "data":"2"},
-      {"field":"On-line CPU(s) list:", "data":"0,1"},
-      {"field":"Thread(s) per core:", "data":"1"},
-      {"field":"Core(s) per socket:", "data":"1"},
-      {"field":"Socket(s) per book:", "data":"1"},
-      {"field":"Book(s) per drawer:", "data":"1"},
-      {"field":"Drawer(s):", "data":"2"},
-      {"field":"NUMA node(s):", "data":"1"},
-      {"field":"Vendor ID:", "data":"IBM/S390"},
-      {"field":"Machine type:", "data":"2964"},
-      {"field":"CPU dynamic MHz:", "data":"5000"},
-      {"field":"CPU static MHz:", "data":"5000"},
-      {"field":"BogoMIPS:", "data":"3033.00"},
-      {"field":"Hypervisor:", "data":"z/VM 6.4.0"},
-      {"field":"Hypervisor vendor:", "data":"IBM"},
-      {"field":"Virtualization type:", "data":"full"},
-      {"field":"Dispatching mode:", "data":"horizontal"},
-      {"field":"L1d cache:", "data":"128K"},
-      {"field":"L1i cache:", "data":"96K"},
-      {"field":"L2d cache:", "data":"2048K"},
-      {"field":"L2i cache:", "data":"2048K"},
-      {"field":"L3 cache:", "data":"65536K"},
-      {"field":"L4 cache:", "data":"491520K"},
-      {"field":"NUMA node0 CPU(s):", "data":"0,1"},
-      {"field":"Flags:", "data":"esan3 zarch stfle msa ldisp eimm dfp edat etf3eh highgprs te vx sie"}
-   ]
-}
+Architecture:                    s390x
+CPU op-mode(s):                  32-bit, 64-bit
+Byte Order:                      Big Endian
+CPU(s):                          2
+On-line CPU(s) list:             0,1
+Thread(s) per core:              1
+Core(s) per socket:              1
+Socket(s) per book:              1
+Book(s) per drawer:              1
+Drawer(s):                       2
+NUMA node(s):                    1
+Vendor ID:                       IBM/S390
+Machine type:                    2964
+CPU dynamic MHz:                 5000
+CPU static MHz:                  5000
+BogoMIPS:                        3033.00
+Hypervisor:                      z/VM 6.4.0
+Hypervisor vendor:               IBM
+Virtualization type:             full
+Dispatching mode:                horizontal
+L1d cache:                       256 KiB
+L1i cache:                       192 KiB
+L2d cache:                       4 MiB
+L2i cache:                       4 MiB
+L3 cache:                        64 MiB
+L4 cache:                        480 MiB
+NUMA node0 CPU(s):               0,1
+Vulnerability Itlb multihit:     Not affected
+Vulnerability L1tf:              Not affected
+Vulnerability Mds:               Not affected
+Vulnerability Meltdown:          Not affected
+Vulnerability Spec store bypass: Not affected
+Vulnerability Spectre v1:        Mitigation; __user pointer sanitization
+Vulnerability Spectre v2:        Mitigation; execute trampolines
+Vulnerability Srbds:             Not affected
+Vulnerability Tsx async abort:   Not affected
+Flags:                           esan3 zarch stfle msa ldisp eimm dfp edat etf3eh highgprs te vx sie

--- a/susemanager-utils/susemanager-sls/src/tests/data/lscpu-json.x86_64.sample
+++ b/susemanager-utils/susemanager-sls/src/tests/data/lscpu-json.x86_64.sample
@@ -1,39 +1,41 @@
-{
-   "lscpu": [
-      {"field":"Architecture:", "data":"x86_64"},
-      {"field":"CPU op-mode(s):", "data":"32-bit, 64-bit"},
-      {"field":"Byte Order:", "data":"Little Endian"},
-      {"field":"Address sizes:", "data":"39 bits physical, 48 bits virtual"},
-      {"field":"CPU(s):", "data":"8"},
-      {"field":"On-line CPU(s) list:", "data":"0-7"},
-      {"field":"Thread(s) per core:", "data":"2"},
-      {"field":"Core(s) per socket:", "data":"4"},
-      {"field":"Socket(s):", "data":"1"},
-      {"field":"NUMA node(s):", "data":"1"},
-      {"field":"Vendor ID:", "data":"GenuineIntel"},
-      {"field":"CPU family:", "data":"6"},
-      {"field":"Model:", "data":"94"},
-      {"field":"Model name:", "data":"Intel(R) Core(TM) i7-6820HQ CPU @ 2.70GHz"},
-      {"field":"Stepping:", "data":"3"},
-      {"field":"CPU MHz:", "data":"2700.000"},
-      {"field":"CPU max MHz:", "data":"3600.0000"},
-      {"field":"CPU min MHz:", "data":"800.0000"},
-      {"field":"BogoMIPS:", "data":"5399.81"},
-      {"field":"Virtualization:", "data":"VT-x"},
-      {"field":"L1d cache:", "data":"128 KiB"},
-      {"field":"L1i cache:", "data":"128 KiB"},
-      {"field":"L2 cache:", "data":"1 MiB"},
-      {"field":"L3 cache:", "data":"8 MiB"},
-      {"field":"NUMA node0 CPU(s):", "data":"0-7"},
-      {"field":"Vulnerability Itlb multihit:", "data":"KVM: Mitigation: VMX disabled"},
-      {"field":"Vulnerability L1tf:", "data":"Mitigation; PTE Inversion; VMX conditional cache flushes, SMT vulnerable"},
-      {"field":"Vulnerability Mds:", "data":"Mitigation; Clear CPU buffers; SMT vulnerable"},
-      {"field":"Vulnerability Meltdown:", "data":"Mitigation; PTI"},
-      {"field":"Vulnerability Spec store bypass:", "data":"Mitigation; Speculative Store Bypass disabled via prctl and seccomp"},
-      {"field":"Vulnerability Spectre v1:", "data":"Mitigation; usercopy/swapgs barriers and __user pointer sanitization"},
-      {"field":"Vulnerability Spectre v2:", "data":"Mitigation; Full generic retpoline, IBPB conditional, IBRS_FW, STIBP conditional, RSB filling"},
-      {"field":"Vulnerability Srbds:", "data":"Mitigation; Microcode"},
-      {"field":"Vulnerability Tsx async abort:", "data":"Mitigation; Clear CPU buffers; SMT vulnerable"},
-      {"field":"Flags:", "data":"fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single pti ssbd ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp md_clear flush_l1d"}
-   ]
-}
+Architecture:            x86_64
+  CPU op-mode(s):        32-bit, 64-bit
+  Address sizes:         39 bits physical, 48 bits virtual
+  Byte Order:            Little Endian
+CPU(s):                  8
+  On-line CPU(s) list:   0-7
+Vendor ID:               GenuineIntel
+  Model name:            Intel(R) Core(TM) i7-6820HQ CPU @ 2.70GHz
+    CPU family:          6
+    Model:               94
+    Thread(s) per core:  2
+    Core(s) per socket:  4
+    Socket(s):           1
+    Stepping:            3
+    CPU max MHz:         3600.0000
+    CPU min MHz:         800.0000
+    BogoMIPS:            5399.81
+    Flags:               fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bt
+                         s rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadli
+                         ne_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single pti ssbd ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1
+                          avx2 smep bmi2 erms invpcid mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp md_clear flush_l1d
+Virtualization features: 
+  Virtualization:        VT-x
+Caches (sum of all):     
+  L1d:                   128 KiB (4 instances)
+  L1i:                   128 KiB (4 instances)
+  L2:                    1 MiB (4 instances)
+  L3:                    8 MiB (1 instance)
+NUMA:                    
+  NUMA node(s):          1
+  NUMA node0 CPU(s):     0-7
+Vulnerabilities:         
+  Itlb multihit:         KVM: Mitigation: Split huge pages
+  L1tf:                  Mitigation; PTE Inversion; VMX conditional cache flushes, SMT vulnerable
+  Mds:                   Mitigation; Clear CPU buffers; SMT vulnerable
+  Meltdown:              Mitigation; PTI
+  Spec store bypass:     Mitigation; Speculative Store Bypass disabled via prctl and seccomp
+  Spectre v1:            Mitigation; usercopy/swapgs barriers and __user pointer sanitization
+  Spectre v2:            Mitigation; Full generic retpoline, IBPB conditional, IBRS_FW, STIBP conditional, RSB filling
+  Srbds:                 Mitigation; Microcode
+  Tsx async abort:       Mitigation; TSX disabled

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Avoid using lscpu -J option in grains (bsc#1195920)
+
 -------------------------------------------------------------------
 Tue Feb 15 10:07:24 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Some systems are old enough to not have the -J lscpu parameter. Instead
parse the regular output with C locale.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17035
4.2: https://github.com/SUSE/spacewalk/pull/17043

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
