### PR TITLE
Adapt required versions

### DIFF
--- a/backend/tito.props
+++ b/backend/tito.props
@@ -1,2 +1,2 @@
 [rhn-conf/rhn_server_xmlrpc.conf]
-min_schema_version=4.3.1
+min_schema_version=4.3.9

--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -8,7 +8,7 @@ java.customer_service_email =
 java.development_environment = 0
 
 # the version of API
-java.apiversion = 25
+java.apiversion = 26
 
 # lifetime for sandboxes, in days
 java.sandbox_lifetime = 3

--- a/java/tito.props
+++ b/java/tito.props
@@ -5,5 +5,5 @@ salt-netapi-client=0.19
 salt-netapi-client=0.19
 
 [conf/rhn_java.conf]
-java.min_schema_version=4.3.1
-java.min_report_schema_version=4.3.0
+java.min_schema_version=4.3.9
+java.min_report_schema_version=4.3.1


### PR DESCRIPTION
## What does this PR change?

- change java api version to 26
- adapt required SQL schema versions

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **internals**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
