### PR TITLE
Avoid throwing exceptions within a finally block

### DIFF
--- a/java/code/src/com/redhat/rhn/common/hibernate/HibernateFactory.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/HibernateFactory.java
@@ -21,6 +21,7 @@ import com.redhat.rhn.common.db.datasource.ModeFactory;
 import com.redhat.rhn.common.db.datasource.SelectMode;
 
 import org.apache.commons.collections.ListUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.hibernate.Hibernate;
@@ -488,60 +489,18 @@ public abstract class HibernateFactory {
             return new byte[0];
         }
 
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        try {
-            return toByteArrayImpl(fromBlob, baos);
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); InputStream is = fromBlob.getBinaryStream()) {
+            IOUtils.copy(is, baos, 4000);
+            return baos.toByteArray();
         }
         catch (SQLException e) {
             LOG.error("SQL Error converting blob to byte array", e);
-            throw new DatabaseException(e.toString());
+            throw new DatabaseException(e.toString(), e);
         }
         catch (IOException e) {
             LOG.error("I/O Error converting blob to byte array", e);
-            throw new DatabaseException(e.toString());
+            throw new DatabaseException(e.toString(), e);
         }
-        finally {
-            try {
-                baos.close();
-            }
-            catch (IOException ex) {
-                throw new DatabaseException(ex.toString());
-            }
-        }
-    }
-
-    /**
-     * helper utility to convert blob to byte array
-     * @param fromBlob blob to convert
-     * @param baos byte array output stream
-     * @return String version of the byte array contents
-     */
-    private static byte[] toByteArrayImpl(Blob fromBlob, ByteArrayOutputStream baos)
-        throws SQLException, IOException {
-
-        byte[] buf = new byte[4000];
-        InputStream is = fromBlob.getBinaryStream();
-        try {
-            for (;;) {
-                int dataSize = is.read(buf);
-                if (dataSize == -1) {
-                    break;
-                }
-                baos.write(buf, 0, dataSize);
-            }
-        }
-        finally {
-            if (is != null) {
-                try {
-                    is.close();
-                }
-                catch (IOException ex) {
-                    throw new RuntimeException(ex);
-                }
-            }
-        }
-        return baos.toByteArray();
     }
 
     /**


### PR DESCRIPTION
## What does this PR change?

This PR removes the throws that are done within a `finally` block.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
