### PR TITLE
Client Tools in the Product Wizard exists not on Uyuni

### DIFF
--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -65,7 +65,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I should see the "Basesystem Module 15 SP2 x86_64" selected
     # Comment following 3 lines if you wish to re-enable testing with beta client tools for SLE15
     And I open the sub-list of the product "Basesystem Module 15 SP2 x86_64"
-    And I open the sub-list of the product "SUSE Manager Client Tools for SLE 15 x86_64"
+    And I open the sub-list of the product "SUSE Manager Client Tools for SLE 15 x86_64" on SUSE Manager
     And I deselect "SUSE Manager Client Tools Beta for SLE 15 x86_64 (BETA)" as a SUSE Manager product
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 15 SP2 x86_64" product has been added
@@ -85,7 +85,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I should see the "Basesystem Module 15 SP3 x86_64" selected
     # Comment following 3 lines if you wish to re-enable testing with beta client tools for SLE15
     And I open the sub-list of the product "Basesystem Module 15 SP3 x86_64"
-    And I open the sub-list of the product "SUSE Manager Client Tools for SLE 15 x86_64"
+    And I open the sub-list of the product "SUSE Manager Client Tools for SLE 15 x86_64" on SUSE Manager
     And I deselect "SUSE Manager Client Tools Beta for SLE 15 x86_64 (BETA)" as a SUSE Manager product
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 15 SP3 x86_64" product has been added

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -558,6 +558,12 @@ When(/^I wait at most (\d+) seconds until the tree item "([^"]+)" contains "([^"
   raise "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query, wait: timeout.to_i)
 end
 
+When(/^I open the sub-list of the product "(.*?)" on (SUSE Manager|Uyuni)$/) do |product, product_version|
+  if $product == product_version
+    step %(I open the sub-list of the product "#{product}")
+  end
+end
+
 When(/^I open the sub-list of the product "(.*?)"$/) do |product|
   xpath = "//span[contains(text(), '#{product}')]/ancestor::div[contains(@class, 'product-details-wrapper')]/div/i[contains(@class, 'fa-angle-right')]"
   # within(:xpath, xpath) do


### PR DESCRIPTION
## What does this PR change?

Client Tools in the Product Wizard does not exist in Uyuni.
We need to ignore this similar to the deselect call.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
