### PR TITLE
QA: Head will contain for now BV 4.3 tests, until we have Manager-4.3 branch in Spacewalk

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -189,22 +189,22 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I click the Add Product button
      And I wait until I see "Debian 11" product has been added
 
-  Scenario: Add SUSE Manager Proxy 4.2 x86_64
+  Scenario: Add SUSE Manager Proxy 4.3 x86_64
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Manager Proxy 4.2 x86_64" as the filtered product description
-    And I select "SUSE Manager Proxy 4.2 x86_64" as a product
-    Then I should see the "SUSE Manager Proxy 4.2 x86_64" selected
+    And I enter "SUSE Manager Proxy 4.3 x86_64" as the filtered product description
+    And I select "SUSE Manager Proxy 4.3 x86_64" as a product
+    Then I should see the "SUSE Manager Proxy 4.3 x86_64" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Manager Proxy 4.2 x86_64" product has been added
+    And I wait until I see "SUSE Manager Proxy 4.3 x86_64" product has been added
 
-  Scenario: Add SUSE Manager Retail Branch Server 4.2 x86_64
+  Scenario: Add SUSE Manager Retail Branch Server 4.3 x86_64
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Manager Retail Branch Server 4.2 x86_64" as the filtered product description
-    And I select "SUSE Manager Retail Branch Server 4.2 x86_64" as a product
-    Then I should see the "SUSE Manager Retail Branch Server 4.2 x86_64" selected
+    And I enter "SUSE Manager Retail Branch Server 4.3 x86_64" as the filtered product description
+    And I select "SUSE Manager Retail Branch Server 4.3 x86_64" as a product
+    Then I should see the "SUSE Manager Retail Branch Server 4.3 x86_64" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Manager Retail Branch Server 4.2 x86_64" product has been added
+    And I wait until I see "SUSE Manager Retail Branch Server 4.3 x86_64" product has been added

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -114,7 +114,7 @@ PACKAGE_BY_CLIENT = { 'sle_client' => 'bison',
                       'debian11_ssh_minion' => 'bison',
                       'opensuse153arm_minion' => 'bison' }.freeze
 
-BASE_CHANNEL_BY_CLIENT = { 'proxy' => 'SLE-Product-SUSE-Manager-Proxy-4.2-Pool',
+BASE_CHANNEL_BY_CLIENT = { 'proxy' => 'SLE-Product-SUSE-Manager-Proxy-4.3-Pool',
                            'sle_client' => 'SLES12-SP4-Pool',
                            'sle_minion' => 'SLES12-SP4-Pool',
                            'ssh_minion' => 'SLES12-SP4-Pool',
@@ -164,7 +164,7 @@ BASE_CHANNEL_BY_CLIENT = { 'proxy' => 'SLE-Product-SUSE-Manager-Proxy-4.2-Pool',
                            'debian11_ssh_minion' => 'debian-11-pool',
                            'opensuse153arm_minion' => 'openSUSE Leap 15.3 (aarch64)' }.freeze
 
-LABEL_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.2-Pool' => 'sle-product-suse-manager-proxy-4.2-pool-x86_64',
+LABEL_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.3-Pool' => 'sle-product-suse-manager-proxy-4.3-pool-x86_64',
                           'SLES11-SP3-Pool' => 'sles11-sp3-pool-i586',
                           'SLES11-SP4-Pool' => 'sles11-sp4-pool-x86_64',
                           'SLES12-SP4-Pool' => 'sles12-sp4-pool-x86_64',
@@ -182,7 +182,7 @@ LABEL_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.2-Pool' => 'sle-prod
                           'debian-11-pool' => 'debian-11-pool-amd64',
                           'openSUSE Leap 15.3 (aarch64)' => 'opensuse_leap15_3-aarch64' }.freeze
 
-CHANNEL_TO_SYNC_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.2-Pool' => 'SUMA-42-PROXY-x86_64',
+CHANNEL_TO_SYNC_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.3-Pool' => 'SUMA-43-PROXY-x86_64',
                                     'SLES11-SP3-Pool' => 'SLE-11-SP3-i586',
                                     'SLES11-SP4-Pool' => 'SLE-11-SP4-x86_64',
                                     'SLES12-SP4-Pool' => 'SLE-12-SP4-x86_64',
@@ -200,7 +200,7 @@ CHANNEL_TO_SYNC_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.2-Pool' =>
                                     'debian-11-pool' => 'debian11-amd64',
                                     'openSUSE Leap 15.3 (aarch64)' => 'openSUSE-Leap-15.3-aarch64-uyuni' }.freeze
 
-PARENT_CHANNEL_TO_SYNC_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.2-Pool' => 'sle-product-suse-manager-proxy-4.2-pool-x86_64',
+PARENT_CHANNEL_TO_SYNC_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.3-Pool' => 'sle-product-suse-manager-proxy-4.3-pool-x86_64',
                                            'SLES11-SP3-Pool' => nil,
                                            'SLES11-SP4-Pool' => nil,
                                            'SLES12-SP4-Pool' => nil,


### PR DESCRIPTION
## What does this PR change?

Head will contain for now BV 4.3 tests, until we have Manager-4.3 branch in Spacewalk

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

**DON'T PORT IT.**
https://github.com/SUSE/spacewalk/issues/16526

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
