### PR TITLE
Use SCC for openSUSE instead of common channels

### DIFF
--- a/testsuite/features/build_validation/add_custom_repositories/srv_common_channels.feature
+++ b/testsuite/features/build_validation/add_custom_repositories/srv_common_channels.feature
@@ -50,15 +50,3 @@ Feature: Add common channels and schedule their synchronization
 
   # No common channels for Ubuntu 20.04
 
-@opensuse153arm_minion
-  Scenario: Add common channels for openSUSE 15.3 ARM
-    When I use spacewalk-common-channel to add channel "opensuse_leap15_3" with arch "aarch64"
-    And I follow the left menu "Software > Manage > Channels"
-    And I follow "openSUSE Leap 15.3 (aarch64)"
-    And I follow "Repositories" in the content area
-    And I select the "External - openSUSE Leap 15.3 (aarch64)" repo
-    And I click on "Save Repositories"
-    Then I should see a "repository information was successfully updated" text
-    When I follow "Sync"
-    And I click on "Sync Now"
-    Then I should see a "Repository sync scheduled for openSUSE Leap 15.3 (aarch64)" text

--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -116,6 +116,17 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
     And I wait until I see "SUSE Linux Enterprise Server 15 SP3 x86_64" product has been added
 
+@opensuse153arm_minion
+  Scenario: Add openSUSE 15.3 for ARM
+    When I follow the left menu "Admin > Setup Wizard > Products"
+    And I wait until I do not see "Loading" text
+    And I enter "openSUSE Leap 15.3 aarch64" as the filtered product description
+    And I select "openSUSE Leap 15.3 aarch64" as a product
+    Then I should see the "openSUSE Leap 15.3 aarch64" selected
+    When I click the Add Product button
+    And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
+    And I wait until I see "openSUSE Leap 15.3 aarch64" product has been added
+
 @ceos7_minion
   Scenario: Add SUSE Linux Enterprise Server with Expanded Support 7
     When I follow the left menu "Admin > Setup Wizard > Products"
@@ -189,6 +200,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I click the Add Product button
      And I wait until I see "Debian 11" product has been added
 
+@proxy
   Scenario: Add SUSE Manager Proxy 4.3 x86_64
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
@@ -199,6 +211,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
     And I wait until I see "SUSE Manager Proxy 4.3 x86_64" product has been added
 
+@proxy
   Scenario: Add SUSE Manager Retail Branch Server 4.3 x86_64
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -198,7 +198,7 @@ CHANNEL_TO_SYNC_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.3-Pool' =>
                                     'debian-9-pool' => 'debian9-amd64',
                                     'debian-10-pool' => 'debian10-amd64',
                                     'debian-11-pool' => 'debian11-amd64',
-                                    'openSUSE Leap 15.3 (aarch64)' => 'openSUSE-Leap-15.3-aarch64-uyuni' }.freeze
+                                    'openSUSE Leap 15.3 (aarch64)' => 'openSUSE-Leap-15.3-aarch64' }.freeze
 
 PARENT_CHANNEL_TO_SYNC_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.3-Pool' => 'sle-product-suse-manager-proxy-4.3-pool-x86_64',
                                            'SLES11-SP3-Pool' => nil,


### PR DESCRIPTION
## What does this PR change?

Use the channel for openSUSE available at SCC instead of using `spacewalk-common-channel` like for Debian and old Ubuntus.

According to the doc https://documentation.suse.com/suma/4.2/en/suse-manager/client-configuration/clients-opensuseleap.html it's the correct way to proceed.


## Links

Ports:
* 4.1: SUSE/spacewalk#17070
* 4.2: SUSE/spacewalk#17071


## Changelogs

- [x] No changelog needed
