### PR TITLE
ReportDB User: prevent to modify the main users

### DIFF
--- a/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb-user
+++ b/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb-user
@@ -74,7 +74,6 @@ default_or_input() {
     eval "$(printf "%q=%q" "$VARIABLE" "$INPUT")"
 }
 
-
 parse_password() {
   for i in $(seq $INTERACTIVE_RETRIES) ; do
     echo -n "Password: "
@@ -182,8 +181,6 @@ if [ "$INTERACTIVE" = "1" ] ; then
       echo "This script is not allowed to change $DBUSER_FROM_RHN_CONF, because it's the $DBNAME Admin (only read-only user allowed)"
       exit 1
   fi
-  
-
   
   if [ "$ACTION" != "d" ]; then
     parse_password

--- a/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb-user
+++ b/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb-user
@@ -169,18 +169,6 @@ if [ "$INTERACTIVE" = "1" ] ; then
   fi
 
   default_or_input "User:" DBUSER ''
-  DBUSER=$(echo $DBUSER | tr '[:upper:]' '[:lower:]')
-  
-  if [ "$DBUSER" == "$SUMA_DBUSER" ]; then
-      echo "No action allowed for user $SUMA_DBUSER, because it's the SUMA User Admin."
-      exit 1
-  fi
-  
-  
-  if [ "$DBUSER" == "$DBUSER_FROM_RHN_CONF" ]; then
-      echo "This script is not allowed to change $DBUSER_FROM_RHN_CONF, because it's the $DBNAME Admin (only read-only user allowed)"
-      exit 1
-  fi
   
   if [ "$ACTION" != "d" ]; then
     parse_password
@@ -213,6 +201,19 @@ else ### INTERACTIVE=0
     exit 1
   fi
 
+fi
+
+
+DBUSER=$(echo $DBUSER | tr '[:upper:]' '[:lower:]')
+if [ "$DBUSER" == "$SUMA_DBUSER" ]; then
+    echo "No action allowed for user $SUMA_DBUSER, because it's the SUMA User Admin."
+    exit 1
+fi
+
+
+if [ "$DBUSER" == "$DBUSER_FROM_RHN_CONF" ]; then
+    echo "This script is not allowed to change $DBUSER_FROM_RHN_CONF, because it's the $DBNAME Admin (only read-only user allowed)"
+    exit 1
 fi
 
 QUERY=""

--- a/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb-user
+++ b/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb-user
@@ -203,7 +203,6 @@ else ### INTERACTIVE=0
 
 fi
 
-
 DBUSER=$(echo $DBUSER | tr '[:upper:]' '[:lower:]')
 if [ "$DBUSER" == "$SUMA_DBUSER" ]; then
     echo "No action allowed for user $SUMA_DBUSER, because it's the SUMA User Admin."

--- a/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb-user
+++ b/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb-user
@@ -2,6 +2,8 @@
 
 DBNAME_ATTRIBUTE="report_db_name"
 RHN_CONF="/etc/rhn/rhn.conf"
+SUMA_DBUSER_ATTRIBUTE="db_user" #the script should not allow changes to this user
+DBUSER_ATTRIBUTE="report_db_user" #the script should not allow changes to this user
 INTERACTIVE=1
 INTERACTIVE_RETRIES=3
 
@@ -24,11 +26,11 @@ options:
   --dbpassword=DBPASSWORD
             Report DB Password
   --add
-            Add the new user
+            Add the new user (case insensitive)
   --delete
-            Delete the user
+            Delete the user (case insensitive)
   --modify
-            Set a new password
+            Set a new password (case insensitive)
 
 HELP
     exit 1
@@ -105,6 +107,11 @@ parse_properties() {
 }
 
 parse_properties $DBNAME_ATTRIBUTE DBNAME
+parse_properties $SUMA_DBUSER_ATTRIBUTE SUMA_DBUSER
+SUMA_DBUSER=$(echo $SUMA_DBUSER | tr '[:upper:]' '[:lower:]')
+
+parse_properties $DBUSER_ATTRIBUTE DBUSER_FROM_RHN_CONF
+DBUSER_FROM_RHN_CONF=$(echo $DBUSER_FROM_RHN_CONF | tr '[:upper:]' '[:lower:]')
 
 if [ -z $DBNAME ]; then
   echo "$DBNAME_ATTRIBUTE is missing. Exit"
@@ -145,7 +152,7 @@ done
 if [ "$INTERACTIVE" = "1" ] ; then
   echo "Report DB Name is: $DBNAME"
   for i in $(seq $INTERACTIVE_RETRIES) ; do
-    default_or_input "[a]dd/[m]odify/[d]elete user. Default is " ACTION 'm'
+    default_or_input "[a]dd/[m]odify/[d]elete user (case insensitive). Default is " ACTION 'm'
       case "$ACTION" in
         a|m|d)
         break
@@ -163,7 +170,21 @@ if [ "$INTERACTIVE" = "1" ] ; then
   fi
 
   default_or_input "User:" DBUSER ''
+  DBUSER=$(echo $DBUSER | tr '[:upper:]' '[:lower:]')
+  
+  if [ "$DBUSER" == "$SUMA_DBUSER" ]; then
+      echo "No action allowed for user $SUMA_DBUSER, because it's the SUMA User Admin."
+      exit 1
+  fi
+  
+  
+  if [ "$DBUSER" == "$DBUSER_FROM_RHN_CONF" ]; then
+      echo "This script is not allowed to change $DBUSER_FROM_RHN_CONF, because it's the $DBNAME Admin (only read-only user allowed)"
+      exit 1
+  fi
+  
 
+  
   if [ "$ACTION" != "d" ]; then
     parse_password
     if [ -z $DBPASSWORD ]; then
@@ -185,7 +206,7 @@ else ### INTERACTIVE=0
     exit 1
   fi
   
-  if [ -z $USER ]; then
+  if [ -z $DBUSER ]; then
     echo "User is missing. Exit"
     exit 1
   fi

--- a/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb-user
+++ b/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb-user
@@ -197,7 +197,7 @@ else ### INTERACTIVE=0
 
 fi
 
-ADMIN_USERS=$(echo "SELECT usename FROM pg_catalog.pg_user WHERE usesuper='t' " | spacewalk-sql -i | tail -n +3 | head -n -2 | tr '[:upper:]' '[:lower:]')
+ADMIN_USERS=$(echo "SELECT usename FROM pg_catalog.pg_user WHERE usesuper='t' " | spacewalk-sql -select-mode - | tail -n +3 | head -n -2 | tr '[:upper:]' '[:lower:]')
 
 for USER in $ADMIN_USERS; do
     if [ "$DBUSER" == "$USER" ]; then

--- a/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb-user
+++ b/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb-user
@@ -2,8 +2,6 @@
 
 DBNAME_ATTRIBUTE="report_db_name"
 RHN_CONF="/etc/rhn/rhn.conf"
-SUMA_DBUSER_ATTRIBUTE="db_user" #the script should not allow changes to this user
-DBUSER_ATTRIBUTE="report_db_user" #the script should not allow changes to this user
 INTERACTIVE=1
 INTERACTIVE_RETRIES=3
 
@@ -106,11 +104,6 @@ parse_properties() {
 }
 
 parse_properties $DBNAME_ATTRIBUTE DBNAME
-parse_properties $SUMA_DBUSER_ATTRIBUTE SUMA_DBUSER
-SUMA_DBUSER=$(echo $SUMA_DBUSER | tr '[:upper:]' '[:lower:]')
-
-parse_properties $DBUSER_ATTRIBUTE DBUSER_FROM_RHN_CONF
-DBUSER_FROM_RHN_CONF=$(echo $DBUSER_FROM_RHN_CONF | tr '[:upper:]' '[:lower:]')
 
 if [ -z $DBNAME ]; then
   echo "$DBNAME_ATTRIBUTE is missing. Exit"
@@ -169,6 +162,7 @@ if [ "$INTERACTIVE" = "1" ] ; then
   fi
 
   default_or_input "User:" DBUSER ''
+  DBUSER=$(echo $DBUSER | tr '[:upper:]' '[:lower:]')
   
   if [ "$ACTION" != "d" ]; then
     parse_password
@@ -203,17 +197,14 @@ else ### INTERACTIVE=0
 
 fi
 
-DBUSER=$(echo $DBUSER | tr '[:upper:]' '[:lower:]')
-if [ "$DBUSER" == "$SUMA_DBUSER" ]; then
-    echo "No action allowed for user $SUMA_DBUSER, because it's the SUMA User Admin."
-    exit 1
-fi
+ADMIN_USERS=$(echo "SELECT usename FROM pg_catalog.pg_user WHERE usesuper='t' " | spacewalk-sql -i | tail -n +3 | head -n -2 | tr '[:upper:]' '[:lower:]')
 
-
-if [ "$DBUSER" == "$DBUSER_FROM_RHN_CONF" ]; then
-    echo "This script is not allowed to change $DBUSER_FROM_RHN_CONF, because it's the $DBNAME Admin (only read-only user allowed)"
-    exit 1
-fi
+for USER in $ADMIN_USERS; do
+    if [ "$DBUSER" == "$USER" ]; then
+        echo "This script is not allowed to change $USER, because it's an admin (only read-only user allowed)"
+        exit 1
+    fi
+done
 
 QUERY=""
 case "$ACTION" in

--- a/spacewalk/uyuni-setup-reportdb/uyuni-setup-reportdb.changes
+++ b/spacewalk/uyuni-setup-reportdb/uyuni-setup-reportdb.changes
@@ -1,4 +1,5 @@
 - remove possibility to change admin user
+
 -------------------------------------------------------------------
 Tue Feb 15 10:10:05 CET 2022 - jgonzalez@suse.com
 

--- a/spacewalk/uyuni-setup-reportdb/uyuni-setup-reportdb.changes
+++ b/spacewalk/uyuni-setup-reportdb/uyuni-setup-reportdb.changes
@@ -1,3 +1,4 @@
+- remove possibility to change admin user
 -------------------------------------------------------------------
 Tue Feb 15 10:10:05 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

- do not allow to change SUMA DB admin user
- do not allow to change ReportDB DB admin user
- remind that postgres in case-insensitive

## GUI diff

No difference.

- [x] **DONE**

## Documentation
N/A

- [x] **DONE**
N/A

## Test coverage
- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/16989

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
