### PR TITLE
Remove pylint checks

### DIFF
--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,3 +1,5 @@
+  * Remove pylint check according to Fedora package guidelines.
+
 -------------------------------------------------------------------
 Tue Feb 15 10:04:10 CET 2022 - jgonzalez@suse.com
 

--- a/proxy/installer/spacewalk-proxy-installer.spec
+++ b/proxy/installer/spacewalk-proxy-installer.spec
@@ -19,7 +19,6 @@
 
 #!BuildIgnore:  udev-mini libudev-mini1
 %if 0%{?fedora} || 0%{?rhel} 
-%{!?pylint_check: %global pylint_check 1}
 %define apacheconfdir %{_sysconfdir}/httpd
 %else
 %define apacheconfdir %{_sysconfdir}/apache2
@@ -59,10 +58,6 @@ Requires:       rhnlib
 Requires:       libxslt
 Requires:       salt
 Requires:       spacewalk-certs-tools >= 1.6.4
-%if 0%{?pylint_check}
-BuildRequires:  python3-rhn-client-tools
-BuildRequires:  spacewalk-python3-pylint
-%endif
 BuildRequires:  /usr/bin/docbook2man
 
 Obsoletes:      proxy-installer < 5.3.0
@@ -117,10 +112,6 @@ install -m 755 rhn-proxy-activate.py $RPM_BUILD_ROOT/%{_usr}/sbin/rhn-proxy-acti
 install -m 755 fetch-certificate.py  $RPM_BUILD_ROOT/%{_usr}/sbin/fetch-certificate
 
 %check
-%if 0%{?pylint_check}
-# check coding style
-spacewalk-python3-pylint .
-%endif
 
 %post
 %if 0%{?suse_version}

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,5 @@
+  * Remove pylint according to Fedora package guidelines.
+
 -------------------------------------------------------------------
 Tue Feb 15 10:03:51 CET 2022 - jgonzalez@suse.com
 

--- a/proxy/proxy/spacewalk-proxy.spec
+++ b/proxy/proxy/spacewalk-proxy.spec
@@ -16,11 +16,6 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
-
-%if 0%{?fedora} || 0%{?rhel} >= 7
-%{!?pylint_check: %global pylint_check 1}
-%endif
-
 Name:           spacewalk-proxy
 Summary:        Spacewalk Proxy Server
 License:        GPL-2.0-only
@@ -34,9 +29,6 @@ BuildRequires:  python3
 BuildArch:      noarch
 Requires:       httpd
 Requires:       python3-uyuni-common-libs
-%if 0%{?pylint_check}
-BuildRequires:  spacewalk-python3-pylint
-%endif
 BuildRequires:  mgr-push >= 4.0.0
 BuildRequires:  python3-mgr-push
 BuildRequires:  spacewalk-backend >= 1.7.24
@@ -243,12 +235,6 @@ install -m 0755 mgr-proxy-ssh-force-cmd $RPM_BUILD_ROOT/%{_sbindir}/mgr-proxy-ss
 install -d -m 0755 $RPM_BUILD_ROOT/%{_var}/lib/spacewalk
 
 %check
-%if 0%{?pylint_check}
-# check coding style
-export PYTHONPATH=$RPM_BUILD_ROOT/usr/share/rhn:$RPM_BUILD_ROOT%{python3_sitelib}:/usr/share/rhn
-# Run pylint check but never fail
-spacewalk-python3-pylint $RPM_BUILD_ROOT/usr/share/rhn ||:
-%endif
 
 %post broker
 if [ -f %{_sysconfdir}/sysconfig/rhn/systemid ]; then

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,5 @@
+  * Remove pylint according to Fedora package guidelines.
+
 -------------------------------------------------------------------
 Tue Feb 15 10:04:35 CET 2022 - jgonzalez@suse.com
 

--- a/spacewalk/setup/spacewalk-setup.spec
+++ b/spacewalk/setup/spacewalk-setup.spec
@@ -23,7 +23,6 @@
 %endif
 %define pythonX %{?build_py3:python3}%{!?build_py3:python2}
 
-%global pylint_check 1
 %if 0%{?suse_version}
 %define apache_user wwwrun
 %define apache_group www
@@ -91,10 +90,6 @@ Requires:       python-certifi
 BuildRequires:  perl-libwww-perl
 %else
 Requires:       %{sbinpath}/restorecon
-%endif
-%if 0%{?pylint_check}
-BuildRequires:  %{pythonX}-setuptools
-BuildRequires:  spacewalk-%{pythonX}-pylint
 %endif
 Requires:       cobbler >= 3.0.0
 Requires:       perl-Satcon
@@ -261,10 +256,6 @@ exit 0
 
 %check
 make test
-%if 0%{?pylint_check}
-# check coding style
-spacewalk-python3-pylint $RPM_BUILD_ROOT%{_datadir}/spacewalk/setup/*.py ||:
-%endif
 
 %files
 %defattr(-,root,root,-)

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+  * Removed pylint according to Fedora packaging guidelines.
+
 -------------------------------------------------------------------
 Tue Jan 18 14:01:26 CET 2022 - jgonzalez@suse.com
 

--- a/utils/spacewalk-utils.spec
+++ b/utils/spacewalk-utils.spec
@@ -16,11 +16,6 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
-
-%if 0%{?fedora} || 0%{?rhel} >= 7
-%{!?pylint_check: %global pylint_check 1}
-%endif
-
 Name:           spacewalk-utils
 Version:        4.3.5
 Release:        1
@@ -35,12 +30,6 @@ BuildRequires:  docbook-utils
 BuildRequires:  fdupes
 BuildRequires:  python3
 BuildRequires:  python3-rpm-macros
-%if 0%{?pylint_check}
-BuildRequires:  python3-solv
-BuildRequires:  python3-uyuni-common-libs
-BuildRequires:  spacewalk-python3-pylint
-BuildRequires:  (python3-PyYAML or python3-pyyaml)
-%endif
 BuildRequires:  uyuni-base-common
 
 # Required by spacewalk-hostname-rename
@@ -139,10 +128,6 @@ pushd %{buildroot}
 popd
 
 %check
-%if 0%{?pylint_check}
-# check coding style
-spacewalk-python3-pylint $RPM_BUILD_ROOT%{python3_sitelib}
-%endif
 
 %files
 %defattr(-,root,root)


### PR DESCRIPTION
## What does this PR change?

remove pylint checks.
Fedora Packaging Guidelines advice against using pylint as it is opinion based (https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#_running_tests)
Tests should be run within CI.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
