### PR TITLE
Replace mock

### DIFF
--- a/susemanager-utils/susemanager-sls/src/tests/mockery.py
+++ b/susemanager-utils/susemanager-sls/src/tests/mockery.py
@@ -4,7 +4,7 @@ try:
     from cStringIO import StringIO
 except ImportError:
     from io import StringIO
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 
 def setup_environment():

--- a/susemanager-utils/susemanager-sls/src/tests/test_beacon_pkgset.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_beacon_pkgset.py
@@ -2,7 +2,7 @@
 Author: Bo Maryniuk <bo@suse.de>
 """
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from . import mockery
 

--- a/susemanager-utils/susemanager-sls/src/tests/test_grains_cpuinfo.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_grains_cpuinfo.py
@@ -4,7 +4,7 @@ Author: bo@suse.de
 
 import json
 import pytest
-from mock import MagicMock, patch, mock_open
+from unittest.mock import MagicMock, patch, mock_open
 from . import mockery
 mockery.setup_environment()
 

--- a/susemanager-utils/susemanager-sls/src/tests/test_grains_virt.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_grains_virt.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import MagicMock, patch, Mock
+from unittest.mock import MagicMock, patch, Mock
 from . import mockery
 mockery.setup_environment()
 

--- a/susemanager-utils/susemanager-sls/src/tests/test_mgr_master_tops.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_mgr_master_tops.py
@@ -3,7 +3,7 @@
 :codeauthor:    Pablo Suárez Hernández <psuarezhernandez@suse.de>
 '''
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from . import mockery
 mockery.setup_environment()
 

--- a/susemanager-utils/susemanager-sls/src/tests/test_module_mainframesysinfo.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_mainframesysinfo.py
@@ -3,7 +3,7 @@ Author: Bo Maryniuk <bo@suse.de>
 '''
 
 import pytest
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from . import mockery
 mockery.setup_environment()
 

--- a/susemanager-utils/susemanager-sls/src/tests/test_module_sumautil.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_sumautil.py
@@ -4,7 +4,7 @@ Author: mc@suse.com
 
 import sys
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from . import mockery
 mockery.setup_environment()
 

--- a/susemanager-utils/susemanager-sls/src/tests/test_module_udevdb.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_udevdb.py
@@ -2,7 +2,7 @@
 Author: Bo Maryniuk <bo@suse.de>
 '''
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from . import mockery
 mockery.setup_environment()
 

--- a/susemanager-utils/susemanager-sls/src/tests/test_module_uyuni_config.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_uyuni_config.py
@@ -3,7 +3,7 @@ Author: Ricardo Mateus <rmateus@suse.com>
 '''
 
 import pytest
-from mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch, call
 from . import mockery
 
 mockery.setup_environment()

--- a/susemanager-utils/susemanager-sls/src/tests/test_module_virt_utils.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_virt_utils.py
@@ -1,7 +1,7 @@
 """
 Unit tests for the virt_utils module
 """
-from mock import Mock, MagicMock, patch, mock_open
+from unittest.mock import Mock, MagicMock, patch, mock_open
 from xml.etree import ElementTree
 import pytest
 

--- a/susemanager-utils/susemanager-sls/src/tests/test_state_mgrcompat.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_state_mgrcompat.py
@@ -5,7 +5,7 @@ Test custom wrapper for "module.run" state module.
 Author: Pablo Suárez Herńandez <psuarezhernandez@suse.com>
 '''
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from . import mockery
 mockery.setup_environment()
 

--- a/susemanager-utils/susemanager-sls/src/tests/test_state_mgrutils.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_state_mgrutils.py
@@ -3,7 +3,7 @@
 Test for mgrutils states
 '''
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from . import mockery
 mockery.setup_environment()
 

--- a/susemanager-utils/susemanager-sls/src/tests/test_state_product.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_state_product.py
@@ -3,7 +3,7 @@ Author: cbbayburt@suse.com
 '''
 
 import sys
-from mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch, call
 from . import mockery
 mockery.setup_environment()
 

--- a/susemanager-utils/susemanager-sls/src/tests/test_state_uyuni_config.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_state_uyuni_config.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch, call
 from . import mockery
 import pdb
 

--- a/susemanager-utils/susemanager-sls/src/tests/test_state_virt_utils.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_state_virt_utils.py
@@ -1,4 +1,4 @@
-from mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch, call
 from . import mockery
 
 mockery.setup_environment()

--- a/susemanager-utils/susemanager-sls/susemanager-sls.spec
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.spec
@@ -39,7 +39,6 @@ Requires(pre):  coreutils
 Requires(posttrans): spacewalk-admin
 Requires:       susemanager-build-keys-web >= 12.0.1
 %if 0%{?build_py3}
-BuildRequires:  python3-mock
 BuildRequires:  python3-pytest
 BuildRequires:  python3-salt
 # Different package names for SUSE and RHEL:

--- a/susemanager-utils/susemanager-sls/test/test_engine.py
+++ b/susemanager-utils/susemanager-sls/test/test_engine.py
@@ -4,7 +4,7 @@ import psycopg2
 import shlex
 import subprocess
 from mgr_events import Responder, DEFAULT_COMMIT_BURST
-from mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch, call
 from sqlalchemy import create_engine
 from sqlalchemy_utils import database_exists, create_database, drop_database
 

--- a/susemanager-utils/susemanager-sls/test/test_pillar_suma_minion.py
+++ b/susemanager-utils/susemanager-sls/test/test_pillar_suma_minion.py
@@ -3,7 +3,7 @@
 :codeauthor:    Michael Calmer <Michael.Calmer@suse.com>
 '''
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import sys


### PR DESCRIPTION
## What does this PR change?

Replace python-mock with built-in unittest.mock

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
