### PR TITLE
change centos 8 urls to vault

### DIFF
--- a/susemanager-sync-data/additional_products.json
+++ b/susemanager-sync-data/additional_products.json
@@ -122,8 +122,8 @@
         ],
         "repositories" : [
             {
-                "id" : -344,
-                "url" : "http://mirrorlist.centos.org/?release=8&arch=aarch64&repo=BaseOS&infra=stock",
+                "id" : -372,
+                "url" : "https://vault.centos.org/centos/8/BaseOS/aarch64/os/",
                 "name" : "centos8",
                 "distro_target" : "aarch64",
                 "description" : "CentOS 8",
@@ -132,8 +132,8 @@
                 "installer_updates" : false
             },
             {
-                "id" : -345,
-                "url" : "http://mirrorlist.centos.org/?release=8&arch=aarch64&repo=AppStream&infra=stock",
+                "id" : -373,
+                "url" : "https://vault.centos.org/centos/8/AppStream/aarch64/os/",
                 "name" : "centos8-appstream",
                 "distro_target" : "aarch64",
                 "description" : "CentOS 8 AppStream",
@@ -142,8 +142,8 @@
                 "installer_updates" : false
             },
             {
-                "id" : -346,
-                "url" : "http://mirrorlist.centos.org/?release=8&arch=aarch64&repo=centosplus&infra=stock",
+                "id" : -374,
+                "url" : "https://vault.centos.org/centos/8/centosplus/aarch64/os/",
                 "name" : "centos8-centosplus",
                 "distro_target" : "aarch64",
                 "description" : "CentOS 8 Plus",
@@ -152,8 +152,8 @@
                 "installer_updates" : false
             },
             {
-                "id" : -347,
-                "url" : "http://mirrorlist.centos.org/?release=8&arch=aarch64&repo=cr&infra=stock",
+                "id" : -375,
+                "url" : "https://vault.centos.org/centos/8/cr/aarch64/os/",
                 "name" : "centos8-cr",
                 "distro_target" : "aarch64",
                 "description" : "CentOS 8 CR",
@@ -162,8 +162,8 @@
                 "installer_updates" : false
             },
             {
-                "id" : -348,
-                "url" : "http://mirrorlist.centos.org/?release=8&arch=aarch64&repo=extras&infra=stock",
+                "id" : -376,
+                "url" : "https://vault.centos.org/centos/8/extras/aarch64/os/",
                 "name" : "centos8-extras",
                 "distro_target" : "aarch64",
                 "description" : "CentOS 8 Extras",
@@ -172,8 +172,8 @@
                 "installer_updates" : false
             },
             {
-                "id" : -349,
-                "url" : "http://mirrorlist.centos.org/?release=8&arch=aarch64&repo=fasttrack&infra=stock",
+                "id" : -377,
+                "url" : "https://vault.centos.org/centos/8/fasttrack/aarch64/os/",
                 "name" : "centos8-fasttrack",
                 "distro_target" : "aarch64",
                 "description" : "CentOS 8 FastTrack",
@@ -182,8 +182,8 @@
                 "installer_updates" : false
             },
             {
-                "id" : -350,
-                "url" : "http://mirrorlist.centos.org/?release=8&arch=aarch64&repo=PowerTools&infra=stock",
+                "id" : -378,
+                "url" : "https://vault.centos.org/centos/8/PowerTools/aarch64/os/",
                 "name" : "centos8-powertools",
                 "distro_target" : "aarch64",
                 "description" : "CentOS 8 PowerTools",
@@ -1912,8 +1912,8 @@
         ],
         "repositories" : [
             {
-                "id" : -145,
-                "url" : "http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=BaseOS&infra=stock",
+                "id" : -365,
+                "url" : "https://vault.centos.org/centos/8/BaseOS/x86_64/os/",
                 "name" : "centos8",
                 "distro_target" : "x86_64",
                 "description" : "CentOS 8",
@@ -1922,8 +1922,8 @@
                 "installer_updates" : false
             },
             {
-                "id" : -146,
-                "url" : "http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=AppStream&infra=stock",
+                "id" : -366,
+                "url" : "https://vault.centos.org/centos/8/AppStream/x86_64/os/",
                 "name" : "centos8-appstream",
                 "distro_target" : "x86_64",
                 "description" : "CentOS 8 AppStream",
@@ -1932,8 +1932,8 @@
                 "installer_updates" : false
             },
             {
-                "id" : -147,
-                "url" : "http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=centosplus&infra=stock",
+                "id" : -367,
+                "url" : "https://vault.centos.org/centos/8/centosplus/x86_64/os/",
                 "name" : "centos8-centosplus",
                 "distro_target" : "x86_64",
                 "description" : "CentOS 8 Plus",
@@ -1942,8 +1942,8 @@
                 "installer_updates" : false
             },
             {
-                "id" : -148,
-                "url" : "http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=cr&infra=stock",
+                "id" : -368,
+                "url" : "https://vault.centos.org/centos/8/cr/x86_64/os/",
                 "name" : "centos8-cr",
                 "distro_target" : "x86_64",
                 "description" : "CentOS 8 CR",
@@ -1952,8 +1952,8 @@
                 "installer_updates" : false
             },
             {
-                "id" : -149,
-                "url" : "http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=extras&infra=stock",
+                "id" : -369,
+                "url" : "https://vault.centos.org/centos/8/extras/x86_64/os/",
                 "name" : "centos8-extras",
                 "distro_target" : "x86_64",
                 "description" : "CentOS 8 Extras",
@@ -1962,8 +1962,8 @@
                 "installer_updates" : false
             },
             {
-                "id" : -150,
-                "url" : "http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=fasttrack&infra=stock",
+                "id" : -370,
+                "url" : "https://vault.centos.org/centos/8/fasttrack/x86_64/os/",
                 "name" : "centos8-fasttrack",
                 "distro_target" : "x86_64",
                 "description" : "CentOS 8 FastTrack",
@@ -1972,8 +1972,8 @@
                 "installer_updates" : false
             },
             {
-                "id" : -151,
-                "url" : "http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=PowerTools&infra=stock",
+                "id" : -371,
+                "url" : "https://vault.centos.org/centos/8/PowerTools/x86_64/os/",
                 "name" : "centos8-powertools",
                 "distro_target" : "x86_64",
                 "description" : "CentOS 8 PowerTools",

--- a/susemanager-sync-data/channel_families.json
+++ b/susemanager-sync-data/channel_families.json
@@ -72,6 +72,14 @@
     "name" : "SUSE Linux Enterprise High Performance Computing LTSS 15 SP3 x86_64"
   },
   {
+    "label" : "HPC15-SP4-LTSS-ARM64",
+    "name" : "SUSE Linux Enterprise High Performance Computing LTSS 15 SP4 ARM64"
+  },
+  {
+    "label" : "HPC15-SP4-LTSS-X86",
+    "name" : "SUSE Linux Enterprise High Performance Computing LTSS 15 SP4 x86_64"
+  },
+  {
     "label" : "HPE-HELION-OPENSTACK-X86",
     "name" : "HPE Helion Openstack (x86)"
   },

--- a/susemanager-sync-data/susemanager-sync-data.changes
+++ b/susemanager-sync-data/susemanager-sync-data.changes
@@ -1,3 +1,5 @@
+- change centos 8 eol urls to vault which still work
+
 -------------------------------------------------------------------
 Fri Dec 03 12:33:33 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Changes centos 8 eol urls to vault which still work.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/16869

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
