### PR TITLE
QA: fixups for CentOS 7 tests

### DIFF
--- a/testsuite/features/secondary/trad_centos_client.feature
+++ b/testsuite/features/secondary/trad_centos_client.feature
@@ -27,6 +27,7 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
   Scenario: Prepare the CentOS 7 traditional client
     When I enable repository "CentOS-Base" on this "ceos_client"
     And I enable client tools repositories on "ceos_client"
+    And I refresh the packages list via package manager on "ceos_client"
     And I install the traditional stack utils on "ceos_client"
     And I install OpenSCAP dependencies on "ceos_client"
     And I register "ceos_client" as traditional client

--- a/testsuite/features/secondary/trad_centos_migrate_to_min.feature
+++ b/testsuite/features/secondary/trad_centos_migrate_to_min.feature
@@ -7,8 +7,16 @@ Feature: Migrate a CentOS 7 traditional client into a Salt minion
   As an authorized user
   I want to migrate this CentOS 7 traditional client to a Salt minion
 
-  Scenario: Prepare the CentOS 7 traditional client in the migration context
+  Scenario: Delete the CentOS minion in the migration context
     Given I am authorized for the "Admin" section
+    When I am on the Systems overview page of this "ceos_client"
+    When I follow "Delete System"
+    Then I should see a "Confirm System Profile Deletion" text
+    When I click on "Delete Profile"
+    And I wait until I see "has been deleted" text
+    Then "ceos_client" should not be registered
+
+  Scenario: Prepare the CentOS 7 traditional client in the migration context
     When I enable repository "CentOS-Base" on this "ceos_client"
     And I enable client tools repositories on "ceos_client"
     And I refresh the packages list via package manager on "ceos_client"

--- a/testsuite/features/secondary/trad_centos_migrate_to_min.feature
+++ b/testsuite/features/secondary/trad_centos_migrate_to_min.feature
@@ -7,10 +7,10 @@ Feature: Migrate a CentOS 7 traditional client into a Salt minion
   As an authorized user
   I want to migrate this CentOS 7 traditional client to a Salt minion
 
-  Scenario: Delete the CentOS minion in the migration context
+  Scenario: Delete the CentOS 7 minion in the migration context
     Given I am authorized for the "Admin" section
     When I am on the Systems overview page of this "ceos_client"
-    When I follow "Delete System"
+    And I follow "Delete System"
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
     And I wait until I see "has been deleted" text


### PR DESCRIPTION
## What does this PR change? 

Fixup of https://github.com/uyuni-project/uyuni/pull/4833

According to the failing [Uyuni tests](https://ci.suse.de/job/uyuni-master-dev-acceptance-tests-NUE/2704/testReport/(root)/Migrate%20a%20CentOS%207%20traditional%20client%20into%20a%20Salt%20minion/Prepare_the_CentOS_7_traditional_client_in_the_migration_context/), we have to delete the minion first to be able to register it as trad. client.
Furthermore I added the repository refresh to our CentOS 7 traditional client test to prevent it failing like it did with the migration tests of CentOS 7 in the past.
## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
- Cucumber tests were edited

- [x] **DONE**

## Links

Manager 4.2
Manager 4.1

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
