### PR TITLE
QA: fixup migration from trad client to minion

### DIFF
--- a/testsuite/features/secondary/trad_deleted_migrate_to_minion.feature
+++ b/testsuite/features/secondary/trad_deleted_migrate_to_minion.feature
@@ -112,3 +112,11 @@ Feature: Migrate a unregistered traditional client into a Salt minion
     Given I am on the Systems overview page of this "sle_client"
     When I follow "Properties" in the content area
     Then I wait until I see "Base System Type:.*Salt" regex, refreshing the page
+
+  Scenario: Cleanup: unregister migrated minion in a deleted client context
+    Given I am on the Systems overview page of this "sle_client"
+    When I follow "Delete System"
+    Then I should see a "Confirm System Profile Deletion" text
+    When I click on "Delete Profile"
+    And I wait until I see "has been deleted" text
+    Then "sle_client" should not be registered


### PR DESCRIPTION
## What does this PR change?

Fixup of https://github.com/uyuni-project/uyuni/pull/4815
At the beginning of the test the Salt minion will get registered. At the end the minion will get deleted again. Hopefully this make the test idempotent again.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
- Cucumber tests were edited

- [x] **DONE**

## Links

[Manager 4.2](https://github.com/SUSE/spacewalk/pull/17097)
[Manager 4.1](https://github.com/SUSE/spacewalk/pull/17098)

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
