### PR TITLE
Hub reporting fix reinstall

### DIFF
--- a/spacewalk/setup/lib/Spacewalk/Setup.pm
+++ b/spacewalk/setup/lib/Spacewalk/Setup.pm
@@ -875,6 +875,11 @@ sub postgresql_reportdb_setup {
 
     postgresql_get_reportdb_answers($opts, $answers);
 
+    if ($opts->{"clear-db"}) {
+        print Spacewalk::Setup::loc("** Database: --clear-db option used.  Clearing report database.\n");
+	postgresql_drop_reportdb($answers);
+    }
+
     system("spacewalk-setup-db-ssl-certificates", $answers->{'report-db-ca-cert'});
     $ENV{PGSSLMODE}="verify-full";
 
@@ -1109,6 +1114,13 @@ sub postgresql_clear_db {
                 $dbh->do($c);
         }
         $dbh->disconnect;
+        return 1;
+}
+
+sub postgresql_drop_reportdb {
+        my $answers = shift;
+
+        system_debug('/usr/bin/uyuni-setup-reportdb', '--db='.$answers->{'report-db-name'}, '--user='.$answers->{'report-db-user'});
         return 1;
 }
 

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,4 @@
+- drop the reporting DB when clear-db option is set
   * Remove pylint according to Fedora package guidelines.
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

When spacewalk-setup is called with --clear-db, we should drop also the reporting database to not prevent a re-installation.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/4867
Fixes https://github.com/SUSE/spacewalk/issues/17182

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
