### PR TITLE
Container proxy configuration generation API

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
@@ -142,7 +142,7 @@ public class HandlerFactory {
                 regularMinionBootstrapper,
                 sshMinionBootstrapper
         );
-        ProxyHandler proxyHandler = new ProxyHandler(xmlRpcSystemHelper);
+        ProxyHandler proxyHandler = new ProxyHandler(xmlRpcSystemHelper, systemManager);
         SystemHandler systemHandler = new SystemHandler(taskomaticApi, xmlRpcSystemHelper, systemEntitlementManager,
                 systemManager, serverGroupManager);
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/LoggingInvocationProcessor.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/LoggingInvocationProcessor.java
@@ -187,6 +187,8 @@ public class LoggingInvocationProcessor implements XmlRpcInvocationInterceptor {
                         argPosition == 11 || argPosition == 12 || argPosition == 13;
             case "admin.payg.setDetails":
                 return argPosition == 1;
+            case "proxy.container_config":
+                return argPosition == 8 || argPosition == 6 || argPosition == 7;
             default:
                 return false;
         }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/SSLCertFaultException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/SSLCertFaultException.java
@@ -12,21 +12,29 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package com.suse.manager.ssl;
+package com.redhat.rhn.frontend.xmlrpc;
 
-import com.redhat.rhn.common.RhnRuntimeException;
+import com.redhat.rhn.FaultException;
 
 /**
- * Exception indicating an error during SSL certificate generation
+ * XML-RPC Fault thrown when generating SSL Certificates
  */
-public class SSLCertGenerationException extends RhnRuntimeException {
+public class SSLCertFaultException extends FaultException {
+    private static final int CODE = 10005;
+    private static final String LABEL = "sslCertFault";
 
     /**
-     * Create a new SSL certificate generation exception
-     *
-     * @param message error message
+     * Constructor
      */
-    public SSLCertGenerationException(String message) {
-        super(message);
+    public SSLCertFaultException() {
+        super(CODE, LABEL, "SSL Certificate fault");
+    }
+
+    /**
+     * Constructor
+     * @param message the error message
+     */
+    public SSLCertFaultException(String message) {
+        super(CODE, LABEL, String.format("SSL Certificate fault: %s", message));
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/ProxyHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/ProxyHandler.java
@@ -48,7 +48,7 @@ import java.util.List;
  * server.
  */
 public class ProxyHandler extends BaseHandler {
-    private static Logger log = Logger.getLogger(ProxyHandler.class);
+    private static final Logger LOG = Logger.getLogger(ProxyHandler.class);
     private final XmlRpcSystemHelper xmlRpcSystemHelper;
 
     /**
@@ -206,7 +206,7 @@ public class ProxyHandler extends BaseHandler {
      */
     public Object[] listProxies(User loggedInUser) {
         List<Server> proxies = ServerFactory.lookupProxiesByOrg(loggedInUser);
-        List toReturn = new ArrayList();
+        List<Object> toReturn = new ArrayList<>();
         for (Server server : proxies) {
             toReturn.add(xmlRpcSystemHelper.format(server));
         }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/test/ProxyHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/test/ProxyHandlerTest.java
@@ -131,15 +131,6 @@ public class ProxyHandlerTest extends RhnJmockBaseTestCase {
         assertEquals(1, rc);
     }
 
-    public void aTestWithExistingProxy() throws Exception {
-        Server server = ServerFactory.lookupById(1005012107L);
-        ClientCertificate cert = SystemManager.createClientCertificate(server);
-        cert.validate(server.getSecret());
-        ProxyHandler ph = new ProxyHandler(xmlRpcSystemHelper, systemManager);
-        int rc = ph.deactivateProxy(cert.toString());
-        assertEquals(1, rc);
-    }
-
     public void testListProxyClients() throws Exception {
         // create user
         User user = UserTestUtils.findNewUser("testuser", "testorg");

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/test/ProxyHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/test/ProxyHandlerTest.java
@@ -54,15 +54,19 @@ import java.util.Set;
 
 public class ProxyHandlerTest extends RhnJmockBaseTestCase {
 
-    private SaltApi saltApi = new TestSaltApi();
-    private SystemQuery systemQuery = new TestSystemQuery();
-    private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery, saltApi);
-    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery, saltApi);
-    private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
+    private static final String TEST_USER = "testuser";
+    private static final String TEST_ORG = "testorg";
+
+    private final SaltApi saltApi = new TestSaltApi();
+    private final SystemQuery systemQuery = new TestSystemQuery();
+    private final RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(
+            systemQuery, saltApi);
+    private final SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery, saltApi);
+    private final XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper
     );
-    private SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON,
+    private final SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON,
             saltApi);
 
     @Override
@@ -73,16 +77,16 @@ public class ProxyHandlerTest extends RhnJmockBaseTestCase {
     }
 
     public void testDeactivateProxyWithReload() throws Exception {
-        User user = UserTestUtils.findNewUser("testuser", "testorg");
+        User user = UserTestUtils.findNewUser(TEST_USER, TEST_ORG);
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         Server server = ServerFactoryTest.createTestProxyServer(user, true);
         assertTrue(server.isProxy());
-        server = SystemManager.deactivateProxy(server);
-        assertFalse(server.isProxy());
+        Server changedServer = SystemManager.deactivateProxy(server);
+        assertFalse(changedServer.isProxy());
     }
 
     public void testActivateProxy() throws Exception {
-        User user = UserTestUtils.findNewUser("testuser", "testorg");
+        User user = UserTestUtils.findNewUser(TEST_USER, TEST_ORG);
         ProxyHandler ph = new ProxyHandler(xmlRpcSystemHelper, systemManager);
 
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
@@ -98,7 +102,7 @@ public class ProxyHandlerTest extends RhnJmockBaseTestCase {
     }
 
     public void testActivateSaltProxy() throws Exception {
-        User user = UserTestUtils.findNewUser("testuser", "testorg");
+        User user = UserTestUtils.findNewUser(TEST_USER, TEST_ORG);
         ProxyHandler ph = new ProxyHandler(xmlRpcSystemHelper, systemManager);
 
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
@@ -114,7 +118,7 @@ public class ProxyHandlerTest extends RhnJmockBaseTestCase {
     }
 
     public void testDeactivateProxy() throws Exception {
-        User user = UserTestUtils.findNewUser("testuser", "testorg");
+        User user = UserTestUtils.findNewUser(TEST_USER, TEST_ORG);
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         Server server = ServerFactoryTest.createTestServer(user, true,
                 ServerConstants.getServerGroupTypeEnterpriseEntitled(),
@@ -133,7 +137,7 @@ public class ProxyHandlerTest extends RhnJmockBaseTestCase {
 
     public void testListProxyClients() throws Exception {
         // create user
-        User user = UserTestUtils.findNewUser("testuser", "testorg");
+        User user = UserTestUtils.findNewUser(TEST_USER, TEST_ORG);
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
 
         // create proxy

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/test/ProxyHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/test/ProxyHandlerTest.java
@@ -18,10 +18,12 @@ import static com.redhat.rhn.domain.server.ServerFactory.createServerPaths;
 import static java.lang.Math.toIntExact;
 
 import com.redhat.rhn.common.client.ClientCertificate;
+import com.redhat.rhn.common.util.Asserts;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerConstants;
 import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.domain.server.ServerPath;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.domain.server.test.ServerFactoryTest;
@@ -29,20 +31,28 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.xmlrpc.proxy.ProxyHandler;
 import com.redhat.rhn.frontend.xmlrpc.system.XmlRpcSystemHelper;
 import com.redhat.rhn.manager.system.SystemManager;
-import com.redhat.rhn.testing.RhnBaseTestCase;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 import com.redhat.rhn.testing.UserTestUtils;
 
+import com.suse.manager.ssl.SSLCertData;
+import com.suse.manager.ssl.SSLCertPair;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
+import com.suse.manager.webui.services.SaltStateGeneratorService;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.manager.webui.services.test.TestSystemQuery;
 
+import org.jmock.Expectations;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
+import org.junit.Assert;
+
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-public class ProxyHandlerTest extends RhnBaseTestCase {
+public class ProxyHandlerTest extends RhnJmockBaseTestCase {
 
     private SaltApi saltApi = new TestSaltApi();
     private SystemQuery systemQuery = new TestSystemQuery();
@@ -52,6 +62,15 @@ public class ProxyHandlerTest extends RhnBaseTestCase {
             regularMinionBootstrapper,
             sshMinionBootstrapper
     );
+    private SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON,
+            saltApi);
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+        SaltStateGeneratorService.INSTANCE.setSkipSetOwner(true);
+    }
 
     public void testDeactivateProxyWithReload() throws Exception {
         User user = UserTestUtils.findNewUser("testuser", "testorg");
@@ -64,7 +83,7 @@ public class ProxyHandlerTest extends RhnBaseTestCase {
 
     public void testActivateProxy() throws Exception {
         User user = UserTestUtils.findNewUser("testuser", "testorg");
-        ProxyHandler ph = new ProxyHandler(xmlRpcSystemHelper);
+        ProxyHandler ph = new ProxyHandler(xmlRpcSystemHelper, systemManager);
 
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         Server server = ServerFactoryTest.createTestServer(user, true,
@@ -80,7 +99,7 @@ public class ProxyHandlerTest extends RhnBaseTestCase {
 
     public void testActivateSaltProxy() throws Exception {
         User user = UserTestUtils.findNewUser("testuser", "testorg");
-        ProxyHandler ph = new ProxyHandler(xmlRpcSystemHelper);
+        ProxyHandler ph = new ProxyHandler(xmlRpcSystemHelper, systemManager);
 
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         Server server = ServerFactoryTest.createTestServer(user, true,
@@ -107,7 +126,7 @@ public class ProxyHandlerTest extends RhnBaseTestCase {
         ClientCertificate cert = SystemManager.createClientCertificate(server);
         cert.validate(server.getSecret());
 
-        ProxyHandler ph = new ProxyHandler(xmlRpcSystemHelper);
+        ProxyHandler ph = new ProxyHandler(xmlRpcSystemHelper, systemManager);
         int rc = ph.deactivateProxy(cert.toString());
         assertEquals(1, rc);
     }
@@ -116,13 +135,9 @@ public class ProxyHandlerTest extends RhnBaseTestCase {
         Server server = ServerFactory.lookupById(1005012107L);
         ClientCertificate cert = SystemManager.createClientCertificate(server);
         cert.validate(server.getSecret());
-        ProxyHandler ph = new ProxyHandler(xmlRpcSystemHelper);
+        ProxyHandler ph = new ProxyHandler(xmlRpcSystemHelper, systemManager);
         int rc = ph.deactivateProxy(cert.toString());
         assertEquals(1, rc);
-    }
-
-    public void testLameTest() {
-        assertNotNull(new ProxyHandler(xmlRpcSystemHelper));
     }
 
     public void testListProxyClients() throws Exception {
@@ -141,9 +156,53 @@ public class ProxyHandlerTest extends RhnBaseTestCase {
         minion.getServerPaths().addAll(proxyPaths);
 
         // call method
-        List<Long> clientIds = new ProxyHandler(xmlRpcSystemHelper).listProxyClients(user, toIntExact(proxy.getId()));
+        List<Long> clientIds = new ProxyHandler(xmlRpcSystemHelper, systemManager)
+                .listProxyClients(user, toIntExact(proxy.getId()));
 
         // verify client id is in results
-        assertContains(clientIds, minion.getId());
+        Asserts.assertContains(clientIds, minion.getId());
+    }
+
+    public void testContainerConfig() throws Exception {
+        User user = UserTestUtils.findNewUser(TEST_USER, TEST_ORG);
+        byte[] dummyConfig = "Dummy config".getBytes();
+        String server = "srv.acme.lab";
+        String proxy = "proxy.acme.lab";
+        String email = "admin@acme.lab";
+
+        SystemManager mockSystemManager = mock(SystemManager.class);
+        context().checking(new Expectations() {{
+            allowing(mockSystemManager).createProxyContainerConfig(user, proxy, server, 2048L, email,
+                    "ROOT_CA", List.of("CA1", "CA2"), new SSLCertPair("PROXY_CERT", "PROXY_KEY"),
+                    null, null, null);
+            will(returnValue(dummyConfig));
+        }});
+
+        byte[] actual = new ProxyHandler(xmlRpcSystemHelper, mockSystemManager).containerConfig(user, proxy, server,
+                2048, email, "ROOT_CA", List.of("CA1", "CA2"), "PROXY_CERT", "PROXY_KEY");
+        assertEquals(dummyConfig, actual);
+    }
+
+    public void testContainerConfigGenerateCert() throws Exception {
+        User user = UserTestUtils.findNewUser(TEST_USER, TEST_ORG);
+        byte[] dummyConfig = "Dummy config".getBytes();
+        String server = "srv.acme.lab";
+        String proxy = "proxy.acme.lab";
+        String email = "admin@acme.lab";
+
+        SystemManager mockSystemManager = mock(SystemManager.class);
+        context().checking(new Expectations() {{
+            allowing(mockSystemManager).createProxyContainerConfig(user, proxy, server, 2048L, email,
+                    null, Collections.emptyList(), null,
+                    new SSLCertPair("CACert", "CAKey"), "CAPass",
+                    new SSLCertData(proxy, List.of("cname1", "cname2"), "DE", "Bayern", "Nurnberg",
+                            "ACME", "ACME Tests", "coyote@acme.lab"));
+            will(returnValue(dummyConfig));
+        }});
+
+        byte[] actual = new ProxyHandler(xmlRpcSystemHelper, mockSystemManager).containerConfig(user, proxy, server,
+                2048, email, "CACert", "CAKey", "CAPass", List.of("cname1", "cname2"),
+                "DE", "Bayern", "Nurnberg", "ACME", "ACME Tests", "coyote@acme.lab");
+        Assert.assertArrayEquals(dummyConfig, actual);
     }
 }

--- a/java/code/src/com/suse/manager/reactor/messaging/test/README.md
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/README.md
@@ -20,3 +20,14 @@ Then run Salt command(s)
 cat file.json | python -m json.tool
 ```
 
+# A more hacky way, but closer to the API reality
+
+- Change the `https` into `http` in `SaltService.SALT_MASTER_URI`
+_ Deploy the change
+- Edit `/etc/salt/master.d/susemanager.conf` to comment the `ssl_crt` and `ssl_key` lines and add `disable_ssl: true` below them.
+- `salt-service restart`
+- On the server `zypper in tcpdump` and `tcpdump -s 0 -A -i lo port 9080`
+
+You will now see the HTTP frames as they are sent to the client, ready to copy them.
+
+**Don't push the change !**

--- a/java/code/src/com/suse/manager/reactor/messaging/test/SaltTestUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/SaltTestUtils.java
@@ -16,6 +16,8 @@ package com.suse.manager.reactor.messaging.test;
 
 import static org.hamcrest.Matchers.equalTo;
 
+import com.redhat.rhn.common.RhnRuntimeException;
+import com.redhat.rhn.common.util.FileUtils;
 import com.redhat.rhn.testing.TestUtils;
 
 import com.suse.salt.netapi.calls.Call;
@@ -35,14 +37,11 @@ import org.hamcrest.Matchers;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Type;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 
 /**
  * Provides utility functions to use in salt-related unit tests.
@@ -83,8 +82,8 @@ public class SaltTestUtils {
     public static <T> Optional<T> getSaltResponse(String filename, Map<String, String> placeholders,
                                                   TypeToken<T> type) {
         try {
-            Path path = new File(TestUtils.findTestData(filename).getPath()).toPath();
-            String content = Files.lines(path).collect(Collectors.joining("\n"));
+            String path = new File(TestUtils.findTestData(filename).getPath()).getAbsolutePath();
+            String content = FileUtils.readStringFromFile(path);
 
             if (placeholders != null) {
                 for (Map.Entry<String, String> entry : placeholders.entrySet()) {
@@ -99,7 +98,7 @@ public class SaltTestUtils {
             return Optional.of(target);
         }
         catch (IOException | ClassNotFoundException e) {
-           throw new RuntimeException(e);
+           throw new RhnRuntimeException(e);
         }
     }
 

--- a/java/code/src/com/suse/manager/ssl/SSLCertData.java
+++ b/java/code/src/com/suse/manager/ssl/SSLCertData.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.ssl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Data contained in an SSL certificate, also used to generate them
+ */
+public class SSLCertData {
+    private final String cn;
+    private final List<String> cnames;
+    private final String country;
+    private final String state;
+    private final String city;
+    private final String org;
+    private final String orgUnit;
+    private final String email;
+
+    /**
+     * Create new data objet
+     *
+     * @param cnIn CN
+     * @param cnamesIn list of cnames
+     * @param countryIn the country
+     * @param stateIn the state
+     * @param cityIn the city
+     * @param orgIn the organization
+     * @param orgUnitIn the organization unit
+     * @param emailIn the mail
+     */
+    public SSLCertData(String cnIn, List<String> cnamesIn, String countryIn, String stateIn, String cityIn,
+                       String orgIn, String orgUnitIn, String emailIn) {
+        cn = cnIn;
+        cnames = cnamesIn;
+        country = countryIn;
+        state = stateIn;
+        city = cityIn;
+        org = orgIn;
+        orgUnit = orgUnitIn;
+        email = emailIn;
+    }
+
+    /**
+     * @return the values as parameters for the rhn-ssl-tool
+     */
+    public List<String> getRhnSslToolParams() {
+        List<String> params = new ArrayList<>();
+
+        if (cn != null) {
+            params.addAll(List.of("--set-hostname", cn));
+        }
+
+        if (cnames != null) {
+            params.addAll(cnames.stream()
+                    .flatMap(cname -> List.of("--set-cname", cname).stream()).collect(Collectors.toList()));
+        }
+
+        if (country != null) {
+            params.addAll(List.of("--set-country", country));
+        }
+
+        if (state != null) {
+            params.addAll(List.of("--set-state", state));
+        }
+
+        if (city != null) {
+            params.addAll(List.of("--set-city", city));
+        }
+
+        if (org != null) {
+            params.addAll(List.of("--set-org", org));
+        }
+
+        if (orgUnit != null) {
+            params.addAll(List.of("--set-org-unit", orgUnit));
+        }
+
+        if (email != null) {
+            params.addAll(List.of("--set-email", email));
+        }
+        return params;
+    }
+
+    /**
+     * @return value of cn
+     */
+    public String getCn() {
+        return cn;
+    }
+
+    @Override
+    public boolean equals(Object oIn) {
+        if (this == oIn) {
+            return true;
+        }
+        if (oIn == null || getClass() != oIn.getClass()) {
+            return false;
+        }
+        SSLCertData that = (SSLCertData) oIn;
+        return Objects.equals(cn, that.cn) &&
+                Objects.equals(cnames, that.cnames) &&
+                Objects.equals(country, that.country) &&
+                Objects.equals(state, that.state) &&
+                Objects.equals(city, that.city) &&
+                Objects.equals(org, that.org) &&
+                Objects.equals(orgUnit, that.orgUnit) &&
+                Objects.equals(email, that.email);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cn, cnames, country, state, city, org, orgUnit, email);
+    }
+}

--- a/java/code/src/com/suse/manager/ssl/SSLCertGenerationException.java
+++ b/java/code/src/com/suse/manager/ssl/SSLCertGenerationException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.ssl;
+
+import com.redhat.rhn.common.RhnRuntimeException;
+
+/**
+ * Exception indicating an error during SSL certificate generation
+ */
+public class SSLCertGenerationException extends RhnRuntimeException {
+
+    /**
+     * Create a new SSL certificate generation exception
+     *
+     * @param message error message
+     * @param t the exception causing the error
+     */
+    public SSLCertGenerationException(String message, Throwable t) {
+        super(message, t);
+    }
+
+    /**
+     * Create a new SSL certificate generation exception
+     *
+     * @param t the exception causing the error
+     */
+    public SSLCertGenerationException(Throwable t) {
+        super(t);
+    }
+}

--- a/java/code/src/com/suse/manager/ssl/SSLCertManager.java
+++ b/java/code/src/com/suse/manager/ssl/SSLCertManager.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.ssl;
+
+import com.redhat.rhn.common.RhnRuntimeException;
+import com.redhat.rhn.common.util.FileUtils;
+
+import com.suse.manager.utils.ExecHelper;
+
+import org.apache.log4j.Logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class helping to generate and check SSL certificates
+ */
+public class SSLCertManager {
+    private static final Logger LOG = Logger.getLogger(SSLCertManager.class);
+
+    private final ExecHelper execHelper;
+    private File sslBuildDir = null;
+
+    /**
+     * Default constructor
+     */
+    public SSLCertManager() {
+        execHelper = new ExecHelper();
+    }
+
+    /**
+     * Constructor to use for testing
+     *
+     * @param helper the exec helper
+     * @param tempDirectory temporary files folder
+     */
+    public SSLCertManager(ExecHelper helper, File tempDirectory) {
+        execHelper = helper;
+        sslBuildDir = tempDirectory;
+    }
+
+    /**
+     * Generate an SSL certificate using a provided CA
+     *
+     * @param caPair the CA certificate and it key used to sign the certificate to generate
+     * @param password the CA private key password
+     * @param data the data to use to create the certificate
+     *
+     * @return the generated certicate and its key
+     * @throws SSLCertGenerationException if anything wrong happens when generating the certificate
+     */
+    public SSLCertPair generateCertificate(SSLCertPair caPair, String password, SSLCertData data)
+            throws SSLCertGenerationException {
+        // Run the ssh-ssl-tool in a temporary folder
+        try {
+            if (sslBuildDir == null) {
+                sslBuildDir = Files.createTempDirectory("ssltool").toFile();
+            }
+
+            // Write the CA data to the temp folder
+            File tempCaCertFile = new File(sslBuildDir, "ca.crt");
+            FileUtils.writeStringToFile(caPair.getCertificate(), tempCaCertFile.getAbsolutePath());
+
+            File tempCaKeyFile = new File(sslBuildDir, "ca.key");
+            FileUtils.writeStringToFile(caPair.getKey(), tempCaKeyFile.getAbsolutePath());
+
+            List<String> command = new ArrayList<>();
+            command.addAll(List.of("rhn-ssl-tool", "--gen-server", "-q", "--no-rpm"));
+            command.addAll(List.of("-d", sslBuildDir.getAbsolutePath()));
+            command.addAll(List.of("--ca-cert", tempCaCertFile.getName()));
+            command.addAll(List.of("--ca-key", tempCaKeyFile.getName()));
+            command.addAll(data.getRhnSslToolParams());
+
+            execHelper.exec(command, password);
+
+            // Read the cert and key files
+            File serverFolder = new File(sslBuildDir, data.getCn().split("\\.")[0]);
+            File serverCertFile = new File(serverFolder, "server.crt");
+            File serverKeyFile = new File(serverFolder, "server.key");
+            return new SSLCertPair(FileUtils.readStringFromFile(serverCertFile.getAbsolutePath()),
+                    FileUtils.readStringFromFile(serverKeyFile.getAbsolutePath()));
+        }
+        catch (RhnRuntimeException err) {
+            throw new SSLCertGenerationException("SSL certificates generation failed", err);
+        }
+        catch (IOException err) {
+            throw new SSLCertGenerationException("Failed to create temporary folder", err);
+        }
+        finally {
+            if (sslBuildDir != null) {
+                try {
+                    org.apache.commons.io.FileUtils.deleteDirectory(sslBuildDir);
+                }
+                catch (IOException err) {
+                    LOG.error("Failed to remove temporary folder", err);
+                }
+            }
+        }
+    }
+}

--- a/java/code/src/com/suse/manager/ssl/SSLCertManager.java
+++ b/java/code/src/com/suse/manager/ssl/SSLCertManager.java
@@ -95,11 +95,8 @@ public class SSLCertManager {
             return new SSLCertPair(FileUtils.readStringFromFile(serverCertFile.getAbsolutePath()),
                     FileUtils.readStringFromFile(serverKeyFile.getAbsolutePath()));
         }
-        catch (RhnRuntimeException err) {
-            throw new SSLCertGenerationException("SSL certificates generation failed", err);
-        }
-        catch (IOException err) {
-            throw new SSLCertGenerationException("Failed to create temporary folder", err);
+        catch (RhnRuntimeException | IOException err) {
+            throw new SSLCertGenerationException(err.getMessage());
         }
         finally {
             if (sslBuildDir != null) {

--- a/java/code/src/com/suse/manager/ssl/SSLCertPair.java
+++ b/java/code/src/com/suse/manager/ssl/SSLCertPair.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.ssl;
+
+import java.util.Objects;
+
+/**
+ * SSL certificate and its key
+ */
+public class SSLCertPair {
+
+    private String certificate;
+    private String key;
+
+    /**
+     * Creates a new pair
+     *
+     * @param certificateIn certificate content in PEM format
+     * @param keyIn private key content in PEM format
+     */
+    public SSLCertPair(String certificateIn, String keyIn) {
+        certificate = certificateIn;
+        key = keyIn;
+    }
+
+    /**
+     * @return value of certificate
+     */
+    public String getCertificate() {
+        return certificate;
+    }
+
+    /**
+     * @param certificateIn value of certificate
+     */
+    public void setCertificate(String certificateIn) {
+        certificate = certificateIn;
+    }
+
+    /**
+     * @return value of key
+     */
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * @param keyIn value of key
+     */
+    public void setKey(String keyIn) {
+        key = keyIn;
+    }
+
+    /**
+     * @return whether the pair has a proper certificate and key
+     */
+    public boolean isComplete() {
+        return certificate != null && key != null;
+    }
+
+    /**
+     * @return if the cert / key values are invalid
+     */
+    public boolean isInvalid() {
+        return certificate == null ^ key == null;
+    }
+
+    @Override
+    public boolean equals(Object oIn) {
+        if (this == oIn) {
+            return true;
+        }
+        if (oIn == null || getClass() != oIn.getClass()) {
+            return false;
+        }
+        SSLCertPair that = (SSLCertPair) oIn;
+        return Objects.equals(certificate, that.certificate) &&
+                Objects.equals(key, that.key);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(certificate, key);
+    }
+}

--- a/java/code/src/com/suse/manager/ssl/test/SSLCertManagerTest.java
+++ b/java/code/src/com/suse/manager/ssl/test/SSLCertManagerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.ssl.test;
+
+import com.redhat.rhn.common.util.FileUtils;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
+
+import com.suse.manager.ssl.SSLCertData;
+import com.suse.manager.ssl.SSLCertManager;
+import com.suse.manager.ssl.SSLCertPair;
+import com.suse.manager.utils.ExecHelper;
+
+import org.hamcrest.collection.IsArrayContainingInAnyOrder;
+import org.jmock.Expectations;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+
+public class SSLCertManagerTest extends RhnJmockBaseTestCase {
+
+    private Runtime runtime;
+    private Process process;
+    private File tempDir;
+    private SSLCertManager certManager;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+        runtime = mock(Runtime.class);
+        process = mock(Process.class);
+        tempDir = Files.createTempDirectory("testssl").toFile();
+        certManager = new SSLCertManager(new ExecHelper(() -> runtime), tempDir);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        org.apache.commons.io.FileUtils.deleteDirectory(tempDir);
+    }
+
+    public void testGenerateSSLCert() throws Exception {
+        ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        context().checking(new Expectations() {{
+            allowing(runtime).exec(with(IsArrayContainingInAnyOrder.arrayContainingInAnyOrder(
+                    "rhn-ssl-tool", "--gen-server", "-q", "--no-rpm", "-d", tempDir.getAbsolutePath(),
+                    "--ca-cert", "ca.crt", "--ca-key", "ca.key", "--set-hostname", "server.acme.lab",
+                    "--set-cname", "srv1.acme.lab", "--set-cname", "srv2.acme.lab", "--set-country", "DE",
+                    "--set-state", "Bayern", "--set-city", "Nurnberg", "--set-org", "SUSE",
+                    "--set-org-unit", "SUSE Tests", "--set-email", "fakemail")));
+            will(returnValue(process));
+            allowing(process).getOutputStream();
+            will(returnValue(outStream));
+            allowing(process).waitFor();
+            will(returnValue(0));
+        }});
+
+        File srvDir = new File(tempDir, "server");
+        srvDir.mkdir();
+        FileUtils.writeStringToFile("FakeCert", new File(srvDir, "server.crt").getAbsolutePath());
+        FileUtils.writeStringToFile("FakeKey", new File(srvDir, "server.key").getAbsolutePath());
+
+        SSLCertData sslData = new SSLCertData("server.acme.lab", List.of("srv1.acme.lab", "srv2.acme.lab"),
+                "DE", "Bayern", "Nurnberg", "SUSE", "SUSE Tests", "fakemail");
+
+        SSLCertPair actual = certManager.generateCertificate(new SSLCertPair("caCert", "caKey"), "capassword", sslData);
+        assertEquals(new SSLCertPair("FakeCert", "FakeKey"), actual);
+
+        assertEquals("capassword", outStream.toString(StandardCharsets.US_ASCII));
+
+        assertFalse(tempDir.exists());
+    }
+}

--- a/java/code/src/com/suse/manager/utils/ExecHelper.java
+++ b/java/code/src/com/suse/manager/utils/ExecHelper.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.utils;
+
+import com.redhat.rhn.common.RhnRuntimeException;
+
+import org.apache.log4j.Logger;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class ExecHelper {
+    private static final Logger LOG = Logger.getLogger(ExecHelper.class);
+
+    private final Supplier<Runtime> runtimeSupplier;
+
+    /**
+     * Create a new helper instance mostly used for testing
+     *
+     * @param runtimeSupplierIn a runtime supplier
+     */
+    public ExecHelper(Supplier<Runtime> runtimeSupplierIn) {
+       runtimeSupplier = runtimeSupplierIn;
+    }
+
+    /**
+     * Default constructor using the current runtime
+     */
+    public ExecHelper() {
+        runtimeSupplier = () -> Runtime.getRuntime();
+    }
+
+    /**
+     * Execute an external process.
+     *
+     * @param command the command to run
+     * @param input the value to pass as standard input of the process
+     *
+     * @throws RhnRuntimeException if anything wrong happens or if the exit code is not 0
+     */
+    public void exec(List<String> command, String input) throws RhnRuntimeException {
+        Process process;
+        try {
+            process = runtimeSupplier.get().exec(command.toArray(new String[0]));
+        }
+        catch (IOException err) {
+            throw new RhnRuntimeException("Failed to run external process", err);
+        }
+
+        // Write to the stdin of the program
+        try (
+                OutputStreamWriter outStream = new OutputStreamWriter(process.getOutputStream());
+                BufferedWriter output = new BufferedWriter(outStream)
+        ) {
+            output.write(input);
+            output.flush();
+        }
+        catch (IOException err) {
+            throw new RhnRuntimeException("Failed to write to external process input");
+        }
+
+        try {
+            if (process.waitFor() != 0) {
+                String errMsg = new String(process.getErrorStream().readAllBytes());
+                throw new RhnRuntimeException("External tool failed: " + errMsg);
+            }
+        }
+        catch (InterruptedException err) {
+            LOG.error(err);
+            Thread.currentThread().interrupt();
+            throw new RhnRuntimeException("External tool interrupted", err);
+        }
+        catch (IOException err) {
+            throw new RhnRuntimeException("Failed to read external process error output", err);
+        }
+    }
+}

--- a/java/code/src/com/suse/manager/webui/controllers/SaltSSHController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/SaltSSHController.java
@@ -23,9 +23,6 @@ import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
 import org.apache.log4j.Logger;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.Optional;
 
 import spark.Request;

--- a/java/code/src/com/suse/manager/webui/controllers/utils/SSHMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/SSHMinionBootstrapper.java
@@ -90,8 +90,8 @@ public class SSHMinionBootstrapper extends AbstractMinionBootstrapper {
     @Override
     protected BootstrapResult bootstrapInternal(BootstrapParameters params, User user,
                                                 String defaultContactMethod) {
-        Optional<MgrUtilRunner.ExecResult> res = saltApi.generateSSHKey(SaltSSHService.SSH_KEY_PATH);
-        if (!res.isPresent()) {
+        Optional<MgrUtilRunner.SshKeygenResult> res = saltApi.generateSSHKey(SaltSSHService.SSH_KEY_PATH);
+        if (res.isEmpty()) {
             LOG.error("Could not generate salt-ssh public key.");
             return new BootstrapResult(false, Optional.empty(), "Could not generate salt-ssh public key.");
         }

--- a/java/code/src/com/suse/manager/webui/controllers/utils/test/AbstractMinionBootstrapperTestBase.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/test/AbstractMinionBootstrapperTestBase.java
@@ -161,7 +161,7 @@ public abstract class AbstractMinionBootstrapperTestBase extends JMockBaseTestCa
             allowing(saltServiceMock).generateKeysAndAccept("myhost", false);
             will(returnValue(keyPair));
 
-            MgrUtilRunner.ExecResult mockResult = new MgrUtilRunner.ExecResult();
+            MgrUtilRunner.ExecResult mockResult = new MgrUtilRunner.SshKeygenResult("key", "pubkey");
             allowing(saltServiceMock).generateSSHKey(SaltSSHService.SSH_KEY_PATH);
             will(returnValue(of(mockResult)));
 
@@ -230,7 +230,7 @@ public abstract class AbstractMinionBootstrapperTestBase extends JMockBaseTestCa
             allowing(saltServiceMock).generateKeysAndAccept("myhost", false);
             will(returnValue(keyPair));
 
-            MgrUtilRunner.ExecResult mockResult = new MgrUtilRunner.ExecResult();
+            MgrUtilRunner.ExecResult mockResult = new MgrUtilRunner.SshKeygenResult("key", "pubkey");
             allowing(saltServiceMock).generateSSHKey(SaltSSHService.SSH_KEY_PATH);
             will(returnValue(of(mockResult)));
 

--- a/java/code/src/com/suse/manager/webui/services/iface/SaltApi.java
+++ b/java/code/src/com/suse/manager/webui/services/iface/SaltApi.java
@@ -16,6 +16,7 @@ package com.suse.manager.webui.services.iface;
 
 import com.redhat.rhn.domain.server.MinionServer;
 
+import com.suse.manager.ssl.SSLCertPair;
 import com.suse.manager.webui.services.impl.SaltSSHService;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.impl.runner.MgrK8sRunner;
@@ -448,4 +449,17 @@ public interface SaltApi {
      * @param minionList minion list
      */
     void refreshPillar(MinionList minionList);
+
+    /**
+     * Check SSL certificates before deploying them.
+     *
+     * @param rootCA root CA used to sign the SSL certificate in PEM format
+     * @param intermediateCAs intermediate CAs used to sign the SSL certificate in PEM format
+     * @param serverCertKey server CRT an Key pair
+     * @return the certificate to deploy
+     *
+     * @throws IllegalArgumentException if the cert check fails due to erroneous certificates
+     */
+     String checkSSLCert(String rootCA, SSLCertPair serverCertKey, List<String> intermediateCAs)
+             throws IllegalArgumentException;
 }

--- a/java/code/src/com/suse/manager/webui/services/iface/SaltApi.java
+++ b/java/code/src/com/suse/manager/webui/services/iface/SaltApi.java
@@ -133,7 +133,7 @@ public interface SaltApi {
      * @param path of the key files
      * @return the result of the runner call as a map
      */
-    Optional<MgrUtilRunner.ExecResult> generateSSHKey(String path);
+    Optional<MgrUtilRunner.SshKeygenResult> generateSSHKey(String path);
 
     /**
      * Chain ssh calls over one or more hops to run a command on the last host in the chain.

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -196,9 +196,29 @@ public class SaltService implements SystemQuery, SaltApi {
     }
 
     /**
+     * Constructor to use for unit testing
+     *
+     * @param client Salt client
+     */
+    public SaltService(SaltClient client) {
+        asyncHttpClient = null;
+        saltClient = client;
+        saltSSHService = new SaltSSHService(saltClient, SaltActionChainGeneratorService.INSTANCE);
+        defaultBatch = Batch.custom().withBatchAsAmount(ConfigDefaults.get().getSaltBatchSize())
+                .withDelay(ConfigDefaults.get().getSaltBatchDelay())
+                .withPresencePingTimeout(ConfigDefaults.get().getSaltPresencePingTimeout())
+                .withPresencePingGatherJobTimeout(ConfigDefaults.get().getSaltPresencePingGatherJobTimeout())
+                .build();
+    }
+
+    /**
      * Close the opened resources when the service is no longer needed
      */
     public void close() {
+        if (asyncHttpClient == null) {
+            return;
+        }
+
         try {
             asyncHttpClient.close();
         }

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -14,6 +14,7 @@
  */
 package com.suse.manager.webui.services.impl;
 
+import com.redhat.rhn.common.RhnRuntimeException;
 import com.redhat.rhn.common.client.ClientCertificate;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.messaging.JavaMailException;
@@ -252,7 +253,7 @@ public class SaltService implements SystemQuery, SaltApi {
                     }, Optional::of);
         }
         catch (SaltException e) {
-            throw new RuntimeException(e);
+            throw new RhnRuntimeException(e);
         }
     }
 
@@ -340,12 +341,12 @@ public class SaltService implements SystemQuery, SaltApi {
             return result.fold(errorHandler, Optional::of);
         }
         catch (SaltException e) {
-            throw new RuntimeException(e);
+            throw new RhnRuntimeException(e);
         }
     }
 
     private RuntimeException noWheelResult() {
-        return new RuntimeException("no wheel results");
+        return new RhnRuntimeException("no wheel results");
     }
 
     /**
@@ -413,7 +414,7 @@ public class SaltService implements SystemQuery, SaltApi {
             return result.getData().getResult().fold(errorHandler, Optional::of);
         }
         catch (SaltException e) {
-            throw new RuntimeException(e);
+            throw new RhnRuntimeException(e);
         }
     }
 
@@ -608,7 +609,7 @@ public class SaltService implements SystemQuery, SaltApi {
             return callSync(Cmd.run(cmd), target);
         }
         catch (SaltException e) {
-            throw new RuntimeException(e);
+            throw new RhnRuntimeException(e);
         }
     }
 
@@ -649,7 +650,7 @@ public class SaltService implements SystemQuery, SaltApi {
                         getEventStream(), cancel).orElseGet(Collections::emptyMap));
             }
             catch (SaltException e) {
-                throw new RuntimeException(e);
+                throw new RhnRuntimeException(e);
             }
         }
 
@@ -664,7 +665,7 @@ public class SaltService implements SystemQuery, SaltApi {
             return callSync(SaltUtil.running(), target);
         }
         catch (SaltException e) {
-            throw new RuntimeException(e);
+            throw new RhnRuntimeException(e);
         }
     }
 
@@ -709,7 +710,7 @@ public class SaltService implements SystemQuery, SaltApi {
                     getEventStream(), cancel).orElseGet(Collections::emptyMap);
         }
         catch (SaltException e) {
-            throw new RuntimeException(e);
+            throw new RhnRuntimeException(e);
         }
     }
 
@@ -726,7 +727,7 @@ public class SaltService implements SystemQuery, SaltApi {
                     .collect(Collectors.toList());
         }
         catch (SaltException e) {
-            throw new RuntimeException(e);
+            throw new RhnRuntimeException(e);
         }
     }
 
@@ -751,7 +752,7 @@ public class SaltService implements SystemQuery, SaltApi {
             callSync(call, minionList);
         }
         catch (SaltException e) {
-            throw new RuntimeException(e);
+            throw new RhnRuntimeException(e);
         }
     }
 
@@ -771,7 +772,7 @@ public class SaltService implements SystemQuery, SaltApi {
             callAsync(modulesRefreshCall, minionList);
         }
         catch (SaltException e) {
-            throw new RuntimeException(e);
+            throw new RhnRuntimeException(e);
         }
     }
 
@@ -785,7 +786,7 @@ public class SaltService implements SystemQuery, SaltApi {
             callSync(call, minionList);
         }
         catch (SaltException e) {
-            throw new RuntimeException(e);
+            throw new RhnRuntimeException(e);
         }
     }
 
@@ -799,7 +800,7 @@ public class SaltService implements SystemQuery, SaltApi {
             callSync(call, minionList);
         }
         catch (SaltException e) {
-            throw new RuntimeException(e);
+            throw new RhnRuntimeException(e);
         }
     }
 
@@ -821,7 +822,7 @@ public class SaltService implements SystemQuery, SaltApi {
             callSync(call, minionList);
         }
         catch (SaltException e) {
-            throw new RuntimeException(e);
+            throw new RhnRuntimeException(e);
         }
     }
 
@@ -966,7 +967,7 @@ public class SaltService implements SystemQuery, SaltApi {
             return callAsync(call, targetIn);
         }
         catch (SaltException e) {
-            throw new RuntimeException(e);
+            throw new RhnRuntimeException(e);
         }
     }
 

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -42,6 +42,7 @@ import com.suse.manager.webui.utils.salt.custom.MgrActionChains;
 import com.suse.manager.webui.utils.salt.custom.PkgProfileUpdateSlsResult;
 import com.suse.manager.webui.utils.salt.custom.ScheduleMetadata;
 import com.suse.salt.netapi.AuthModule;
+import com.suse.salt.netapi.calls.AbstractCall;
 import com.suse.salt.netapi.calls.LocalAsyncResult;
 import com.suse.salt.netapi.calls.LocalCall;
 import com.suse.salt.netapi.calls.RunnerCall;
@@ -132,24 +133,24 @@ public class SaltService implements SystemQuery, SaltApi {
     private static final Logger LOG = Logger.getLogger(SaltService.class);
 
     // Salt properties
-    private final URI SALT_MASTER_URI = URI.create("https://" +
+    private static final URI SALT_MASTER_URI = URI.create("https://" +
             com.redhat.rhn.common.conf.Config.get()
                     .getString(ConfigDefaults.SALT_API_HOST, "localhost") +
             ":" + com.redhat.rhn.common.conf.Config.get()
                     .getString(ConfigDefaults.SALT_API_PORT, "9080"));
-    private final String SALT_USER = "admin";
-    private final String SALT_PASSWORD = com.redhat.rhn.common.conf.Config.get().getString("server.secret_key");
-    private final AuthModule AUTH_MODULE = AuthModule.FILE;
+    private static final String SALT_USER = "admin";
+    private static final String SALT_PASSWORD = com.redhat.rhn.common.conf.Config.get().getString("server.secret_key");
+    private static final AuthModule AUTH_MODULE = AuthModule.FILE;
 
     // Shared salt client instance
-    private final SaltClient SALT_CLIENT;
+    private final SaltClient saltClient;
     private final CloseableHttpAsyncClient asyncHttpClient;
 
     // executing salt-ssh calls
     private final SaltSSHService saltSSHService;
-    private final AuthMethod PW_AUTH = new AuthMethod(new PasswordAuth(SALT_USER, SALT_PASSWORD, AUTH_MODULE));
+    private static final AuthMethod PW_AUTH = new AuthMethod(new PasswordAuth(SALT_USER, SALT_PASSWORD, AUTH_MODULE));
 
-    private static final Predicate<? super String> SALT_MINION_PREDICATE = (mid) ->
+    private static final Predicate<? super String> SALT_MINION_PREDICATE = mid ->
             MinionPendingRegistrationService.containsSSHMinion(mid) ||
                         MinionServerFactory
                                 .findByMinionId(mid)
@@ -158,6 +159,10 @@ public class SaltService implements SystemQuery, SaltApi {
 
     private static final String CLEANUP_MINION_SALT_STATE = "cleanup_minion";
     protected static final String MINION_UNREACHABLE_ERROR = "minion_unreachable";
+
+    private static final String GENERIC_RUNNER_ERROR = "Generic Salt error for runner call %s: %s";
+    private static final String SSH_RUNNER_ERROR = "SaltSSH error for runner call %s: %s";
+    private static final String PAYLOAD_CALL_TEMPLATE = "%s with payload [%s]";
 
     /**
      * Enum of all the available status for Salt keys.
@@ -185,8 +190,8 @@ public class SaltService implements SystemQuery, SaltApi {
                 .build();
         asyncHttpClient.start();
 
-        SALT_CLIENT = new SaltClient(SALT_MASTER_URI, new HttpAsyncClientImpl(asyncHttpClient));
-        saltSSHService = new SaltSSHService(SALT_CLIENT, SaltActionChainGeneratorService.INSTANCE);
+        saltClient = new SaltClient(SALT_MASTER_URI, new HttpAsyncClientImpl(asyncHttpClient));
+        saltSSHService = new SaltSSHService(saltClient, SaltActionChainGeneratorService.INSTANCE);
         defaultBatch = Batch.custom().withBatchAsAmount(ConfigDefaults.get().getSaltBatchSize())
                         .withDelay(ConfigDefaults.get().getSaltBatchDelay())
                         .withPresencePingTimeout(ConfigDefaults.get().getSaltPresencePingTimeout())
@@ -258,7 +263,7 @@ public class SaltService implements SystemQuery, SaltApi {
         return callSyncResult(call, minionId).flatMap(r ->
             r.fold(error -> {
                 LOG.warn(error.toString());
-                return Optional.<R>empty();
+                return Optional.empty();
             }, Optional::of)
         );
     }
@@ -283,17 +288,13 @@ public class SaltService implements SystemQuery, SaltApi {
         return callSync(call, p ->
                 p.fold(
                         e -> {
-                            LOG.error("Function [" + e.getFunctionName() +
-                                    "] not available for runner call " +
-                                    runnerCallToString(call)
-                            );
+                            LOG.error(String.format("Function [%s] not available for runner call %s",
+                                    e.getFunctionName(), runnerCallToString(call)));
                             return Optional.empty();
                         },
                         e -> {
-                            LOG.error("Module [" + e.getModuleName() +
-                                    "] not supported for runner call " +
-                                    runnerCallToString(call)
-                            );
+                            LOG.error(String.format("Module [%s] not supported for runner call %s",
+                                    e.getModuleName(), runnerCallToString(call)));
                             return Optional.empty();
                         },
                         e -> {
@@ -303,24 +304,22 @@ public class SaltService implements SystemQuery, SaltApi {
                             return Optional.empty();
                         },
                         e -> {
-                            LOG.error("Generic Salt error for runner call " +
-                                    runnerCallToString(call) +
-                                    ": " + e.getMessage());
+                            LOG.error(String.format(GENERIC_RUNNER_ERROR, runnerCallToString(call), e.getMessage()));
                             return Optional.empty();
                         },
                         e -> {
-                            LOG.error("SaltSSH error for runner call " +
-                                    runnerCallToString(call) +
-                                    ": " + e.getMessage());
+                            LOG.error(String.format(SSH_RUNNER_ERROR, runnerCallToString(call), e.getMessage()));
                             return Optional.empty();
                         }
                 ));
     }
 
+    private String callToString(AbstractCall<?> call) {
+        return String.format("[%s.%s]", call.getModuleName(), call.getFunctionName());
+    }
+
     private String runnerCallToString(RunnerCall<?> call) {
-        return "[" + call.getModuleName() + "." +
-                call.getFunctionName() + "] with payload [" +
-                call.getPayload() + "]";
+        return String.format(PAYLOAD_CALL_TEMPLATE, call, call.getPayload());
     }
 
     /**
@@ -336,22 +335,23 @@ public class SaltService implements SystemQuery, SaltApi {
                                     Function<SaltError, Optional<R>> errorHandler) {
         try {
             LOG.debug("Runner callSync: " + runnerCallToString(call));
-            Result<R> result = adaptException(call.callSync(SALT_CLIENT, PW_AUTH));
-            return result.fold(errorHandler::apply,
-                    Optional::of
-            );
+            Result<R> result = adaptException(call.callSync(saltClient, PW_AUTH));
+            return result.fold(errorHandler, Optional::of);
         }
         catch (SaltException e) {
             throw new RuntimeException(e);
         }
     }
 
+    private RuntimeException noWheelResult() {
+        return new RuntimeException("no wheel results");
+    }
+
     /**
      * {@inheritDoc}
      */
     public Key.Names getKeys() {
-        return callSync(Key.listAll())
-                .orElseThrow(() -> new RuntimeException("no wheel results"));
+        return callSync(Key.listAll()).orElseThrow(this::noWheelResult);
     }
 
     /**
@@ -365,17 +365,13 @@ public class SaltService implements SystemQuery, SaltApi {
         return callSync(call,  p ->
                 p.fold(
                     e -> {
-                        LOG.error("Function [" + e.getFunctionName() +
-                                "] not available for wheel call " +
-                                wheelCallToString(call)
-                        );
+                        LOG.error(String.format("Function [%s] not available for wheel call %s",
+                                e.getFunctionName(), wheelCallToString(call)));
                         return Optional.empty();
                     },
                     e -> {
-                        LOG.error("Module [" + e.getModuleName() +
-                                "] not supported for wheel call " +
-                                wheelCallToString(call)
-                        );
+                        LOG.error(String.format("Module [%s] not supported for wheel call %s",
+                                e.getModuleName(), wheelCallToString(call)));
                         return Optional.empty();
                     },
                     e -> {
@@ -412,10 +408,8 @@ public class SaltService implements SystemQuery, SaltApi {
                                      Function<SaltError, Optional<R>> errorHandler) {
         try {
             LOG.debug("Wheel callSync: " + wheelCallToString(call));
-            WheelResult<Result<R>> result = adaptException(call.callSync(SALT_CLIENT, PW_AUTH));
-            return result.getData().getResult().fold(
-                    errorHandler::apply,
-                    Optional::of);
+            WheelResult<Result<R>> result = adaptException(call.callSync(saltClient, PW_AUTH));
+            return result.getData().getResult().fold(errorHandler, Optional::of);
         }
         catch (SaltException e) {
             throw new RuntimeException(e);
@@ -423,9 +417,7 @@ public class SaltService implements SystemQuery, SaltApi {
     }
 
     private String wheelCallToString(WheelCall<?> call) {
-        return "[" + call.getModuleName() + "." +
-                call.getFunctionName() + "] with payload [" +
-                call.getPayload() + "]";
+        return String.format(PAYLOAD_CALL_TEMPLATE, call, call.getPayload());
     }
 
     /**
@@ -448,8 +440,7 @@ public class SaltService implements SystemQuery, SaltApi {
      * {@inheritDoc}
      */
     public Key.Fingerprints getFingerprints() {
-        return callSync(Key.finger("*"))
-                .orElseThrow(() -> new RuntimeException("no wheel results"));
+        return callSync(Key.finger("*")).orElseThrow(this::noWheelResult);
     }
 
     /**
@@ -457,8 +448,7 @@ public class SaltService implements SystemQuery, SaltApi {
      */
     public Key.Pair generateKeysAndAccept(String id,
             boolean force) {
-        return callSync(Key.genAccept(id, Optional.of(force)))
-                .orElseThrow(() -> new RuntimeException("no wheel results"));
+        return callSync(Key.genAccept(id, Optional.of(force))).orElseThrow(this::noWheelResult);
     }
 
     /**
@@ -495,24 +485,27 @@ public class SaltService implements SystemQuery, SaltApi {
      * {@inheritDoc}
      */
     public void acceptKey(String match) {
-        callSync(Key.accept(match))
-                .orElseThrow(() -> new RuntimeException("no wheel results"));
+        if (callSync(Key.accept(match)).isEmpty()) {
+            throw noWheelResult();
+        }
     }
 
     /**
      * {@inheritDoc}
      */
     public void deleteKey(String minionId) {
-        callSync(Key.delete(minionId))
-                .orElseThrow(() -> new RuntimeException("no wheel results"));
+        if (callSync(Key.delete(minionId)).isEmpty()) {
+            throw noWheelResult();
+        }
     }
 
     /**
      * {@inheritDoc}
      */
     public void rejectKey(String minionId) {
-        callSync(Key.reject(minionId))
-                .orElseThrow(() -> new RuntimeException("no wheel results"));
+        if (callSync(Key.reject(minionId)).isEmpty()) {
+            throw noWheelResult();
+        }
     }
 
     // Reconnecting time (in seconds) to Salt event bus
@@ -535,6 +528,7 @@ public class SaltService implements SystemQuery, SaltApi {
                 eventStream.addEventListener(new EventListener() {
                     @Override
                     public void notify(com.suse.salt.netapi.datatypes.Event event) {
+                        // Only listening for close
                     }
 
                     @Override
@@ -581,8 +575,8 @@ public class SaltService implements SystemQuery, SaltApi {
         if (ConfigDefaults.get().isPostgresql()) {
             return new PGEventStream();
         }
-        Token token = adaptException(SALT_CLIENT.login(SALT_USER, SALT_PASSWORD, AUTH_MODULE));
-        return SALT_CLIENT.events(token, 0, 0, 0);
+        Token token = adaptException(saltClient.login(SALT_USER, SALT_PASSWORD, AUTH_MODULE));
+        return saltClient.events(token, 0, 0, 0);
     }
 
     /**
@@ -621,7 +615,7 @@ public class SaltService implements SystemQuery, SaltApi {
             LocalCall<R> callIn, Target<?> target, EventStream events,
             CompletableFuture<GenericError> cancel) throws SaltException {
         LocalCall<R> call = callIn.withMetadata(ScheduleMetadata.getDefaultMetadata().withBatchMode());
-        return adaptException(call.callAsync(SALT_CLIENT, target, PW_AUTH, events, cancel, defaultBatch));
+        return adaptException(call.callAsync(saltClient, target, PW_AUTH, events, cancel, defaultBatch));
     }
 
     /**
@@ -861,7 +855,7 @@ public class SaltService implements SystemQuery, SaltApi {
             ScheduleMetadata metadata = ScheduleMetadata.getDefaultMetadata().withBatchMode();
             LOG.debug("Local callSync: " + SaltService.localCallToString(callIn));
             List<Map<String, Result<T>>> callResult =
-                    adaptException(callIn.withMetadata(metadata).callSync(SALT_CLIENT,
+                    adaptException(callIn.withMetadata(metadata).callSync(saltClient,
                             new MinionList(regularMinionIds), PW_AUTH, defaultBatch));
             results.putAll(
                     callResult.stream().flatMap(map -> map.entrySet().stream())
@@ -879,14 +873,10 @@ public class SaltService implements SystemQuery, SaltApi {
         ScheduleMetadata metadata = ScheduleMetadata.getDefaultMetadata().withBatchMode();
         LOG.debug("Local callSync: " + SaltService.localCallToString(callIn));
         List<Map<String, Result<T>>> callResult =
-                adaptException(callIn.withMetadata(metadata).callSync(SALT_CLIENT,
+                adaptException(callIn.withMetadata(metadata).callSync(saltClient,
                         target, PW_AUTH, defaultBatch));
-        Map<String, Result<T>> results =
-                callResult.stream().flatMap(map -> map.entrySet().stream())
-                        .collect(Collectors.toMap(Entry::getKey,
-                                Entry::getValue));
-
-        return results;
+        return callResult.stream().flatMap(map -> map.entrySet().stream())
+                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
     }
 
     /**
@@ -914,9 +904,7 @@ public class SaltService implements SystemQuery, SaltApi {
      * @return string representation
      */
     public static String localCallToString(LocalCall<?> call) {
-        return "[" + call.getModuleName() + "." +
-                call.getFunctionName() + "] with payload [" +
-                call.getPayload() + "]";
+        return String.format(PAYLOAD_CALL_TEMPLATE, call, call.getPayload());
     }
 
     /**
@@ -955,7 +943,7 @@ public class SaltService implements SystemQuery, SaltApi {
         ScheduleMetadata metadata =
                 Opt.fold(metadataIn, ScheduleMetadata::getDefaultMetadata, Function.identity()).withBatchMode();
         LOG.debug("Local callAsync: " + SaltService.localCallToString(callIn));
-        return adaptException(callIn.withMetadata(metadata).callAsync(SALT_CLIENT, target, PW_AUTH, defaultBatch));
+        return adaptException(callIn.withMetadata(metadata).callAsync(saltClient, target, PW_AUTH, defaultBatch));
     }
 
     /**
@@ -1019,7 +1007,7 @@ public class SaltService implements SystemQuery, SaltApi {
                     minion.getMinionId())
                     .map(r -> ((Number) r.get("seconds")).longValue());
 
-            if (!uptime.isPresent()) {
+            if (uptime.isEmpty()) {
                 LOG.error("Can't get uptime for " + minion.getMinionId());
             }
         }
@@ -1034,7 +1022,8 @@ public class SaltService implements SystemQuery, SaltApi {
      */
     public void updateSystemInfo(MinionList minionTarget) {
         try {
-            callAsync(State.apply(Arrays.asList(ApplyStatesEventMessage.SYSTEM_INFO), Optional.empty()), minionTarget,
+            callAsync(State.apply(Collections.singletonList(ApplyStatesEventMessage.SYSTEM_INFO),
+                    Optional.empty()), minionTarget,
                     Optional.of(ScheduleMetadata.getDefaultMetadata().withMinionStartup()));
         }
         catch (SaltException ex) {
@@ -1052,16 +1041,16 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
-    private Optional<Map<String, ApplyResult>> applyState(
-            String minionId, String state) {
-        return callSync(State.apply(Arrays.asList(state), Optional.empty()), minionId);
+    private Optional<Map<String, ApplyResult>> applyState(String minionId, String state) {
+        return callSync(State.apply(Collections.singletonList(state), Optional.empty()), minionId);
     }
 
     /**
      * {@inheritDoc}
      */
     public Optional<RedhatProductInfo> redhatProductInfo(String minionId) {
-        return callSync(State.apply(Arrays.asList("packages.redhatproductinfo"), Optional.empty()), minionId)
+        return callSync(State.apply(Collections.singletonList("packages.redhatproductinfo"),
+                Optional.empty()), minionId)
                 .map(result -> {
                     if (result.isEmpty()) {
                         return new RedhatProductInfo();
@@ -1149,37 +1138,30 @@ public class SaltService implements SystemQuery, SaltApi {
         Optional<Map<Boolean, String>> result = callSync(call,
                 err -> err.fold(
                         e -> {
-                            LOG.error("Function [" + e.getFunctionName() +
-                                    " not available for runner call " +
-                                    "[mgrutil.move_minion_uploaded_files].");
+                            LOG.error(String.format("Function [%s] not available for runner call %s.",
+                                    e.getFunctionName(), callToString(call)));
                             return Optional.of(Collections.singletonMap(false,
-                                    "Function [" + e.getFunctionName()));
+                                    String.format("Function [%s] not available", e.getFunctionName())));
                         },
                         e -> {
-                            LOG.error("Module [" + e.getModuleName() +
-                                    "] not supported for runner call " +
-                                    "[mgrutil.move_minion_uploaded_files].");
+                            LOG.error(String.format("Module [%s] not supported for runner call %s.",
+                                    e.getModuleName(), callToString(call)));
                             return Optional.of(Collections.singletonMap(false,
-                                    "Module [" + e.getModuleName() + "] not supported"));
+                                    String.format("Module [%s] not supported", e.getModuleName())));
                         },
                         e -> {
-                            LOG.error("Error parsing json response from " +
-                                    "runner call [mgrutil.move_minion_uploaded_files]: " +
-                                    e.getJson());
+                            LOG.error(String.format("Error parsing json response from runner call %s: %s",
+                                    callToString(call), e.getJson()));
                             return Optional.of(Collections.singletonMap(false,
                                     "Error parsing json response: " + e.getJson()));
                         },
                         e -> {
-                            LOG.error("Generic Salt error for runner call " +
-                                    "[mgrutil.move_minion_uploaded_files]: " +
-                                    e.getMessage());
+                            LOG.error(String.format(GENERIC_RUNNER_ERROR, callToString(call), e.getMessage()));
                             return Optional.of(Collections.singletonMap(false,
                                     "Generic Salt error: " + e.getMessage()));
                         },
                         e -> {
-                            LOG.error("SaltSSH error for runner call " +
-                                    "[mgrutil.move_minion_uploaded_files]: " +
-                                    e.getMessage());
+                            LOG.error(String.format(SSH_RUNNER_ERROR, callToString(call), e.getMessage()));
                             return Optional.of(Collections.singletonMap(false,
                                     "SaltSSH error: " + e.getMessage()));
                         }
@@ -1262,33 +1244,26 @@ public class SaltService implements SystemQuery, SaltApi {
         return callSync(call,
                 err -> err.fold(
                     e -> {
-                        LOG.error("Function [" + e.getFunctionName() +
-                                " not available for runner call " +
-                                "[mgrk8s.get_all_containers].");
+                        LOG.error(String.format("Function [%s] not available for runner call %s.",
+                                e.getFunctionName(), callToString(call)));
                         throw new NoSuchElementException();
                     },
                     e -> {
-                        LOG.error("Module [" + e.getModuleName() +
-                                "] not supported for runner call " +
-                                "[mgrk8s.get_all_containers].");
+                        LOG.error(String.format("Module [%s] not supported for runner call %s",
+                                e.getModuleName(), callToString(call)));
                         throw new NoSuchElementException();
                     },
                     e -> {
-                        LOG.error("Error parsing json response from " +
-                                "runner call [mgrk8s.get_all_containers]: " +
-                                e.getJson());
+                        LOG.error(String.format("Error parsing json response from runner call %s: %s",
+                                callToString(call), e.getJson()));
                         throw new NoSuchElementException();
                     },
                     e -> {
-                        LOG.error("Generic Salt error for runner call " +
-                                "[mgrk8s.get_all_containers]: " +
-                                e.getMessage());
+                        LOG.error(String.format(GENERIC_RUNNER_ERROR, callToString(call), e.getMessage()));
                         throw new NoSuchElementException();
                     },
                     e -> {
-                        LOG.error("SaltSSH error for runner call " +
-                                "[mgrk8s.get_all_containers]: " +
-                                e.getMessage());
+                        LOG.error(String.format(SSH_RUNNER_ERROR, callToString(call), e.getMessage()));
                         throw new NoSuchElementException();
                     }
                 )
@@ -1334,11 +1309,15 @@ public class SaltService implements SystemQuery, SaltApi {
 
         String absolutePath = path.toAbsolutePath().toString();
         RunnerCall<String> createFile = MgrRunner.writeTextFile(absolutePath, contents);
-        callSync(createFile).orElseThrow(() -> new IllegalStateException("Can't create SSH priv key file " + path));
+        if (callSync(createFile).isEmpty()) {
+            throw new IllegalStateException("Can't create SSH priv key file " + path);
+        }
 
         // this might not be needed, the file is created with sane perms already
         RunnerCall<String> setMode = MgrRunner.setFileMode(absolutePath, "0600");
-        callSync(setMode).orElseThrow(() -> new IllegalStateException("Can't set mode for SSH priv key file " + path));
+        if (callSync(setMode).isEmpty()) {
+            throw new IllegalStateException("Can't set mode for SSH priv key file " + path);
+        }
     }
 
     /**
@@ -1372,8 +1351,7 @@ public class SaltService implements SystemQuery, SaltApi {
             return response.get().values().stream().filter(value -> !value.isResult())
                     .map(StateApplyResult::getComment)
                     .collect(Collectors.collectingAndThen(Collectors.toList(),
-                            (list) -> list.isEmpty() ? Optional.<List<String>>empty() :
-                                    Optional.of(list)));
+                            list -> list.isEmpty() ? Optional.empty() : Optional.of(list)));
         }
         return Optional.of(Collections.singletonList(SaltService.MINION_UNREACHABLE_ERROR));
     }

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -25,6 +25,7 @@ import com.redhat.rhn.manager.system.SystemManager;
 
 import com.suse.manager.reactor.PGEventStream;
 import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
+import com.suse.manager.ssl.SSLCertPair;
 import com.suse.manager.utils.MailHelper;
 import com.suse.manager.utils.MinionServerUtils;
 import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
@@ -1371,5 +1372,18 @@ public class SaltService implements SystemQuery, SaltApi {
         RunnerCall<MgrUtilRunner.ExecResult> call =
                 MgrKiwiImageRunner.collectImage(minion.getMinionId(), minion.getIpAddress(), filepath, imageStore);
         return callSync(call);
+    }
+
+    @Override
+    public String checkSSLCert(String rootCA, SSLCertPair serverCertKey, List<String> intermediateCAs)
+            throws IllegalArgumentException {
+        RunnerCall<Map<String, String>> call = MgrUtilRunner.checkSSLCert(rootCA, serverCertKey, intermediateCAs);
+        Map<String, String> result = callSync(call)
+                .orElseThrow(() -> new IllegalArgumentException("Unknown error while checking certificates"));
+        String error = result.getOrDefault("error", null);
+        if (error != null) {
+            throw new IllegalArgumentException(error);
+        }
+        return result.get("cert");
     }
 }

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -90,7 +90,6 @@ import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.apache.http.impl.nio.client.HttpAsyncClients;
 import org.apache.log4j.Logger;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.FileSystems;
@@ -1215,13 +1214,9 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
-    public Optional<MgrUtilRunner.ExecResult> generateSSHKey(String path) {
-        File pubKey = new File(path + ".pub");
-        if (!pubKey.isFile()) {
-            RunnerCall<MgrUtilRunner.ExecResult> call = MgrUtilRunner.generateSSHKey(path);
-            return callSync(call);
-        }
-        return Optional.of(MgrUtilRunner.ExecResult.success());
+    public Optional<MgrUtilRunner.SshKeygenResult> generateSSHKey(String path) {
+        RunnerCall<MgrUtilRunner.SshKeygenResult> call = MgrUtilRunner.generateSSHKey(path);
+        return callSync(call);
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/services/impl/runner/MgrUtilRunner.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/runner/MgrUtilRunner.java
@@ -14,6 +14,7 @@
  */
 package com.suse.manager.webui.services.impl.runner;
 
+import com.suse.manager.ssl.SSLCertPair;
 import com.suse.salt.netapi.calls.RunnerCall;
 
 import com.google.gson.annotations.SerializedName;
@@ -239,5 +240,23 @@ public class MgrUtilRunner {
         args.put("basepath", basePath);
         args.put("actionpath", actionPath);
         return new RunnerCall<>("mgrutil.move_minion_uploaded_files", Optional.of(args), new TypeToken<>() { });
+    }
+
+    /**
+     * Check SSL certificates before deploying them.
+     *
+     * @param rootCA root CA used to sign the SSL certificate in PEM format
+     * @param intermediateCAs intermediate CAs used to sign the SSL certificate in PEM format
+     * @param serverCrtKey server CRT and Key pair
+     * @return the certificate and key to deploy
+     */
+    public static RunnerCall<Map<String, String>> checkSSLCert(String rootCA, SSLCertPair serverCrtKey,
+                                                            List<String> intermediateCAs) {
+        Map<String, Object> args = new LinkedHashMap<>();
+        args.put("root_ca", rootCA);
+        args.put("server_crt", serverCrtKey.getCertificate());
+        args.put("server_key", serverCrtKey.getKey());
+        args.put("intermediate_cas", intermediateCAs);
+        return new RunnerCall<>("mgrutil.check_ssl_cert", Optional.of(args), new TypeToken<>() { });
     }
 }

--- a/java/code/src/com/suse/manager/webui/services/impl/runner/MgrUtilRunner.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/runner/MgrUtilRunner.java
@@ -131,12 +131,6 @@ public class MgrUtilRunner {
         private String comment;
 
         /**
-         * Constructor.
-         */
-        public RemoveKnowHostResult() {
-        }
-
-        /**
          * Only needed for unit tests.
          * @param statusIn status
          * @param commentIn comment
@@ -169,11 +163,7 @@ public class MgrUtilRunner {
     public static RunnerCall<ExecResult> deleteRejectedKey(String minionId) {
         Map<String, Object> args = new LinkedHashMap<>();
         args.put("minion", minionId);
-        RunnerCall<ExecResult> call =
-                new RunnerCall<>("mgrutil.delete_rejected_key", Optional.of(args),
-                        new TypeToken<>() {
-                        });
-        return call;
+        return new RunnerCall<>("mgrutil.delete_rejected_key", Optional.of(args), new TypeToken<>() { });
     }
 
     /**
@@ -184,10 +174,7 @@ public class MgrUtilRunner {
     public static RunnerCall<SshKeygenResult> generateSSHKey(String path) {
         Map<String, Object> args = new LinkedHashMap<>();
         args.put("path", path);
-        RunnerCall<SshKeygenResult> call =
-                new RunnerCall<>("mgrutil.ssh_keygen", Optional.of(args),
-                        new TypeToken<>() { });
-        return call;
+        return new RunnerCall<>("mgrutil.ssh_keygen", Optional.of(args), new TypeToken<>() { });
     }
 
     /**
@@ -200,11 +187,7 @@ public class MgrUtilRunner {
         Map<String, Object> args = new LinkedHashMap<>();
         args.put("user", user);
         args.put("hostname", hostname);
-        RunnerCall<RemoveKnowHostResult> call =
-                new RunnerCall<>("mgrutil.remove_ssh_known_host", Optional.of(args),
-                        new TypeToken<>() {
-                        });
-        return call;
+        return new RunnerCall<>("mgrutil.remove_ssh_known_host", Optional.of(args), new TypeToken<>() { });
     }
 
     /**
@@ -234,11 +217,7 @@ public class MgrUtilRunner {
         args.put("options", options);
         args.put("command", command);
         args.put("outputfile", outputfile);
-        RunnerCall<ExecResult> call =
-                new RunnerCall<>("mgrutil.chain_ssh_cmd", Optional.of(args),
-                        new TypeToken<>() {
-                        });
-        return call;
+        return new RunnerCall<>("mgrutil.chain_ssh_cmd", Optional.of(args), new TypeToken<>() { });
     }
 
     /**
@@ -259,10 +238,6 @@ public class MgrUtilRunner {
         args.put("dirtomove", dirToMove);
         args.put("basepath", basePath);
         args.put("actionpath", actionPath);
-        RunnerCall<Map<Boolean, String>> call =
-                new RunnerCall<>("mgrutil.move_minion_uploaded_files", Optional.of(args),
-                        new TypeToken<>() {
-                        });
-        return call;
+        return new RunnerCall<>("mgrutil.move_minion_uploaded_files", Optional.of(args), new TypeToken<>() { });
     }
 }

--- a/java/code/src/com/suse/manager/webui/services/impl/runner/MgrUtilRunner.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/runner/MgrUtilRunner.java
@@ -37,7 +37,7 @@ public class MgrUtilRunner {
     public static class ExecResult {
 
         @SerializedName("retcode")
-        private int returnCode;
+        protected int returnCode;
         @SerializedName("stdout")
         private String stdout;
         @SerializedName("stderr")
@@ -72,6 +72,50 @@ public class MgrUtilRunner {
             ExecResult res = new ExecResult();
             res.returnCode = 0;
             return res;
+        }
+    }
+
+    /**
+     * ssh-keygen result
+     */
+    public static class SshKeygenResult extends ExecResult {
+        private String key;
+
+        @SerializedName("public_key")
+        private String publicKey;
+
+        /**
+         * Create a result with key pair, mostly for testing purpose
+         *
+         * @param keyIn the ssh key
+         * @param pubKeyIn the ssh public key
+         */
+        public SshKeygenResult(String keyIn, String pubKeyIn) {
+            key = keyIn;
+            publicKey = pubKeyIn;
+            returnCode = 0;
+        }
+
+        /**
+         * Create an empty result with return code 0
+         * @return a result with return code 0.
+         */
+        public static SshKeygenResult success() {
+            SshKeygenResult res = new SshKeygenResult(null, null);
+            return res;
+        }
+        /**
+         * @return value of key
+         */
+        public String getKey() {
+            return key;
+        }
+
+        /**
+         * @return value of publicKey
+         */
+        public String getPublicKey() {
+            return publicKey;
         }
     }
 
@@ -134,16 +178,15 @@ public class MgrUtilRunner {
 
     /**
      * Generate a ssh key pair.
-     * @param path path where to generate the keys
+     * @param path path where to generate the keys or null to return them
      * @return the execution result
      */
-    public static RunnerCall<ExecResult> generateSSHKey(String path) {
+    public static RunnerCall<SshKeygenResult> generateSSHKey(String path) {
         Map<String, Object> args = new LinkedHashMap<>();
         args.put("path", path);
-        RunnerCall<ExecResult> call =
+        RunnerCall<SshKeygenResult> call =
                 new RunnerCall<>("mgrutil.ssh_keygen", Optional.of(args),
-                        new TypeToken<>() {
-                        });
+                        new TypeToken<>() { });
         return call;
     }
 

--- a/java/code/src/com/suse/manager/webui/services/impl/test/SaltServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/test/SaltServiceTest.java
@@ -123,7 +123,7 @@ public class SaltServiceTest extends JMockBaseTestCaseWithUser {
         Optional<MgrUtilRunner.SshKeygenResult> res = systemQuery
                 .generateSSHKey(keyPath.substring(0, keyPath.length() - 4));
         assertTrue(res.isPresent());
-        assertEquals(0, res.get().getReturnCode());
+        assertEquals(0, res.orElseThrow().getReturnCode());
         systemQuery.close();
     }
 

--- a/java/code/src/com/suse/manager/webui/services/impl/test/service/ssh_keygen.json
+++ b/java/code/src/com/suse/manager/webui/services/impl/test/service/ssh_keygen.json
@@ -1,0 +1,9 @@
+{
+  "return": [
+    {
+      "key": "private key",
+      "public_key": "public key",
+      "retcode": 0
+    }
+  ]
+}

--- a/java/code/src/com/suse/manager/webui/services/test/TestSaltApi.java
+++ b/java/code/src/com/suse/manager/webui/services/test/TestSaltApi.java
@@ -16,6 +16,7 @@ package com.suse.manager.webui.services.test;
 
 import com.redhat.rhn.domain.server.MinionServer;
 
+import com.suse.manager.ssl.SSLCertPair;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.impl.SaltSSHService;
 import com.suse.manager.webui.services.impl.SaltService;
@@ -277,5 +278,11 @@ public class TestSaltApi implements SaltApi {
 
     @Override
     public void refreshPillar(MinionList minionList) {
+    }
+
+    @Override
+    public String checkSSLCert(String rootCA, SSLCertPair serverCertKey,
+                                         List<String> intermediateCAs) throws IllegalArgumentException {
+        throw new UnsupportedOperationException();
     }
 }

--- a/java/code/src/com/suse/manager/webui/services/test/TestSaltApi.java
+++ b/java/code/src/com/suse/manager/webui/services/test/TestSaltApi.java
@@ -96,7 +96,7 @@ public class TestSaltApi implements SaltApi {
     }
 
     @Override
-    public Optional<MgrUtilRunner.ExecResult> generateSSHKey(String path) {
+        public Optional<MgrUtilRunner.SshKeygenResult> generateSSHKey(String path) {
         throw new UnsupportedOperationException();
     }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add XML-RPC API to generate proxy containers configuration
 - Improve image management
 - Store delta image info in the database
 - fix class cast exception during action chains (bsc#1195772)

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Add proxy config generation subcommand
 - implement system.bootstrap (bsc#1194909)
 - Option 'org_createfirst' added to perform initial organization and user creation
 - Added gettext build requirement for RHEL.

--- a/spacecmd/src/bin/spacecmd
+++ b/spacecmd/src/bin/spacecmd
@@ -94,7 +94,7 @@ if __name__ == '__main__':
             except AttributeError: # Python 2
                 sys.stdout = codecs.getwriter(locale.getpreferredencoding())(sys.stdout)
 
-        usage = '%(prog)s [options] [command]'
+        usage = '%(prog)s [options] [command] [-- [command options]]'
         parser = argparse.ArgumentParser(usage=usage)
         parser.add_argument('-c', '--config',
                              help=_('config file to use [default: ~/.spacecmd/config]'))

--- a/spacecmd/src/spacecmd/proxy.py
+++ b/spacecmd/src/spacecmd/proxy.py
@@ -1,0 +1,152 @@
+#
+# Licensed under the GNU General Public License Version 3
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright (c) 2022 SUSE LLC
+
+import gettext
+import logging
+from spacecmd.utils import *
+
+translation = gettext.translation('spacecmd', fallback=True)
+try:
+    _ = translation.ugettext
+except AttributeError:
+    _ = translation.gettext
+
+def help_proxy_container_config(self):
+    print(_('proxy_container_config: create a proxy system and return its configuration file'))
+    print(_('''usage: proxy_container_config [options] PROXY_FQDN SERVER_FQDN MAX_CACHE EMAIL ROOT_CA CRT KEY
+
+parameters:
+  PROXY_FQDN  the fully qualified domain name of the proxy to create.
+  SERVER_FQDN the fully qualified domain name of the server to connect to proxy to.
+  MAX_CACHE   the maximum cache size in MB. 60% of the storage is a good value.
+  EMAIL       the email of the proxy administrator
+  CA          path to the root CA used to sign the proxy certificate in PEM format
+  CRT         path to the proxy certificate in PEM format
+  KEY         path to the proxy certificate private key in PEM format
+
+options:
+  -o, --output Path where to create the generated configuration. Default: 'config.zip'
+  -i, --intermediate-ca  Path to an intermediate CA used to sign the proxy
+            certicate in PEM format. May be provided multiple times.
+
+examples:
+  proxy_container_config -o config.zip proxy.lab server.lab 1024 proxy@acme.org root_ca.crt proxy.crt proxy.key
+'''))
+
+
+def do_proxy_container_config(self, args):
+    arg_parser = get_argument_parser()
+    arg_parser.add_argument('-r', '--root-ca', default='')
+    arg_parser.add_argument('-i', '--intermediate-ca', action='append', default=[])
+    arg_parser.add_argument('-c', '--certificate', default='')
+    arg_parser.add_argument('-k', '--key', default='')
+    arg_parser.add_argument('-o', '--output', default='config.zip')
+
+    args, options = parse_command_arguments(args, arg_parser)
+
+    if len(args) != 7:
+        self.help_container_config()
+        return
+
+    (proxy_fqdn, server_fqdn, max_cache, email, root_ca, certificate, key) = args
+
+    root_ca = read_file(root_ca)
+    intermediate_cas = [read_file(path) for path in options.intermediate_ca]
+    cert = read_file(certificate)
+    key = read_file(key)
+
+    config = self.client.proxy.container_config(self.session,
+            proxy_fqdn, server_fqdn, int(max_cache), email,
+            root_ca, intermediate_cas, cert, key,
+    )
+
+    with open(options.output, 'wb') as fd:
+        fd.write(config.data)
+    return options.output
+
+
+def help_proxy_container_config_generate_cert(self):
+    print(_('proxy_container_config_generate_cert: create a proxy system and return its configuration file'))
+    print(_('''usage: proxy_container_config_generate_cert PROXY_FQDN SERVER_FQDN MAX_CACHE EMAIL CA_CRT CA_KEY CA_PASSWORD
+
+parameters:
+  PROXY_FQDN  the fully qualified domain name of the proxy to create.
+  SERVER_FQDN the fully qualified domain name of the server to connect to proxy to.
+  MAX_CACHE   the maximum cache size in MB. 60% of the storage is a good value.
+  EMAIL       the email of the proxy administrator
+  CA_CRT path to the certificate of the CA to use to generate a new proxy certificate
+  CA_KEY path to the private key of the CA to use to generate a new proxy certificate
+  CA_PASSWORD path to a file containing the password of the CA private key
+
+options:
+  -o, --output Path where to create the generated configuration. Default: 'config.zip'
+  --ssl-cname alternate name of the proxy to set in the certificate. Can be provided multiple times
+  --ssl-country country code to set in the certificate. If omitted, default values from mgr-ssl-tool will be used.
+  --ssl-state state name to set in the certificate. If omitted, default values from mgr-ssl-tool will be used.
+  --ssl-city the city name to set in the certificate. If omitted, default values from mgr-ssl-tool will be used.
+  --ssl-org the organization name to set in the certificate. If omitted, default values from mgr-ssl-tool will be used.
+  --ssl-org-unit the organization unit name to set in the certificate. If omitted, default values from mgr-ssl-tool will be used.
+  --ssl-email the email to set in the certificate. If omitted, default values from mgr-ssl-tool will be used.
+
+examples:
+  proxy_container_config proxy.lab server.lab 1024 proxy@acme.org ssl-build/RHN-ORG-TRUSTED-SSL-CERT ssl-build/RHN-ORG-PRIVATE-SSL-KEY ca-password.txt
+'''))
+
+
+def do_proxy_container_config_generate_cert(self, args):
+    arg_parser = get_argument_parser()
+    arg_parser.add_argument('-o', '--output', default='config.zip')
+    arg_parser.add_argument('--ssl-cname', action='append', default=[])
+    arg_parser.add_argument('--ssl-country', default='')
+    arg_parser.add_argument('--ssl-state', default='')
+    arg_parser.add_argument('--ssl-city', default='')
+    arg_parser.add_argument('--ssl-org', default='')
+    arg_parser.add_argument('--ssl-org-unit', default='')
+    arg_parser.add_argument('--ssl-email', default='')
+
+    args, options = parse_command_arguments(args, arg_parser)
+
+    if len(args) != 7:
+        self.help_container_config()
+        return
+
+    (proxy_fqdn, server_fqdn, max_cache, email, ca_cert, ca_key, ca_password) = args
+
+    ca_cert = read_file(ca_cert)
+    ca_key = read_file(ca_key)
+    ca_password = read_file(ca_password)
+
+    config = self.client.proxy.container_config(self.session, proxy_fqdn, server_fqdn, int(max_cache), email,
+            ca_cert, ca_key, ca_password, options.ssl_cname, options.ssl_country, options.ssl_state,
+            options.ssl_city, options.ssl_org, options.ssl_org_unit, options.ssl_email)
+
+    with open(options.output, 'wb') as fd:
+        fd.write(config.data)
+    return options.output
+
+
+def read_file(path):
+    '''
+    utility function reading a file and returning its content.
+    '''
+    if not path:
+        return None
+
+    with open(path, 'r') as fd:
+        return fd.read()

--- a/spacecmd/src/spacecmd/shell.py
+++ b/spacecmd/src/spacecmd/shell.py
@@ -59,7 +59,7 @@ class SpacewalkShell(Cmd):
     __module_list = ['activationkey', 'configchannel', 'cryptokey',
                      'custominfo', 'distribution', 'errata',
                      'filepreservation', 'group', 'kickstart',
-                     'misc', 'org', 'package', 'repo', 'report', 'schedule',
+                     'misc', 'org', 'package', 'proxy', 'repo', 'report', 'schedule',
                      'snippet', 'softwarechannel', 'ssm', 'api',
                      'system', 'user', 'utils', 'scap']
 

--- a/spacewalk/certs-tools/mgr_ssl_cert_setup.py
+++ b/spacewalk/certs-tools/mgr_ssl_cert_setup.py
@@ -95,6 +95,7 @@ def processCommandline():
     parser.add_argument(
         "-k", "--server-key-file", help="Path to the Server Private Key"
     )
+    parser.add_argument("--check-only", "-c", action="store_true")
     parser.add_argument("--verbose", "-v", action="count", default=0)
 
     options = parser.parse_args()
@@ -525,6 +526,10 @@ def _main():
         options.server_key_file,
         options.intermediate_ca_file,
     )
+    if options.check_only:
+        getContainersSetup(files_content.root_ca, files_content.intermediate_cas, files_content.server_cert, files_content.server_key)
+        sys.exit(0)
+
     certData = prepareData(
             files_content.root_ca,
             files_content.server_cert,

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,4 @@
+- Generate openssl CA configuration if missing when creating server certificate
 - Do not generate Salt Bundle sections in bootstrap for traditional
 - Reuse certificate code.
 - Allow alternative certificate filenames for update-ca-cert-trust.sh.

--- a/susemanager-utils/susemanager-sls/modules/runners/mgrutil.py
+++ b/susemanager-utils/susemanager-sls/modules/runners/mgrutil.py
@@ -8,6 +8,8 @@ import shutil
 import salt.utils
 import tempfile
 
+import certs.mgr_ssl_cert_setup
+
 log = logging.getLogger(__name__)
 
 GROUP_OWNER = 'susemanager'
@@ -129,3 +131,13 @@ def move_minion_uploaded_files(minion=None, dirtomove=None, basepath=None, actio
         return {False: str(err)}
     return {True: scapstorepath}
 
+
+def check_ssl_cert(root_ca, server_crt, server_key, intermediate_cas):
+    '''
+    Check that the provided certificates are valid and return the certificate and key to deploy.
+    '''
+    try:
+        cert = certs.mgr_ssl_cert_setup.getContainersSetup(root_ca, intermediate_cas, server_crt, server_key)
+        return {"cert": cert}
+    except certs.mgr_ssl_cert_setup.CertCheckError as err:
+        return {"error": str(err)}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Expose SSL certificate check to Salt runner
 - Fix possible traceback in uyuni roster if no ssh port in the DB
 - Virtualization fixes for python2
 - fixing how the return code is returned in mgrutil runner (bsc#1194909)

--- a/susemanager-utils/susemanager-sls/susemanager-sls.spec
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.spec
@@ -43,6 +43,7 @@ Requires:       susemanager-build-keys-web >= 12.0.1
 %if 0%{?build_py3}
 BuildRequires:  python3-pytest
 BuildRequires:  python3-salt
+BuildRequires:  python3-spacewalk-certs-tools
 # Different package names for SUSE and RHEL:
 Requires:       (python3-PyYAML >= 5.1 or python3-pyyaml >= 5.1)
 %else


### PR DESCRIPTION
## What does this PR change?

This PR adds an XML-RPC API and `spacecmd` command to generate the configuration for containerized proxies. 

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/16866

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
