### PR TITLE
QA: Wait until Prometheus services are active

### DIFF
--- a/testsuite/features/secondary/min_centos_monitoring.feature
+++ b/testsuite/features/secondary/min_centos_monitoring.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 # This feature depends on:
 # - features/secondary/srv_monitoring.feature : As this feature disable/re-enable monitoring capabilities
@@ -44,8 +44,11 @@ Feature: Monitor SUMA environment with Prometheus on a CentOS Salt minion
     And I wait until event "Apply highstate scheduled by admin" is completed
 
   Scenario: Visit monitoring endpoints on the CentOS minion
-    When I visit "Prometheus node exporter" endpoint of this "ceos_minion"
+    When I wait until "prometheus-node_exporter" service is active on "ceos_minion"
+    And I visit "Prometheus node exporter" endpoint of this "ceos_minion"
+    And I wait until "prometheus-apache_exporter" service is active on "ceos_minion"
     And I visit "Prometheus apache exporter" endpoint of this "ceos_minion"
+    And I wait until "prometheus-postgres_exporter" service is active on "ceos_minion"
     And I visit "Prometheus postgres exporter" endpoint of this "ceos_minion"
 
   Scenario: Cleanup: undo Prometheus exporter formulas on the CentOS minion

--- a/testsuite/features/secondary/min_monitoring.feature
+++ b/testsuite/features/secondary/min_monitoring.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 # This feature depends on:
 # - features/secondary/srv_monitoring.feature : As this feature disable/re-enable monitoring capabilities
@@ -53,9 +53,13 @@ Feature: Monitor SUMA environment with Prometheus on a SLE Salt minion
     And I wait until event "Apply highstate scheduled by admin" is completed
 
   Scenario: Visit monitoring endpoints on the minion
-    When I visit "Prometheus" endpoint of this "sle_minion"
+    When I wait until "prometheus" service is active on "sle_minion"
+    And I visit "Prometheus" endpoint of this "sle_minion"
+    And I wait until "prometheus-node_exporter" service is active on "sle_minion"
     And I visit "Prometheus node exporter" endpoint of this "sle_minion"
+    And I wait until "prometheus-apache_exporter" service is active on "sle_minion"
     And I visit "Prometheus apache exporter" endpoint of this "sle_minion"
+    And I wait until "prometheus-postgres_exporter" service is active on "sle_minion"
     And I visit "Prometheus postgres exporter" endpoint of this "sle_minion"
 
   Scenario: Cleanup: undo Prometheus and Prometheus exporter formulas


### PR DESCRIPTION
## What does this PR change?

Wait until Prometheus services are active, as currently it seems we need a bit more time until it's fully usable, once the apply states event has finished.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.1 https://github.com/SUSE/spacewalk/pull/17101
- Manager-4.2 https://github.com/SUSE/spacewalk/pull/17102

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
