### PR TITLE
Reposync client cert check

### DIFF
--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -35,6 +35,7 @@ import errno
 import multiprocessing
 
 from rhn.connections import idn_puny_to_unicode
+from rhn.stringutils import ustr
 
 from uyuni.common.usix import raise_with_tb
 
@@ -360,14 +361,34 @@ def clear_ssl_cache():
     shutil.rmtree(ssldir, True)
 
 
+def verify_certificates_dates(certs):
+    cert = ""
+    is_cert = False
+    has_valid_certs = False
+    for line in certs.split('\n'):
+        if not is_cert and line.startswith("-----BEGIN CERTIFICATE"):
+            is_cert = True
+        if is_cert:
+            cert += line + '\n'
+        if is_cert and line.startswith("-----END CERTIFICATE"):
+            if not verify_certificate_dates(cert):
+                return False
+            cert = ""
+            is_cert = False
+            has_valid_certs = True
+    return has_valid_certs
+
+
 def get_single_ssl_set(keys, check_dates=False):
     """Picks one of available SSL sets for given repository."""
     if check_dates:
         for ssl_set in keys:
-            if verify_certificate_dates(str(ssl_set['ca_cert'])) and \
+            if verify_certificates_dates(ustr(ssl_set['ca_cert'])) and \
                 (not ssl_set['client_cert'] or
-                 verify_certificate_dates(str(ssl_set['client_cert']))):
+                 verify_certificates_dates(ustr(ssl_set['client_cert']))):
                 return ssl_set
+            else:
+                log(0, "++ Invalid Certificate found ++")
     # Get first
     else:
         return keys[0]
@@ -380,7 +401,7 @@ class RepoSync(object):
                  filters=None, no_errata=False, sync_kickstart=False, latest=False,
                  metadata_only=False, strict=0, excluded_urls=None, no_packages=False,
                  log_dir="reposync", log_level=None, force_kickstart=False, force_all_errata=False,
-                 check_ssl_dates=False, force_null_org_content=False, show_packages_only=False,
+                 check_ssl_dates=True, force_null_org_content=False, show_packages_only=False,
                  noninteractive=False, deep_verify=False):
         self.regen = False
         self.fail = fail

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- enable check for client certificates in reposync
 - remove auto inherit of host entitlements for virtual guests
   * Fix reposync update notice formatting and date parsing (bsc#1194447)
   * supportconfig spacewalk-debug: extract task schedule data from db


### PR DESCRIPTION
## What does this PR change?

Checking Client Certificates in reposync exist, but was disabled when using spacewalk-repo-sync.
This change enable the check by default and improved it by checking all certificates configured.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **manual tested**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11861
Tracks https://github.com/SUSE/spacewalk/pull/17112

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
