### PR TITLE
QA: Raise exception again in AfterStep, instead of failing the scenario

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -105,13 +105,10 @@ After do |scenario|
   page.instance_variable_set(:@touched, false)
 end
 
-AfterStep do |scenario|
+AfterStep do
   if has_css?('.senna-loading', wait: 0)
     STDOUT.puts "WARN: Step ends with an ajax transition not finished, let's wait a bit!"
-    unless has_no_css?('.senna-loading', wait: 15)
-      # Note: See the special behavior of this step here: https://github.com/cucumber/cucumber-ruby/issues/1101
-      scenario.fail!(StandardError.new('Timeout: Waiting AJAX transition'))
-    end
+    raise StandardError, 'Timeout: Waiting AJAX transition' unless has_no_css?('.senna-loading', wait: 20)
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

Raise exception again in AfterStep, instead of failing the scenario

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
