### PR TITLE
QA: Change validation of activation key value

### DIFF
--- a/testsuite/features/secondary/trad_migrate_to_minion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_minion.feature
@@ -45,10 +45,6 @@ Feature: Migrate a traditional client into a Salt minion
     When I run "systemctl status nhsd" on "sle_client" without error control
     Then the command should fail
 
-  Scenario: Check that minion has the new activation key
-    Given I am on the Systems overview page of this "sle_client"
-    Then the activation key should be "1-SUSE-KEY-x86_64"
-
   Scenario: Check that channels are still the same after migration
     Given I am on the Systems overview page of this "sle_client"
     Then I should see a "Test-Channel-x86_64" text

--- a/testsuite/features/secondary/trad_migrate_to_minion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_minion.feature
@@ -116,8 +116,3 @@ Feature: Migrate a traditional client into a Salt minion
     Given I am on the Systems overview page of this "sle_client"
     When I follow "Properties" in the content area
     Then I wait until I see "Base System Type:.*Management" regex, refreshing the page
-
-  Scenario: Cleanup: check that we still have the activation key
-    Given I am on the Systems overview page of this "sle_client"
-    Then the activation key should be "1-SUSE-KEY-x86_64"
-    

--- a/testsuite/features/secondary/trad_migrate_to_minion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_minion.feature
@@ -120,3 +120,4 @@ Feature: Migrate a traditional client into a Salt minion
   Scenario: Cleanup: check that we still have the activation key
     Given I am on the Systems overview page of this "sle_client"
     Then the activation key should be "1-SUSE-KEY-x86_64"
+    

--- a/testsuite/features/secondary/trad_migrate_to_minion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2021 SUSE LLC
+# Copyright (c) 2017-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_traditional_client
@@ -44,6 +44,10 @@ Feature: Migrate a traditional client into a Salt minion
   Scenario: Check that service nhsd has been stopped
     When I run "systemctl status nhsd" on "sle_client" without error control
     Then the command should fail
+
+  Scenario: Check that minion has the new activation key
+    Given I am on the Systems overview page of this "sle_client"
+    Then the activation key should be "1-SUSE-KEY-x86_64"
 
   Scenario: Check that channels are still the same after migration
     Given I am on the Systems overview page of this "sle_client"
@@ -112,3 +116,7 @@ Feature: Migrate a traditional client into a Salt minion
     Given I am on the Systems overview page of this "sle_client"
     When I follow "Properties" in the content area
     Then I wait until I see "Base System Type:.*Management" regex, refreshing the page
+
+  Scenario: Cleanup: check that we still have the activation key
+    Given I am on the Systems overview page of this "sle_client"
+    Then the activation key should be "1-SUSE-KEY-x86_64"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -78,12 +78,6 @@ Then(/^the system name for "([^"]*)" should be correct$/) do |host|
   step %(I should see a "#{system_name}" text)
 end
 
-Then(/^the activation key should be "([^"]*)"$/) do |activation_key_value|
-  shown_activation_key = find(:xpath, "//td[text()='Activation Key:']/following-sibling::td[1]").text
-  log "Found #{shown_activation_key} as activation key"
-  raise unless activation_key_value.eql? shown_activation_key
-end
-
 # rubocop:disable Metrics/BlockLength
 Then(/^the uptime for "([^"]*)" should be correct$/) do |host|
   # TODO remove extra logging information once debugged

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -78,6 +78,12 @@ Then(/^the system name for "([^"]*)" should be correct$/) do |host|
   step %(I should see a "#{system_name}" text)
 end
 
+Then(/^the activation key should be "([^"]*)"$/) do |activation_key_value|
+  shown_activation_key = find(:xpath, "//td[text()='Activation Key:']/following-sibling::td[1]").text
+  log "Found #{shown_activation_key} as activation key"
+  raise unless activation_key_value.eql? shown_activation_key
+end
+
 # rubocop:disable Metrics/BlockLength
 Then(/^the uptime for "([^"]*)" should be correct$/) do |host|
   # TODO remove extra logging information once debugged


### PR DESCRIPTION
## What does this PR change?
Make activation keys' validation not depend on whitespaces and be dependent on the element's value instead, making the test less flaky. Also synched to the Suse Manager's 4.1 and 4.2 branches, which had changes to this feature that weren't yet reflected here.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were modified

- [x] **DONE**

## Links and Ports

Fixes https://github.com/SUSE/spacewalk/issues/17106
- 4.1 https://github.com/SUSE/spacewalk/pull/17108
- 4.2 https://github.com/SUSE/spacewalk/pull/17109

- [ ] **DONE**

## Changelogs
- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
