### PR TITLE
Hardening suggestion: permissions for

### DIFF
--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -666,7 +666,7 @@ echo "#### SYMLINKS END ####"
 
 %post -n spacewalk-taskomatic
 %if 0%{?rhel}
-%systemd_post taskomatic.service 
+%systemd_post taskomatic.service
 %else
 %service_add_post taskomatic.service
 %endif
@@ -706,7 +706,7 @@ chown tomcat:%{apache_group} /var/log/rhn/gatherer.log
 %dir %{_localstatedir}/lib/spacewalk
 %defattr(644,tomcat,tomcat,775)
 %attr(775, %{salt_user_group}, %{salt_user_group}) %dir %{serverdir}/susemanager/salt/salt_ssh
-%attr(775, %{salt_user_group}, %{salt_user_group}) %dir %{serverdir}/susemanager/salt/salt_ssh/temp_bootstrap_keys
+%attr(700, %{salt_user_group}, %{salt_user_group}) %dir %{serverdir}/susemanager/salt/salt_ssh/temp_bootstrap_keys
 %attr(775, root, tomcat) %dir %{serverdir}/tomcat/webapps
 %dir %{serverdir}/susemanager
 %dir %{serverdir}/susemanager/salt


### PR DESCRIPTION
## What does this PR change?

/srv/susemanager/salt/salt_ssh/temp_bootstrap_keys directory can be 0700 instead of 0755. In this directory SUMA will store ssh private key files and it will create them with 0700 permission, so the directory itself can have the same.

## GUI diff

No difference.

- [ X ] **DONE**

## Documentation
- No documentation needed: this PR enforces the permissions schema on the temporary key folder. The files contained are 0600 owned by salt user and salt group, so there is no need for more permissions on folder

- [ X ] **DONE**

## Test coverage
- No tests: just SPEC file change

- [ X ] **DONE**

- [ X ] **DONE**

## Links

- See also https://github.com/SUSE/spacewalk/issues/17695

## Changelogs

/srv/susemanager/salt/salt_ssh/temp_bootstrap_keys directory can be 0700 instead of 0755. In this directory SUMA will store ssh private key files and it will create them with 0700 permission, so the directory itself can have the same.


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
