### PR TITLE
Fix syntax for eclipse compiler

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
@@ -576,6 +576,7 @@ public class SaltSSHService {
      * Return the Map of Result objects that contain either the error from SSHResult or the
      * unwrapped return value from SSHResult.
      */
+    @SuppressWarnings("java:S2293")
     private <T> Map<String, Result<T>> unwrapSSHReturn(Map<String,
             Result<SSHResult<T>>> sshResults) {
          return sshResults.entrySet().stream()

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
@@ -582,14 +582,14 @@ public class SaltSSHService {
                 .collect(Collectors.toMap(
                         Map.Entry::getKey,
                         kv -> kv.getValue().fold(
-                                err -> new Result<>(Xor.left(err)),
+                                err -> new Result<T>(Xor.left(err)),
                                 succ -> {
                                     if (succ.getReturn().isPresent()) {
-                                        return new Result<>(Xor.right(
+                                        return new Result<T>(Xor.right(
                                                 succ.getReturn().get()));
                                     }
                                     else {
-                                        return new Result<>(Xor.left(
+                                        return new Result<T>(Xor.left(
                                                 succ.getStderr().map(stderr ->
                                                         new GenericError("Error unwrapping ssh return: " + stderr))
                                                         .orElse(new GenericError(

--- a/susemanager-utils/testing/docker/scripts/init-pgsql-db4eclipse.sh
+++ b/susemanager-utils/testing/docker/scripts/init-pgsql-db4eclipse.sh
@@ -20,6 +20,7 @@ echo $PERLLIB
 
 export SYSTEMD_NO_WRAP=1
 #sysctl -w kernel.shmmax=18446744073709551615
+su - postgres -c "/usr/lib/postgresql/bin/pg_ctl stop" ||:
 su - postgres -c "/usr/lib/postgresql/bin/pg_ctl start" ||:
 
 # this copy the latest schema from the git into the system


### PR DESCRIPTION
## What does this PR change?

Eclipse needs this syntax to compile the code.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
