### PR TITLE
QA: Use FQDN in salt client naming scheme for branch network

### DIFF
--- a/testsuite/features/core/proxy_branch_network.feature
+++ b/testsuite/features/core/proxy_branch_network.feature
@@ -78,6 +78,8 @@ Feature: Setup Uyuni for Retail branch network
     And I uncheck enable route box
     And I uncheck enable NAT box
     And I enter "example" in branch id field
+    And I enter "FQDN" in salt client naming scheme field
+    And I check Do not prefix salt client ID with Branch ID box
     And I click on "Save Formula"
     Then I should see a "Formula saved" text
 

--- a/testsuite/features/step_definitions/retail_steps.rb
+++ b/testsuite/features/step_definitions/retail_steps.rb
@@ -374,6 +374,7 @@ When(/^I enter "([^"]*)" in (.*) field$/) do |value, field|
     'third available zone name'    => 'bind#available_zones#2#$key',
     'TFTP base directory'          => 'tftpd#root_dir',
     'branch id'                    => 'pxe#branch_id',
+    'salt client naming scheme'    => 'pxe#minion_id_naming',
     'disk id'                      => 'partitioning#0#$key',
     'disk device'                  => 'partitioning#0#device',
     'first partition id'           => 'partitioning#0#partitions#0#$key',

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -59,10 +59,11 @@ FIELD_IDS = { 'NIC'                             => 'branch_network#nic',
               'language'                        => 'keyboard_and_language#language',
               'keyboard layout'                 => 'keyboard_and_language#keyboard_layout' }.freeze
 
-BOX_IDS = { 'enable SLAAC with routing' => 'branch_network#firewall#enable_SLAAC_with_routing',
-            'include forwarders'        => 'bind#config#include_forwarders',
-            'enable route'              => 'branch_network#firewall#enable_route',
-            'enable NAT'                => 'branch_network#firewall#enable_NAT' }.freeze
+BOX_IDS = { 'enable SLAAC with routing'                   => 'branch_network#firewall#enable_SLAAC_with_routing',
+            'include forwarders'                          => 'bind#config#include_forwarders',
+            'enable route'                                => 'branch_network#firewall#enable_route',
+            'enable NAT'                                  => 'branch_network#firewall#enable_NAT',
+            'Do not prefix salt client ID with Branch ID' => 'pxe#disable_id_prefix' }.freeze
 
 BULLET_STYLE = { 'failing' => 'fa-times text-danger',
                  'warning' => 'fa-hand-o-right text-danger',


### PR DESCRIPTION
## What does this PR change?

Use FQDN in salt client naming scheme for branch network

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
