### PR TITLE
CODEOWNERS: Fix release-engineering syntax

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,8 +33,8 @@
 # Uyuni Code Owners
 
 # Release Engineering
-rel-eng/ @release-engineering
-tito.props @release-engineering
+rel-eng/ @uyuni-project/release-engineering
+tito.props @uyuni-project/release-engineering
 
 # Cobbler
 java/conf/cobbler/snippets/ @SchoolGuy


### PR DESCRIPTION
## What does this PR change?
Specify the `@uyuni-project/release-engineering` group correctly.

## GUI diff

No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only addresses the Git repository

- [x] **DONE**

## Test coverage
- No tests: No code change

- [x] **DONE**

## Links
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
