### PR TITLE
Logging for virt

### DIFF
--- a/backend/server/rhnVirtualization.py
+++ b/backend/server/rhnVirtualization.py
@@ -1014,32 +1014,10 @@ class VirtualizationListener:
 class EntitlementVirtualizationListener(VirtualizationListener):
 
     def guest_registered(self, host_sid, guest_sid):
-        host_system_slots = server_lib.check_entitlement(host_sid, True)
-        #host_system_slots = list(host_system_slots.keys())
-
-        if "virtualization_host" in host_system_slots:
-            host_system_slots.remove("virtualization_host")
-        if "foreign_entitled" in host_system_slots:
-            host_system_slots.remove("foreign_entitled")
-
-        guest_system_slots = server_lib.check_entitlement(guest_sid)
-        guest_system_slots = list(guest_system_slots.keys())
-
-        for entitlement in host_system_slots:
-            if entitlement not in guest_system_slots:
-                try:
-                    rhnSQL.transaction(entitlement)
-                    procedure.rhn_entitlements.entitle_server(guest_sid,
-                                                              entitlement)
-                except rhnSQL.SQLError:
-                    e = sys.exc_info()[1]
-                    rhnSQL.rollback(entitlement)
-                    log_error("Error adding entitlement %s to host ID-%s: %s"
-                              % (entitlement, guest_sid, str(e)))
-                    # rhnSQL.rollback()
-                    return
-
-        # rhnSQL.commit()
+        # dropped code which entitle the guest to all entitlements of the host
+        # this does not make sense when host and guest can have different
+        # base entitlements (salt vs. management)
+        pass
 
 
 # This file provides an interface that allows components of the RHN server to

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- remove auto inherit of host entitlements for virtual guests
   * Fix reposync update notice formatting and date parsing (bsc#1194447)
   * supportconfig spacewalk-debug: extract task schedule data from db
   * Define report_db_sslroot default during package build.

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/AbstractVirtualizationController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/AbstractVirtualizationController.java
@@ -90,6 +90,7 @@ public abstract class AbstractVirtualizationController {
             return Long.parseLong(request.params("sid"));
         }
         catch (NumberFormatException e) {
+            LOG.error("Invalid server id: " + request.params("sid"), e);
             throw Spark.halt(HttpStatus.SC_NOT_FOUND, "Invalid server id: " + request.params("sid"));
         }
     }
@@ -156,6 +157,7 @@ public abstract class AbstractVirtualizationController {
             return json(response, result);
         }
         catch (Exception e) {
+            LOG.error("Bad Request", e);
             throw Spark.halt(HttpStatus.SC_BAD_REQUEST);
         }
     }

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualGuestsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualGuestsController.java
@@ -349,10 +349,12 @@ public class VirtualGuestsController extends AbstractVirtualizationController {
                         })
                     ).orElse(false);
                     if (!inCluster) {
+                        LOG.error("No such virtual machine");
                         throw Spark.halt(HttpStatus.SC_BAD_REQUEST, "No such virtual machine");
                     }
                 },
                 () -> {
+                    LOG.error("No such virtual machine");
                     throw Spark.halt(HttpStatus.SC_BAD_REQUEST, "No such virtual machine");
                 }
             );
@@ -379,6 +381,7 @@ public class VirtualGuestsController extends AbstractVirtualizationController {
         Map<String, Object> data = new HashMap<>();
 
         if (!host.hasEntitlement(EntitlementManager.SALT)) {
+            LOG.error("Only for Salt-managed virtual hosts");
             Spark.halt(HttpStatus.SC_BAD_REQUEST, "Only for Salt-managed virtual hosts");
         }
 
@@ -438,6 +441,7 @@ public class VirtualGuestsController extends AbstractVirtualizationController {
             ensureAccessToVirtualInstance(user, guest);
         }
         catch (LookupException e) {
+            LOG.error("Unauthorized", e);
             Spark.halt(HttpStatus.SC_UNAUTHORIZED, e.getLocalizedMessage());
         }
 
@@ -466,12 +470,14 @@ public class VirtualGuestsController extends AbstractVirtualizationController {
      */
     public String refreshConsoleToken(Request request, Response response, User user) {
         if (!TokenBuilder.verifyToken(request.body())) {
+            LOG.error("Invalid token");
             Spark.halt(HttpStatus.SC_FORBIDDEN, "Invalid token");
         }
 
         String guestUuid = request.params("guestuuid");
         VirtualInstance guest = getVirtualInstanceFromUuid(guestUuid);
         if (guest == null) {
+            LOG.error("Virtual machine not found");
             Spark.halt(HttpStatus.SC_NOT_FOUND, "Virtual machine not found");
         }
         Server host = guest.getHostSystem();
@@ -479,6 +485,7 @@ public class VirtualGuestsController extends AbstractVirtualizationController {
             ensureAccessToVirtualInstance(user, guest);
         }
         catch (LookupException e) {
+            LOG.error("Unauthorized", e);
             Spark.halt(HttpStatus.SC_UNAUTHORIZED, e.getLocalizedMessage());
         }
 
@@ -505,7 +512,8 @@ public class VirtualGuestsController extends AbstractVirtualizationController {
             return null;
         }
         if (guests.size() > 1) {
-            Spark.halt(HttpStatus.SC_NOT_FOUND, "More than one virtual machine machine this UUID");
+            LOG.error("More than one virtual machine found for this UUID: " + uuid);
+            Spark.halt(HttpStatus.SC_NOT_FOUND, "More than one virtual machine found for this UUID");
         }
         return guests.get(0);
     }
@@ -518,7 +526,7 @@ public class VirtualGuestsController extends AbstractVirtualizationController {
             token = tokenBuilder.getToken();
         }
         catch (JoseException e) {
-            LOG.error(e);
+            LOG.error("Service unavailable", e);
             Spark.halt(HttpStatus.SC_SERVICE_UNAVAILABLE);
         }
         return token;
@@ -535,6 +543,7 @@ public class VirtualGuestsController extends AbstractVirtualizationController {
      */
     public Boolean refresh(Request request, Response response, User user, Server host) {
         if (noHostSupportAction(host, true)) {
+            LOG.error("Action not supported for this host");
             Spark.halt(HttpStatus.SC_BAD_REQUEST, "Action not supported for this host");
         }
 
@@ -556,6 +565,7 @@ public class VirtualGuestsController extends AbstractVirtualizationController {
      */
     public String setMemory(Request request, Response response, User user, Server host) {
         if (noHostSupportAction(host, false)) {
+            LOG.error("Action not supported for this host");
             Spark.halt(HttpStatus.SC_BAD_REQUEST, "Action not supported for this host");
         }
 
@@ -577,6 +587,7 @@ public class VirtualGuestsController extends AbstractVirtualizationController {
      */
     public String setVcpu(Request request, Response response, User user, Server host) {
         if (noHostSupportAction(host, false)) {
+            LOG.error("Action not supported for this host");
             Spark.halt(HttpStatus.SC_BAD_REQUEST, "Action not supported for this host");
         }
 
@@ -598,6 +609,7 @@ public class VirtualGuestsController extends AbstractVirtualizationController {
      */
     public String restart(Request request, Response response, User user, Server host) {
         if (noHostSupportAction(host, false)) {
+            LOG.error("Action not supported for this host");
             Spark.halt(HttpStatus.SC_BAD_REQUEST, "Action not supported for this host");
         }
 
@@ -620,6 +632,7 @@ public class VirtualGuestsController extends AbstractVirtualizationController {
      */
     public String shutdown(Request request, Response response, User user, Server host) {
         if (noHostSupportAction(host, false)) {
+            LOG.error("Action not supported for this host");
             Spark.halt(HttpStatus.SC_BAD_REQUEST, "Action not supported for this host");
         }
 
@@ -649,6 +662,7 @@ public class VirtualGuestsController extends AbstractVirtualizationController {
         actionsMap.put("delete", ActionFactory.TYPE_VIRTUALIZATION_DELETE);
 
         if (noHostSupportAction(host, false)) {
+            LOG.error("Action not supported for this host");
             Spark.halt(HttpStatus.SC_BAD_REQUEST, "Action not supported for this host");
         }
 
@@ -671,6 +685,7 @@ public class VirtualGuestsController extends AbstractVirtualizationController {
      */
     public String migrate(Request request, Response response, User user, Server host) {
         if (noHostSupportAction(host, true)) {
+            LOG.error("Action not supported for this host");
             Spark.halt(HttpStatus.SC_BAD_REQUEST, "Action not supported for this host");
         }
 
@@ -692,6 +707,7 @@ public class VirtualGuestsController extends AbstractVirtualizationController {
      */
     public String update(Request request, Response response, User user, Server host) {
         if (noHostSupportAction(host, false)) {
+            LOG.error("Action not supported for this host");
             Spark.halt(HttpStatus.SC_BAD_REQUEST, "Action not supported for this host");
         }
 
@@ -728,6 +744,7 @@ public class VirtualGuestsController extends AbstractVirtualizationController {
      */
     public String newGuest(Request request, Response response, User user, Server host) {
         if (noHostSupportAction(host, true)) {
+            LOG.error("Action not supported for this host");
             Spark.halt(HttpStatus.SC_BAD_REQUEST, "Action not supported for this host");
         }
 
@@ -742,6 +759,7 @@ public class VirtualGuestsController extends AbstractVirtualizationController {
                                 BiConsumer<Action, Integer> setter,
                                 Class<T> dataClass) {
         if (noHostSupportAction(host, false)) {
+            LOG.error("Action not supported for this host");
             Spark.halt(HttpStatus.SC_BAD_REQUEST, "Action not supported for this host");
         }
 


### PR DESCRIPTION
## What does this PR change?

Fixes 2 problems:

- no error logs when we return spark.halt() with errors in virtualization
- remove inherit of host entitlements to virtual guests. This break when the host is salt entitled but the VM should be traditionally managed.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/17139

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
