### PR TITLE
Fix bash config parser

### DIFF
--- a/spacewalk/admin/spacewalk-startup-helper
+++ b/spacewalk/admin/spacewalk-startup-helper
@@ -68,7 +68,7 @@ check_db_version() {
 parse_rhn_property() {
     ATTRIBUTE="$1"
     VAR="$2"
-    VALUE=$(grep "^$ATTRIBUTE" /etc/rhn/rhn.conf |cut -d'=' -f2 | tail -n1 | tr -d '\n ')
+    VALUE=$(grep "^$ATTRIBUTE" /etc/rhn/rhn.conf |cut -d'=' -f2 | tail -n1 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | tr -d '\n')
     eval "$(printf "%q=%q" "$VAR" "$VALUE")"
 }
 

--- a/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb-user
+++ b/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb-user
@@ -99,7 +99,7 @@ set_value() {
 parse_properties() {
     ATTRIBUTE="$1"
     VAR="$2"
-    VALUE=$(grep "^$ATTRIBUTE" $RHN_CONF |cut -d'=' -f2 | tail -n1 | tr -d '\n ')
+    VALUE=$(grep "^$ATTRIBUTE" $RHN_CONF |cut -d'=' -f2 | tail -n1 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | tr -d '\n')
     eval "$(printf "%q=%q" "$VAR" "$VALUE")"
 }
 

--- a/spacewalk/uyuni-setup-reportdb/uyuni-setup-reportdb.changes
+++ b/spacewalk/uyuni-setup-reportdb/uyuni-setup-reportdb.changes
@@ -1,3 +1,4 @@
+- keep whitespaces in values when parsing rhn.conf
 - Use alternative certificate directory for RHEL.
 - remove possibility to change admin user
 


### PR DESCRIPTION
## What does this PR change?

While parsing rhn.conf, all whitespaces in values got stripped.
This PR strip only leading and trailing whitespaces and keep spaces inside of the value.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/4925

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
