### PR TITLE
Do not generate Salt Bundle sections to traditional bootstrap script

### DIFF
--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,4 @@
+- Do not generate Salt Bundle sections in bootstrap for traditional
 - Reuse certificate code.
 - Allow alternative certificate filenames for update-ca-cert-trust.sh.
 - Add dynamic version for bootstrap script header (bsc#1186336)


### PR DESCRIPTION
## What does this PR change?

Do not generate Salt Bundle sections to the bootstrap script for traditional clients

## GUI diff

No difference.


## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: already covered

## Changelogs

- Do not generate Salt Bundle sections in bootstrap for traditional

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
