### PR TITLE
TESTSUITE Failing Scenario: Install package in the future and check for staging

### DIFF
--- a/testsuite/features/secondary/min_salt_install_with_staging.feature
+++ b/testsuite/features/secondary/min_salt_install_with_staging.feature
@@ -50,7 +50,7 @@ Feature: Install a package on the SLES minion with staging enabled
     And I follow "Install" in the content area
     When I check row with "orion-dummy-1.1-1.1" and arch of "sle_minion"
     And I click on "Install Selected Packages"
-    And I pick 2 minutes from now as schedule time
+    And I pick 3 minutes from now as schedule time
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text
     And I wait until the package "orion-dummy-1.1-1.1" has been cached on this "sle_minion"
@@ -61,7 +61,7 @@ Feature: Install a package on the SLES minion with staging enabled
     And I follow "Patches" in the content area
     When I check "virgo-dummy-3456" in the list
     And I click on "Apply Patches"
-    And I pick 2 minutes from now as schedule time
+    And I pick 3 minutes from now as schedule time
     And I click on "Confirm"
     Then I should see a "1 patch update has been scheduled for" text
     And I wait until the package "virgo-dummy-2.0-1.1.noarch" has been cached on this "sle_minion"

--- a/testsuite/features/secondary/min_ubuntu_salt_install_with_staging.feature
+++ b/testsuite/features/secondary/min_ubuntu_salt_install_with_staging.feature
@@ -52,7 +52,7 @@ Feature: Install a package on the Ubuntu minion with staging enabled
     And I follow "Install" in the content area
     When I check "orion-dummy-1.1-X" in the list
     And I click on "Install Selected Packages"
-    And I pick 2 minutes from now as schedule time
+    And I pick 3 minutes from now as schedule time
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text
     And I wait until the package "orion-dummy_1.1" has been cached on this "ubuntu_minion"


### PR DESCRIPTION
## What does this PR change?

The `Install package in the future and check for staging` scenario is failing. 

According to the comments of the colleagues: 

> The package is not anymore cached. It's happening in all our latest testsuite runs on Uyuni/Head CI.

After further investigations:

> It seems our parameters are set up a bit in a way that makes this test bit flaky. 
>
> java.salt_content_staging_window = 0.033 (~1.98 minutes)
> java.salt_content_staging_advance = 0.05 (3 minutes)
> 
> Now in our test, we schedule it 2 minutes in the future https://github.com/SUSE/spacewalk/blob/f1ba1f514b700c74a5cd34524d1615ab84b8bd9e/testsuite/features/secondary/min_salt_install_with_staging.feature#L53
> 
> So IIUC,  I see that the staging window started even before the current time, I didn't look into the code thoroughly but it seems, that is causing the issue. So I would recommend either adjusting the parameters that our salt_content_staging_advance should at least start after the current time or increasing the time in our test from 2 minutes to at least 3 minutes. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage

- Cucumber tests were adjusted

- [x] **DONE**

## Links

Fixes [#](https://github.com/SUSE/spacewalk/issues/17083)

- [x] **DONE**

## Changelogs

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
