### PR TITLE
QA: Increase timeout for PXE boot minion

### DIFF
--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -189,7 +189,8 @@ Feature: PXE boot a Retail terminal
     And I follow the left menu "Systems > Overview"
     And I wait until I see the name of "pxeboot_minion", refreshing the page
     And I follow this "pxeboot_minion" link
-    And I wait until event "Apply states [util.syncstates, saltboot] scheduled by (none)" is completed
+    # Workaround: Increase timeout temporarily get rid of timeout issues
+    And I wait at most 350 seconds until event "Apply states [util.syncstates, saltboot] scheduled by (none)" is completed
     And I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until radio button "Test-Channel-x86_64" is checked, refreshing the page
@@ -312,7 +313,8 @@ Feature: PXE boot a Retail terminal
   Scenario: Bootstrap the PXE boot minion
     When I create bootstrap script and set the activation key "1-SUSE-KEY-x86_64" in the bootstrap script on the proxy
     And I bootstrap pxeboot minion via bootstrap script on the proxy
-    And I wait at most 180 seconds until Salt master sees "pxeboot_minion" as "unaccepted"
+    # Workaround: Increase timeout temporarily get rid of timeout issues
+    And I wait at most 350 seconds until Salt master sees "pxeboot_minion" as "unaccepted"
     And I accept key of pxeboot minion in the Salt master
     Then I follow the left menu "Systems > Overview"
     And I wait until I see the name of "pxeboot_minion", refreshing the page


### PR DESCRIPTION
## What does this PR change?

This will increase our timeout for applying the saltboot sync for the PXE boot minion. Hopefully this will fix some of our timeout issues.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links

Issue https://github.com/SUSE/spacewalk/issues/17009

[Manager 4.2](https://github.com/SUSE/spacewalk/pull/17164)
[Manager 4.1](https://github.com/SUSE/spacewalk/pull/17165)

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
