### PR TITLE
Revert "Add SLES15SP4 and SUMA Proxy 4.3 to bootstrap repo definitions (#4939)

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1239,26 +1239,6 @@ DATA = {
         'PDID' : [2145, 2225], 'BETAPDID' : [], 'PKGLIST' : PKGLIST15_TRAD + ONLYSLE15 + PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/sle/15/3/bootstrap/'
     },
-    'SLE-15-SP4-aarch64' : {
-        'PDID' : [2296, 1709], 'BETAPDID' : [1925], 'PKGLIST' : PKGLIST15_TRAD + ONLYSLE15 + PKGLIST15_SALT + PKGLIST15_X86_ARM,
-        'DEST' : DOCUMENT_ROOT + '/pub/repositories/sle/15/4/bootstrap/'
-    },
-    'SLE-15-SP4-ppc64le' : {
-        'PDID' : [2297, 1710], 'BETAPDID' : [1926], 'PKGLIST' : PKGLIST15_TRAD + ONLYSLE15 + PKGLIST15_SALT + PKGLIST15_PPC,
-        'DEST' : DOCUMENT_ROOT + '/pub/repositories/sle/15/4/bootstrap/'
-    },
-    'SLE-15-SP4-s390x' : {
-        'PDID' : [2298, 1711], 'BETAPDID' : [1927], 'PKGLIST' : PKGLIST15_TRAD + ONLYSLE15 + PKGLIST15_SALT + PKGLIST15_Z,
-        'DEST' : DOCUMENT_ROOT + '/pub/repositories/sle/15/4/bootstrap/'
-    },
-    'SLE-15-SP4-x86_64' : {
-        'PDID' : [2299, 1712], 'BETAPDID' : [1928], 'PKGLIST' : PKGLIST15_TRAD + ONLYSLE15 + PKGLIST15_SALT + PKGLIST15_X86_ARM,
-        'DEST' : DOCUMENT_ROOT + '/pub/repositories/sle/15/4/bootstrap/'
-    },
-    'SUMA-43-PROXY-x86_64' : {
-        'PDID' : [2299, 2384], 'BETAPDID' : [], 'PKGLIST' : PKGLIST15_TRAD + ONLYSLE15 + PKGLIST15_SALT + PKGLIST15_X86_ARM,
-        'DEST' : DOCUMENT_ROOT + '/pub/repositories/sle/15/4/bootstrap/'
-    },    
     'openSUSE-Leap-42.3-x86_64' : {
         'BASECHANNEL' : 'opensuse_leap42_3-x86_64', 'PKGLIST' : PKGLIST12 + ONLYOPENSUSE42 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensuse/42/3/bootstrap/'

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,5 +1,3 @@
-  * Add SLES15SP4 and SUMA Proxy 4.3 to bootstrap 
-    repo definitions (bsc#1196702)
   * Added gettext build requirement for RHEL.
   * Reuse existing certificate code.
 


### PR DESCRIPTION

This reverts commit d920c15743bd64af631d1d3ad76288f017ae63f6.

Wrong branch

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
