### PR TITLE
Reposync: fix to ensure configured http proxy is used

### DIFF
--- a/backend/satellite_tools/download.py
+++ b/backend/satellite_tools/download.py
@@ -114,7 +114,7 @@ class PyCurlFileObjectThread(PyCurlFileObject):
         self.parent = parent
         (url, parts) = opts.urlparser.parse(url, opts)
         (scheme, host, path, parm, query, frag) = parts
-        opts.find_proxy(url, scheme)
+        opts.find_proxy(url, scheme.decode("utf-8"))
         super().__init__(url, filename, opts)
 
     def _do_open(self):

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Ensure configured http_proxy is used in reposync
 - enable check for client certificates in reposync
 - remove auto inherit of host entitlements for virtual guests
   * Fix reposync update notice formatting and date parsing (bsc#1194447)


### PR DESCRIPTION
## What does this PR change?

After upgrade of urlgrabber to >= 4, proxy variable wasn't set correctly due to missing type conversion.
Conversion from `byte` to `string` as well as unittest added. For further details, see related issue.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bug fix

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes #4932

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"