### PR TITLE
depend channel state on deployment of the mgr ca cert

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -1,3 +1,7 @@
+##
+##  java bootstrapping calls certs.sls before this state
+##
+
 # Make sure no SUSE Manager server aliasing left over from ssh-push via tunnel
 mgr_server_localhost_alias_absent:
   host.absent:

--- a/susemanager-utils/susemanager-sls/salt/certs/debian.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/debian.sls
@@ -1,4 +1,4 @@
-mgr_download_mgr_cert:
+mgr_ca_cert:
   file.managed:
     - name: /usr/local/share/ca-certificates/susemanager/RHN-ORG-TRUSTED-SSL-CERT.crt
     - makedirs: True
@@ -10,4 +10,4 @@ mgr_update_ca_certs:
     - name: /usr/sbin/update-ca-certificates
     - runas: root
     - onchanges:
-      - file: /usr/local/share/ca-certificates/susemanager/RHN-ORG-TRUSTED-SSL-CERT.crt
+      - file: mgr_ca_cert

--- a/susemanager-utils/susemanager-sls/salt/certs/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/init.sls
@@ -1,3 +1,7 @@
+mgr_absent_ca_package:
+  pkg.removed:
+    - name: rhn-org-trusted-ssl-cert
+
 {% macro includesls(os_family) -%}
 {% include 'certs/{0}.sls'.format(os_family) -%}
 {%- endmacro %}

--- a/susemanager-utils/susemanager-sls/salt/certs/redhat.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/redhat.sls
@@ -5,18 +5,20 @@ enable_ca_store:
     - runas: root
     - unless: "/usr/bin/update-ca-trust check | grep \"PEM/JAVA Status: ENABLED\""
 {%- endif %}
-/etc/pki/ca-trust/source/anchors/RHN-ORG-TRUSTED-SSL-CERT:
+
+mgr_ca_cert:
   file.managed:
+    - name: /etc/pki/ca-trust/source/anchors/RHN-ORG-TRUSTED-SSL-CERT
     - source:
       - salt://certs/RHN-ORG-TRUSTED-SSL-CERT
 {%- if grains['osrelease']|int == 6 %}
     - require:
       - cmd: enable_ca_store
 {%- endif %}
+
 update-ca-certificates:
   cmd.run:
     - name: /usr/bin/update-ca-trust extract
     - runas: root
     - onchanges:
-      - file: /etc/pki/ca-trust/source/anchors/RHN-ORG-TRUSTED-SSL-CERT
-
+      - file: mgr_ca_cert

--- a/susemanager-utils/susemanager-sls/salt/certs/suse.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/suse.sls
@@ -1,25 +1,28 @@
-{%- if grains['osrelease']|int == 11 %}
-/etc/ssl/certs/RHN-ORG-TRUSTED-SSL-CERT.pem:
-{%- else %}
-/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT:
-{%- endif %}
+mgr_ca_cert:
   file.managed:
-    - source:
-      - salt://certs/RHN-ORG-TRUSTED-SSL-CERT
+{%- if grains['osrelease']|int == 11 %}
+    - name: /etc/ssl/certs/RHN-ORG-TRUSTED-SSL-CERT.pem
+{%- else %}
+    - name: /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT
+{%- endif %}
+    - source: salt://certs/RHN-ORG-TRUSTED-SSL-CERT
 
 {%- if grains['osrelease']|int == 11 %}
-salt://certs/update-multi-cert.sh:
+mgr_split_ca:
   cmd.wait_script:
+    - name: salt://certs/update-multi-cert.sh:
     - runas: root
     - watch:
-        - file: /etc/ssl/certs/RHN-ORG-TRUSTED-SSL-CERT.pem
+        - file: mgr_ca_cert
 
 c_rehash:
   cmd.run:
     - name: /usr/bin/c_rehash
     - runas: root
     - onchanges:
-      - file: /etc/ssl/certs/*
+      - file: mgr_ca_cert
+    - require:
+      - cmd: mgr_split_ca
 {%- else %}
 
 update-ca-certificates:
@@ -27,7 +30,7 @@ update-ca-certificates:
     - name: /usr/sbin/update-ca-certificates
     - runas: root
     - onchanges:
-      - file: /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT
+      - file: mgr_ca_cert
 {%- if grains['saltversioninfo'][0] >= 3002 %} # Workaround for bsc#1188641
     - unless:
       - fun: service.status

--- a/susemanager-utils/susemanager-sls/salt/channels/gpg-keys.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/gpg-keys.sls
@@ -44,7 +44,7 @@ trust_suse_manager_tools_rhel_gpg_key:
 
 {%- elif grains['os_family'] == 'Debian' %}
 install_gnupg_debian:
-  pkg.latest:
+  pkg.installed:
     - pkgs:
       - gnupg
 

--- a/susemanager-utils/susemanager-sls/salt/channels/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/init.sls
@@ -1,5 +1,6 @@
 include:
   - util.syncstates
+  - certs
 
 {%- if grains['os_family'] == 'RedHat' %}
 
@@ -82,8 +83,9 @@ mgrchannels_repo:
     - user: root
     - group: root
     - mode: 644
-{%- if grains['os_family'] == 'RedHat' %}
     - require:
+       - file: mgr_ca_cert
+{%- if grains['os_family'] == 'RedHat' %}
 {%- if is_dnf %}
        - file: mgrchannels_susemanagerplugin_dnf
        - file: mgrchannels_susemanagerplugin_conf_dnf

--- a/susemanager-utils/susemanager-sls/salt/ssh_bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/ssh_bootstrap/init.sls
@@ -1,3 +1,7 @@
+##
+##  java bootstrapping calls certs.sls before this state
+##
+
 mgr_ssh_identity:
   ssh_auth.present:
     - user: {{ salt['pillar.get']('mgr_sudo_user') or 'root' }}


### PR DESCRIPTION
## What does this PR change?

There is no dependency on the CA certificate deployment at the channel states.
This can cause the problem, that a package installation/update is triggered, but the required CA certificate is deployed later.
This result in SSL errors on the client.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes 
Contains also a fix for https://github.com/uyuni-project/uyuni/issues/4962
Tracks 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
