### PR TITLE
Set RHEL cert folder for reportdb if default folder does not exist

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -379,6 +379,8 @@ report-db-port=$REPORT_DB_PORT
 report-db-user=$REPORT_DB_USER
 report-db-password=$REPORT_DB_PASS
 report-db-ca-cert=/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT
+[ ! -d "/etc/pki/trust/anchors" ] && report-db-ca-cert=/etc/pki/ca-trust/source/anchors/RHN-ORG-TRUSTED-SSL-CERT
+
 enable-tftp=$MANAGER_ENABLE_TFTP
 " > /root/spacewalk-answers
     if [ -n "$SCC_USER" ]; then

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,4 +1,5 @@
-- set default for registration batch size
+  * Set RHEL cert folder for reportdb if default folder does not exist. 
+  * set default for registration batch size
   * Added gettext build requirement for RHEL.
   * Reuse existing certificate code.
 


### PR DESCRIPTION
## What does this PR change?

Adapt report-db-ca-cert to contain Enterprise Linux folder if the SUSE folder does not exist.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered
manually tested positive path on Alma OK

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
