### PR TITLE
include util.syncstates

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/init.sls
@@ -1,3 +1,6 @@
+include:
+  - util.syncstates
+
 {%- if grains['os_family'] == 'RedHat' %}
 
 {%- set yum_version = salt['pkg.version']("yum") %}


### PR DESCRIPTION
## What does this PR change?

After fixing require syncstates, the state itself is missing. We need to include the state file as well.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/17189

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
