### PR TITLE
Finding empty profiles by mac address must be case insentitive

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -1531,7 +1531,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
      * Tests finding an empty profile by hostname and HW addresses.
      */
     public void testFindByHostnameAndHwAddrs() throws Exception {
-        String hwAddr = "11:22:33:44:55:66";
+        String hwAddr = "11:22:AA:bb:55:66";
         MinionServer minion = createEmptyProfile(of("myhost"), of(hwAddr));
 
         // lookup by hostname should match
@@ -1551,7 +1551,8 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
 
         // lookup by hostname and HW addrs should match
         Set<String> moreAddrs = new HashSet<>();
-        moreAddrs.add(hwAddr);
+        // Change mac address case to validate case insensitive match
+        moreAddrs.add("11:22:aa:BB:55:66");
         moreAddrs.add("11:22:33:44:55:77");
         List<MinionServer> fromDb4 = SystemManager.findMatchingEmptyProfiles(of("myhost"), moreAddrs);
         assertEquals(1, fromDb4.size());

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -550,6 +550,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                 .get("hwaddr_interfaces").orElse(Collections.emptyMap());
         return hwInterfaces.values().stream()
                 .filter(hwAddress -> !hwAddress.equalsIgnoreCase("00:00:00:00:00:00"))
+                .map(String::toLowerCase)
                 .collect(Collectors.toSet());
     }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Finding empty profiles by mac address must be case insensitive (bsc#1196407)
 - prepare to use new postgresql-jdbc driver with stringprep and saslprep
   support (bsc#1196693)
 - allow SCC to display the last check-in time for registered systems


### PR DESCRIPTION
## What does this PR change?

When matching MAC addresses during empty profiles lookup we should ignore MAC address case.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17130
Tracks https://github.com/SUSE/spacewalk/pull/17177

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
