### PR TITLE
Fix possible traceback in uyuni if no ssh push port in the DB

### DIFF
--- a/susemanager-utils/susemanager-sls/modules/roster/uyuni.py
+++ b/susemanager-utils/susemanager-sls/modules/roster/uyuni.py
@@ -299,7 +299,7 @@ class UyuniRoster:
                     minion_id=prow.minion_id,
                     proxies=proxies,
                     tunnel=prow.tunnel,
-                    ssh_push_port=int(prow.ssh_push_port),
+                    ssh_push_port=int(prow.ssh_push_port or SSH_PUSH_PORT),
                 )
             proxies = []
             if row is None:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix possible traceback in uyuni roster if no ssh port in the DB
 - fixing how the return code is returned in mgrutil runner (bsc#1194909)
 - Use /var/lib/susemanager/formula_data if /srv/susemanager/formula_data is missing.
 - Avoid using lscpu -J option in grains (bsc#1195920)


### PR DESCRIPTION
## What does this PR change?

Fixes the possible traceback:
```
...
  File "/usr/share/susemanager/modules/roster/uyuni.py", line 302, in targets
    ssh_push_port=int(prow.ssh_push_port),
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: No unit tests for the module yet (TBD)

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/4927

## Changelogs

- Fix possible traceback in uyuni roster if no ssh port in the DB

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
