### PR TITLE
QA: Add hostname and reverse lookup time sanity check

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -9,17 +9,25 @@ require 'nokogiri'
 
 Then(/^"([^"]*)" should have a FQDN$/) do |host|
   node = get_target(host)
+  initial_time = Time.now
   result, return_code = node.run('hostname -f', check_errors: false)
+  end_time = Time.now
+  resolution_time = end_time - initial_time
   result.delete!("\n")
   raise 'cannot determine hostname' unless return_code.zero?
+  raise "FQDN resolution for #{node.full_hostname} took too long (#{resolution_time} seconds)" unless resolution_time <= 2
   raise 'hostname is not fully qualified' unless result == node.full_hostname
 end
 
 Then(/^reverse resolution should work for "([^"]*)"$/) do |host|
   node = get_target(host)
+  initial_time = Time.now
   result, return_code = node.run("getent hosts #{node.full_hostname}", check_errors: false)
+  end_time = Time.now
+  resolution_time = end_time - initial_time
   result.delete!("\n")
   raise 'cannot do reverse resolution' unless return_code.zero?
+  raise "reverse resolution for #{node.full_hostname} took too long (#{resolution_time} seconds)" unless resolution_time <= 2
   raise "reverse resolution for #{node.full_hostname} returned #{result}, expected to see #{node.full_hostname}" unless result.include? node.full_hostname
 end
 


### PR DESCRIPTION
## What does this PR change?
Adds a new validation to the sanity check stage of the CI to ensure the hostname and reverse name resolution don't take more than 2 seconds - else, fails the stage as there's something wrong with the network that will fail other important features.

## GUI diff
No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage
- Cucumber tests were modified

- [ ] **DONE**

## Links
Fixes https://github.com/SUSE/spacewalk/issues/17203
- [4.1](https://github.com/SUSE/spacewalk/pull/17220)
- [4.2](https://github.com/SUSE/spacewalk/pull/17221)

- [ ] **DONE**

## Changelogs

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
