### PR TITLE
Script to find repository URLs from a MI number

### DIFF
--- a/testsuite/ext-tools/maintenance_crawler.rb
+++ b/testsuite/ext-tools/maintenance_crawler.rb
@@ -1,0 +1,205 @@
+# source 'https://rubygems.org'
+#
+# gem 'nokogiri'
+
+#!/usr/bin/env ruby
+
+require 'open-uri'
+require 'optparse'
+require 'monitor'
+require 'nokogiri'
+
+class MaintenanceCrawler
+
+  def initialize(mi_number, options = {})
+    @verbose = options[:verbose]
+    @thread_count = options[:thread_count]
+    @architecture = options[:architecture]
+    
+    @root_url = "http://download.suse.de/download/ibs/SUSE:/Maintenance:/#{mi_number}/"
+  end
+
+  # Perform the site crawl
+  # 1. Creates a queue of urls to crawl (starting with the root url)
+  # 2. Create a thread pool (using size thread_count, defined when created)
+  # 3. While queue not empty, threads will process URLs
+  def crawl
+    puts "Crawling #{@root_url}" if @verbose
+    @pages = {}
+    @crawl_queue = Queue.new
+    @crawl_queue << "#{@root_url}"
+
+    @crawl_queue.extend MonitorMixin
+    crawl_queue_cond = @crawl_queue.new_cond
+
+    threads = []
+    active_threads = 0
+    crawl_complete = false
+
+
+    @thread_count.times do |i|
+
+      # Register/count each active thread
+      @crawl_queue.synchronize do
+        active_threads += 1
+      end
+
+      resources = nil
+      url = nil
+
+      threads << Thread.new do
+        loop do
+          # Synchronize on critical code which adds to the pages and queue
+          @crawl_queue.synchronize do
+            unless resources.nil?
+              update_pages_and_queue(url, resources)
+              print_status(url) if @verbose
+            else
+              # URL Error, skip. Could add future functionality for n-retries?
+              @pages.delete url
+            end
+
+            # 1. If empty queue + no other threads running implies that we've
+            #    completed the site crawl. Can be modified by all threads
+            # 2. Wake up other threads which will either process more urls or
+            #    exit depending on 'crawl_complete' and queue state
+            # 3. Wait until queue is not empty or crawling is marked as complete
+            # 4. Thread has woken up, exit if we're done crawling
+            # 5. If not done, bump active thread count and re-enter loop
+            crawl_complete = true if @crawl_queue.empty? and active_threads == 1
+            crawl_queue_cond.broadcast unless @crawl_queue.empty? and !crawl_complete
+            active_threads -= 1
+            crawl_queue_cond.wait_while { @crawl_queue.empty? and !crawl_complete }
+            Thread.exit if crawl_complete
+            active_threads += 1
+
+            url = @crawl_queue.shift
+          end
+
+          resources = crawl_url url
+        end
+      end
+    end
+
+    threads.each { |t| t.join }
+  end
+
+  # Get the pages hash. Each entry contains a hash for the links and assets
+  def get_pages
+    @pages
+  end
+
+  # Print the repos
+  def get_repos
+    repos = []
+    @pages.each do |page|
+      page[1][:links].each do |link|
+       repos << page[0] if link.match /repo$/ and page[0].include? "#{@architecture}/"
+      end
+    end
+    repos.uniq
+  end
+
+
+  private
+
+  # Retrieves HTML for the given url, extract all links and assets and return in a hash
+  def crawl_url(url)
+    begin
+      html = Nokogiri::HTML(open(url).read)
+    rescue Exception => e
+      puts "Error reading #{url} :: #{e}" if @verbose
+      return nil
+    end
+
+    links = html.css('a').map { |link| process_url link['href'] }.compact
+
+    return {links: links.uniq}
+  end
+
+  def process_url(url)
+    return nil if url.nil? or url.empty? or url.include? '../' or not url.include? './'
+
+    bad_matches = [
+      /^(http(?!#{Regexp.escape @root_url.gsub('http','')})|\/\/)/, # Discard external links
+      /^mailto/, # Discard mailto links
+      /^tel/, # Discard telephone
+      /^javascript/ # Discard javascript triggers
+    ]
+
+    # Case slightly more open to extension
+    case url
+      when *bad_matches
+        return nil
+      else
+        return URI.join(@root_url, url).to_s
+    end
+  end
+  
+  # Output the current completions/total_queued to the console
+  # Defaults to single-line-update but verbose (-v) mode triggers full output
+  def print_status(url)
+    done = @pages.values.compact.length.to_s.rjust(2, '0')
+    total = @pages.length.to_s.rjust(2, '0')
+    print "\r#{" "*80}\r" unless @verbose
+    print "Crawled #{done}/#{total}: #{url}"
+    print "\n" if @verbose
+    STDOUT.flush
+  end
+
+  # Sets the page resources for the given URL and adds any new links
+  # to the crawl queue
+  def update_pages_and_queue(url, resources)
+    @pages[url] = resources
+    resources[:links].each do |link|
+      unless @pages.has_key? link
+        @crawl_queue.enq(link)
+        @pages[link] = nil
+      end
+    end
+  end
+end
+
+# Gather Command Line Options
+options = {}
+options[:verbose] = false
+options[:thread_count] = 1
+options[:architecture] = 'x86_64'
+
+opt_parser = OptionParser.new do |opt|
+  opt.banner = 'Usage: simple_crawler MI_Number [OPTIONS]'
+  opt.separator  ''
+  opt.separator  'Options'
+
+  opt.on('-t n', '--thread-count=n', OptionParser::DecimalInteger, 'Process using a thread pool of size n') do |thread_count|
+    options[:thread_count] = thread_count
+  end
+
+  opt.on('-v', '--verbose', 'show all urls processed') do
+    options[:verbose] = true
+  end
+
+  opt.on('-a', '--architecture=name', 'filter by architecture') do |architecture|
+    options[:architecture] = architecture
+  end
+
+  opt.on('-h', '--help', 'help (show this)') do
+    puts opt_parser
+    exit
+  end
+end
+
+# Run crawler
+opt_parser.parse!
+
+# Require Maintenance Incidence Number
+if ARGV.count < 1
+  puts opt_parser
+  exit
+end
+
+# Crawl domain URL
+mi_number = ARGV[0]
+c = MaintenanceCrawler.new(mi_number, options)
+c.crawl
+puts c.get_repos


### PR DESCRIPTION
## What does this PR change?

Script to find repository URLs from a MI number

Related to : https://github.com/SUSE/spacewalk/issues/12728
Jenkins Job: https://ci.suse.de/view/Manager/view/Manager-qa/job/uyuni-master-qa-mu-repositories-crawler/

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
