### PR TITLE
unproxy action before casting (bsc#1195772)

### DIFF
--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -647,7 +647,8 @@ public class SaltUtils {
 
     private void handleStateApplyData(ServerAction serverAction, JsonElement jsonResult, long retcode,
             boolean success) {
-        ApplyStatesAction applyStatesAction = (ApplyStatesAction)serverAction.getParentAction();
+        ApplyStatesAction applyStatesAction =
+                (ApplyStatesAction)HibernateFactory.unproxy(serverAction.getParentAction());
 
         // Revisit the action status if test=true
         if (applyStatesAction.getDetails().isTest() && success && retcode == 0) {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix class cast exception during action chains (bsc#1195772)
 - Finding empty profiles by mac address must be case insensitive (bsc#1196407)
 - prepare to use new postgresql-jdbc driver with stringprep and saslprep
   support (bsc#1196693)


### PR DESCRIPTION
## What does this PR change?

fixes class cast exception when hibernate object is proxy.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
