### PR TITLE
spacewalk-java: Avoid empty file list

### DIFF
--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -627,13 +627,22 @@ if [ -e %{_javadir}/ongres-stringprep/stringprep.jar ]; then
     ln -s -f %{_javadir}/ongres-stringprep/stringprep.jar $RPM_BUILD_ROOT$RHN_SEARCH_BUILD_DIR/ongres-stringprep_stringprep.jar
     ln -s -f %{_javadir}/ongres-stringprep/saslprep.jar $RPM_BUILD_ROOT$RHN_SEARCH_BUILD_DIR/ongres-stringprep_saslprep.jar
     echo "
+%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/ongres-scram_client.jar
+%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/ongres-scram_common.jar
 %{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/ongres-stringprep_stringprep.jar
 %{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/ongres-stringprep_saslprep.jar
+%{_prefix}/share/rhn/search/lib/ongres-scram_client.jar
+%{_prefix}/share/rhn/search/lib/ongres-scram_common.jar
 %{_prefix}/share/rhn/search/lib/ongres-stringprep_stringprep.jar
 %{_prefix}/share/rhn/search/lib/ongres-stringprep_saslprep.jar
     " > .mfiles-postgresql
 else
-    touch .mfiles-postgresql
+    echo "
+%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/ongres-scram_client.jar
+%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/ongres-scram_common.jar
+%{_prefix}/share/rhn/search/lib/ongres-scram_client.jar
+%{_prefix}/share/rhn/search/lib/ongres-scram_common.jar
+    " > .mfiles-postgresql
 fi
 
 
@@ -926,10 +935,6 @@ chown tomcat:%{apache_group} /var/log/rhn/gatherer.log
 %dir %{_prefix}/share/rhn/search
 %dir %{_prefix}/share/rhn/search/lib
 %{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/postgresql-jdbc.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/ongres-scram_client.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/ongres-scram_common.jar
 %{_prefix}/share/rhn/search/lib/postgresql-jdbc.jar
-%{_prefix}/share/rhn/search/lib/ongres-scram_client.jar
-%{_prefix}/share/rhn/search/lib/ongres-scram_common.jar
 
 %changelog


### PR DESCRIPTION
## What does this PR change?

Enterprise Linux stops building when the postgres file list is empty. This change guarantees that it always contains files.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
