### PR TITLE
Don't use log4j.properties in apidocs generation

### DIFF
--- a/java/build.xml
+++ b/java/build.xml
@@ -215,6 +215,8 @@
       <pathelement location="build/classes" />
     </path>
 
+    <move file="${build.dir}/classes/log4j.properties" tofile="${build.dir}/classes/log4j.properties.bak" />
+
     <mkdir dir="${report.dir}/apidocs" />
     <mkdir dir="${report.dir}/apidocs/${template.dir}/" />
     <mkdir dir="${report.dir}/apidocs/${template.dir}/handlers/" />
@@ -229,6 +231,8 @@
       </fileset>
       <excludepackage name="**/*" />
     </javadoc>
+
+    <move file="${build.dir}/classes/log4j.properties.bak" tofile="${build.dir}/classes/log4j.properties" />
 
   </target>
 

--- a/java/manager-build.xml
+++ b/java/manager-build.xml
@@ -451,6 +451,8 @@
       <path refid="libjars" />
     </path>
 
+    <move file="${build.dir}/classes/log4j.properties" tofile="${build.dir}/classes/log4j.properties.bak" />
+
     <mkdir dir="${report.dir}/apidocs" />
     <mkdir dir="${report.dir}/apidocs/${template.dir}/" />
     <mkdir dir="${report.dir}/apidocs/${template.dir}/handlers/" />
@@ -465,6 +467,8 @@
       </fileset>
       <excludepackage name="**/*" />
     </javadoc>
+    
+    <move file="${build.dir}/classes/log4j.properties.bak" tofile="${build.dir}/classes/log4j.properties" />
 
   </target>
 


### PR DESCRIPTION
## What does this PR change?

Remove useless ugly logging errors when building apidocs

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: tooling

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
