### PR TITLE
 Enable HSTS for Apache to force traffic to be in HTTPS

### DIFF
--- a/proxy/installer/spacewalk-proxy-installer.spec
+++ b/proxy/installer/spacewalk-proxy-installer.spec
@@ -117,6 +117,7 @@ install -m 755 fetch-certificate.py  $RPM_BUILD_ROOT/%{_usr}/sbin/fetch-certific
 %if 0%{?suse_version}
 if [ -f /etc/sysconfig/apache2 ]; then
     sysconf_addword /etc/sysconfig/apache2 APACHE_MODULES proxy_http
+    sysconf_addword /etc/sysconfig/apache2 APACHE_MODULES headers
 fi
 if [ -e /etc/squid/squid.conf ]; then
     sed -i -e"s/^range_offset_limit -1 KB/range_offset_limit none/" /etc/squid/squid.conf

--- a/proxy/proxy/httpd-conf/spacewalk-proxy.conf
+++ b/proxy/proxy/httpd-conf/spacewalk-proxy.conf
@@ -50,3 +50,6 @@
 </IfModule>
 
 SSLProxyEngine on
+
+# Enable HSTS
+Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains"

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,4 +1,5 @@
-  * Remove pylint according to Fedora package guidelines.
+- Enable HSTS for Apache to force traffic to be in HTTPS
+- Remove pylint according to Fedora package guidelines.
 
 -------------------------------------------------------------------
 Tue Feb 15 10:03:51 CET 2022 - jgonzalez@suse.com

--- a/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
+++ b/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
@@ -164,6 +164,10 @@ Header set Content-Security-Policy: "default-src 'self' https: wss: ; script-src
 Header set X-XSS-Protection "1; mode=block"
 Header set X-Content-Type-Options "nosniff"
 Header set X-Permitted-Cross-Domain-Policies "master-only"
+
+# Enable HSTS
+Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains"
+
 # make sure the js MIME is not x-js
 AddType "application/javascript" .js
 

--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,3 +1,5 @@
+- Enable HSTS for Apache to force traffic to be in HTTPS
+
 -------------------------------------------------------------------
 Mon Feb 21 12:07:41 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This is a new edition of #4464 to enable HSTS headers for Apache on the server and proxy in order to force traffic to always use HTTPS.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

No documentation needed: only internal and user invisible changes?

- [ ] **DONE**

## Test coverage

No tests: already covered?

- [ ] **DONE**

## Links

Previous PR: #4464 
Tracks downstream issue: https://github.com/SUSE/spacewalk/issues/16202

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
