### PR TITLE
Revert "QA: Raise exception again in AfterStep, instead of failing the scenario"

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -105,10 +105,13 @@ After do |scenario|
   page.instance_variable_set(:@touched, false)
 end
 
-AfterStep do
+AfterStep do |scenario|
   if has_css?('.senna-loading', wait: 0)
     STDOUT.puts "WARN: Step ends with an ajax transition not finished, let's wait a bit!"
-    raise StandardError, 'Timeout: Waiting AJAX transition' unless has_no_css?('.senna-loading', wait: 20)
+    unless has_no_css?('.senna-loading', wait: 15)
+      # Note: See the special behavior of this step here: https://github.com/cucumber/cucumber-ruby/issues/1101
+      scenario.fail!(StandardError.new('Timeout: Waiting AJAX transition'))
+    end
   end
 end
 


### PR DESCRIPTION
Reverts uyuni-project/uyuni#4896

This is causing the failures from empty variables. As soon as a scenario fails some variable (haven't found it yet specifically) is empty and causes the failures.