### PR TITLE
systemd-rpm-macros only available of rhel8 or later

### DIFF
--- a/client/rhel/mgr-daemon/mgr-daemon.spec
+++ b/client/rhel/mgr-daemon/mgr-daemon.spec
@@ -79,7 +79,9 @@ Requires(post): systemd-units
 Requires(preun): systemd-units
 BuildRequires:  systemd-units
 %else
+%if 0%{?rhel} >= 8
 BuildRequires:  systemd-rpm-macros
+%endif
 Requires(post): chkconfig
 Requires(preun): chkconfig
 # This is for /sbin/service


### PR DESCRIPTION
## What does this PR change?

Macro package not available on RHEL 7.

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
