### PR TITLE
Modify push-to-obs.sh to push containers

### DIFF
--- a/susemanager-utils/testing/docker/scripts/push-to-obs.sh
+++ b/susemanager-utils/testing/docker/scripts/push-to-obs.sh
@@ -67,6 +67,8 @@ fi
 # Build SRPMS
 echo "*************** BUILDING PACKAGES ***************"
 ./build-packages-for-obs.sh ${PACKAGES}
+echo "********** BUILDING CONTAINER IMAGES ************"
+./build-containers-for-obs.sh
 
 # Submit 
 for DESTINATION in $(echo ${DESTINATIONS}|tr ',' ' '); do


### PR DESCRIPTION
## What does this PR change?

Modify push-to-obs.sh to push containers

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Modify push-to-obs.sh to push containers

- [x] **DONE**

## Test coverage
- No tests: This is required for tests

- [x] **DONE**

## Links

Nothing

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
