### PR TITLE
use public API

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/test/ProxyHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/test/ProxyHandlerTest.java
@@ -46,7 +46,6 @@ import com.suse.manager.webui.services.test.TestSystemQuery;
 
 import org.jmock.Expectations;
 import org.jmock.imposters.ByteBuddyClassImposteriser;
-import org.junit.Assert;
 
 import java.util.Collections;
 import java.util.List;
@@ -198,6 +197,6 @@ public class ProxyHandlerTest extends RhnJmockBaseTestCase {
         byte[] actual = new ProxyHandler(xmlRpcSystemHelper, mockSystemManager).containerConfig(user, proxy, server,
                 2048, email, "CACert", "CAKey", "CAPass", List.of("cname1", "cname2"),
                 "DE", "Bayern", "Nurnberg", "ACME", "ACME Tests", "coyote@acme.lab");
-        Assert.assertArrayEquals(dummyConfig, actual);
+        assertEquals(dummyConfig, actual);
     }
 }


### PR DESCRIPTION
## What does this PR change?

The used assert function is treated in eclipse as "not public" and produce compile errors.
Use a public API method

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
