### PR TITLE
fix DOCTYPE of hibernate mapping files

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/ActionArchType.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionArchType.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.action.ActionArchType"
                 table="rhnArchTypeActions" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/action/ActionChain.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionChain.hbm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
 
     <class name="com.redhat.rhn.domain.action.ActionChain" table="rhnActionChain">

--- a/java/code/src/com/redhat/rhn/domain/action/ActionChainEntry.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionChainEntry.hbm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.action.ActionChainEntry" table="rhnActionChainEntry">
         <id name="id" column="action_id">

--- a/java/code/src/com/redhat/rhn/domain/action/ActionStatus.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionStatus.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.action.ActionStatus"
         table="rhnActionStatus" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/action/ActionType.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionType.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.action.ActionType"
         table="rhnActionType" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <!-- This is set to -1 since its Abstract so we never get a base Action -->
     <class name="com.redhat.rhn.domain.action.Action" table="rhnAction"

--- a/java/code/src/com/redhat/rhn/domain/action/channel/SubscribeChannelsActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/channel/SubscribeChannelsActionDetails.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
         PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-        "http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.action.channel.SubscribeChannelsActionDetails"
            table="rhnActionSubChannels">

--- a/java/code/src/com/redhat/rhn/domain/action/config/ConfigDateDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/config/ConfigDateDetails.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.action.config.ConfigDateDetails"
                 table="rhnActionConfigDate" >

--- a/java/code/src/com/redhat/rhn/domain/action/config/ConfigDateFileAction.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/config/ConfigDateFileAction.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class
                 name="com.redhat.rhn.domain.action.config.ConfigDateFileAction"

--- a/java/code/src/com/redhat/rhn/domain/action/config/ConfigRevisionAction.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/config/ConfigRevisionAction.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.action.config.ConfigRevisionAction"
                 table="rhnActionConfigRevision" >

--- a/java/code/src/com/redhat/rhn/domain/action/config/ConfigRevisionActionResult.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/config/ConfigRevisionActionResult.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class
                 name="com.redhat.rhn.domain.action.config.ConfigRevisionActionResult"

--- a/java/code/src/com/redhat/rhn/domain/action/config/DaemonConfigDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/config/DaemonConfigDetails.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class
                 name="com.redhat.rhn.domain.action.config.DaemonConfigDetails"

--- a/java/code/src/com/redhat/rhn/domain/action/dup/DistUpgradeActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/dup/DistUpgradeActionDetails.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
   <class name="com.redhat.rhn.domain.action.dup.DistUpgradeActionDetails"
          table="rhnActionDup">

--- a/java/code/src/com/redhat/rhn/domain/action/dup/DistUpgradeChannelTask.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/dup/DistUpgradeChannelTask.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
 	<class name="com.redhat.rhn.domain.action.dup.DistUpgradeChannelTask"
          table="rhnActionDupChannel" >

--- a/java/code/src/com/redhat/rhn/domain/action/errata/ActionPackageDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/errata/ActionPackageDetails.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
   <class name="com.redhat.rhn.domain.action.errata.ActionPackageDetails" table="rhnActionPackageDetails">
     <id name="id" type="long" column="id">

--- a/java/code/src/com/redhat/rhn/domain/action/image/DeployImageActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/image/DeployImageActionDetails.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
   <class name="com.redhat.rhn.domain.action.image.DeployImageActionDetails"
          table="rhnActionImageDeploy">

--- a/java/code/src/com/redhat/rhn/domain/action/kickstart/KickstartActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/kickstart/KickstartActionDetails.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.action.kickstart.KickstartActionDetails"
         table="rhnActionKickstart" >

--- a/java/code/src/com/redhat/rhn/domain/action/kickstart/KickstartGuestActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/kickstart/KickstartGuestActionDetails.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.action.kickstart.KickstartGuestActionDetails"
         table="rhnActionKickstartGuest" >

--- a/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageActionDetails.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.action.rhnpackage.PackageActionDetails"
         table="rhnActionPackage" >

--- a/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageActionRemovalFailure.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageActionRemovalFailure.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.action.rhnpackage.PackageActionRemovalFailure"
            table="rhnActionPackageRemovalFailure" >

--- a/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageActionResult.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageActionResult.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.action.rhnpackage.PackageActionResult"
            table="rhnServerActionPackageResult" >

--- a/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesActionDetails.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.action.salt.ApplyStatesActionDetails"
             table="rhnActionApplyStates">

--- a/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesActionResult.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesActionResult.hbm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-        "classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.action.salt.ApplyStatesActionResult"
             table="rhnActionApplyStatesResult" >

--- a/java/code/src/com/redhat/rhn/domain/action/salt/PlaybookActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/PlaybookActionDetails.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.action.salt.PlaybookActionDetails"
             table="rhnActionPlaybook">

--- a/java/code/src/com/redhat/rhn/domain/action/salt/build/ImageBuildActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/build/ImageBuildActionDetails.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.action.salt.build.ImageBuildActionDetails"
             table="rhnActionImageBuild">

--- a/java/code/src/com/redhat/rhn/domain/action/salt/build/ImageBuildActionResult.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/build/ImageBuildActionResult.hbm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-        "classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.action.salt.build.ImageBuildActionResult"
             table="rhnActionImageBuildResult" >

--- a/java/code/src/com/redhat/rhn/domain/action/salt/inspect/ImageInspectActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/inspect/ImageInspectActionDetails.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.action.salt.inspect.ImageInspectActionDetails"
             table="rhnActionImageInspect">

--- a/java/code/src/com/redhat/rhn/domain/action/salt/inspect/ImageInspectActionResult.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/inspect/ImageInspectActionResult.hbm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-        "classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.action.salt.inspect.ImageInspectActionResult"
             table="rhnActionImageInspectResult" >

--- a/java/code/src/com/redhat/rhn/domain/action/scap/ScapActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/scap/ScapActionDetails.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.action.scap.ScapActionDetails"
                 table="rhnActionScap" >

--- a/java/code/src/com/redhat/rhn/domain/action/script/ScriptActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/script/ScriptActionDetails.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.action.script.ScriptActionDetails"
                 table="rhnActionScript" >

--- a/java/code/src/com/redhat/rhn/domain/action/script/ScriptResult.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/script/ScriptResult.hbm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-        "classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.action.script.ScriptResult"
                 table="rhnServerActionScriptResult" >

--- a/java/code/src/com/redhat/rhn/domain/action/server/ServerAction.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/server/ServerAction.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.action.server.ServerAction"
                    table="rhnServerAction" >

--- a/java/code/src/com/redhat/rhn/domain/audit/XccdfBenchmark.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/audit/XccdfBenchmark.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.audit.XccdfBenchmark"
                 table="rhnXccdfBenchmark"

--- a/java/code/src/com/redhat/rhn/domain/audit/XccdfIdent.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/audit/XccdfIdent.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
         PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-        "classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.audit.XccdfIdent"
            table="rhnXccdfIdent"

--- a/java/code/src/com/redhat/rhn/domain/audit/XccdfIdentSystem.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/audit/XccdfIdentSystem.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
         PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-        "classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.audit.XccdfIdentSystem"
            table="rhnXccdfIdentSystem"

--- a/java/code/src/com/redhat/rhn/domain/audit/XccdfProfile.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/audit/XccdfProfile.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.audit.XccdfProfile"
                 table="rhnXccdfProfile"

--- a/java/code/src/com/redhat/rhn/domain/audit/XccdfRuleResult.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/audit/XccdfRuleResult.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
         PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-        "classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.audit.XccdfRuleResult"
            table="rhnXccdfRuleresult"

--- a/java/code/src/com/redhat/rhn/domain/audit/XccdfRuleResultType.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/audit/XccdfRuleResultType.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
         PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-        "classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.audit.XccdfRuleResultType"
            table="rhnXccdfRuleresultType"

--- a/java/code/src/com/redhat/rhn/domain/audit/XccdfTestResult.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/audit/XccdfTestResult.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.audit.XccdfTestResult"
                 table="rhnXccdfTestresult"

--- a/java/code/src/com/redhat/rhn/domain/channel/AccessToken.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/AccessToken.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.channel.AccessToken" table="suseChannelAccessToken">
         <id name="id" type="long" column="id">

--- a/java/code/src/com/redhat/rhn/domain/channel/Channel.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/Channel.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.channel.Channel"
         table="rhnChannel">

--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelArch.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelArch.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.channel.ChannelArch"
         table="rhnChannelArch" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFamily.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFamily.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.channel.ChannelFamily"
                 table="rhnChannelFamily">

--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelProduct.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelProduct.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.channel.ChannelProduct"
         table="rhnChannelProduct" >

--- a/java/code/src/com/redhat/rhn/domain/channel/ContentSource.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/ContentSource.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.channel.ContentSource"
         table="rhnContentSource" >

--- a/java/code/src/com/redhat/rhn/domain/channel/ContentSourceFilter.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/ContentSourceFilter.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.channel.ContentSourceFilter"
         table="rhnContentSourceFilter" >

--- a/java/code/src/com/redhat/rhn/domain/channel/ContentSourceType.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/ContentSourceType.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.channel.ContentSourceType"
         table="rhnContentSourceType" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/channel/DistChannelMap.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/DistChannelMap.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.channel.DistChannelMap"
         table="rhnDistChannelMap">

--- a/java/code/src/com/redhat/rhn/domain/channel/PrivateChannelFamily.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/PrivateChannelFamily.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.channel.PrivateChannelFamily"
                 table="rhnPrivateChannelFamily">

--- a/java/code/src/com/redhat/rhn/domain/channel/ProductName.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/ProductName.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.channel.ProductName"
         table="rhnProductName">

--- a/java/code/src/com/redhat/rhn/domain/channel/PublicChannelFamily.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/PublicChannelFamily.hbm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.channel.PublicChannelFamily" table="rhnPublicChannelFamily">
         <id column="channel_family_id" type="long">

--- a/java/code/src/com/redhat/rhn/domain/channel/ReleaseChannelMap.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/ReleaseChannelMap.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.channel.ReleaseChannelMap"
         table="rhnReleaseChannelMap">

--- a/java/code/src/com/redhat/rhn/domain/channel/RepoMetadata.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/RepoMetadata.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.channel.RepoMetadata"

--- a/java/code/src/com/redhat/rhn/domain/common/ArchType.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/common/ArchType.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.common.ArchType"
         table="rhnArchType" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/common/Checksum.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/common/Checksum.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping default-access="property">
     <class name="com.redhat.rhn.domain.common.Checksum"
         table="rhnChecksum" >

--- a/java/code/src/com/redhat/rhn/domain/common/ChecksumType.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/common/ChecksumType.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.common.ChecksumType"
         table="rhnChecksumType" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/common/ExceptionMessage.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/common/ExceptionMessage.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.common.ExceptionMessage"
         table="rhnException" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/common/FileList.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/common/FileList.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.common.FileList"
         table="rhnFileList">

--- a/java/code/src/com/redhat/rhn/domain/common/ProvisionState.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/common/ProvisionState.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.common.ProvisionState"
         table="rhnProvisionState">

--- a/java/code/src/com/redhat/rhn/domain/common/TinyUrl.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/common/TinyUrl.hbm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-    "classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.common.TinyUrl" table="rhntinyurl">
         <id name="token" type="string" column="TOKEN">

--- a/java/code/src/com/redhat/rhn/domain/config/ConfigChannel.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/config/ConfigChannel.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.config.ConfigChannel"
                 table="rhnConfigChannel" >

--- a/java/code/src/com/redhat/rhn/domain/config/ConfigChannelType.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/config/ConfigChannelType.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.config.ConfigChannelType"
                 table="rhnConfigChannelType" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/config/ConfigContent.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/config/ConfigContent.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.config.ConfigContent"
                 table="rhnConfigContent" >

--- a/java/code/src/com/redhat/rhn/domain/config/ConfigFile.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/config/ConfigFile.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.config.ConfigFile" table="rhnConfigFile"
                 >

--- a/java/code/src/com/redhat/rhn/domain/config/ConfigFileName.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/config/ConfigFileName.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.config.ConfigFileName"
            table="rhnConfigFileName"

--- a/java/code/src/com/redhat/rhn/domain/config/ConfigFileState.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/config/ConfigFileState.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.config.ConfigFileState"
                 table="rhnConfigFileState" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/config/ConfigFileType.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/config/ConfigFileType.hbm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.config.ConfigFileType" table="RHNCONFIGFILETYPE">
         <id column="ID" name="id" type="long">

--- a/java/code/src/com/redhat/rhn/domain/config/ConfigInfo.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/config/ConfigInfo.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.config.ConfigInfo"
                table="rhnConfigInfo"

--- a/java/code/src/com/redhat/rhn/domain/config/ConfigRevision.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/config/ConfigRevision.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.config.ConfigRevision" table="rhnConfigRevision" >
                 <id name="id" type="long" column="id">

--- a/java/code/src/com/redhat/rhn/domain/credentials/Credentials.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/credentials/Credentials.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
   <class name="com.redhat.rhn.domain.credentials.Credentials"
          table="SUSECREDENTIALS">

--- a/java/code/src/com/redhat/rhn/domain/credentials/CredentialsType.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/credentials/CredentialsType.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.credentials.CredentialsType"
         table="SUSECREDENTIALSTYPE" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/errata/Bug.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/errata/Bug.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.errata.Bug"
         table="rhnErrataBuglist" >

--- a/java/code/src/com/redhat/rhn/domain/errata/Cve.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/errata/Cve.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.errata.Cve"
         table="rhnCve" >

--- a/java/code/src/com/redhat/rhn/domain/errata/Errata.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/errata/Errata.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.errata.Errata"
         table="rhnErrata" >

--- a/java/code/src/com/redhat/rhn/domain/errata/ErrataFile.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/errata/ErrataFile.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.errata.ErrataFile" table="rhnErrataFile">
         <id name="id" type="long" column="id">

--- a/java/code/src/com/redhat/rhn/domain/errata/ErrataFileType.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/errata/ErrataFileType.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.errata.ErrataFileType"
           table="rhnErrataFileType" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/errata/Keyword.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/errata/Keyword.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.errata.Keyword"
         table="rhnErrataKeyword" >

--- a/java/code/src/com/redhat/rhn/domain/errata/Severity.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/errata/Severity.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.errata.Severity"
                 table="rhnErrataSeverity" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/iss/IssMaster.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/iss/IssMaster.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.iss.IssMaster"
         table="rhnissmaster" >

--- a/java/code/src/com/redhat/rhn/domain/iss/IssMasterOrg.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/iss/IssMasterOrg.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.iss.IssMasterOrg"
         table="rhnissmasterorgs" >

--- a/java/code/src/com/redhat/rhn/domain/iss/IssSlave.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/iss/IssSlave.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.iss.IssSlave"
         table="rhnissslave" >

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartCommand.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartCommand.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.kickstart.KickstartCommand"
            table="rhnKickstartCommand">

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartCommandName.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartCommandName.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.kickstart.KickstartCommandName"
         table="rhnKickstartCommandName">

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartData.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartData.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.kickstart.KickstartData" table="RHNKSDATA" discriminator-value="wizard">
 

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartDefaultRegToken.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartDefaultRegToken.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.kickstart.KickstartDefaultRegToken"
         table="rhnkickstartdefaultregtoken" >

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartDefaults.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartDefaults.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.kickstart.KickstartDefaults"
         table="rhnkickstartdefaults" >

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartInstallType.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartInstallType.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.kickstart.KickstartInstallType"
         table="rhnKsInstallType" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartIpRange.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartIpRange.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.kickstart.KickstartIpRange"
         table="rhnkickstartiprange" >

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartPackage.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartPackage.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.kickstart.KickstartPackage"
         table="rhnKickstartPackage">

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartPreserveFileList.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartPreserveFileList.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.kickstart.KickstartPreserveFileList"
         table="rhnkickstartpreservefilelist" >

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartScript.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartScript.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.kickstart.KickstartScript"
         table="rhnKickstartScript" >

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartSessionHistory.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartSessionHistory.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.kickstart.KickstartSessionHistory"
         table="rhnkickstartsessionhistory" >

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartSessionQueries.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartSessionQueries.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
 
     <query name="KickstartSession.findByServer">

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartSessionState.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartSessionState.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.kickstart.KickstartSessionState"
         table="rhnkickstartsessionstate" >

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartSession_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartSession_legacyUser.hbm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-    "classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.kickstart.KickstartSession"
         table="rhnkickstartsession" >

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartTreeType.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartTreeType.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.kickstart.KickstartTreeType"
         table="rhnKsTreeType" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartVirtualizationType.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartVirtualizationType.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.kickstart.KickstartVirtualizationType"
         table="rhnKickstartVirtualizationType" >

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartableTree.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartableTree.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.kickstart.KickstartableTree"
         table="rhnKickstartableTree">

--- a/java/code/src/com/redhat/rhn/domain/kickstart/crypto/CryptoKey.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/crypto/CryptoKey.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.kickstart.crypto.CryptoKey"
         table="rhnCryptoKey" >

--- a/java/code/src/com/redhat/rhn/domain/kickstart/crypto/CryptoKeyType.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/crypto/CryptoKeyType.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.kickstart.crypto.CryptoKeyType"
         table="rhnCryptoKeyType" >

--- a/java/code/src/com/redhat/rhn/domain/matcher/MatcherRunData.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/matcher/MatcherRunData.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
         PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-        "classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.matcher.MatcherRunData"
            table="suseMatcherRunData">

--- a/java/code/src/com/redhat/rhn/domain/org/CustomDataKey_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/org/CustomDataKey_legacyUser.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.org.CustomDataKey"
            table="rhnCustomDataKey">

--- a/java/code/src/com/redhat/rhn/domain/org/Org.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/org/Org.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.org.Org"
            table="WEB_CUSTOMER">

--- a/java/code/src/com/redhat/rhn/domain/org/OrgAdminManagement.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/org/OrgAdminManagement.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.org.OrgAdminManagement"
            table="rhnOrgAdminManagement">

--- a/java/code/src/com/redhat/rhn/domain/org/OrgConfig.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/org/OrgConfig.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.org.OrgConfig"
            table="rhnOrgConfiguration">

--- a/java/code/src/com/redhat/rhn/domain/org/SystemMigration.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/org/SystemMigration.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.org.SystemMigration" table="rhnSystemMigrations">
 

--- a/java/code/src/com/redhat/rhn/domain/org/TemplateCategory.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/org/TemplateCategory.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.org.TemplateCategory"
            table="RHNTEMPLATECATEGORY"

--- a/java/code/src/com/redhat/rhn/domain/org/TemplateString.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/org/TemplateString.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.org.TemplateString"
            table="RHNTEMPLATESTRING">

--- a/java/code/src/com/redhat/rhn/domain/org/usergroup/ExtGroup.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/org/usergroup/ExtGroup.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.org.usergroup.ExtGroup"
         table="rhnUserExtGroup">

--- a/java/code/src/com/redhat/rhn/domain/org/usergroup/UserGroupImpl.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/org/usergroup/UserGroupImpl.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.org.usergroup.UserGroupImpl"
         table="RHNUSERGROUP">

--- a/java/code/src/com/redhat/rhn/domain/org/usergroup/UserGroupMembers.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/org/usergroup/UserGroupMembers.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.org.usergroup.UserGroupMembers"
         table="rhnUserGroupMembers">

--- a/java/code/src/com/redhat/rhn/domain/product/SUSEProduct.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/product/SUSEProduct.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
   <class name="com.redhat.rhn.domain.product.SUSEProduct"
          table="suseProducts">

--- a/java/code/src/com/redhat/rhn/domain/product/SUSEProductChannel.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/product/SUSEProductChannel.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
   <class name="com.redhat.rhn.domain.product.SUSEProductChannel" table="suseProductChannel">
 

--- a/java/code/src/com/redhat/rhn/domain/product/SUSEProductExtension.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/product/SUSEProductExtension.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
   <class name="com.redhat.rhn.domain.product.SUSEProductExtension"
          table="suseProductExtension" >

--- a/java/code/src/com/redhat/rhn/domain/product/SUSEProductUpgrade.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/product/SUSEProductUpgrade.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
   <class name="com.redhat.rhn.domain.product.SUSEProductUpgrade"
          table="rhnActionDupProduct" >

--- a/java/code/src/com/redhat/rhn/domain/reactor/SaltEvent.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/reactor/SaltEvent.hbm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <sql-query name="SaltEvent.countSaltEvents">
         <![CDATA[

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageArch.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageArch.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.rhnpackage.PackageArch"
         table="rhnPackageArch" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageCapability.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageCapability.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.rhnpackage.PackageCapability"
         table="rhnPackageCapability">

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageDelta.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageDelta.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.rhnpackage.PackageDelta"
         table="rhnPackageDelta">

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageEvr.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageEvr.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.rhnpackage.PackageEvr"
         table="rhnPackageEvr">

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageFile.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageFile.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.rhnpackage.PackageFile"
         table="rhnPackageFile">

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageGroup.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageGroup.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.rhnpackage.PackageGroup"
            table="rhnPackageGroup">

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageKey.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageKey.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.rhnpackage.PackageKey"
         table="rhnPackageKey">

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageKeyType.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageKeyType.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.rhnpackage.PackageKeyType"
         table="rhnPackageKeyType" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageName.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageName.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.rhnpackage.PackageName"
         table="rhnPackageName">

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageNevra.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageNevra.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.rhnpackage.PackageNevra"
         table="rhnPackageNevra">

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageProvider.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageProvider.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.rhnpackage.PackageProvider"
         table="rhnPackageProvider" mutable="true">

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageSource.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageSource.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.rhnpackage.PackageSource"
            table="rhnPackageSource">

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/Package_satellite.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/Package_satellite.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.rhnpackage.Package"
            table="rhnPackage">

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/profile/Profile.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/profile/Profile.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.rhnpackage.profile.Profile"
                 table="rhnServerProfile">

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/profile/ProfileEntry.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/profile/ProfileEntry.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.rhnpackage.profile.ProfileEntry"
                 table="rhnServerProfilePackage" >

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/profile/ProfileType.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/profile/ProfileType.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.rhnpackage.profile.ProfileType"
                 table="rhnServerProfileType" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/role/Role.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/role/Role.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.role.RoleImpl"
            mutable="false"

--- a/java/code/src/com/redhat/rhn/domain/rpm/SourceRpm.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rpm/SourceRpm.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.rpm.SourceRpm"
            table="rhnSourceRpm">

--- a/java/code/src/com/redhat/rhn/domain/server/CPU.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/CPU.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.server.CPU"
                 table="rhnCPU">

--- a/java/code/src/com/redhat/rhn/domain/server/CPUArch.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/CPUArch.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.server.CPUArch"
                 table="rhnCPUArch" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/server/Capability.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Capability.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.Capability"
                  table="rhnClientCapabilityName" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/server/ClientCapability.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/ClientCapability.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
         PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-        "classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.ClientCapability"
            table="rhnClientCapability" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/server/ContactMethod.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/ContactMethod.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.ContactMethod"
         table="suseServerContactMethod" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/server/CustomDataValue_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/CustomDataValue_legacyUser.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.server.CustomDataValue"
                    table="rhnServerCustomDataValue" >

--- a/java/code/src/com/redhat/rhn/domain/server/Device.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Device.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.Device" table="rhnDevice">
         <id name="id" type="long" column="id">

--- a/java/code/src/com/redhat/rhn/domain/server/Dmi.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Dmi.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.Dmi" table="rhnServerDmi">
         <id name="id" type="long" column="id">

--- a/java/code/src/com/redhat/rhn/domain/server/Feature.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Feature.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.Feature"
                  table="rhnFeature" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/server/InstalledPackage.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/InstalledPackage.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.InstalledPackage"
                 table="rhnServerPackage" >

--- a/java/code/src/com/redhat/rhn/domain/server/InstalledProduct.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/InstalledProduct.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.InstalledProduct"
                 table="suseInstalledProduct" >

--- a/java/code/src/com/redhat/rhn/domain/server/InvalidSnapshotReason.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/InvalidSnapshotReason.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
 
     <class name="com.redhat.rhn.domain.server.InvalidSnapshotReason" table="rhnSnapshotInvalidReason">

--- a/java/code/src/com/redhat/rhn/domain/server/Location.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Location.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.Location"
         table="rhnServerLocation" >

--- a/java/code/src/com/redhat/rhn/domain/server/NetworkInterface.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/NetworkInterface.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.NetworkInterface"
         table="rhnServerNetInterface">

--- a/java/code/src/com/redhat/rhn/domain/server/Note_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Note_legacyUser.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.server.Note"
                 table="rhnServerNotes">

--- a/java/code/src/com/redhat/rhn/domain/server/PinnedSubscription.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/PinnedSubscription.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.PinnedSubscription"
         table="susePinnedSubscription">

--- a/java/code/src/com/redhat/rhn/domain/server/ProxyInfo.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/ProxyInfo.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.ProxyInfo"
         table="rhnProxyInfo" >

--- a/java/code/src/com/redhat/rhn/domain/server/PushClient.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/PushClient.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.PushClient"
         table="rhnpushclient" >

--- a/java/code/src/com/redhat/rhn/domain/server/PushClientState.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/PushClientState.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.PushClientState"
         table="rhnPushClientState" >

--- a/java/code/src/com/redhat/rhn/domain/server/Ram.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Ram.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.Ram" table="rhnRam">
         <id name="id" type="long" column="id">

--- a/java/code/src/com/redhat/rhn/domain/server/ServerArch.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerArch.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.ServerArch"
         table="rhnServerArch" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFQDN.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFQDN.hbm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.ServerFQDN" table="rhnServerFQDN">
         <id name="id" type="long" column="id">

--- a/java/code/src/com/redhat/rhn/domain/server/ServerGroup.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerGroup.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.ServerGroup" table="rhnServerGroup">
         <id name="id" type="long" column="id">

--- a/java/code/src/com/redhat/rhn/domain/server/ServerGroupType.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerGroupType.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.ServerGroupType"
         table="rhnServerGroupType" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/server/ServerHistoryEvent.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerHistoryEvent.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.ServerHistoryEvent" table="rhnserverhistory">
         <id name="id" type="long" column="id">

--- a/java/code/src/com/redhat/rhn/domain/server/ServerInfo.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerInfo.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.ServerInfo"
         table="rhnServerInfo" mutable="true">

--- a/java/code/src/com/redhat/rhn/domain/server/ServerLock_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerLock_legacyUser.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.ServerLock"
         table="rhnServerLock" >

--- a/java/code/src/com/redhat/rhn/domain/server/ServerNetAddress4.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerNetAddress4.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.ServerNetAddress4"
         table="rhnServerNetAddress4">

--- a/java/code/src/com/redhat/rhn/domain/server/ServerNetAddress6.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerNetAddress6.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.ServerNetAddress6"
         table="rhnServerNetAddress6">

--- a/java/code/src/com/redhat/rhn/domain/server/ServerPath.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerPath.hbm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.ServerPath" table="rhnServerPath">
         <composite-id name="id" class="com.redhat.rhn.domain.server.ServerPathId">

--- a/java/code/src/com/redhat/rhn/domain/server/ServerSnapshot.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerSnapshot.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
 
     <class name="com.redhat.rhn.domain.server.ServerSnapshot" table="rhnSnapshot">

--- a/java/code/src/com/redhat/rhn/domain/server/ServerSnapshotTagLink.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerSnapshotTagLink.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.ServerSnapshotTagLink" table="rhnSnapshotTag">
 

--- a/java/code/src/com/redhat/rhn/domain/server/ServerUuid.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerUuid.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.ServerUuid"
         table="rhnServeruuid" >

--- a/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.Server" table="rhnServer">
         <id name="id" type="long" column="id">

--- a/java/code/src/com/redhat/rhn/domain/server/SnapshotTag.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/SnapshotTag.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
 
     <class name="com.redhat.rhn.domain.server.SnapshotTag" table="rhnTag">

--- a/java/code/src/com/redhat/rhn/domain/server/SnapshotTagName.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/SnapshotTagName.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.server.SnapshotTagName"
                 table="rhnTagName">

--- a/java/code/src/com/redhat/rhn/domain/server/VirtualInstance.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/VirtualInstance.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 
 <hibernate-mapping>
         <import class="com.redhat.rhn.domain.server.GuestAndNonVirtHostView"/>

--- a/java/code/src/com/redhat/rhn/domain/server/VirtualInstanceInfo.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/VirtualInstanceInfo.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.VirtualInstanceInfo" table="RhnVirtualInstanceInfo">

--- a/java/code/src/com/redhat/rhn/domain/server/VirtualInstanceState.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/VirtualInstanceState.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.VirtualInstanceState"

--- a/java/code/src/com/redhat/rhn/domain/server/VirtualInstanceType.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/VirtualInstanceType.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.server.VirtualInstanceType"

--- a/java/code/src/com/redhat/rhn/domain/server/virtualhostmanager/VirtualHostManager.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/virtualhostmanager/VirtualHostManager.hbm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
 
     <class name="com.redhat.rhn.domain.server.virtualhostmanager.VirtualHostManager" table="suseVirtualHostManager">

--- a/java/code/src/com/redhat/rhn/domain/server/virtualhostmanager/VirtualHostManagerConfig.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/virtualhostmanager/VirtualHostManagerConfig.hbm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
 
     <class name="com.redhat.rhn.domain.server.virtualhostmanager.VirtualHostManagerConfig" table="suseVHMConfig">

--- a/java/code/src/com/redhat/rhn/domain/session/WebSessionImpl.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/session/WebSessionImpl.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.session.WebSessionImpl"
         table="PXTSessions">

--- a/java/code/src/com/redhat/rhn/domain/state/PackageState.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/state/PackageState.hbm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.state.PackageState" table="susePackageState">
         <id name="id" type="long" column="id">

--- a/java/code/src/com/redhat/rhn/domain/state/StateRevision.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/state/StateRevision.hbm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.state.StateRevision" table="suseStateRevision">
         <id name="id" type="long" column="id">

--- a/java/code/src/com/redhat/rhn/domain/task/Task.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/task/Task.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.task.Task"
         table="rhnTaskQueue">

--- a/java/code/src/com/redhat/rhn/domain/test/TestImpl.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/test/TestImpl.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.test.TestImpl"
         table="PERSIST_TEST">

--- a/java/code/src/com/redhat/rhn/domain/token/ActivationKey.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/token/ActivationKey.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.token.ActivationKey"
         table="rhnActivationKey">

--- a/java/code/src/com/redhat/rhn/domain/token/TokenPackage.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/token/TokenPackage.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.token.TokenPackage" table="rhnRegTokenPackages">
 

--- a/java/code/src/com/redhat/rhn/domain/token/Token_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/token/Token_legacyUser.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.token.Token" table="rhnRegToken">
         <id name="id" type="long" column="id">

--- a/java/code/src/com/redhat/rhn/domain/user/Pane.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/user/Pane.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.user.Pane"
            table="RHNINFOPANE">

--- a/java/code/src/com/redhat/rhn/domain/user/RhnTimeZone.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/user/RhnTimeZone.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.user.RhnTimeZone"
            table="RHNTIMEZONE"  mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/user/State.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/user/State.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.user.State"
         table="rhnWebContactChangeState" mutable="false">

--- a/java/code/src/com/redhat/rhn/domain/user/UserServerPreference.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/user/UserServerPreference.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.user.UserServerPreference"
         table="rhnUserServerprefs" >

--- a/java/code/src/com/redhat/rhn/domain/user/legacy/AddressImpl.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/user/legacy/AddressImpl.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.user.AddressImpl"
            table="WEB_USER_SITE_INFO">

--- a/java/code/src/com/redhat/rhn/domain/user/legacy/PersonalInfo.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/user/legacy/PersonalInfo.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.user.legacy.PersonalInfo"
            table="WEB_USER_PERSONAL_INFO"

--- a/java/code/src/com/redhat/rhn/domain/user/legacy/StateChange.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/user/legacy/StateChange.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.user.StateChange"
         table="rhnWebContactChangeLog">

--- a/java/code/src/com/redhat/rhn/domain/user/legacy/UserImpl.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/user/legacy/UserImpl.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
         <class name="com.redhat.rhn.domain.user.legacy.UserImpl"
            table="WEB_CONTACT">

--- a/java/code/src/com/redhat/rhn/domain/user/legacy/UserInfo.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/user/legacy/UserInfo.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.user.legacy.UserInfo"
            table="RHNUSERINFO"

--- a/java/code/src/com/redhat/rhn/taskomatic/domain/TaskoBunch.hbm.xml
+++ b/java/code/src/com/redhat/rhn/taskomatic/domain/TaskoBunch.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.taskomatic.domain.TaskoBunch"
         table="rhnTaskoBunch">

--- a/java/code/src/com/redhat/rhn/taskomatic/domain/TaskoRun.hbm.xml
+++ b/java/code/src/com/redhat/rhn/taskomatic/domain/TaskoRun.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.taskomatic.domain.TaskoRun"
         table="rhnTaskoRun">

--- a/java/code/src/com/redhat/rhn/taskomatic/domain/TaskoSchedule.hbm.xml
+++ b/java/code/src/com/redhat/rhn/taskomatic/domain/TaskoSchedule.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.taskomatic.domain.TaskoSchedule"
         table="rhnTaskoSchedule">

--- a/java/code/src/com/redhat/rhn/taskomatic/domain/TaskoTask.hbm.xml
+++ b/java/code/src/com/redhat/rhn/taskomatic/domain/TaskoTask.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.taskomatic.domain.TaskoTask"
         table="rhnTaskoTask">

--- a/java/code/src/com/redhat/rhn/taskomatic/domain/TaskoTemplate.hbm.xml
+++ b/java/code/src/com/redhat/rhn/taskomatic/domain/TaskoTemplate.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-"classpath://org/hibernate/hibernate-mapping-3.0.dtd">
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.taskomatic.domain.TaskoTemplate"
         table="rhnTaskoTemplate">


### PR DESCRIPTION
## What does this PR change?

Fix the DOCTPYPE of hibernate mapping files to prevent errors in eclipse

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **dev only**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
