### PR TITLE
Fix push-to-obs to push container images

### DIFF
--- a/susemanager-utils/testing/docker/scripts/push-to-obs.sh
+++ b/susemanager-utils/testing/docker/scripts/push-to-obs.sh
@@ -1,4 +1,5 @@
 #!/bin/sh -e
+set -x
 
 REL_ENG_FOLDER="/manager/rel-eng"
 
@@ -64,11 +65,27 @@ if [ "$(echo ${DESTINATIONS}|cut -d',' -f2)" != "" ]; then
   export KEEP_SRPMS=TRUE
 fi
 
+# separate packages and container images
+IMAGES=
+PKGS=
+for P in ${PACKAGES}; do
+    if [ -f packages/${P} ]; then
+        PKGS="${PKGS} ${P}"
+    else
+        IMAGES="${IMAGES} ${P}"
+    fi
+done
+
 # Build SRPMS
-echo "*************** BUILDING PACKAGES ***************"
-./build-packages-for-obs.sh ${PACKAGES}
-echo "********** BUILDING CONTAINER IMAGES ************"
-./build-containers-for-obs.sh
+if [ -z "${PACKAGES}" -o -n "${PKGS}" ]; then
+  echo "*************** BUILDING PACKAGES ***************"
+  ./build-packages-for-obs.sh ${PKGS}
+fi
+
+if [ -z "${PACKAGES}" -o -n "${IMAGES}" ]; then
+  echo "********** BUILDING CONTAINER IMAGES ************"
+  ./build-containers-for-obs.sh ${IMAGES}
+fi
 
 # Submit 
 for DESTINATION in $(echo ${DESTINATIONS}|tr ',' ' '); do


### PR DESCRIPTION
## What does this PR change?

The docker-based automation script loops over all packages in rel-eng.
In order to push container images it needs to loops on them as well.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: automation tools fix

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
