### PR TITLE
Improve clm info message

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -439,7 +439,7 @@ public class ContentManager {
                 .flatMap(src -> src.asSoftwareSource().stream())
                 .filter(src -> {
                     // we are interested in sources that have targets with patches needing resync
-                    Optional<SoftwareEnvironmentTarget> tgt = lookupTarget(src.getChannel(), firstEnv, user);
+                    Optional<SoftwareEnvironmentTarget> tgt = lookupTargetByChannel(src.getChannel(), firstEnv, user);
                     return tgt
                             .map(t -> !ChannelManager.listErrataNeedingResync(t.getChannel(), user).isEmpty())
                             .orElse(false);
@@ -789,13 +789,13 @@ public class ContentManager {
                 !extractFiltersOfType(env.getContentProject().getActiveFilters(), ModuleFilter.class).isEmpty();
 
         // first make sure the leader exists
-        SoftwareEnvironmentTarget leaderTarget = lookupTarget(leader, env, user)
+        SoftwareEnvironmentTarget leaderTarget = lookupTargetByChannel(leader, env, user)
                 .map(tgt -> fixTargetProperties(tgt, leader, null, moduleFiltersPresent))
                 .orElseGet(() -> createSoftwareTarget(leader, empty(), env, user, moduleFiltersPresent));
 
         // then do the same with the children
         Stream<Pair<Channel, SoftwareEnvironmentTarget>> nonLeaderTargets = channels
-                .map(src -> lookupTarget(src, env, user)
+                .map(src -> lookupTargetByChannel(src, env, user)
                         .map(tgt -> fixTargetProperties(tgt, src, leaderTarget.getChannel(), moduleFiltersPresent))
                         .map(tgt -> Pair.of(src, tgt))
                         .orElseGet(() -> Pair.of(src, createSoftwareTarget(
@@ -849,7 +849,14 @@ public class ContentManager {
         return swTgt;
     }
 
-    private static Optional<SoftwareEnvironmentTarget> lookupTarget(Channel srcChannel, ContentEnvironment env,
+    /**
+     * Return a Software Target by given Channel in an environment.
+     * @param srcChannel the source channel
+     * @param env the CLM environment
+     * @param user the user
+     * @return found software target
+     */
+    public static Optional<SoftwareEnvironmentTarget> lookupTargetByChannel(Channel srcChannel, ContentEnvironment env,
             User user) {
         return ContentProjectFactory
                 .lookupEnvironmentTargetByChannelLabel(channelLabelInEnvironment(srcChannel.getLabel(), env), user);

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/mappers/ResponseMappers.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/mappers/ResponseMappers.java
@@ -106,10 +106,11 @@ public class ResponseMappers {
      *
      * @param sourcesDB the list of db envs
      * @param swSourcesWithUnsyncedPatches
+     * @param sourceTagetChannelIds
      * @return the List&lt;EnvironmentResponse&gt; view beans
      */
     public static List<ProjectSoftwareSourceResponse> mapSourcesFromDB(List<SoftwareProjectSource> sourcesDB,
-            Set<SoftwareProjectSource> swSourcesWithUnsyncedPatches) {
+            Set<SoftwareProjectSource> swSourcesWithUnsyncedPatches, Map<Long, Long> sourceTagetChannelIds) {
         return sourcesDB
                 .stream()
                 .map(sourceDb -> {
@@ -120,6 +121,8 @@ public class ResponseMappers {
                     projectSourceResponse.setType(ProjectSource.Type.SW_CHANNEL.getLabel());
                     projectSourceResponse.setState(sourceDb.getState().name());
                     projectSourceResponse.setHasUnsyncedPatches(swSourcesWithUnsyncedPatches.contains(sourceDb));
+                    projectSourceResponse.setTargetChannelId(sourceTagetChannelIds
+                            .getOrDefault(sourceDb.getChannel().getId(), null));
                     return projectSourceResponse;
                 })
                 .collect(Collectors.toList());
@@ -164,10 +167,11 @@ public class ResponseMappers {
      * @param projectDB the project db entity
      * @param envsDB the list of db envs
      * @param swSourcesWithUnsyncedPatches set of {@link SoftwareProjectSource}s with patches out of sync
+     * @param sourceTagetChannelIds mapping source to target channel ids
      * @return full project view response bean
      */
     public static ProjectResponse mapProjectFromDB(ContentProject projectDB, List<ContentEnvironment> envsDB,
-            Set<SoftwareProjectSource> swSourcesWithUnsyncedPatches) {
+            Set<SoftwareProjectSource> swSourcesWithUnsyncedPatches, Map<Long, Long> sourceTagetChannelIds) {
 
         ProjectResponse project = new ProjectResponse();
 
@@ -177,7 +181,7 @@ public class ResponseMappers {
                         .stream()
                         .flatMap(source -> stream(source.asSoftwareSource()))
                         .collect(Collectors.toList()),
-                swSourcesWithUnsyncedPatches
+                swSourcesWithUnsyncedPatches, sourceTagetChannelIds
         ));
         project.setFilters(mapProjectFilterFromDB(projectDB.getProjectFilters()));
         project.setEnvironments(mapEnvironmentsFromDB(envsDB));

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/response/ProjectSoftwareSourceResponse.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/response/ProjectSoftwareSourceResponse.java
@@ -26,6 +26,7 @@ public class ProjectSoftwareSourceResponse {
     private String state;
     private String type;
     private boolean hasUnsyncedPatches;
+    private Long targetChannelId;
 
     public void setChannelId(Long channelIdIn) {
         this.channelId = channelIdIn;
@@ -49,6 +50,10 @@ public class ProjectSoftwareSourceResponse {
 
     public void setHasUnsyncedPatches(boolean hasUnsyncedPatchesIn) {
         hasUnsyncedPatches = hasUnsyncedPatchesIn;
+    }
+
+    public void setTargetChannelId(Long targetChannelIdIn) {
+        targetChannelId = targetChannelIdIn;
     }
 }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Provide link to Sync page when unsynced patches message show up
+  (bsc#1196094)
 - Optimize adding new products function (bsc#1193707)
 - Allow monitoring entitlement for debian 11 and 10
 - warning log when hardware refresh result is not serializable

--- a/web/html/src/manager/content-management/shared/components/panels/sources/sources.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/sources.tsx
@@ -53,7 +53,7 @@ const ModalSourceCreationContent = ({ isLoading, softwareSources, onChange }) =>
 };
 
 const renderSourceEntry = (source) => {
-  const unsyncedPatches = source.hasUnsyncedPatches ? "(" + t("has unsynchronized patches") + ")" : "";
+  const unsyncedPatches = source.hasUnsyncedPatches ? "<a target="_blank" href="/rhn/channels/manage/errata/SyncErrata.do?cid=" + source.targetChannelId + ">(" + t("has unsynchronized patches") + ")</a>" : "";
   if (source.state === statesEnum.enum.ATTACHED.key) {
     return (
       // TODO: If you touch this code, please make sure the `href` property here is obsolete and remove it

--- a/web/html/src/manager/content-management/shared/components/panels/sources/sources.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/sources.tsx
@@ -53,7 +53,16 @@ const ModalSourceCreationContent = ({ isLoading, softwareSources, onChange }) =>
 };
 
 const renderSourceEntry = (source) => {
-  const unsyncedPatches = source.hasUnsyncedPatches ? "<a target="_blank" href="/rhn/channels/manage/errata/SyncErrata.do?cid=" + source.targetChannelId + ">(" + t("has unsynchronized patches") + ")</a>" : "";
+  const unsyncedPatches = source.hasUnsyncedPatches ? (
+    <a
+      target="_blank"
+      href={"/rhn/channels/manage/errata/SyncErrata.do?cid=" + source.targetChannelId}
+      rel="noopener noreferrer"
+    >
+      ( {t("has unsynchronized patches")} )
+    </a>
+  ) : null;
+
   if (source.state === statesEnum.enum.ATTACHED.key) {
     return (
       // TODO: If you touch this code, please make sure the `href` property here is obsolete and remove it

--- a/web/html/src/manager/content-management/shared/type/project.type.ts
+++ b/web/html/src/manager/content-management/shared/type/project.type.ts
@@ -17,6 +17,7 @@ export type ProjectSoftwareSourceType = {
   state: string;
   type: string;
   hasUnsyncedPatches: boolean;
+  targetChannelId: number | null | undefined;
 };
 
 export type ProjectEnvironmentType = {

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Provide link to Sync page when unsynced patches message show up
+  (bsc#1196094)
 - susemanager-nodejs-sdk-devel is now provided by spacewalk-web
 - Clearify CLM environment status message
 


### PR DESCRIPTION
## What does this PR change?

The message "unsynced patches" raise questions. Make it a link to a page which has details on what has changed.

## GUI diff

No difference.

Before:

![image](https://user-images.githubusercontent.com/1038917/157492286-24501495-508d-40e1-829d-edbc34773951.png)

After:

![image](https://user-images.githubusercontent.com/1038917/157492412-0718d6d3-05cb-43c2-b4dd-704fdfa8cc7c.png)

![image](https://user-images.githubusercontent.com/1038917/157492523-6dff9e96-509e-40b8-8d89-4223c9f2eae9.png)

- [x] **DONE**

## Documentation
- 

- [ ] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/17217

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
