### PR TITLE
Remove exception and leave stdout only

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -107,8 +107,8 @@ end
 
 AfterStep do
   if has_css?('.senna-loading', wait: 0)
-    STDOUT.puts "WARN: Step ends with an ajax transition not finished, let's wait a bit!"
-    raise StandardError, 'Timeout: Waiting AJAX transition' unless has_no_css?('.senna-loading', wait: 20)
+    STDOUT.puts "WARN: Step ends with an ajax transition not finished, let's wait a bit!" unless has_no_css?('.senna-loading', wait: 20)
+#    raise StandardError, 'Timeout: Waiting AJAX transition' unless has_no_css?('.senna-loading', wait: 20)
   end
 end
 

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -107,8 +107,8 @@ end
 
 AfterStep do
   if has_css?('.senna-loading', wait: 0)
-    STDOUT.puts "WARN: Step ends with an ajax transition not finished, let's wait a bit!"
-    STDOUT.puts "Timeout: Waiting AJAX transition" unless has_no_css?('.senna-loading', wait: 20)
+    STDOUT.puts 'WARN: Step ends with an ajax transition not finished, let\'s wait a bit!'
+    STDOUT.puts 'Timeout: Waiting AJAX transition' unless has_no_css?('.senna-loading', wait: 20)
   end
 end
 

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -107,8 +107,8 @@ end
 
 AfterStep do
   if has_css?('.senna-loading', wait: 0)
-    STDOUT.puts "WARN: Step ends with an ajax transition not finished, let's wait a bit!" unless has_no_css?('.senna-loading', wait: 20)
-#    raise StandardError, 'Timeout: Waiting AJAX transition' unless has_no_css?('.senna-loading', wait: 20)
+    STDOUT.puts "WARN: Step ends with an ajax transition not finished, let's wait a bit!"
+    STDOUT.puts "Timeout: Waiting AJAX transition" unless has_no_css?('.senna-loading', wait: 20)
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

Fixes AfterStep when a scenario fails to not raise the exception but only print in stdout. That should clear some red tests. Before when a test failed the AfterStep hook also failed making all the scenarios in the feature red. Now we will be able to see exactly the real failing scenarios.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes no issue, directly from testsuite review.
Tracks:
4.2: https://github.com/SUSE/spacewalk/pull/17279
4.1: https://github.com/SUSE/spacewalk/pull/17280

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
