### PR TITLE
Fix certificate date check

### DIFF
--- a/spacewalk/certs-tools/mgr_ssl_cert_setup.py
+++ b/spacewalk/certs-tools/mgr_ssl_cert_setup.py
@@ -212,7 +212,7 @@ def isValid(startdate, enddate, subject):
 
     start = datetime.strptime(startdate, "%b %d %H:%M:%S %Y %Z")
     end = datetime.strptime(enddate, "%b %d %H:%M:%S %Y %Z")
-    now = datetime.now()
+    now = datetime.utcnow()
     if now < start:
         raise CertCheckError("Certificate '{}' not yet valid".format(subject))
     if now > end:

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,5 @@
+- compare timestamps in the right timezone
+
 -------------------------------------------------------------------
 Fri Mar 11 16:48:15 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

The timestamp in the certificates are UTC. Compare them with UTC time and not localtime.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/4990

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
