### PR TITLE
Containerized proxy tests

### DIFF
--- a/testsuite/.rubocop_todo.yml
+++ b/testsuite/.rubocop_todo.yml
@@ -408,6 +408,7 @@ Style/GlobalVars:
     - 'features/support/commonlib.rb'
     - 'features/support/env.rb'
     - 'features/support/twopence_init.rb'
+    - 'features/support/xmlrpc_client.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.

--- a/testsuite/config/cucumber.yml
+++ b/testsuite/config/cucumber.yml
@@ -6,6 +6,7 @@ building_container_images: --tags @scope_building_container_images
 changing_software_channels: --tags @scope_changing_software_channels
 cobbler: --tags @scope_cobbler
 configuration_channels: --tags @scope_configuration_channels
+containerized_proxy: --tags @scope_containerized_proxy
 content_lifecycle_management: --tags @scope_content_lifecycle_management
 content_staging: --tags @scope_content_staging
 cve_audit: --tags @scope_cve_audit

--- a/testsuite/features/build_validation/containerization/proxy_as_pod_basic_tests.feature
+++ b/testsuite/features/build_validation/containerization/proxy_as_pod_basic_tests.feature
@@ -1,0 +1,275 @@
+# Copyright (c) 2022 SUSE LLC
+# Licensed under the terms of the MIT license.
+#
+# This feature DON'T aims to prepare the Proxy to be tested by all our supported clients
+# This feature will run in isolation only validating the basic steps on a SLES 15 SP4 Minion
+#
+# The scenarios in this feature are skipped if:
+# * there is no proxy ($proxy is nil)
+# * there is no salt minion ($sle15sp4_minion is nil)
+
+@proxy
+@sle15sp4_minion
+Feature: Register and test a Containerized Proxy
+  In order to test Containerized Proxy
+  As the system administrator
+  I want to register the proxy to the server
+  
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+    And I am logged in API as user "admin" and password "admin"
+
+  Scenario: Pre-requisite: Unregister Salt minion in the traditional proxy
+    Given I am on the Systems overview page of this "sle15sp4_minion"
+    When I stop salt-minion on "sle15sp4_minion"
+    And I follow "Delete System"
+    Then I should see a "Confirm System Profile Deletion" text
+    When I click on "Delete Profile"
+    Then I wait until I see "Cleanup timed out. Please check if the machine is reachable." text
+    When I click on "Delete Profile Without Cleanup" in "An error occurred during cleanup" modal
+    And I wait until I see "has been deleted" text
+    Then "sle15sp4_minion" should not be registered
+
+  Scenario: Pre-requisite: Stop traditional proxy service
+    When I stop salt-minion on "proxy"
+    And I run "spacewalk-proxy stop" on "proxy"
+    And I wait until "squid" service is inactive on "proxy"
+    And I wait until "apache2" service is inactive on "proxy"
+    And I wait until "jabberd" service is inactive on "proxy"
+
+  Scenario: Generate Containerized Proxy configuration
+    When I generate the configuration "/tmp/proxy_container_config.tar.gz" of Containerized Proxy on the server
+    And I copy "/tmp/proxy_container_config.tar.gz" file from "server" to "proxy"
+    And I run "tar xzf /tmp/proxy_container_config.tar.gz -C /etc/uyuni/proxy/" on "proxy"
+
+  Scenario: Set-up the Containerized Proxy service to support Avahi
+    And I add avahi hosts in Containerized Proxy configuration
+
+  Scenario: Start Containerized Proxy services
+    When I start "uyuni-proxy-pod" service on "proxy"
+    And I wait until "uyuni-proxy-pod" service is active on "proxy"
+    And I wait until "uyuni-proxy-httpd" service is active on "proxy"
+    And I wait until "uyuni-proxy-salt-broker" service is active on "proxy"
+    And I wait until "uyuni-proxy-squid" service is active on "proxy"
+    And I wait until "uyuni-proxy-ssh" service is active on "proxy"
+    And I wait until "uyuni-proxy-tftpd" service is active on "proxy"
+    And I wait until port "8022" is listening on "proxy"
+    And I wait until port "8080" is listening on "proxy"
+    And I wait until port "443" is listening on "proxy"
+    And I visit "Proxy" endpoint of this "proxy"
+
+  Scenario: Containerized Proxy should be registered automatically
+    When I follow the left menu "Systems"
+    And I wait until I see the name of "containerized_proxy", refreshing the page
+
+  Scenario: Remove the offending key in salt known hosts
+    When I remove offending SSH key of "containerized_proxy" at port "8022" for "/var/lib/salt/.ssh/known_hosts" on "server"
+
+  Scenario: Bootstrap a Salt minion in the Containerized Proxy
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I enter the hostname of "sle15sp4_minion" as "hostname"
+    And I enter "22" as "port"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I select the hostname of "containerized_proxy" from "proxies"
+    And I click on "Bootstrap"
+    And I wait until I see "Successfully bootstrapped host!" text
+
+  Scenario: Check the new bootstrapped minion in System Overview page
+    When I follow the left menu "Salt > Keys"
+    And I wait until I do not see "Loading..." text
+    Then I should see a "accepted" text
+    When I follow the left menu "Systems > System List > All"
+    And I wait until I see the name of "sle15sp4_minion", refreshing the page
+    And I wait until onboarding is completed for "sle15sp4_minion"
+    Then the Salt master can reach "sle15sp4_minion"
+
+  Scenario: Check connection from minion to Containerized Proxy
+    Given I am on the Systems overview page of this "sle15sp4_minion"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see "containerized_proxy" short hostname
+
+  Scenario: Check registration on Containerized Proxy of minion
+    When I follow the left menu "Systems > System List > All"
+    And I follow this "containerized_proxy" link
+    And I follow "Details" in the content area
+    And I follow "Proxy" in the content area
+    Then I should see "sle15sp4_minion" hostname
+
+  Scenario: Salt minion grains are displayed correctly on the details page
+    Given I am on the Systems overview page of this "sle15sp4_minion"
+    Then the hostname for "sle15sp4_minion" should be correct
+    And the kernel for "sle15sp4_minion" should be correct
+    And the OS version for "sle15sp4_minion" should be correct
+    And the IPv4 address for "sle15sp4_minion" should be correct
+    And the IPv6 address for "sle15sp4_minion" should be correct
+    And the system ID for "sle15sp4_minion" should be correct
+    And the system name for "sle15sp4_minion" should be correct
+    And the uptime for "sle15sp4_minion" should be correct
+    And I should see several text fields for "sle15sp4_minion"
+
+  Scenario: Install a patch on the Salt minion
+    When I follow "Software" in the content area
+    And I follow "Patches" in the content area
+    When I check the first patch in the list
+    And I click on "Apply Patches"
+    And I click on "Confirm"
+    Then I should see a "1 patch update has been scheduled for" text
+    And I wait until event "Patch Update:" is completed
+
+  Scenario: Remove package from Salt minion
+    When I follow "Software" in the content area
+    And I follow "Install"
+    And I enter the package for "sle15sp4_minion" as the filtered package name
+    And I click on the filter button
+    And I check the package for "sle15sp4_minion" in the list
+    And I click on "Install Selected Packages"
+    And I click on "Confirm"
+    Then I should see a "1 package install has been scheduled for" text
+    And I wait until event "Package Install/Upgrade scheduled by admin" is completed
+
+  Scenario: Run a remote command on Salt minion
+    When I follow the left menu "Salt > Remote Commands"
+    Then I should see a "Remote Commands" text in the content area
+    When I enter command "echo 'My remote command output'"
+    And I enter the hostname of "sle15sp4_minion" as "target"
+    And I click on preview
+    Then I should see a "Target systems (1)" text
+    When I wait until I do not see "pending" text
+    And I click on run
+    And I wait until I see "show response" text
+    And I expand the results for "sle15sp4_minion"
+    Then I should see "My remote command output" in the command output for "sle15sp4_minion"
+
+  Scenario: Check that Software package refresh works on a Salt minion
+    Given I am on the Systems overview page of this "sle15sp4_minion"
+    When I follow "Software" in the content area
+    And I click on "Update Package List"
+    And I wait until event "Package List Refresh scheduled by admin" is completed
+
+  Scenario: Check that Hardware Refresh button works on a Salt minion
+    When I follow "Details" in the content area
+    And I follow "Hardware"
+    And I click on "Schedule Hardware Refresh"
+    Then I should see a "You have successfully scheduled a hardware profile refresh" text
+    And I wait until event "Hardware List Refresh scheduled by admin" is completed
+
+  Scenario: Create a configuration channel named "Pod Proxy Channel"
+    When I follow the left menu "Configuration > Channels"
+    And I follow "Create Config Channel"
+    And I enter "Pod Proxy Channel" as "cofName"
+    And I enter "podproxychannel" as "cofLabel"
+    And I enter "This is a configuration channel for different system types" as "cofDescription"
+    And I click on "Create Config Channel"
+    Then I should see a "Pod Proxy Channel" text
+
+  Scenario: Add a configuration file into the "Pod Proxy Channel" configuration channel
+    When I follow the left menu "Configuration > Channels"
+    And I follow "Pod Proxy Channel"
+    And I follow "Create Configuration File or Directory"
+    And I enter "/etc/s-mgr/config" as "cffPath"
+    And I enter "COLOR=white" in the editor
+    And I click on "Create Configuration File"
+    Then I should see a "Revision 1 of /etc/s-mgr/config from channel Pod Proxy Channel" text
+
+  Scenario: Subscribe a Salt minion to the configuration channel
+    Given I am on the Systems overview page of this "sle15sp4_minion"
+    When I follow "Configuration" in the content area
+    And I follow "Manage Configuration Channels" in the content area
+    And I follow first "Subscribe to Channels" in the content area
+    And I check "Pod Proxy Channel" in the list
+    And I click on "Continue"
+    And I click on "Update Channel Rankings"
+    Then I should see a "Channel Subscriptions successfully changed for" text
+
+  Scenario: Deploy the configuration file to Salt minion
+    And I follow the left menu "Configuration > Channels"
+    And I follow "Pod Proxy Channel"
+    And I follow "Deploy all configuration files to selected subscribed systems"
+    And I enter the hostname of "sle15sp4_minion" as the filtered system name
+    And I click on the filter button
+    And I check the "sle15sp4_minion" client
+    And I click on "Confirm & Deploy to Selected Systems"
+    Then I should see a "/etc/s-mgr/config" link
+    When I click on "Deploy Files to Selected Systems"
+    Then I should see a "being scheduled" text
+    And I should see a "0 revision-deploys overridden." text
+    And I wait until file "/etc/s-mgr/config" exists on "sle15sp4_minion"
+    Then file "/etc/s-mgr/config" should contain "COLOR=white" on "sle15sp4_minion"
+
+  Scenario: Reboot the Salt minion and wait until reboot is completed
+    Given I am on the Systems overview page of this "sle15sp4_minion"
+    When I follow first "Schedule System Reboot"
+    Then I should see a "System Reboot Confirmation" text
+    And I should see a "Reboot system" button
+    When I click on "Reboot system"
+    Then I should see a "Reboot scheduled for system" text
+    And I wait at most 600 seconds until event "System reboot scheduled by admin" is completed
+    Then I should see a "This action's status is: Completed" text
+
+  Scenario: Cleanup: Unregister a Salt minion in the Containerized Proxy
+    Given I am on the Systems overview page of this "sle15sp4_minion"
+    When I stop salt-minion on "sle15sp4_minion"
+    And I follow "Delete System"
+    Then I should see a "Confirm System Profile Deletion" text
+    When I click on "Delete Profile"
+    Then I wait until I see "Cleanup timed out. Please check if the machine is reachable." text
+    When I click on "Delete Profile Without Cleanup" in "An error occurred during cleanup" modal
+    And I wait until I see "has been deleted" text
+    Then "sle15sp4_minion" should not be registered
+
+  Scenario: Cleanup: Unregister Containerized Proxy
+    When I follow the left menu "Systems > System List > All"
+    And I follow this "containerized_proxy" link
+    When I follow "Delete System"
+    Then I should see a "Confirm System Profile Deletion" text
+    When I click on "Delete Profile"
+    And I wait until I see "has been deleted" text
+    Then "containerized_proxy" should not be registered
+
+  Scenario: Cleanup: Stop Containerized Proxy services
+    When I stop "uyuni-proxy-pod" service on "proxy"
+
+  Scenario: Cleanup: Remove Containerized Proxy configuration
+    When I ensure folder "/etc/uyuni/proxy/*" doesn't exist on "proxy"
+    And I remove "/tmp/proxy_container_config.zip" from "proxy"
+    And I remove "/tmp/proxy_container_config.zip" from "server"
+
+  Scenario: Cleanup: Remove "Pod Proxy Channel" configuration channel
+    When I follow the left menu "Configuration > Channels"
+    And I follow "Pod Proxy Channel"
+    And I follow "Delete Channel"
+    And I click on "Delete Config Channel"
+    Then I should see a "Channel 'Pod Proxy Channel' has been deleted" text
+
+  Scenario: Cleanup: Start traditional proxy service
+    When I start salt-minion on "proxy"
+    And I run "spacewalk-proxy start" on "proxy"
+    And I wait until "squid" service is active on "proxy"
+    And I wait until "apache2" service is active on "proxy"
+    And I wait until "jabberd" service is active on "proxy"
+
+  Scenario: Cleanup: Bootstrap a Salt minion in the traditional proxy
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I enter the hostname of "sle15sp4_minion" as "hostname"
+    And I enter "22" as "port"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I select the hostname of "proxy" from "proxies"
+    And I click on "Bootstrap"
+    And I wait until I see "Successfully bootstrapped host!" text
+
+  Scenario: Cleanup: Check the new bootstrapped minion in System Overview page
+    When I follow the left menu "Salt > Keys"
+    And I wait until I do not see "Loading..." text
+    Then I should see a "accepted" text
+    When I follow the left menu "Systems > System List > All"
+    And I wait until I see the name of "sle15sp4_minion", refreshing the page
+    And I wait until onboarding is completed for "sle15sp4_minion"
+    Then the Salt master can reach "sle15sp4_minion"
+
+  Scenario: Cleanup: Logout from API
+    When I logout from API

--- a/testsuite/features/core/proxy_register_as_pod.feature
+++ b/testsuite/features/core/proxy_register_as_pod.feature
@@ -1,0 +1,53 @@
+# Copyright (c) 2022 SUSE LLC
+# Licensed under the terms of the MIT license.
+#
+# The scenarios in this feature are skipped if:
+# * there is no proxy ($proxy is nil)
+# * there is no scope @scope_containerized_proxy
+#
+# Alternative: Bootstrap the proxy as a Pod
+
+@scope_containerized_proxy
+@proxy
+Feature: Setup Containerized Proxy
+  In order to use a Containerized Proxy with the server
+  As the system administrator
+  I want to register the Containerized Proxy on the server
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Pre-requisite: Stop traditional proxy service
+    When I stop salt-minion on "proxy"
+    And I run "spacewalk-proxy stop" on "proxy"
+    And I wait until "squid" service is inactive on "proxy"
+    And I wait until "apache2" service is inactive on "proxy"
+    And I wait until "jabberd" service is inactive on "proxy"
+
+  Scenario: Generate Containerized Proxy configuration
+    When I generate the configuration "/tmp/proxy_container_config.tar.gz" of Containerized Proxy on the server
+    And I copy "/tmp/proxy_container_config.tar.gz" file from "server" to "proxy"
+    And I run "tar xzf /tmp/proxy_container_config.tar.gz -C /etc/uyuni/proxy/" on "proxy"
+
+  Scenario: Set-up the Containerized Proxy service to support Avahi
+    And I add avahi hosts in Containerized Proxy configuration
+
+  Scenario: Start Containerized Proxy services
+    When I start "uyuni-proxy-pod" service on "proxy"
+    And I wait until "uyuni-proxy-pod" service is active on "proxy"
+    And I wait until "uyuni-proxy-httpd" service is active on "proxy"
+    And I wait until "uyuni-proxy-salt-broker" service is active on "proxy"
+    And I wait until "uyuni-proxy-squid" service is active on "proxy"
+    And I wait until "uyuni-proxy-ssh" service is active on "proxy"
+    And I wait until "uyuni-proxy-tftpd" service is active on "proxy"
+    And I wait until port "8022" is listening on "proxy"
+    And I wait until port "8080" is listening on "proxy"
+    And I wait until port "443" is listening on "proxy"
+    And I visit "Proxy" endpoint of this "proxy"
+
+  Scenario: Containerized Proxy should be registered automatically
+    When I follow the left menu "Systems"
+    And I wait until I see the name of "containerized_proxy", refreshing the page
+
+  Scenario: Remove the offending key in salt known hosts
+    When I remove offending SSH key of "containerized_proxy" at port "8022" for "/var/lib/salt/.ssh/known_hosts" on "server"

--- a/testsuite/features/secondary/proxy_as_pod_basic_tests.feature
+++ b/testsuite/features/secondary/proxy_as_pod_basic_tests.feature
@@ -1,0 +1,274 @@
+# Copyright (c) 2022 SUSE LLC
+# Licensed under the terms of the MIT license.
+#
+# The scenarios in this feature are skipped if:
+# * there is no proxy ($proxy is nil)
+# * there is no salt minion ($sle_minion is nil)
+# * there is no scope @scope_containerized_proxy
+
+@scope_containerized_proxy
+@proxy
+@sle_minion
+Feature: Register and test a Containerized Proxy
+  In order to test Containerized Proxy
+  As the system administrator
+  I want to register the proxy to the server
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+    And I am logged in API as user "admin" and password "admin"
+
+  Scenario: Pre-requisite: Unregister Salt minion in the traditional proxy
+    Given I am on the Systems overview page of this "sle_minion"
+    When I stop salt-minion on "sle_minion"
+    And I follow "Delete System"
+    Then I should see a "Confirm System Profile Deletion" text
+    When I click on "Delete Profile"
+    Then I wait until I see "Cleanup timed out. Please check if the machine is reachable." text
+    When I click on "Delete Profile Without Cleanup" in "An error occurred during cleanup" modal
+    And I wait until I see "has been deleted" text
+    Then "sle_minion" should not be registered
+
+  Scenario: Pre-requisite: Stop traditional proxy service
+    When I stop salt-minion on "proxy"
+    And I run "spacewalk-proxy stop" on "proxy"
+    And I wait until "squid" service is inactive on "proxy"
+    And I wait until "apache2" service is inactive on "proxy"
+    And I wait until "jabberd" service is inactive on "proxy"
+
+  Scenario: Generate Containerized Proxy configuration
+    When I generate the configuration "/tmp/proxy_container_config.tar.gz" of Containerized Proxy on the server
+    And I copy "/tmp/proxy_container_config.tar.gz" file from "server" to "proxy"
+    And I run "tar xzf /tmp/proxy_container_config.tar.gz -C /etc/uyuni/proxy/" on "proxy"
+
+  Scenario: Set-up the Containerized Proxy service to support Avahi
+    And I add avahi hosts in Containerized Proxy configuration
+
+  Scenario: Start Containerized Proxy services
+    When I start "uyuni-proxy-pod" service on "proxy"
+    And I wait until "uyuni-proxy-pod" service is active on "proxy"
+    And I wait until "uyuni-proxy-httpd" service is active on "proxy"
+    And I wait until "uyuni-proxy-salt-broker" service is active on "proxy"
+    And I wait until "uyuni-proxy-squid" service is active on "proxy"
+    And I wait until "uyuni-proxy-ssh" service is active on "proxy"
+    And I wait until "uyuni-proxy-tftpd" service is active on "proxy"
+    And I wait until port "8022" is listening on "proxy"
+    And I wait until port "8080" is listening on "proxy"
+    And I wait until port "443" is listening on "proxy"
+    And I visit "Proxy" endpoint of this "proxy"
+
+  Scenario: Containerized Proxy should be registered automatically
+    When I follow the left menu "Systems"
+    And I wait until I see the name of "containerized_proxy", refreshing the page
+
+  Scenario: Remove the offending key in salt known hosts
+    When I remove offending SSH key of "containerized_proxy" at port "8022" for "/var/lib/salt/.ssh/known_hosts" on "server"
+
+  Scenario: Bootstrap a Salt minion in the Containerized Proxy
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I enter the hostname of "sle_minion" as "hostname"
+    And I enter "22" as "port"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I select the hostname of "containerized_proxy" from "proxies"
+    And I click on "Bootstrap"
+    And I wait until I see "Successfully bootstrapped host!" text
+
+  Scenario: Check the new bootstrapped minion in System Overview page
+    When I follow the left menu "Salt > Keys"
+    And I wait until I do not see "Loading..." text
+    Then I should see a "accepted" text
+    When I follow the left menu "Systems > System List > All"
+    And I wait until I see the name of "sle_minion", refreshing the page
+    And I wait until onboarding is completed for "sle_minion"
+    Then the Salt master can reach "sle_minion"
+
+  Scenario: Check connection from minion to Containerized Proxy
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see "containerized_proxy" short hostname
+
+  Scenario: Check registration on Containerized Proxy of minion
+    When I follow the left menu "Systems > System List > All"
+    And I follow this "containerized_proxy" link
+    And I follow "Details" in the content area
+    And I follow "Proxy" in the content area
+    Then I should see "sle_minion" hostname
+
+  Scenario: Salt minion grains are displayed correctly on the details page
+    Given I am on the Systems overview page of this "sle_minion"
+    Then the hostname for "sle_minion" should be correct
+    And the kernel for "sle_minion" should be correct
+    And the OS version for "sle_minion" should be correct
+    And the IPv4 address for "sle_minion" should be correct
+    And the IPv6 address for "sle_minion" should be correct
+    And the system ID for "sle_minion" should be correct
+    And the system name for "sle_minion" should be correct
+    And the uptime for "sle_minion" should be correct
+    And I should see several text fields for "sle_minion"
+
+  Scenario: Install a patch on the Salt minion
+    When I follow "Software" in the content area
+    And I follow "Patches" in the content area
+    When I check the first patch in the list
+    And I click on "Apply Patches"
+    And I click on "Confirm"
+    Then I should see a "1 patch update has been scheduled for" text
+    And I wait until event "Patch Update:" is completed
+
+  Scenario: Remove package from Salt minion
+    When I follow "Software" in the content area
+    And I follow "Install"
+    And I enter the package for "sle_minion" as the filtered package name
+    And I click on the filter button
+    And I check the package for "sle_minion" in the list
+    And I click on "Install Selected Packages"
+    And I click on "Confirm"
+    Then I should see a "1 package install has been scheduled for" text
+    And I wait until event "Package Install/Upgrade scheduled by admin" is completed
+
+  Scenario: Run a remote command on Salt minion
+    When I follow the left menu "Salt > Remote Commands"
+    Then I should see a "Remote Commands" text in the content area
+    When I enter command "echo 'My remote command output'"
+    And I enter the hostname of "sle_minion" as "target"
+    And I click on preview
+    Then I should see a "Target systems (1)" text
+    When I wait until I do not see "pending" text
+    And I click on run
+    And I wait until I see "show response" text
+    And I expand the results for "sle_minion"
+    Then I should see "My remote command output" in the command output for "sle_minion"
+
+  Scenario: Check that Software package refresh works on a Salt minion
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I click on "Update Package List"
+    And I wait until event "Package List Refresh scheduled by admin" is completed
+
+  Scenario: Check that Hardware Refresh button works on a Salt minion
+    When I follow "Details" in the content area
+    And I follow "Hardware"
+    And I click on "Schedule Hardware Refresh"
+    Then I should see a "You have successfully scheduled a hardware profile refresh" text
+    And I wait until event "Hardware List Refresh scheduled by admin" is completed
+
+  Scenario: Create a configuration channel named "Pod Proxy Channel"
+    When I follow the left menu "Configuration > Channels"
+    And I follow "Create Config Channel"
+    And I enter "Pod Proxy Channel" as "cofName"
+    And I enter "podproxychannel" as "cofLabel"
+    And I enter "This is a configuration channel for different system types" as "cofDescription"
+    And I click on "Create Config Channel"
+    Then I should see a "Pod Proxy Channel" text
+
+  Scenario: Add a configuration file into the "Pod Proxy Channel" configuration channel
+    When I follow the left menu "Configuration > Channels"
+    And I follow "Pod Proxy Channel"
+    And I follow "Create Configuration File or Directory"
+    And I enter "/etc/s-mgr/config" as "cffPath"
+    And I enter "COLOR=white" in the editor
+    And I click on "Create Configuration File"
+    Then I should see a "Revision 1 of /etc/s-mgr/config from channel Pod Proxy Channel" text
+
+  Scenario: Subscribe a Salt minion to the configuration channel
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Configuration" in the content area
+    And I follow "Manage Configuration Channels" in the content area
+    And I follow first "Subscribe to Channels" in the content area
+    And I check "Pod Proxy Channel" in the list
+    And I click on "Continue"
+    And I click on "Update Channel Rankings"
+    Then I should see a "Channel Subscriptions successfully changed for" text
+
+  Scenario: Deploy the configuration file to Salt minion
+    And I follow the left menu "Configuration > Channels"
+    And I follow "Pod Proxy Channel"
+    And I follow "Deploy all configuration files to selected subscribed systems"
+    And I enter the hostname of "sle_minion" as the filtered system name
+    And I click on the filter button
+    And I check the "sle_minion" client
+    And I click on "Confirm & Deploy to Selected Systems"
+    Then I should see a "/etc/s-mgr/config" link
+    When I click on "Deploy Files to Selected Systems"
+    Then I should see a "being scheduled" text
+    And I should see a "0 revision-deploys overridden." text
+    And I wait until file "/etc/s-mgr/config" exists on "sle_minion"
+    Then file "/etc/s-mgr/config" should contain "COLOR=white" on "sle_minion"
+
+  Scenario: Reboot the Salt minion and wait until reboot is completed
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow first "Schedule System Reboot"
+    Then I should see a "System Reboot Confirmation" text
+    And I should see a "Reboot system" button
+    When I click on "Reboot system"
+    Then I should see a "Reboot scheduled for system" text
+    And I wait at most 600 seconds until event "System reboot scheduled by admin" is completed
+    Then I should see a "This action's status is: Completed" text
+
+  Scenario: Cleanup: Unregister a Salt minion in the Containerized Proxy
+    Given I am on the Systems overview page of this "sle_minion"
+    When I stop salt-minion on "sle_minion"
+    And I follow "Delete System"
+    Then I should see a "Confirm System Profile Deletion" text
+    When I click on "Delete Profile"
+    Then I wait until I see "Cleanup timed out. Please check if the machine is reachable." text
+    When I click on "Delete Profile Without Cleanup" in "An error occurred during cleanup" modal
+    And I wait until I see "has been deleted" text
+    Then "sle_minion" should not be registered
+
+  Scenario: Cleanup: Unregister Containerized Proxy
+    When I follow the left menu "Systems > System List > All"
+    And I follow this "containerized_proxy" link
+    When I follow "Delete System"
+    Then I should see a "Confirm System Profile Deletion" text
+    When I click on "Delete Profile"
+    And I wait until I see "has been deleted" text
+    Then "containerized_proxy" should not be registered
+
+  Scenario: Cleanup: Stop Containerized Proxy services
+    When I stop "uyuni-proxy-pod" service on "proxy"
+
+  Scenario: Cleanup: Remove Containerized Proxy configuration
+    When I ensure folder "/etc/uyuni/proxy/*" doesn't exist on "proxy"
+    And I remove "/tmp/proxy_container_config.zip" from "proxy"
+    And I remove "/tmp/proxy_container_config.zip" from "server"
+
+  Scenario: Cleanup: Remove "Pod Proxy Channel" configuration channel
+    When I follow the left menu "Configuration > Channels"
+    And I follow "Pod Proxy Channel"
+    And I follow "Delete Channel"
+    And I click on "Delete Config Channel"
+    Then I should see a "Channel 'Pod Proxy Channel' has been deleted" text
+
+  Scenario: Cleanup: Start traditional proxy service
+    When I start salt-minion on "proxy"
+    And I run "spacewalk-proxy start" on "proxy"
+    And I wait until "squid" service is active on "proxy"
+    And I wait until "apache2" service is active on "proxy"
+    And I wait until "jabberd" service is active on "proxy"
+
+  Scenario: Cleanup: Bootstrap a Salt minion in the traditional proxy
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I enter the hostname of "sle_minion" as "hostname"
+    And I enter "22" as "port"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I select the hostname of "proxy" from "proxies"
+    And I click on "Bootstrap"
+    And I wait until I see "Successfully bootstrapped host!" text
+
+  Scenario: Cleanup: Check the new bootstrapped minion in System Overview page
+    When I follow the left menu "Salt > Keys"
+    And I wait until I do not see "Loading..." text
+    Then I should see a "accepted" text
+    When I follow the left menu "Systems > System List > All"
+    And I wait until I see the name of "sle_minion", refreshing the page
+    And I wait until onboarding is completed for "sle_minion"
+    Then the Salt master can reach "sle_minion"
+
+  Scenario: Cleanup: Logout from API
+    When I logout from API

--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -4,7 +4,11 @@
 require 'json'
 require 'socket'
 
-$api_test = $product == 'Uyuni' ? ApiTestHttp.new($server.full_hostname) : ApiTestXmlrpc.new($server.full_hostname)
+$api_test = if $debug_mode
+              ApiTestXmlrpc.new($server.full_hostname)
+            else
+              $product == 'Uyuni' ? ApiTestHttp.new($server.full_hostname) : ApiTestXmlrpc.new($server.full_hostname)
+            end
 
 ## auth namespace
 

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -236,10 +236,14 @@ When(/^I apply highstate on "([^"]*)"$/) do |host|
   $server.run_until_ok("#{cmd} #{system_name} state.highstate")
 end
 
-When(/^I wait until "([^"]*)" service is active on "([^"]*)"$/) do |service, host|
+When(/^I wait until "([^"]*)" service is (active|inactive) on "([^"]*)"$/) do |service, status, host|
   node = get_target(host)
   cmd = "systemctl is-active #{service}"
-  node.run_until_ok(cmd)
+  repeat_until_timeout do
+    out, _err, _code = node.run(cmd, check_errors: false, separated_results: true)
+    break if out.strip == status
+    sleep 2
+  end
 end
 
 When(/^I wait until "([^"]*)" exporter service is active on "([^"]*)"$/) do |service, host|
@@ -500,6 +504,15 @@ When(/^I copy "([^"]*)" to "([^"]*)"$/) do |file, host|
   raise 'File injection failed' unless return_code.zero?
 end
 
+When(/^I copy "([^"]*)" file from "([^"]*)" to "([^"]*)"$/) do |file_path, from_host, to_host|
+  from_node = get_target(from_host)
+  to_node = get_target(to_host)
+  return_code = file_extract(from_node, file_path, file_path)
+  raise 'File extraction failed' unless return_code.zero?
+  return_code = file_inject(to_node, file_path, file_path)
+  raise 'File injection failed' unless return_code.zero?
+end
+
 Then(/^the PXE default profile should be enabled$/) do
   step %(I wait until file "/srv/tftpboot/pxelinux.cfg/default" contains "ONTIMEOUT pxe-default-profile" on server)
 end
@@ -659,6 +672,11 @@ end
 
 Then(/^I should see "(.*?)" in the output$/) do |arg1|
   raise "Command Output #{@command_output} don't include #{arg1}" unless @command_output.include? arg1
+end
+
+When(/^I (start|stop) "([^"]*)" service on "([^"]*)"$/) do |action, service, host|
+  node = get_target(host)
+  node.run("systemctl #{action} #{service}")
 end
 
 Then(/^service "([^"]*)" is enabled on "([^"]*)"$/) do |service, host|
@@ -1518,7 +1536,7 @@ When(/^I copy unset package file on server$/) do
   raise 'File injection failed' unless return_code.zero?
 end
 
-And(/^I copy vCenter configuration file on server$/) do
+When(/^I copy vCenter configuration file on server$/) do
   base_dir = File.dirname(__FILE__) + "/../upload_files/virtualization/"
   return_code = file_inject($server, base_dir + 'vCenter.json', '/var/tmp/vCenter.json')
   raise 'File injection failed' unless return_code.zero?
@@ -1544,8 +1562,9 @@ Then(/^export folder "(.*?)" shouldn't exist on server$/) do |folder|
   raise "Folder exists" if folder_exists?($server, folder)
 end
 
-When(/^I ensure folder "(.*?)" doesn't exist$/) do |folder|
-  folder_delete($server, folder) if folder_exists?($server, folder)
+When(/^I ensure folder "(.*?)" doesn't exist on "(.*?)"$/) do |folder, host|
+  node = get_target(host)
+  folder_delete(node, folder) if folder_exists?(node, folder)
 end
 
 ## ReportDB ##
@@ -1673,4 +1692,40 @@ end
 Then(/^I flush firewall on "([^"]*)"$/) do |target|
   node = get_target(target)
   node.run("iptables -F INPUT")
+end
+
+When(/^I generate the configuration "([^"]*)" of Containerized Proxy on the server$/) do |file_path|
+  # Doc: https://www.uyuni-project.org/uyuni-docs/en/uyuni/reference/spacecmd/proxy_container.html
+  command = "echo spacewalk > cert_pass && spacecmd -u admin -p admin proxy_container_config_generate_cert" \
+            " -- -o #{file_path} -p 8022 #{$proxy.full_hostname.sub('pxy', 'pod-pxy')} #{$server.full_hostname}" \
+            " 2048 galaxy-noise@suse.de --ca-pass cert_pass" \
+            " && rm cert_pass"
+  $server.run(command)
+end
+
+When(/^I add avahi hosts in Containerized Proxy configuration$/) do
+  if $server.full_hostname.include? 'tf.local'
+    hosts_list = ""
+    $host_by_node.each do |node, _host|
+      hosts_list += "--add-host=#{node.full_hostname}:#{node.public_ip} "
+    end
+    hosts_list = escape_regex(hosts_list)
+    regex = "s/^#?EXTRA_POD_ARGS=.*$/EXTRA_POD_ARGS=#{hosts_list}/g;"
+    $proxy.run("sed -i.bak -Ee '#{regex}' /etc/sysconfig/uyuni-proxy-systemd-services")
+    log "Avahi hosts added: #{hosts_list}"
+    log 'The Development team has not been working to support avahi in Containerized Proxy, yet. This is best effort.'
+  else
+    log 'Record not added - avahi domain was not detected'
+  end
+end
+
+When(/^I remove offending SSH key of "([^"]*)" at port "([^"]*)" for "([^"]*)" on "([^"]*)"$/) do |key_host, key_port, known_hosts_path, host|
+  system_name = get_system_name(key_host)
+  node = get_target(host)
+  node.run("ssh-keygen -R [#{system_name}]:#{key_port} -f #{known_hosts_path}")
+end
+
+When(/^I wait until port "([^"]*)" is listening on "([^"]*)"$/) do |port, host|
+  node = get_target(host)
+  node.run_until_ok("lsof  -i:#{port}")
 end

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -72,9 +72,7 @@ Then(/^the IPv6 address for "([^"]*)" should be correct$/) do |host|
 end
 
 Then(/^the system ID for "([^"]*)" should be correct$/) do |host|
-  $api_test.auth.login('admin', 'admin')
   client_id = $api_test.system.search_by_name(get_system_name(host)).first['id']
-  $api_test.auth.logout
   step %(I should see a "#{client_id.to_s}" text)
 end
 
@@ -436,7 +434,7 @@ Given(/^metadata generation finished for "([^"]*)"$/) do |channel|
   $server.run_until_ok("ls /var/cache/rhn/repodata/#{channel}/*updateinfo.xml.gz")
 end
 
-And(/^I push package "([^"]*)" into "([^"]*)" channel$/) do |arg1, arg2|
+When(/^I push package "([^"]*)" into "([^"]*)" channel$/) do |arg1, arg2|
   srvurl = "http://#{ENV['SERVER']}/APP"
   command = "rhnpush --server=#{srvurl} -u admin -p admin --nosig -c #{arg2} #{arg1} "
   $server.run(command, timeout: 500)
@@ -520,7 +518,7 @@ When(/^I view the subscription list for "([^"]*)"$/) do |user|
   end
 end
 
-And(/^I select "(.*?)" in the dropdown list of the architecture filter$/) do |architecture|
+When(/^I select "(.*?)" in the dropdown list of the architecture filter$/) do |architecture|
   # let the the select2js box filter open the hidden options
   xpath_query = "//div[@id='s2id_product-arch-filter']/ul/li/input"
   raise "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query).click
@@ -569,7 +567,7 @@ When(/^I select the addon "(.*?)"$/) do |addon|
   raise "xpath: #{xpath} not found" unless find(:xpath, xpath).set(true)
 end
 
-And(/^I should see that the "(.*?)" product is "(.*?)"$/) do |product, recommended|
+Then(/^I should see that the "(.*?)" product is "(.*?)"$/) do |product, recommended|
   xpath = "//span[text()[normalize-space(.) = '#{product}'] and ./span/text() = '#{recommended}']"
   raise "xpath: #{xpath} not found" unless find(:xpath, xpath)
 end
@@ -581,7 +579,7 @@ Then(/^I should see the "(.*?)" selected$/) do |product|
   end
 end
 
-And(/^I wait until I see "(.*?)" product has been added$/) do |product|
+When(/^I wait until I see "(.*?)" product has been added$/) do |product|
   repeat_until_timeout(message: "Couldn't find the installed product #{product} in the list") do
     xpath = "//span[contains(text(), '#{product}')]/ancestor::div[contains(@class, 'product-details-wrapper')]"
     begin
@@ -946,7 +944,7 @@ Given(/^I have a valid token for organization "(.*?)" and channel "(.*?)"$/) do 
   @token = token(server_secret, org: org, onlyChannels: [channel])
 end
 
-And(/^I should see the toggler "([^"]*)"$/) do |target_status|
+Then(/^I should see the toggler "([^"]*)"$/) do |target_status|
   case target_status
   when 'enabled'
     xpath = "//i[contains(@class, 'fa-toggle-on')]"
@@ -959,7 +957,7 @@ And(/^I should see the toggler "([^"]*)"$/) do |target_status|
   end
 end
 
-And(/^I click on the "([^"]*)" toggler$/) do |target_status|
+When(/^I click on the "([^"]*)" toggler$/) do |target_status|
   case target_status
   when 'enabled'
     xpath = "//i[contains(@class, 'fa-toggle-on')]"
@@ -972,7 +970,7 @@ And(/^I click on the "([^"]*)" toggler$/) do |target_status|
   end
 end
 
-And(/^I should see the child channel "([^"]*)" "([^"]*)"$/) do |target_channel, target_status|
+Then(/^I should see the child channel "([^"]*)" "([^"]*)"$/) do |target_channel, target_status|
   step %(I should see a "#{target_channel}" text)
 
   xpath = "//label[contains(text(), '#{target_channel}')]"
@@ -988,7 +986,7 @@ And(/^I should see the child channel "([^"]*)" "([^"]*)"$/) do |target_channel, 
   end
 end
 
-And(/^I should see the child channel "([^"]*)" "([^"]*)" and "([^"]*)"$/) do |target_channel, target_status, is_disabled|
+Then(/^I should see the child channel "([^"]*)" "([^"]*)" and "([^"]*)"$/) do |target_channel, target_status, is_disabled|
   step %(I should see a "#{target_channel}" text)
 
   xpath = "//label[contains(text(), '#{target_channel}')]"
@@ -1005,7 +1003,7 @@ And(/^I should see the child channel "([^"]*)" "([^"]*)" and "([^"]*)"$/) do |ta
   end
 end
 
-And(/^I select the child channel "([^"]*)"$/) do |target_channel|
+When(/^I select the child channel "([^"]*)"$/) do |target_channel|
   step %(I should see a "#{target_channel}" text)
 
   xpath = "//label[contains(text(), '#{target_channel}')]"
@@ -1015,7 +1013,7 @@ And(/^I select the child channel "([^"]*)"$/) do |target_channel|
   find(:xpath, "//input[@id='#{channel_checkbox_id}']").click
 end
 
-And(/^I should see "([^"]*)" "([^"]*)" for the "([^"]*)" channel$/) do |target_radio, target_status, target_channel|
+Then(/^I should see "([^"]*)" "([^"]*)" for the "([^"]*)" channel$/) do |target_radio, target_status, target_channel|
   xpath = "//a[contains(text(), '#{target_channel}')]"
   channel_id = find(:xpath, xpath)['href'].split('?')[1].split('=')[1]
 
@@ -1040,7 +1038,7 @@ And(/^I should see "([^"]*)" "([^"]*)" for the "([^"]*)" channel$/) do |target_r
   end
 end
 
-And(/^the notification badge and the table should count the same amount of messages$/) do
+Then(/^the notification badge and the table should count the same amount of messages$/) do
   table_notifications_count = count_table_items
 
   badge_xpath = "//i[contains(@class, 'fa-bell')]/following-sibling::*[text()='#{table_notifications_count}']"
@@ -1054,7 +1052,7 @@ And(/^the notification badge and the table should count the same amount of messa
   end
 end
 
-And(/^I wait until radio button "([^"]*)" is checked, refreshing the page$/) do |arg1|
+When(/^I wait until radio button "([^"]*)" is checked, refreshing the page$/) do |arg1|
   unless has_checked_field?(arg1)
     repeat_until_timeout(message: "Couldn't find checked radio button #{arg1}") do
       break if has_checked_field?(arg1)
@@ -1080,7 +1078,7 @@ Then(/^I check the first notification message$/) do
   end
 end
 
-And(/^I delete it via the "([^"]*)" button$/) do |target_button|
+When(/^I delete it via the "([^"]*)" button$/) do |target_button|
   if count_table_items != '0'
     xpath_for_delete_button = "//button[@title='#{target_button}']"
     raise "xpath: #{xpath_for_delete_button} not found" unless find(:xpath, xpath_for_delete_button).click
@@ -1089,7 +1087,7 @@ And(/^I delete it via the "([^"]*)" button$/) do |target_button|
   end
 end
 
-And(/^I mark as read it via the "([^"]*)" button$/) do |target_button|
+When(/^I mark as read it via the "([^"]*)" button$/) do |target_button|
   if count_table_items != '0'
     xpath_for_read_button = "//button[@title='#{target_button}']"
     raise "xpath: #{xpath_for_read_button} not found" unless find(:xpath, xpath_for_read_button).click
@@ -1212,7 +1210,7 @@ When(/^I backup the SSH authorized_keys file of host "([^"]*)"$/) do |host|
   raise 'error backing up authorized_keys on host' if ret_code.nonzero?
 end
 
-And(/^I add pre\-generated SSH public key to authorized_keys of host "([^"]*)"$/) do |host|
+When(/^I add pre\-generated SSH public key to authorized_keys of host "([^"]*)"$/) do |host|
   key_filename = 'id_rsa_bootstrap-passphrase_linux.pub'
   target = get_target(host)
   ret_code = file_inject(
@@ -1378,7 +1376,7 @@ Then(/^I add the Cobbler parameter "([^"]*)" with value "([^"]*)" to item "(dist
   raise "error in adding parameter and value to Cobbler #{item}.\nLogs:\n#{result}" if code.nonzero?
 end
 
-And(/^I check the Cobbler parameter "([^"]*)" with value "([^"]*)" in the isolinux.cfg$/) do |param, value|
+When(/^I check the Cobbler parameter "([^"]*)" with value "([^"]*)" in the isolinux.cfg$/) do |param, value|
   tmp_dir = "/var/cache/cobbler/buildiso"
   result, code = $server.run("cat #{tmp_dir}/isolinux/isolinux.cfg | grep -o #{param}=#{value}")
   raise "error while verifying isolinux.cfg parameter for Cobbler buildiso.\nLogs:\n#{result}" if code.nonzero?

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -430,14 +430,14 @@ end
 
 When(/^I select the hostname of "([^"]*)" from "([^"]*)"((?: if present)?)$/) do |host, field, if_present|
   begin
-    node = get_target(host)
+    system_name = get_system_name(host)
   rescue
     raise "Host #{host} not found" if if_present.empty?
 
     log "Host #{host} is not deployed, not trying to select it"
     return
   end
-  step %(I select "#{node.full_hostname}" from "#{field}")
+  step %(I select "#{system_name}" from "#{field}")
 end
 
 When(/^I follow this "([^"]*)" link$/) do |host|
@@ -994,15 +994,15 @@ end
 When(/^I visit "([^"]*)" endpoint of this "([^"]*)"$/) do |service, host|
   node = get_target(host)
   system_name = get_system_name(host)
-  port, text = case service
-               when 'Prometheus' then [9090, 'graph']
-               when 'Prometheus node exporter' then [9100, 'Node Exporter']
-               when 'Prometheus apache exporter' then [9117, 'Apache Exporter']
-               when 'Prometheus postgres exporter' then [9187, 'Postgres Exporter']
-               else raise "Unknown port for service #{service}"
-               end
-  _output, code = node.run("curl -s http://#{system_name}:#{port} | grep -i '#{text}'")
-  raise unless code.zero?
+  port, protocol, path, text = case service
+                               when 'Proxy' then [443, 'https', '/pub/', 'Index of /pub']
+                               when 'Prometheus' then [9090, 'http', '', 'graph']
+                               when 'Prometheus node exporter' then [9100, 'http', '', 'Node Exporter']
+                               when 'Prometheus apache exporter' then [9117, 'http', '', 'Apache Exporter']
+                               when 'Prometheus postgres exporter' then [9187, 'http', '', 'Postgres Exporter']
+                               else raise "Unknown port for service #{service}"
+                               end
+  node.run_until_ok("curl -s -k #{protocol}://#{system_name}:#{port}#{path} | grep -i '#{text}'")
 end
 
 When(/^I select the next maintenance window$/) do

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -137,16 +137,12 @@ end
 
 Then(/^"(.*?)" should not be registered$/) do |host|
   system_name = get_system_name(host)
-  $api_test.auth.login('admin', 'admin')
   refute_includes($api_test.system.list_systems.map { |s| s['name'] }, system_name)
-  $api_test.auth.logout
 end
 
 Then(/^"(.*?)" should be registered$/) do |host|
   system_name = get_system_name(host)
-  $api_test.auth.login('admin', 'admin')
   assert_includes($api_test.system.list_systems.map { |s| s['name'] }, system_name)
-  $api_test.auth.logout
 end
 
 Then(/^"(.*?)" should have been reformatted$/) do |host|

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -3,6 +3,8 @@
 
 require 'tempfile'
 require 'yaml'
+require 'nokogiri'
+require 'timeout'
 
 # return current URL
 def current_url
@@ -233,11 +235,9 @@ def get_uptime_from_host(host)
   { seconds: seconds, minutes: minutes, hours: hours, days: days }
 end
 
-# Copyright (c) 2010-2022 SUSE LLC.
-# Licensed under the terms of the MIT license.
-
-require 'nokogiri'
-require 'timeout'
+def escape_regex(text)
+  text.gsub(%r{([$.*\[/^])}) { |match| "\\#{match}" }
+end
 
 def get_system_id(node)
   $api_test.system.search_by_name(node.full_hostname).first['id']

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -163,13 +163,11 @@ def get_system_name(host)
       word =~ /example.sle15sp4terminal-/
     end
     system_name = 'sle15sp4terminal.example.org' if system_name.nil?
+  when 'containerized_proxy'
+    system_name = $proxy.full_hostname.sub('pxy', 'pod-pxy')
   else
-    begin
-      node = get_target(host)
-      system_name = node.full_hostname
-    rescue RuntimeError => e
-      STDOUT.puts e.message
-    end
+    node = get_target(host)
+    system_name = node.full_hostname
   end
   system_name
 end
@@ -250,6 +248,7 @@ end
 $node_by_host = { 'localhost'                 => $localhost,
                   'server'                    => $server,
                   'proxy'                     => $proxy,
+                  'containerized_proxy'       => $proxy,
                   'sle_minion'                => $minion,
                   'ssh_minion'                => $ssh_minion,
                   'rhlike_minion'             => $rhlike_minion,
@@ -305,14 +304,6 @@ end
 def client_public_ip(host)
   node = $node_by_host[host]
   raise "Cannot resolve node for host '#{host}'" if node.nil?
-
-  # For each node that we support we must know which network interface uses (see the case below).
-  # Having the IP as an attribute is something useful for the clients.
-  # Let's not implement it for nodes where we are likely not need this feature (e.g. ctl).
-  not_implemented = [$localhost]
-  not_implemented.each do |it|
-    return 'NOT_IMPLEMENTED' if node == it
-  end
 
   %w[br0 eth0 eth1 ens0 ens1 ens2 ens3 ens4 ens5 ens6].each do |dev|
     output, code = node.run("ip address show dev #{dev} | grep 'inet '", check_errors: false)

--- a/testsuite/features/support/xmlrpc_client.rb
+++ b/testsuite/features/support/xmlrpc_client.rb
@@ -7,7 +7,8 @@ require 'xmlrpc/client'
 class XmlrpcClient
   def initialize(host)
     puts 'Activating XML-RPC API'
-    @xmlrpc_client = XMLRPC::Client.new2('https://' + host + '/rpc/api', nil, DEFAULT_TIMEOUT)
+    protocol = $debug_mode ? 'http://' : 'https://'
+    @xmlrpc_client = XMLRPC::Client.new2(protocol + host + '/rpc/api', nil, DEFAULT_TIMEOUT)
   end
 
   def call(name, params)

--- a/testsuite/run_sets/build_validation_containerization.yml
+++ b/testsuite/run_sets/build_validation_containerization.yml
@@ -1,0 +1,4 @@
+# This file describes the order of features in a Build Validation test suite run.
+
+## Features supporting containerization of our product
+- features/build_validation/containerization/proxy_as_pod_basic_tests.feature

--- a/testsuite/run_sets/container_proxy.yml
+++ b/testsuite/run_sets/container_proxy.yml
@@ -1,0 +1,18 @@
+# This file describes the order of features in a normal testsuite run.
+#
+# If you create new features, please see conventions about naming of the
+# feature files in testsuite/docs/Guidelines.md in "Rules for features" chapter,
+# as well as guidelines about idempotency in "Idempotency" chapter.
+
+## Core features BEGIN ###
+
+# IMMUTABLE ORDER
+
+# initialize Uyuni proxy
+  # one of: proxy_register_as_trad_with_script.feature
+  #         proxy_register_as_minion_with_script.feature
+  #         proxy_register_as_minion_with_gui.feature
+- features/core/proxy_register_as_pod.feature
+- features/core/proxy_branch_network.feature
+
+## Core features END ###

--- a/testsuite/run_sets/min_proxy.yml
+++ b/testsuite/run_sets/min_proxy.yml
@@ -8,21 +8,10 @@
 
 # IMMUTABLE ORDER
 
-# initialize Uyuni server
-- features/core/srv_first_settings.feature
-- features/core/srv_disable_local_repos_off.feature
-- features/core/srv_organization_credentials.feature
-- features/core/srv_user_preferences.feature
-- features/core/srv_channels_add.feature
-- features/core/srv_create_repository.feature
-- features/core/srv_create_activationkey.feature
-- features/core/srv_osimage.feature
-- features/core/srv_docker.feature
-
 # initialize Uyuni proxy
-  # one of: proxy_register_as_minion_with_script.feature
+  # one of: proxy_register_as_trad_with_script.feature
+  #         proxy_register_as_minion_with_script.feature
   #         proxy_register_as_minion_with_gui.feature
-  #         proxy_register_as_pod.feature
 - features/core/proxy_register_as_minion_with_script.feature
 - features/core/proxy_branch_network.feature
 

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -55,5 +55,5 @@
 - features/secondary/min_move_from_and_to_proxy.feature
 - features/secondary/minssh_move_from_and_to_proxy.feature
 - features/secondary/srv_rename_hostname.feature
-
+- features/secondary/proxy_as_pod_basic_tests.feature
 ## Secondary features END ##


### PR DESCRIPTION
## What does this PR change?

**Card:** https://github.com/SUSE/spacewalk/issues/17133

Related PR: https://github.com/SUSE/susemanager-ci/pull/516

It's prepared to run as _first phase_ agreement **(running the containerized proxy test as a feature in the secondary stage)**, but the feature to use it as _second phase_ agreement is also implemented (replacing the traditional proxy by the pod proxy in the core stage). This means that we keep the feature `testsuite/features/core/proxy_register_as_pod.feature` unused and not added to any YAML file.

In addition:
- I refactored the init of the API Handler in order to always use HTTP when we are in debug mode (so in our IDEs to developer our tests) that way we will not need workarounds in our local environments.
- I also fixed spelling in the Gherkin keywords used in some places.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation included for now

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

- [Manager-4.3](https://github.com/SUSE/spacewalk/pull/19685)

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
