### PR TITLE
Change permissions only when needed

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -353,6 +353,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Key.Names getKeys() {
         return callSync(Key.listAll()).orElseThrow(this::noWheelResult);
     }
@@ -426,6 +427,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public boolean keyExists(String id, KeyStatus... statusIn) {
         final Set<KeyStatus> status = new HashSet<>(Arrays.asList(statusIn));
         if (status.isEmpty()) {
@@ -442,6 +444,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Key.Fingerprints getFingerprints() {
         return callSync(Key.finger("*")).orElseThrow(this::noWheelResult);
     }
@@ -449,6 +452,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Key.Pair generateKeysAndAccept(String id,
             boolean force) {
         return callSync(Key.genAccept(id, Optional.of(force))).orElseThrow(this::noWheelResult);
@@ -457,6 +461,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public <T> Optional<T> getGrains(String minionId, TypeToken<T> type, String... grainNames) {
        return callSync(Grains.item(false, type, grainNames), minionId);
     }
@@ -464,6 +469,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Optional<Map<String, Object>> getGrains(String minionId) {
         return callSync(Grains.items(false), minionId);
     }
@@ -471,6 +477,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Optional<String> getMachineId(String minionId) {
         return getGrain(minionId, "machine_id").flatMap(grain -> {
           if (grain instanceof String) {
@@ -487,6 +494,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void acceptKey(String match) {
         if (callSync(Key.accept(match)).isEmpty()) {
             throw noWheelResult();
@@ -496,6 +504,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void deleteKey(String minionId) {
         if (callSync(Key.delete(minionId)).isEmpty()) {
             throw noWheelResult();
@@ -505,6 +514,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void rejectKey(String minionId) {
         if (callSync(Key.reject(minionId)).isEmpty()) {
             throw noWheelResult();
@@ -585,6 +595,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public EventStream getEventStream() {
         return createOrGetEventStream();
     }
@@ -605,6 +616,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Map<String, Result<String>> runRemoteCommand(MinionList target, String cmd) {
         try {
             return callSync(Cmd.run(cmd), target);
@@ -624,6 +636,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Map<String, CompletionStage<Result<String>>> runRemoteCommandAsync(
             MinionList target, String cmd, CompletableFuture<GenericError> cancel) {
 
@@ -661,6 +674,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Map<String, Result<List<SaltUtil.RunningInfo>>> running(MinionList target) {
         try {
             return callSync(SaltUtil.running(), target);
@@ -682,6 +696,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Optional<Map<String, Jobs.ListJobsEntry>> jobsByMetadata(Object metadata) {
         return callSync(Jobs.listJobs(metadata));
     }
@@ -689,6 +704,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Optional<Map<String, Jobs.ListJobsEntry>> jobsByMetadata(Object metadata,
                                                                     LocalDateTime startTime, LocalDateTime endTime) {
         return callSync(Jobs.listJobs(metadata, startTime, endTime));
@@ -697,6 +713,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Optional<Jobs.Info> listJob(String jid) {
         return callSync(Jobs.listJob(jid));
     }
@@ -704,6 +721,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Map<String, CompletionStage<Result<Boolean>>> matchAsync(
             String target, CompletableFuture<GenericError> cancel) {
         try {
@@ -718,6 +736,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public List<String> matchCompoundSync(String target) {
         try {
             Map<String, Result<Boolean>> result =
@@ -735,6 +754,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Optional<CompletionStage<Map<String, Result<Boolean>>>> matchAsyncSSH(
             String target, CompletableFuture<GenericError> cancel) {
         return saltSSHService.matchAsyncSSH(target, cancel);
@@ -760,6 +780,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void refreshPillar(MinionList minionList) {
         try {
             LocalCall<Boolean> call = SaltUtil.refreshPillar(Optional.empty(),
@@ -780,6 +801,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void syncGrains(MinionList minionList) {
         try {
             LocalCall<List<String>> call = SaltUtil.syncGrains(Optional.empty(),
@@ -794,6 +816,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void syncModules(MinionList minionList) {
         try {
             LocalCall<List<String>> call = SaltUtil.syncModules(Optional.empty(),
@@ -816,6 +839,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void syncAll(MinionList minionList) {
         try {
              LocalCall<Map<String, Object>> call = SaltUtil.syncAll(Optional.empty(),
@@ -941,6 +965,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public <T> Optional<LocalAsyncResult<T>> callAsync(LocalCall<T> callIn, Target<?> target,
             Optional<ScheduleMetadata> metadataIn) throws SaltException {
         ScheduleMetadata metadata =
@@ -962,6 +987,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Optional<LocalAsyncResult<String>> checkIn(MinionList targetIn) throws SaltException {
         try {
             LocalCall<String> call = Test.echo("checkIn");
@@ -1023,6 +1049,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void updateSystemInfo(MinionList minionTarget) {
         try {
             callAsync(State.apply(Collections.singletonList(ApplyStatesEventMessage.SYSTEM_INFO),
@@ -1037,6 +1064,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Optional<String> getMasterHostname(String minionId) {
         return callSync(Config.get(Config.MASTER), minionId);
     }
@@ -1051,6 +1079,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Optional<RedhatProductInfo> redhatProductInfo(String minionId) {
         return callSync(State.apply(Collections.singletonList("packages.redhatproductinfo"),
                 Optional.empty()), minionId)
@@ -1092,6 +1121,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Result<SSHResult<Map<String, ApplyResult>>> bootstrapMinion(
             BootstrapParameters parameters, List<String> bootstrapMods,
             Map<String, Object> pillarData) throws SaltException {
@@ -1101,6 +1131,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Map<Boolean, String> storeMinionScapFiles(
             MinionServer minion, String uploadDir, Long actionId) {
         String actionPath = ScapFileManager
@@ -1204,6 +1235,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Optional<MgrUtilRunner.SshKeygenResult> generateSSHKey(String path) {
         RunnerCall<MgrUtilRunner.SshKeygenResult> call = MgrUtilRunner.generateSSHKey(path);
         return callSync(call);
@@ -1212,6 +1244,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Optional<MgrUtilRunner.RemoveKnowHostResult> removeSaltSSHKnownHost(String hostname) {
         RunnerCall<MgrUtilRunner.RemoveKnowHostResult> call = MgrUtilRunner.removeSSHKnowHost("salt", hostname);
         return callSync(call);
@@ -1221,6 +1254,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Optional<MgrUtilRunner.ExecResult> deleteRejectedKey(String minionId) {
         RunnerCall<MgrUtilRunner.ExecResult> call = MgrUtilRunner.deleteRejectedKey(minionId);
         return callSync(call);
@@ -1229,6 +1263,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Optional<MgrUtilRunner.ExecResult> chainSSHCommand(List<String> hosts,
                                                     String clientKey,
                                                     String proxyKey,
@@ -1245,6 +1280,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Optional<List<MgrK8sRunner.Container>> getAllContainers(String kubeconfig,
                                                         String context) {
         RunnerCall<MgrK8sRunner.ContainersList> call =
@@ -1295,6 +1331,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Optional<List<String>> cleanupMinion(MinionServer minion,
                                                    int timeout) {
         boolean sshPush = Stream.of(
@@ -1367,6 +1404,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public SaltSSHService getSaltSSHService() {
         return saltSSHService;
     }
@@ -1374,6 +1412,7 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Optional<MgrUtilRunner.ExecResult> collectKiwiImage(MinionServer minion, String filepath,
             String imageStore) {
         RunnerCall<MgrUtilRunner.ExecResult> call =

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -102,6 +102,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.GroupPrincipal;
 import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.nio.file.attribute.UserPrincipalLookupService;
 import java.time.LocalDateTime;
@@ -1180,14 +1181,19 @@ public class SaltService implements SystemQuery, SaltApi {
                 .getFileAttributeView(dir,
                         PosixFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
         try {
-            posixAttrs.setPermissions(PosixFilePermissions.fromString("rwxrwxr-x"));
+            Set<PosixFilePermission> wantedPers = PosixFilePermissions.fromString("rwxrwxr-x");
+            if (!posixAttrs.readAttributes().permissions().equals(wantedPers)) {
+                posixAttrs.setPermissions(wantedPers);
+            }
         }
         catch (IOException e) {
             LOG.warn(String.format("Could not set 'rwxrwxr-x' permissions on %s: %s",
                     dir, e.getMessage()));
         }
         try {
-            posixAttrs.setGroup(group);
+            if (!posixAttrs.readAttributes().group().equals(group)) {
+                posixAttrs.setGroup(group);
+            }
         }
         catch (IOException e) {
             LOG.warn(String.format("Could not set group on %s to %s: %s",

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- change directory owner and permissions only when needed
 - Provide link to Sync page when unsynced patches message show up
   (bsc#1196094)
 - Optimize adding new products function (bsc#1193707)


### PR DESCRIPTION
## What does this PR change?

Check the owner and permssions before we try to change it.
If we have already correct settings, we can skip it and prevent warnings if we do not have the permissions to change it as we run as user tomcat.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/17305 https://github.com/SUSE/spacewalk/pull/17306

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
