### PR TITLE
handle npe when packages are null

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManager.java
@@ -287,7 +287,12 @@ public class UbuntuErrataManager {
                 Set<Package> packages = e.getValue().entrySet().stream()
                         .flatMap(x -> x.getValue().stream())
                         .collect(Collectors.toSet());
-                errata.getPackages().addAll(packages);
+                if (errata.getPackages() == null) {
+                    errata.setPackages(packages);
+                }
+                else {
+                    errata.getPackages().addAll(packages);
+                }
 
                 Set<Channel> matchingChannels = e.getValue().entrySet().stream()
                         .filter(c -> !c.getValue().isEmpty())


### PR DESCRIPTION
## What does this PR change?

Adds back the ubuntu errata npe fix that got lost during some rebase

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed

- [ ] **DONE**

## Test coverage
- No tests

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
