### PR TITLE
QA: Try/Catch page.reset when browser has not opened windows

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -369,8 +369,13 @@ end
 #
 
 Given(/^I am not authorized$/) do
-  page.reset!
-  visit Capybara.app_host
+  begin
+    page.reset!
+  rescue NoMethodError
+    log 'The browser session could not be cleaned.'
+  ensure
+    visit Capybara.app_host
+  end
   raise "Button 'Sign In' not visible" unless find_button('Sign In').visible?
 end
 
@@ -494,8 +499,13 @@ end
 # login, logout steps
 
 Given(/^I am authorized as "([^"]*)" with password "([^"]*)"$/) do |user, passwd|
-  page.reset!
-  visit Capybara.app_host
+  begin
+    page.reset!
+  rescue NoMethodError
+    log 'The browser session could not be cleaned.'
+  ensure
+    visit Capybara.app_host
+  end
   next if all(:xpath, "//header//span[text()='#{user}']", wait: 0).any?
 
   find(:xpath, "//header//i[@class='fa fa-sign-out']").click if all(:xpath, "//header//i[@class='fa fa-sign-out']", wait: 0).any?


### PR DESCRIPTION
## What does this PR change?

Try/Catch page.reset when browser has not opened windows

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were refactored

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
