### PR TITLE
Fix exception when image store is deleted before image

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/image/ImageInfoFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/image/ImageInfoFactory.java
@@ -322,7 +322,8 @@ public class ImageInfoFactory extends HibernateFactory {
             query.where(builder.and(
                     builder.equal(root.get("name"), image.getName()),
                     builder.equal(root.get("version"), image.getVersion()),
-                    builder.equal(root.get("store"), image.getStore().getId()),
+                    builder.equal(root.get("store"),
+                                  Optional.ofNullable(image.getStore()).map(store -> store.getId()).orElse(null)),
                     builder.isTrue(root.get("obsolete"))));
             getSession().createQuery(query).getResultList().stream().forEach(obsImage -> {
                 delete(obsImage, saltApi);
@@ -582,7 +583,8 @@ public class ImageInfoFactory extends HibernateFactory {
         query.where(builder.and(
                 builder.equal(root.get("name"), image.getName()),
                 builder.equal(root.get("version"), image.getVersion()),
-                builder.equal(root.get("store"), image.getStore().getId()),
+                builder.equal(root.get("store"),
+                              Optional.ofNullable(image.getStore()).map(store -> store.getId()).orElse(null)),
                 builder.isFalse(root.get("obsolete")),
                 builder.lessThan(root.get("revisionNumber"), image.getRevisionNumber())
                 ));

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Fix exception when image store is deleted before image
+
 -------------------------------------------------------------------
 Wed Mar 16 12:11:47 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This fixes a null pointer exception when a store is deleted before image.
The problem appears in cucumber test "Build image with authenticated registry. Cleanup: delete registry image."

An alternative fix would be to disallow images without store, but that would require deleting of such images on migration. So this fix is less intrusive.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- covered by cucumber tests

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17288
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
