### PR TITLE
QA: Lock Capybara and Cucumber gem version

### DIFF
--- a/testsuite/Gemfile
+++ b/testsuite/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'require_all'
-gem 'capybara'
-gem 'cucumber', '>= 7.1.0'
+gem 'capybara', '3.35.3'
+gem 'cucumber', '7.1.0'
 gem 'cucumber-html-formatter'
 gem 'selenium-webdriver'
 gem 'rack'


### PR DESCRIPTION
## What does this PR change?

Lock Capybara and Cucumber gem version, to prevent this issue:
![image](https://user-images.githubusercontent.com/2827771/158986704-ecb65b8f-5374-4d98-9f71-acb29eec14ce.png)


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
