### PR TITLE
Reposync doesn't use http_proxy when syncing EL7 Repositories

### DIFF
--- a/python/spacewalk/satellite_tools/download.py
+++ b/python/spacewalk/satellite_tools/download.py
@@ -114,7 +114,7 @@ class PyCurlFileObjectThread(PyCurlFileObject):
         self.parent = parent
         (url, parts) = opts.urlparser.parse(url, opts)
         (scheme, host, path, parm, query, frag) = parts
-        opts.find_proxy(url, scheme.decode("utf-8"))
+        opts.find_proxy(url, scheme)
         super().__init__(url, filename, opts)
 
     def _do_open(self):

--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -80,6 +80,17 @@ RPM_PUBKEY_VERSION_RELEASE_RE = re.compile(r'^gpg-pubkey-([0-9a-fA-F]+)-([0-9a-f
 APACHE_USER = 'wwwrun'
 APACHE_GROUP = 'www'
 
+
+# Monkey Patch 'urlgrabber.grabber' method 'find_proxy' to enforce type string for variable 'scheme'
+# Workaround due to wrong byte/string handling in 'urlgrabber' package
+# Required by reposync to connect through http_proxy as configured
+def find_proxy(self, url, scheme):
+    urlgrabber_find_proxy(self, url, scheme.decode('utf-8'))
+
+urlgrabber_find_proxy = urlgrabber.grabber.URLGrabberOptions.find_proxy
+urlgrabber.grabber.URLGrabberOptions.find_proxy = find_proxy
+
+
 class ZyppoSync:
     """
     This class prepares a environment for running Zypper inside a dedicated reposync root

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Fix reposync issue, http_proxy ignored when syncing EL7 repositories
+
 -------------------------------------------------------------------
 Fri Mar 11 15:44:57 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Sort of refactoring of https://github.com/uyuni-project/uyuni/pull/4953 to ensure other plugins / methods use the configured `http_proxy`.

In case of openSUSE Repositories, the issue occurred here (and was fixed in https://github.com/uyuni-project/uyuni/pull/4953 by adding `decode`)
https://github.com/uyuni-project/uyuni/blob/0aaf348aa3cad372206cac2b3381f17264b82c43/python/spacewalk/satellite_tools/download.py#L117

For EL7 bases repositories I could track it down to:
https://github.com/uyuni-project/uyuni/blob/0aaf348aa3cad372206cac2b3381f17264b82c43/python/spacewalk/satellite_tools/repo_plugins/yum_src.py#L526

See related Issue https://github.com/uyuni-project/uyuni/issues/4850

But any of the other `urlgrabber.urlgrab` calls will also end up in ignoring the `http_proxy` settings due to the byte / string conversion issue in `urlgrabber`.

I know that Monkey Patching should be avoided but I didn't saw a better way as long the behavior is not fixed directly in `urlgrabber` (see https://github.com/rpm-software-management/urlgrabber/issues/33), happy to discuss alternative approaches.

Successfully tested with openSUSE, Oracle Linux 8, CentOS 7 and Ubunut 20.04 Repositories.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/4850

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
