### PR TITLE
Use head container for cobbler testing

### DIFF
--- a/susemanager-utils/testing/docker/scripts/Makefile
+++ b/susemanager-utils/testing/docker/scripts/Makefile
@@ -1,4 +1,10 @@
+# If you want to test with the head container, you can do it withç
+# PRODUCT=SUSE-Manager make
+ifeq ($(PRODUCT), SUSE-Manager)
+DOCKER_CONTAINER = registry.suse.de/devel/galaxy/manager/head/docker/containers/suma-head-cobbler
+else
 DOCKER_CONTAINER = registry.opensuse.org/systemsmanagement/uyuni/master/docker/containers/uyuni-master-cobbler
+endif
 
 all :: cobbler_tests
 


### PR DESCRIPTION

## What does this PR change?

Let the user specify the head container via a environment variable

## GUI diff

No difference.
- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests
- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
