### PR TITLE
Improve schedule info

### DIFF
--- a/web/html/src/components/panels/InnerPanel.tsx
+++ b/web/html/src/components/panels/InnerPanel.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import { SectionToolbar } from "components/section-toolbar/section-toolbar";
-import { cloneReactElement } from "components/utils";
+import { cloneReactElement, HelpLink } from "components/utils";
 
 type Props = {
   title: string;
@@ -9,9 +9,12 @@ type Props = {
   buttons?: React.ReactNode[];
   buttonsLeft?: React.ReactNode[];
   children: React.ReactNode;
+  summary?: React.ReactNode;
+  helpUrl?: string;
 };
 
 function InnerPanel(props: Props) {
+  const help = props.helpUrl ? <HelpLink url={props.helpUrl} /> : null;
   let toolbar: React.ReactNode = null;
 
   if (props.buttons?.length || props.buttonsLeft?.length) {
@@ -42,7 +45,10 @@ function InnerPanel(props: Props) {
       <h2>
         <i className={`fa ${props.icon}`} />
         {props.title}
+        &nbsp;
+        {help}
       </h2>
+      <p>{props.summary}</p>
       {toolbar}
       <div className="row">
         <div className="panel panel-default">

--- a/web/html/src/manager/maintenance/list/maintenance-windows-list.tsx
+++ b/web/html/src/manager/maintenance/list/maintenance-windows-list.tsx
@@ -38,6 +38,12 @@ const MaintenanceWindowsList = (props: MaintenanceListProps) => {
         title={t("Maintenance") + " " + (type === "schedule" ? t("Schedules") : t("Calendars"))}
         icon="spacewalk-icon-schedule"
         buttons={buttons}
+        helpUrl="reference/schedule/maintenance-windows.html"
+        summary={
+          type === "schedule"
+            ? t("Below is a list of Maintenance Schedules available to the current user.")
+            : t("Below is a list of Maintenance Calendars available to the current user.")
+        }
       >
         <div className="panel panel-default">
           <div className="panel-heading">

--- a/web/html/src/manager/state/recurring-states-list.tsx
+++ b/web/html/src/manager/state/recurring-states-list.tsx
@@ -60,6 +60,21 @@ class RecurringStatesList extends React.Component<Props, State> {
         title={t("Recurring States")}
         icon="spacewalk-icon-salt"
         buttons={this.props.disableCreate ? [] : buttons}
+        summary={
+          <>
+            <p>{t("The following recurring actions have been created.")}</p>
+            {this.props.disableCreate ? (
+              <p>
+                {t(
+                  "To create new recurring actions head to the system, group or organization you want to create the action for."
+                )}
+              </p>
+            ) : null}
+          </>
+        }
+        // We only want to display the help icon in the 'Schedule > Recurring States' page so we use disableCreate as
+        // an indicator whether we currently render this page
+        helpUrl={this.props.disableCreate ? "reference/schedule/recurring-actions.html" : ""}
       >
         <div className="panel panel-default">
           <div className="panel-heading">


### PR DESCRIPTION
## What does this PR change?

Add help icon and info text to recurring action and maintenance window pages

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation

- No documentation needed: 

- [ ] **DONE**

## Test coverage

- No tests: **add explanation**

- [ ] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/17151

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
