### PR TITLE
Send ubuntu errata notifications

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManager.java
@@ -53,6 +53,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -226,6 +227,7 @@ public class UbuntuErrataManager {
                         .map(CveFactory::lookupOrInsertByName)
                         .collect(Collectors.toMap(Cve::getName, e -> e)));
 
+        Set<Errata> changedErrata = new HashSet<>();
         TimeUtils.logTime(LOG, "writing " + ubuntuErrataInfo.size() + " erratas to db", () -> ubuntuErrataInfo.stream()
                 .flatMap(entry -> {
 
@@ -289,9 +291,10 @@ public class UbuntuErrataManager {
                         .collect(Collectors.toSet());
                 if (errata.getPackages() == null) {
                     errata.setPackages(packages);
+                        changedErrata.add(errata);
                 }
-                else {
-                    errata.getPackages().addAll(packages);
+                else if (errata.getPackages().addAll(packages)) {
+                    changedErrata.add(errata);
                 }
 
                 Set<Channel> matchingChannels = e.getValue().entrySet().stream()
@@ -299,10 +302,22 @@ public class UbuntuErrataManager {
                         .map(Map.Entry::getKey)
                         .collect(Collectors.toSet());
 
-                errata.getChannels().addAll(matchingChannels);
+                if (errata.getChannels().addAll(matchingChannels)) {
+                    changedErrata.add(errata);
+                }
 
+                if (errata.getId() == null) {
+                    changedErrata.add(errata);
+                }
                 return errata;
             });
         }).forEach(ErrataFactory::save));
+
+            // add changed errata to notification queue
+            changedErrata.stream()
+                .forEach(e -> {
+                    LOG.info("add errata to notification queue");
+                    e.addNotification(new Date());
+                });
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -48,6 +48,7 @@ import com.redhat.rhn.domain.errata.ErrataFile;
 import com.redhat.rhn.domain.errata.Severity;
 import com.redhat.rhn.domain.image.ImageInfo;
 import com.redhat.rhn.domain.org.Org;
+import com.redhat.rhn.domain.product.Tuple2;
 import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.rhnset.RhnSet;
 import com.redhat.rhn.domain.role.RoleFactory;
@@ -81,8 +82,6 @@ import com.redhat.rhn.taskomatic.TaskomaticApiException;
 import com.redhat.rhn.taskomatic.task.TaskConstants;
 
 import com.suse.manager.utils.MinionServerUtils;
-
-import com.google.common.collect.Maps;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
@@ -1520,11 +1519,11 @@ public class ErrataManager extends BaseManager {
 
         java.sql.Date newDate = new java.sql.Date(date.getTime());
         List<Map<String, Object>> notifyList = errataToChannels.entrySet().stream()
-                .flatMap(entry -> entry.getValue().stream().map(cid -> Maps.immutableEntry(cid, entry.getKey())))
+                .flatMap(entry -> entry.getValue().stream().map(cid -> new Tuple2<>(cid, entry.getKey())))
                 .map(entry -> {
                     Map<String, Object> params = new HashMap<>();
-                    params.put("cid", entry.getKey());
-                    params.put("eid", entry.getValue());
+                    params.put("cid", entry.getA());
+                    params.put("eid", entry.getB());
                     params.put("datetime", newDate);
                     return params;
                 })

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -82,6 +82,8 @@ import com.redhat.rhn.taskomatic.task.TaskConstants;
 
 import com.suse.manager.utils.MinionServerUtils;
 
+import com.google.common.collect.Maps;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
@@ -1479,7 +1481,7 @@ public class ErrataManager extends BaseManager {
      * @param errataId the errata ID to send notifications about
      * @param channelId the channel ID with which to decide which systems
      *       and users to send errata for
-     * @param date  the date
+     * @param date the date
      */
     public static void addErrataNotification(long errataId, long channelId, Date date) {
         Map<String, Object> params = new HashMap<>();
@@ -1504,6 +1506,33 @@ public class ErrataManager extends BaseManager {
         m.executeUpdate(params);
     }
 
+    /**
+     * Send errata notifications for all errataids and channel
+     * @param errataToChannels map with errataids to list of channel ids
+     * @param date the date
+     */
+    public static void bulkErrataNotification(Map<Long, List<Long>> errataToChannels, Date date) {
+        List<Map<String, Object>> eidList = errataToChannels.entrySet().stream()
+                .map(entry -> Collections.singletonMap("eid", (Object)entry.getKey()))
+                .collect(Collectors.toList());
+        WriteMode m = ModeFactory.getWriteMode("Errata_queries",  "clear_errata_notification");
+        m.executeUpdates(eidList);
+
+        java.sql.Date newDate = new java.sql.Date(date.getTime());
+        List<Map<String, Object>> notifyList = errataToChannels.entrySet().stream()
+                .flatMap(entry -> entry.getValue().stream().map(cid -> Maps.immutableEntry(cid, entry.getKey())))
+                .map(entry -> {
+                    Map<String, Object> params = new HashMap<>();
+                    params.put("cid", entry.getKey());
+                    params.put("eid", entry.getValue());
+                    params.put("datetime", newDate);
+                    return params;
+                })
+                .collect(Collectors.toList());
+
+        WriteMode w = ModeFactory.getWriteMode("Errata_queries",  "insert_errata_notification");
+        w.executeUpdates(notifyList);
+    }
     /**
      * delete any present and then enqueue a channel notification for the
      * given channel and erratum. This will trigger the taskomatic ErrataQueue

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- send notifications for new or changed ubuntu errata (bsc#1196977)
 - Allow using a custom SSH port for proxies
 - Hide useless fields for containerized proxies in UI
 - Keep virtualization notifications websocket alive


### PR DESCRIPTION
## What does this PR change?

Add new and changed ubuntu errata to the notification queue to send email when new errata arrive.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/17316

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
