### PR TITLE
Fix NPE in maintenance calendar display

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/maintenance/MaintenanceController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/maintenance/MaintenanceController.java
@@ -24,6 +24,7 @@ import static spark.Spark.post;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.ActionType;
+import com.redhat.rhn.domain.user.RhnTimeZone;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.EntityNotExistsException;
 
@@ -53,6 +54,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 import spark.Request;
@@ -176,7 +178,15 @@ public class MaintenanceController {
      * @return the date string in the user configured timezone
      */
     private static String applyTimezoneShift(User user, Long date) {
-        ZoneId zoneId = ZoneId.of(user.getTimeZone().getOlsonName());
+        RhnTimeZone timezone = user.getTimeZone();
+        ZoneId zoneId;
+        if (timezone == null) {
+            // Fallback to server timezone if no user timezone is configured
+            zoneId = TimeZone.getDefault().toZoneId();
+        }
+        else {
+            zoneId = ZoneId.of(timezone.getOlsonName());
+        }
        return ZonedDateTime.ofInstant(Instant.ofEpochMilli(date), zoneId)
                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm z"));
     }


### PR DESCRIPTION
## What does this PR change?

Address a NPE when there is no user timezone configured in the db. In this case we will fallback to the server timezone.

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation

- No documentation needed: 

- [ ] **DONE**

## Test coverage

- No tests: 

- [ ] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/17146

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
