### PR TITLE
Fix sonarqube double indexing of python files

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.projectKey=uyuni-project_uyuni
-sonar.sources=java,python/rhn,python,branding,proxy,susemanager,susemanager-utils,uyuni,web,spacecmd/src
+sonar.sources=java,python/rhn,python/spacewalk,python/uyuni,branding,proxy,susemanager,susemanager-utils,uyuni,web,spacecmd/src
 sonar.java.binaries=java/build/classes/
 sonar.java.libraries=java/lib/*.jar
 sonar.junit.reportPaths=java/test-results/


### PR DESCRIPTION
## What does this PR change?

Fixes the following scanner error:
```
ERROR: Error during SonarScanner execution
ERROR: File python/rhn/rhnLockfile.py can't be indexed twice. Please check that inclusion/exclusion patterns produce disjoint sets for main and test files
```

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
