### PR TITLE
fix schema migration reportdb test

### DIFF
--- a/susemanager-utils/testing/docker/scripts/schema_migration_reportdb_test_pgsql.sh
+++ b/susemanager-utils/testing/docker/scripts/schema_migration_reportdb_test_pgsql.sh
@@ -35,9 +35,9 @@ fi
 
 # Database schema creation
 
-for i in ${schema_rpms};do
-  rpm -ivh /root/${i}
-done
+pushd /root/ 
+rpm -ivh ${schema_rpms}
+popd
 
 export PERLLIB=/manager/spacewalk/setup/lib/:/manager/web/modules/rhn/:/manager/web/modules/pxt/:/manager/schema/spacewalk/lib
 export PATH=/manager/schema/spacewalk/:/manager/spacewalk/setup/bin/:$PATH


### PR DESCRIPTION
## What does this PR change?

Fixes "error: Failed dependencies:
	susemanager-schema-utility is needed by susemanager-schema-4.3.8-150400.1.5.noarch"

when running the schema migration reportdb tests

## GUI diff

No difference.



- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests
- [X] **DONE**

## Links

related to https://github.com/SUSE/spacewalk/issues/14922
- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
