### PR TITLE
QE: Add tests for ReportDB

### DIFF
--- a/testsuite/Gemfile
+++ b/testsuite/Gemfile
@@ -23,3 +23,4 @@ gem 'rubocop'
 # Add repository https://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/<your_distro> and install twopence RPMs
 # or build and install from https://github.com/openSUSE/twopence
 gem 'twopence'
+gem 'pg'

--- a/testsuite/config/cucumber.yml
+++ b/testsuite/config/cucumber.yml
@@ -37,3 +37,4 @@ xmlrpc: --tags @scope_xmlrpc
 power_management: --tags @scope_power_management
 retracted_patches: --tags @scope_retracted_patches
 ansible: --tags @scope_ansible
+reportdb: --tags @scope_reportdb

--- a/testsuite/features/secondary/srv_reportdb.feature
+++ b/testsuite/features/secondary/srv_reportdb.feature
@@ -1,0 +1,56 @@
+# Copyright (c) 2022 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@scope_reportdb
+Feature: ReportDB
+  In order to use reporting tools
+  As an authorized user
+  I want to be able to access and use the Report Database named "reportdb"
+
+Scenario: Log in as admin user
+  Given I am authorized for the "Admin" section
+
+Scenario: Populate the report database after bootstrapping minions
+  When I schedule a task to update ReportDB
+
+Scenario: Connect to the ReportDB on the server with admin user
+  Given I can connect to the ReportDB on the Server
+  And I have a user with admin access to the ReportDB
+
+Scenario: Create read-only user
+  When I create a read-only user for the ReportDB
+  Then I should see the read-only user listed on the ReportDB user accounts
+
+Scenario: External read-only user can connect to ReportDB and make queries
+  When I connect to the ReportDB with read-only user from external machine
+  Then I should be able to query the ReportDB
+
+Scenario: Read-only user can't make changes in the ReportDB
+  Then I should not be able to "insert" data in a ReportDB "table" as a read-only user
+  And I should not be able to "update" data in a ReportDB "table" as a read-only user
+  And I should not be able to "delete" data in a ReportDB "table" as a read-only user
+  And I should not be able to "insert" data in a ReportDB "view" as a read-only user
+  And I should not be able to "update" data in a ReportDB "view" as a read-only user
+  And I should not be able to "delete" data in a ReportDB "view" as a read-only user
+
+Scenario: ReportDB admin user can't access product database from external machine
+  Given I know the ReportDB admin user credentials
+  Then I should be able to connect to the ReportDB with the ReportDB admin user
+  And I should not be able to connect to product database with the ReportDB admin user
+
+Scenario: The systems should match between the UI and the ReportDB
+  When I follow the left menu "Systems > Overview"
+  And I make a list of the existing systems
+  Then I should find the systems from the UI in the ReportDB
+
+@sle_minion
+Scenario: System changes should be reflected in systems, on ReportDB
+  Given I have "sle_minion" with "Arrakeen" as "City" property
+  And I know the current synced_date for "sle_minion"
+  When I schedule a task to update ReportDB
+  Then I should find the updated "City" property as "Arrakeen" on the "sle_minion", on ReportDB
+
+Scenario: Cleanup: delete read-only user
+  When I delete the read-only user for the ReportDB
+  Then I shouldn't see the read-only user listed on the ReportDB user accounts
+

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1346,3 +1346,14 @@ When(/^I enter the reactivation key of "([^"]*)"$/) do |host|
   log "Reactivation Key: #{react_key}"
   step %(I enter "#{react_key}" as "reactivationKey")
 end
+
+When(/^I schedule a task to update ReportDB$/) do
+  steps %(
+    When I follow the left menu "Admin > Task Schedules"
+    And I follow "update-reporting-default"
+    And I follow "mgr-update-reporting-bunch"
+    And I click on "Single Run Schedule"
+    Then I should see a "bunch was scheduled" text
+    And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
+  )
+end

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -1032,3 +1032,19 @@ When(/^I refresh the page$/) do
     # ignored
   end
 end
+
+When(/^I make a list of the existing systems$/) do
+  system_elements_list = find_all(:xpath, "//td[contains(@class, 'sortedCol')]")
+  $systems_list = []
+  system_elements_list.each { |el| $systems_list << el.text }
+end
+
+Given(/^I have "([^"]*)" with "([^"]*)" as "([^"]*)" property$/) do |host, property_value, property_name|
+  steps %(
+    Given I am on the Systems overview page of this "#{host}"
+    When I follow "Properties" in the content area
+    And I enter "#{property_value}" as "#{property_name}"
+    And I click on "Update Properties"
+    Then I should see a "System properties changed" text
+  )
+end

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -215,3 +215,14 @@ def extract_logs_from_node(node)
   code = file_extract(node, "/tmp/#{node.full_hostname}-logs.tar.xz", "logs/#{node.full_hostname}-logs.tar.xz")
   raise 'Download log archive failed' unless code.zero?
 end
+
+def reportdb_server_query(query)
+  "echo \"#{query}\" | spacewalk-sql --reportdb --select-mode -"
+end
+
+def get_variable_from_conf_file(host, file_path, variable_name)
+  node = get_target(host)
+  variable_value, return_code = node.run("sed -n 's/^#{variable_name} = \\(.*\\)/\\1/p' < #{file_path}")
+  raise "Reading #{variable_name} from file on #{host} #{file_path} failed" unless return_code.zero?
+  variable_value.strip!
+end

--- a/testsuite/features/upload_files/create_user_reportdb.exp
+++ b/testsuite/features/upload_files/create_user_reportdb.exp
@@ -1,0 +1,20 @@
+set user [lindex $argv 0]
+
+spawn /usr/bin/uyuni-setup-reportdb-user
+match_max 100000
+expect -exact "Report DB Name is: reportdb\r
+\[a\]dd/\[m\]odify/\[d\]elete user (case insensitive). Default is  \[m\]: "
+send -- "a\r"
+expect -exact "a\r
+User: \[\]: "
+send -- "$user\r"
+expect -exact "$user\r
+Password: "
+send -- "linux\r"
+expect -exact "\r
+Password (again): "
+send -- "linux\r"
+expect -exact "\r
+Confirm? \[y/n\] \[y\]: "
+send -- "y\r"
+expect eof

--- a/testsuite/features/upload_files/delete_user_reportdb.exp
+++ b/testsuite/features/upload_files/delete_user_reportdb.exp
@@ -1,0 +1,14 @@
+set user [lindex $argv 0]
+
+spawn /usr/bin/uyuni-setup-reportdb-user
+match_max 100000
+expect -exact "Report DB Name is: reportdb\r
+\[a\]dd/\[m\]odify/\[d\]elete user (case insensitive). Default is  \[m\]: "
+send -- "d\r"
+expect -exact "d\r
+User: \[\]: "
+send -- "$user\r"
+expect -exact "$user\r
+Confirm? \[y/n\] \[y\]: "
+send -- "y\r"
+expect eof

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -33,6 +33,7 @@
 - features/secondary/srv_notifications.feature
 - features/secondary/srv_payg_ssh_connection.feature
 - features/secondary/srv_push_package.feature
+- features/secondary/srv_reportdb.feature
 - features/secondary/trad_spacewalk_channel.feature
 
 - features/secondary/proxy_retail_pxeboot_and_mass_import.feature


### PR DESCRIPTION
## What does this PR change?

Adds tests for ReportDB Feature.
Tests:
- Taskomatic job populating ReportDB
- Being able to connect to ReportDB from the server
- Being able to create (and delete) a read-only user for ReportDB
- Being able to connect to ReportDB with read-only user from external machine (controller)
- Ensuring read-only user can't add, modify or delete table from ReportDB
- Validating systems table lists the same systems as the UI Systems Overview
- Ensuring admin user can't connect to product database from external machine (controller)
- Making sure a system's property is changed in the ReportDB when changed in the UI and the `synced_date` is updated after the Taskomatic job

## GUI diff
No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/16595
Followed up by https://github.com/SUSE/susemanager-ci/pull/513
No backports needed, as it's for a new feature.

- [ ] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
