### PR TITLE
Container improvements: use foreign entitlement and use non-22 SSH port

### DIFF
--- a/containers/proxy-httpd-image/Dockerfile
+++ b/containers/proxy-httpd-image/Dockerfile
@@ -39,7 +39,7 @@ RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-li
 RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-licenses \
  python3-rhnlib spacewalk-proxy-broker \
  spacewalk-proxy-common spacewalk-proxy-package-manager \
- spacewalk-proxy-redirect spacewalk-ssl-cert-check
+ spacewalk-proxy-redirect spacewalk-ssl-cert-check spacewalk-proxy-html
 
 RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-licenses python3-PyYAML
 

--- a/containers/proxy-httpd-image/proxy-httpd-image.changes
+++ b/containers/proxy-httpd-image/proxy-httpd-image.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Mar 18 09:17:29 UTC 2022 - Cédric Bosdonnat <cbosdonnat@suse.com>
+
+- Add spacewalk-proxy-html package
+
+-------------------------------------------------------------------
 Tue Mar 15 14:39:46 UTC 2022 - Cédric Bosdonnat <cbosdonnat@suse.com>
 
 - Initial version

--- a/containers/proxy-ssh-image/Dockerfile
+++ b/containers/proxy-ssh-image/Dockerfile
@@ -36,6 +36,7 @@ VOLUME "/etc/uyuni"
 
 # Additional material
 COPY mgr-proxy-ssh-force-cmd /usr/sbin/mgr-proxy-ssh-force-cmd
+RUN chmod a+x /usr/sbin/mgr-proxy-ssh-force-cmd
 
 COPY uyuni-configure.py /usr/bin/uyuni-configure.py
 RUN chmod +x /usr/bin/uyuni-configure.py

--- a/containers/proxy-ssh-image/proxy-ssh-image.changes
+++ b/containers/proxy-ssh-image/proxy-ssh-image.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Mar 23 09:04:14 UTC 2022 - Cédric Bosdonnat <cbosdonnat@suse.com>
+
+- Make /usr/sbin/mgr-proxy-ssh-force-cmd executable 
+
+-------------------------------------------------------------------
 Tue Mar 15 14:42:38 UTC 2022 - Cédric Bosdonnat <cbosdonnat@suse.com>
 
 - Initial version

--- a/containers/proxy-systemd-services/uyuni-proxy-pod.service
+++ b/containers/proxy-systemd-services/uyuni-proxy-pod.service
@@ -14,7 +14,7 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=/etc/sysconfig/uyuni-proxy-systemd-services
 Restart=on-failure
 ExecStartPre=/bin/rm -f %t/uyuni-proxy-pod.pid %t/uyuni-proxy-pod.pod-id
-ExecStartPre=/usr/bin/podman pod create --infra-conmon-pidfile %t/uyuni-proxy-pod.pid --pod-id-file %t/uyuni-proxy-pod.pod-id --name proxy-pod --publish 22:22 --publish 8080:8080 --publish 443:443 --publish 4505:4505 --publish 4506:4506 --replace $EXTRA_POD_ARGS
+ExecStartPre=/usr/bin/podman pod create --infra-conmon-pidfile %t/uyuni-proxy-pod.pid --pod-id-file %t/uyuni-proxy-pod.pod-id --name proxy-pod --publish 8022:22 --publish 8080:8080 --publish 443:443 --publish 4505:4505 --publish 4506:4506 --replace $EXTRA_POD_ARGS
 ExecStart=/usr/bin/podman pod start --pod-id-file %t/uyuni-proxy-pod.pod-id
 ExecStop=/usr/bin/podman pod stop --ignore --pod-id-file %t/uyuni-proxy-pod.pod-id -t 10
 ExecStopPost=/usr/bin/podman pod rm --ignore -f --pod-id-file %t/uyuni-proxy-pod.pod-id

--- a/containers/proxy-systemd-services/uyuni-proxy-systemd-services.spec
+++ b/containers/proxy-systemd-services/uyuni-proxy-systemd-services.spec
@@ -47,7 +47,7 @@ install -d -m 755 %{buildroot}/%{_localstatedir}/lib/uyuni/proxy-rhn-cache
 install -d -m 755 %{buildroot}/%{_localstatedir}/lib/uyuni/proxy-tftpboot
 install -d -m 755 %{buildroot}%{_sbindir}
 
-%if 0%{?sle_version}
+%if !0%{?is_opensuse}
 sed 's/^NAMESPACE=.*$/NAMESPACE=registry.suse.com\/suse\/manager\/4.3/' -i uyuni-container-proxy-services.config
 %endif
 install -D -m 644 uyuni-container-proxy-services.config %{buildroot}%{_fillupdir}/sysconfig.%{name}

--- a/java/code/src/com/redhat/rhn/common/security/acl/Access.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/Access.java
@@ -348,6 +348,21 @@ public class Access extends BaseHandler {
     }
 
     /**
+     * Uses the sid param to decide if a system is a proxy
+     * @param ctx Context Map to pass in
+     * @param params Parameters to use (unused)
+     * @return true if a system is a proxy, false otherwise
+     */
+    public boolean aclSystemIsProxy(Object ctx, String[] params) {
+        Map map = (Map) ctx;
+        Long sid = getAsLong(map.get("sid"));
+        User user = (User) map.get("user");
+        Server lookedUp = SystemManager.lookupByIdAndUser(sid, user);
+
+        return lookedUp.isProxy();
+    }
+
+    /**
      * Check if a system has a management entitlement
      * @param ctx Context map to pass in.
      * @param params Parameters to use to fetch from context.

--- a/java/code/src/com/redhat/rhn/domain/server/ProxyInfo.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/ProxyInfo.hbm.xml
@@ -11,6 +11,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                 <param name="property">server</param>
             </generator>
         </id>
+        <property name="sshPort" type="integer" column="ssh_port" />
         <one-to-one name="server"
             class="com.redhat.rhn.domain.server.Server"
             constrained="true"/>

--- a/java/code/src/com/redhat/rhn/domain/server/ProxyInfo.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ProxyInfo.java
@@ -28,6 +28,7 @@ public class ProxyInfo {
     private Server server;
     private PackageEvr version;
     private Long id;
+    private Integer sshPort;
 
     /**
      * @return the id
@@ -74,6 +75,20 @@ public class ProxyInfo {
         this.server = s;
     }
 
+    /**
+     * @return value of sshPort
+     */
+    public Integer getSshPort() {
+        return sshPort;
+    }
+
+    /**
+     * @param sshPortIn value of sshPort
+     */
+    public void setSshPort(Integer sshPortIn) {
+        sshPort = sshPortIn;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -89,6 +104,7 @@ public class ProxyInfo {
         return new EqualsBuilder()
                 .append(server, proxyInfo.server)
                 .append(version, proxyInfo.version)
+                .append(sshPort, proxyInfo.sshPort)
                 .isEquals();
     }
 
@@ -97,6 +113,7 @@ public class ProxyInfo {
         return new HashCodeBuilder(17, 37)
                 .append(server)
                 .append(version)
+                .append(sshPort)
                 .toHashCode();
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -312,8 +312,9 @@ public class ServerFactory extends HibernateFactory {
         Set<ServerPath> paths = new HashSet<>();
         for (ServerPath parentPath : proxyServer.getServerPaths()) {
             ServerPath path = findServerPath(server, parentPath.getId().getProxyServer()).orElseGet(() -> {
+                Server parentProxyServer = parentPath.getId().getProxyServer();
                 ServerPath newPath = new ServerPath();
-                newPath.setId(new ServerPathId(server, parentPath.getId().getProxyServer()));
+                newPath.setId(new ServerPathId(server, parentProxyServer));
                 newPath.setHostname(parentPath.getHostname());
                 return newPath;
             });

--- a/java/code/src/com/redhat/rhn/domain/server/ServerPath.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerPath.java
@@ -41,10 +41,12 @@ public class ServerPath extends BaseDomainHelper {
     }
 
     /**
+     * @param idIn the server path id
      * @param positionIn the server position in the path chain
      * @param hostnameIn the hostname of the server
      */
-    public ServerPath(Long positionIn, String hostnameIn) {
+    public ServerPath(ServerPathId idIn, Long positionIn, String hostnameIn) {
+        this.id = idIn;
         this.position = positionIn;
         this.hostname = hostnameIn;
     }

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/ProxyClientsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/ProxyClientsAction.java
@@ -61,9 +61,14 @@ public class ProxyClientsAction extends BaseSystemsAction {
             Optional<InstalledProduct> proxyProduct = server.getInstalledProducts().stream()
                     .filter(p -> p.getName().toLowerCase().contains("proxy"))
                     .findFirst();
-            request.setAttribute("version", proxyProduct.isPresent() ?
-                    proxyProduct.get().getVersion() :
-                    server.getProxyInfo().getVersion().getVersion());
+            if (proxyProduct.isPresent() || server.getProxyInfo().getVersion() != null) {
+                request.setAttribute("version", proxyProduct.isPresent() ?
+                        proxyProduct.get().getVersion() :
+                        server.getProxyInfo().getVersion().getVersion());
+            }
+            else {
+                request.setAttribute("version", null);
+            }
 
             DataResult<SystemOverview> result = getDataResult(user, null, formIn);
             if (result.isEmpty()) {

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -9357,6 +9357,9 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
       <trans-unit id="bootstrap.minion.error.salt">
         <source>Error during applying the bootstrap state, message: {0}</source>
       </trans-unit>
+      <trans-unit id="bootstrap.minion.error.salt.unexpected">
+        <source>Error during applying the bootstrap state. Check the server logs.</source>
+      </trans-unit>
       <trans-unit id="setup.product.error.dataneedsrefresh">
         <source>Product data needs refresh.</source>
       </trans-unit>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -20659,6 +20659,12 @@ The Tree Path, Base Channel, and Installer Generation should always match. This 
           <context context-type="sourcefile">/systems/details/Overview.do</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sdc.details.overview.sshport" xml:space="preserve">
+        <source>SSH Port:</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/systems/details/Overview.do</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sdc.details.overview.virtualization" xml:space="preserve">
         <source>Virtualization:</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/ProxyHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/ProxyHandler.java
@@ -253,6 +253,7 @@ public class ProxyHandler extends BaseHandler {
      *
      * @param loggedInUser the current user
      * @param proxyName  the FQDN of the proxy
+     * @param proxyPort the SSH port the proxy listens on
      * @param server the FQDN of the server the proxy uses
      * @param maxCache the maximum memory cache size
      * @param email the email of proxy admin
@@ -265,6 +266,7 @@ public class ProxyHandler extends BaseHandler {
      * @xmlrpc.doc Compute and download the configuration for proxy containers
      * @xmlrpc.param #session_key()
      * @xmlrpc.param #param("string", "proxyName", "The FQDN of the proxy")
+     * @xmlrpc.param #param("int", "proxyPort", "The SSH port the proxy listens on")
      * @xmlrpc.param #param("string", "server", "The server FQDN the proxy will connect to")
      * @xmlrpc.param #param("int", "maxCache", "Max cache size in MB")
      * @xmlrpc.param #param("string", "email", "The proxy admin email")
@@ -274,7 +276,8 @@ public class ProxyHandler extends BaseHandler {
      * @xmlrpc.param #param("string", "proxyKey", "proxy SSL private key in PEM format")
      *  @xmlrpc.returntype #array_single("byte", "binary object - package file")
      */
-    public byte[] containerConfig(User loggedInUser, String proxyName, String server, Integer maxCache, String email,
+    public byte[] containerConfig(User loggedInUser, String proxyName, Integer proxyPort, String server,
+                                  Integer maxCache, String email,
                                   String rootCA, List<String> intermediateCAs, String proxyCrt, String proxyKey) {
         try {
             SSLCertPair proxyCrtKey = new SSLCertPair(proxyCrt, proxyKey);
@@ -282,8 +285,8 @@ public class ProxyHandler extends BaseHandler {
                 throw new InvalidParameterException("Both proxyCrt and proxyKey need to be provided");
             }
 
-            return systemManager.createProxyContainerConfig(loggedInUser, proxyName, server, maxCache.longValue(),
-                    email, rootCA, intermediateCAs, proxyCrtKey, null, null, null);
+            return systemManager.createProxyContainerConfig(loggedInUser, proxyName, proxyPort, server,
+                    maxCache.longValue(), email, rootCA, intermediateCAs, proxyCrtKey, null, null, null);
         }
         catch (InstantiationException e) {
             LOG.error("Failed to generate proxy system id", e);
@@ -304,6 +307,7 @@ public class ProxyHandler extends BaseHandler {
      *
      * @param loggedInUser the current user
      * @param proxyName  the FQDN of the proxy
+     * @param proxyPort the SSH port the proxy listens on
      * @param server the FQDN of the server the proxy uses
      * @param maxCache the maximum memory cache size
      * @param email the email of proxy admin
@@ -323,6 +327,7 @@ public class ProxyHandler extends BaseHandler {
      * @xmlrpc.doc Compute and download the configuration for proxy containers
      * @xmlrpc.param #session_key()
      * @xmlrpc.param #param("string", "proxyName", "The FQDN of the proxy")
+     * @xmlrpc.param #param("int", "proxyPort", "The SSH port the proxy listens on")
      * @xmlrpc.param #param("string", "server", "The server FQDN the proxy will connect to")
      * @xmlrpc.param #param("int", "maxCache", "Max cache size in MB")
      * @xmlrpc.param #param("string", "email", "The proxy admin email")
@@ -338,7 +343,8 @@ public class ProxyHandler extends BaseHandler {
      * @xmlrpc.param #param("string", "sslEmail", "The email to set in the SSL certificate")
      *  @xmlrpc.returntype #array_single("byte", "binary object - package file")
      */
-    public byte[] containerConfig(User loggedInUser, String proxyName, String server, Integer maxCache, String email,
+    public byte[] containerConfig(User loggedInUser, String proxyName, Integer proxyPort, String server,
+                                  Integer maxCache, String email,
                                   String caCrt, String caKey, String caPassword,
                                   List<String> cnames, String country, String state, String city,
                                   String org, String orgUnit, String sslEmail) {
@@ -350,8 +356,8 @@ public class ProxyHandler extends BaseHandler {
 
             SSLCertData certData = new SSLCertData(nullable(proxyName), cnames, nullable(country),
                     nullable(state), nullable(city), nullable(org), nullable(orgUnit), nullable(sslEmail));
-            return systemManager.createProxyContainerConfig(loggedInUser, proxyName, server, maxCache.longValue(),
-                    email, null, Collections.emptyList(), null, caCrtKey, caPassword, certData);
+            return systemManager.createProxyContainerConfig(loggedInUser, proxyName, proxyPort, server,
+                    maxCache.longValue(), email, null, Collections.emptyList(), null, caCrtKey, caPassword, certData);
         }
         catch (InstantiationException e) {
             LOG.error("Failed to generate proxy system id", e);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/test/ProxyHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/test/ProxyHandlerTest.java
@@ -166,14 +166,14 @@ public class ProxyHandlerTest extends RhnJmockBaseTestCase {
 
         SystemManager mockSystemManager = mock(SystemManager.class);
         context().checking(new Expectations() {{
-            allowing(mockSystemManager).createProxyContainerConfig(user, proxy, server, 2048L, email,
+            allowing(mockSystemManager).createProxyContainerConfig(user, proxy, 8022, server, 2048L, email,
                     "ROOT_CA", List.of("CA1", "CA2"), new SSLCertPair("PROXY_CERT", "PROXY_KEY"),
                     null, null, null);
             will(returnValue(dummyConfig));
         }});
 
-        byte[] actual = new ProxyHandler(xmlRpcSystemHelper, mockSystemManager).containerConfig(user, proxy, server,
-                2048, email, "ROOT_CA", List.of("CA1", "CA2"), "PROXY_CERT", "PROXY_KEY");
+        byte[] actual = new ProxyHandler(xmlRpcSystemHelper, mockSystemManager).containerConfig(user, proxy, 8022,
+                server, 2048, email, "ROOT_CA", List.of("CA1", "CA2"), "PROXY_CERT", "PROXY_KEY");
         assertEquals(dummyConfig, actual);
     }
 
@@ -186,7 +186,7 @@ public class ProxyHandlerTest extends RhnJmockBaseTestCase {
 
         SystemManager mockSystemManager = mock(SystemManager.class);
         context().checking(new Expectations() {{
-            allowing(mockSystemManager).createProxyContainerConfig(user, proxy, server, 2048L, email,
+            allowing(mockSystemManager).createProxyContainerConfig(user, proxy, 22, server, 2048L, email,
                     null, Collections.emptyList(), null,
                     new SSLCertPair("CACert", "CAKey"), "CAPass",
                     new SSLCertData(proxy, List.of("cname1", "cname2"), "DE", "Bayern", "Nurnberg",
@@ -194,7 +194,7 @@ public class ProxyHandlerTest extends RhnJmockBaseTestCase {
             will(returnValue(dummyConfig));
         }});
 
-        byte[] actual = new ProxyHandler(xmlRpcSystemHelper, mockSystemManager).containerConfig(user, proxy, server,
+        byte[] actual = new ProxyHandler(xmlRpcSystemHelper, mockSystemManager).containerConfig(user, proxy, 22, server,
                 2048, email, "CACert", "CAKey", "CAPass", List.of("cname1", "cname2"),
                 "DE", "Bayern", "Nurnberg", "ACME", "ACME Tests", "coyote@acme.lab");
         assertEquals(dummyConfig, actual);

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -2224,6 +2224,7 @@ public class SystemManager extends BaseManager {
         config.put("server", server);
         config.put("max_cache_size_mb", maxCache);
         config.put("email", email);
+        config.put("server_version", ConfigDefaults.get().getProductVersion());
         Server proxySystem = getOrCreateProxySystem(user, proxyName);
 
         zipOut.putNextEntry(new ZipEntry("config.yaml"));

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -2177,6 +2177,10 @@ public class SystemManager extends BaseManager {
         server.updateServerInfo();
         ServerFactory.save(server);
 
+        ProxyInfo info = new ProxyInfo();
+        info.setServer(server);
+        server.setProxyInfo(info);
+
         systemEntitlementManager.setBaseEntitlement(server, EntitlementManager.FOREIGN);
         return server;
     }

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -2149,7 +2149,7 @@ public class SystemManager extends BaseManager {
         return () -> new RhnRuntimeException(message);
     }
 
-    private Server getOrCreateProxySystem(User creator, String fqdn) {
+    private Server getOrCreateProxySystem(User creator, String fqdn, Integer port) {
         Optional<Server> existing = ServerFactory.findByFqdn(fqdn);
         if (existing.isPresent()) {
             Server server = existing.get();
@@ -2179,6 +2179,7 @@ public class SystemManager extends BaseManager {
 
         ProxyInfo info = new ProxyInfo();
         info.setServer(server);
+        info.setSshPort(port);
         server.setProxyInfo(info);
 
         systemEntitlementManager.setBaseEntitlement(server, EntitlementManager.FOREIGN);
@@ -2190,6 +2191,7 @@ public class SystemManager extends BaseManager {
      *
      * @param user the current user
      * @param proxyName  the FQDN of the proxy
+     * @param proxyPort  the SSH port the proxy listens on
      * @param server the FQDN of the server the proxy uses
      * @param maxCache the maximum memory cache size
      * @param email the email of proxy admin
@@ -2204,7 +2206,7 @@ public class SystemManager extends BaseManager {
      *               Can be omitted if proxyCertKey is not provided
      * @return the configuration file
      */
-    public byte[] createProxyContainerConfig(User user, String proxyName, String server,
+    public byte[] createProxyContainerConfig(User user, String proxyName, Integer proxyPort, String server,
                                              Long maxCache, String email,
                                              String rootCA, List<String> intermediateCAs,
                                              SSLCertPair proxyCertKey,
@@ -2225,7 +2227,7 @@ public class SystemManager extends BaseManager {
         config.put("max_cache_size_mb", maxCache);
         config.put("email", email);
         config.put("server_version", ConfigDefaults.get().getProductVersion());
-        Server proxySystem = getOrCreateProxySystem(user, proxyName);
+        Server proxySystem = getOrCreateProxySystem(user, proxyName, proxyPort);
 
         zipOut.putNextEntry(new ZipEntry("config.yaml"));
         zipOut.write(YamlHelper.INSTANCE.dump(config).getBytes());

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -59,6 +59,7 @@ import com.redhat.rhn.domain.server.Note;
 import com.redhat.rhn.domain.server.ProxyInfo;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerConstants;
+import com.redhat.rhn.domain.server.ServerFQDN;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.ServerGroup;
 import com.redhat.rhn.domain.server.ServerGroupFactory;
@@ -2161,6 +2162,7 @@ public class SystemManager extends BaseManager {
         Server server = ServerFactory.createServer();
         server.setName(fqdn);
         server.setHostname(fqdn);
+        server.getFqdns().add(new ServerFQDN(server, fqdn));
         server.setOrg(creator.getOrg());
         server.setCreator(creator);
 

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -1889,8 +1889,8 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
             will(returnValue(apacheCert));
         }});
 
-        byte[] actual = systemManager.createProxyContainerConfig(user, proxyName, serverName, maxCache, email, rootCA,
-                otherCAs, new SSLCertPair(cert, key), null, null, null);
+        byte[] actual = systemManager.createProxyContainerConfig(user, proxyName, 8022, serverName, maxCache, email,
+                rootCA, otherCAs, new SSLCertPair(cert, key), null, null, null);
         Map<String, String> content = readZipData(actual);
         assertEquals(sshPushKey, content.get("server_ssh_push"));
         assertEquals(sshPushPubKey, content.get("server_ssh_push.pub"));

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -25,6 +25,7 @@ import static java.util.Optional.empty;
 import static java.util.Optional.of;
 
 import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.db.datasource.ModeFactory;
 import com.redhat.rhn.common.db.datasource.WriteMode;
@@ -1904,6 +1905,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         assertEquals(serverName, yaml.get("server"));
         assertEquals(Long.toString(maxCache), yaml.get("max_cache_size_mb"));
         assertEquals(email, yaml.get("email"));
+        assertEquals(ConfigDefaults.get().getProductVersion(), yaml.get("server_version"));
     }
 
     public void testCreateProxyContainerConfigExisting() throws InstantiationException, IOException {

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -1910,8 +1910,18 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         // For some reason duplicating the ORG_ADMIN role setting is required
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         String proxyName = "pxy.mgr.lab";
-        systemManager.createSystemProfile(user, proxyName, Map.of("hostname", proxyName));
+        createTestProxy(proxyName);
         testCreateProxyContainerConfig();
+    }
+
+    private void createTestProxy(String fqdn) {
+        Server proxy = ServerFactoryTest.createUnentitledTestServer(
+                user, true, ServerFactoryTest.TYPE_SERVER_PROXY, new Date());
+        proxy.setName(fqdn);
+        proxy.setHostname(fqdn);
+        proxy.getProxyInfo().setVersion(null);
+
+        systemEntitlementManager.setBaseEntitlement(proxy, EntitlementManager.FOREIGN);
     }
 
     private Map<String, String> readZipData(byte[] data) throws IOException {

--- a/java/code/src/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapper.java
@@ -42,7 +42,6 @@ import com.suse.manager.webui.utils.gson.BootstrapParameters;
 import com.suse.salt.netapi.calls.LocalCall;
 import com.suse.salt.netapi.calls.modules.State;
 import com.suse.salt.netapi.calls.modules.State.ApplyResult;
-import com.suse.salt.netapi.exception.SaltException;
 import com.suse.salt.netapi.results.SSHResult;
 import com.suse.utils.Opt;
 
@@ -214,13 +213,11 @@ public abstract class AbstractMinionBootstrapper {
                     }
             );
         }
-        catch (SaltException e) {
+        catch (Exception e) {
             LOG.error("Exception during bootstrap: " + e.getMessage(), e);
             return new BootstrapResult(false, Optional.empty(),
-                    LOC.getMessage("bootstrap.minion.error.salt", e.getMessage()));
-        }
-        catch (Exception e) {
-            return new BootstrapResult(false, Optional.empty(), e.getMessage());
+                    e.getMessage() != null ? LOC.getMessage("bootstrap.minion.error.salt", e.getMessage()) :
+                            LOC.getMessage("bootstrap.minion.error.salt.unexpected"));
         }
     }
 

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
@@ -114,7 +114,8 @@ public class SaltSSHService {
 
     private static final int SSL_PORT = 443;
 
-    public static final int SSH_PUSH_PORT = 22;
+    public static final int SSH_DEFAULT_PORT = 22;
+    public static final int SSH_PUSH_PORT = SSH_DEFAULT_PORT;
 
     private static final Logger LOG = Logger.getLogger(SaltSSHService.class);
     private static final String CLEANUP_SSH_MINION_SALT_STATE = "cleanup_ssh_minion";
@@ -364,7 +365,8 @@ public class SaltSSHService {
      * directly to the minion
      */
     public static List<String> proxyPathToHostnames(Server proxy) {
-        return proxyPathToHostnames(proxy.getServerPaths(), Optional.of(proxy.getHostname()));
+        String port = Optional.ofNullable(proxy.getProxyInfo().getSshPort()).map(p -> ":" + p).orElse("");
+        return proxyPathToHostnames(proxy.getServerPaths(), Optional.of(proxy.getHostname() + port));
     }
 
     /**
@@ -379,7 +381,11 @@ public class SaltSSHService {
         }
 
         List<ServerPath> proxyPath = sortServerPaths(serverPaths);
-        List<String> hostnamePath = proxyPath.stream().map(ServerPath::getHostname).collect(Collectors.toList());
+        List<String> hostnamePath = proxyPath.stream().map(path -> {
+            String port = Optional.ofNullable(path.getId().getProxyServer().getProxyInfo().getSshPort())
+                    .map(p -> ":" + p.toString()).orElse("");
+            return path.getHostname() + port;
+        }).collect(Collectors.toList());
 
         lastProxy.ifPresent(hostnamePath::add);
 
@@ -416,7 +422,10 @@ public class SaltSSHService {
         StringBuilder proxyCommand = new StringBuilder();
         proxyCommand.append("ProxyCommand='");
         for (int i = 0; i < proxyPath.size(); i++) {
-            String proxyHostname = proxyPath.get(i);
+            String[] proxyHostPort = proxyPath.get(i).split(":");
+            String proxyHostname = proxyHostPort[0];
+            String proxyPort = proxyHostPort.length > 1 ? proxyHostPort[1] : Integer.toString(SSH_DEFAULT_PORT);
+
             String key;
             String stdioFwd = "";
             if (i == 0) {
@@ -430,8 +439,8 @@ public class SaltSSHService {
             }
 
             proxyCommand.append(String.format(
-                    "/usr/bin/ssh -i %s -o StrictHostKeyChecking=no -o User=%s%s %s ",
-                    key, PROXY_SSH_PUSH_USER, stdioFwd, proxyHostname));
+                    "/usr/bin/ssh -p %s -i %s -o StrictHostKeyChecking=no -o User=%s%s %s ",
+                    proxyPort, key, PROXY_SSH_PUSH_USER, stdioFwd, proxyHostname));
         }
         proxyCommand.append("'");
         return Optional.of(Arrays.asList("StrictHostKeyChecking=no", proxyCommand.toString()));
@@ -751,8 +760,7 @@ public class SaltSSHService {
     public static Optional<String> retrieveSSHPushProxyPubKey(long proxyId) {
         Server proxy = ServerFactory.lookupById(proxyId);
         String keyFile = proxy.getHostname() + ".pub";
-        List<String> proxyPath = proxyPathToHostnames(proxy.getServerPaths(),
-                Optional.of(proxy.getHostname()));
+        List<String> proxyPath = proxyPathToHostnames(proxy);
 
         Map<String, String> options = new HashMap<>();
         options.put("StrictHostKeyChecking", "no");

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
@@ -515,7 +515,7 @@ public class SaltSSHService {
                         parameters.getPort().orElse(SSH_PUSH_PORT)),
                     getSshPushTimeout(),
                     minionOpts(parameters.getHost(), contactMethod),
-                    Optional.of(getSaltSSHPreflightScriptPath()),
+                    Optional.ofNullable(getSaltSSHPreflightScriptPath()),
                     Optional.of(Arrays.asList(
                             bootstrapProxyPath.isEmpty() ?
                                     ConfigDefaults.get().getCobblerHost() :

--- a/java/code/webapp/WEB-INF/nav/system_detail.xml
+++ b/java/code/webapp/WEB-INF/nav/system_detail.xml
@@ -14,7 +14,7 @@
     <rhn-tab name="Proxy" url="/rhn/systems/details/ProxyClients.do" acl="system_is_proxy()">
     </rhn-tab>
     <rhn-tab name="Reactivation" url="/rhn/systems/details/Activation.do" acl="system_feature(ftr_agent_smith)"/>
-    <rhn-tab name="Hardware">
+    <rhn-tab name="Hardware" acl="not system_has_foreign_entitlement() or not system_is_proxy()">
       <rhn-tab-url>/rhn/systems/details/SystemHardware.do</rhn-tab-url>
     </rhn-tab>
     <rhn-tab name="Transfer" acl="user_role(org_admin)" url="/rhn/systems/details/SystemMigrate.do" />
@@ -166,7 +166,7 @@
     <rhn-tab name="Join" url="/rhn/systems/details/groups/Add.do"/>
   </rhn-tab>
 
-  <rhn-tab name="Virtualization" acl="system_has_virtualization_entitlement() or system_has_foreign_entitlement()">
+  <rhn-tab name="Virtualization" acl="not system_is_proxy(); system_has_virtualization_entitlement() or system_has_foreign_entitlement()">
     <rhn-tab-url>/rhn/manager/systems/details/virtualization/guests/${sid}</rhn-tab-url>
     <rhn-tab name="Guests" url="/rhn/manager/systems/details/virtualization/guests/${sid}"/>
     <rhn-tab name="Storage" url="/rhn/manager/systems/details/virtualization/storage/${sid}" acl="system_has_salt_entitlement()"/>

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
@@ -8,6 +8,7 @@
 <body>
 <%@ include file="/WEB-INF/pages/common/fragments/systems/system-header.jspf" %>
 
+  <rhn:require acl="not system_is_proxy() or not system_has_foreign_entitlement()">
   <div class="panel panel-default">
     <div class="panel-heading">
       <h4><bean:message key="sdc.details.overview.systemstatus"/></h4>
@@ -63,6 +64,7 @@
       </c:choose>
     </div>
   </div>
+  </rhn:require>
 
   <div class="row-0">
     <div class="col-md-6">
@@ -86,6 +88,7 @@
             </c:choose>
             </td>
           </tr>
+          <rhn:require acl="not system_is_proxy() or not system_has_foreign_entitlement()">
           <tr>
             <td><bean:message key="sdc.details.overview.ipaddy"/></td>
             <td>
@@ -158,6 +161,7 @@
               </c:if>
             </td>
           </tr>
+          </rhn:require>
           <tr>
             <td><bean:message key="sdc.details.overview.sysid"/></td>
             <td><c:out value="${system.id}" /></td>

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
@@ -88,6 +88,21 @@
             </c:choose>
             </td>
           </tr>
+          <rhn:require acl="system_is_proxy()">
+          <tr>
+            <td><bean:message key="sdc.details.overview.sshport"/></td>
+            <td>
+            <c:choose>
+              <c:when test="${system.proxyInfo.sshPort == null}">
+                <c:out value="22" />
+              </c:when>
+              <c:otherwise>
+                <c:out value="${system.proxyInfo.sshPort}" />
+              </c:otherwise>
+            </c:choose>
+            </td>
+          </tr>
+          </rhn:require>
           <rhn:require acl="not system_is_proxy() or not system_has_foreign_entitlement()">
           <tr>
             <td><bean:message key="sdc.details.overview.ipaddy"/></td>

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/proxyclients.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/proxyclients.jsp
@@ -11,6 +11,7 @@
 
     <h2><rhn:icon type="header-proxy" /><bean:message key="sdc.details.proxyclients.header"/></h2>
 
+    <rhn:require acl="not system_has_foreign_entitlement()">
     <c:choose>
       <c:when test="${requestScope.version != null}">
         <p><bean:message key="sdc.details.proxy.licensed" arg0="${requestScope.version}" /></p>
@@ -19,6 +20,7 @@
         <p><bean:message key="sdc.details.proxy.unlicensed" /></p>
       </c:otherwise>
     </c:choose>
+    </rhn:require>
     <rl:listset name="systemListSet" legend="system">
       <c:set var="noAddToSsm" value="1" />
       <%@ include file="/WEB-INF/pages/common/fragments/systems/system_listdisplay.jspf" %>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Hide useless fields for containerized proxies in UI
 - Keep virtualization notifications websocket alive
 - Fix NPE when accessing cancelled action via system history (bsc#1195762)
 - CVE Audit: Show patch as available in the currently installed product even if successor

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Allow using a custom SSH port for proxies
 - Hide useless fields for containerized proxies in UI
 - Keep virtualization notifications websocket alive
 - Fix NPE when accessing cancelled action via system history (bsc#1195762)

--- a/schema/spacewalk/common/tables/rhnProxyInfo.sql
+++ b/schema/spacewalk/common/tables/rhnProxyInfo.sql
@@ -21,7 +21,12 @@ CREATE TABLE rhnProxyInfo
                           REFERENCES rhnServer (id),
     proxy_evr_id  NUMERIC
                       CONSTRAINT rhn_proxy_info_peid_fk
-                          REFERENCES rhnPackageEVR (id)
+                          REFERENCES rhnPackageEVR (id),
+    ssh_port      NUMERIC,
+    created             TIMESTAMPTZ
+                            DEFAULT (current_timestamp) NOT NULL,
+    modified            TIMESTAMPTZ
+                            DEFAULT (current_timestamp) NOT NULL
 )
 
 ;

--- a/schema/spacewalk/postgres/triggers/rhnProxyInfo.sql
+++ b/schema/spacewalk/postgres/triggers/rhnProxyInfo.sql
@@ -18,7 +18,5 @@ BEGIN
 END;
 $$ LANGUAGE PLPGSQL;
 
-DROP TRIGGER IF EXISTS rhn_proxy_info_mod_trig;
-
 CREATE TRIGGER rhn_proxy_info_mod_trig BEFORE INSERT OR UPDATE ON rhnProxyInfo
     FOR EACH ROW EXECUTE PROCEDURE rhn_proxy_info_mod_trig_fun();

--- a/schema/spacewalk/postgres/triggers/rhnProxyInfo.sql
+++ b/schema/spacewalk/postgres/triggers/rhnProxyInfo.sql
@@ -1,0 +1,24 @@
+--
+-- Copyright (c) 2022 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- triggers for suseImageInfo
+
+CREATE OR REPLACE FUNCTION rhn_proxy_info_mod_trig_fun() RETURNS TRIGGER AS
+$$
+BEGIN
+    new.modified := current_timestamp;
+    return new;
+END;
+$$ LANGUAGE PLPGSQL;
+
+DROP TRIGGER IF EXISTS rhn_proxy_info_mod_trig;
+
+CREATE TRIGGER rhn_proxy_info_mod_trig BEFORE INSERT OR UPDATE ON rhnProxyInfo
+    FOR EACH ROW EXECUTE PROCEDURE rhn_proxy_info_mod_trig_fun();

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,5 @@
+- Store proxy SSH port in database
+
 -------------------------------------------------------------------
 Fri Mar 11 15:42:02 CET 2022 - jgonzalez@suse.com
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.9-to-susemanager-schema-4.3.10/001-rhnProxyInfo-port.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.9-to-susemanager-schema-4.3.10/001-rhnProxyInfo-port.sql
@@ -1,0 +1,18 @@
+ALTER TABLE rhnProxyInfo
+    ADD COLUMN IF NOT EXISTS ssh_port NUMERIC,
+    ADD COLUMN IF NOT EXISTS created  TIMESTAMPTZ DEFAULT (current_timestamp) NOT NULL,
+    ADD COLUMN IF NOT EXISTS modified TIMESTAMPTZ DEFAULT (current_timestamp) NOT NULL;
+
+
+CREATE OR REPLACE FUNCTION rhn_proxy_info_mod_trig_fun() RETURNS TRIGGER AS
+$$
+BEGIN
+    new.modified := current_timestamp;
+    return new;
+END;
+$$ LANGUAGE PLPGSQL;
+
+DROP TRIGGER IF EXISTS rhn_proxy_info_mod_trig ON rhnProxyInfo;
+
+CREATE TRIGGER rhn_proxy_info_mod_trig BEFORE INSERT OR UPDATE ON rhnProxyInfo
+    FOR EACH ROW EXECUTE PROCEDURE rhn_proxy_info_mod_trig_fun();

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,5 @@
+- Add parameter to set containerized proxy SSH port
+
 -------------------------------------------------------------------
 Fri Mar 11 16:47:59 CET 2022 - jgonzalez@suse.com
 

--- a/spacecmd/src/spacecmd/proxy.py
+++ b/spacecmd/src/spacecmd/proxy.py
@@ -61,7 +61,7 @@ def do_proxy_container_config(self, args):
     args, options = parse_command_arguments(args, arg_parser)
 
     if len(args) != 7:
-        self.help_container_config()
+        self.help_proxy_container_config()
         return
 
     (proxy_fqdn, server_fqdn, max_cache, email, root_ca, certificate, key) = args
@@ -123,7 +123,7 @@ def do_proxy_container_config_generate_cert(self, args):
     args, options = parse_command_arguments(args, arg_parser)
 
     if len(args) != 7:
-        self.help_container_config()
+        self.help_proxy_container_config_generate_cert()
         return
 
     (proxy_fqdn, server_fqdn, max_cache, email, ca_cert, ca_key, ca_password) = args

--- a/spacecmd/src/spacecmd/proxy.py
+++ b/spacecmd/src/spacecmd/proxy.py
@@ -17,6 +17,7 @@
 #
 # Copyright (c) 2022 SUSE LLC
 
+import getpass
 import gettext
 import logging
 from spacecmd.utils import *
@@ -62,7 +63,7 @@ def do_proxy_container_config(self, args):
 
     args, options = parse_command_arguments(args, arg_parser)
 
-    if len(args) != 7:
+    if len(args) != 4:
         self.help_proxy_container_config()
         return
 
@@ -85,20 +86,22 @@ def do_proxy_container_config(self, args):
 
 def help_proxy_container_config_generate_cert(self):
     print(_('proxy_container_config_generate_cert: create a proxy system and return its configuration file'))
-    print(_('''usage: proxy_container_config_generate_cert PROXY_FQDN SERVER_FQDN MAX_CACHE EMAIL CA_CRT CA_KEY CA_PASSWORD
+    print(_('''usage: proxy_container_config_generate_cert PROXY_FQDN SERVER_FQDN MAX_CACHE EMAIL
 
 parameters:
   PROXY_FQDN  the fully qualified domain name of the proxy to create.
   SERVER_FQDN the fully qualified domain name of the server to connect to proxy to.
   MAX_CACHE   the maximum cache size in MB. 60% of the storage is a good value.
   EMAIL       the email of the proxy administrator
-  CA_CRT path to the certificate of the CA to use to generate a new proxy certificate
-  CA_KEY path to the private key of the CA to use to generate a new proxy certificate
-  CA_PASSWORD path to a file containing the password of the CA private key
 
 options:
   -o, --output Path where to create the generated configuration. Default: 'config.zip'
   -p, --ssh-port SSH port the proxy listens one. Default: 22
+  --ca-crt path to the certificate of the CA to use to generate a new proxy certificate.
+           Using /root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT by default.
+  --ca-key path to the private key of the CA to use to generate a new proxy certificate.
+           Using /root/ssl-build/RHN-ORG-PRIVATE-SSL-KEY by default.
+  --ca-pass path to a file containing the password of the CA private key, will be prompted if not passed.
   --ssl-cname alternate name of the proxy to set in the certificate. Can be provided multiple times
   --ssl-country country code to set in the certificate. If omitted, default values from mgr-ssl-tool will be used.
   --ssl-state state name to set in the certificate. If omitted, default values from mgr-ssl-tool will be used.
@@ -108,7 +111,7 @@ options:
   --ssl-email the email to set in the certificate. If omitted, default values from mgr-ssl-tool will be used.
 
 examples:
-  proxy_container_config proxy.lab server.lab 1024 proxy@acme.org ssl-build/RHN-ORG-TRUSTED-SSL-CERT ssl-build/RHN-ORG-PRIVATE-SSL-KEY ca-password.txt
+  proxy_container_config proxy.lab server.lab 1024 proxy@acme.org --ca-pass password-file
 '''))
 
 
@@ -116,6 +119,9 @@ def do_proxy_container_config_generate_cert(self, args):
     arg_parser = get_argument_parser()
     arg_parser.add_argument('-o', '--output', default='config.zip')
     arg_parser.add_argument('-p', '--ssh-port', type=int, default=22)
+    arg_parser.add_argument('--ca-cert', default='/root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT')
+    arg_parser.add_argument('--ca-key', default='/root/ssl-build/RHN-ORG-PRIVATE-SSL-KEY')
+    arg_parser.add_argument('--ca-pass')
     arg_parser.add_argument('--ssl-cname', action='append', default=[])
     arg_parser.add_argument('--ssl-country', default='')
     arg_parser.add_argument('--ssl-state', default='')
@@ -126,15 +132,18 @@ def do_proxy_container_config_generate_cert(self, args):
 
     args, options = parse_command_arguments(args, arg_parser)
 
-    if len(args) != 7:
+    if len(args) != 4:
         self.help_proxy_container_config_generate_cert()
         return
 
-    (proxy_fqdn, server_fqdn, max_cache, email, ca_cert, ca_key, ca_password) = args
+    (proxy_fqdn, server_fqdn, max_cache, email) = args
 
-    ca_cert = read_file(ca_cert)
-    ca_key = read_file(ca_key)
-    ca_password = read_file(ca_password)
+    ca_cert = read_file(options.ca_cert)
+    ca_key = read_file(options.ca_key)
+    if options.ca_pass:
+        ca_password = read_file(options.ca_pass)
+    else:
+        ca_password = getpass.getpass("SSL CA private key password: ")
 
     config = self.client.proxy.container_config(self.session, proxy_fqdn, options.ssh_port,
             server_fqdn, int(max_cache), email,

--- a/spacecmd/src/spacecmd/proxy.py
+++ b/spacecmd/src/spacecmd/proxy.py
@@ -42,6 +42,7 @@ parameters:
 
 options:
   -o, --output Path where to create the generated configuration. Default: 'config.zip'
+  -p, --ssh-port SSH port the proxy listens one. Default: 22
   -i, --intermediate-ca  Path to an intermediate CA used to sign the proxy
             certicate in PEM format. May be provided multiple times.
 
@@ -57,6 +58,7 @@ def do_proxy_container_config(self, args):
     arg_parser.add_argument('-c', '--certificate', default='')
     arg_parser.add_argument('-k', '--key', default='')
     arg_parser.add_argument('-o', '--output', default='config.zip')
+    arg_parser.add_argument('-p', '--ssh-port', type=int, default=22)
 
     args, options = parse_command_arguments(args, arg_parser)
 
@@ -72,7 +74,7 @@ def do_proxy_container_config(self, args):
     key = read_file(key)
 
     config = self.client.proxy.container_config(self.session,
-            proxy_fqdn, server_fqdn, int(max_cache), email,
+            proxy_fqdn, options.ssh_port, server_fqdn, int(max_cache), email,
             root_ca, intermediate_cas, cert, key,
     )
 
@@ -96,6 +98,7 @@ parameters:
 
 options:
   -o, --output Path where to create the generated configuration. Default: 'config.zip'
+  -p, --ssh-port SSH port the proxy listens one. Default: 22
   --ssl-cname alternate name of the proxy to set in the certificate. Can be provided multiple times
   --ssl-country country code to set in the certificate. If omitted, default values from mgr-ssl-tool will be used.
   --ssl-state state name to set in the certificate. If omitted, default values from mgr-ssl-tool will be used.
@@ -112,6 +115,7 @@ examples:
 def do_proxy_container_config_generate_cert(self, args):
     arg_parser = get_argument_parser()
     arg_parser.add_argument('-o', '--output', default='config.zip')
+    arg_parser.add_argument('-p', '--ssh-port', type=int, default=22)
     arg_parser.add_argument('--ssl-cname', action='append', default=[])
     arg_parser.add_argument('--ssl-country', default='')
     arg_parser.add_argument('--ssl-state', default='')
@@ -132,7 +136,8 @@ def do_proxy_container_config_generate_cert(self, args):
     ca_key = read_file(ca_key)
     ca_password = read_file(ca_password)
 
-    config = self.client.proxy.container_config(self.session, proxy_fqdn, server_fqdn, int(max_cache), email,
+    config = self.client.proxy.container_config(self.session, proxy_fqdn, options.ssh_port,
+            server_fqdn, int(max_cache), email,
             ca_cert, ca_key, ca_password, options.ssl_cname, options.ssl_country, options.ssl_state,
             options.ssl_city, options.ssl_org, options.ssl_org_unit, options.ssl_email)
 

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,5 @@
+- Add randomness to first generated server serial
+
 -------------------------------------------------------------------
 Tue Mar 15 16:30:36 CET 2022 - jgonzalez@suse.com
 

--- a/spacewalk/certs-tools/sslToolConfig.py
+++ b/spacewalk/certs-tools/sslToolConfig.py
@@ -24,6 +24,7 @@ import os
 import sys
 import copy
 import time
+import random
 import socket
 
 ## local imports
@@ -496,8 +497,9 @@ def figureSerial(caCertFilename, serialFilename, indexFilename):
     # REMEMBER: openssl will incremented the serial number each time
     # as well.
     if serial <= caSerial:
-        serial = incSerial(hex(caSerial))
-        serial = eval('0x' + serial)
+        random.seed()
+        max_serial = eval("0x" + "F" * 40)
+        serial = random.randrange(1, max_serial - caSerial / 2)
     serial = fixSerial(hex(serial))
 
     # create the serial file if it doesn't exist

--- a/susemanager-utils/susemanager-sls/modules/runners/mgrutil.py
+++ b/susemanager-utils/susemanager-sls/modules/runners/mgrutil.py
@@ -70,10 +70,11 @@ def chain_ssh_cmd(hosts=None, clientkey=None, proxykey=None, user="root", option
     '''
     cmd = []
     for idx, hostname in enumerate(hosts):
+        host_port = hostname.split(":")
         key = clientkey if idx == 0 else proxykey
         opts = " ".join(["-o {}={}".format(opt, val) for opt, val in list(options.items())])
-        ssh = "/usr/bin/ssh -i {} {} -o User={} {}"\
-            .format(key, opts, user, hostname)
+        ssh = "/usr/bin/ssh -p {} -i {} {} -o User={} {}"\
+            .format(host_port[1] if len(host_port) > 1 else 22, key, opts, user, host_port[0])
         cmd.extend(shlex.split(ssh))
     cmd.append(command)
     ret = _cmd(cmd)

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Accept non standard proxy SSH port
+
 -------------------------------------------------------------------
 Fri Mar 11 16:49:07 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Using the bootstrap entitlement for the fake containerized proxy system could lead to issues since this could have been overwritten. This PR switches to the `Foreign` entitlement as suggested by @mcalmer during the review.

The current implementation requires the use of port 22 for the SSH connection on proxies. This PR changes it to allow custom SSH port on containerized proxies and defaults to 8022. Spreading this setting to regular proxies could be implemented in a subsequent PR.

## GUI diff

After:

![After](https://user-images.githubusercontent.com/397931/159234967-de503762-09d7-4a19-b57c-93b002e3547a.png)

- [X] **DONE**

## Documentation
- No documentation needed: All the containerized proxy documentation will be submitted once the feature is almost complete since it would be subject to heavy changes.
- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17254 and https://github.com/SUSE/spacewalk/issues/17303

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
