### PR TITLE
Fix schema idempotent issue

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- fix check on allowVendorChange
 - Store proxy SSH port in database
 
 -------------------------------------------------------------------

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.2-to-susemanager-schema-4.2.3/001-rhnActionDup-add-alllow-vendor-change.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.2-to-susemanager-schema-4.2.3/001-rhnActionDup-add-alllow-vendor-change.sql
@@ -1,6 +1,4 @@
 ALTER TABLE rhnActionDup DROP CONSTRAINT IF EXISTS rhn_actiondup_avc_ck;
 ALTER TABLE rhnActionDup
-  ADD COLUMN IF NOT EXISTS allow_vendor_change CHAR(1)
-  DEFAULT ('N') NOT NULL
-  CONSTRAINT rhn_actiondup_avc_ck
-  CHECK (allow_vendor_change in ('Y','N'));
+  ADD COLUMN IF NOT EXISTS allow_vendor_change CHAR(1) DEFAULT ('N') NOT NULL;
+ALTER TABLE rhnActionDup ADD CONSTRAINT rhn_actiondup_avc_ck CHECK (allow_vendor_change in ('Y', 'N'));

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.9-to-susemanager-schema-4.3.10/010-alllow-vendor-change-constrains.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.9-to-susemanager-schema-4.3.10/010-alllow-vendor-change-constrains.sql
@@ -1,0 +1,3 @@
+-- take care that the check exists. We might have lost it in the past
+ALTER TABLE rhnActionDup DROP CONSTRAINT IF EXISTS rhn_actiondup_avc_ck;
+ALTER TABLE rhnActionDup ADD CONSTRAINT rhn_actiondup_avc_ck CHECK (allow_vendor_change in ('Y', 'N'));


### PR DESCRIPTION
## What does this PR change?

fix check on allowVendorChange after schema update was called multiple times.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/17347

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
