### PR TITLE
Add `data-testid` support to the Select component

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -172,8 +172,8 @@ When(/^I check "([^"]*)" if not checked$/) do |arg1|
 end
 
 When(/^I select "([^"]*)" from "([^"]*)"$/) do |option, field|
-  xpath_option = ".//*[contains(@class, 'class-#{field}__option') and contains(text(),'#{option}')]"
-  xpath_field = "//*[contains(@class, 'class-#{field}__control')]/../*[@name='#{field}']/.."
+  xpath_option = ".//*[contains(@class, 'data-testid-#{field}-child__option') and contains(text(),'#{option}')]"
+  xpath_field = "//*[contains(@class, 'data-testid-#{field}-child__control')]/../*[@name='#{field}']/.."
   if has_select?(field, with_options: [option], wait: 1)
     select(option, from: field)
   else
@@ -905,7 +905,7 @@ Then(/^option "([^"]*)" is selected as "([^"]*)"$/) do |option, field|
   next if has_select?(field, selected: option)
 
   # Custom React selector
-  next if has_xpath?("//*[contains(@class, 'class-#{field}__value-container')]/*[contains(text(),'#{option}')]")
+  next if has_xpath?("//*[contains(@class, 'data-testid-#{field}-child__value-container')]/*[contains(text(),'#{option}')]")
 
   raise "#{option} is not selected as #{field}"
 end
@@ -918,7 +918,7 @@ When(/^I wait until option "([^"]*)" appears in list "([^"]*)"$/) do |option, fi
     break if has_select?(field, with_options: [option])
 
     # Custom React selector
-    break if has_xpath?("//*[contains(@class, 'class-#{field}__value-container')]/*[contains(text(),'#{option}')]")
+    break if has_xpath?("//*[contains(@class, 'data-testid-#{field}-child__value-container')]/*[contains(text(),'#{option}')]")
   end
 end
 

--- a/web/html/src/components/combobox.tsx
+++ b/web/html/src/components/combobox.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 
 import Creatable from "react-select/creatable";
 
+import withTestAttributes from "./input/select-test-attributes";
+
 type ReactSelectItem = {
   value: string | null | undefined;
   id: any | null | undefined;
@@ -20,6 +22,9 @@ type ComboboxProps = {
   selectedId?: (number | null | undefined) | (string | null | undefined);
   onFocus?: () => void;
   onSelect: (value: ComboboxItem) => void;
+
+  /** Id for testing purposes */
+  "data-testid"?: string;
 };
 
 type ComboboxState = {
@@ -75,6 +80,7 @@ export class Combobox extends React.Component<ComboboxProps, ComboboxState> {
       label: item.text,
     }));
 
+    const testAttributes = withTestAttributes(this.props["data-testid"], this.props.name);
     return (
       <Creatable
         id={this.props.id}
@@ -85,7 +91,7 @@ export class Combobox extends React.Component<ComboboxProps, ComboboxState> {
         options={options}
         styles={colourStyles}
         menuPortalTarget={document.body}
-        classNamePrefix={`class-${this.props.name}`}
+        {...testAttributes}
       />
     );
   }

--- a/web/html/src/components/input/Select.tsx
+++ b/web/html/src/components/input/Select.tsx
@@ -7,6 +7,7 @@ import { AsyncPaginate as AsyncPaginateSelect } from "react-select-async-paginat
 
 import { FormContext } from "./Form";
 import { InputBase, InputBaseProps } from "./InputBase";
+import withTestAttributes from "./select-test-attributes";
 
 type SingleMode = InputBaseProps<string> & {
   /** Set to true to allow multiple selected values */
@@ -48,6 +49,9 @@ type CommonSelectProps = (SingleMode | MultiMode) & {
 
   /** name of the field to map in the form model */
   name?: string;
+
+  /** Id for testing purposes */
+  "data-testid"?: string;
 };
 
 type SelectProps = CommonSelectProps & {
@@ -144,7 +148,12 @@ export function Select(props: Props) {
       return;
     }
     const value = (formContext.model || {})[props.name || ""];
-    if (isAsync(props) && typeof defaultValueOption !== "undefined" && getOptionValue(defaultValueOption) !== value) {
+    if (
+      props.name &&
+      isAsync(props) &&
+      typeof defaultValueOption !== "undefined" &&
+      getOptionValue(defaultValueOption) !== value
+    ) {
       Loggerhead.error(
         `Mismatched defaultValueOption for async select for form field "${props.name}": expected ${getOptionValue(
           defaultValueOption
@@ -166,26 +175,28 @@ export function Select(props: Props) {
         const value = (formContext.model || {})[props.name || ""];
 
         // Common props to pass to both 'react-select' and 'react-select/async'
-        const commonProps = {
-          className: inputClass ? ` ${inputClass}` : "",
-          name: props.name,
-          inputId: props.name,
-          isDisabled: props.disabled,
-          onBlur: onBlur,
-          onChange: onChange,
-          getOptionLabel: (option) => (option != null ? getOptionLabel(option) : ""),
-          getOptionValue: (option) => (option != null ? getOptionValue(option) : ""),
-          formatOptionLabel: formatOptionLabel,
-          placeholder: placeholder,
-          isLoading: isLoading,
-          noOptionsMessage: () => emptyText,
-          isClearable: isClearable,
-          styles: bootstrapStyles,
-          isMulti: props.isMulti,
-          // TODO: Create a separate div in body so we don't invalidate the layout every time, see https://github.com/SUSE/spacewalk/issues/17076
-          menuPortalTarget: document.body,
-          classNamePrefix: `class-${props.name}`,
-        };
+        const commonProps = Object.assign(
+          {
+            className: inputClass ? ` ${inputClass}` : "",
+            name: props.name,
+            inputId: props.name,
+            isDisabled: props.disabled,
+            onBlur: onBlur,
+            onChange: onChange,
+            getOptionLabel: (option) => (option != null ? getOptionLabel(option) : ""),
+            getOptionValue: (option) => (option != null ? getOptionValue(option) : ""),
+            formatOptionLabel: formatOptionLabel,
+            placeholder: placeholder,
+            isLoading: isLoading,
+            noOptionsMessage: () => emptyText,
+            isClearable: isClearable,
+            styles: bootstrapStyles,
+            isMulti: props.isMulti,
+            // TODO: Create a separate div in body so we don't invalidate the layout every time, see https://github.com/SUSE/spacewalk/issues/17076
+            menuPortalTarget: document.body,
+          },
+          withTestAttributes(props["data-testid"], props.name)
+        );
 
         if (isAsync(props)) {
           if (props.paginate) {

--- a/web/html/src/components/input/select-test-attributes.tsx
+++ b/web/html/src/components/input/select-test-attributes.tsx
@@ -1,0 +1,31 @@
+import { components as WrapperComponents } from "react-select";
+
+const TestIdContainer = function ({ children, ...props }) {
+  const innerProps = Object.assign(
+    {
+      "data-testid": props.selectProps["data-testid"],
+    },
+    props.innerProps
+  );
+  return (
+    <WrapperComponents.SelectContainer {...props} innerProps={innerProps}>
+      {children}
+    </WrapperComponents.SelectContainer>
+  );
+};
+
+export default function withTestAttributes(testId: string | undefined, fallbackName: string | undefined) {
+  // The name-based fallback is used to keep compatibility with existing forms that use the `name` prop for binding to tests
+  const testClassName = testId || fallbackName || undefined;
+  const classNamePrefix = testClassName ? `data-testid-${testClassName}-child` : undefined;
+
+  return {
+    classNamePrefix,
+    components: testId
+      ? {
+          SelectContainer: TestIdContainer,
+        }
+      : undefined,
+    "data-testid": testId,
+  };
+}

--- a/web/html/src/manager/content-management/shared/components/panels/sources/channels/channels-selection.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/channels/channels-selection.tsx
@@ -156,9 +156,13 @@ const ChannelsSelection = (props: PropsType) => {
     );
   }
 
-  const defaultValueOption = props.initialSelectedSources[0]
+  const initialSource = props.initialSelectedSources[0];
+  const defaultValueOption = initialSource
     ? {
-        base: props.initialSelectedSources[0],
+        base: {
+          id: initialSource.channelId,
+          name: initialSource.name,
+        },
       }
     : undefined;
 
@@ -166,6 +170,7 @@ const ChannelsSelection = (props: PropsType) => {
     <React.Fragment>
       <div className="row">
         <Select
+          data-testid="selectedBaseChannel"
           loadOptions={loadSelectOptions}
           defaultValueOption={defaultValueOption}
           paginate={true}

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Improved test integration for dropdowns
+
 -------------------------------------------------------------------
 Tue Apr 19 12:10:52 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Add `data-testid` support to the shared Select component. This will allow us to easily fetch and set the value in Cucumber tests.  

I haven't updated any of the related test code since I'm not sure which parts need to be addressed, hence the WIP in the title. Perhaps @srbarrios or @ktsamis can give me a hand with this?  

Other than that, feel free to review.  

In general, does this approach work for you?

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
