### PR TITLE
Hide private methods in XMLRPC handlers

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/BaseHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/BaseHandler.java
@@ -43,7 +43,9 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -84,16 +86,10 @@ public class BaseHandler implements XmlRpcInvocationHandler {
      */
     @Override
     public Object invoke(String methodCalled, List params) throws XmlRpcFault {
-        Class myClass = this.getClass();
-        Method[] methods;
-        try {
-            methods = myClass.getMethods();
-        }
-        catch (SecurityException e) {
-            // This should _never_ happen, because the Handler classes must
-            // have public classes if they're expected to work.
-            throw new XmlRpcFault(-1, "no public methods in class " + myClass);
-        }
+        Class<? extends BaseHandler> myClass = this.getClass();
+        Method[] methods = Arrays.stream(myClass.getDeclaredMethods())
+                .filter(m -> Modifier.isPublic(m.getModifiers()))
+                .toArray(Method[]::new);
 
         String[] byNamespace = methodCalled.split("\\.");
         String beanifiedMethod = StringUtil.beanify(byNamespace[byNamespace.length - 1]);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Hide private methods in XMLRPC handlers
 - update last checkin only if job is successful (bsc#1197007)
 - Fixed broken help link for system overview
 - send notifications for new or changed ubuntu errata (bsc#1196977)


### PR DESCRIPTION
Prevent inherited and private methods in handlers to be exposed with the XMLRPC API.

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
