### PR TITLE
HW refresh stuck

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -763,13 +763,13 @@ public class SaltService implements SystemQuery, SaltApi {
         try {
             LocalCall<Boolean> call = SaltUtil.refreshPillar(Optional.empty(),
                     Optional.empty());
-            callSync(call, minionList);
+            callAsync(call, minionList);
 
             // Salt pillar refresh doesn't reload the modules with the new pillar
             LocalCall<Boolean> modulesRefreshCall = new LocalCall<>("saltutil.refresh_modules",
                     Optional.empty(), Optional.empty(), new TypeToken<>() {
             });
-            callSync(modulesRefreshCall, minionList);
+            callAsync(modulesRefreshCall, minionList);
         }
         catch (SaltException e) {
             throw new RhnRuntimeException(e);

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -763,13 +763,13 @@ public class SaltService implements SystemQuery, SaltApi {
         try {
             LocalCall<Boolean> call = SaltUtil.refreshPillar(Optional.empty(),
                     Optional.empty());
-            callAsync(call, minionList);
+            callSync(call, minionList);
 
             // Salt pillar refresh doesn't reload the modules with the new pillar
             LocalCall<Boolean> modulesRefreshCall = new LocalCall<>("saltutil.refresh_modules",
                     Optional.empty(), Optional.empty(), new TypeToken<>() {
             });
-            callAsync(modulesRefreshCall, minionList);
+            callSync(modulesRefreshCall, minionList);
         }
         catch (SaltException e) {
             throw new RhnRuntimeException(e);

--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/HwProfileUpdateSlsResult.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/HwProfileUpdateSlsResult.java
@@ -21,6 +21,8 @@ import com.suse.salt.netapi.results.StateApplyResult;
 
 import com.google.gson.annotations.SerializedName;
 
+import org.apache.log4j.Logger;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +33,8 @@ import java.util.Optional;
  * Object representation of the results of a call to state.apply hardware.profileupdate.
  */
 public class HwProfileUpdateSlsResult {
+
+    private static final Logger LOG = Logger.getLogger(HwProfileUpdateSlsResult.class);
 
     @SerializedName("mgrcompat_|-grains_|-grains.items_|-module_run")
     private StateApplyResult<Ret<Map<String, Object>>> grains;
@@ -78,6 +82,10 @@ public class HwProfileUpdateSlsResult {
      * @return the grains
      */
     public Map<String, Object> getGrains() {
+        if (grains == null) {
+            LOG.warn("grains value is null");
+            return Collections.emptyMap();
+        }
         return grains.getChanges().getRet();
     }
 
@@ -85,6 +93,10 @@ public class HwProfileUpdateSlsResult {
      * @return information about CPUs
      */
     public Map<String, Object> getCpuInfo() {
+        if (cpuInfo == null) {
+            LOG.warn("cpuInfo value is null");
+            return Collections.emptyMap();
+        }
         return cpuInfo.getChanges().getRet();
     }
 
@@ -92,6 +104,10 @@ public class HwProfileUpdateSlsResult {
      * @return exported contents of the udevdb
      */
     public List<Map<String, Object>> getUdevdb() {
+        if (udevdb == null) {
+            LOG.warn("udevdb value is null");
+            return Collections.emptyList();
+        }
         return udevdb.getChanges().getRet();
     }
 
@@ -99,6 +115,10 @@ public class HwProfileUpdateSlsResult {
      * @return network interfaces
      */
     public Map<String, Network.Interface> getNetworkInterfaces() {
+        if (networkInterfaces == null) {
+            LOG.warn("networkInterfaces value is null");
+            return Collections.emptyMap();
+        }
         return networkInterfaces.getChanges().getRet();
     }
 
@@ -106,6 +126,10 @@ public class HwProfileUpdateSlsResult {
      * @return network IPs
      */
     public Map<SumaUtil.IPVersion, SumaUtil.IPRoute> getNetworkIPs() {
+        if (networkIPs == null) {
+            LOG.warn("networkIPs value is null");
+            return Collections.emptyMap();
+        }
         return networkIPs.getChanges().getRet();
     }
 
@@ -113,6 +137,10 @@ public class HwProfileUpdateSlsResult {
      * @return network modules
      */
     public Map<String, Optional<String>> getNetworkModules() {
+        if (networkModules == null) {
+            LOG.warn("networkModules value is null");
+            return Collections.emptyMap();
+        }
         return networkModules.getChanges().getRet();
     }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,4 +1,3 @@
-- refresh pillar make a sync call
 - warning log when hardware refresh result is not serializable
 - Hide private methods in XMLRPC handlers
 - update last checkin only if job is successful (bsc#1197007)

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- warning log when hardware refresh result is not serializable
 - update last checkin only if job is successful (bsc#1197007)
 - Fixed broken help link for system overview
 - send notifications for new or changed ubuntu errata (bsc#1196977)

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- refresh pillar make a sync call
 - warning log when hardware refresh result is not serializable
 - update last checkin only if job is successful (bsc#1197007)
 - Fixed broken help link for system overview


### PR DESCRIPTION
## What does this PR change?
- Due to some issue on salt-api, the result of the action `hardware refresh` is not a serializable by `HwProfileUpdateSlsResult`: in this case the action remain stuck. Although the issue is in salt-api, we should log a warning to show when this raise condition happens. 
- Not sure if it's related to the HW refresh issue, but we noticed that the bootstrapping of a salt-ssh minion generates some async calls ( `addEntitlementToServer -> updatePillarAfterGroupUpdateForServers -> refreshPillar` ). Change the call made by refreshPillar sync

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- [x] **DONE**

## Test coverage

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17290

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
