### PR TITLE
Handle salt bundle in set_proxy.sls

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/set_proxy.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/set_proxy.sls
@@ -1,4 +1,12 @@
 {%- set conf_file = '/etc/salt/minion.d/susemanager.conf' %}
+{%- set salt_service = 'salt-minion' %}
+
+{# Prefer venv-salt-minion if installed #}
+{%- if salt['pkg.version']('venv-salt-minion') %}
+{%- set conf_file = '/etc/venv-salt-minion/minion.d/susemanager.conf' %}
+{%- set salt_service = 'venv-salt-minion' %}
+{%- endif -%}
+
 {%- set pattern = '^master:.*' %}
 
 {% if salt['file.search'](conf_file, pattern) -%}
@@ -12,7 +20,7 @@
 restart:
   mgrcompat.module_run:
     - name: cmd.run_bg
-    - cmd: "sleep 2; service salt-minion restart"
+    - cmd: "sleep 2; service {{ salt_service }} restart"
     - python_shell: true
 
 {% else -%}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Handle salt bundle in set_proxy.sls
 - Accept non standard proxy SSH port
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

This fixes set_proxy.sls to use correct config file and service name on minions with salt bundle.

## GUI diff

No difference.

## Documentation
- No documentation needed: bugfix

## Test coverage

TBD
- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests" (Test skipped, there are no changes to test)
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
