### PR TITLE
When measuring time taken, do not count ssh

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -21,11 +21,12 @@ end
 
 Then(/^reverse resolution should work for "([^"]*)"$/) do |host|
   node = get_target(host)
-  initial_time = Time.now
-  result, return_code = node.run("getent hosts #{node.full_hostname}", check_errors: false)
-  end_time = Time.now
-  resolution_time = end_time - initial_time
-  result.delete!("\n")
+  result, return_code = node.run("date +%s; getent hosts #{node.full_hostname}; date +%s", check_errors: false)
+  lines = result.split("\n")
+  initial_time = lines[0]
+  result = lines[1]
+  end_time = lines[2]
+  resolution_time = end_time.to_i - initial_time.to_i
   raise 'cannot do reverse resolution' unless return_code.zero?
   raise "reverse resolution for #{node.full_hostname} took too long (#{resolution_time} seconds)" unless resolution_time <= 2
   raise "reverse resolution for #{node.full_hostname} returned #{result}, expected to see #{node.full_hostname}" unless result.include? node.full_hostname


### PR DESCRIPTION
## What does this PR change?

In the Build Validation test suite, the controller is in the USA and the ARM minion is in Orthos network in Nuremberg. They are connected through a tunnel.

This adds a significant time to the reverse DNS resolution test, which should not be taken into account in the sanity checks.


## Changelogs

- [x] No changelog needed
