### PR TITLE
Configure tftp container

### DIFF
--- a/containers/proxy-httpd-image/Dockerfile
+++ b/containers/proxy-httpd-image/Dockerfile
@@ -39,7 +39,8 @@ RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-li
 RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-licenses \
  python3-rhnlib spacewalk-proxy-broker \
  spacewalk-proxy-common spacewalk-proxy-package-manager \
- spacewalk-proxy-redirect spacewalk-ssl-cert-check spacewalk-proxy-html
+ spacewalk-proxy-redirect spacewalk-ssl-cert-check spacewalk-proxy-html \
+ susemanager-tftpsync-recv
 
 RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-licenses python3-PyYAML
 

--- a/containers/proxy-httpd-image/proxy-httpd-image.changes
+++ b/containers/proxy-httpd-image/proxy-httpd-image.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar 28 09:33:31 UTC 2022 - Ondrej Holecek <oholecek@suse.com>
+
+- Add susemanager-tftpsync-recv package and its configuration to
+  allow cobbler tftpsync functionality
+
+-------------------------------------------------------------------
 Fri Mar 18 09:17:29 UTC 2022 - Cédric Bosdonnat <cbosdonnat@suse.com>
 
 - Add spacewalk-proxy-html package

--- a/containers/proxy-httpd-image/uyuni-configure.py
+++ b/containers/proxy-httpd-image/uyuni-configure.py
@@ -5,9 +5,37 @@ import subprocess
 import re
 import shutil
 import yaml
+import socket
 import sys
 
 config_path = "/etc/uyuni/"
+
+def getIPs(fqdn: str) -> [str, str]:
+    addrinfo = socket.getaddrinfo(fqdn, None)
+    ipv4s = set(map(lambda r: r[4][0], filter(lambda f: f[0] == socket.AF_INET, addrinfo)))
+    ipv6s = set(map(lambda r: r[4][0], filter(lambda f: f[0] == socket.AF_INET6, addrinfo)))
+    ipv4, ipv6 = "", ""
+
+    if len(ipv4s) == 0 and len(ipv6s) == 0:
+       print("FATAL: Cannot determine proxy IPv4 nor IPv6 from FQDN {}".format(fqdn))
+       sys.exit(1)
+
+    try:
+       ipv4 = ipv4s.pop()
+       if len(ipv4s) > 0:
+          print("WARNING: Cannot determine unique IPv4 address for the proxy. TFTP sync may not work. Using IPv4 {}".format(ipv4))
+    except KeyError:
+       print("WARNING: No IPv4 address detected for proxy. If this is single stack IPv6 setup this warning can be ignored")
+
+    try:
+       ipv6 = ipv6s.pop()
+       if len(ipv6s) > 0:
+          print("Multiple IPv6 addresses resolved, using IPv6 {}".format(ipv6))
+    except KeyError:
+       print("WARNING: No IPv6 address detected for proxy. If this is single stack IPv4 setup this warning can be ignored")
+
+    print(f"DEBUG: detected ips '{ipv4}', '{ipv6}' for fqdn {fqdn}")
+    return (ipv4, ipv6)
 
 # read from file
 with open(config_path + "config.yaml") as source:
@@ -47,9 +75,13 @@ with open(config_path + "config.yaml") as source:
         file.write(file_content)
         file.truncate()
 
+    # resolve needed IP addresses
+    serverIPv4, serverIPv6 = getIPs(config['server'])
+    proxyIPv4, proxyIPv6 = getIPs(config['proxy_fqdn'])
+
     # Create conf file
     with open("/etc/rhn/rhn.conf", "w") as file:
-        file.write(f'''# Automatically generated Spacewalk Proxy Server configuration file.
+        file.write(f'''# Automatically generated Uyuni Proxy Server configuration file.
         # -------------------------------------------------------------------------
 
         # SSL CA certificate location
@@ -67,11 +99,40 @@ with open(config_path + "config.yaml") as source:
         # Location of locally built, custom packages
         proxy.pkg_dir = /var/spool/rhn-proxy
         
-        # Hostname of RHN Classic Server or Red Hat Satellite
+        # Hostname of Uyuni, SUSE Manager Server or another proxy
         proxy.rhn_parent = {config['server']}
         
         # Destination of all tracebacks, etc.
-        traceback_mail = {config['email']}''')
+        traceback_mail = {config['email']}
+
+        # Tftp sync configuration
+        tftpsync.server_fqdn = {config['server']}
+        tftpsync.server_ip = {serverIPv4}
+        tftpsync.server_ip6 = {serverIPv6}
+        tftpsync.proxy_ip = {proxyIPv4}
+        tftpsync.proxy_ip6 = {proxyIPv6}
+        tftpsync.proxy_fqdn = {config['proxy_fqdn']}
+        tftpsync.tftpboot = /srv/tftpboot''')
+
+    with open("/etc/apache2/conf.d/susemanager-tftpsync-recv.conf", "w") as file:
+        requireIPv4 = ""
+        requireIPv6 = ""
+        if len(proxyIPv4) > 0:
+           requireIPv4 = "Require ip {}".format(proxyIPv4)
+        if len(proxyIPv6) > 0:
+           requireIPv6 = "Require ip {}".format(proxyIPv6)
+        file.write(f'''<Directory "/srv/www/tftpsync">
+    <IfVersion >= 2.4>
+        <RequireAny>
+            {requireIPv4}
+            {requireIPv6}
+        </RequireAny>
+    </IfVersion>
+</Directory>
+
+WSGIScriptAlias /tftpsync/add /srv/www/tftpsync/add
+WSGIScriptAlias /tftpsync/delete /srv/www/tftpsync/delete''')
+
     os.system('chown root:www /etc/rhn/rhn.conf')
     os.system('chmod 640 /etc/rhn/rhn.conf')
 
@@ -81,3 +142,5 @@ os.system('chmod -R 755 /srv/www/htdocs/pub')
 os.system('chown -R wwwrun:www /var/spool/rhn-proxy')
 os.system('chmod -R 750 /var/spool/rhn-proxy')
 os.system('chown -R wwwrun:root /var/cache/rhn/proxy-auth')
+os.system('chown -R wwwrun:root /srv/tftpboot')
+os.system('chmod 755 /srv/tftpboot')

--- a/containers/proxy-systemd-services/uyuni-container-proxy-tftpd.service
+++ b/containers/proxy-systemd-services/uyuni-container-proxy-tftpd.service
@@ -14,7 +14,7 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=/etc/sysconfig/uyuni-proxy-systemd-services
 Restart=on-failure
 ExecStartPre=/bin/rm -f %t/uyuni-container-proxy-tftpd.pid %t/uyuni-container-proxy-tftpd.ctr-id
-ExecStart=/usr/bin/podman run --conmon-pidfile %t/uyuni-container-proxy-tftpd.pid --cidfile %t/uyuni-container-proxy-tftpd.ctr-id --cgroups=no-conmon --pod-id-file %t/uyuni-proxy-pod.pod-id -d --replace -dt -v ${CONFIG_DIR}:/etc/uyuni:ro --name uyuni-proxy-tftpd ${NAMESPACE}/proxy-tftpd
+ExecStart=/usr/bin/podman run --conmon-pidfile %t/uyuni-container-proxy-tftpd.pid --cidfile %t/uyuni-container-proxy-tftpd.ctr-id --cgroups=no-conmon --pod-id-file %t/uyuni-proxy-pod.pod-id -d --replace -dt -v ${CONFIG_DIR}:/etc/uyuni:ro -v ${TFTPBOOT_DIR}:/srv/tftpboot:ro --name uyuni-proxy-tftpd ${NAMESPACE}/proxy-tftpd
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/uyuni-container-proxy-tftpd.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/uyuni-container-proxy-tftpd.ctr-id
 PIDFile=%t/uyuni-container-proxy-tftpd.pid

--- a/containers/proxy-systemd-services/uyuni-proxy-pod.service
+++ b/containers/proxy-systemd-services/uyuni-proxy-pod.service
@@ -14,7 +14,7 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=/etc/sysconfig/uyuni-proxy-systemd-services
 Restart=on-failure
 ExecStartPre=/bin/rm -f %t/uyuni-proxy-pod.pid %t/uyuni-proxy-pod.pod-id
-ExecStartPre=/usr/bin/podman pod create --infra-conmon-pidfile %t/uyuni-proxy-pod.pid --pod-id-file %t/uyuni-proxy-pod.pod-id --name proxy-pod --publish 8022:22 --publish 8080:8080 --publish 443:443 --publish 4505:4505 --publish 4506:4506 --replace $EXTRA_POD_ARGS
+ExecStartPre=/usr/bin/podman pod create --infra-conmon-pidfile %t/uyuni-proxy-pod.pid --pod-id-file %t/uyuni-proxy-pod.pod-id --name proxy-pod --publish 8022:22 --publish 69:69 --publish 8080:8080 --publish 443:443 --publish 4505:4505 --publish 4506:4506 --replace $EXTRA_POD_ARGS
 ExecStart=/usr/bin/podman pod start --pod-id-file %t/uyuni-proxy-pod.pod-id
 ExecStop=/usr/bin/podman pod stop --ignore --pod-id-file %t/uyuni-proxy-pod.pod-id -t 10
 ExecStopPost=/usr/bin/podman pod rm --ignore -f --pod-id-file %t/uyuni-proxy-pod.pod-id

--- a/containers/proxy-tftpd-image/Dockerfile
+++ b/containers/proxy-tftpd-image/Dockerfile
@@ -28,10 +28,11 @@ LABEL org.opensuse.reference="${REFERENCE_PREFIX}/proxy-tftpd:%PKG_VERSION%.%REL
 # tftp
 EXPOSE 69/udp
 
-VOLUME "/etc/uyuni"
+VOLUME [ "/etc/uyuni", "/srv/tftpboot" ]
 
-# TODO: check installation
+RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-licenses tftp python3-PyYAML
 
-RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-licenses tftp
+COPY uyuni-configure.py /usr/bin/uyuni-configure.py
+RUN chmod +x /usr/bin/uyuni-configure.py
 
-# TODO: add RUN directive
+CMD uyuni-configure.py && ( source /etc/sysconfig/tftp; /usr/sbin/in.tftpd -L -u "$TFTP_USER" -s "$TFTP_DIRECTORY" $TFTP_OPTIONS )

--- a/containers/proxy-tftpd-image/proxy-tftpd-image.changes
+++ b/containers/proxy-tftpd-image/proxy-tftpd-image.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Mar 28 09:34:34 UTC 2022 - Ondrej Holecek <oholecek@suse.com>
+
+- Finalize server configuration and start command
+
+-------------------------------------------------------------------
 Tue Mar 15 14:43:07 UTC 2022 - Cédric Bosdonnat <cbosdonnat@suse.com>
 
 - Initial version

--- a/containers/proxy-tftpd-image/uyuni-configure.py
+++ b/containers/proxy-tftpd-image/uyuni-configure.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python3
 
 import os
-import subprocess
-import re
 import yaml
 import sys
 
@@ -12,18 +10,6 @@ config_path = "/etc/uyuni/"
 with open(config_path + "config.yaml") as source:
     config = yaml.safe_load(source)
    
-    server_version = config.get("server_version")
-    # Only check version for SUSE Manager, not Uyuni
-    matcher = re.fullmatch(r"([0-9]+\.[0-9]+\.)[0-9]+", server_version)
-    if matcher:
-        major_version = matcher.group(1)
-        container_version = subprocess.run(["rpm", "-q", "--queryformat", "%{version}", "spacewalk-proxy-common"],
-                stdout=subprocess.PIPE, universal_newlines=True).stdout
-        if not container_version.startswith(major_version):
-            print("FATAL: Proxy container image version (%s) doesn't match server major version (%s)".format(
-                container_version, major_version), file=sys.stderr)
-            sys.exit(1)
-    
     tftp_config = "/etc/sysconfig/tftp"
     tftp_root = "/srv/tftpboot"
     with open(tftp_config, "w") as file:
@@ -40,5 +26,4 @@ if not os.access(tftp_root, os.R_OK | os.X_OK):
    print("FATAL: TFTP root directory does not have correct permissions.")
    sys.exit(1)
 
-print("DEBUG: configuration finished")
 sys.exit(0)

--- a/containers/proxy-tftpd-image/uyuni-configure.py
+++ b/containers/proxy-tftpd-image/uyuni-configure.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python3
+
+import os
+import subprocess
+import re
+import yaml
+import sys
+
+config_path = "/etc/uyuni/"
+
+# read from file
+with open(config_path + "config.yaml") as source:
+    config = yaml.safe_load(source)
+   
+    server_version = config.get("server_version")
+    # Only check version for SUSE Manager, not Uyuni
+    matcher = re.fullmatch(r"([0-9]+\.[0-9]+\.)[0-9]+", server_version)
+    if matcher:
+        major_version = matcher.group(1)
+        container_version = subprocess.run(["rpm", "-q", "--queryformat", "%{version}", "spacewalk-proxy-common"],
+                stdout=subprocess.PIPE, universal_newlines=True).stdout
+        if not container_version.startswith(major_version):
+            print("FATAL: Proxy container image version (%s) doesn't match server major version (%s)".format(
+                container_version, major_version), file=sys.stderr)
+            sys.exit(1)
+    
+    tftp_config = "/etc/sysconfig/tftp"
+    tftp_root = "/srv/tftpboot"
+    with open(tftp_config, "w") as file:
+        file.write(f'''# Automatically generated Uyuni Proxy Server configuration file.
+        TFTP_USER="tftp"
+        TFTP_OPTIONS="{config.get('tftp_options', '')} "
+        TFTP_DIRECTORY="{tftp_root}"''')
+
+    os.system("chown root:tftp {}".format(tftp_config))
+    os.system("chmod 640 {}".format(tftp_config))
+
+# Make sure we can read 
+if not os.access(tftp_root, os.R_OK | os.X_OK):
+   print("FATAL: TFTP root directory does not have correct permissions.")
+   sys.exit(1)
+
+print("DEBUG: configuration finished")
+sys.exit(0)

--- a/containers/proxy-tftpd-image/uyuni-configure.py
+++ b/containers/proxy-tftpd-image/uyuni-configure.py
@@ -28,9 +28,9 @@ with open(config_path + "config.yaml") as source:
     tftp_root = "/srv/tftpboot"
     with open(tftp_config, "w") as file:
         file.write(f'''# Automatically generated Uyuni Proxy Server configuration file.
-        TFTP_USER="tftp"
-        TFTP_OPTIONS="{config.get('tftp_options', '')} "
-        TFTP_DIRECTORY="{tftp_root}"''')
+TFTP_USER="tftp"
+TFTP_OPTIONS="{config.get('tftp_options', '')} "
+TFTP_DIRECTORY="{tftp_root}"''')
 
     os.system("chown root:tftp {}".format(tftp_config))
     os.system("chmod 640 {}".format(tftp_config))

--- a/containers/run-proxy.sh
+++ b/containers/run-proxy.sh
@@ -23,6 +23,7 @@ done
 
 podman pod create --name proxy-pod \
   --publish 22:22 \
+  --publish 69:69 \
   --publish 8080:8080 \
   --publish 443:443 \
   --publish 4505:4505 \
@@ -54,5 +55,6 @@ podman run --rm=true -d --pod proxy-pod \
 
 podman run --rm=true -dt --pod proxy-pod \
   -v $CONFIG_DIR:/etc/uyuni \
+  -v $TFTPBOOT_DIR:/srv/tftpboot:ro \
   --name proxy-tftpd \
   $REGISTRY/proxy-tftpd


### PR DESCRIPTION
## What does this PR change?

This configures http and tftp container to be usable with cobber sync and then PXE autoinstallaion

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17357

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
