### PR TITLE
QE: RuboCop: Disable Metrics/ClassLength

### DIFF
--- a/testsuite/.rubocop.yml
+++ b/testsuite/.rubocop.yml
@@ -3,3 +3,5 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   EnabledByDefault: true
 
+Metrics/ClassLength:
+  Enabled: false


### PR DESCRIPTION
## What does this PR change?

This disables the Metrics/ClassLength cop in RuboCop.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage
- No tests: 

- [x] **DONE**

## Links

Manager 4.2: https://github.com/SUSE/spacewalk/pull/17377
Manager 4.1: https://github.com/SUSE/spacewalk/pull/17376

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
