### PR TITLE
proxy-systemd-services: Adapted to build on Enterprise Linux

### DIFF
--- a/containers/proxy-systemd-services/uyuni-proxy-systemd-services.changes
+++ b/containers/proxy-systemd-services/uyuni-proxy-systemd-services.changes
@@ -1,3 +1,4 @@
+- Adapted to work on Enterprise Linux.
 - Add package to SLE and Client tools (jsc#SLE-24145)
 
 -------------------------------------------------------------------

--- a/containers/proxy-systemd-services/uyuni-proxy-systemd-services.spec
+++ b/containers/proxy-systemd-services/uyuni-proxy-systemd-services.spec
@@ -25,11 +25,13 @@ Version:        4.3.0
 Release:        1
 URL:            https://github.com/uyuni-project/uyuni
 Source0:        %{name}-%{version}-1.tar.gz
-Source1:        %{name}-rpmlintrc
+Source1:        https://raw.githubusercontent.com/uyuni-project/uyuni/%{name}-%{version}-1/containers/proxy-systemd-services/%{name}-rpmlintrc
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 Requires:       podman
-Requires(post): %{fillup_prereq}
+%if 0%{?suse_version}
+Requires(post): %fillup_prereq
+%endif
 BuildRequires:  systemd-rpm-macros
 
 %description
@@ -50,7 +52,11 @@ install -d -m 755 %{buildroot}%{_sbindir}
 %if !0%{?is_opensuse}
 sed 's/^NAMESPACE=.*$/NAMESPACE=registry.suse.com\/suse\/manager\/4.3/' -i uyuni-container-proxy-services.config
 %endif
+%if 0%{?rhel}
+install -D -m 644 uyuni-container-proxy-services.config %{buildroot}%{_sysconfdir}/sysconfig/uyuni-container-proxy-services.config
+%else
 install -D -m 644 uyuni-container-proxy-services.config %{buildroot}%{_fillupdir}/sysconfig.%{name}
+%endif
 
 for service in %{SERVICES}; do
     install -D -m 644 uyuni-${service}.service %{buildroot}%{_unitdir}/uyuni-${service}.service
@@ -67,7 +73,9 @@ done
 %endif
 
 %post
+%if 0%{?suse_version}
 %fillup_only
+%endif
 for service in %{SERVICES}; do
     %if 0%{?rhel}
         %systemd_post uyuni-${service}.service
@@ -98,7 +106,11 @@ done
 %defattr(-,root,root)
 %{_unitdir}/*.service
 %{_sbindir}/rcuyuni-*
+%if 0%{?rhel}
+%{_sysconfdir}/sysconfig/uyuni-container-proxy-services.config
+%else
 %{_fillupdir}/sysconfig.%{name}
+%endif
 %{_sysconfdir}/uyuni
 %{_localstatedir}/lib/uyuni
 


### PR DESCRIPTION
## What does this PR change?

Adapted to build on Enterprise Linux

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
