### PR TITLE
spacewalk-certs-tools: Adapt mgr_ssl_cert_setup.py to work on Python 3.9

### DIFF
--- a/spacewalk/certs-tools/mgr_ssl_cert_setup.py
+++ b/spacewalk/certs-tools/mgr_ssl_cert_setup.py
@@ -190,7 +190,7 @@ def prepareData(root_ca_content, server_cert_content, intermediate_ca_content):
 
 def isCA(cert):
     out = subprocess.run(
-        ["openssl", "x509", "-noout", "-ext", "basicConstraints", "-in", "-"],
+        ["openssl", "x509", "-noout", "-ext", "basicConstraints"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         input=cert.encode("utf-8"),
@@ -233,8 +233,6 @@ def getCertData(cert):
             "-issuer",
             "-issuer_hash",
             "-modulus",
-            "-in",
-            "-",
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -272,7 +270,7 @@ def getCertData(cert):
 
 def getCertWithText(cert):
     out = subprocess.run(
-        ["openssl", "x509", "-text", "-in", "-"],
+        ["openssl", "x509", "-text"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         input=cert.encode("utf-8"),
@@ -286,7 +284,7 @@ def getCertWithText(cert):
 def getRsaKey(key):
     # set an invalid password to prevent asking in case of an encrypted one
     out = subprocess.run(
-        ["openssl", "rsa", "-passin", "pass:invalid", "-in", "-"],
+        ["openssl", "rsa", "-passin", "pass:invalid"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         input=key.encode("utf-8")
@@ -299,7 +297,7 @@ def getRsaKey(key):
 
 def checkKeyBelongToCert(key, cert):
     out = subprocess.run(
-        ["openssl", "rsa", "-noout", "-modulus", "-in", "-"],
+        ["openssl", "rsa", "-noout", "-modulus"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         input=key.encode("utf-8"),
@@ -309,7 +307,7 @@ def checkKeyBelongToCert(key, cert):
         raise CertCheckError("Invalid Key")
     keyModulus = out.stdout.decode("utf-8")
     out = subprocess.run(
-        ["openssl", "x509", "-noout", "-modulus", "-in", "-"],
+        ["openssl", "x509", "-noout", "-modulus"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         input=cert.encode("utf-8"),

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,4 @@
+- Adapted openssl call in mgr_ssl_cert_setup.py to work on Python 3.9.
 - Add randomness to first generated server serial
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Adapted openssl call in mgr_ssl_cert_setup.py to work on Python 3.9

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
