### PR TITLE
Use dpkg-deb to extract deb files instead of ar

### DIFF
--- a/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
+++ b/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
@@ -219,7 +219,11 @@ if [ -n "${VENV_SOURCE}" ]; then
         VENV_HASH=$(dpkg -s venv-salt-minion | sha256sum | tr -d '\- ')
     fi
     if [ -f "${VENV_TMP_DIR}/${VENV_HASH_FILE}" ]; then
-        PRE_VENV_HASH=$(cat "${VENV_TMP_DIR}/${VENV_HASH_FILE}")
+        if [ -x "${VENV_TMP_DIR}/bin/python" ]; then
+            PRE_VENV_HASH=$(cat "${VENV_TMP_DIR}/${VENV_HASH_FILE}")
+        else
+            rm -f "${VENV_TMP_DIR}/${VENV_HASH_FILE}"
+        fi
     fi
     if [ "${VENV_HASH}" != "${PRE_VENV_HASH}" ]; then
         if [ "${VENV_SOURCE}" = "bootstrap" ]; then
@@ -246,6 +250,10 @@ if [ -n "${VENV_SOURCE}" ]; then
         else
             cp -r "${VENV_INST_DIR}" "${VENV_TMP_DIR}"
             pushd "${VENV_TMP_DIR}" > /dev/null
+        fi
+        if [ -x bin/python ]; then
+            rm -f "${VENV_TMP_DIR}/${VENV_HASH_FILE}"
+            exit_with_message_code "Error: Unable to extract the bundle from ${TEMP_DIR}/${VENV_PKG_FILE}!" 6
         fi
         grep -m1 -r "^#\!${VENV_INST_DIR}" bin/ | sed 's/:.*//' | sort | uniq | xargs -I '{}' sed -i "1s=^#!${VENV_INST_DIR}/bin/.*=#!${VENV_TMP_DIR}/bin/python=" {}
         sed -i "s#${VENV_INST_DIR}#${VENV_TMP_DIR}#g" bin/python

--- a/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
+++ b/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
@@ -235,16 +235,8 @@ if [ -n "${VENV_SOURCE}" ]; then
             mkdir -p "${VENV_TMP_DIR}"
             pushd "${VENV_TMP_DIR}" > /dev/null
             if [ "${VENV_PKG_FILE##*\.}" = "deb" ]; then
-                DEB_DATA=$(ar -t "${TEMP_DIR}/${VENV_PKG_FILE}" | grep '^data\.')
-                DATA_EXT="${DEB_DATA##*\.}"
-                if [ "${DATA_EXT}" = "xz" ]; then
-                    TAR_CMD="Jx"
-                elif [ "${DATA_EXT}" = "bzip" ]; then
-                    TAR_CMD="jx"
-                elif [ "${DATA_EXT}" = "gz" ]; then
-                    TAR_CMD="zx"
-                fi
-                ar -p "${TEMP_DIR}/${VENV_PKG_FILE}" "${DEB_DATA}" | tar "${TAR_CMD}" ./usr/lib/venv-salt-minion
+                dpkg-deb -x "${TEMP_DIR}/${VENV_PKG_FILE}" .
+                rm -rf etc lib var usr/bin usr/sbin usr/share usr/lib/tmpfiles.d
             else
                 rpm2cpio "${TEMP_DIR}/${VENV_PKG_FILE}" | cpio -idm '*/lib/venv-salt-minion/*' >> /dev/null 2>&1
             fi

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,6 @@
+- Use dpkg-deb to extract deb files instead of ar
+  with salt ssh preflight on Debian based distros
+
 -------------------------------------------------------------------
 Fri Mar 11 16:49:07 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Some of Debian based distros has no `ar` from `binutils` installed by-default.
This change is modifies the pre flight script to extract `deb` packages with `dpkg-deb -x ...` instead of using `ar`

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: Testing with bootstrap repo creation (used to get the package from) is not implemented in any test system

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
