### PR TITLE
Fix popup message on deploy conf files for BV 4.3

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -132,7 +132,7 @@ Feature: Smoke tests for <client>
     And I click on "Confirm & Deploy to Selected Systems"
     Then I should see a "/etc/s-mgr/config" link
     When I click on "Deploy Files to Selected Systems"
-    Then I should see a "being scheduled" text
+    Then I should see a "scheduled for deploy" text
     And I should see a "0 revision-deploys overridden." text
     When I force picking pending events on "<client>" if necessary
     And I wait until file "/etc/s-mgr/config" exists on "<client>"


### PR DESCRIPTION
## What does this PR change?

Fix popup message on deploy conf files for BV 4.3

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes no issue, directly from BV review
Tracks This is for master only, not for 4.2 because in 4.2 we still have the same old message.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
