### PR TITLE
New c3p0 dependencies

### DIFF
--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -106,14 +106,8 @@
   <property name="jaxb" value="${jaxb-api} ${jaxb-core} ${jaxb-runtime} ${txw2} ${istack-commons}"/>
 
 
-  <property name="hibernate3.2deps" value="hibernate3"/>
-
-  <property name="hibernate3.6deps" value="hibernate3/hibernate-ehcache-3 hibernate3/hibernate-c3p0-3 hibernate3/hibernate-core-3 ${hibernate-commons-annotations} slf4j/api jboss-logging javassist slf4j/log4j12 ${ehcache} hibernate-jpa-2.0-api"/>
-
   <property name="hibernate5deps" value="hibernate-ehcache-5 hibernate-c3p0-5 hibernate-core-5 ${hibernate-commons-annotations} slf4j/api jakarta-persistence-api byte-buddy jboss-logging javassist slf4j/log4j12 ${ehcache} classmate statistics hibernate-types-52-2.12.1 jackson-databind jackson-core jackson-annotations"/>
 
-  <available file="${java.lib.dir}/hibernate3.jar" type="file" property="hibernate" value="${hibernate3.2deps}" />
-  <available file="${java.lib.dir}/hibernate3/hibernate-core-3.jar" type="file" property="hibernate" value="${hibernate3.6deps}" />
   <available file="${java.lib.dir}/hibernate-core-5.jar" type="file" property="hibernate" value="${hibernate5deps}" />
 
   <condition property="jmock-jars"

--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -110,6 +110,9 @@
 
   <available file="${java.lib.dir}/hibernate-core-5.jar" type="file" property="hibernate" value="${hibernate5deps}" />
 
+  <property name="c3p0" value="c3p0"/>
+  <available file="${java.lib.dir}/mchange-commons/mchange-commons-java.jar" type="file" property="c3p0" value="${c3p0} mchange-commons/mchange-commons-java"/>
+
   <condition property="jmock-jars"
                 value="jmock jmock-cglib"
                  else="">
@@ -160,7 +163,7 @@
        concurrent xalan-j2" />
 
   <property name="run.jar.dependencies"
-      value="antlr objectweb-asm/asm ${cglib-jar} c3p0 commons-discovery dom4j ${jaf} ${jta11-jars} ojdbc14 sitemesh
+      value="antlr objectweb-asm/asm ${cglib-jar} ${c3p0} commons-discovery dom4j ${jaf} ${jta11-jars} ojdbc14 sitemesh
              taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec
              xalan-j2 xalan-j2-serializer xerces-j2 ${common.jar.dependencies}" />
 
@@ -182,7 +185,7 @@
       ${install.common.jar.dependencies} xalan-j2" />
 
   <property name="install.run.jar.dependencies"
-      value="antlr objectweb-asm/asm ${cglib-jar} c3p0 commons-discovery dom4j dwr ${jaf} ${jta11-jars} sitemesh
+      value="antlr objectweb-asm/asm ${cglib-jar} ${c3p0} commons-discovery dom4j dwr ${jaf} ${jta11-jars} sitemesh
              taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec
              xalan-j2 xalan-j2-serializer xerces-j2 ${install.common.jar.dependencies}" />
 
@@ -198,7 +201,7 @@
              concurrent simple-core snakeyaml simple-xml ${commons-jexl}" />
 
   <property name="dist.jar.dependencies"
-      value="antlr objectweb-asm/asm bcel c3p0 ${cglib-jar}
+      value="antlr objectweb-asm/asm bcel ${c3p0} ${cglib-jar}
              commons-collections commons-beanutils commons-cli commons-codec
              commons-digester commons-discovery commons-el commons-fileupload commons-io
              ${commons-lang} commons-logging

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -58,6 +58,7 @@
         <dependency org="suse" name="jose4j" rev="0.5.1" />
         <dependency org="suse" name="log4j" rev="1.2.12" />
         <dependency org="suse" name="jsch" rev="0.1.55" />
+        <dependency org="suse" name="mchange-commons-java" rev="0.2.20" />
         <dependency org="suse" name="netty-buffer" rev="4.1.44.Final" />
         <dependency org="suse" name="netty-codec" rev="4.1.44.Final" />
         <dependency org="suse" name="netty-common" rev="4.1.44.Final" />

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -153,6 +153,9 @@ artifacts:
     repository: Leap
   - artifact: jsch
     repository: Uyuni_Other
+  - artifact: mchange-commons-java
+    package: mchange-commons
+    repository: Uyuni_Other
   - artifact: netty-buffer
     package: netty
     repository: Uyuni_Other

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- adapt for new c3p0 and mchange-commons package
 - Set default image download protocol to http
 - Container proxy configuration handler
 - Hibernate: set a non-singleton ehcache

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -764,113 +764,11 @@ chown tomcat:%{apache_group} /var/log/rhn/gatherer.log
 %{serverdir}/tomcat/webapps/rhn/WEB-INF/nav
 %{serverdir}/tomcat/webapps/rhn/WEB-INF/pages
 %{serverdir}/tomcat/webapps/rhn/WEB-INF/*.xml
-# list of all jar symlinks without any version numbers
-# and wildcards (except non-symlink velocity)
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/antlr.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/bcel.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/c3p0*.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/mchange-commons*.jar
-%if 0%{?fedora} || 0%{?sle_version} >= 150200 || 0%{?rhel}
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/cglib_cglib.jar
-%else
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/cglib.jar
-%endif
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/commons-beanutils.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/commons-cli.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/commons-codec.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/commons-collections.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/commons-digester.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/commons-discovery.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/commons-el.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/commons-fileupload.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/commons-io.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/commons-logging.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/*commons-validator.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/concurrent*.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/dom4j.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/dwr.jar
 
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/snakeyaml.jar
-# SUSE extra runtime dependencies: spark, jade4j, salt API client + dependencies
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/apache-commons-jexl_commons-jexl.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/commons-lang3.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/google-gson_google-gsongson.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/httpcomponents_httpclient.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/httpcomponents_httpcore.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/httpcomponents_httpcore-nio.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/httpasyncclient.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/ical4j.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/jade4j.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/jose4j.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/netty*.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/salt-netapi-client.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/slf4j_api.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/slf4j_log4j12*.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/spark-core.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/spark-template-jade.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/spy.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/simpleclient*.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/pgjdbc-ng.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/java-saml-core.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/java-saml.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/joda-time.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/stax-api.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/stax2-api.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/woodstox-core-asl.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/xmlsec.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/byte-buddy.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/jakarta-persistence-api.jar
-
-# Hibernate and related
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/hibernate-core-5.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/hibernate-c3p0-5.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/hibernate-ehcache-5.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/hibernate-commons-annotations.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/hibernate-types-52-2.12.1.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/ehcache-core.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/classmate.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/javassist.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/jboss-logging.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/statistics.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/jackson-databind.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/jackson-core.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/jackson-annotations.jar
-
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/jaf.jar
-%if 0%{?sle_version} >= 150200
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/javax.mail.jar
-%else
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/javamail.jar
-%endif
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/jcommon*.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/jdom.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/geronimo-jta-1.1-api.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/log4j*.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/oro.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/quartz.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/redstone-xmlrpc-client.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/redstone-xmlrpc.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/rhn.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/simple-core.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/simple-xml.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/sitemesh.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/stringtree-json.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/xalan-j2.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/xalan-j2-serializer.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/xerces-j2.jar
-
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/struts.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/objectweb-asm_asm.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/taglibs-standard-impl.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/taglibs-standard-jstlel.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/taglibs-standard-spec.jar
-%if !0%{?suse_version}
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/glassfish-jaxb_jaxb-core.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/glassfish-jaxb_jaxb-runtime.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/glassfish-jaxb_txw2.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/istack-commons-runtime.jar
-%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/jaxb-api.jar
-%endif
+# all jars in WEB-INF/lib/
+%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib
+%exclude %{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/postgresql-jdbc.jar
+%exclude %{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/ongres-*.jar
 
 # owned by cobbler needs cobbler permissions
 %attr(755,root,root) %dir %{cobprofdir}
@@ -900,7 +798,6 @@ chown tomcat:%{apache_group} /var/log/rhn/gatherer.log
 %attr(755, tomcat, root) %dir %{_localstatedir}/lib/spacewalk/scc
 %attr(755, tomcat, root) %dir %{_localstatedir}/lib/spacewalk/subscription-matcher
 %dir %{serverdir}/tomcat/webapps/rhn/WEB-INF
-%dir %{serverdir}/tomcat/webapps/rhn/WEB-INF/lib
 
 %files -n spacewalk-taskomatic
 %defattr(644,root,root,775)

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -769,6 +769,7 @@ chown tomcat:%{apache_group} /var/log/rhn/gatherer.log
 %{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/antlr.jar
 %{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/bcel.jar
 %{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/c3p0*.jar
+%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/mchange-commons*.jar
 %if 0%{?fedora} || 0%{?sle_version} >= 150200 || 0%{?rhel}
 %{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/cglib_cglib.jar
 %else

--- a/search-server/spacewalk-search/buildconf/build-props.xml
+++ b/search-server/spacewalk-search/buildconf/build-props.xml
@@ -6,8 +6,11 @@
 
   <property name="ivy.settings.file" value="buildconf/ivyconf.xml" />
 
+  <property name="c3p0" value="c3p0"/>
+  <available file="/usr/share/java/mchange-commons/mchange-commons-java.jar" type="file" property="c3p0" value="${c3p0} mchange-commons/mchange-commons-java"/>
+
   <property name="jpackage.jars"
-      value="c3p0 cglib commons-cli commons-codec commons-httpclient commons-lang3
+      value="${c3p0} cglib commons-cli commons-codec commons-httpclient commons-lang3
              commons-logging ${log4j-jars} objectweb-asm/asm oro
              quartz redstone-xmlrpc redstone-xmlrpc-client simple-core
              slf4j/api slf4j/simple junit nutch-core hadoop picocontainer

--- a/search-server/spacewalk-search/buildconf/obs-maven-config.yaml
+++ b/search-server/spacewalk-search/buildconf/obs-maven-config.yaml
@@ -44,6 +44,9 @@ artifacts:
     repository: Uyuni_Other
   - artifact: c3p0
     repository: Uyuni_Other
+  - artifact: mchange-commons-java
+    package: mchange-commons
+    repository: Uyuni_Other
   - artifact: picocontainer
     repository: Uyuni_Other
   - artifact: hadoop

--- a/search-server/spacewalk-search/ivy.xml
+++ b/search-server/spacewalk-search/ivy.xml
@@ -12,6 +12,7 @@
         <dependency org="suse" name="log4j" rev="1.2.12" />
         <dependency org="suse" name="nutch-core" rev="1.0.1" />
         <dependency org="suse" name="c3p0" rev="0.9.5.2" />
+        <dependency org="suse" name="mchange-commons-java" rev="0.2.20" />
         <dependency org="suse" name="picocontainer" rev="1.3" />
         <dependency org="suse" name="hadoop" rev="0.18.1" />
 

--- a/search-server/spacewalk-search/spacewalk-search.changes
+++ b/search-server/spacewalk-search/spacewalk-search.changes
@@ -1,3 +1,5 @@
+- adapt for new c3p0 and mchange-commons package
+
 -------------------------------------------------------------------
 Tue Jan 18 13:59:26 CET 2022 - jgonzalez@suse.com
 

--- a/search-server/spacewalk-search/spacewalk-search.spec
+++ b/search-server/spacewalk-search/spacewalk-search.spec
@@ -139,6 +139,9 @@ ln -s -f %{_prefix}/share/rhn/search/lib/spacewalk-search-%{version}.jar $RPM_BU
 mkdir -p  $RPM_BUILD_ROOT/%{_sbindir}/
 ln -sf service $RPM_BUILD_ROOT/%{_sbindir}/rcrhn-search
 
+# cleanup unwanted jar
+rm -f $RPM_BUILD_ROOT%{_prefix}/share/rhn/search/lib/junit.jar
+
 %post
 %if 0%{?rhel}
 %systemd_post rhn-search.service


### PR DESCRIPTION
## What does this PR change?

Use new c3p0 package from Factory. The difference is, that mchange-commons is not included, but a separate package which requires a new symlink in the jar directory for tomcat, taskomatic and search server.

This PR also cleaned up some old ant checks for outdated hibernate versions which would not work anymore.

It also simplify the filelist of spacewalk-java to include all jars which are available in the directory. Same happens already for taskomatic and search server.

Ivy repos were also adapted to work with the new package.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Partly fix https://github.com/SUSE/spacewalk/issues/17321

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
