### PR TITLE
Modify the Dockerfile to set SUSE Manager label variables

### DIFF
--- a/rel-eng/push-packages-to-obs.sh
+++ b/rel-eng/push-packages-to-obs.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 set -e
 #
 # For all packages prepared by build-packages-for-obs.sh in
@@ -249,16 +250,14 @@ while read PKG_NAME; do
     continue
   }
 
-  if [ "${OSCAPI}" = "https://api.suse.de" -a -f "$SRPM_PKG_DIR/Dockerfile" -a "$SRPM_PKG_DIR/_service" ]; then
-    SERVICE="
-  <service name=\"docker_tags_helper\" mode=\"buildtime\">
-     <param name=\"buildtag_replace\">/uyuni/suse\/manager\/4.3/</param>
-     <param name=\"prefix_replace\">/org\.opensuse\.uyuni/com.suse.manager/</param>
-  </service>
-"
-    SERVICES_START=$(sed -n "0,/<services>/p" $SRPM_PKG_DIR/_service)
-    SERVICES_END=$(sed -n "/<service /,/<\/services>/p" $SRPM_PKG_DIR/_service)
-      echo "$SERVICES_START$SERVICE$SERVICES_END" >"$SRPM_PKG_DIR/_service"
+  if [ "${OSCAPI}" = "https://api.suse.de" -a -f "$SRPM_PKG_DIR/Dockerfile" ]; then
+      VERSION=$(sed 's/^\([0-9]\+\.[0-9]\+\).*$/\1/' ${BASE_DIR}/packages/uyuni-base)
+      sed "/^#\!BuildTag:/s/uyuni/suse\/manager\/${VERSION}/" -i $SRPM_PKG_DIR/Dockerfile
+      sed "/^# labelprefix=/s/org\.opensuse\.uyuni/com.suse.manager/" -i $SRPM_PKG_DIR/Dockerfile
+      sed "s/^ARG VENDOR=.*$/ARG VENDOR=\"SUSE LLC\"/" -i $SRPM_PKG_DIR/Dockerfile
+      sed "s/^ARG PRODUCT=.*$/ARG PRODUCT=\"SUSE Manager\"/" -i $SRPM_PKG_DIR/Dockerfile
+      sed "s/^ARG URL=.*$/ARG URL=\"https:\/\/www.suse.com\/products\/suse-manager\/\"/" -i $SRPM_PKG_DIR/Dockerfile
+      sed "s/^ARG REFERENCE_PREFIX=.*$/ARG REFERENCE_PREFIX=\"registry.suse.com\/suse\/manager\/${VERSION}\"/" -i $SRPM_PKG_DIR/Dockerfile
   fi
 
   # update from obs (create missing package on the fly)


### PR DESCRIPTION
## What does this PR change?

Handling these values with OBS BuildFlag: dockerarg leads to issues due
to the whitespaces, doing the sed work at push time on the Dockerfile
rather than on ther _services is easier.

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
