### PR TITLE
hibernate: set a non-singleton ehcache

### DIFF
--- a/java/buildconf/test/rhn.conf.postgresql-example
+++ b/java/buildconf/test/rhn.conf.postgresql-example
@@ -17,7 +17,7 @@ hibernate.connection.driver_proto = jdbc:postgresql
 
 hibernate.use_outer_join = true
 hibernate.jdbc.batch_size = 0
-hibernate.cache.region.factory_class = org.hibernate.cache.ehcache.SingletonEhCacheRegionFactory
+hibernate.cache.region.factory_class = org.hibernate.cache.ehcache.EhCacheRegionFactory
 hibernate.cache.use_query_cache = true
 hibernate.bytecode.use_reflection_optimizer = false
 hibernate.jdbc.batch_size = 0

--- a/java/conf/default/rhn_hibernate.conf
+++ b/java/conf/default/rhn_hibernate.conf
@@ -33,6 +33,6 @@ hibernate.cache.use_query_cache=true
 hibernate.bytecode.use_reflection_optimizer=false
 hibernate.jdbc.batch_size=0
 hibernate.cache.provider_class=org.hibernate.cache.EhCacheProvider
-hibernate.cache.region.factory_class=org.hibernate.cache.ehcache.SingletonEhCacheRegionFactory
+hibernate.cache.region.factory_class=org.hibernate.cache.ehcache.EhCacheRegionFactory
 hibernate.id.new_generator_mappings = false
 hibernate.cache.ehcache.missing_cache_strategy=create

--- a/java/conf/default/rhn_reporting_hibernate.conf
+++ b/java/conf/default/rhn_reporting_hibernate.conf
@@ -33,6 +33,6 @@ reporting.hibernate.cache.use_query_cache=true
 reporting.hibernate.bytecode.use_reflection_optimizer=false
 reporting.hibernate.jdbc.batch_size=0
 reporting.hibernate.cache.provider_class=org.hibernate.cache.EhCacheProvider
-reporting.hibernate.cache.region.factory_class=org.hibernate.cache.ehcache.SingletonEhCacheRegionFactory
+reporting.hibernate.cache.region.factory_class=org.hibernate.cache.ehcache.EhCacheRegionFactory
 reporting.hibernate.id.new_generator_mappings = false
 reporting.hibernate.cache.ehcache.missing_cache_strategy=create

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Hibernate: set a non-singleton ehcache
 - Allow monitoring entitlement for debian 11 and 10
 - warning log when hardware refresh result is not serializable
 - Hide private methods in XMLRPC handlers


### PR DESCRIPTION
## What does this PR change?
ssh push action remain stuck and this error appears in `rhn_taskomatic_daemon.log`
```
022-03-29 14:12:23,291 [DefaultQuartzScheduler_Worker-18] ERROR com.redhat.rhn.taskomatic.task.SSHMinionActionExecutor  - Executing a task threw an exception: java.lang.IllegalStateException
2022-03-29 14:12:23,291 [DefaultQuartzScheduler_Worker-18] ERROR com.redhat.rhn.taskomatic.task.SSHMinionActionExecutor  - Message: The default-query-results-region Cache is not alive (STATUS_SHUTDOWN)
2022-03-29 14:12:23,291 [DefaultQuartzScheduler_Worker-18] ERROR com.redhat.rhn.taskomatic.task.SSHMinionActionExecutor  - Cause: null
2022-03-29 14:12:23,292 [DefaultQuartzScheduler_Worker-18] ERROR com.redhat.rhn.taskomatic.task.SSHMinionActionExecutor  - Stack trace:java.lang.IllegalStateException: The default-query-results-region Cache is not alive (STATUS_SHUTDOWN)
        at net.sf.ehcache.Cache$CacheStatus.checkAlive(Cache.java:4097)
        at net.sf.ehcache.Cache.checkStatus(Cache.java:2788)
        at net.sf.ehcache.Cache.get(Cache.java:1744)
        at org.hibernate.cache.ehcache.internal.StorageAccessImpl.getFromCache(StorageAccessImpl.java:47)
        at org.hibernate.cache.spi.support.DirectAccessRegionTemplate.getFromCache(DirectAccessRegionTemplate.java:39)
        at org.hibernate.cache.internal.QueryResultsCacheImpl.getCachedData(QueryResultsCacheImpl.java:191)
        at org.hibernate.cache.internal.QueryResultsCacheImpl.get(QueryResultsCacheImpl.java:155)
        at org.hibernate.cache.internal.QueryResultsCacheImpl.get(QueryResultsCacheImpl.java:136)
        at org.hibernate.loader.Loader.getResultFromQueryCache(Loader.java:2716)
        at org.hibernate.loader.Loader.listUsingQueryCache(Loader.java:2624)
        at org.hibernate.loader.Loader.list(Loader.java:2596)
        at org.hibernate.loader.hql.QueryLoader.list(QueryLoader.java:505)
        at org.hibernate.hql.internal.ast.QueryTranslatorImpl.list(QueryTranslatorImpl.java:395)
        at org.hibernate.engine.query.spi.HQLQueryPlan.performList(HQLQueryPlan.java:220)
        at org.hibernate.internal.SessionImpl.list(SessionImpl.java:1526)
        at org.hibernate.query.internal.AbstractProducedQuery.doList(AbstractProducedQuery.java:1598)
        at org.hibernate.query.internal.AbstractProducedQuery.list(AbstractProducedQuery.java:1566)
        at org.hibernate.query.internal.AbstractProducedQuery.uniqueResult(AbstractProducedQuery.java:1608)
        at com.redhat.rhn.common.hibernate.HibernateFactory.lookupObjectByNamedQuery(HibernateFactory.java:195)
        at com.redhat.rhn.domain.rhnpackage.PackageFactory.lookupPackageArchByLabel(PackageFactory.java:239)
        at com.suse.manager.utils.SaltUtils.createInstalledPackage(SaltUtils.java:1489)
        at com.suse.manager.utils.SaltUtils.lambda$createPackagesFromSalt$90(SaltUtils.java:1460)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
        at java.base/java.util.HashMap$EntrySpliterator.forEachRemaining(HashMap.java:1764)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
        at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
        at com.suse.manager.utils.SaltUtils.createPackagesFromSalt(SaltUtils.java:1463)
        at com.suse.manager.utils.SaltUtils.updatePackages(SaltUtils.java:1411)
        at com.suse.manager.utils.SaltUtils.lambda$handlePackageProfileUpdate$73(SaltUtils.java:1249)
        at com.redhat.rhn.common.hibernate.HibernateFactory.lambda$doWithoutAutoFlushing$0(HibernateFactory.java:711)
        at com.redhat.rhn.common.hibernate.HibernateFactory.doWithoutAutoFlushing(HibernateFactory.java:655)
        at com.redhat.rhn.common.hibernate.HibernateFactory.doWithoutAutoFlushing(HibernateFactory.java:710)
        at com.redhat.rhn.common.hibernate.HibernateFactory.doWithoutAutoFlushing(HibernateFactory.java:683)
        at com.suse.manager.utils.SaltUtils.handlePackageProfileUpdate(SaltUtils.java:1249)
        at com.suse.manager.utils.SaltUtils.lambda$updateServerAction$21(SaltUtils.java:553)
        at java.base/java.util.Optional.ifPresent(Optional.java:183)
        at com.suse.manager.utils.SaltUtils.updateServerAction(SaltUtils.java:553)
        at com.suse.manager.webui.services.SaltServerActionService.lambda$executeSSHAction$134(SaltServerActionService.java:2535)
        at com.suse.salt.netapi.utils.Xor$Right.consume(Xor.java:189)
        at com.suse.salt.netapi.results.Result.consume(Result.java:47)
        at com.suse.manager.webui.services.SaltServerActionService.lambda$executeSSHAction$135(SaltServerActionService.java:2513)
        at java.base/java.util.Optional.ifPresent(Optional.java:183)
        at com.suse.manager.webui.services.SaltServerActionService.executeSSHAction(SaltServerActionService.java:2508)
        at com.redhat.rhn.taskomatic.task.SSHMinionActionExecutor.execute(SSHMinionActionExecutor.java:76)
        at com.redhat.rhn.taskomatic.task.RhnJavaJob.execute(RhnJavaJob.java:89)
        at com.redhat.rhn.taskomatic.TaskoJob.execute(TaskoJob.java:158)
        at org.quartz.core.JobRunShell.run(JobRunShell.java:202)
        at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:573)
```

The error might be caused by the usage of a singleton ehcache, since now we have 2 Hibernate SessionFactory ( one for the spacewalk db and the other for the report db) https://github.com/hibernate/hibernate-orm/blob/main/documentation/src/main/asciidoc/userguide/chapters/caching/Caching.adoc#singletonehcacheregionfactory  .

I tested the changes and they seems to be fine, but the problem is not always reproducible

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17290

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "susemanager_unittests" (Test skipped, there are no changes to test)
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
