### PR TITLE
API for image management

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/image/ImageInfoFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/image/ImageInfoFactory.java
@@ -290,6 +290,20 @@ public class ImageInfoFactory extends HibernateFactory {
     }
 
     /**
+     * Delete a {@link ImageFile}.
+     *
+     * @param file the file to delete
+     * @param saltApi the SaltApi used to delete the related file
+     */
+    public static void deleteImageFile(ImageFile file, SaltApi saltApi) {
+        file.getImageInfo().getImageFiles().remove(file);
+        if (!file.isExternal()) {
+            removeImageFile(OSImageStoreUtils.getOSImageFilePath(file), saltApi);
+        }
+        instance.removeObject(file);
+    }
+
+    /**
      * Delete a {@link ImageInfo}.
      *
      * @param imageInfo the image info to delete
@@ -651,4 +665,39 @@ public class ImageInfoFactory extends HibernateFactory {
         instance.saveObject(info);
         return info;
     }
+
+    /**
+     * Lookup an ImageFile by file name
+     * @param org the the organization
+     * @param file the file name
+     * @return the image file
+     */
+    public static Optional<ImageFile> lookupImageFile(Org org, String file) {
+        CriteriaBuilder builder = getSession().getCriteriaBuilder();
+        CriteriaQuery<ImageFile> query = builder.createQuery(ImageFile.class);
+
+        Root<ImageFile> root = query.from(ImageFile.class);
+        query.where(builder.and(
+                builder.equal(root.get("file"), file),
+                builder.equal(root.join("imageInfo").get("org"), org)));
+        return getSession().createQuery(query).uniqueResultOptional();
+    }
+
+    /**
+     * Lookup an DeltaImageInfo by file name
+     * @param org the the organization
+     * @param file the file name
+     * @return the delta image info
+     */
+    public static Optional<DeltaImageInfo> lookupDeltaImageFile(Org org, String file) {
+        CriteriaBuilder builder = getSession().getCriteriaBuilder();
+        CriteriaQuery<DeltaImageInfo> query = builder.createQuery(DeltaImageInfo.class);
+
+        Root<DeltaImageInfo> root = query.from(DeltaImageInfo.class);
+        query.where(builder.and(
+                builder.equal(root.get("file"), file),
+                builder.equal(root.join("sourceImageInfo").get("org"), org)));
+        return getSession().createQuery(query).uniqueResultOptional();
+    }
+
 }

--- a/java/code/src/com/redhat/rhn/frontend/security/PxtAuthenticationService.java
+++ b/java/code/src/com/redhat/rhn/frontend/security/PxtAuthenticationService.java
@@ -73,6 +73,7 @@ public class PxtAuthenticationService extends BaseAuthenticationService {
         set.add("/rhn/common/DownloadFile");
         // search (safe to be unprotected, since it has no modifying side-effects)
         set.add("/rhn/Search.do");
+        set.add("/rhn/manager/upload/image");
 
         POST_UNPROTECTED_URIS = UnmodifiableSet.decorate(set);
     }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
@@ -167,7 +167,7 @@ public class HandlerFactory {
         factory.addHandler("image.delta", new DeltaImageInfoHandler());
         factory.addHandler("image.store", new ImageStoreHandler());
         factory.addHandler("image.profile", new ImageProfileHandler());
-        factory.addHandler("image", new ImageInfoHandler());
+        factory.addHandler("image", new ImageInfoHandler(saltApi));
         factory.addHandler("kickstart", new KickstartHandler());
         factory.addHandler("kickstart.filepreservation", new FilePreservationListHandler());
         factory.addHandler("kickstart.keys", new CryptoKeysHandler());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/DeltaImageInfoHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/DeltaImageInfoHandler.java
@@ -76,7 +76,7 @@ public class DeltaImageInfoHandler extends BaseHandler {
      * @param targetImageId the target Image id
      * @param file the file path
      * @param pillar pillar data
-     * @return the image inspect action id
+     * @return 1 on success
      *
      * @xmlrpc.doc Import an image and schedule an inspect afterwards
      * @xmlrpc.param #param("string", "sessionKey")
@@ -84,7 +84,7 @@ public class DeltaImageInfoHandler extends BaseHandler {
      * @xmlrpc.param #param("int", "targetImageId")
      * @xmlrpc.param #param("string", "file")
      * @xmlrpc.param #param("struct", "pillar")
-     * @xmlrpc.returntype #param_desc("int", "id", "ID of the inspect action created")
+     * @xmlrpc.returntype #return_int_success()
      */
     public Long createDeltaImage(User loggedInUser, Integer sourceImageId, Integer targetImageId,
             String file, Map<String, Object> pillar) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/ImageInfoHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/ImageInfoHandler.java
@@ -15,9 +15,10 @@
 package com.redhat.rhn.frontend.xmlrpc.image;
 
 import com.redhat.rhn.FaultException;
-import com.redhat.rhn.GlobalInstanceHolder;
+import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.errata.ErrataFactory;
+import com.redhat.rhn.domain.image.ImageFile;
 import com.redhat.rhn.domain.image.ImageInfo;
 import com.redhat.rhn.domain.image.ImageInfoCustomDataValue;
 import com.redhat.rhn.domain.image.ImageInfoFactory;
@@ -28,6 +29,7 @@ import com.redhat.rhn.domain.image.ImageStore;
 import com.redhat.rhn.domain.image.ImageStoreFactory;
 import com.redhat.rhn.domain.image.ImageStoreType;
 import com.redhat.rhn.domain.org.Org;
+import com.redhat.rhn.domain.server.Pillar;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.token.ActivationKey;
@@ -35,6 +37,8 @@ import com.redhat.rhn.domain.token.ActivationKeyFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.dto.ErrataOverview;
 import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
+import com.redhat.rhn.frontend.xmlrpc.EntityExistsFaultException;
+import com.redhat.rhn.frontend.xmlrpc.EntityNotExistsFaultException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidParameterException;
 import com.redhat.rhn.frontend.xmlrpc.NoSuchImageException;
 import com.redhat.rhn.frontend.xmlrpc.NoSuchImageProfileException;
@@ -42,6 +46,8 @@ import com.redhat.rhn.frontend.xmlrpc.NoSuchImageStoreException;
 import com.redhat.rhn.frontend.xmlrpc.NoSuchSystemException;
 import com.redhat.rhn.frontend.xmlrpc.TaskomaticApiException;
 import com.redhat.rhn.frontend.xmlrpc.activationkey.NoSuchActivationKeyException;
+
+import com.suse.manager.webui.services.iface.SaltApi;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -59,6 +65,19 @@ import java.util.stream.Collectors;
  * @xmlrpc.doc Provides methods to access and modify images.
  */
 public class ImageInfoHandler extends BaseHandler {
+
+    private final SaltApi saltApi;
+
+    /**
+     * Constructor
+     *
+     * @param saltApiIn the salt API
+     */
+    public ImageInfoHandler(SaltApi saltApiIn) {
+        saltApi = saltApiIn;
+    }
+
+
 
     /**
      * List all images visible for the logged in user
@@ -113,11 +132,42 @@ public class ImageInfoHandler extends BaseHandler {
         if (!opt.isPresent()) {
             throw new NoSuchImageException();
         }
-        return opt.get().getPillar().getPillar();
+        return Optional.ofNullable(opt.get().getPillar()).map(p -> p.getPillar())
+                       .orElseGet(() -> new HashMap<String, Object>());
     }
 
     /**
-     * Schedule an image import
+     * Set Image Pillar
+     * @param loggedInUser The Current User
+     * @param imageId the Image id
+     * @param pillar the new pillar
+     * @return 1 on success
+     *
+     * @xmlrpc.doc Get pillar of an Image
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("int", "imageId")
+     * @xmlrpc.param #param("struct", "pillar")
+     * @xmlrpc.returntype #return_int_success()
+     */
+    public int setPillar(User loggedInUser, Integer imageId, Map<String, Object> pillar) {
+        ensureImageAdmin(loggedInUser);
+        Optional<ImageInfo> imageOpt = ImageInfoFactory.lookupByIdAndOrg(imageId,
+                loggedInUser.getOrg());
+        if (!imageOpt.isPresent()) {
+            throw new NoSuchImageException();
+        }
+        Optional.ofNullable(imageOpt.get().getPillar()).ifPresentOrElse(
+            p -> p.setPillar(pillar),
+            () -> {
+                Pillar newPillar = new Pillar("Image" + imageId, pillar, loggedInUser.getOrg());
+                HibernateFactory.getSession().save(newPillar);
+                imageOpt.get().setPillar(newPillar);
+            });
+        return 1;
+    }
+
+    /**
+     * @deprecated Schedule a Container image import
      * @param loggedInUser The current user
      * @param name The name
      * @param version The version
@@ -141,9 +191,44 @@ public class ImageInfoHandler extends BaseHandler {
      * the following inspect can run")
      * @xmlrpc.returntype #param_desc("int", "id", "ID of the inspect action created")
      */
+    @Deprecated
     public Long importImage(User loggedInUser, String name, String version,
             Integer buildHostId, String storeLabel, String activationKey,
             Date earliestOccurrence) {
+        return  importContainerImage(loggedInUser, name, version,
+            buildHostId, storeLabel, activationKey, earliestOccurrence);
+    }
+
+
+    /**
+     * Schedule a Container image import
+     * @param loggedInUser The current user
+     * @param name The name
+     * @param version The version
+     * @param buildHostId The system ID of the build host
+     * @param storeLabel The store label
+     * @param activationKey The activation key
+     * @param earliestOccurrence Earliest occurrence of the following image inspect
+     * @return the image inspect action id
+     *
+     * @xmlrpc.doc Import an image and schedule an inspect afterwards
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param_desc("string", "name", "image name as specified in the
+     * store")
+     * @xmlrpc.param #param_desc("string", "version", "version to import or empty")
+     * @xmlrpc.param #param_desc("int", "buildHostId", "system ID of the build
+     * host")
+     * @xmlrpc.param #param("string", "storeLabel")
+     * @xmlrpc.param #param_desc("string", "activationKey", "activation key to get
+     * the channel data from")
+     * @xmlrpc.param #param_desc("dateTime.iso8601", "earliestOccurrence", "earliest
+     * the following inspect can run")
+     * @xmlrpc.returntype #param_desc("int", "id", "ID of the inspect action created")
+     */
+    public Long importContainerImage(User loggedInUser, String name, String version,
+            Integer buildHostId, String storeLabel, String activationKey,
+            Date earliestOccurrence) {
+        ensureImageAdmin(loggedInUser);
         if (StringUtils.isEmpty(name)) {
             throw new InvalidParameterException("Image name cannot be empty.");
         }
@@ -174,6 +259,132 @@ public class ImageInfoHandler extends BaseHandler {
             throw new TaskomaticApiException(e.getMessage());
         }
     }
+
+    /**
+     * Import an OS image
+     * @param loggedInUser The current user
+     * @param name The name
+     * @param version The version
+     * @param arch The architecture
+     * @return the image id
+     *
+     * @xmlrpc.doc Import an image and schedule an inspect afterwards
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param_desc("string", "name", "image name as specified in the
+     * store")
+     * @xmlrpc.param #param_desc("string", "version", "version to import")
+     * @xmlrpc.param #param_desc("string", "arch", image architecture")
+     * @xmlrpc.returntype #param_desc("int", "id", "ID of the image")
+     */
+    public Long importOSImage(User loggedInUser, String name, String version, String arch) {
+        ensureImageAdmin(loggedInUser);
+        if (StringUtils.isEmpty(name)) {
+            throw new InvalidParameterException("Image name cannot be empty.");
+        }
+        ImageStore store = ImageStoreFactory.lookupBylabelAndOrg("SUSE Manager OS Image Store", loggedInUser.getOrg())
+                        .orElseThrow(NoSuchImageStoreException::new);
+
+        // Create an image info entry
+        ImageInfo info = new ImageInfo();
+
+        info.setName(name);
+        info.setVersion(version);
+        info.setStore(store);
+        info.setOrg(loggedInUser.getOrg());
+        info.setImageType(ImageProfile.TYPE_KIWI);
+        info.setBuilt(true);
+
+        // Image arch should be the same as the build host
+        // If this is not the case, we can set the correct value in the inspect action
+        // return event
+        info.setImageArch(ServerFactory.lookupServerArchByLabel(arch));
+        ImageInfoFactory.save(info);
+
+
+        ImageInfoFactory.updateRevision(info);
+
+        ImageInfoFactory.save(info);
+
+        return info.getId();
+
+    }
+
+    /**
+     * Delete image file
+     * @param loggedInUser The Current User
+     * @param imageId the Image id
+     * @param file the file name
+     * @return 1 on success
+     *
+     * @xmlrpc.doc Delete image file
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param_desc("int", "imageId", "ID of the image")
+     * @xmlrpc.param #param_desc("string", "file", "the file name")
+     * @xmlrpc.returntype #return_int_success()
+     */
+    public int deleteImageFile(User loggedInUser, Integer imageId, String file) {
+        ensureImageAdmin(loggedInUser);
+        Optional<ImageFile> opt = ImageInfoFactory.lookupImageFile(loggedInUser.getOrg(), file);
+
+        if (!opt.isPresent()) {
+            throw new EntityNotExistsFaultException(file);
+        }
+
+        if (opt.get().getImageInfo().getId() != imageId.longValue()) {
+            // the found file belongs to different image
+            // there is no file attached to this image
+            throw new EntityNotExistsFaultException(file);
+        }
+
+        ImageInfoFactory.deleteImageFile(opt.get(), saltApi);
+
+        return 1;
+    }
+
+    /**
+     * Add image file to an OS image
+     * @param loggedInUser The Current User
+     * @param imageId the Image id
+     * @param file the file name, it must exist in the store
+     * @param type the image type
+     * @param external the file is external
+     * @return 1 on success
+     *
+     * @xmlrpc.doc Delete image file
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param_desc("int", "imageId", "ID of the image")
+     * @xmlrpc.param #param_desc("string", "file", "the file name, it must exist in the store")
+     * @xmlrpc.param #param_desc("string", "type", "the image type")
+     * @xmlrpc.param #param_desc("boolean", "external", "the file is external")
+     * @xmlrpc.returntype #return_int_success()
+     */
+    public Long addImageFile(User loggedInUser, Integer imageId, String file, String type, Boolean external) {
+        ensureImageAdmin(loggedInUser);
+
+        Optional<ImageInfo> opt = ImageInfoFactory.lookupByIdAndOrg(imageId,
+                loggedInUser.getOrg());
+        if (!opt.isPresent()) {
+            throw new NoSuchImageException();
+        }
+
+        if (ImageInfoFactory.lookupImageFile(loggedInUser.getOrg(), file).isPresent()) {
+            throw new EntityExistsFaultException(file);
+        }
+
+        if (ImageInfoFactory.lookupDeltaImageFile(loggedInUser.getOrg(), file).isPresent()) {
+            throw new EntityExistsFaultException(file);
+        }
+
+        ImageFile imageFile = new ImageFile();
+        imageFile.setFile(file);
+        imageFile.setType(type);
+        imageFile.setExternal(external);
+        imageFile.setImageInfo(opt.get());
+        opt.get().getImageFiles().add(imageFile);
+        return 1L;
+    }
+
+
 
     /**
      * Schedule an image build
@@ -333,7 +544,7 @@ public class ImageInfoHandler extends BaseHandler {
         if (!opt.isPresent()) {
             throw new NoSuchImageException();
         }
-        ImageInfoFactory.deleteWithObsoletes(opt.get(), GlobalInstanceHolder.SALT_API);
+        ImageInfoFactory.deleteWithObsoletes(opt.get(), saltApi);
         return 1;
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ImageFileSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ImageFileSerializer.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.frontend.xmlrpc.serializer;
 
 import com.redhat.rhn.domain.image.ImageFile;
+import com.redhat.rhn.domain.image.OSImageStoreUtils;
 import com.redhat.rhn.frontend.xmlrpc.serializer.util.SerializerHelper;
 
 import java.io.IOException;
@@ -27,10 +28,11 @@ import redstone.xmlrpc.XmlRpcSerializer;
  * ImageFileSerializer
  * @xmlrpc.doc
  * #struct_begin("Image information")
- *   #prop_desc("string", "file", "file name")
+ *   #prop_desc("string", "file", "file name without path")
  *   #prop_desc("string", "type", "file type")
  *   #prop_desc("boolean", "external", "true if the file is external,
  *          false otherwise")
+ *   #prop_desc("string", "url", "file url")
  * #struct_end()
  */
 public class ImageFileSerializer extends RhnXmlRpcCustomSerializer {
@@ -43,6 +45,7 @@ public class ImageFileSerializer extends RhnXmlRpcCustomSerializer {
         helper.add("file", file.getFile());
         helper.add("type", file.getType());
         helper.add("external", file.isExternal());
+        helper.add("url", OSImageStoreUtils.getOSImageFileURI(file));
         helper.writeTo(writer);
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ImageInfoSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ImageInfoSerializer.java
@@ -51,6 +51,7 @@ public class ImageInfoSerializer extends RhnXmlRpcCustomSerializer {
         ImageStore store = image.getStore();
         helper.add("id", image.getId());
         helper.add("name", image.getName());
+        helper.add("type", image.getImageType());
         helper.add("version", image.getVersion());
         helper.add("revision", image.getRevisionNumber());
         helper.add("arch", image.getImageArch().getLabel());

--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -40,6 +40,7 @@ import com.suse.manager.webui.controllers.FrontendLogController;
 import com.suse.manager.webui.controllers.ImageBuildController;
 import com.suse.manager.webui.controllers.ImageProfileController;
 import com.suse.manager.webui.controllers.ImageStoreController;
+import com.suse.manager.webui.controllers.ImageUploadController;
 import com.suse.manager.webui.controllers.MinionController;
 import com.suse.manager.webui.controllers.MinionsAPI;
 import com.suse.manager.webui.controllers.NotificationMessageController;
@@ -214,6 +215,9 @@ public class Router implements SparkApplication {
 
         // Rhn Set API
         SetController.initRoutes();
+
+        // Image Upload
+        ImageUploadController.initRoutes();
     }
 
     private void  initNotFoundRoutes(JadeTemplateEngine jade) {

--- a/java/code/src/com/suse/manager/webui/controllers/ImageUploadController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/ImageUploadController.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.webui.controllers;
+
+import static com.suse.manager.webui.services.SaltConstants.SALT_FILE_GENERATION_TEMP_PATH;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withImageAdmin;
+
+import com.redhat.rhn.GlobalInstanceHolder;
+import com.redhat.rhn.domain.image.ImageInfoFactory;
+import com.redhat.rhn.domain.image.OSImageStoreUtils;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.manager.EntityExistsException;
+
+import com.suse.manager.webui.utils.gson.ResultJson;
+
+import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.fileupload.disk.DiskFileItem;
+import org.apache.commons.fileupload.disk.DiskFileItemFactory;
+import org.apache.commons.fileupload.servlet.ServletFileUpload;
+import org.apache.http.HttpStatus;
+import org.apache.log4j.Logger;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.List;
+
+import spark.Request;
+import spark.Response;
+import spark.Spark;
+
+/**
+ * Controller class for image file upload.
+ */
+public class ImageUploadController {
+
+    private static final Logger LOG = Logger.getLogger(ImageUploadController.class);
+
+    private ImageUploadController() { }
+
+    /**
+     * Initialize request routes for the pages served by ImageUploadController
+     *
+     */
+    public static void initRoutes() {
+
+        Spark.post("/manager/upload/image", withImageAdmin(ImageUploadController::uploadImage));
+    }
+
+
+    /**
+     * Upload Image File
+     *
+     * @param request the request
+     * @param response the response
+     * @param user the user
+     * @return the json response
+     */
+    public static String uploadImage(Request request, Response response, User user) {
+        try {
+            DiskFileItemFactory fileItemFactory = new DiskFileItemFactory();
+            fileItemFactory.setSizeThreshold(0);
+
+            // tmp directory writable by tomcat, redable by salt
+            fileItemFactory.setRepository(new File(SALT_FILE_GENERATION_TEMP_PATH));
+            List<FileItem> items = new ServletFileUpload(fileItemFactory).parseRequest(request.raw());
+
+            try {
+                items.stream().forEach(item -> {
+                    if (ImageInfoFactory.lookupDeltaImageFile(user.getOrg(), item.getName()).isPresent() ||
+                        ImageInfoFactory.lookupImageFile(user.getOrg(), item.getName()).isPresent()) {
+                        throw new EntityExistsException("Image file already exists");
+                    }
+                    DiskFileItem diskFileItem = (DiskFileItem) item;
+                    if (diskFileItem == null) {
+                        throw new RuntimeException("Can't get uploaded file");
+                    }
+
+                    // copy file to final location using salt
+                    GlobalInstanceHolder.SALT_API.copyFile(diskFileItem.getStoreLocation().toPath(),
+                        Paths.get(OSImageStoreUtils.getOSImageStorePathForOrg(user.getOrg()) + item.getName()))
+                        .orElseThrow(() -> new RuntimeException("Can't move the image file"));
+                });
+            }
+            finally {
+                // do not rely on GC, delete the file now
+                items.stream().forEach(item -> {
+                    DiskFileItem diskFileItem = (DiskFileItem) item;
+                    if (diskFileItem != null) {
+                        diskFileItem.delete();
+                    }
+                });
+            }
+        }
+        catch (Exception e) {
+            LOG.error("Image upload error", e);
+            return json(response, HttpStatus.SC_INTERNAL_SERVER_ERROR,
+                        ResultJson.error(e.getMessage()));
+        }
+        return json(response, ResultJson.success());
+    }
+}

--- a/java/code/src/com/suse/manager/webui/services/iface/SaltApi.java
+++ b/java/code/src/com/suse/manager/webui/services/iface/SaltApi.java
@@ -96,6 +96,16 @@ public interface SaltApi {
     Optional<Boolean> removeFile(Path path);
 
     /**
+     * Copy given file using RunnerCall
+     *
+     * @param src the source path of file to be removed
+     * @param dst the destination path of file to be removed
+     * @throws IllegalStateException if the given path is not absolute
+     * @return Optional with true if the file deletion succeeded.
+     */
+    Optional<Boolean> copyFile(Path src, Path dst);
+
+    /**
      * Performs an test.echo on a target set of minions for checkIn purpose.
      * @param targetIn the target
      * @return the LocalAsyncResult of the test.echo call

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -1376,6 +1376,18 @@ public class SaltService implements SystemQuery, SaltApi {
         return callSync(createFile);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Optional<Boolean> copyFile(Path src, Path dst) {
+        ensureAbsolutePath(src);
+        ensureAbsolutePath(dst);
+        RunnerCall<Boolean> call = MgrRunner.copyFile(src.toAbsolutePath().toString(),
+                                              dst.toAbsolutePath().toString(), false, false);
+        return callSync(call);
+    }
+
     private void ensureAbsolutePath(Path path) {
         if (!path.isAbsolute()) {
             throw new IllegalStateException("Given path is not absolute: " + path);

--- a/java/code/src/com/suse/manager/webui/services/impl/runner/MgrRunner.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/runner/MgrRunner.java
@@ -76,5 +76,25 @@ public class MgrRunner {
                 "path", absolutePath)),
                 new TypeToken<Boolean>() { });
     }
+
+    /**
+     * {@link RunnerCall} for copying a file
+     * The result of the call is the boolean, which is true, if the path was successfully copied.
+     *
+     * @param src the source path of the file
+     * @param dst the destination path of the file
+     * @param recurse recurse into subdirectories
+     * @param removeExisting remove all files in the target directory, and then copy files from the source
+     * @return the runner call
+     */
+    public static RunnerCall<Boolean> copyFile(String src, String dst, boolean recurse, boolean removeExisting) {
+        return new RunnerCall("salt.cmd", Optional.of(Map.of(
+                "fun", "file.copy",
+                "src", src,
+                "dst", dst,
+                "recurse", recurse,
+                "remove_existing", removeExisting)),
+                new TypeToken<Boolean>() { });
+    }
 }
 

--- a/java/code/src/com/suse/manager/webui/services/test/TestSaltApi.java
+++ b/java/code/src/com/suse/manager/webui/services/test/TestSaltApi.java
@@ -77,6 +77,11 @@ public class TestSaltApi implements SaltApi {
     }
 
     @Override
+    public Optional<Boolean> copyFile(Path src, Path dst) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Optional<LocalAsyncResult<String>> checkIn(MinionList targetIn) throws SaltException {
         throw new UnsupportedOperationException();
     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Improve XMLRPC API for image management
+- Allow image upload via HTTP
 - Remove doc search functionality
 - adapt for new c3p0 and mchange-commons package
 - Set default image download protocol to http


### PR DESCRIPTION
## What does this PR change?

Add new API calls and new fields in image lists.
Add image upload controller.

Image upload is compatible with the future HTTP API:
```
curl -H "Content-Type: application/json" -c cookies   -d "{'login':'admin','password':'admin'}" https://srv.tf.local/rhn/manager/api/login
curl -H "Content-Type: multipart/form-data" -F "data=@POS_Image_JeOS7_uyuni.x86_64-7.0.0-build87.tar.xz" -c cookies -b cookies https://srv.tf.local/rhn/manager/upload/image
```
## GUI diff

No difference.

- [x] **DONE**

## Documentation
- TBD

- [ ] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/16645
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
