### PR TITLE
Spacecmd api boolean param

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- parse boolean paramaters correctly (bsc#1197689)
 - Add parameter to set containerized proxy SSH port
 
 -------------------------------------------------------------------

--- a/spacecmd/src/spacecmd/api.py
+++ b/spacecmd/src/spacecmd/api.py
@@ -109,6 +109,7 @@ def do_api(self, args):
         if (output != sys.stdout):
             output.close()
 
-    except xmlrpclib.Fault:
+    except xmlrpclib.Fault as e:
+        logging.error(e)
         if (output != sys.stdout):
             output.close()

--- a/spacecmd/src/spacecmd/utils.py
+++ b/spacecmd/src/spacecmd/utils.py
@@ -614,11 +614,8 @@ def parse_str(s, type_to=None):
         if re.match(r'[1-9]\d*', s):
             return int(s)
 
-        if s == "True":
-            return True
-
-        if s == "False":
-            return False
+        if s in ("False", "True"):
+            return eval(s)
 
         if re.match(r'{.*}', s):
             return json.loads(s)  # retry with json module

--- a/spacecmd/src/spacecmd/utils.py
+++ b/spacecmd/src/spacecmd/utils.py
@@ -614,6 +614,12 @@ def parse_str(s, type_to=None):
         if re.match(r'[1-9]\d*', s):
             return int(s)
 
+        if s == "True":
+            return True
+
+        if s == "False":
+            return False
+
         if re.match(r'{.*}', s):
             return json.loads(s)  # retry with json module
 

--- a/spacecmd/tests/test_utils.py
+++ b/spacecmd/tests/test_utils.py
@@ -491,6 +491,8 @@ class TestSCUtils:
         """
         assert spacecmd.utils.parse_str("1234567", int) == 1234567
         assert spacecmd.utils.parse_str("1234567") == 1234567
+        assert spacecmd.utils.parse_str("True") == True
+        assert spacecmd.utils.parse_str("False") == False
         assert spacecmd.utils.parse_str("ABC1234567") == "ABC1234567"
         assert spacecmd.utils.parse_str('{"foo": "bar"}') == {"foo": "bar"}
         assert spacecmd.utils.parse_str('{"number": 123}') == {"number": 123}
@@ -524,6 +526,12 @@ class TestSCUtils:
         assert i == 1234567
         assert s == "abcXYZ012"
         assert d["channelLabel"] == "foo-i386-5"
+
+        i, b, s, b2 = spacecmd.utils.parse_api_args('1234,True,abc1234,False')
+        assert i == 1234
+        assert b == True
+        assert s == "abc1234"
+        assert b2 == False
 
     def test_json_dump_to_file(self):
         """


### PR DESCRIPTION
## What does this PR change?

Using "spacecmd api" with boolean paramaters fail as they are not parsed correctly and converted to strings.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/17415

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
