### PR TITLE
Prevent building python2 subpackages for SLE15

### DIFF
--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
@@ -1,3 +1,6 @@
+- Fix the condition for preventing building python 2 subpackage
+  for SLE15
+
 -------------------------------------------------------------------
 Fri Mar 11 15:08:56 CET 2022 - jgonzalez@suse.com
 

--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.spec
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.spec
@@ -23,7 +23,7 @@
 %global __python /usr/bin/python3
 %endif
 
-%if !(0%{?rhel} >= 8 || 0%{?sle_version} >= 150400 )
+%if !(0%{?rhel} >= 8 || 0%{?sle_version} >= 150000 )
 %global build_py2   1
 %endif
 

--- a/client/tools/mgr-cfg/mgr-cfg.changes
+++ b/client/tools/mgr-cfg/mgr-cfg.changes
@@ -1,3 +1,6 @@
+- Fix the condition for preventing building python 2 subpackage
+  for SLE15 (bsc#1197579)
+
 -------------------------------------------------------------------
 Fri Mar 11 14:43:33 CET 2022 - jgonzalez@suse.com
 

--- a/client/tools/mgr-cfg/mgr-cfg.spec
+++ b/client/tools/mgr-cfg/mgr-cfg.spec
@@ -36,7 +36,7 @@
 %global __python /usr/bin/python2 
 %endif
 
-%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || (0%{?suse_version} && 0%{?sle_version} < 150400) || 0%{?ubuntu} || 0%{?debian}
+%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || (0%{?suse_version} && 0%{?sle_version} < 150000) || 0%{?ubuntu} || 0%{?debian}
 %global build_py2   1
 %endif
 

--- a/client/tools/mgr-osad/mgr-osad.changes
+++ b/client/tools/mgr-osad/mgr-osad.changes
@@ -1,3 +1,6 @@
+- Fix the condition for preventing building python 2 subpackage
+  for SLE15
+
 -------------------------------------------------------------------
 Fri Mar 11 15:00:11 CET 2022 - jgonzalez@suse.com
 

--- a/client/tools/mgr-osad/mgr-osad.spec
+++ b/client/tools/mgr-osad/mgr-osad.spec
@@ -39,7 +39,7 @@
 %global default_py3 1
 %endif
 
-%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || (0%{?suse_version} && 0%{?sle_version} < 150400)
+%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || (0%{?suse_version} && 0%{?sle_version} < 150000)
 %global build_py2   1
 %endif
 

--- a/client/tools/mgr-push/mgr-push.changes
+++ b/client/tools/mgr-push/mgr-push.changes
@@ -1,3 +1,6 @@
+- Fix the condition for preventing building python 2 subpackage
+  for SLE15
+
 -------------------------------------------------------------------
 Fri Mar 11 14:44:59 CET 2022 - jgonzalez@suse.com
 

--- a/client/tools/mgr-push/mgr-push.spec
+++ b/client/tools/mgr-push/mgr-push.spec
@@ -28,7 +28,7 @@
 %global default_py3 1
 %endif
 
-%if !( 0%{?rhel} >= 8 || 0%{?sle_version} >= 150400 )
+%if !( 0%{?rhel} >= 8 || 0%{?sle_version} >= 150000 )
 %global build_py2   1
 %endif
 

--- a/client/tools/mgr-virtualization/mgr-virtualization.changes
+++ b/client/tools/mgr-virtualization/mgr-virtualization.changes
@@ -1,3 +1,6 @@
+- Fix the condition for preventing building python 2 subpackage
+  for SLE15
+
 -------------------------------------------------------------------
 Fri Mar 11 15:06:20 CET 2022 - jgonzalez@suse.com
 

--- a/client/tools/mgr-virtualization/mgr-virtualization.spec
+++ b/client/tools/mgr-virtualization/mgr-virtualization.spec
@@ -35,7 +35,7 @@
 %global default_py3 1
 %endif
 
-%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || (0%{?suse_version} && 0%{?sle_version} < 150400)
+%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || (0%{?suse_version} && 0%{?sle_version} < 150000)
 %global build_py2   1
 %endif
 

--- a/client/tools/spacewalk-koan/spacewalk-koan.changes
+++ b/client/tools/spacewalk-koan/spacewalk-koan.changes
@@ -1,3 +1,6 @@
+- Fix the condition for preventing building python 2 subpackage
+  for SLE15
+
 -------------------------------------------------------------------
 Fri Mar 11 15:09:17 CET 2022 - jgonzalez@suse.com
 

--- a/client/tools/spacewalk-koan/spacewalk-koan.spec
+++ b/client/tools/spacewalk-koan/spacewalk-koan.spec
@@ -25,7 +25,7 @@
 %global default_py3 1
 %endif
 
-%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || (0%{?suse_version} && 0%{?sle_version} < 150400)
+%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || (0%{?suse_version} && 0%{?sle_version} < 150000)
 %global build_py2   1
 %endif
 

--- a/client/tools/spacewalk-oscap/spacewalk-oscap.changes
+++ b/client/tools/spacewalk-oscap/spacewalk-oscap.changes
@@ -1,3 +1,6 @@
+- Fix the condition for preventing building python 2 subpackage
+  for SLE15
+
 -------------------------------------------------------------------
 Mon Mar 21 15:13:16 CET 2022 - jgonzalez@suse.com
 

--- a/client/tools/spacewalk-oscap/spacewalk-oscap.spec
+++ b/client/tools/spacewalk-oscap/spacewalk-oscap.spec
@@ -22,7 +22,7 @@
 %global default_py3 1
 %endif
 
-%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || (0%{?suse_version} && 0%{?sle_version} < 150400)
+%if ( 0%{?fedora} && 0%{?fedora} < 28 ) || ( 0%{?rhel} && 0%{?rhel} < 8 ) || (0%{?suse_version} && 0%{?sle_version} < 150000)
 %global build_py2   1
 %endif
 

--- a/python/rhn/rhnlib.changes
+++ b/python/rhn/rhnlib.changes
@@ -1,3 +1,6 @@
+- Fix the condition for preventing building python 2 subpackage
+  for SLE15
+
 -------------------------------------------------------------------
 Fri Mar 11 15:44:41 CET 2022 - jgonzalez@suse.com
 

--- a/python/rhn/rhnlib.spec
+++ b/python/rhn/rhnlib.spec
@@ -26,7 +26,7 @@
 %endif
 %endif
 
-%if !(0%{?rhel} >= 8 || 0%{?sle_version} >= 150400 )
+%if !(0%{?rhel} >= 8 || 0%{?sle_version} >= 150000 )
 %global build_py2   1
 %{!?__python2:%global __python2 /usr/bin/python2}
 %if %{undefined python2_sitelib}

--- a/suseRegisterInfo/suseRegisterInfo.changes
+++ b/suseRegisterInfo/suseRegisterInfo.changes
@@ -1,3 +1,6 @@
+- Fix the condition for preventing building python 2 subpackage
+  for SLE15
+
 -------------------------------------------------------------------
 Tue Jan 18 14:02:57 CET 2022 - jgonzalez@suse.com
 

--- a/suseRegisterInfo/suseRegisterInfo.spec
+++ b/suseRegisterInfo/suseRegisterInfo.spec
@@ -21,7 +21,7 @@
 %global default_py3 1
 %endif
 
-%if !( 0%{?rhel} >= 8 || 0%{?sle_version} >= 150400 )
+%if !( 0%{?rhel} >= 8 || 0%{?sle_version} >= 150000 )
 %global build_py2   1
 %global __python /usr/bin/python2
 %{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}


### PR DESCRIPTION
## What does this PR change?

Prevent building python2 subpackages for SLE15

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17379

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
