### PR TITLE
Drop stale TODOs

### DIFF
--- a/containers/proxy-httpd-image/Dockerfile
+++ b/containers/proxy-httpd-image/Dockerfile
@@ -32,10 +32,6 @@ EXPOSE 443/tcp
 
 VOLUME ["/etc/uyuni", "/srv/tftpboot", "/var/cache/rhn"]
 
-# TODO: remove, devel
-RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-licenses vim less
-
-# TODO: check and adjust
 RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-licenses \
  python3-rhnlib spacewalk-proxy-broker \
  spacewalk-proxy-common spacewalk-proxy-package-manager \

--- a/containers/proxy-httpd-image/proxy-httpd-image.changes
+++ b/containers/proxy-httpd-image/proxy-httpd-image.changes
@@ -1,3 +1,5 @@
+- Drop stale TODOs
+
 -------------------------------------------------------------------
 Mon Mar 28 09:33:31 UTC 2022 - Ondrej Holecek <oholecek@suse.com>
 

--- a/containers/proxy-ssh-image/proxy-ssh-image.changes
+++ b/containers/proxy-ssh-image/proxy-ssh-image.changes
@@ -1,3 +1,5 @@
+- Drop stale TODOs
+
 -------------------------------------------------------------------
 Wed Mar 23 09:04:14 UTC 2022 - Cédric Bosdonnat <cbosdonnat@suse.com>
 

--- a/containers/proxy-ssh-image/uyuni-configure.py
+++ b/containers/proxy-ssh-image/uyuni-configure.py
@@ -18,7 +18,6 @@ with open("/etc/uyuni/config.yaml") as source:
     os.system(f'groupadd -r {SSH_PUSH_USER}')
     os.system(f'useradd -r -g {SSH_PUSH_USER} -m -d {SSH_PUSH_USER_HOME} -c "susemanager ssh push tunnel" {SSH_PUSH_USER}')
 
-
     # create .ssh dir in home and set permissions
     os.makedirs(SSH_PUSH_KEY_DIR)
     os.system(f'chown {SSH_PUSH_USER}:{SSH_PUSH_USER} {SSH_PUSH_KEY_DIR}')
@@ -27,17 +26,12 @@ with open("/etc/uyuni/config.yaml") as source:
     # copy the ssh push server/parent key files
     shutil.copyfile("/etc/uyuni/server_ssh_push", f"{SSH_PUSH_KEY_DIR}/{SSH_PUSH_KEY_FILE}")
     shutil.copyfile("/etc/uyuni/server_ssh_push.pub", f"{SSH_PUSH_KEY_DIR}/{SSH_PUSH_KEY_FILE}.pub")
-
     
     # change owner to {SSH_PUSH_USER}
     os.system(f'chown {SSH_PUSH_USER}:{SSH_PUSH_USER} {SSH_PUSH_KEY_DIR}/{SSH_PUSH_KEY_FILE}')
     os.system(f'chmod 600 {SSH_PUSH_KEY_DIR}/{SSH_PUSH_KEY_FILE}')
     os.system(f'chown {SSH_PUSH_USER}:{SSH_PUSH_USER} {SSH_PUSH_KEY_DIR}/{SSH_PUSH_KEY_FILE}.pub')
     os.system(f'chmod 644 {SSH_PUSH_KEY_DIR}/{SSH_PUSH_KEY_FILE}.pub')
-
-    # TODO
-    # copy the public key to apache's pub dir
-    # cp {SSH_PUSH_KEY_DIR}/{SSH_PUSH_KEY_FILE}.pub ${HTMLPUB_DIR}/
 
     # Authorize the server to ssh into this container
     shutil.copyfile("/etc/uyuni/server_ssh_key.pub", f"{SSH_PUSH_KEY_DIR}/authorized_keys")


### PR DESCRIPTION
## What does this PR change?

Cleanup of uselss code/comments https://github.com/SUSE/spacewalk/issues/17396

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: drop comments

- [x] **DONE**

## Test coverage
- No tests: drop comments

- [x] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/17396
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
