### PR TITLE
QE: Improve uptime tests code

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -79,23 +79,16 @@ Then(/^the system name for "([^"]*)" should be correct$/) do |host|
 end
 
 Then(/^the uptime for "([^"]*)" should be correct$/) do |host|
-  node = get_target(host)
-  uptime, _return_code = node.run('cat /proc/uptime') # run code on node only once, to get uptime
-  uptime_seconds = uptime.split[0].to_f # return only the uptime in seconds, as a float
-  uptime_minutes = (uptime_seconds / 60.0) # 60 seconds; the .0 forces a float division
-  uptime_hours = (uptime_minutes / 60.0) # 60 minutes
-  uptime_days = (uptime_hours / 24.0) # 24 hours
-
+  uptime = get_uptime_from_host(host)
   # rounded values to nearest integer number
-  rounded_uptime_minutes = uptime_minutes.round
-  rounded_uptime_hours = uptime_hours.round
-
+  rounded_uptime_minutes = uptime[:minutes].round
+  rounded_uptime_hours = uptime[:hours].round
   # needed for the library's conversion of 24h multiples plus 11 hours to consider the next day
   eleven_hours_in_seconds = 39600 # 11 hours * 60 minutes * 60 seconds
-  rounded_uptime_days = ((uptime_seconds + eleven_hours_in_seconds) / 86400.0).round # 60 seconds * 60 minutes * 24 hours
+  rounded_uptime_days = ((uptime[:seconds] + eleven_hours_in_seconds) / 86400.0).round # 60 seconds * 60 minutes * 24 hours
 
   # the moment.js library being used has some weird rules, which these conditionals follow
-  if (uptime_days >= 1 && rounded_uptime_days < 2) || (uptime_days < 1 && rounded_uptime_hours >= 22) # shows "a day ago" after 22 hours and before it's been 1.5 days
+  if (uptime[:days] >= 1 && rounded_uptime_days < 2) || (uptime[:days] < 1 && rounded_uptime_hours >= 22) # shows "a day ago" after 22 hours and before it's been 1.5 days
     step %(I should see a "a day ago" text)
   elsif rounded_uptime_hours > 1 && rounded_uptime_hours <= 21
     step %(I should see a "#{rounded_uptime_hours} hours ago" text)
@@ -103,9 +96,9 @@ Then(/^the uptime for "([^"]*)" should be correct$/) do |host|
     step %(I should see a "an hour ago" text)
   elsif rounded_uptime_minutes > 1 && rounded_uptime_hours < 1
     step %(I should see a "#{rounded_uptime_minutes} minutes ago" text)
-  elsif uptime_seconds >= 45 && rounded_uptime_minutes == 1
+  elsif uptime[:seconds] >= 45 && rounded_uptime_minutes == 1
     step %(I should see a "a minute ago" text)
-  elsif uptime_seconds < 45
+  elsif uptime[:seconds] < 45
     step %(I should see a "a few seconds ago" text)
   elsif rounded_uptime_days < 25
     step %(I should see a "#{rounded_uptime_days} days ago" text) # shows "a month ago" from 25 days onwards

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -226,3 +226,13 @@ def get_variable_from_conf_file(host, file_path, variable_name)
   raise "Reading #{variable_name} from file on #{host} #{file_path} failed" unless return_code.zero?
   variable_value.strip!
 end
+
+def get_uptime_from_host(host)
+  node = get_target(host)
+  uptime, _return_code = node.run('cat /proc/uptime') # run code on node only once, to get uptime
+  seconds = Float(uptime.split[0]) # return only the uptime in seconds, as a float
+  minutes = (seconds / 60.0) # 60 seconds; the .0 forces a float division
+  hours = (minutes / 60.0) # 60 minutes
+  days = (hours / 24.0) # 24 hours
+  { seconds: seconds, minutes: minutes, hours: hours, days: days }
+end


### PR DESCRIPTION
## What does this PR change?

Just improves the step for uptime tests by extracting some of the code into a separate method.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were modified

- [x] **DONE**

## Ports
- 4.1
- 4.2

- [ ] **DONE**

## Changelogs
- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
