### PR TITLE
Fix architecture detection for the Salt Bundle

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -311,7 +311,7 @@ function test_venv_enabled() {
     elif [ $AVOID_VENV_SALT_MINION -ne 1 ]; then
         local repourl="$CLIENT_REPO_URL"
         if [ "$INSTALLER" == "zypper" ] || [ "$INSTALLER" == "yum" ]; then
-            ARCH=$(rpm --eval "%{_host_cpu}")
+            ARCH=$(rpm --eval "%{_arch}")
         else
             ARCH=$(dpkg --print-architecture)
         fi

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,6 @@
+- Use _arch instead of _host_cpu macro to detect the arch
+  of the Salt Bundle to be deployed (bsc#1197759)
+
 -------------------------------------------------------------------
 Tue Mar 15 16:30:36 CET 2022 - jgonzalez@suse.com
 

--- a/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
+++ b/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
@@ -77,7 +77,7 @@ else
 fi
 
 if [ "$INSTALLER" == "zypper" ] || [ "$INSTALLER" == "yum" ]; then
-    ARCH=$(rpm --eval "%{_host_cpu}")
+    ARCH=$(rpm --eval "%{_arch}")
 else
     ARCH=$(dpkg --print-architecture)
 fi

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,6 @@
+- Use _arch instead of _host_cpu macro to detect the arch
+  of the Salt Bundle to be deployed (bsc#1197759)
+
 -------------------------------------------------------------------
 Thu Mar 31 12:22:55 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Use `%{_arch}` instead of `%{_host_cpu}` to detect package architecure for the Salt Bundle to be deployed.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: alternative architecutres are not covered with the tests

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1197759

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
