### PR TITLE
Fix improper error handling on extracting package by preflight script

### DIFF
--- a/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
+++ b/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
@@ -247,13 +247,13 @@ if [ -n "${VENV_SOURCE}" ]; then
             mv usr usr.tmp
             mv usr.tmp/lib/venv-salt-minion/* .
             rm -rf usr.tmp
+            if [ ! -x bin/python ]; then
+                rm -f "${VENV_TMP_DIR}/${VENV_HASH_FILE}"
+                exit_with_message_code "Error: Unable to extract the bundle from ${TEMP_DIR}/${VENV_PKG_FILE}!" 6
+            fi
         else
             cp -r "${VENV_INST_DIR}" "${VENV_TMP_DIR}"
             pushd "${VENV_TMP_DIR}" > /dev/null
-        fi
-        if [ -x bin/python ]; then
-            rm -f "${VENV_TMP_DIR}/${VENV_HASH_FILE}"
-            exit_with_message_code "Error: Unable to extract the bundle from ${TEMP_DIR}/${VENV_PKG_FILE}!" 6
         fi
         grep -m1 -r "^#\!${VENV_INST_DIR}" bin/ | sed 's/:.*//' | sort | uniq | xargs -I '{}' sed -i "1s=^#!${VENV_INST_DIR}/bin/.*=#!${VENV_TMP_DIR}/bin/python=" {}
         sed -i "s#${VENV_INST_DIR}#${VENV_TMP_DIR}#g" bin/python

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,6 @@
+- Fix the improper condition for checking if the Salt Bundle
+  was extracted with pre flight script
+
 -------------------------------------------------------------------
 Thu Mar 31 15:55:44 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fixes improper error handling on checking if the package was extracted.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
