### PR TITLE
drop and re-create the reportdb in the test correctly

### DIFF
--- a/susemanager-utils/testing/docker/scripts/clear-db-answers-pgsql.txt
+++ b/susemanager-utils/testing/docker/scripts/clear-db-answers-pgsql.txt
@@ -6,7 +6,7 @@ db-name=susemanager
 db-host=
 report-db-backend=postgresql
 report-db-user=pythia
-report-db-password=spacewalk
+report-db-password=oracle
 report-db-name=reportdb
 report-db-host=
 

--- a/susemanager-utils/testing/docker/scripts/schema_migration_reportdb_test_pgsql.sh
+++ b/susemanager-utils/testing/docker/scripts/schema_migration_reportdb_test_pgsql.sh
@@ -60,6 +60,7 @@ smdba system-check autotuning --max_connections=50
 
 # this command will fail with certificate error. This is ok, so ignore the error
 spacewalk-setup --skip-system-version-test --skip-selinux-test --skip-fqdn-test --skip-ssl-cert-generation --skip-ssl-vhost-setup --skip-services-check --clear-db --answer-file=clear-db-answers-pgsql.txt --external-postgresql --non-interactive ||:
+/manager/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb remove --db reportdb --user pythia ||:
 /manager/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb create --db reportdb --user pythia --password spacewalk --local
 
 # this copy the latest schema from the git into the system


### PR DESCRIPTION
## What does this PR change?

Containers might have a reportdb already. Drop it before re-creating it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
