### PR TITLE
Accept kernel_options as string from Cobbler

### DIFF
--- a/java/code/src/org/cobbler/CobblerObject.java
+++ b/java/code/src/org/cobbler/CobblerObject.java
@@ -316,8 +316,15 @@ public abstract class CobblerObject {
     /**
      * @return the kernelOptions
      */
+    @SuppressWarnings("unchecked")
     public Map<String, Object> getKernelOptions() {
-        return (Map<String, Object>)dataMap.get(KERNEL_OPTIONS);
+        Object kernelOpts = dataMap.get(KERNEL_OPTIONS);
+        try {
+            return (Map<String, Object>) kernelOpts;
+        }
+        catch (ClassCastException e) {
+            return parseKernelOpts((String) kernelOpts);
+        }
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Accept kernel_options as string from Cobbler
 - Fix virtFileSize type after cobbler upgrade
 - Redefine available power_management.types for cobbler >= 3.3.1
 - Improved task to update the reporting database


### PR DESCRIPTION
The new Cobbler returns `kernel_options` as a string instead of a `dict`. This PR accepts both types for kernel options.

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
