### PR TITLE
Better free product check

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -802,8 +802,9 @@ public class ContentSyncManager {
             else if (c != null &&
                     repo.getProducts().stream()
                         .map(SUSEProductSCCRepository::getProduct)
-                        .anyMatch(p -> p.getFree() &&
-                                p.getChannelFamily().getLabel().equals("SLE-M-T"))) {
+                        .filter(SUSEProduct::getFree)
+                        .anyMatch(p -> p.getChannelFamily().getLabel().startsWith("SLE-M-T") ||
+                                p.getChannelFamily().getLabel().startsWith("OPENSUSE"))) {
                 log.debug("Free repo detected. Setting NoAuth for " + repo.getUrl());
                 newAuth = new SCCRepositoryNoAuth();
             }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- detect free products in Alpha and Beta stage and prevent checks
+  on openSUSE products (bsc#1197488)
 - Implement JSON over HTTP API
 - Preserve parameter names in bytecode
 - Disable CSRF tokens for API routes


### PR DESCRIPTION
## What does this PR change?

We skip checks on URLs for free products. Currently we skipped the test only when the product class of that product was
"SLE-M-T" which failed when these products were still in Alpha or Beta stage and the product class was "SLE-M-T-ALPHA" or "SLE-M-T-BETA".
We also performed a check on openSUSE product URLs as the product class is "OPENSUSE".

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/17427

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
