### PR TITLE
Proxy httpd container missing subfolder

### DIFF
--- a/containers/proxy-httpd-image/uyuni-configure.py
+++ b/containers/proxy-httpd-image/uyuni-configure.py
@@ -141,6 +141,8 @@ os.system('chown -R root:root /srv/www/htdocs/pub')
 os.system('chmod -R 755 /srv/www/htdocs/pub')
 os.system('chown -R wwwrun:www /var/spool/rhn-proxy')
 os.system('chmod -R 750 /var/spool/rhn-proxy')
+if not os.path.exists('/var/cache/rhn/proxy-auth'):
+    os.makedirs('/var/cache/rhn/proxy-auth')
 os.system('chown -R wwwrun:root /var/cache/rhn/proxy-auth')
 os.system('chown -R wwwrun:root /srv/tftpboot')
 os.system('chmod 755 /srv/tftpboot')


### PR DESCRIPTION
## What does this PR change?

Fix: make sure a subfolder is there or create it otherwise.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: fix

- [x] **DONE**

## Test coverage
- No tests: fix

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
