### PR TITLE
Fix tftpsync ipv6 config

### DIFF
--- a/tftpsync/susemanager-tftpsync-recv/configure-tftpsync.sh
+++ b/tftpsync/susemanager-tftpsync-recv/configure-tftpsync.sh
@@ -111,13 +111,13 @@ default_or_input "SUSE Manager Proxy FQDN" SUMA_PROXY_FQDN $(hostname -f)
 
 default_or_input "SUSE Manager Proxy IPv4 Address" SUMA_PROXY_IP $(getent ahostsv4 $SUMA_PROXY_FQDN | awk '{ print $1 }' | head -1 || echo "")
 
-default_or_input "SUSE Manager Proxy IPv6 Address" SUMA_PROXY_IP6 $(getent ahostsv6 $SUMA_PROXY_FQDN | awk '{ print $1 }' | head -1 || echo "")
+default_or_input "SUSE Manager Proxy IPv6 Address" SUMA_PROXY_IP6 $(getent ahostsv6 $SUMA_PROXY_FQDN | awk '{ print $1 }' | head -1 | grep -v '^::' || echo "")
 
 default_or_input "SUSE Manager Server FQDN" SUMA_FQDN $PARENT_FQDN
 
 default_or_input "SUSE Manager Parent IPv4 Address" SUMA_IP $(getent ahostsv4 $SUMA_FQDN | awk '{ print $1 }' | head -1 || echo "" )
 
-default_or_input "SUSE Manager Parent IPv6 Address" SUMA_IP6 $(getent ahostsv6 $SUMA_FQDN | awk '{ print $1 }' | head -1 || echo "" )
+default_or_input "SUSE Manager Parent IPv6 Address" SUMA_IP6 $(getent ahostsv6 $SUMA_FQDN | awk '{ print $1 }' | head -1 | grep -v '^::' || echo "" )
 
 
 
@@ -180,8 +180,13 @@ fi
 
 sed -i "s/^[[:space:]]*Allow from[[:space:]].*$/#        Allow from /g" /etc/apache2/conf.d/susemanager-tftpsync-recv.conf
 sed -i "s/^[[:space:]]*Require ip[[:space:]].*$/#        Require ip /g" /etc/apache2/conf.d/susemanager-tftpsync-recv.conf
-sed -i "0,/^[[:space:]#]*Allow from[[:space:]].*/s/^[[:space:]#]*Allow from[[:space:]].*$/        Allow from $SUMA_IP\n        Allow from $SUMA_IP6/" /etc/apache2/conf.d/susemanager-tftpsync-recv.conf
-sed -i "0,/^[[:space:]#]*Require ip[[:space:]].*/s/^[[:space:]#]*Require ip[[:space:]].*$/        Require ip $SUMA_IP\n        Require ip $SUMA_IP6/" /etc/apache2/conf.d/susemanager-tftpsync-recv.conf
+if [ -n "$SUMA_IP6" ]; then
+    sed -i "0,/^[[:space:]#]*Allow from[[:space:]].*/s/^[[:space:]#]*Allow from[[:space:]].*$/        Allow from $SUMA_IP\n        Allow from $SUMA_IP6/" /etc/apache2/conf.d/susemanager-tftpsync-recv.conf
+    sed -i "0,/^[[:space:]#]*Require ip[[:space:]].*/s/^[[:space:]#]*Require ip[[:space:]].*$/        Require ip $SUMA_IP\n        Require ip $SUMA_IP6/" /etc/apache2/conf.d/susemanager-tftpsync-recv.conf
+else
+    sed -i "s/^[[:space:]#]*Allow from[[:space:]].*/        Allow from $SUMA_IP/" /etc/apache2/conf.d/susemanager-tftpsync-recv.conf
+    sed -i "s/^[[:space:]#]*Require ip[[:space:]].*/        Require ip $SUMA_IP/" /etc/apache2/conf.d/susemanager-tftpsync-recv.conf
+fi
 
 
 #######################################

--- a/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
+++ b/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
@@ -1,3 +1,5 @@
+- prevent configuration of invalid IPv6 addresses
+
 -------------------------------------------------------------------
 Tue Jan 18 14:08:42 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

IPv6 transition IP addresses are invalid in the apache configuration.
Do not configure IPv6 addresses which start with '::' 
And allow configurations without IPv6 addresses specified

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
