### PR TITLE
Temporary disable the Salt Bundle with Salt-SSH

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
@@ -253,7 +253,7 @@ public class SaltSSHService {
                                 minion.getSSHPushPort().orElse(SSH_PUSH_PORT)),
                             sshTimeout,
                             minionOpts(mid, contactMethodLabel),
-                            Optional.of(getSaltSSHPreflightScriptPath()),
+                            Optional.ofNullable(getSaltSSHPreflightScriptPath()),
                             Optional.of(Arrays.asList(
                                     proxyPath.isEmpty() ?
                                             ConfigDefaults.get().getCobblerHost() :
@@ -515,7 +515,7 @@ public class SaltSSHService {
                         parameters.getPort().orElse(SSH_PUSH_PORT)),
                     getSshPushTimeout(),
                     minionOpts(parameters.getHost(), contactMethod),
-                    Optional.of(getSaltSSHPreflightScriptPath()),
+                    Optional.ofNullable(getSaltSSHPreflightScriptPath()),
                     Optional.of(Arrays.asList(
                             bootstrapProxyPath.isEmpty() ?
                                     ConfigDefaults.get().getCobblerHost() :

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Prevent error on setting web.ssh_salt_pre_flight_script to blank
+
 -------------------------------------------------------------------
 Wed Mar 23 10:32:00 CET 2022 - jgonzalez@suse.com
 

--- a/web/conf/rhn_web.conf
+++ b/web/conf/rhn_web.conf
@@ -111,7 +111,9 @@ ssh_push_sudo_user =
 ssh_push_task_timeout = 0
 
 # preflight script to run on ssh push minions to deploy Salt Bundle
-ssh_salt_pre_flight_script = /usr/share/susemanager/salt-ssh/preflight.sh
+# ssh_salt_pre_flight_script = /usr/share/susemanager/salt-ssh/preflight.sh
+# disable pre flight script temporary, until salt with the requred feature will be released
+ssh_salt_pre_flight_script =
 
 # use salt-thin as a fallback method if Salt Bundle is not available
 ssh_use_salt_thin = false

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,6 @@
+- Set default web.ssh_salt_pre_flight_script to blank to disable
+  using the Salt Bundle for Salt SSH temporary
+
 -------------------------------------------------------------------
 Fri Mar 11 15:31:32 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

As `salt` with the required feature was not published yet, we have to disable using the Salt Bundle with Salt SSH

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Links

Tracks https://github.com/uyuni-project/uyuni/issues/5136

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
