### PR TITLE
Rollback disabling salt ssh preflight script

### DIFF
--- a/web/conf/rhn_web.conf
+++ b/web/conf/rhn_web.conf
@@ -111,9 +111,7 @@ ssh_push_sudo_user =
 ssh_push_task_timeout = 0
 
 # preflight script to run on ssh push minions to deploy Salt Bundle
-# ssh_salt_pre_flight_script = /usr/share/susemanager/salt-ssh/preflight.sh
-# disable pre flight script temporary, until salt with the requred feature will be released
-ssh_salt_pre_flight_script =
+ssh_salt_pre_flight_script = /usr/share/susemanager/salt-ssh/preflight.sh
 
 # use salt-thin as a fallback method if Salt Bundle is not available
 ssh_use_salt_thin = false


### PR DESCRIPTION
## What does this PR change?

Rolls back pre flight script disabling from https://github.com/uyuni-project/uyuni/pull/5140

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: already covered

## Links

Tracks https://github.com/uyuni-project/uyuni/issues/5136

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
