### PR TITLE
QE: Add Cobbler buildiso tests

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/dto/kickstart/KickstartDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/kickstart/KickstartDto.java
@@ -36,7 +36,7 @@ public class KickstartDto extends BaseDto {
     private String cobblerId;
     private String cobblerUrl;
     private int virtMemory;
-    private int virtSpace;
+    private double virtSpace;
     private int virtCpus;
     private String virtBridge;
     private String macAddress;
@@ -217,7 +217,7 @@ public class KickstartDto extends BaseDto {
     /**
      * @return Returns the virtSpace.
      */
-    public int getVirtSpace() {
+    public double getVirtSpace() {
         return virtSpace;
     }
 
@@ -225,7 +225,7 @@ public class KickstartDto extends BaseDto {
     /**
      * @param virtSpaceIn The virtSpace to set.
      */
-    public void setVirtSpace(int virtSpaceIn) {
+    public void setVirtSpace(double virtSpaceIn) {
         this.virtSpace = virtSpaceIn;
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -9000,8 +9000,11 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
       <trans-unit id="cveaudit.notfound" xml:space="preserve">
         <source>The specified CVE number was not found in our database. You can get more information about this CVE from the links given below.</source>
       </trans-unit>
-      <trans-unit id="cobbler.powermanagement.ipmitool" xml:space="preserve">
+      <trans-unit id="cobbler.powermanagement.ipmilan" xml:space="preserve">
         <source>IPMI</source>
+      </trans-unit>
+      <trans-unit id="cobbler.powermanagement.ipmilanplus" xml:space="preserve">
+        <source>IPMI lanplus</source>
       </trans-unit>
       <trans-unit id="setup-wizard.next" xml:space="preserve">
         <source>Next</source>

--- a/java/code/src/org/cobbler/Profile.java
+++ b/java/code/src/org/cobbler/Profile.java
@@ -271,8 +271,8 @@ public class Profile extends CobblerObject {
      /**
      * @return the VirtFileSize
      */
-     public int getVirtFileSize() {
-         return (Integer)dataMap.get(VIRT_FILE_SIZE);
+     public double getVirtFileSize() {
+         return (Double)dataMap.get(VIRT_FILE_SIZE);
      }
 
      /**
@@ -356,7 +356,7 @@ public class Profile extends CobblerObject {
       /**
       * @param virtFileSizeIn the VirtFileSize
       */
-      public void  setVirtFileSize(int virtFileSizeIn) {
+      public void  setVirtFileSize(double virtFileSizeIn) {
           modify(VIRT_FILE_SIZE, virtFileSizeIn);
       }
 

--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -90,7 +90,7 @@ java.cobbler_bootstrap.extra_kernel_options = ROOTFS_FSCK=0
 # Power management settings
 # A comma-separated list of fence agents that are allowable.
 # Agent name is X where agent command is /usr/sbin/fence_X
-java.power_management.types = ipmitool, redfish
+java.power_management.types = ipmilan, ipmilanplus, redfish
 
 # how large can config file be to be editable in webUI (in kilobytes)
 java.config_file_edit_size = 32

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix virtFileSize type after cobbler upgrade
 - Redefine available power_management.types for cobbler >= 3.3.1
 - Improved task to update the reporting database
 - Improve image management

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Redefine available power_management.types for cobbler >= 3.3.1
 - Improved task to update the reporting database
 - Improve image management
 - Store delta image info in the database

--- a/spacewalk/admin/Makefile.admin
+++ b/spacewalk/admin/Makefile.admin
@@ -42,10 +42,10 @@ CONF_FILES = service-list
 
 SYSTEMD_FILES = spacewalk.target spacewalk-wait-for-tomcat.service spacewalk-wait-for-salt.service \
 		spacewalk-wait-for-jabberd.service spacewalk-wait-for-taskomatic.service salt-secrets-config.service \
-		mgr-websockify.service uyuni-check-database.service uyuni-update-config.service
+		mgr-websockify.service uyuni-check-database.service uyuni-update-config.service cobbler-refresh-mkloaders.service
 
 SYSTEMD_OVERRIDE_SERVICES = tomcat.service apache2.service salt-master.service salt-api.service rhn-search.service \
-			    taskomatic.service salt-secrets-config.service
+			    taskomatic.service salt-secrets-config.service cobbler-refresh-mkloaders.service
 
 
 BIN_INSTALL    = install -m 755

--- a/spacewalk/admin/cobbler-refresh-mkloaders.service
+++ b/spacewalk/admin/cobbler-refresh-mkloaders.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Refresh Cobbler bootloaders
+After=cobblerd.service
+After=taskomatic.service
+
+[Service]
+ExecStart=/usr/bin/cobbler mkloaders
+Type=oneshot
+RemainAfterExit=yes

--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,4 @@
+- Ensure "cobbler mkloaders" is executed after restarting services
 - Reuse certificate update code.
 
 -------------------------------------------------------------------

--- a/spacewalk/admin/spacewalk-admin.spec
+++ b/spacewalk/admin/spacewalk-admin.spec
@@ -124,6 +124,7 @@ fi
 %{_unitdir}/spacewalk-wait-for-jabberd.service
 %{_unitdir}/spacewalk-wait-for-taskomatic.service
 %{_unitdir}/salt-secrets-config.service
+%{_unitdir}/cobbler-refresh-mkloaders.service
 %{_unitdir}/mgr-websockify.service
 %{_unitdir}/uyuni-check-database.service
 %{_unitdir}/uyuni-update-config.service

--- a/spacewalk/admin/spacewalk.target
+++ b/spacewalk/admin/spacewalk.target
@@ -16,6 +16,7 @@ Requires=cobblerd.service
 Requires=taskomatic.service
 Requires=spacewalk-wait-for-taskomatic.service
 Requires=salt-secrets-config.service
+Requires=cobbler-refresh-mkloaders.service
 
 [Install]
 WantedBy=multi-user.target

--- a/spacewalk/admin/spacewalk.target.SUSE
+++ b/spacewalk/admin/spacewalk.target.SUSE
@@ -14,6 +14,7 @@ Requires=taskomatic.service
 Requires=spacewalk-wait-for-taskomatic.service
 Requires=salt-secrets-config.service
 Requires=mgr-websockify.service
+Requires=cobbler-refresh-mkloaders.service
 
 [Install]
 WantedBy=multi-user.target

--- a/spacewalk/setup/bin/spacewalk-setup
+++ b/spacewalk/setup/bin/spacewalk-setup
@@ -268,6 +268,7 @@ sub setup_cobbler {
     close(FILE);
   }
   if ( system("ps -A | grep cobblerd") == 0 ) {
+    system("cobbler mkloaders");
     system("cobbler sync");
   }
 

--- a/spacewalk/setup/bin/spacewalk-setup-cobbler
+++ b/spacewalk/setup/bin/spacewalk-setup-cobbler
@@ -54,8 +54,14 @@ def manipulate_cobbler_settings(config_dir: str, settings_yaml: str):
     with open(full_path) as settings_file:
         filecontent = yaml.safe_load(settings_file.read())
     filecontent["server"] = socket.getfqdn()
-    filecontent["next_server_v4"] = socket.getfqdn()
-    filecontent["next_server_v6"] = socket.getfqdn()
+    filecontent["next_server_v4"] = socket.getaddrinfo(filecontent["server"], None, socket.AF_INET)[1][4][0]
+
+    # In case there is no IPv6 address, we get a OSError (socket.gaierror)
+    try:
+        filecontent["next_server_v6"] = socket.getaddrinfo(filecontent["server"], None, socket.AF_INET6)[1][4][0]
+    except OSError:
+        filecontent["next_server_v6"] = ""
+
     filecontent["pxe_just_once"] = True
     filecontent["redhat_management_server"] = socket.getfqdn()
     yaml_dump = yaml.safe_dump(filecontent)

--- a/spacewalk/setup/bin/spacewalk-setup-cobbler
+++ b/spacewalk/setup/bin/spacewalk-setup-cobbler
@@ -26,7 +26,7 @@ parser.add_argument('--apache2-config-directory', '-a', dest='httpd_config_direc
                     help='The directory where the Apache config file "cobbler.conf" is in.')
 
 COBBLER_CONFIG_DIRECTORY = "/etc/cobbler/"
-COBBLER_CONFIG_FILES = ["modules.conf", "settings"]
+COBBLER_CONFIG_FILES = ["modules.conf", "settings.yaml"]
 HTTPD_CONFIG_DIRECTORY = "/etc/httpd/conf.d/"
 COBBLER_HTTP_CONFIG = "cobbler.conf"
 

--- a/spacewalk/setup/bin/spacewalk-setup-cobbler
+++ b/spacewalk/setup/bin/spacewalk-setup-cobbler
@@ -54,7 +54,8 @@ def manipulate_cobbler_settings(config_dir: str, settings_yaml: str):
     with open(full_path) as settings_file:
         filecontent = yaml.safe_load(settings_file.read())
     filecontent["server"] = socket.getfqdn()
-    filecontent["next_server"] = socket.getfqdn()
+    filecontent["next_server_v4"] = socket.getfqdn()
+    filecontent["next_server_v6"] = socket.getfqdn()
     filecontent["pxe_just_once"] = True
     filecontent["redhat_management_server"] = socket.getfqdn()
     yaml_dump = yaml.safe_dump(filecontent)

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,5 +1,6 @@
+- Adjust next_server cobbler settings for cobbler >= 3.3.1
 - drop the reporting DB when clear-db option is set
-  * Remove pylint according to Fedora package guidelines.
+- Remove pylint according to Fedora package guidelines.
 
 -------------------------------------------------------------------
 Tue Feb 15 10:04:35 CET 2022 - jgonzalez@suse.com

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,4 @@
+- Execute "cobbler mkloaders" when setting up cobbler
 - Adjust next_server cobbler settings for cobbler >= 3.3.1
 - drop the reporting DB when clear-db option is set
 - Remove pylint according to Fedora package guidelines.

--- a/spacewalk/setup/spacewalk-setup.spec
+++ b/spacewalk/setup/spacewalk-setup.spec
@@ -91,7 +91,7 @@ BuildRequires:  perl-libwww-perl
 %else
 Requires:       %{sbinpath}/restorecon
 %endif
-Requires:       cobbler >= 3.0.0
+Requires:       cobbler >= 3.3.2
 Requires:       perl-Satcon
 Requires:       spacewalk-admin
 Requires:       spacewalk-backend-tools
@@ -117,9 +117,6 @@ Requires(post): libxslt-tools
 
 Provides:       salt-formulas-configuration
 Conflicts:      otherproviders(salt-formulas-configuration)
-
-# Workaround for different Cobbler versions. Remove below section once "Requires: cobbler >= 3.2.1"
-Requires(post): cobbler
 
 %description
 A collection of post-installation scripts for managing Spacewalk's initial
@@ -243,13 +240,6 @@ fi
 
 if grep 'authn_spacewalk' /etc/cobbler/modules.conf > /dev/null 2>&1; then
     sed -i 's/module = authn_spacewalk/module = authentication.spacewalk/' /etc/cobbler/modules.conf
-fi
-
-# Workaround for different Cobbler versions. Remove below section once "Requires: cobbler >= 3.2.1" and update
-# https://github.com/uyuni-project/uyuni/blob/ea02d4cdf5a91daefa468884548a8b1e60370d3c/spacewalk/setup/bin/spacewalk-setup-cobbler#L29
-COBBLER_VERSION=$(grep "version " /etc/cobbler/version)
-if [[ $(echo -e "version = 3.2.0\n${COBBLER_VERSION}" | sort -rV | head -n 1) != "version = 3.2.0" ]]; then
-  sed -i 's/COBBLER_CONFIG_FILES = \["modules.conf", "settings"\]/COBBLER_CONFIG_FILES = \["modules.conf", "settings.yaml"\]/' /usr/bin/spacewalk-setup-cobbler
 fi
 
 exit 0

--- a/testsuite/.rubocop_todo.yml
+++ b/testsuite/.rubocop_todo.yml
@@ -270,7 +270,7 @@ Metrics/MethodLength:
 # Offense count: 1
 # Configuration parameters: CountKeywordArgs.
 Metrics/ParameterLists:
-  Max: 7
+  Max: 8
 
 Metrics/CyclomaticComplexity:
   Max: 10

--- a/testsuite/features/secondary/srv_cobbler_buildiso.feature
+++ b/testsuite/features/secondary/srv_cobbler_buildiso.feature
@@ -1,0 +1,72 @@
+# Copyright (c) 2022 SUSE LLC.
+# Licensed under the terms of the MIT license.
+
+@scope_cobbler
+Feature: Cobbler buildiso
+  Builds several ISOs with Cobbler and checks the configuration files and ISOs afterwards.
+
+  Scenario: Log in as testing user in the cobbler buildiso context
+    Given I am authorized as "testing" with password "testing"
+
+  Scenario: Copy cobbler profiles on the server in the cobbler buildiso context
+    When I copy autoinstall mocked files on server
+
+  Scenario: Create a dummy distro in the cobbler buildiso context
+    Given cobblerd is running
+    Then create distro "testdistro" as user "testing" with password "testing"
+
+  Scenario: Create dummy profiles in the cobbler buildiso context
+    Given distro "testdistro" exists
+    Then create profile "orchid" for distro "testdistro" as user "testing" with password "testing"
+    And create profile "flame" for distro "testdistro" as user "testing" with password "testing"
+    And create profile "pearl" for distro "testdistro" as user "testing" with password "testing"
+
+  Scenario: Check cobbler created a distro and profiles in the cobbler buildiso context
+    When I follow the left menu "Systems > Autoinstallation > Profiles"
+    Then I should see a "testdistro" text
+    And I should see a "orchid" text
+    And I should see a "flame" text
+    And I should see a "pearl" text
+
+  Scenario: Create dummy system in the Cobbler buildiso context
+    Given profile "orchid" exists
+    Then create system "testsystem" for profile "orchid" as user "testing" with password "testing"
+    And I add the Cobbler parameter "name-servers" with value "9.9.9.9" to item "system" with name "testsystem"
+
+  Scenario: Prepare the cobbler buildiso context
+    When I prepare Cobbler for the buildiso command
+
+  Scenario: Run Cobbler buildiso with all profiles and check isolinux config file in the cobbler buildiso context
+    When I run Cobbler buildiso for distro "testdistro" and all profiles
+    And I check Cobbler buildiso ISO "profile_all" with xorriso
+    And I check the Cobbler parameter "nameserver" with value "9.9.9.9" in the isolinux.cfg
+
+  Scenario: Run Cobbler buildiso with selected profile in the cobbler buildiso context
+    When I run Cobbler buildiso for distro "testdistro" and profile "orchid"
+    And I check Cobbler buildiso ISO "orchid" with xorriso
+
+  # TODO: Fails unless https://github.com/cobbler/cobbler/issues/2995 is fixed
+  Scenario: Run Cobbler buildiso with selected profile and without dns entries in the cobbler buildiso context
+    When I run Cobbler buildiso for distro "testdistro" and profile "orchid" without dns entries
+    And I check Cobbler buildiso ISO "orchid" with xorriso
+
+  Scenario: Run Cobbler buildiso airgapped with all profiles in the cobbler buildiso context
+    When I run Cobbler buildiso "airgapped" for distro "testdistro"
+    And I check Cobbler buildiso ISO "airgapped" with xorriso
+
+  Scenario: Run Cobbler buildiso standalone with all profiles in the cobbler buildiso context
+    When I run Cobbler buildiso "standalone" for distro "testdistro"
+    And I check Cobbler buildiso ISO "standalone" with xorriso
+
+  Scenario: Cleanup: delete test distro and profiles in the cobbler buildiso context
+    Given I am authorized as "testing" with password "testing"
+    Then remove system "testsystem" as user "testing" with password "testing"
+    When I remove kickstart profiles and distros
+    And I follow the left menu "Systems > Autoinstallation > Profiles"
+    Then I should not see a "testdistro" text
+    And I should not see a "orchid" text
+    And I should not see a "flame" text
+    And I should not see a "flame" text
+
+  Scenario: Cleanup: Remove buildiso tmpdir and built ISO file in the cobbler buildiso context
+    When I cleanup after Cobbler buildiso

--- a/testsuite/features/secondary/srv_distro_cobbler.feature
+++ b/testsuite/features/secondary/srv_distro_cobbler.feature
@@ -17,7 +17,7 @@ Feature: Cobbler and distribution autoinstallation
   Scenario: Create dummy profile
     Given cobblerd is running
     And distro "testdistro" exists
-    Then create profile "testprofile" as user "testing" with password "testing"
+    Then create profile "testprofile" for distro "testdistro" as user "testing" with password "testing"
 
   Scenario: Check cobbler created distro and profile
     When I follow the left menu "Systems > Autoinstallation > Profiles"

--- a/testsuite/features/secondary/srv_power_management.feature
+++ b/testsuite/features/secondary/srv_power_management.feature
@@ -27,7 +27,7 @@ Feature: IPMI Power management
     And the cobbler report should contain "Power Management Address       : 127.0.0.1" for "sle_client"
     And the cobbler report should contain "Power Management Username      : ipmiusr" for "sle_client"
     And the cobbler report should contain "Power Management Password      : test" for "sle_client"
-    And the cobbler report should contain "Power Management Type          : ipmitool" for "sle_client"
+    And the cobbler report should contain "Power Management Type          : ipmilan" for "sle_client"
 
   Scenario: Test IPMI functions
     When I follow "Provisioning" in the content area
@@ -70,7 +70,7 @@ Feature: IPMI Power management
     And the cobbler report should contain "Power Management Username      : testing" for "sle_client"
     And the cobbler report should contain "Power Management Password      : qwertz" for "sle_client"
     And the cobbler report should contain "Power Management Address       : 127.0.0.1" for "sle_client"
-    And the cobbler report should contain "Power Management Type          : ipmitool" for "sle_client"
+    And the cobbler report should contain "Power Management Type          : ipmilan" for "sle_client"
 
   Scenario: Check power management SSM operation
     And I follow the left menu "Systems > System Set Manager > Overview"
@@ -89,7 +89,7 @@ Feature: IPMI Power management
     Then the cobbler report should contain "Power Management Address       :" for "sle_client"
     And the cobbler report should contain "Power Management Username      :" for "sle_client"
     And the cobbler report should contain "Power Management Password      :" for "sle_client"
-    And the cobbler report should contain "Power Management Type          : ipmitool" for "sle_client"
+    And the cobbler report should contain "Power Management Type          : ipmilan" for "sle_client"
 
   Scenario: Cleanup: tear down the IPMI host
     When the server stops mocking an IPMI host

--- a/testsuite/features/secondary/srv_power_management_redfish.feature
+++ b/testsuite/features/secondary/srv_power_management_redfish.feature
@@ -82,11 +82,11 @@ Feature: Redfish Power management
     When I set power management value "" for "powerAddress"
     And I set power management value "" for "powerUsername"
     And I set power management value "" for "powerPassword"
-    And I set power management value "ipmitool" for "powerType"
+    And I set power management value "ipmilan" for "powerType"
     Then the cobbler report should contain "Power Management Address       :" for "sle_minion"
     And the cobbler report should contain "Power Management Username      :" for "sle_minion"
     And the cobbler report should contain "Power Management Password      :" for "sle_minion"
-    And the cobbler report should contain "Power Management Type          : ipmitool" for "sle_minion"
+    And the cobbler report should contain "Power Management Type          : ipmilan" for "sle_minion"
 
   Scenario: Cleanup: tear down the Redfish host
     When the server stops mocking a Redfish host

--- a/testsuite/features/secondary/srv_xmlrpc_power_management.feature
+++ b/testsuite/features/secondary/srv_xmlrpc_power_management.feature
@@ -11,7 +11,7 @@ Feature: IPMI Power management test for XMLRPC
     Given I am logged in via XML-RPC powermgmt as user "admin" and password "admin"
     And I want to operate on this "sle_client"
     When I fetch power management values
-    Then power management results should have "ipmitool" for "powerType"
+    Then power management results should have "ipmilan" for "powerType"
 
   Scenario: Save power management values  for XMLRPC test
     Given I am logged in via XML-RPC powermgmt as user "admin" and password "admin"
@@ -19,11 +19,11 @@ Feature: IPMI Power management test for XMLRPC
     When I set power management value "127.0.0.1" for "powerAddress"
     And I set power management value "ipmiusr" for "powerUsername"
     And I set power management value "test" for "powerPassword"
-    And I set power management value "ipmitool" for "powerType"
+    And I set power management value "ipmilan" for "powerType"
     Then the cobbler report should contain "Power Management Address       : 127.0.0.1" for "sle_client"
     And the cobbler report should contain "Power Management Username      : ipmiusr" for "sle_client"
     And the cobbler report should contain "Power Management Password      : test" for "sle_client"
-    And the cobbler report should contain "Power Management Type          : ipmitool" for "sle_client"
+    And the cobbler report should contain "Power Management Type          : ipmilan" for "sle_client"
 
   Scenario: Test IPMI functions for XMLRPC test
     Given I am logged in via XML-RPC powermgmt as user "admin" and password "admin"
@@ -44,7 +44,7 @@ Feature: IPMI Power management test for XMLRPC
     Then the cobbler report should contain "Power Management Address       :" for "sle_client"
     And the cobbler report should contain "Power Management Username      :" for "sle_client"
     And the cobbler report should contain "Power Management Password      :" for "sle_client"
-    And the cobbler report should contain "Power Management Type          : ipmitool" for "sle_client"
+    And the cobbler report should contain "Power Management Type          : ipmilan" for "sle_client"
 
   Scenario: Cleanup: tear down the IPMI host for XMLRPC test
     When the server stops mocking an IPMI host

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -765,7 +765,7 @@ When(/^I register this client for SSH push via tunnel$/) do
   # perform the registration
   filename = File.basename(path)
   bootstrap_timeout = 600
-  $server.run("expect #{filename}", timeout: bootstrap_timeout)
+  $server.run("expect #{filename}", timeout: bootstrap_timeout, verbose: true)
   # restore files from backups
   $server.run('mv /etc/hosts.BACKUP /etc/hosts')
   $server.run('mv /etc/sysconfig/rhn/up2date.BACKUP /etc/sysconfig/rhn/up2date')

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1375,14 +1375,14 @@ When(/^I prepare Cobbler for the buildiso command$/) do
   $server.run("mkdir -p #{tmp_dir}")
   # we need bootloaders for the buildiso command
   _out, code = $server.run("cobbler mkloaders")
-  raise 'error in cobbler mkloaders.\nLogs:\n#{_out}' if code.nonzero?
+  raise "error in cobbler mkloaders.\nLogs:\n#{_out}" if code.nonzero?
 end
 
 When(/^I run Cobbler buildiso for distro "([^"]*)" and all profiles$/) do |distro|
   tmp_dir = "/var/cache/cobbler/buildiso"
   iso_dir = "/var/cache/cobbler"
   _out, code = $server.run("cobbler buildiso --tempdir=#{tmp_dir} --iso #{iso_dir}/profile_all.iso --distro=#{distro}")
-  raise 'error in cobbler buildiso.\nLogs:\n#{_out}' if code.nonzero?
+  raise "error in cobbler buildiso.\nLogs:\n#{_out}" if code.nonzero?
   profiles = ['orchid', 'flame', 'pearl']
   isolinux_profiles = []
   cobbler_profiles = []
@@ -1396,24 +1396,24 @@ When(/^I run Cobbler buildiso for distro "([^"]*)" and all profiles$/) do |distr
       isolinux_profiles.push(result_isolinux)
     end
   end
-  raise 'error during comparison of Cobbler profiles.\nLogs:\nCobbler profiles:\n#{cobbler_profiles}\nisolinux profiles:\n#{isolinux_profiles}' unless cobbler_profiles == isolinux_profiles
+  raise "error during comparison of Cobbler profiles.\nLogs:\nCobbler profiles:\n#{cobbler_profiles}\nisolinux profiles:\n#{isolinux_profiles}" unless cobbler_profiles == isolinux_profiles
 end
 
 When(/^I run Cobbler buildiso for distro "([^"]*)" and profile "([^"]*)"$/) do |distro, profile|
   tmp_dir = "/var/cache/cobbler/buildiso"
   iso_dir = "/var/cache/cobbler"
   _out, code = $server.run("cobbler buildiso --tempdir=#{tmp_dir} --iso #{iso_dir}/#{profile}.iso --distro=#{distro} --profile=#{profile}")
-  raise 'error in cobbler buildiso.\nLogs:\n#{_out}' if code.nonzero?
+  raise "error in cobbler buildiso.\nLogs:\n#{_out}" if code.nonzero?
 end
 
 When(/^I run Cobbler buildiso for distro "([^"]*)" and profile "([^"]*)" without dns entries$/) do |distro, profile|
   tmp_dir = "/var/cache/cobbler/buildiso"
   iso_dir = "/var/cache/cobbler"
   _out, code = $server.run("cobbler buildiso --tempdir=#{tmp_dir} --iso #{iso_dir}/#{profile}.iso --distro=#{distro} --profile=#{profile} --exclude-dns")
-  raise 'error in cobbler buildiso.\nLogs:\n#{_out}' if code.nonzero?
+  raise "error in cobbler buildiso.\nLogs:\n#{_out}" if code.nonzero?
   result, code = $server.run("cat #{tmp_dir}/isolinux/isolinux.cfg | grep -o nameserver")
   # we have to fail here if the command suceeds
-  raise 'error in Cobbler buildiso, nameserver parameter found in isolinux.cfg but should not be found.\nLogs:\n#{result}' if code.zero?
+  raise "error in Cobbler buildiso, nameserver parameter found in isolinux.cfg but should not be found.\nLogs:\n#{result}" if code.zero?
 end
 
 When(/^I run Cobbler buildiso "([^"]*)" for distro "([^"]*)"$/) do |param, distro|
@@ -1426,7 +1426,7 @@ When(/^I run Cobbler buildiso "([^"]*)" for distro "([^"]*)"$/) do |param, distr
   $server.run("mv #{tmp_dir} #{source_dir}")
   $server.run("mkdir -p #{tmp_dir}")
   _out, code = $server.run("cobbler buildiso --tempdir=#{tmp_dir} --iso #{iso_dir}/#{param}.iso --distro=#{distro} --#{param} --source=#{source_dir}")
-  raise 'error in cobbler buildiso.\nLogs:\n#{_out}' if code.nonzero?
+  raise "error in cobbler buildiso.\nLogs:\n#{_out}" if code.nonzero?
 end
 
 When(/^I check Cobbler buildiso ISO "([^"]*)" with xorriso$/) do |name|
@@ -1439,24 +1439,24 @@ EOF")
   iso_filter = "awk '/^El Torito boot img[[:space:]]+:[[:space:]]+[0-9]+[[:space:]]+[a-zA-Z]+[[:space:]]+y/{print $7}'"
   iso_file = "#{tmp_dir}/xorriso_#{name}"
   _out, code = $server.run("#{xorriso} | #{iso_filter} >> #{iso_file}")
-  raise 'error while executing xorriso.\nLogs:\n#{_out}' if code.nonzero?
+  raise "error while executing xorriso.\nLogs:\n#{_out}" if code.nonzero?
   _out, code = $server.run("diff #{tmp_dir}/test_image #{tmp_dir}/xorriso_#{name}")
-  raise 'error in verifying Cobbler buildiso image with xorriso.\nLogs:\n#{_out}' if code.nonzero?
+  raise "error in verifying Cobbler buildiso image with xorriso.\nLogs:\n#{_out}" if code.nonzero?
 end
 
 Then(/^I add the Cobbler parameter "([^"]*)" with value "([^"]*)" to item "(distro|profile|system)" with name "([^"]*)"$/) do |param, value, item, name|
   result, code = $server.run("cobbler #{item} edit --name=#{name} --#{param}=#{value}")
   puts("cobbler #{item} edit --name #{name} #{param}=#{value}")
-  raise 'error in adding parameter and value to Cobbler distro/profile/system.\nLogs:\n#{result}' if code.nonzero?
+  raise "error in adding parameter and value to Cobbler distro/profile/system.\nLogs:\n#{result}" if code.nonzero?
 end
 
 And(/^I check the Cobbler parameter "([^"]*)" with value "([^"]*)" in the isolinux.cfg$/) do |param, value|
   tmp_dir = "/var/cache/cobbler/buildiso"
   result, code = $server.run("cat #{tmp_dir}/isolinux/isolinux.cfg | grep -o #{param}=#{value}")
-  raise 'error during veryfying isolinux.cfg parameter for Cobbler buildiso.\nLogs:\n#{result}' if code.nonzero?
+  raise "error during veryfying isolinux.cfg parameter for Cobbler buildiso.\nLogs:\n#{result}" if code.nonzero?
 end
 
 When(/^I cleanup after Cobbler buildiso$/) do
   result, code = $server.run("rm -Rf /var/cache/cobbler")
-  raise 'error during Cobbler buildiso cleanup.\nLogs:\n#{result}' if code.nonzero?
+  raise "error during Cobbler buildiso cleanup.\nLogs:\n#{result}" if code.nonzero?
 end

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1375,15 +1375,15 @@ When(/^I prepare Cobbler for the buildiso command$/) do
   $server.run("mkdir -p #{tmp_dir}")
   # we need bootloaders for the buildiso command
   _out, code = $server.run("cobbler mkloaders")
-  raise 'error in cobbler mkloaders, check the Cobbler logs' if code.nonzero?
+  raise 'error in cobbler mkloaders.\nLogs:\n#{_out}' if code.nonzero?
 end
 
 When(/^I run Cobbler buildiso for distro "([^"]*)" and all profiles$/) do |distro|
   tmp_dir = "/var/cache/cobbler/buildiso"
   iso_dir = "/var/cache/cobbler"
   _out, code = $server.run("cobbler buildiso --tempdir=#{tmp_dir} --iso #{iso_dir}/profile_all.iso --distro=#{distro}")
-  raise 'error in cobbler buildiso, check the Cobbler logs' if code.nonzero?
-  profiles = ["orchid", "flame", "pearl"]
+  raise 'error in cobbler buildiso.\nLogs:\n#{_out}' if code.nonzero?
+  profiles = ['orchid', 'flame', 'pearl']
   isolinux_profiles = []
   cobbler_profiles = []
   profiles.each do |profile|
@@ -1403,15 +1403,14 @@ When(/^I run Cobbler buildiso for distro "([^"]*)" and profile "([^"]*)"$/) do |
   tmp_dir = "/var/cache/cobbler/buildiso"
   iso_dir = "/var/cache/cobbler"
   _out, code = $server.run("cobbler buildiso --tempdir=#{tmp_dir} --iso #{iso_dir}/#{profile}.iso --distro=#{distro} --profile=#{profile}")
-  raise 'error in cobbler buildiso, check the Cobbler logs' if code.nonzero?
+  raise 'error in cobbler buildiso.\nLogs:\n#{_out}' if code.nonzero?
 end
 
 When(/^I run Cobbler buildiso for distro "([^"]*)" and profile "([^"]*)" without dns entries$/) do |distro, profile|
   tmp_dir = "/var/cache/cobbler/buildiso"
   iso_dir = "/var/cache/cobbler"
   _out, code = $server.run("cobbler buildiso --tempdir=#{tmp_dir} --iso #{iso_dir}/#{profile}.iso --distro=#{distro} --profile=#{profile} --exclude-dns")
-  raise 'error in cobbler buildiso, check the Cobbler logs' if code.nonzero?
-  # TODO Check for missing nameserver entry in isolinux.cfg
+  raise 'error in cobbler buildiso.\nLogs:\n#{_out}' if code.nonzero?
   result, code = $server.run("cat #{tmp_dir}/isolinux/isolinux.cfg | grep -o nameserver")
   # we have to fail here if the command suceeds
   raise 'error in Cobbler buildiso, nameserver parameter found in isolinux.cfg but should not be found' if code.zero?
@@ -1427,7 +1426,7 @@ When(/^I run Cobbler buildiso "([^"]*)" for distro "([^"]*)"$/) do |param, distr
   $server.run("mv #{tmp_dir} #{source_dir}")
   $server.run("mkdir -p #{tmp_dir}")
   _out, code = $server.run("cobbler buildiso --tempdir=#{tmp_dir} --iso #{iso_dir}/#{param}.iso --distro=#{distro} --#{param} --source=#{source_dir}")
-  raise 'error in cobbler buildiso, check the Cobbler logs' if code.nonzero?
+  raise 'error in cobbler buildiso.\nLogs:\n#{_out}' if code.nonzero?
 end
 
 When(/^I check Cobbler buildiso ISO "([^"]*)" with xorriso$/) do |name|
@@ -1448,7 +1447,7 @@ end
 Then(/^I add the Cobbler parameter "([^"]*)" with value "([^"]*)" to item "(distro|profile|system)" with name "([^"]*)"$/) do |param, value, item, name|
   result, code = $server.run("cobbler #{item} edit --name=#{name} --#{param}=#{value}")
   puts("cobbler #{item} edit --name #{name} #{param}=#{value}")
-  raise 'error in adding parameter and value to Cobbler distro/profile/system' if code.nonzero?
+  raise 'error in adding parameter and value to Cobbler distro/profile/system.\nLogs:\n#{result}' if code.nonzero?
 end
 
 And(/^I check the Cobbler parameter "([^"]*)" with value "([^"]*)" in the isolinux.cfg$/) do |param, value|

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1447,7 +1447,7 @@ end
 Then(/^I add the Cobbler parameter "([^"]*)" with value "([^"]*)" to item "(distro|profile|system)" with name "([^"]*)"$/) do |param, value, item, name|
   result, code = $server.run("cobbler #{item} edit --name=#{name} --#{param}=#{value}")
   puts("cobbler #{item} edit --name #{name} #{param}=#{value}")
-  raise "error in adding parameter and value to Cobbler distro/profile/system.\nLogs:\n#{result}" if code.nonzero?
+  raise "error in adding parameter and value to Cobbler #{item}.\nLogs:\n#{result}" if code.nonzero?
 end
 
 And(/^I check the Cobbler parameter "([^"]*)" with value "([^"]*)" in the isolinux.cfg$/) do |param, value|

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1374,15 +1374,15 @@ When(/^I prepare Cobbler for the buildiso command$/) do
   tmp_dir = "/var/cache/cobbler/buildiso"
   $server.run("mkdir -p #{tmp_dir}")
   # we need bootloaders for the buildiso command
-  _out, code = $server.run("cobbler mkloaders")
-  raise "error in cobbler mkloaders.\nLogs:\n#{_out}" if code.nonzero?
+  out, code = $server.run("cobbler mkloaders")
+  raise "error in cobbler mkloaders.\nLogs:\n#{out}" if code.nonzero?
 end
 
 When(/^I run Cobbler buildiso for distro "([^"]*)" and all profiles$/) do |distro|
   tmp_dir = "/var/cache/cobbler/buildiso"
   iso_dir = "/var/cache/cobbler"
-  _out, code = $server.run("cobbler buildiso --tempdir=#{tmp_dir} --iso #{iso_dir}/profile_all.iso --distro=#{distro}")
-  raise "error in cobbler buildiso.\nLogs:\n#{_out}" if code.nonzero?
+  out, code = $server.run("cobbler buildiso --tempdir=#{tmp_dir} --iso #{iso_dir}/profile_all.iso --distro=#{distro}")
+  raise "error in cobbler buildiso.\nLogs:\n#{out}" if code.nonzero?
   profiles = ['orchid', 'flame', 'pearl']
   isolinux_profiles = []
   cobbler_profiles = []
@@ -1402,15 +1402,15 @@ end
 When(/^I run Cobbler buildiso for distro "([^"]*)" and profile "([^"]*)"$/) do |distro, profile|
   tmp_dir = "/var/cache/cobbler/buildiso"
   iso_dir = "/var/cache/cobbler"
-  _out, code = $server.run("cobbler buildiso --tempdir=#{tmp_dir} --iso #{iso_dir}/#{profile}.iso --distro=#{distro} --profile=#{profile}")
-  raise "error in cobbler buildiso.\nLogs:\n#{_out}" if code.nonzero?
+  out, code = $server.run("cobbler buildiso --tempdir=#{tmp_dir} --iso #{iso_dir}/#{profile}.iso --distro=#{distro} --profile=#{profile}")
+  raise "error in cobbler buildiso.\nLogs:\n#{out}" if code.nonzero?
 end
 
 When(/^I run Cobbler buildiso for distro "([^"]*)" and profile "([^"]*)" without dns entries$/) do |distro, profile|
   tmp_dir = "/var/cache/cobbler/buildiso"
   iso_dir = "/var/cache/cobbler"
-  _out, code = $server.run("cobbler buildiso --tempdir=#{tmp_dir} --iso #{iso_dir}/#{profile}.iso --distro=#{distro} --profile=#{profile} --exclude-dns")
-  raise "error in cobbler buildiso.\nLogs:\n#{_out}" if code.nonzero?
+  out, code = $server.run("cobbler buildiso --tempdir=#{tmp_dir} --iso #{iso_dir}/#{profile}.iso --distro=#{distro} --profile=#{profile} --exclude-dns")
+  raise "error in cobbler buildiso.\nLogs:\n#{out}" if code.nonzero?
   result, code = $server.run("cat #{tmp_dir}/isolinux/isolinux.cfg | grep -o nameserver")
   # we have to fail here if the command suceeds
   raise "error in Cobbler buildiso, nameserver parameter found in isolinux.cfg but should not be found.\nLogs:\n#{result}" if code.zero?
@@ -1425,23 +1425,23 @@ When(/^I run Cobbler buildiso "([^"]*)" for distro "([^"]*)"$/) do |param, distr
   source_dir = "/var/cache/cobbler/source_#{param}"
   $server.run("mv #{tmp_dir} #{source_dir}")
   $server.run("mkdir -p #{tmp_dir}")
-  _out, code = $server.run("cobbler buildiso --tempdir=#{tmp_dir} --iso #{iso_dir}/#{param}.iso --distro=#{distro} --#{param} --source=#{source_dir}")
-  raise "error in cobbler buildiso.\nLogs:\n#{_out}" if code.nonzero?
+  out, code = $server.run("cobbler buildiso --tempdir=#{tmp_dir} --iso #{iso_dir}/#{param}.iso --distro=#{distro} --#{param} --source=#{source_dir}")
+  raise "error in cobbler buildiso.\nLogs:\n#{out}" if code.nonzero?
 end
 
 When(/^I check Cobbler buildiso ISO "([^"]*)" with xorriso$/) do |name|
   tmp_dir = "/var/cache/cobbler"
-  _out, code = $server.run("cat >#{tmp_dir}/test_image <<-EOF
+  out, code = $server.run("cat >#{tmp_dir}/test_image <<-EOF
 BIOS
 UEFI
 EOF")
   xorriso = "xorriso -indev #{tmp_dir}/#{name}.iso -report_el_torito 2>/dev/null"
   iso_filter = "awk '/^El Torito boot img[[:space:]]+:[[:space:]]+[0-9]+[[:space:]]+[a-zA-Z]+[[:space:]]+y/{print $7}'"
   iso_file = "#{tmp_dir}/xorriso_#{name}"
-  _out, code = $server.run("#{xorriso} | #{iso_filter} >> #{iso_file}")
-  raise "error while executing xorriso.\nLogs:\n#{_out}" if code.nonzero?
-  _out, code = $server.run("diff #{tmp_dir}/test_image #{tmp_dir}/xorriso_#{name}")
-  raise "error in verifying Cobbler buildiso image with xorriso.\nLogs:\n#{_out}" if code.nonzero?
+  out, code = $server.run("#{xorriso} | #{iso_filter} >> #{iso_file}")
+  raise "error while executing xorriso.\nLogs:\n#{out}" if code.nonzero?
+  out, code = $server.run("diff #{tmp_dir}/test_image #{tmp_dir}/xorriso_#{name}")
+  raise "error in verifying Cobbler buildiso image with xorriso.\nLogs:\n#{out}" if code.nonzero?
 end
 
 Then(/^I add the Cobbler parameter "([^"]*)" with value "([^"]*)" to item "(distro|profile|system)" with name "([^"]*)"$/) do |param, value, item, name|

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1374,21 +1374,21 @@ When(/^I prepare Cobbler for the buildiso command$/) do
   tmp_dir = "/var/cache/cobbler/buildiso"
   $server.run("mkdir -p #{tmp_dir}")
   # we need bootloaders for the buildiso command
-  out, code = $server.run("cobbler mkloaders")
+  out, code = $server.run("cobbler mkloaders", verbose: true)
   raise "error in cobbler mkloaders.\nLogs:\n#{out}" if code.nonzero?
 end
 
 When(/^I run Cobbler buildiso for distro "([^"]*)" and all profiles$/) do |distro|
   tmp_dir = "/var/cache/cobbler/buildiso"
   iso_dir = "/var/cache/cobbler"
-  out, code = $server.run("cobbler buildiso --tempdir=#{tmp_dir} --iso #{iso_dir}/profile_all.iso --distro=#{distro}")
+  out, code = $server.run("cobbler buildiso --tempdir=#{tmp_dir} --iso #{iso_dir}/profile_all.iso --distro=#{distro}", verbose: true)
   raise "error in cobbler buildiso.\nLogs:\n#{out}" if code.nonzero?
   profiles = ['orchid', 'flame', 'pearl']
   isolinux_profiles = []
   cobbler_profiles = []
   profiles.each do |profile|
     # get all profiles from Cobbler
-    result_cobbler, code = $server.run("cobbler profile list | grep -o #{profile}")
+    result_cobbler, code = $server.run("cobbler profile list | grep -o #{profile}", verbose: true)
     cobbler_profiles.push(result_cobbler) if code.zero?
     # get all profiles from isolinux.cfg
     result_isolinux, code = $server.run("cat #{tmp_dir}/isolinux/isolinux.cfg | grep -o #{profile} | cut -c -6 | head -n 1")
@@ -1402,14 +1402,14 @@ end
 When(/^I run Cobbler buildiso for distro "([^"]*)" and profile "([^"]*)"$/) do |distro, profile|
   tmp_dir = "/var/cache/cobbler/buildiso"
   iso_dir = "/var/cache/cobbler"
-  out, code = $server.run("cobbler buildiso --tempdir=#{tmp_dir} --iso #{iso_dir}/#{profile}.iso --distro=#{distro} --profile=#{profile}")
+  out, code = $server.run("cobbler buildiso --tempdir=#{tmp_dir} --iso #{iso_dir}/#{profile}.iso --distro=#{distro} --profile=#{profile}", verbose: true)
   raise "error in cobbler buildiso.\nLogs:\n#{out}" if code.nonzero?
 end
 
 When(/^I run Cobbler buildiso for distro "([^"]*)" and profile "([^"]*)" without dns entries$/) do |distro, profile|
   tmp_dir = "/var/cache/cobbler/buildiso"
   iso_dir = "/var/cache/cobbler"
-  out, code = $server.run("cobbler buildiso --tempdir=#{tmp_dir} --iso #{iso_dir}/#{profile}.iso --distro=#{distro} --profile=#{profile} --exclude-dns")
+  out, code = $server.run("cobbler buildiso --tempdir=#{tmp_dir} --iso #{iso_dir}/#{profile}.iso --distro=#{distro} --profile=#{profile} --exclude-dns", verbose: true)
   raise "error in cobbler buildiso.\nLogs:\n#{out}" if code.nonzero?
   result, code = $server.run("cat #{tmp_dir}/isolinux/isolinux.cfg | grep -o nameserver")
   # we have to fail here if the command suceeds
@@ -1425,7 +1425,7 @@ When(/^I run Cobbler buildiso "([^"]*)" for distro "([^"]*)"$/) do |param, distr
   source_dir = "/var/cache/cobbler/source_#{param}"
   $server.run("mv #{tmp_dir} #{source_dir}")
   $server.run("mkdir -p #{tmp_dir}")
-  out, code = $server.run("cobbler buildiso --tempdir=#{tmp_dir} --iso #{iso_dir}/#{param}.iso --distro=#{distro} --#{param} --source=#{source_dir}")
+  out, code = $server.run("cobbler buildiso --tempdir=#{tmp_dir} --iso #{iso_dir}/#{param}.iso --distro=#{distro} --#{param} --source=#{source_dir}", verbose: true)
   raise "error in cobbler buildiso.\nLogs:\n#{out}" if code.nonzero?
 end
 
@@ -1445,7 +1445,7 @@ EOF")
 end
 
 Then(/^I add the Cobbler parameter "([^"]*)" with value "([^"]*)" to item "(distro|profile|system)" with name "([^"]*)"$/) do |param, value, item, name|
-  result, code = $server.run("cobbler #{item} edit --name=#{name} --#{param}=#{value}")
+  result, code = $server.run("cobbler #{item} edit --name=#{name} --#{param}=#{value}", verbose: true)
   puts("cobbler #{item} edit --name #{name} #{param}=#{value}")
   raise "error in adding parameter and value to Cobbler #{item}.\nLogs:\n#{result}" if code.nonzero?
 end

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1396,7 +1396,7 @@ When(/^I run Cobbler buildiso for distro "([^"]*)" and all profiles$/) do |distr
       isolinux_profiles.push(result_isolinux)
     end
   end
-  raise 'error during comparison of Cobbler profiles' unless cobbler_profiles == isolinux_profiles
+  raise 'error during comparison of Cobbler profiles.\nLogs:\nCobbler profiles:\n#{cobbler_profiles}\nisolinux profiles:\n#{isolinux_profiles}' unless cobbler_profiles == isolinux_profiles
 end
 
 When(/^I run Cobbler buildiso for distro "([^"]*)" and profile "([^"]*)"$/) do |distro, profile|
@@ -1413,7 +1413,7 @@ When(/^I run Cobbler buildiso for distro "([^"]*)" and profile "([^"]*)" without
   raise 'error in cobbler buildiso.\nLogs:\n#{_out}' if code.nonzero?
   result, code = $server.run("cat #{tmp_dir}/isolinux/isolinux.cfg | grep -o nameserver")
   # we have to fail here if the command suceeds
-  raise 'error in Cobbler buildiso, nameserver parameter found in isolinux.cfg but should not be found' if code.zero?
+  raise 'error in Cobbler buildiso, nameserver parameter found in isolinux.cfg but should not be found.\nLogs:\n#{result}' if code.zero?
 end
 
 When(/^I run Cobbler buildiso "([^"]*)" for distro "([^"]*)"$/) do |param, distro|
@@ -1439,9 +1439,9 @@ EOF")
   iso_filter = "awk '/^El Torito boot img[[:space:]]+:[[:space:]]+[0-9]+[[:space:]]+[a-zA-Z]+[[:space:]]+y/{print $7}'"
   iso_file = "#{tmp_dir}/xorriso_#{name}"
   _out, code = $server.run("#{xorriso} | #{iso_filter} >> #{iso_file}")
-  raise 'error while executing xorriso' if code.nonzero?
+  raise 'error while executing xorriso.\nLogs:\n#{_out}' if code.nonzero?
   _out, code = $server.run("diff #{tmp_dir}/test_image #{tmp_dir}/xorriso_#{name}")
-  raise 'error in verifying Cobbler buildiso image with xorriso' if code.nonzero?
+  raise 'error in verifying Cobbler buildiso image with xorriso.\nLogs:\n#{_out}' if code.nonzero?
 end
 
 Then(/^I add the Cobbler parameter "([^"]*)" with value "([^"]*)" to item "(distro|profile|system)" with name "([^"]*)"$/) do |param, value, item, name|
@@ -1453,10 +1453,10 @@ end
 And(/^I check the Cobbler parameter "([^"]*)" with value "([^"]*)" in the isolinux.cfg$/) do |param, value|
   tmp_dir = "/var/cache/cobbler/buildiso"
   result, code = $server.run("cat #{tmp_dir}/isolinux/isolinux.cfg | grep -o #{param}=#{value}")
-  raise 'error during veryfying isolinux.cfg parameter for Cobbler buildiso' if code.nonzero?
+  raise 'error during veryfying isolinux.cfg parameter for Cobbler buildiso.\nLogs:\n#{result}' if code.nonzero?
 end
 
 When(/^I cleanup after Cobbler buildiso$/) do
   result, code = $server.run("rm -Rf /var/cache/cobbler")
-  raise 'error during Cobbler buildiso cleanup' if code.nonzero?
+  raise 'error during Cobbler buildiso cleanup.\nLogs:\n#{result}' if code.nonzero?
 end

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -46,39 +46,6 @@ class CobblerTest
     result
   end
 
-  def profile_create(name, distro, location)
-    begin
-      profile_id = @server.call('new_profile', @token)
-    rescue
-      raise 'creating profile failed.' + $ERROR_INFO.to_s
-    end
-    begin
-      @server.call('modify_profile', profile_id, 'name', name, @token)
-      @server.call('modify_profile', profile_id, 'distro', distro, @token)
-      @server.call('modify_profile', profile_id, 'kickstart', location, @token)
-    rescue
-      raise 'modify profile failed.' + $ERROR_INFO.to_s
-    end
-    begin
-      @server.call('save_profile', profile_id, @token)
-    rescue
-      raise 'saving profile failed.' + $ERROR_INFO.to_s
-    end
-    profile_id
-  end
-
-  def profile_exists(name)
-    exists('profiles', 'name', name)
-  end
-
-  def system_exists(name)
-    exists('systems', 'name', name)
-  end
-
-  def distro_exists(name)
-    exists('distros', 'name', name)
-  end
-
   def distro_create(name, kernel, initrd, breed = 'suse')
     begin
       distro_id = @server.call('new_distro', @token)
@@ -91,6 +58,69 @@ class CobblerTest
       raise 'creating distribution failed.' + $ERROR_INFO.to_s
     end
     distro_id
+  end
+
+  def profile_create(name, distro, location)
+    begin
+      profile_id = @server.call('new_profile', @token)
+    rescue
+      raise 'creating profile failed.' + $ERROR_INFO.to_s
+    end
+    begin
+      @server.call('modify_profile', profile_id, 'name', name, @token)
+      @server.call('modify_profile', profile_id, 'distro', distro, @token)
+      @server.call('modify_profile', profile_id, 'kickstart', location, @token)
+    rescue
+      raise 'modifying profile failed.' + $ERROR_INFO.to_s
+    end
+    begin
+      @server.call('save_profile', profile_id, @token)
+    rescue
+      raise 'saving profile failed.' + $ERROR_INFO.to_s
+    end
+    profile_id
+  end
+
+  # every system needs at least a name and a profile
+  def system_create(name, profile)
+    begin
+      system_id = @server.call('new_system', @token)
+    rescue
+      raise 'creating system failed.' + $ERROR_INFO.to_s
+    end
+    begin
+      @server.call('modify_system', system_id, 'name', name, @token)
+      @server.call('modify_system', system_id, 'profile', profile, @token)
+    rescue
+      raise 'modifying system failed.' + $ERROR_INFO.to_s
+    end
+    begin
+      @server.call('save_system', system_id, @token)
+    rescue
+      raise 'saving system failed.' + $ERROR_INFO.to_s
+    end
+    system_id
+  end
+
+  def system_remove(name)
+    raise "system cannot be found. #{$ERROR_INFO}" unless system_exists(name)
+    begin
+      @server.call('remove_system', name, @token)
+    rescue
+      raise "deleting system failed. #{$ERROR_INFO}"
+    end
+  end
+
+  def distro_exists(name)
+    exists('distros', 'name', name)
+  end
+
+  def profile_exists(name)
+    exists('profiles', 'name', name)
+  end
+
+  def system_exists(name)
+    exists('systems', 'name', name)
   end
 
   def repo_exists(name)

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -409,3 +409,13 @@ def debug_server_on_realtime_failure
   end
   STDOUT.puts
 end
+
+# get the Cobbler log output when we test it
+After('@scope_cobbler') do |scenario|
+  STDOUT.puts '=> /var/log/cobbler/cobbler.log'
+  out, _code = $server.run("tail -n20 /var/log/cobbler/cobbler.log")
+  out.each_line do |line|
+    STDOUT.puts line.to_s
+  end
+  STDOUT.puts
+end

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -411,7 +411,7 @@ def debug_server_on_realtime_failure
 end
 
 # get the Cobbler log output when we test it
-After('@scope_cobbler') do |scenario|
+After('@scope_cobbler') do
   STDOUT.puts '=> /var/log/cobbler/cobbler.log'
   out, _code = $server.run("tail -n20 /var/log/cobbler/cobbler.log")
   out.each_line do |line|

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -409,13 +409,3 @@ def debug_server_on_realtime_failure
   end
   STDOUT.puts
 end
-
-# get the Cobbler log output when we test it
-After('@scope_cobbler') do
-  STDOUT.puts '=> /var/log/cobbler/cobbler.log'
-  out, _code = $server.run("tail -n20 /var/log/cobbler/cobbler.log")
-  out.each_line do |line|
-    STDOUT.puts line.to_s
-  end
-  STDOUT.puts
-end

--- a/testsuite/features/support/lavanda.rb
+++ b/testsuite/features/support/lavanda.rb
@@ -65,15 +65,16 @@ module LavandaBasic
   end
 
   # run functions
-  def run(cmd, separated_results: false, check_errors: true, timeout: DEFAULT_TIMEOUT, user: 'root', successcodes: [0], buffer_size: 65536)
+  def run(cmd, separated_results: false, check_errors: true, timeout: DEFAULT_TIMEOUT, user: 'root', successcodes: [0], buffer_size: 65536, verbose: false)
     if separated_results
       out, err, _lo, _rem, code = test_and_store_results_separately(cmd, user, timeout, buffer_size)
     else
       out, _lo, _rem, code = test_and_store_results_together(cmd, user, timeout, buffer_size)
     end
     if check_errors
-      raise "FAIL: #{cmd} returned #{code}. output : #{out}" unless successcodes.include?(code)
+      raise "FAIL: #{cmd} returned status code = #{code}.\nOutput:\n#{out}" unless successcodes.include?(code)
     end
+    STDOUT.puts "#{cmd} returned status code = #{code}.\nOutput:\n#{out}" if verbose
     if separated_results
       [out, err, code]
     else

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -14,6 +14,7 @@
 - features/secondary/srv_manage_activationkey.feature
 - features/secondary/srv_xmlrpc_activationkey.feature
 - features/secondary/srv_distro_cobbler.feature
+- features/secondary/srv_cobbler_buildiso.feature
 - features/secondary/srv_mainpage.feature
 - features/secondary/srv_xmlrpc_user.feature
 - features/secondary/srv_salt_download_endpoint.feature

--- a/tftpsync/susemanager-tftpsync/configure-tftpsync.sh
+++ b/tftpsync/susemanager-tftpsync/configure-tftpsync.sh
@@ -40,14 +40,14 @@ for proxy in $@; do
     fi
 done
 
-cp /etc/cobbler/settings /etc/cobbler/settings.bak
+cp /etc/cobbler/settings.yaml /etc/cobbler/settings.yaml.bak
 # remove proxies section from conf
-cat /etc/cobbler/settings.bak | awk '{if(/^proxies:/) x=1; else if (x == 1 && /^[[:space:]]*-/) x=1; else print }' > /etc/cobbler/settings
+cat /etc/cobbler/settings.yaml.bak | awk '{if(/^proxies:/) x=1; else if (x == 1 && /^[[:space:]]*-/) x=1; else print }' > /etc/cobbler/settings.yaml
 
 # create new proxies section
-echo "proxies:" >> /etc/cobbler/settings
+echo "proxies:" >> /etc/cobbler/settings.yaml
 for proxy in $@; do
-    echo " - \"$proxy\"" >> /etc/cobbler/settings
+    echo " - \"$proxy\"" >> /etc/cobbler/settings.yaml
 done
 
 # remove cache file to push all files again

--- a/tftpsync/susemanager-tftpsync/susemanager-tftpsync.changes
+++ b/tftpsync/susemanager-tftpsync/susemanager-tftpsync.changes
@@ -1,3 +1,5 @@
+- Adjust sync_post_tftpd_proxies module to cobbler >= 3.3.1
+
 -------------------------------------------------------------------
 Mon Aug 09 11:11:44 CEST 2021 - jgonzalez@suse.com
 

--- a/tftpsync/susemanager-tftpsync/sync_post_tftpd_proxies.py
+++ b/tftpsync/susemanager-tftpsync/sync_post_tftpd_proxies.py
@@ -179,7 +179,7 @@ def check_push(fn, tftpbootdir, settings, lcache='/var/lib/cobbler'):
                 logger.debug("mtime differ - old: %s new: %s" % (db[fn][0], mtime))
             if os.path.exists(fn):
                 cmd = '/usr/bin/sha1sum %s'%fn
-                key = utils.subprocess_get(None,cmd).split(' ')[0]
+                key = utils.subprocess_get(cmd).split(' ')[0]
                 if _DEBUG:
                     logger.debug("checking checksum - old: %s new: %s" % (db[fn][1], key))
                 if key == db[fn][1]:

--- a/tftpsync/susemanager-tftpsync/sync_post_tftpd_proxies.py
+++ b/tftpsync/susemanager-tftpsync/sync_post_tftpd_proxies.py
@@ -189,7 +189,7 @@ def check_push(fn, tftpbootdir, settings, lcache='/var/lib/cobbler'):
     if key is None:
         if os.path.exists(fn):
             cmd = '/usr/bin/sha1sum %s'%fn
-            key = utils.subprocess_get(None,cmd).split(' ')[0]
+            key = utils.subprocess_get(cmd).split(' ')[0]
 
     if _DEBUG:
         logger.debug("push(%s) ? %s" % (fn, needpush))


### PR DESCRIPTION
## What does this PR change?

This PR will

- extend the already implemented Cobbler steps to include checking for profiles
- add tests for Cobbler `buildiso`

in preparation of including Cobbler 3.3.2 to Manager 4.3 Beta 3.

Superseeds #5045 in order to merge it into `master-fixes-for-new-cobbler` instead of `master`.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17250

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
