### PR TITLE
fix criteria query

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/HubReportDbUpdateDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/HubReportDbUpdateDriver.java
@@ -57,8 +57,9 @@ public class HubReportDbUpdateDriver implements QueueDriver<MgrServerInfo> {
     public List<MgrServerInfo> getCandidates() {
         CriteriaBuilder builder = HibernateFactory.getSession().getCriteriaBuilder();
         CriteriaQuery<MgrServerInfo> criteria = builder.createQuery(MgrServerInfo.class);
+        criteria.from(MgrServerInfo.class);
         Query<MgrServerInfo> query = HibernateFactory.getSession().createQuery(criteria);
-        List<MgrServerInfo> mgrServerInfos = (List<MgrServerInfo>)query.list();
+        List<MgrServerInfo> mgrServerInfos = query.list();
         return mgrServerInfos.stream().filter(info ->
                 Optional.ofNullable(info.getReportDbLastSynced())
                         .map(time -> time.toInstant().plus(24, ChronoUnit.HOURS).isBefore(Instant.now()))


### PR DESCRIPTION
## What does this PR change?

fixes criteria query exception

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
