### PR TITLE
run mgr-update-reporting-hub after mgr-update-reporting is finished

### DIFF
--- a/schema/spacewalk/common/data/rhnTaskoSchedule.sql
+++ b/schema/spacewalk/common/data/rhnTaskoSchedule.sql
@@ -169,6 +169,6 @@ INSERT INTO rhnTaskoSchedule (id, job_label, bunch_id, active_from, cron_expr)
 INSERT INTO rhnTaskoSchedule (id, job_label, bunch_id, active_from, cron_expr)
 VALUES (sequence_nextval('rhn_tasko_schedule_id_seq'), 'update-reporting-hub-default',
         (SELECT id FROM rhnTaskoBunch WHERE name='mgr-update-reporting-hub-bunch'),
-        current_timestamp, '0 0 0 ? * *');
+        current_timestamp, '0 30 1 ? * *');
 
 commit;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.9-to-susemanager-schema-4.3.10/006-hub-reporting-task.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.9-to-susemanager-schema-4.3.10/006-hub-reporting-task.sql
@@ -10,7 +10,7 @@ WHERE NOT EXISTS (
 INSERT INTO rhnTaskoSchedule (id, job_label, bunch_id, active_from, cron_expr)
 SELECT sequence_nextval('rhn_tasko_schedule_id_seq'), 'update-reporting-hub-default',
        (SELECT id FROM rhnTaskoBunch WHERE name='mgr-update-reporting-hub-bunch'),
-       current_timestamp, '0 0 0 ? * *'
+       current_timestamp, '0 30 1 ? * *'
 WHERE NOT EXISTS (
         SELECT 1 FROM rhnTaskoSchedule
         WHERE job_label = 'update-reporting-hub-default'


### PR DESCRIPTION
## What does this PR change?

Take care that the job on hub is runninge after the jobs on the peripheral servers are finished.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- in general docs

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
