### PR TITLE
try to re-use CA cert and key if they are available locally

### DIFF
--- a/spacewalk/setup/bin/spacewalk-setup
+++ b/spacewalk/setup/bin/spacewalk-setup
@@ -690,9 +690,11 @@ sub setup_ssl_certs {
                      '-cert-expiration' => $answers->{'ssl-ca-cert-expiration'},
                     );
     $answers->{'ssl-ca-cert'} = File::Spec->catfile($answers->{'ssl-dir'}, "RHN-ORG-TRUSTED-SSL-CERT");
-  } elsif ($use_own_certs) {
+  } else {
+    if (! $use_own_certs) {
+      $answers->{'ssl-ca-cert'} = File::Spec->catfile($answers->{'ssl-dir'}, "RHN-ORG-TRUSTED-SSL-CERT");
+    }
     my @osImageOpts = ("--ca-cert-full-path=$answers->{'ssl-ca-cert'}");
-
     Spacewalk::Setup::system_or_exit(['/usr/sbin/mgr-package-rpm-certificate-osimage', @osImageOpts], 35, 'Could not import CA certificate.');
     Spacewalk::Setup::system_or_exit(['/usr/sbin/mgr-package-rpm-certificate-osimage', '--target-os', 'SLE11', @osImageOpts], 35, 'Could not import CA certificate.');
   }

--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -411,6 +411,11 @@ ssl-server-cert = $SERVER_CERT
 ssl-server-key = $SERVER_KEY" >> /root/spacewalk-answers
     else
         echo "ssl-use-existing-certs = N" >> /root/spacewalk-answers
+
+	# check if CA Cert and Key exists and try to use it to generate the server certs
+	if [ -e /root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT -a -e /root/ssl-build/RHN-ORG-PRIVATE-SSL-KEY ]; then
+            PARAM_CC="$PARAM_CC --skip-ssl-ca-generation"
+        fi
     fi
 
     PARAM_DB="--external-postgresql"


### PR DESCRIPTION
## What does this PR change?

Re-use existing CA cert and key if it was made available from the hub server.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [x] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
