### PR TITLE
fix writing last_synced

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/HubReportDbUpdateWorker.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/HubReportDbUpdateWorker.java
@@ -150,6 +150,8 @@ public class HubReportDbUpdateWorker implements QueueWorker {
             finally {
                 remoteDB.closeSession();
                 remoteDB.closeSessionFactory();
+                localRcm.closeSession();
+                localRcm.close();
             }
         }
         catch (Exception e) {

--- a/java/code/src/com/redhat/rhn/taskomatic/task/HubReportDbUpdateWorker.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/HubReportDbUpdateWorker.java
@@ -26,14 +26,15 @@ import com.redhat.rhn.common.db.datasource.SelectMode;
 import com.redhat.rhn.common.db.datasource.WriteMode;
 import com.redhat.rhn.common.hibernate.ConnectionManager;
 import com.redhat.rhn.common.hibernate.ConnectionManagerFactory;
+import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.hibernate.ReportDbHibernateFactory;
 import com.redhat.rhn.common.util.TimeUtils;
 import com.redhat.rhn.domain.credentials.Credentials;
 import com.redhat.rhn.domain.server.MgrServerInfo;
+import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.taskomatic.task.threaded.QueueWorker;
 import com.redhat.rhn.taskomatic.task.threaded.TaskQueue;
-
 
 import org.apache.log4j.LogMF;
 import org.apache.log4j.Logger;
@@ -129,8 +130,10 @@ public class HubReportDbUpdateWorker implements QueueWorker {
                 TABLES.forEach(table -> {
                     updateRemoteData(remoteDB.getSession(), localRh.getSession(), table, mgrServerInfo.getId());
                 });
-                mgrServerInfo.setReportDbLastSynced(new Date());
-                ServerFactory.save(mgrServerInfo.getServer());
+                Server mgrServer = ServerFactory.lookupById(mgrServerInfo.getId());
+                mgrServer.getMgrServerInfo().setReportDbLastSynced(new Date());
+                ServerFactory.save(mgrServer);
+                HibernateFactory.commitTransaction();
                 localRcm.commitTransaction();
                 log.info("Reporting db updated for server " + mgrServerInfo.getServer().getId() + " successfully.");
             }


### PR DESCRIPTION
## What does this PR change?

To write last_sync, we need to lookup the server object in the worker thread.
Commit directly to really write it to the DB.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
