### PR TITLE
Fix reboot time on salt-ssh client (bsc#1197591)

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -2524,38 +2524,37 @@ public class SaltServerActionService {
                     }, jsonResult -> {
                         String function = (String) call.getPayload().get("fun");
 
-                        // reboot needs special handling in case of ssh push
-                        if (action.getActionType().equals(ActionFactory.TYPE_REBOOT) &&
-                            sa.getStatus().equals(ActionFactory.STATUS_QUEUED)) {
-                        // if the status is already PICKED_UP, don't change it
-                        // if the status is FAILED or COMPLETED, don't change it
+                        /* bsc#1197591 ssh push reboot has an answer that is not a failure but the action needs to
+                        *  stay in picked up, in this way SSHPushDriver::getCandidates can schedule a reboot correctly
+                        */
+                        if (!action.getActionType().equals(ActionFactory.TYPE_REBOOT)) {
+                            saltUtils.updateServerAction(sa, 0L, true, "n/a", jsonResult, function);
+                        }
+                        else if (sa.getStatus().equals(ActionFactory.STATUS_QUEUED)) {
                             sa.setStatus(ActionFactory.STATUS_PICKED_UP);
                             sa.setPickupTime(new Date());
-                        }
-                        else {
-                            saltUtils.updateServerAction(sa, 0L, true, "n/a",
-                                    jsonResult, function);
                         }
 
                         // Perform a "check-in" after every executed action
                         minion.updateServerInfo();
 
-                    // Perform a package profile update in the end if necessary
-                    if (forcePkgRefresh || saltUtils.shouldRefreshPackageList(function, Optional.of(jsonResult))) {
-                        LOG.info("Scheduling a package profile update");
-                        Action pkgList;
-                        try {
-                            pkgList = ActionManager.schedulePackageRefresh(minion.getOrg(), minion);
-                            executeSSHAction(pkgList, minion);
-                        }
-                        catch (TaskomaticApiException e) {
-                            LOG.error("Could not schedule package refresh for minion: " +
+                        // Perform a package profile update in the end if necessary
+                        if (forcePkgRefresh || saltUtils.shouldRefreshPackageList(function, Optional.of(jsonResult))) {
+                            LOG.info("Scheduling a package profile update");
+
+                            Action pkgList;
+                            try {
+                                pkgList = ActionManager.schedulePackageRefresh(minion.getOrg(), minion);
+                                executeSSHAction(pkgList, minion);
+                            }
+                            catch (TaskomaticApiException e) {
+                                LOG.error("Could not schedule package refresh for minion: " +
                                     minion.getMinionId());
-                            LOG.error(e);
+                                LOG.error(e);
+                            }
                         }
-                    }
-                 });
-              });
+                    });
+                });
             }
         }
     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix reboot time on salt-ssh client(bsc#1197591)
 - detect free products in Alpha and Beta stage and prevent checks
   on openSUSE products (bsc#1197488)
 - Implement JSON over HTTP API

--- a/testsuite/features/secondary/min_ssh_tunnel.feature
+++ b/testsuite/features/secondary/min_ssh_tunnel.feature
@@ -2,23 +2,24 @@
 # Licensed under the terms of the MIT license.
 
 @scope_salt_ssh
+@ssh_minion
 Feature: Register a Salt system to be managed via SSH tunnel
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
   Scenario: Delete the Salt minion for SSH tunnel bootstrap
-    Given I am on the Systems overview page of this "sle_minion"
+    Given I am on the Systems overview page of this "ssh_minion"
     When I follow "Delete System"
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
     And I wait until I see "has been deleted" text
-    Then "sle_minion" should not be registered
+    Then "ssh_minion" should not be registered
 
   Scenario: Register this minion for push via SSH tunnel
     When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
-    And I enter the hostname of "sle_minion" as "hostname"
+    And I enter the hostname of "ssh_minion" as "hostname"
     And I enter "22" as "port"
     And I enter "root" as "user"
     And I enter "linux" as "password"
@@ -27,14 +28,14 @@ Feature: Register a Salt system to be managed via SSH tunnel
     And I check "manageWithSSH"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
-    And I wait until onboarding is completed for "sle_minion"
+    And I wait until onboarding is completed for "ssh_minion"
 
   Scenario: The contact method is SSH tunnel on this minion
-    Given I am on the Systems overview page of this "sle_minion"
+    Given I am on the Systems overview page of this "ssh_minion"
     Then I should see a "Push via SSH tunnel" text
 
   Scenario: Install a package from this SSH tunnel minion
-    Given I am on the Systems overview page of this "sle_minion"
+    Given I am on the Systems overview page of this "ssh_minion"
     When I follow "Software" in the content area
     And I follow "Install"
     And I enter "milkyway-dummy" as the filtered package name
@@ -43,11 +44,11 @@ Feature: Register a Salt system to be managed via SSH tunnel
     And I click on "Install Selected Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text
-    When I force picking pending events on "sle_minion" if necessary
+    When I force picking pending events on "ssh_minion" if necessary
     Then I wait until event "Package Install/Upgrade scheduled by admin" is completed
 
   Scenario: Remove a package from this SSH tunnel minion
-    Given I am on the Systems overview page of this "sle_minion"
+    Given I am on the Systems overview page of this "ssh_minion"
     And I follow "Software" in the content area
     And I follow "List / Remove"
     And I enter "milkyway-dummy" as the filtered package name
@@ -56,33 +57,33 @@ Feature: Register a Salt system to be managed via SSH tunnel
     And I click on "Remove Packages"
     And I click on "Confirm"
     Then I should see a "1 package removal has been scheduled" text
-    When I force picking pending events on "sle_minion" if necessary
+    When I force picking pending events on "ssh_minion" if necessary
     Then I wait until event "Package Removal scheduled by admin" is completed
 
   Scenario: Run a remote command on this SSH tunnel minion
     When I follow the left menu "Salt > Remote Commands"
     Then I should see a "Remote Commands" text in the content area
     When I enter command "echo 'My remote command output'"
-    And I enter the hostname of "sle_minion" as "target"
+    And I enter the hostname of "ssh_minion" as "target"
     And I click on preview
-    Then I should see a "Target systems (1)" text
+    Then I wait until I do not see "Target systems (1)" text
     When I wait until I do not see "pending" text
     And I click on run
     And I wait until I see "show response" text
-    And I expand the results for "sle_minion"
-    Then I should see "My remote command output" in the command output for "sle_minion"
+    And I expand the results for "ssh_minion"
+    Then I should see "My remote command output" in the command output for "ssh_minion"
 
   Scenario: Cleanup: delete the SSH tunnel minion
-    Given I am on the Systems overview page of this "sle_minion"
+    Given I am on the Systems overview page of this "ssh_minion"
     When I follow "Delete System"
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
     And I wait until I see "has been deleted" text
-    Then "sle_minion" should not be registered
+    Then "ssh_minion" should not be registered
 
   Scenario: Cleanup: register a Salt minion after SSH tunnel tests
-    When I bootstrap minion client "sle_minion" using bootstrap script with activation key "1-SUSE-KEY-x86_64" from the proxy
-    And I wait at most 10 seconds until Salt master sees "sle_minion" as "unaccepted"
-    And I accept "sle_minion" key in the Salt master
-    Then I should see "sle_minion" via spacecmd
-    And I wait until onboarding is completed for "sle_minion"
+    When I bootstrap minion client "ssh_minion" using bootstrap script with activation key "1-SUSE-KEY-x86_64" from the proxy
+    And I wait at most 10 seconds until Salt master sees "ssh_minion" as "unaccepted"
+    And I accept "ssh_minion" key in the Salt master
+    Then I should see "ssh_minion" via spacecmd
+    And I wait until onboarding is completed for "ssh_minion"


### PR DESCRIPTION
## What does this PR change?
ssh push reboot action has a valid response which contains the `shutdown` command, but the action needs to remain pending in order to execute `mgractionchains.resume` correctly. The problem does not happen with salt minion because the job `mgractionchains.resume` is executing after startup.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17388

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
