### PR TITLE
Show image build log in UI

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/image/ImageInfo.java
+++ b/java/code/src/com/redhat/rhn/domain/image/ImageInfo.java
@@ -82,6 +82,7 @@ public class ImageInfo extends BaseDomainHelper {
     private Pillar pillar;
     private Set<DeltaImageInfo> deltaSourceFor = new HashSet<>();
     private Set<DeltaImageInfo> deltaTargetFor = new HashSet<>();
+    private String buildLog;
 
     /**
      * @return the id
@@ -315,6 +316,14 @@ public class ImageInfo extends BaseDomainHelper {
     }
 
     /**
+     * @return build log
+     */
+    @Column(name = "log")
+    public String getBuildLog() {
+        return buildLog;
+    }
+
+    /**
      * @param idIn id to set
      */
     public void setId(Long idIn) {
@@ -465,6 +474,10 @@ public class ImageInfo extends BaseDomainHelper {
      */
     public void setPillar(Pillar pillarIn) {
         this.pillar = pillarIn;
+    }
+
+    public void setBuildLog(String buildLogIn) {
+        buildLog = buildLogIn;
     }
 
     public void setDeltaSourceFor(Set<DeltaImageInfo> deltaSourceForIn) {

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -1568,6 +1568,11 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
     private ImageInfo doTestContainerImageBuild(MinionServer server, String imageName, String imageVersion,
                                                 ImageProfile profile, Consumer<ImageInfo> assertions) throws Exception {
+
+        context().checking(new Expectations() {{
+            allowing(saltServiceMock).copyFile(with(any(Path.class)), with(any(Path.class)));
+            will(returnValue(Optional.empty()));
+        }});
         // schedule the build
         long actionId = ImageInfoFactory.scheduleBuild(server.getId(), imageVersion, profile, new Date(), user);
         ImageBuildAction buildAction = (ImageBuildAction) ActionFactory.lookupById(actionId);
@@ -1665,6 +1670,8 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                                     "-5.3.18-150300.59.54-default.kernel",
                             user.getOrg().getId())))));
             will(returnValue(Optional.of(true)));
+            allowing(saltServiceMock).copyFile(with(any(Path.class)), with(any(Path.class)));
+            will(returnValue(Optional.empty()));
         }});
         systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.OSIMAGE_BUILD_HOST);
 

--- a/java/code/src/com/suse/manager/webui/controllers/ImageBuildController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/ImageBuildController.java
@@ -147,6 +147,8 @@ public class ImageBuildController {
                 withUser(imageBuildController::getPatches));
         Spark.get("/manager/api/cm/images/packages/:id",
                 withUser(imageBuildController::getPackages));
+        Spark.get("/manager/api/cm/images/buildlog/:id",
+                withUser(imageBuildController::getBuildLog));
         post("/manager/api/cm/images/inspect/:id",
                 withImageAdmin(imageBuildController::inspect));
         post("/manager/api/cm/images/delete", withImageAdmin(ImageBuildController::delete));
@@ -615,6 +617,41 @@ public class ImageBuildController {
 
         return json(res, imageInfo.map(ImageBuildController::getImageInfoWithPackageList)
                     .orElse(null));
+    }
+
+    /**
+     * Gets build log for single image info object in JSON
+     *
+     * @param req the request object
+     * @param res the response object
+     * @param user the authorized user
+     * @return the result JSON object
+     */
+    public Object getBuildLog(Request req, Response res, User user) {
+        Long id;
+        try {
+            id = Long.parseLong(req.params("id"));
+        }
+        catch (NumberFormatException e) {
+            throw new NotFoundException();
+        }
+
+        Optional<ImageOverview> imageInfo =
+                ImageInfoFactory.lookupOverviewByIdAndOrg(id, user.getOrg());
+
+        return json(res, imageInfo.map(ImageBuildController::getBuildLogJson)
+                    .orElse(null));
+    }
+
+    private static JsonObject getBuildLogJson(ImageOverview imageOverview) {
+        JsonObject json = GSON
+                .toJsonTree(ImageInfoJson.fromImageInfo(imageOverview), ImageInfoJson.class)
+                .getAsJsonObject();
+        ImageInfoFactory.lookupById(imageOverview.getId()).ifPresent(imageInfo -> {
+            json.addProperty("buildlog", imageInfo.getBuildLog());
+        });
+
+        return json;
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/services/SaltConstants.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltConstants.java
@@ -29,6 +29,8 @@ public class SaltConstants {
 
     public static final String SALT_FILE_GENERATION_TEMP_PATH = "/srv/susemanager/tmp";
 
+    public static final String SALT_CP_PUSH_ROOT_PATH = "/var/cache/salt/master/minions/";
+
     public static final String SALT_SSH_DIR_PATH = "/var/lib/salt/.ssh";
 
     public static final String PILLAR_DATA_FILE_PREFIX = "pillar";

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Show image build log in UI
 - Build bundle less images and create pxe profile for pxe images
   Introduce saltboot-group handing and pxe management of them
   Part of saltboot containerization workflow

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -746,7 +746,7 @@ chown tomcat:%{apache_group} /var/log/rhn/gatherer.log
 %attr(775,tomcat,susemanager) %dir %{serverdir}/susemanager/pillar_data
 %attr(775,tomcat,susemanager) %dir %{serverdir}/susemanager/pillar_data/images
 %dir %{serverdir}/susemanager/formula_data
-%attr(750, tomcat, %{salt_user_group}) %dir %{serverdir}/susemanager/tmp
+%attr(770, tomcat, %{salt_user_group}) %dir %{serverdir}/susemanager/tmp
 %dir %{serverdir}/tomcat/webapps/rhn/
 %{serverdir}/tomcat/webapps/rhn/apidoc/
 %{serverdir}/tomcat/webapps/rhn/css/

--- a/web/html/src/manager/images/image-view-buildlog.tsx
+++ b/web/html/src/manager/images/image-view-buildlog.tsx
@@ -1,0 +1,17 @@
+import { BootstrapPanel } from "components/panels/BootstrapPanel";
+
+function ImageViewBuildLog(props) {
+  return (
+    <BootstrapPanel title={t("Build Log")}>
+      <div className="auto-overflow">
+        {props.data.buildlog ? (
+          <textarea className="form-control" name="buildlog" rows={30} value={props.data.buildlog} readOnly />
+        ) : (
+          t("Build log is not available.")
+        )}
+      </div>
+    </BootstrapPanel>
+  );
+}
+
+export { ImageViewBuildLog };

--- a/web/html/src/manager/images/image-view.tsx
+++ b/web/html/src/manager/images/image-view.tsx
@@ -9,6 +9,7 @@ import { ModalButton } from "components/dialog/ModalButton";
 import { ModalLink } from "components/dialog/ModalLink";
 import { Messages } from "components/messages";
 import { Utils as MessagesUtils } from "components/messages";
+import { BootstrapPanel } from "components/panels/BootstrapPanel";
 import { TopPanel } from "components/panels/TopPanel";
 import { PopUp } from "components/popup";
 import { TabContainer } from "components/tab-container";
@@ -238,7 +239,8 @@ class ImageView extends React.Component<ImageViewProps, ImageViewState> {
 
   getImageInfoDetails(id, tab) {
     let url;
-    if (tab === "patches" || tab === "packages") url = "/rhn/manager/api/cm/images/" + tab + "/" + id;
+    if (tab === "patches" || tab === "packages" || tab === "buildlog")
+      url = "/rhn/manager/api/cm/images/" + tab + "/" + id;
     //overview, runtime
     else url = "/rhn/manager/api/cm/images/" + id;
 
@@ -752,6 +754,20 @@ class ImageViewList extends React.Component<ImageViewListProps, ImageViewListSta
   }
 }
 
+function ImageViewBuildLog(props) {
+  return (
+    <BootstrapPanel title={t("Build Log")}>
+      <div className="auto-overflow">
+        {props.data.buildlog ? (
+          <textarea className="form-control" name="buildlog" rows={30} value={props.data.buildlog} readOnly />
+        ) : (
+          t("Build log is not available.")
+        )}
+      </div>
+    </BootstrapPanel>
+  );
+}
+
 type ImageViewDetailsProps = {
   data: any;
   runtimeInfoEnabled: any;
@@ -782,8 +798,14 @@ class ImageViewDetails extends React.Component<ImageViewDetailsProps> {
     return (
       <div>
         <TabContainer
-          labels={[t("Overview"), t("Patches"), t("Packages"), this.props.runtimeInfoEnabled ? t("Runtime") : null]}
-          hashes={this.getHashUrls(["overview", "patches", "packages", "runtime"])}
+          labels={[
+            t("Overview"),
+            t("Patches"),
+            t("Packages"),
+            t("Build Log"),
+            this.props.runtimeInfoEnabled ? t("Runtime") : null,
+          ]}
+          hashes={this.getHashUrls(["overview", "patches", "packages", "buildlog", "runtime"])}
           initialActiveTabHash={window.location.hash}
           onTabHashChange={this.onTabChange}
           tabs={[
@@ -798,8 +820,9 @@ class ImageViewDetails extends React.Component<ImageViewDetailsProps> {
             />,
             <ImageViewPatches key="2" data={data} />,
             <ImageViewPackages key="3" data={data} />,
+            <ImageViewBuildLog key="4" data={data} />,
             this.props.runtimeInfoEnabled ? (
-              <ImageViewRuntime key="4" data={data} gotRuntimeInfo={this.props.gotRuntimeInfo} />
+              <ImageViewRuntime key="5" data={data} gotRuntimeInfo={this.props.gotRuntimeInfo} />
             ) : null,
           ]}
         />

--- a/web/html/src/manager/images/image-view.tsx
+++ b/web/html/src/manager/images/image-view.tsx
@@ -9,7 +9,6 @@ import { ModalButton } from "components/dialog/ModalButton";
 import { ModalLink } from "components/dialog/ModalLink";
 import { Messages } from "components/messages";
 import { Utils as MessagesUtils } from "components/messages";
-import { BootstrapPanel } from "components/panels/BootstrapPanel";
 import { TopPanel } from "components/panels/TopPanel";
 import { PopUp } from "components/popup";
 import { TabContainer } from "components/tab-container";
@@ -20,6 +19,7 @@ import { Table } from "components/table/Table";
 import { Utils } from "utils/functions";
 import Network from "utils/network";
 
+import { ImageViewBuildLog } from "./image-view-buildlog";
 import { ImageViewOverview } from "./image-view-overview";
 import { ImageViewPackages } from "./image-view-packages";
 import { ImageViewPatches } from "./image-view-patches";
@@ -752,20 +752,6 @@ class ImageViewList extends React.Component<ImageViewListProps, ImageViewListSta
       </div>
     );
   }
-}
-
-function ImageViewBuildLog(props) {
-  return (
-    <BootstrapPanel title={t("Build Log")}>
-      <div className="auto-overflow">
-        {props.data.buildlog ? (
-          <textarea className="form-control" name="buildlog" rows={30} value={props.data.buildlog} readOnly />
-        ) : (
-          t("Build log is not available.")
-        )}
-      </div>
-    </BootstrapPanel>
-  );
 }
 
 type ImageViewDetailsProps = {

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Show image build log in UI
 - Upgrade minimist to fix CVE-2021-44906
 - Container proxy configuration new webUI page
 - Resolve race conditions in CLM (bsc#1195710)


### PR DESCRIPTION
## What does this PR change?

Store image build log in DB and show it in UI.

## GUI diff

Before:

After:
New tab "Build Log" in Image details.

- [x] **DONE**

## Documentation

TBD

- [ ] **DONE**

## Test coverage
- Cucumber tests: TBD

- [ ] **DONE**

## Links

Fixes #

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
