### PR TITLE
Fix java unit tests coverage ant target

### DIFF
--- a/java/manager-build.xml
+++ b/java/manager-build.xml
@@ -298,33 +298,6 @@
 
   <target name="deploy-restart" depends="deploy, restart-tomcat, restart-taskomatic" />
 
-  <target name="test-legacy" depends="jar" description="Run unit tests">
-    <mkdir dir="${tests.results.dir}" />
-
-    <loadfile property="tests.includes.text" srcFile="${tests.includes}"/>
-    <loadfile property="tests.excludes.text" srcFile="${tests.excludes}"/>
-    <echo message="Running tests including:" />
-    <echo message="${tests.includes.text}" />
-    <echo message="and excluding:" />
-    <echo message="${tests.excludes.text}" />
-
-    <junit fork="yes" forkmode="once" maxmemory="256m" dir="${basedir}/buildconf"
-	    failureproperty="junit_failed">
-      <sysproperty key="rhn-home" value="." />
-      <sysproperty key="java.awt.headless" value="true" />
-      <sysproperty key="log4j.threshold" value="warn" />
-      <sysproperty key="rhn.config.dir" value="${tests.configuration.path}" />
-
-      <jvmarg value="-ea" />
-      <classpath refid="managertestjars" />
-      <formatter type="xml" usefile="true" />
-      <formatter type="brief" usefile="false" />
-      <batchtest todir="${tests.results.dir}">
-        <zipfileset src="${build.dir}/rhn.jar" includesfile="${tests.includes}" excludesfile="${tests.excludes}" />
-      </batchtest>
-    </junit>
-  </target>
-
   <target name="test-report" depends="test" description="Run unit tests and produce a report">
     <junitreport todir="${tests.results.dir}">
       <fileset dir="${tests.results.dir}">
@@ -347,6 +320,8 @@
     <echo message="${tests.includes.text}" />
     <echo message="and excluding:" />
     <echo message="${tests.excludes.text}" />
+    <taskdef resource="org/jacoco/ant/antlib.xml" classpathref="libjars" />
+    <agent property="jacocoagent" destfile="${tests.coverage.destfile}"/>
 
     <!-- Once all CI containers are using ant 1.10+ we can add the printSummary="true" parameter
          Before it outputs useless over-verbose Junit5 summary for each test summary for each test summary for each test... -->
@@ -366,9 +341,10 @@
             <fork>
                 <sysproperty key="rhn-home" value="." />
                 <sysproperty key="java.awt.headless" value="true" />
-                <sysproperty key="log4j.threshold" value="true" />
+                <sysproperty key="log4j.threshold" value="warn" />
                 <sysproperty key="rhn.config.dir" value="${tests.configuration.path}" />
                 <jvmarg value="-ea" />
+                <jvmarg value="${jacocoagent}"/>
             </fork>
             <zipfileset src="${build.dir}/rhn.jar" includesfile="${tests.includes}" excludesfile="${tests.excludes}" />
             <listener type="legacy-brief" sendSysOut="true"/>
@@ -401,35 +377,7 @@
     </checkstyle>
   </target>
 
-  <target name="test-coverage" depends="jar" description="Measure unit test coverage">
-    <taskdef resource="org/jacoco/ant/antlib.xml" classpathref="libjars" />
-
-    <loadfile property="tests.includes.text" srcFile="${tests.includes}"/>
-    <loadfile property="tests.excludes.text" srcFile="${tests.excludes}"/>
-    <echo message="Running tests with coverage including:" />
-    <echo message="${tests.includes.text}" />
-    <echo message="and excluding:" />
-    <echo message="${tests.excludes.text}" />
-
-    <coverage destfile="${tests.coverage.destfile}">
-      <junit fork="yes" forkmode="once" maxmemory="256m" dir="${basedir}/buildconf">
-        <sysproperty key="rhn-home" value="." />
-        <sysproperty key="java.awt.headless" value="true" />
-        <sysproperty key="log4j.threshold" value="warn" />
-        <sysproperty key="rhn.config.dir" value="${tests.configuration.path}" />
-
-        <jvmarg value="-ea" />
-        <classpath refid="managertestjars" />
-        <formatter type="xml" usefile="true" />
-        <formatter type="brief" usefile="false" />
-        <batchtest todir="${tests.results.dir}">
-          <zipfileset src="${build.dir}/rhn.jar" includesfile="${tests.includes}" excludesfile="${tests.excludes}" />
-        </batchtest>
-      </junit>
-    </coverage>
-  </target>
-
-  <target name="test-coverage-report" depends="test-coverage" description="Generate the unit test coverage reports">
+  <target name="test-coverage-report" depends="test" description="Generate the unit test coverage reports">
     <taskdef resource="org/jacoco/ant/antlib.xml" classpathref="libjars" />
     <report>
       <executiondata>


### PR DESCRIPTION
## What does this PR change?

Update coverage test target to Junit5

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
