### PR TITLE
Add TIP for Timeout Session Lifetime

### DIFF
--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -814,5 +814,6 @@ Following code is expected to be a part of function used as step definition for 
 ```
 
 NOTE: This solution was tested and worked properly, but there was no time gain in comparison with old solution using capybara steps.
+
 TIP: We still can play with timeout value in our test environment, if necessary. See default value [here](https://github.com/uyuni-project/uyuni/blob/master/web/conf/rhn_web.conf#L29-L31)
 

--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -814,4 +814,5 @@ Following code is expected to be a part of function used as step definition for 
 ```
 
 NOTE: This solution was tested and worked properly, but there was no time gain in comparison with old solution using capybara steps.
+TIP: We still can play with timeout value in our test environment, if necessary. See default value [here](https://github.com/uyuni-project/uyuni/blob/master/web/conf/rhn_web.conf#L29-L31)
 


### PR DESCRIPTION
## What does this PR change?

Add TIP for Timeout Session Lifetime

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Documentation needed: We added a tip about web session timeout

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
