### PR TITLE
add translation string for new Hub Reporting tasks

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -23738,6 +23738,12 @@ given channel.</source>
           <context context-type="sourcefile">/rhn/admin/BunchDetail.do</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="bunch.jsp.description.mgr-update-reporting-hub-bunch" xml:space="preserve">
+        <source>Update Hub Reporting Database</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/admin/BunchDetail.do</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="bunch.jsp.description.update-payg-data-bunch" xml:space="preserve">
         <source>Collect authentication data from configure pay-as-you-go cloud instances</source>
             <context-group name="ctx">
@@ -24158,6 +24164,9 @@ given channel.</source>
       </trans-unit>
       <trans-unit id="task.status.mgr-update-reporting" xml:space="preserve">
         <source>Update Reporting Database</source>
+      </trans-unit>
+      <trans-unit id="task.status.mgr-update-reporting-hub" xml:space="preserve">
+        <source>Update Hub Reporting Database</source>
       </trans-unit>
       <trans-unit id="actions.jsp.pickedup" xml:space="preserve">
         <source>Picked Up</source>

--- a/java/code/src/com/redhat/rhn/taskomatic/task/HubReportDbUpdateWorker.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/HubReportDbUpdateWorker.java
@@ -48,7 +48,7 @@ import java.util.Map;
 public class HubReportDbUpdateWorker implements QueueWorker {
 
     private static final int BATCH_SIZE = Config.get()
-            .getInt(ConfigDefaults.REPORT_DB_BATCH_SIZE, 100);
+            .getInt(ConfigDefaults.REPORT_DB_BATCH_SIZE, 500);
     private TaskQueue parentQueue;
     private final MgrServerInfo mgrServerInfo;
     private Logger log;

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ReportDbUpdateTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ReportDbUpdateTask.java
@@ -40,7 +40,7 @@ import java.util.Map;
 public class ReportDbUpdateTask extends RhnJavaJob {
 
     private static final int BATCH_SIZE = Config.get()
-            .getInt(ConfigDefaults.REPORT_DB_BATCH_SIZE, 100);
+            .getInt(ConfigDefaults.REPORT_DB_BATCH_SIZE, 500);
 
 
     private void fillReportDbTable(Session session, String xmlName, String tableName, long mgmId) {


### PR DESCRIPTION
## What does this PR change?

The new hub reporting taskomatic job needs some translation strings

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
