### PR TITLE
QE: Cucumber methods should use log method instead of puts

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -85,7 +85,7 @@ enable_assertions
 # embed a screenshot after each failed scenario
 After do |scenario|
   current_epoch = Time.new.to_i
-  STDOUT.puts "This scenario took: #{current_epoch - @scenario_start_time} seconds"
+  log "This scenario took: #{current_epoch - @scenario_start_time} seconds"
   if scenario.failed?
     begin
       Dir.mkdir("screenshots") unless File.directory?("screenshots")
@@ -107,15 +107,15 @@ end
 
 AfterStep do
   if has_css?('.senna-loading', wait: 0)
-    STDOUT.puts 'WARN: Step ends with an ajax transition not finished, let\'s wait a bit!'
-    STDOUT.puts 'Timeout: Waiting AJAX transition' unless has_no_css?('.senna-loading', wait: 20)
+    log 'WARN: Step ends with an ajax transition not finished, let\'s wait a bit!'
+    log 'Timeout: Waiting AJAX transition' unless has_no_css?('.senna-loading', wait: 20)
   end
 end
 
 Before do
   current_time = Time.new
   @scenario_start_time = current_time.to_i
-  STDOUT.puts "This scenario ran at: #{current_time}\n"
+  log "This scenario ran at: #{current_time}\n"
 end
 
 # do some tests only if the corresponding node exists


### PR DESCRIPTION
## What does this PR change?

Few time ago we lost in a refactor the timestamps about when a scenario starts and ends.
This PR will get them back.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were refactored

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
