### PR TITLE
Hub reporting pagination for generated queries

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/GeneratedSelectMode.java
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/GeneratedSelectMode.java
@@ -31,8 +31,8 @@ public class GeneratedSelectMode extends SelectMode {
      * @param session hibernate database session to be used
      * @param sqlStatement the sql statement to execute
      */
-    public GeneratedSelectMode(String name, Session session, String sqlStatement) {
-        super(session, new DynamicParsedMode(name, sqlStatement, List.of()));
+    public GeneratedSelectMode(String name, Session session, String sqlStatement, List<String> parameters) {
+        super(session, new DynamicParsedMode(name, sqlStatement, parameters));
     }
 
     private static class DynamicParsedMode implements ParsedMode {

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ReportDBHelper.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ReportDBHelper.java
@@ -55,8 +55,9 @@ public class ReportDBHelper {
      * @return select mode query
      */
     public static SelectMode generateQuery(Session session, String table) {
-        final String sqlStatement = "SELECT * FROM " + table + " WHERE mgm_id = 1";
-        return new GeneratedSelectMode("select." + table, session, sqlStatement);
+        final String sqlStatement = "SELECT * FROM " + table +
+                " WHERE mgm_id = 1 ORDER BY ctid OFFSET :offset LIMIT :limit";
+        return new GeneratedSelectMode("select." + table, session, sqlStatement, List.of("offset", "limit"));
     }
 
     /**


### PR DESCRIPTION
## What does this PR change?

adding pagination to generated queries

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
