### PR TITLE
New container doesn't use tftp package but python server

### DIFF
--- a/containers/proxy-tftpd-image/_service
+++ b/containers/proxy-tftpd-image/_service
@@ -4,7 +4,7 @@
     <param name="file">Dockerfile</param>
     <param name="regex">%PKG_VERSION%</param>
     <param name="parse-version">patch</param>
-    <param name="package">tftp</param>
+    <param name="package">python3-fbtftp</param>
   </service>
   <service mode="buildtime" name="docker_label_helper"/>
 </services>


### PR DESCRIPTION
## What does this PR change?

New container doesn't use tftp package but python server so we need to change _service file to reflect this

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
