### PR TITLE
Fix failing image building and inspection unit tests

### DIFF
--- a/java/code/src/com/redhat/rhn/testing/ImageTestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/ImageTestUtils.java
@@ -19,6 +19,7 @@ import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.credentials.Credentials;
 import com.redhat.rhn.domain.credentials.CredentialsFactory;
 import com.redhat.rhn.domain.image.DockerfileProfile;
+import com.redhat.rhn.domain.image.ImageFile;
 import com.redhat.rhn.domain.image.ImageInfo;
 import com.redhat.rhn.domain.image.ImageInfoCustomDataValue;
 import com.redhat.rhn.domain.image.ImagePackage;
@@ -398,5 +399,19 @@ public class ImageTestUtils {
         MinionServer server = MinionServerFactoryTest.createTestMinionServer(user);
         entitlementManager.addEntitlementToServer(server, EntitlementManager.CONTAINER_BUILD_HOST);
         return server;
+    }
+
+    /**
+     * Test create image file
+     * @param image
+     * @param filename
+     * @param type
+     */
+    public static void createImageFile(ImageInfo image, String filename, String type) {
+        ImageFile file = new ImageFile();
+        file.setFile(filename);
+        file.setType(type);
+        file.setImageInfo(image);
+        image.getImageFiles().add(file);
     }
 }

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -1646,10 +1646,12 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                     with(equal("/var/lib/Kiwi/build129/images.build/POS_Image_JeOS7.x86_64-7.0.0")),
                     with(equal(String.format("/srv/www/os-images/%d/POS_Image_JeOS7-7.0.0-1/",
                             user.getOrg().getId()))));
+            will(returnValue(Optional.of(mockResult)));
             allowing(saltServiceMock).collectKiwiImage(with(equal(server)),
                     with(equal("/var/lib/Kiwi/build129/images.build/POS_Image_JeOS7.x86_64-7.0.0.initrd")),
                     with(equal(String.format("/srv/www/os-images/%d/POS_Image_JeOS7-7.0.0-1/",
                             user.getOrg().getId()))));
+            will(returnValue(Optional.of(mockResult)));
             allowing(saltServiceMock).collectKiwiImage(with(equal(server)),
                     with(equal("/var/lib/Kiwi/build129/images.build/POS_Image_JeOS7.x86_64-7.0.0-5.3.18-150300.59.54" +
                             "-default.kernel")),
@@ -1660,10 +1662,12 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                     with(equal(Paths.get(String.format(
                             "/srv/www/os-images/%d/POS_Image_JeOS7-7.0.0-1/POS_Image_JeOS7.x86_64-7.0.0",
                             user.getOrg().getId())))));
+            will(returnValue(Optional.of(true)));
             allowing(saltServiceMock).removeFile(
                     with(equal(Paths.get(String.format(
                             "/srv/www/os-images/%d/POS_Image_JeOS7-7.0.0-1/POS_Image_JeOS7.x86_64-7.0.0.initrd",
                             user.getOrg().getId())))));
+            will(returnValue(Optional.of(true)));
             allowing(saltServiceMock).removeFile(
                     with(equal(Paths.get(String.format(
                             "/srv/www/os-images/%d/POS_Image_JeOS7-7.0.0-1/POS_Image_JeOS7.x86_64-7.0.0" +
@@ -1727,6 +1731,8 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                                     "-build129.tar.xz",
                             user.getOrg().getId())))));
             will(returnValue(Optional.of(true)));
+            allowing(saltServiceMock).copyFile(with(any(Path.class)), with(any(Path.class)));
+            will(returnValue(Optional.empty()));
         }});
         systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.OSIMAGE_BUILD_HOST);
 
@@ -1761,16 +1767,17 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         MgrUtilRunner.ExecResult mockResult = new MgrUtilRunner.ExecResult();
         context().checking(new Expectations() {{
             allowing(saltServiceMock).generateSSHKey(with(equal(SaltSSHService.SSH_KEY_PATH)));
-            allowing(saltServiceMock).collectKiwiImage(with(equal(server)),
-                    with(equal("/var/lib/Kiwi/build06/images/POS_Image_JeOS6.x86_64-6.0.0-build06.tgz")),
-                    with(equal(String.format("/srv/www/os-images/%d/POS_Image_JeOS6-6.0.0-0/",
-                            user.getOrg().getId()))));
-            will(returnValue(Optional.of(mockResult)));
             allowing(saltServiceMock).removeFile(
-                    with(equal(Paths.get(String.format(
-                            "/srv/www/os-images/%d/POS_Image_JeOS6-6.0.0-0/POS_Image_JeOS6.x86_64-6.0.0-build06.tgz",
-                                             user.getOrg().getId())))));
+                    with(equal(Paths.get(String.format("/srv/www/os-images/%d/image", user.getOrg().getId())))));
             will(returnValue(Optional.of(true)));
+            allowing(saltServiceMock).removeFile(
+                    with(equal(Paths.get(String.format("/srv/www/os-images/%d/kernel", user.getOrg().getId())))));
+            will(returnValue(Optional.of(true)));
+            allowing(saltServiceMock).removeFile(
+                    with(equal(Paths.get(String.format("/srv/www/os-images/%d/initrd", user.getOrg().getId())))));
+            will(returnValue(Optional.of(true)));
+            allowing(saltServiceMock).copyFile(with(any(Path.class)), with(any(Path.class)));
+            will(returnValue(Optional.empty()));
         }});
         systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.OSIMAGE_BUILD_HOST);
 
@@ -1788,12 +1795,14 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
             assertTrue(map.containsKey("boot_images"));
             Map<String, Map<String, Map<String, Object>>> bootImages =
                         (Map<String, Map<String, Map<String, Object>>>) map.get("boot_images");
+            assertTrue(bootImages.containsKey("POS_Image_JeOS6-6.0.0-1"));
+            assertTrue(bootImages.get("POS_Image_JeOS6-6.0.0-1").containsKey("initrd"));
             assertEquals(
-            "http://ftp/saltboot/boot/POS_Image_JeOS6.x86_64-6.0.0-build24/initrd-netboot-suse-SLES12.x86_64-2.1.1.gz",
-                    bootImages.get("POS_Image_JeOS6-6.0.0").get("initrd").get("url"));
+            "initrd-netboot-suse-SLES12.x86_64-2.1.1.gz",
+                    bootImages.get("POS_Image_JeOS6-6.0.0-1").get("initrd").get("filename"));
             Map<String, Map<String, Map<String, Object>>> images =
                         (Map<String, Map<String, Map<String, Object>>>) map.get("images");
-            assertEquals("http://ftp/saltboot/image/POS_Image_JeOS6.x86_64-6.0.0-build24/POS_Image_JeOS6.x86_64-6.0.0",
+            assertEquals("http://ftp/saltboot/image/POS_Image_JeOS6.x86_64-6.0.0-1/POS_Image_JeOS6.x86_64-6.0.0",
                         images.get("POS_Image_JeOS6").get("6.0.0-1").get("url"));
             assertEquals(Long.valueOf(1490026496), images.get("POS_Image_JeOS6").get("6.0.0-1").get("size"));
             assertEquals("a64dbc025c748bde968b888db6b7b9e3",
@@ -1829,6 +1838,8 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                     with(equal(String.format("/srv/www/os-images/%d/POS_Image_JeOS6-6.0.0-0/",
                             user.getOrg().getId()))));
             will(returnValue(Optional.of(mockResult)));
+            allowing(saltServiceMock).copyFile(with(any(Path.class)), with(any(Path.class)));
+            will(returnValue(Optional.empty()));
         }});
         systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.OSIMAGE_BUILD_HOST);
 
@@ -1850,11 +1861,11 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
             Map<String, Map<String, Map<String, Object>>> bootImages =
                         (Map<String, Map<String, Map<String, Object>>>) map.get("boot_images");
             assertEquals(
-            "http://ftp/saltboot/boot/POS_Image_JeOS6.x86_64-6.0.0-build24/initrd-netboot-suse-SLES12.x86_64-2.1.1.gz",
-                    bootImages.get("POS_Image_JeOS6-6.0.0").get("initrd").get("url"));
+            "initrd-netboot-suse-SLES12.x86_64-2.1.1.gz",
+                    bootImages.get("POS_Image_JeOS6-6.0.0-1").get("initrd").get("filename"));
             Map<String, Map<String, Map<String, Object>>> images =
                         (Map<String, Map<String, Map<String, Object>>>) map.get("images");
-            assertEquals("http://ftp/saltboot/image/POS_Image_JeOS6.x86_64-6.0.0-build24/POS_Image_JeOS6.x86_64-6.0.0",
+            assertEquals("http://ftp/saltboot/image/POS_Image_JeOS6.x86_64-6.0.0-1/POS_Image_JeOS6.x86_64-6.0.0",
                         images.get("POS_Image_JeOS6").get("6.0.0-1").get("url"));
             assertEquals(Long.valueOf(1490026496), images.get("POS_Image_JeOS6").get("6.0.0-1").get("size"));
             assertEquals("a64dbc025c748bde968b888db6b7b9e3",
@@ -1907,7 +1918,14 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         TestUtils.reload(buildAction);
         Optional<ImageInfo> imgInfoBuild = ImageInfoFactory.lookupByBuildAction(buildAction);
         assertTrue(imgInfoBuild.isPresent());
+        // Basic image info and image list is taken from ImageInfo
+        imgInfoBuild.get().setName("POS_Image_JeOS6");
+        imgInfoBuild.get().setVersion("6.0.0");
         imgInfoBuild.get().setRevisionNumber(1);
+
+        ImageTestUtils.createImageFile(imgInfoBuild.get(), "kernel", "kernel");
+        ImageTestUtils.createImageFile(imgInfoBuild.get(), "initrd", "initrd");
+        ImageTestUtils.createImageFile(imgInfoBuild.get(), "image", "image");
 
         actionId = ImageInfoFactory.scheduleInspect(imgInfoBuild.get(), new Date(), user);
 

--- a/java/code/src/com/suse/manager/reactor/messaging/test/image.inspect.kiwi.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/image.inspect.kiwi.json
@@ -39,7 +39,7 @@
                 "changes": {
                     "ret": {
                         "image": {
-                            "hash": "a64dbc025c748bde968b888db6b7b9e3",
+                            "hash": "md5:a64dbc025c748bde968b888db6b7b9e3",
                             "compression": null,
                             "name": "POS_Image_JeOS6",
                             "filepath": "/var/lib/Kiwi/build24/images.build/POS_Image_JeOS6.x86_64-6.0.0",
@@ -2346,7 +2346,7 @@
                         "boot_image": {
                             "kernel": {
                                 "version": "4.4.126-94.22-default",
-                                "hash": "ec5473654d2fdca4f60c7d2f8f86e45c",
+                                "hash": "md5:ec5473654d2fdca4f60c7d2f8f86e45c",
                                 "filename": "initrd-netboot-suse-SLES12.x86_64-2.1.1.kernel.4.4.126-94.22-default",
                                 "size": 6053712
                             },
@@ -2355,7 +2355,7 @@
                             "name": "initrd-netboot-suse-SLES12",
                             "initrd": {
                                 "version": "2.1.1",
-                                "hash": "e39757568fbd014656307e04508e01fb",
+                                "hash": "md5:e39757568fbd014656307e04508e01fb",
                                 "filename": "initrd-netboot-suse-SLES12.x86_64-2.1.1.gz",
                                 "size": 101571905
                             }

--- a/java/code/src/com/suse/manager/reactor/messaging/test/image.inspect.kiwi_compressed.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/image.inspect.kiwi_compressed.json
@@ -39,7 +39,7 @@
                 "changes": {
                     "ret": {
                         "image": {
-                            "hash": "a64dbc025c748bde968b888db6b7b9e3",
+                            "hash": "md5:a64dbc025c748bde968b888db6b7b9e3",
                             "compression": null,
                             "name": "POS_Image_JeOS6",
                             "filepath": "/var/lib/Kiwi/build24/images.build/POS_Image_JeOS6.x86_64-6.0.0",
@@ -2348,7 +2348,7 @@
                         "boot_image": {
                             "kernel": {
                                 "version": "4.4.126-94.22-default",
-                                "hash": "ec5473654d2fdca4f60c7d2f8f86e45c",
+                                "hash": "md5:ec5473654d2fdca4f60c7d2f8f86e45c",
                                 "filename": "initrd-netboot-suse-SLES12.x86_64-2.1.1.kernel.4.4.126-94.22-default",
                                 "size": 6053712
                             },
@@ -2357,7 +2357,7 @@
                             "name": "initrd-netboot-suse-SLES12",
                             "initrd": {
                                 "version": "2.1.1",
-                                "hash": "e39757568fbd014656307e04508e01fb",
+                                "hash": "md5:e39757568fbd014656307e04508e01fb",
                                 "filename": "initrd-netboot-suse-SLES12.x86_64-2.1.1.gz",
                                 "size": 101571905
                             }

--- a/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
@@ -122,9 +122,11 @@ public enum SaltStateGeneratorService {
                 pillar.add("boot_images", bootImagePillar);
             }
 
-            for (File f : Paths.get(SUMA_PILLAR_IMAGES_DATA_PATH).toFile().listFiles()) {
-                if (f.getName().startsWith(PILLAR_IMAGE_DATA_FILE_PREFIX + "-" + image.getBasename())) {
-                    f.delete();
+            if (Paths.get(SUMA_PILLAR_IMAGES_DATA_PATH).toFile().exists()) {
+                for (File f : Paths.get(SUMA_PILLAR_IMAGES_DATA_PATH).toFile().listFiles()) {
+                    if (f.getName().startsWith(PILLAR_IMAGE_DATA_FILE_PREFIX + "-" + image.getBasename())) {
+                        f.delete();
+                    }
                 }
             }
 


### PR DESCRIPTION
## What does this PR change?

Unit tests weren't properly updated and actual reason was carefully hidden behind some nonsense database insert problem. Only when commenting out transaction rollback (thanks @nadvornik for finding it) actual errors were presented.
This PR correctly adapts unit tests after PR https://github.com/uyuni-project/uyuni/pull/5109

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
