### PR TITLE
removed log4j-over-slf4j

### DIFF
--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -66,8 +66,7 @@
 
   <available file="${java.lib.dir}/log4j/log4j-core.jar" type="file" property="log4j-core" value="log4j/log4j-core" />
   <available file="${java.lib.dir}/log4j/log4j-api.jar" type="file" property="log4j-api" value="log4j/log4j-api" />
-  <available file="${java.lib.dir}/log4j/log4j-jcl.jar" type="file" property="log4j-jcl" value="log4j/log4j-jcl" />
-  <property name="log4j-jars" value="${log4j-core} ${log4j-api} ${log4j-jcl}"/>
+  <property name="log4j-jars" value="${log4j-core} ${log4j-api}"/>
 
   <condition property="jta11-jars" value="geronimo-jta-1.1-api" else="jta">
     <available file="${java.lib.dir}/geronimo-jta-1.1-api.jar" />

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -58,7 +58,6 @@
         <dependency org="suse" name="jose4j" rev="0.5.1" />
         <dependency org="suse" name="log4j-api" rev="2.13.0" />
         <dependency org="suse" name="log4j-core" rev="2.13.0" />
-        <dependency org="suse" name="log4j-jcl" rev="2.13.0" />
         <dependency org="suse" name="jsch" rev="0.1.55" />
         <dependency org="suse" name="mchange-commons-java" rev="0.2.20" />
         <dependency org="suse" name="netty-buffer" rev="4.1.44.Final" />

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -156,9 +156,6 @@ artifacts:
     jar: log4j-api.jar
     package: log4j
     repository: Leap
-  - artifact: log4j-jcl
-    jar: log4j-jcl.jar
-    repository: Leap
   - artifact: log4j-slf4j-impl
     jar: log4j-slf4j-impl.jar
     package: log4j-slf4j

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/SyncErrataPackagesAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/SyncErrataPackagesAction.java
@@ -55,7 +55,7 @@ public class SyncErrataPackagesAction extends RhnAction implements
         Listable<PackageOverview> {
 
 
-    private Logger log = LogManager.getLogger(SyncErrataPackagesAction.class);
+    private static final Logger log = LogManager.getLogger(SyncErrataPackagesAction.class);
 
     /**
      *

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -137,7 +137,6 @@ BuildRequires:  libxml2-tools
 %endif
 BuildRequires:  log4j
 BuildRequires:  log4j-slf4j
-BuildRequires:  log4j-over-slf4j
 BuildRequires:  log4j-jcl
 BuildRequires:  netty
 BuildRequires:  objectweb-asm
@@ -241,7 +240,6 @@ Requires:       jcommon
 Requires:       jdom
 Requires:       jta
 Requires:       log4j-slf4j
-Requires:       log4j-over-slf4j
 Requires:       redstone-xmlrpc
 Requires:       simple-core
 Requires:       simple-xml

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -137,7 +137,6 @@ BuildRequires:  libxml2-tools
 %endif
 BuildRequires:  log4j
 BuildRequires:  log4j-slf4j
-BuildRequires:  log4j-jcl
 BuildRequires:  netty
 BuildRequires:  objectweb-asm
 BuildRequires:  perl


### PR DESCRIPTION
## What does this PR change?

Fixed log4j migration issue

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
