### PR TITLE
Fix wrong sql scripts for reportdb creation

### DIFF
--- a/schema/reportdb/common/views/ActionsReport.sql
+++ b/schema/reportdb/common/views/ActionsReport.sql
@@ -10,7 +10,8 @@
 --
 
 CREATE OR REPLACE VIEW ActionsReport AS
-  SELECT DISTINCT SystemAction.action_id
+  SELECT DISTINCT SystemAction.mgm_id
+             , SystemAction.action_id
              , SystemAction.earliest_action
              , SystemAction.event
              , SystemAction.action_name
@@ -19,5 +20,7 @@ CREATE OR REPLACE VIEW ActionsReport AS
              , string_agg(SystemAction.hostname, ';') FILTER(WHERE status = 'Completed') OVER(PARTITION BY action_id) AS completed_systems
              , string_agg(SystemAction.hostname, ';') FILTER(WHERE status = 'Failed') OVER(PARTITION BY action_id) AS failed_systems
              , SystemAction.archived
+             , SystemAction.synced_date
     FROM SystemAction
+ORDER BY SystemAction.mgm_id, SystemAction.action_id
 ;

--- a/schema/reportdb/common/views/ChannelsReport.sql
+++ b/schema/reportdb/common/views/ChannelsReport.sql
@@ -19,6 +19,6 @@ CREATE OR REPLACE VIEW ChannelsReport AS
             , Channel.synced_date
     FROM Channel
             LEFT JOIN ChannelPackage ON ( Channel.mgm_id = ChannelPackage.mgm_id AND Channel.channel_id = ChannelPackage.channel_id )
-GROUP BY Channel.channel_id, Channel.label, Channel.name, Channel.organization
+GROUP BY Channel.mgm_id, Channel.channel_id, Channel.label, Channel.name, Channel.organization, Channel.synced_date
 ORDER BY Channel.mgm_id, Channel.channel_id
 ;

--- a/schema/reportdb/common/views/CustomChannelsReport.sql
+++ b/schema/reportdb/common/views/CustomChannelsReport.sql
@@ -26,6 +26,7 @@ CREATE OR REPLACE VIEW CustomChannelsReport AS
              , Channel.arch
              , Channel.checksum_type
              , repositories.channel_repositories
+             , Channel.synced_date
     FROM Channel
              LEFT JOIN repositories ON ( Channel.mgm_id = repositories.mgm_id AND Channel.channel_id = repositories.channel_id )
    WHERE Channel.organization IS NOT NULL

--- a/schema/reportdb/common/views/ErrataChannelsReport.sql
+++ b/schema/reportdb/common/views/ErrataChannelsReport.sql
@@ -15,6 +15,7 @@ CREATE OR REPLACE VIEW ErrataChannelsReport AS
             , errata_id
             , channel_label
             , channel_id
+            , synced_date
     FROM ChannelErrata
 ORDER BY mgm_id, advisory_name, errata_id, channel_label, channel_id
 ;

--- a/schema/reportdb/common/views/ErrataListReport.sql
+++ b/schema/reportdb/common/views/ErrataListReport.sql
@@ -22,7 +22,8 @@ CREATE OR REPLACE VIEW ErrataListReport AS
             , Errata.synced_date
     FROM Errata
             LEFT JOIN SystemErrata ON ( Errata.mgm_id = SystemErrata.mgm_id AND Errata.errata_id = SystemErrata.errata_id )
-GROUP BY Errata.errata_id
+GROUP BY Errata.mgm_id
+            , Errata.errata_id
             , Errata.advisory_name
             , Errata.advisory_type
             , Errata.cve
@@ -30,5 +31,5 @@ GROUP BY Errata.errata_id
             , Errata.issue_date
             , Errata.update_date
             , Errata.synced_date
-ORDER BY advisory_name
+ORDER BY Errata.mgm_id, Errata.advisory_name
 ;

--- a/schema/reportdb/common/views/ErrataSystemsReport.sql
+++ b/schema/reportdb/common/views/ErrataSystemsReport.sql
@@ -30,3 +30,4 @@ CREATE OR REPLACE VIEW ErrataSystemsReport AS
             LEFT JOIN SystemNetAddressV4 ON ( System.mgm_id = SystemNetAddressV4.mgm_id AND System.system_id = SystemNetAddressV4.system_id AND SystemNetInterface.interface_id = SystemNetAddressV4.interface_id )
             LEFT JOIN V6Addresses ON ( System.mgm_id = V6Addresses.mgm_id AND System.system_id = V6Addresses.system_id AND SystemNetInterface.interface_id = V6Addresses.interface_id )
 ORDER BY SystemErrata.mgm_id, SystemErrata.errata_id, SystemErrata.system_id
+;

--- a/schema/reportdb/common/views/PackagesUpdatesNewestReport.sql
+++ b/schema/reportdb/common/views/PackagesUpdatesNewestReport.sql
@@ -21,6 +21,7 @@ CREATE OR REPLACE VIEW PackagesUpdatesNewestReport AS
             , SystemPackageUpdate.epoch AS newer_epoch
             , SystemPackageUpdate.version AS newer_version
             , SystemPackageUpdate.release AS newer_release
+            , SystemPackageUpdate.synced_date
     FROM System
             INNER JOIN SystemPackageUpdate ON ( System.mgm_id = SystemPackageUpdate.mgm_id AND System.system_id = SystemPackageUpdate.system_id )
             INNER JOIN SystemPackageInstalled ON ( System.mgm_id = SystemPackageInstalled.mgm_id AND System.system_id = SystemPackageInstalled.system_id AND SystemPackageInstalled.name = SystemPackageUpdate.name )

--- a/schema/reportdb/upgrade/uyuni-reportdb-schema-4.3.2-to-uyuni-reportdb-schema-4.3.3/003-additional-tables.sql
+++ b/schema/reportdb/upgrade/uyuni-reportdb-schema-4.3.2-to-uyuni-reportdb-schema-4.3.3/003-additional-tables.sql
@@ -350,6 +350,7 @@ CREATE OR REPLACE VIEW PackagesUpdatesNewestReport AS
             , SystemPackageUpdate.epoch AS newer_epoch
             , SystemPackageUpdate.version AS newer_version
             , SystemPackageUpdate.release AS newer_release
+            , SystemPackageUpdate.synced_date
     FROM System
             INNER JOIN SystemPackageUpdate ON ( System.mgm_id = SystemPackageUpdate.mgm_id AND System.system_id = SystemPackageUpdate.system_id )
             INNER JOIN SystemPackageInstalled ON ( System.mgm_id = SystemPackageInstalled.mgm_id AND System.system_id = SystemPackageInstalled.system_id AND SystemPackageInstalled.name = SystemPackageUpdate.name )
@@ -409,6 +410,7 @@ CREATE OR REPLACE VIEW ErrataChannelsReport AS
             , errata_id
             , channel_label
             , channel_id
+            , synced_date
     FROM ChannelErrata
 ORDER BY mgm_id, advisory_name, errata_id, channel_label, channel_id
 ;

--- a/schema/reportdb/upgrade/uyuni-reportdb-schema-4.3.2-to-uyuni-reportdb-schema-4.3.3/004-additional-views.sql
+++ b/schema/reportdb/upgrade/uyuni-reportdb-schema-4.3.2-to-uyuni-reportdb-schema-4.3.3/004-additional-views.sql
@@ -6,7 +6,8 @@ ALTER TABLE SystemAction
 ;
 
 CREATE OR REPLACE VIEW ActionsReport AS
-  SELECT DISTINCT SystemAction.action_id
+  SELECT DISTINCT SystemAction.mgm_id
+             , SystemAction.action_id
              , SystemAction.earliest_action
              , SystemAction.event
              , SystemAction.action_name
@@ -15,7 +16,9 @@ CREATE OR REPLACE VIEW ActionsReport AS
              , string_agg(SystemAction.hostname, ';') FILTER(WHERE status = 'Completed') OVER(PARTITION BY action_id) AS completed_systems
              , string_agg(SystemAction.hostname, ';') FILTER(WHERE status = 'Failed') OVER(PARTITION BY action_id) AS failed_systems
              , SystemAction.archived
+             , SystemAction.synced_date
     FROM SystemAction
+ORDER BY SystemAction.mgm_id, SystemAction.action_id
 ;
 
 ALTER TABLE Channel
@@ -63,6 +66,7 @@ CREATE OR REPLACE VIEW CustomChannelsReport AS
              , Channel.arch
              , Channel.checksum_type
              , repositories.channel_repositories
+             , Channel.synced_date
     FROM Channel
              LEFT JOIN repositories ON ( Channel.mgm_id = repositories.mgm_id AND Channel.channel_id = repositories.channel_id )
    WHERE Channel.organization IS NOT NULL
@@ -93,7 +97,7 @@ GROUP BY Errata.mgm_id
             , Errata.issue_date
             , Errata.update_date
             , Errata.synced_date
-ORDER BY advisory_name
+ORDER BY Errata.mgm_id, Errata.advisory_name
 ;
 
 CREATE OR REPLACE VIEW ErrataSystemsReport AS


### PR DESCRIPTION
## What does this PR change?

This PR fixes the errors in the SQL script to create the reporting database

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests:  no code changes

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
