### PR TITLE
HTTP API APIDOC fix

### DIFF
--- a/java/code/internal/src/com/redhat/rhn/internal/doclet/ApiDoclet.java
+++ b/java/code/internal/src/com/redhat/rhn/internal/doclet/ApiDoclet.java
@@ -243,7 +243,8 @@ public abstract class ApiDoclet implements Doclet {
                 // Less robust that the old implementation but should still do the job
                 if (element.getSuperclass() != null) {
                     Element parent = types.asElement(element.getSuperclass());
-                    return parent.getSimpleName().contentEquals("RhnXmlRpcCustomSerializer");
+                    return parent.getSimpleName().contentEquals("RhnXmlRpcCustomSerializer") ||
+                            parent.getSimpleName().contentEquals("ApiResponseSerializer");
                 }
                 return false;
             })


### PR DESCRIPTION
Enables doc generation for `ApiResponseSerializer` base class.

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
