### PR TITLE
fix channels optional flag

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/MgrSyncChannelDtoSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/MgrSyncChannelDtoSerializer.java
@@ -61,7 +61,7 @@ public class MgrSyncChannelDtoSerializer extends ApiResponseSerializer<MgrSyncCh
                 .add("is_signed", src.isSigned())
                 .add("label", src.getLabel())
                 .add("name", src.getName())
-                .add("optional", src.isMandatory())
+                .add("optional", !src.isMandatory())
                 .add("parent", Optional.ofNullable(src.getParentLabel()).orElse("BASE"))
                 .add("product_name", src.getProductName())
                 .add("product_version", src.getProductVersion())


### PR DESCRIPTION
## What does this PR change?

During the migration of the Serializers a small bug was introduced.
We store in the database a "mandatory" flag, but we provide in the API the opposite (optional).

This cause the testsuite to fail when it look for a channel of an extension product.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17482

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
