### PR TITLE
QE: Add hardware refresh before overview tests

### DIFF
--- a/testsuite/features/secondary/allcli_overview_systems_details.feature
+++ b/testsuite/features/secondary/allcli_overview_systems_details.feature
@@ -7,19 +7,36 @@ Feature: The system details of each minion and client provides an overview of th
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
+@sle_client
+  Scenario: Traditional client hardware refresh
+    Given I am on the Systems overview page of this "sle_client"
+    When I follow "Hardware"
+    And I click on "Schedule Hardware Refresh"
+    Then I should see a "You have successfully scheduled a hardware profile refresh" text
+    And I wait until event "Hardware List Refresh scheduled by admin" is completed
+
+@sle_client
   Scenario: Traditional client grains are displayed correctly on the details page
     Given I am on the Systems overview page of this "sle_client"
     Then the hostname for "sle_client" should be correct
     And the kernel for "sle_client" should be correct
     And the OS version for "sle_client" should be correct
     And the IPv4 address for "sle_client" should be correct
-    # WORKAROUND: disabled for the moment due to a possible bug (#bsc1193858)
-    # And the IPv6 address for "sle_client" should be correct
+    And the IPv6 address for "sle_client" should be correct
     And the system ID for "sle_client" should be correct
     And the system name for "sle_client" should be correct
     And the uptime for "sle_client" should be correct
     And I should see several text fields for "sle_client"
 
+@sle_minion
+  Scenario: SLE Minion hardware refresh
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Hardware"
+    And I click on "Schedule Hardware Refresh"
+    Then I should see a "You have successfully scheduled a hardware profile refresh" text
+    And I wait until event "Hardware List Refresh scheduled by admin" is completed
+
+@sle_minion
   Scenario: Minion grains are displayed correctly on the details page
     Given I am on the Systems overview page of this "sle_minion"
     Then the hostname for "sle_minion" should be correct
@@ -31,6 +48,14 @@ Feature: The system details of each minion and client provides an overview of th
     And the system name for "sle_minion" should be correct
     And the uptime for "sle_minion" should be correct
     And I should see several text fields for "sle_minion"
+
+@centos_minion
+  Scenario: CentOS Minion hardware refresh
+    Given I am on the Systems overview page of this "ceos_minion"
+    When I follow "Hardware"
+    And I click on "Schedule Hardware Refresh"
+    Then I should see a "You have successfully scheduled a hardware profile refresh" text
+    And I wait until event "Hardware List Refresh scheduled by admin" is completed
 
 @centos_minion
   Scenario: CentOS minion grains are displayed correctly on the details page
@@ -46,6 +71,14 @@ Feature: The system details of each minion and client provides an overview of th
     And I should see several text fields for "ceos_minion"
 
 @ubuntu_minion
+  Scenario: Ubuntu Minion hardware refresh
+    Given I am on the Systems overview page of this "ubuntu_minion"
+    When I follow "Hardware"
+    And I click on "Schedule Hardware Refresh"
+    Then I should see a "You have successfully scheduled a hardware profile refresh" text
+    And I wait until event "Hardware List Refresh scheduled by admin" is completed
+
+@ubuntu_minion
   Scenario: Ubuntu minion grains are displayed correctly on the details page
     Given I am on the Systems overview page of this "ubuntu_minion"
     Then the hostname for "ubuntu_minion" should be correct
@@ -57,6 +90,14 @@ Feature: The system details of each minion and client provides an overview of th
     And the system name for "ubuntu_minion" should be correct
     And the uptime for "ubuntu_minion" should be correct
     And I should see several text fields for "ubuntu_minion"
+
+@ssh_minion
+  Scenario: SSH Minion hardware refresh
+    Given I am on the Systems overview page of this "ssh_minion"
+    When I follow "Hardware"
+    And I click on "Schedule Hardware Refresh"
+    Then I should see a "You have successfully scheduled a hardware profile refresh" text
+    And I wait until event "Hardware List Refresh scheduled by admin" is completed
 
 @ssh_minion
   Scenario: SSH-managed minion grains are displayed correctly on the details page


### PR DESCRIPTION
## What does this PR change?

This adds a hardware refresh before testing the systems overview page for each client. This will hopefully prevent the IPv6 issues we saw in our testsuite. So even if the IP addresses change we still have the correct ones because of the hardware refresh shortly before testing it.
Furthermore I added the right tags for the Salt minion and the trad. client.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were adjusted

- [x] **DONE**

## Links


- Fixes https://github.com/SUSE/spacewalk/issues/16626
- Manager 4.2
- Manager 4.1
- https://bugzilla.suse.com/show_bug.cgi?id=1193858
- https://bugzilla.suse.com/show_bug.cgi?id=1196469


- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
