### PR TITLE
Add headers and http_proxy modules to be in sync with regular proxy

### DIFF
--- a/containers/proxy-httpd-image/Dockerfile
+++ b/containers/proxy-httpd-image/Dockerfile
@@ -40,6 +40,9 @@ RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-li
 
 RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-licenses python3-PyYAML
 
+RUN sysconf_addword /etc/sysconfig/apache2 APACHE_MODULES headers
+RUN sysconf_addword /etc/sysconfig/apache2 APACHE_MODULES proxy_http
+
 COPY uyuni-configure.py /usr/bin/uyuni-configure.py
 RUN chmod +x /usr/bin/uyuni-configure.py
 

--- a/containers/proxy-httpd-image/proxy-httpd-image.changes
+++ b/containers/proxy-httpd-image/proxy-httpd-image.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Apr 11 10:46:36 UTC 2022 - Ondrej Holecek <oholecek@suse.com>
+
+- Add headers and http_proxy modules to be in sync with regular
+  proxy
+
+-------------------------------------------------------------------
 Mon Apr 11 08:49:52 UTC 2022 - Dario Leidi <dleidi@suse.com>
 
 - Align the image version to the product one


### PR DESCRIPTION
## What does this PR change?

HTST support added dependency on headers module but this was not reflected in http container. This PR adds them.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
