### PR TITLE
Add HTTPS validation using provided CA cert

### DIFF
--- a/containers/proxy-tftpd-image/proxy-tftpd-image.changes
+++ b/containers/proxy-tftpd-image/proxy-tftpd-image.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Apr 11 19:12:37 UTC 2022 - Ondrej Holecek <oholecek@suse.com>
+
+- Add HTTPS validation using provided CA cert
+  Fix HSTS enablement issues
+
+-------------------------------------------------------------------
 Mon Apr 11 08:51:29 UTC 2022 - Dario Leidi <dleidi@suse.com>
 
 - Align the image version to the product one

--- a/containers/proxy-tftpd-image/tftp_wrapper.py
+++ b/containers/proxy-tftpd-image/tftp_wrapper.py
@@ -12,6 +12,9 @@ from fbtftp.base_handler import ResponseData
 from fbtftp.base_handler import StringResponseData
 from fbtftp.base_server import BaseServer
 
+def stats(s):
+    pass
+
 class FileResponseData(ResponseData):
     def __init__(self, path):
         self._size = os.stat(path).st_size
@@ -27,9 +30,9 @@ class FileResponseData(ResponseData):
         self._reader.close()
 
 class HttpResponseData(ResponseData):
-    def __init__(self, url):
+    def __init__(self, url, capath):
         # request file by url and store it
-        self._request = requests.get(url, stream=True)
+        self._request = requests.get(url, stream=True, verify=capath)
         self._stream = self._request.iter_content(chunk_size=1024)
         self._content = b''
     def read(self, requested):
@@ -54,13 +57,15 @@ class HttpResponseData(ResponseData):
         self._request.close()
 
 class TFTPHandler(BaseHandler):
-    def __init__(self, server_addr, peer, path, options, root, url, saltboot):
+    def __init__(self, server_addr, peer, path, options, root, url, capath):
         self._root = root
         self._url = url
-        self._saltboot = saltboot
-        super().__init__(server_addr, peer, path, options, None)
+        self._capath = capath
+        super().__init__(server_addr, peer, path, options, stats)
 
     def get_response_data(self):
+        capath = self._capath
+        target = self._url
         path = self._path
         if self._path[0] == '/':
             path = self._path[1:]
@@ -69,40 +74,34 @@ class TFTPHandler(BaseHandler):
         if path.startswith("pxelinux.cfg/01-"):
             # request specific system configuration
             logging.debug(f"Got request for {path}, forwarding to HTTP")
-            return HttpResponseData("http://{}/tftp/{}".format(self._url, path))
+            return HttpResponseData(f"https://{target}/tftp/{path}", capath)
         elif path.startswith("pxelinux.cfg/default"):
             # server local default
             logging.debug(f"Got request for {path}, forwarding to HTTP")
-            if self._saltboot:
-                # saltboot mode use proxy fqdn filename in saltboot directory to get custom saltboot
-                # group defaults
-                # TODO: disabled for now until server support
-                pass
-#                return HttpResponseData("http://{}/tftp/saltboot/{}".format(self._url, self._url))
-            return HttpResponseData("http://{}/tftp/{}".format(self._url, path))
+            return HttpResponseData(f"https://{target}/tftp/{path}", capath)
         elif path.startswith("pxelinux.cfg/"):
             # ignore other pxelinux.cfg files
             logging.debug(f"Got request for {path}, ignoring")
             return StringResponseData("")
         # The rest get from http
         logging.debug(f"Got request for {path}, forwarding to HTTP")
-        return HttpResponseData("http://{}/tftp/{}".format(self._url, path))
+        return HttpResponseData(f"https://{target}/tftp/{path}", capath)
 
 class TFTPServer(BaseServer):
-    def __init__(self, address, port, retries, timeout, root, url, saltboot):
+    def __init__(self, address, port, retries, timeout, root, url, capath):
         self._root = root
         self._url = url
-        self._saltboot = saltboot
+        self._capath = capath
         super().__init__(address, port, retries, timeout, None)
 
     def get_handler(self, server_addr, peer, path, options):
         return TFTPHandler(
-            server_addr, peer, path, options, self._root, self._url, self._saltboot
+            server_addr, peer, path, options, self._root, self._url, self._capath
         )
 
 def get_arguments():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--ip", type=str, default="::", help="IP address to bind to")
+    parser.add_argument("--ip", type=str, default="0.0.0.0", help="IP address to bind to")
     parser.add_argument("--port", type=int, default=69, help="port to bind to")
     parser.add_argument(
         "--retries", type=int, default=5, help="Number of per-packet retries"
@@ -117,10 +116,13 @@ def get_arguments():
         "--httpHost", type=str, default="localhost", help="Hostname where to forward HTTP requests"
     )
     parser.add_argument(
-        "--logLevel", choices=['error', 'warning', 'info', 'debug'], default="error", help="Logging level for the server"
+        "--logLevel", choices=['error', 'warning', 'info', 'debug'], default="debug", help="Logging level for the server"
     )
     parser.add_argument(
         "--configFile", type=str, default="/etc/uyuni/config.yaml", help="Path to configuration file"
+    )
+    parser.add_argument(
+        "--caPath", type=str, default="/etc/uyuni/ca.crt", help="Path to CA certificate"
     )
     return parser.parse_args()
 
@@ -132,7 +134,6 @@ def main():
         with open(args.configFile) as source:
             config = yaml.safe_load(source)
             args.httpHost = config['proxy_fqdn']
-            args.saltboot = config.get('saltboot_mode', True)
 
     except IOError as err:
         logging.warning(f"Configuration file reading error {err}, ignoring")
@@ -146,7 +147,7 @@ def main():
         args.timeout,
         args.root,
         args.httpHost,
-        args.saltboot
+        args.caPath
     )
     try:
         server.run()


### PR DESCRIPTION
## What does this PR change?

- Add HTTPS validation using provided CA cert
- Fix HSTS enablement issues
- Remove some experimental code
- make default logging level debug (can be removed prior GA, but is useful for validation)

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
