### PR TITLE
QE: Increase timeout for advanced search tests

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -260,7 +260,7 @@ When(/^I click on "([^"]*)"$/) do |text|
   if text == 'Search' && has_text?('Could not connect to search server.', wait: 0)
     click_button(text, match: :first, wait: false)
     start = Time.new
-    timeout = 5
+    timeout = 10
     while (has_text?('Could not connect to search server.', wait: 0) || has_text?('No matches found', wait: 0)) &&
           (Time.new - start <= timeout)
 


### PR DESCRIPTION
## What does this PR change?
Increase advanced search test timeout from 5 to 10 seconds to give the search index enough time to update before performing a search and considering it a fail.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were modified

- [x] **DONE**

## Links
- 4.1 https://github.com/SUSE/spacewalk/pull/17499
- 4.2 https://github.com/SUSE/spacewalk/pull/17498

- [ ] **DONE**

## Changelogs
- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
