### PR TITLE
Simplify log4j handling in build.xml

### DIFF
--- a/java/build.xml
+++ b/java/build.xml
@@ -280,7 +280,7 @@
   <!-- We may want to break this down so that we can specify directories or
        classes to operate on.  But, hopefully our checkstyle report will
        generally be clean, so we may be able to always check all classes. -->
-  <target name="checkstyle" depends="init,do-compile-main">
+  <target name="checkstyle" depends="init,compile-main">
     <mkdir dir="${report.dir}" />
     <checkstyle config="buildconf/checkstyle.xml" failOnViolation="true" >
       <property key="javadoc.method.scope" value="public" />
@@ -369,10 +369,9 @@
     </javac>
   </target>
 
-  <target name="compile-main" depends="do-compile-main, setup-log4j"/>
-
-  <target name="do-compile-main" depends="link-jars,prepare"
+  <target name="compile-main" depends="link-jars,prepare"
           description="Compile the main codebase" unless="installbuild">
+    <copy tofile="${build.dir}/classes/log4j2.xml" file="${src.dir}/src/log4j2.xml"/>
     <mkdir dir="${build.dir}/classes" />
     <javac destdir="${build.dir}/classes"
            optimize="off"
@@ -397,19 +396,6 @@
          <exclude name="**/log4j2.xml" />
       </fileset>
     </copy>
-  </target>
-
-  <target name ="setup-log4j" >
-    <property name="dest.log4j" location = "${build.dir}/classes/log4j2.xml"/>
-    <if>
-      <available file="${custom.log4j}"/>
-      <then>
-        <copy tofile="${dest.log4j}" file="${custom.log4j}"/>
-      </then>
-      <else>
-        <copy tofile="${dest.log4j}" file="${src.dir}/src/log4j2.xml"/>
-      </else>
-    </if>
   </target>
 
   <target name="compile-all" depends="link-jars,prepare"

--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -105,7 +105,7 @@
   <property name="jaxb" value="${jaxb-api} ${jaxb-core} ${jaxb-runtime} ${txw2} ${istack-commons}"/>
 
 
-  <property name="hibernate5deps" value="hibernate-ehcache-5 hibernate-c3p0-5 hibernate-core-5 ${hibernate-commons-annotations} slf4j/api jakarta-persistence-api byte-buddy jboss-logging javassist slf4j/log4j ${ehcache} classmate statistics hibernate-types-52-2.12.1 jackson-databind jackson-core jackson-annotations"/>
+  <property name="hibernate5deps" value="hibernate-ehcache-5 hibernate-c3p0-5 hibernate-core-5 ${hibernate-commons-annotations} slf4j/api jakarta-persistence-api byte-buddy jboss-logging javassist log4j/log4j-slf4j-impl ${ehcache} classmate statistics hibernate-types-52-2.12.1 jackson-databind jackson-core jackson-annotations"/>
 
   <available file="${java.lib.dir}/hibernate-core-5.jar" type="file" property="hibernate" value="${hibernate5deps}" />
 
@@ -137,7 +137,7 @@
              ${log4j-jars} oro redstone-xmlrpc-client redstone-xmlrpc ${struts-jars} ${tomcat-jars}
              bcprov bcpg jcommon stringtree-json postgresql-jdbc ongres-scram/client ongres-scram/common
              ${stringprep-jars} taglibs-standard-impl taglibs-standard-jstlel
-             taglibs-standard-spec logdriver quartz dwr slf4j-api slf4j-log4j
+             taglibs-standard-spec logdriver quartz dwr slf4j-api log4j/log4j-slf4j-impl
              concurrent velocity-engine-core simple-core  mockobjects mockobjects-core mockobjects-jdk1.4-j2ee1.3 strutstest" />
 
   <!-- deps needed for testing, but required to build -->
@@ -174,7 +174,7 @@
 
   <!-- SUSE extra dependencies: runtime only -->
   <property name="suse-runtime-jars" value="${commons-lang} concurrentlinkedhashmap-lru
-    slf4j/api slf4j/log4j ${product-runtime-jars}" />
+    slf4j/api log4j/log4j-slf4j-impl ${product-runtime-jars}" />
 
   <property name="install.build.jar.dependencies"
       value="ant ant/ant-junit ${ant-contrib.path} antlr ${jasper-jars} ${test.build.jar.dependencies}

--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -4,7 +4,6 @@
   <property environment="env" />
 
   <property file="${user.home}/.rhn.properties" />
-  <property name="custom.log4j" location="${user.home}/.log4j.properties" />
   <property name="src.dir" location="${rhn-home}/code" />
   <property name="build.dir" location="${rhn-home}/build" />
   <property name="lib.dir" location="${rhn-home}/lib" />

--- a/java/code/src/log4j2.xml
+++ b/java/code/src/log4j2.xml
@@ -98,6 +98,9 @@
         </Logger>
         -->
 
+        <!-- this should shut up hibernate until this gets fixed upstream -->
+        <Logger name="org.hibernate.orm.deprecation" level="error" />
+
         <!-- this silences ehcache on Fedoras complaining about using default values -->
         <Logger name="org.hibernate.cache.ehcache.AbstractEhcacheRegionFactory" level="error" />
 

--- a/java/manager-build.xml
+++ b/java/manager-build.xml
@@ -186,7 +186,7 @@
   <target name="deploy" depends="webapp, open-ssh-socket" description="Deploy a new copy of SUSE Manager">
     <echo message="Copying files to remote host..." />
     <exec failonerror="true" executable="rsync">
-      <arg line="-a --delete --rsh '${rsync.arg.rsh}' ${build.dir}/webapp/ ${deploy.user}@${deploy.host}:${deploy.dir}/" />
+      <arg line="-a --delete --rsh '${rsync.arg.rsh}' --exclude log4j2.xml ${build.dir}/webapp/ ${deploy.user}@${deploy.host}:${deploy.dir}/" />
     </exec>
 
     <echo message="Linking the branding jar..." />

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -611,11 +611,6 @@ install -m 644 conf/cobbler/snippets/wait_for_networkmanager_script $RPM_BUILD_R
 
 ln -s -f %{_javadir}/dwr.jar $RPM_BUILD_ROOT%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/dwr.jar
 
-# special links for taskomatic
-TASKOMATIC_BUILD_DIR=%{_prefix}/share/spacewalk/taskomatic
-rm -f $RPM_BUILD_ROOT$TASKOMATIC_BUILD_DIR/slf4j*nop.jar
-rm -f $RPM_BUILD_ROOT$TASKOMATIC_BUILD_DIR/slf4j*simple.jar
-
 # special links for rhn-search
 RHN_SEARCH_BUILD_DIR=%{_prefix}/share/rhn/search/lib
 ln -s -f %{_javadir}/postgresql-jdbc.jar $RPM_BUILD_ROOT$RHN_SEARCH_BUILD_DIR/postgresql-jdbc.jar


### PR DESCRIPTION
## What does this PR change?

Remove the handling of custom log4j configuration in `build.xml` since that is never used.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
