### PR TITLE
QE: Fix flackiness of a test case

### DIFF
--- a/testsuite/features/secondary/srv_advanced_search.feature
+++ b/testsuite/features/secondary/srv_advanced_search.feature
@@ -14,14 +14,14 @@ Feature: Advanced Search
 
   Scenario: No search results - inverse results
     When I follow the left menu "Systems > Advanced Search"
-    And I enter minion hostname on the search field
+    And I enter "sle_minion" hostname on the search field
     And I select "Hostname" from "Field to Search"
     And I check "invertlabel"
     And I click on "Search"
     Then I should see a "No results found." text
 
   Scenario: One search result for City
-    Given I have a system with "Little Whinging" as "City" property
+    Given I have a property "City" with value "Little Whinging" on "sle_minion"
     When I follow the left menu "Systems > Advanced Search"
     And I enter "Little Whinging" on the search field
     And I select "City" from "Field to Search"
@@ -30,7 +30,7 @@ Feature: Advanced Search
     Then I should land on system's overview page
 
   Scenario: One search result for State/Province
-    Given I have a system with "Surrey" as "State/Province" property
+    Given I have a property "State/Province" with value "Surrey" on "sle_minion"
     When I follow the left menu "Systems > Advanced Search"
     And I enter "Surrey" on the search field
     And I select "State/Province" from "Field to Search"
@@ -39,7 +39,7 @@ Feature: Advanced Search
     Then I should land on system's overview page
 
   Scenario: One search result for Country
-    Given I have a system with "Portugal (PT)" as "Country" listed property
+    Given I have a combobox property "Country" with value "Portugal (PT)" on "sle_minion"
     When I follow the left menu "Systems > Advanced Search"
     And I enter "PT" on the search field
     And I select "Country Code" from "Field to Search"
@@ -49,7 +49,7 @@ Feature: Advanced Search
 
   Scenario: One search result for hostname using "Fine grained search results"
     When I follow the left menu "Systems > Advanced Search"
-    And I enter minion hostname on the search field
+    And I enter "sle_minion" hostname on the search field
     And I select "Hostname" from "Field to Search"
     And I check "fineGrainedlabel"
     And I click on "Search"
@@ -57,7 +57,7 @@ Feature: Advanced Search
 
   Scenario: List results for hostname
     When I follow the left menu "Systems > Advanced Search"
-    And I enter minion hostname on the search field
+    And I enter "sle_minion" hostname on the search field
     And I select "Hostname" from "Field to Search"
     And I click on "Search"
-    Then I should see minion hostname as first search result
+    Then I should see "sle_minion" hostname as first search result

--- a/testsuite/features/secondary/srv_reportdb.feature
+++ b/testsuite/features/secondary/srv_reportdb.feature
@@ -45,7 +45,7 @@ Feature: ReportDB
 
   @sle_minion
   Scenario: System changes should be reflected in systems, on ReportDB
-    Given I have "sle_minion" with "Arrakeen" as "City" property
+    Given I have a property "City" with value "Arrakeen" on "sle_minion"
     And I know the current synced_date for "sle_minion"
     When I schedule a task to update ReportDB
     Then I should find the updated "City" property as "Arrakeen" on the "sle_minion", on ReportDB
@@ -53,4 +53,3 @@ Feature: ReportDB
   Scenario: Cleanup: delete read-only user
     When I delete the read-only user for the ReportDB
     Then I shouldn't see the read-only user listed on the ReportDB user accounts
-

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -1068,32 +1068,9 @@ When(/^I make a list of the existing systems$/) do
   system_elements_list.each { |el| $systems_list << el.text }
 end
 
-Given(/^I have "([^"]*)" with "([^"]*)" as "([^"]*)" property$/) do |host, property_value, property_name|
+Given(/^I have a property "([^"]*)" with value "([^"]*)" on "([^"]*)"$/) do |property_name, property_value, host|
   steps %(
-    Given I am on the Systems overview page of this "#{host}"
-    When I follow "Properties" in the content area
-    And I enter "#{property_value}" as "#{property_name}"
-    And I click on "Update Properties"
-    Then I should see a "System properties changed" text
-  )
-end
-
-# Select first system listed
-When(/^I select the first system in the list$/) do
-  within(:xpath, '//section') do
-    row = find(:xpath, "//div[@class='table-responsive']/table/tbody/tr[.//td]", match: :first)
-    # click first link in first row
-    within(row) do
-      first('a').click
-    end
-  end
-end
-
-# Change first system's property
-Given(/^I have a system with "([^"]*)" as "([^"]*)" property$/) do |property_value, property_name|
-  steps %(
-    When I follow the left menu "Systems > Overview"
-    And I select the first system in the list
+    When I am on the Systems overview page of this "#{host}"
     And I follow "Properties" in the content area
     And I enter "#{property_value}" as "#{property_name}"
     And I click on "Update Properties"
@@ -1102,11 +1079,9 @@ Given(/^I have a system with "([^"]*)" as "([^"]*)" property$/) do |property_val
         )
 end
 
-# Change first system's property when it's a list
-Given(/^I have a system with "([^"]*)" as "([^"]*)" listed property$/) do |property_value, property_name|
+Given(/^I have a combobox property "([^"]*)" with value "([^"]*)" on "([^"]*)"$/) do |property_name, property_value, host|
   steps %(
-    When I follow the left menu "Systems > Overview"
-    And I select the first system in the list
+    When I am on the Systems overview page of this "#{host}"
     And I follow "Properties" in the content area
     And I select "#{property_value}" from "#{property_name}"
     And I click on "Update Properties"
@@ -1126,16 +1101,17 @@ Then(/^I should land on system's overview page$/) do
         )
 end
 
-When(/^I enter minion hostname on the search field$/) do
-  step %(I enter "#{$minion.full_hostname}" on the search field)
+When(/^I enter "([^"]*)" hostname on the search field$/) do |host|
+  system_name = get_system_name(host)
+  step %(I enter "#{system_name}" on the search field)
 end
 
-Then(/^I should see minion hostname as first search result$/) do
-  hostname = $minion.full_hostname
+Then(/^I should see "([^"]*)" hostname as first search result$/) do |host|
+  system_name = get_system_name(host)
   within(:xpath, '//section') do
     row = find(:xpath, "//div[@class='table-responsive']/table/tbody/tr[.//td]", match: :first)
     within(row) do
-      raise "Text '#{hostname}' not found" unless has_text?(hostname)
+      raise "Text '#{system_name}' not found" unless has_text?(system_name)
     end
   end
 end

--- a/testsuite/features/support/xmlrpc_system.rb
+++ b/testsuite/features/support/xmlrpc_system.rb
@@ -95,4 +95,10 @@ class XMLRPCSystemTest < XMLRPCBaseTest
   def obtain_reactivation_key(server)
     @connection.call('system.obtainReactivationKey', @sid, server)
   end
+
+  # Namespace system.search
+  # Provides methods to perform system search requests using the search server
+  def system_search_by_hostname(hostname)
+    @connection.call('system.search.hostname', @sid, hostname)
+  end
 end


### PR DESCRIPTION
## What does this PR change?

By using a XMLRPC call (https://suma-head-srv.mgr.suse.de/rhn/apidoc/handlers/SystemSearchHandler.jsp#hostname), this PR tries to check first if the rhn-search service is responding correctly, before try the same feature using WebUI.

I would like feedback about where we should add this step, for now is embedded inside the step to clean the index of rhn-search service, but we could think of having it separately. **This is just a helper to assure the service is ready, the test will be the steps made on the WebUI.**

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were refactored

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
