### PR TITLE
Add missing dependencies for Salt 3004 into bootstrap repository for SLE15 family (bsc#1198221)

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -453,6 +453,8 @@ PKGLIST15_SALT = [
     "python3-simplejson",
     "python3-six",
     "python3-urllib3",
+    "python3-immutables*",
+    "python3-contextvars*",
     "timezone",
     "salt",
     "python3-salt",

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+* Add missing dependencies for Salt 3004 into bootstrap repository
+  for SLE15 family (bsc#1198221)
 - sort pg_hba.conf file (bsc#1198154)
 - delopy local CA under different name in the truststore to avoid
   conflicts with CAs deployed during a registration


### PR DESCRIPTION
## What does this PR change?

This PR adds missing dependencies required for Salt 3004 into the bootstrap repository definition for SLE15 family. New dependencies `python3-contextvars` and `python3-immutables`.

Currently, in case of using the BETA client tools, where Salt 3004 is already shipped, if these dependencies are not part of bootstrap repository and we try to bootstrap a minion without using Salt Bundle, then we face the following error due missing depedencies:

```console
CHECKING THE REGISTRATION STACK
-------------------------------------------------
* check for necessary packages being installed...
* client codebase is sle-15-sp3
package salt is not installed
package salt-minion is not installed
* going to install missing packages...
 adding client software repository at https://xxxxxxxxxxx/pub/repositories/sle/15/3/bootstrap
Retrieving repository 'susemanager:bootstrap' metadata .............................................................................................[done]
Building repository 'susemanager:bootstrap' cache ..................................................................................................[done]
Specified repositories have been refreshed.
Loading repository data...
Reading installed packages...
Resolving package dependencies...
2 Problems:
Problem: nothing provides python3-contextvars needed by python3-salt-3004-159000.8.53.1.x86_64
Problem: nothing provides python3-contextvars needed by python3-salt-3004-159000.8.53.1.x86_64

Problem: nothing provides python3-contextvars needed by python3-salt-3004-159000.8.53.1.x86_64
 Solution 1: do not install salt-3004-159000.8.53.1.x86_64
 Solution 2: break python3-salt-3004-159000.8.53.1.x86_64 by ignoring some of its dependencies

Choose from above solutions by number or skip, retry or cancel [1/2/s/r/c/d/?] (c): c
no package provides salt
ERROR: Failed to install all missing packages.


If you use the bundle instead of salt-minion the client works.
```

**NOTE:** These new packages were added into the bootstrap repository definition as "optionals", since Uyuni does not have them yet but SUMA HEAD does.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **to be covered by cucumber**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/17522

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
