### PR TITLE
Testsuite: kill avahi started during container build

### DIFF
--- a/testsuite/features/profiles/Docker/add_packages.sh
+++ b/testsuite/features/profiles/Docker/add_packages.sh
@@ -17,3 +17,6 @@ zypper rr sles12sp4
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref
 zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar python3 python3-xml
+
+# kill avahi
+/usr/sbin/avahi-daemon -k

--- a/testsuite/features/profiles/Docker/authprofile/add_packages.sh
+++ b/testsuite/features/profiles/Docker/authprofile/add_packages.sh
@@ -21,3 +21,6 @@ zypper rr sles12sp4
 zypper --non-interactive --gpg-auto-import-keys ref
 zypper --non-interactive in hoag-dummy orion-dummy
 zypper --non-interactive up milkyway-dummy
+
+# kill avahi
+/usr/sbin/avahi-daemon -k

--- a/testsuite/features/profiles/Docker/serverhost/add_packages.sh
+++ b/testsuite/features/profiles/Docker/serverhost/add_packages.sh
@@ -21,3 +21,6 @@ zypper rr sles12sp4
 zypper --non-interactive --gpg-auto-import-keys ref
 zypper --non-interactive in hoag-dummy orion-dummy
 zypper --non-interactive up milkyway-dummy
+
+# kill avahi
+/usr/sbin/avahi-daemon -k

--- a/testsuite/features/profiles/internal_nue/Docker/add_packages.sh
+++ b/testsuite/features/profiles/internal_nue/Docker/add_packages.sh
@@ -17,3 +17,6 @@ zypper rr sles12sp4
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref
 zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar python3 python3-xml
+
+# kill avahi
+/usr/sbin/avahi-daemon -k

--- a/testsuite/features/profiles/internal_nue/Docker/authprofile/add_packages.sh
+++ b/testsuite/features/profiles/internal_nue/Docker/authprofile/add_packages.sh
@@ -21,3 +21,6 @@ zypper rr sles12sp4
 zypper --non-interactive --gpg-auto-import-keys ref
 zypper --non-interactive in hoag-dummy orion-dummy
 zypper --non-interactive up milkyway-dummy
+
+# kill avahi
+/usr/sbin/avahi-daemon -k

--- a/testsuite/features/profiles/internal_nue/Docker/serverhost/add_packages.sh
+++ b/testsuite/features/profiles/internal_nue/Docker/serverhost/add_packages.sh
@@ -21,3 +21,6 @@ zypper rr sles12sp4
 zypper --non-interactive --gpg-auto-import-keys ref
 zypper --non-interactive in hoag-dummy orion-dummy
 zypper --non-interactive up milkyway-dummy
+
+# kill avahi
+/usr/sbin/avahi-daemon -k

--- a/testsuite/features/profiles/internal_prv/Docker/add_packages.sh
+++ b/testsuite/features/profiles/internal_prv/Docker/add_packages.sh
@@ -17,3 +17,6 @@ zypper rr sles12sp4
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref
 zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar python3 python3-xml
+
+# kill avahi
+/usr/sbin/avahi-daemon -k

--- a/testsuite/features/profiles/internal_prv/Docker/authprofile/add_packages.sh
+++ b/testsuite/features/profiles/internal_prv/Docker/authprofile/add_packages.sh
@@ -21,3 +21,6 @@ zypper rr sles12sp4
 zypper --non-interactive --gpg-auto-import-keys ref
 zypper --non-interactive in hoag-dummy orion-dummy
 zypper --non-interactive up milkyway-dummy
+
+# kill avahi
+/usr/sbin/avahi-daemon -k

--- a/testsuite/features/profiles/internal_prv/Docker/serverhost/add_packages.sh
+++ b/testsuite/features/profiles/internal_prv/Docker/serverhost/add_packages.sh
@@ -21,3 +21,6 @@ zypper rr sles12sp4
 zypper --non-interactive --gpg-auto-import-keys ref
 zypper --non-interactive in hoag-dummy orion-dummy
 zypper --non-interactive up milkyway-dummy
+
+# kill avahi
+/usr/sbin/avahi-daemon -k


### PR DESCRIPTION
## What does this PR change?

add_packages.sh starts avahi during container build. 
This PR makes sure it is killed at the end.

I haven't reproduced it, but I think it might fix the testsuite problem which appears in /var/log/messages of buildhost as:
```
Apr 12 00:40:27 suma-head-min-build dockerd[31861]: time="2022-04-12T00:40:27.528622699+02:00" level=error msg="Can't add file /var/lib/docker/overlay2/c52305f48482e3c8a8ebf15fbf53bba6305c1a363a752a1933c090bc207
d3706/diff/run/avahi-daemon/socket to tar: archive/tar: sockets not supported"
Apr 12 00:40:30 suma-head-min-build salt-minion[23163]: [ERROR   ] {'ret': {'Time_Elapsed': 0.0208282470703125, 'retcode': 1, 'Errors': ['An image does not exist locally with the tag: registry.mgr.suse.de/suse_key']}}
```


## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
