### PR TITLE
Add URL pillar entries to saltboot boot images

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -1797,12 +1797,21 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         (Map<String, Map<String, Map<String, Object>>>) map.get("boot_images");
             assertTrue(bootImages.containsKey("POS_Image_JeOS6-6.0.0-1"));
             assertTrue(bootImages.get("POS_Image_JeOS6-6.0.0-1").containsKey("initrd"));
+            assertTrue(bootImages.get("POS_Image_JeOS6-6.0.0-1").containsKey("kernel"));
             assertEquals(
             "initrd-netboot-suse-SLES12.x86_64-2.1.1.gz",
                     bootImages.get("POS_Image_JeOS6-6.0.0-1").get("initrd").get("filename"));
+            assertTrue(bootImages.get("POS_Image_JeOS6-6.0.0-1").get("initrd").containsKey("url"));
+            assertTrue(bootImages.get("POS_Image_JeOS6-6.0.0-1").get("kernel").containsKey("url"));
+            assertEquals("https://ftp/saltboot/boot/POS_Image_JeOS6.x86_64-6.0.0-1/" +
+                            "initrd-netboot-suse-SLES12.x86_64-2.1.1.kernel.4.4.126-94.22-default",
+                    bootImages.get("POS_Image_JeOS6-6.0.0-1").get("kernel").get("url"));
+            assertEquals("https://ftp/saltboot/boot/POS_Image_JeOS6.x86_64-6.0.0-1/" +
+                            "initrd-netboot-suse-SLES12.x86_64-2.1.1.gz",
+                    bootImages.get("POS_Image_JeOS6-6.0.0-1").get("initrd").get("url"));
             Map<String, Map<String, Map<String, Object>>> images =
                         (Map<String, Map<String, Map<String, Object>>>) map.get("images");
-            assertEquals("http://ftp/saltboot/image/POS_Image_JeOS6.x86_64-6.0.0-1/POS_Image_JeOS6.x86_64-6.0.0",
+            assertEquals("https://ftp/saltboot/image/POS_Image_JeOS6.x86_64-6.0.0-1/POS_Image_JeOS6.x86_64-6.0.0",
                         images.get("POS_Image_JeOS6").get("6.0.0-1").get("url"));
             assertEquals(Long.valueOf(1490026496), images.get("POS_Image_JeOS6").get("6.0.0-1").get("size"));
             assertEquals("a64dbc025c748bde968b888db6b7b9e3",
@@ -1865,7 +1874,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                     bootImages.get("POS_Image_JeOS6-6.0.0-1").get("initrd").get("filename"));
             Map<String, Map<String, Map<String, Object>>> images =
                         (Map<String, Map<String, Map<String, Object>>>) map.get("images");
-            assertEquals("http://ftp/saltboot/image/POS_Image_JeOS6.x86_64-6.0.0-1/POS_Image_JeOS6.x86_64-6.0.0",
+            assertEquals("https://ftp/saltboot/image/POS_Image_JeOS6.x86_64-6.0.0-1/POS_Image_JeOS6.x86_64-6.0.0",
                         images.get("POS_Image_JeOS6").get("6.0.0-1").get("url"));
             assertEquals(Long.valueOf(1490026496), images.get("POS_Image_JeOS6").get("6.0.0-1").get("size"));
             assertEquals("a64dbc025c748bde968b888db6b7b9e3",

--- a/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
@@ -176,7 +176,7 @@ public enum SaltStateGeneratorService {
         imagePillarDetails.put("size", image.getSize());
         imagePillarDetails.put("sync", imagePillarDetailsSync);
         imagePillarDetails.put("type", image.getType());
-        imagePillarDetails.put("url", "http://ftp/saltboot/" + localPath + "/" + image.getFilename());
+        imagePillarDetails.put("url", "https://ftp/saltboot/" + localPath + "/" + image.getFilename());
 
         imagePillarBase.put(version + "-" + revision, imagePillarDetails);
         imagePillar.put(imageInfo.getName(), imagePillarBase);
@@ -204,11 +204,15 @@ public enum SaltStateGeneratorService {
         bootImagePillarInitrd.put("hash", bootImage.getInitrd().getChecksum().getChecksum());
         bootImagePillarInitrd.put("size", bootImage.getInitrd().getSize());
         bootImagePillarInitrd.put("version", bootImage.getInitrd().getVersion());
+        bootImagePillarInitrd.put("url", "https://ftp/saltboot/boot/" + bootLocalPath + "/" +
+                bootImage.getInitrd().getFilename());
 
         bootImagePillarKernel.put("filename", bootImage.getKernel().getFilename());
         bootImagePillarKernel.put("hash", bootImage.getKernel().getChecksum().getChecksum());
         bootImagePillarKernel.put("size", bootImage.getKernel().getSize());
         bootImagePillarKernel.put("version", bootImage.getKernel().getVersion());
+        bootImagePillarKernel.put("url", "https://ftp/saltboot/boot/" + bootLocalPath + "/" +
+                bootImage.getKernel().getFilename());
 
         bootImagePillarSync.put("local_path", bootLocalPath);
         if (isBundle) {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add url pillar info to built boot-images
 - Fix reboot time on salt-ssh client(bsc#1197591)
 - detect free products in Alpha and Beta stage and prevent checks
   on openSUSE products (bsc#1197488)


### PR DESCRIPTION
## What does this PR change?

Restore previously removed kernel and initrd url by mistake. And switch to use https by default.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
