### PR TITLE
Handle missing tables gracefully during hub synchronisation

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/GeneratedSelectMode.java
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/GeneratedSelectMode.java
@@ -16,7 +16,6 @@ package com.redhat.rhn.common.db.datasource;
 
 import org.hibernate.Session;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -112,7 +111,7 @@ public class GeneratedSelectMode extends SelectMode {
 
         @Override
         public List<String> getParameterList() {
-            return new ArrayList<>(parameters);
+            return List.copyOf(parameters);
         }
 
         @Override

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ReportDBHelper.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ReportDBHelper.java
@@ -24,6 +24,7 @@ import com.redhat.rhn.common.db.datasource.WriteMode;
 import org.apache.logging.log4j.Logger;
 import org.hibernate.Session;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,6 +78,19 @@ public class ReportDBHelper {
 
         log.debug("Order Columns of " + table + " by: " + ordercolumns);
         return ordercolumns;
+    }
+
+    /**
+     * Generated a query for checking if a table exists
+     * @param session session the query should use
+     * @param tables tables list name
+     * @return select mode query
+     */
+    public static SelectMode generateExistingTables(Session session, List<String> tables) {
+        List<String> selectContent =
+                tables.stream().map(t -> "to_regclass('" + t + "') AS " + t).collect(Collectors.toList());
+        final String sqlStatement = "SELECT " + String.join(",", selectContent);
+        return new GeneratedSelectMode("exists.reportdbtables" , session, sqlStatement, Collections.emptyList());
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Handle missing tables gracefully during hub synchronisation
 - improve performance of synchronizing peripheral report databases
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Currently synchronisation mechanism beetween hub and peripheral server assume that the db are exactly the same: this scenario is not always verified (e.g. during an upgrade, when the systems have different packages version).
The changes would like to enforce this functionalities, handling the case when a table in the hub does not exist in a peripheral server.

## GUI diff


After:

- [x] **DONE**

## Documentation

- [x] **DONE**

## Test coverage

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17428

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
