### PR TITLE
Remove kiwi_info annotations, salt doesn't suppor them

### DIFF
--- a/susemanager-utils/susemanager-sls/src/modules/kiwi_info.py
+++ b/susemanager-utils/susemanager-sls/src/modules/kiwi_info.py
@@ -150,7 +150,7 @@ _compression_types = [
     { 'suffix': '',    'compression': None }
     ]
 
-def image_details(dest: str, bundle_dest: str = None) -> dict:
+def image_details(dest, bundle_dest = None):
     res = {}
     buildinfo = parse_buildinfo(dest) or guess_buildinfo(dest)
     kiwiresult = parse_kiwi_result(dest)
@@ -202,7 +202,7 @@ def image_details(dest: str, bundle_dest: str = None) -> dict:
 
     return res
 
-def inspect_image(dest: str, build_id: str, bundle_dest: str = None) -> dict:
+def inspect_image(dest, build_id, bundle_dest = None):
     res = image_details(dest, bundle_dest)
     if not res:
       return None
@@ -226,7 +226,7 @@ def inspect_image(dest: str, build_id: str, bundle_dest: str = None) -> dict:
     return res
 
 
-def inspect_boot_image(dest: str) -> dict:
+def inspect_boot_image(dest):
     res = None
     files = __salt__['file.readdir'](dest)
 
@@ -302,7 +302,7 @@ def inspect_boot_image(dest: str) -> dict:
     return res
 
 
-def inspect_bundles(dest: str, basename: str) -> dict:
+def inspect_bundles(dest, basename):
     res = []
     files = __salt__['file.readdir'](dest)
 
@@ -331,8 +331,7 @@ def inspect_bundles(dest: str, basename: str) -> dict:
             res.append(res1)
     return res
 
-# TODO consider adding checksum to validate upload
-def build_info(dest: str, build_id: str, bundle_dest: str = None) -> dict:
+def build_info(dest, build_id, bundle_dest = None):
     res = {}
     buildinfo = parse_buildinfo(dest) or guess_buildinfo(dest)
     kiwiresult = parse_kiwi_result(dest)

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Remove kiwi_info annotations, salt doesn't suppor them (bsc#1198480)
 - implement grains module for mgr_server to expose report database
   settings and more
 - Build bundle less images, adapt inspection of such images


### PR DESCRIPTION
## What does this PR change?
Remove kiwi_info annotations, salt doesn't suppor them

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
