### PR TITLE
Use correct image version from ImageInfo

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/image/ImageInfoFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/image/ImageInfoFactory.java
@@ -166,7 +166,7 @@ public class ImageInfoFactory extends HibernateFactory {
 
         // Schedule the build
         ImageBuildAction action = ActionManager.scheduleImageBuild(user,
-                Collections.singletonList(buildHostId), version, profile, earliest);
+                Collections.singletonList(buildHostId), info.getVersion(), profile, earliest);
         taskomaticApi.scheduleActionExecution(action);
 
         info.setBuildAction(action);

--- a/java/code/src/com/redhat/rhn/manager/action/ActionChainManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionChainManager.java
@@ -734,7 +734,7 @@ public class ActionChainManager {
         action.setSchedulerUser(user);
 
         ImageBuildActionDetails actionDetails = new ImageBuildActionDetails();
-        actionDetails.setVersion(version);
+        actionDetails.setVersion(info.getVersion());
         actionDetails.setImageProfileId(profile.getProfileId());
         action.setDetails(actionDetails);
         ActionFactory.save(action);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix handling of empty image version
 - Add url pillar info to built boot-images
 - Fix reboot time on salt-ssh client(bsc#1197591)
 - detect free products in Alpha and Beta stage and prevent checks


### PR DESCRIPTION
## What does this PR change?

This makes sure that image build action uses correct version string from ImageInfo.
createImageInfo() may change the value from empty string to "latest".

This should fix the failures in the testsuite where docker build is scheduled via XML RPC API
with empty version string.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- covered by Cucumber tests

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
