### PR TITLE
Add openSUSE Leap 15.4 repositories to spacewalk-common-channels

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1111,6 +1111,78 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
 
+[opensuse_leap15_4]
+checksum = sha256
+archs    = x86_64, aarch64
+name     = openSUSE Leap 15.4 (%(arch)s)
+gpgkey_url = http://download.opensuse.org/distribution/leap/15.4/repo/oss/repodata/repomd.xml.key
+gpgkey_id = 3DBDC284
+gpgkey_fingerprint = 22C0 7BA5 3417 8CD0 2EFE  22AA B88B 2FD4 3DBD C284
+repo_url = http://download.opensuse.org/distribution/leap/15.4/repo/oss/
+dist_map_release = 15.4
+
+[opensuse_leap15_4-non-oss]
+label    = %(base_channel)s-non-oss
+name     = openSUSE 15.4 non oss (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_leap15_4-%(arch)s
+repo_url = http://download.opensuse.org/distribution/leap/15.4/repo/non-oss/
+
+[opensuse_leap15_4-updates]
+label    = %(base_channel)s-updates
+name     = openSUSE Leap 15.4 Updates (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_leap15_4-%(arch)s
+repo_url = http://download.opensuse.org/update/leap/15.4/oss/
+
+[opensuse_leap15_4-non-oss-updates]
+label    = %(base_channel)s-non-oss-updates
+name     = openSUSE Leap 15.4 non oss Updates (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_leap15_4-%(arch)s
+repo_url = http://download.opensuse.org/update/leap/15.4/non-oss/
+
+[opensuse_leap15_4-sle-updates]
+label    = %(base_channel)s-sle-updates
+name     = Update repository with updates from SUSE Linux Enterprise 15 (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_leap15_4-%(arch)s
+repo_url = http://download.opensuse.org/update/leap/15.4/sle/
+
+[opensuse_leap15_4-backports-updates]
+label    = %(base_channel)s-backports-updates
+name     = Update repository of openSUSE Backports (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_leap15_4-%(arch)s
+repo_url = http://download.opensuse.org/update/leap/15.4/backports/
+
+# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap 15.X releases
+[opensuse_leap15_4-uyuni-client]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = x86_64, aarch64
+base_channels = opensuse_leap15_4-%(arch)s
+checksum = sha256
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+
+# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap 15.X releases
+[opensuse_leap15_4-uyuni-client-devel]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = x86_64, aarch64
+base_channels = opensuse_leap15_4-%(arch)s
+checksum = sha256
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+
 [opensuse_tumbleweed]
 checksum = sha256
 archs    = x86_64, aarch64
@@ -1762,10 +1834,20 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/
 
+[uyuni-server-stable-leap-154]
+name     = Uyuni Server Stable for %(base_channel_name)s
+archs    = x86_64, aarch64
+base_channels = opensuse_leap15_4-%(arch)s
+checksum = sha256
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/
+
 [uyuni-server-devel-leap]
 name     = Uyuni Server Devel for %(base_channel_name)s (Development)
 archs    = x86_64
-base_channels = opensuse_leap15_3-%(arch)s
+base_channels = opensuse_leap15_4-%(arch)s
 checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Server-POOL-x86_64-Media1/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
@@ -1802,10 +1884,20 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/
 
+[uyuni-proxy-stable-leap-154]
+name     = Uyuni Proxy Stable for %(base_channel_name)s
+archs    = x86_64, aarch64
+base_channels = opensuse_leap15_4-%(arch)s
+checksum = sha256
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/
+
 [uyuni-proxy-devel-leap]
 name     = Uyuni Proxy Devel for %(base_channel_name)s (Development)
 archs    = x86_64
-base_channels = opensuse_leap15_3-%(arch)s
+base_channels = opensuse_leap15_4-%(arch)s
 checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- openSUSE Leap 15.4 repositories 
+
 -------------------------------------------------------------------
 Fri Mar 11 15:22:33 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Add openSUSE Leap 15.4 repositories to spacewalk-common-channels

```
uyuni-refmaster-srv:~ # spacewalk-common-channels -a x86_64 opensuse_leap15_4*
SUSE Manager username: admin
SUSE Manager password: 

uyuni-refmaster-srv:~ # spacewalk-common-channels -a aarch64 opensuse_leap15_4*
SUSE Manager username: admin
SUSE Manager password:

uyuni-refmaster-srv:~ # spacewalk-repo-sync -l|grep leap
12:01:54 opensuse_leap15_4-aarch64-backports-updates | http://download.opensuse.org/update/leap/15.4/backports/
12:01:54 opensuse_leap15_4-x86_64-sle-updates | http://download.opensuse.org/update/leap/15.4/sle/
12:01:54 opensuse_leap15_4-x86_64-non-oss | http://download.opensuse.org/distribution/leap/15.4/repo/non-oss/
12:01:54 opensuse_leap15_4-x86_64-non-oss-updates | http://download.opensuse.org/update/leap/15.4/non-oss/
12:01:54 opensuse_leap15_4-uyuni-client-devel-x86_64 | https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
12:01:54 opensuse_leap15_4-aarch64 | http://download.opensuse.org/distribution/leap/15.4/repo/oss/
12:01:54 opensuse_leap15_4-x86_64-updates | http://download.opensuse.org/update/leap/15.4/oss/
12:01:54 opensuse_leap15_4-x86_64 | http://download.opensuse.org/distribution/leap/15.4/repo/oss/
12:01:54 opensuse_leap15_4-uyuni-client-devel-aarch64 | https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
12:01:54 opensuse_leap15_4-uyuni-client-aarch64 | https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
12:01:54 opensuse_leap15_4-uyuni-client-x86_64 | https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
12:01:54 opensuse_leap15_4-aarch64-non-oss | http://download.opensuse.org/distribution/leap/15.4/repo/non-oss/
12:01:54 opensuse_leap15_4-aarch64-updates | http://download.opensuse.org/update/leap/15.4/oss/
12:01:54 opensuse_leap15_4-aarch64-sle-updates | http://download.opensuse.org/update/leap/15.4/sle/
12:01:54 opensuse_leap15_4-aarch64-non-oss-updates | http://download.opensuse.org/update/leap/15.4/non-oss/
12:01:54 opensuse_leap15_4-x86_64-backports-updates | http://download.opensuse.org/update/leap/15.4/backports/

```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Documentation issue was created: https://github.com/SUSE/spacewalk/issues/17541

- [x] **DONE**

## Test coverage
- No tests: Tool not covered by tests

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17537

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
