### PR TITLE
Enable bootstrapping for Debian11 for SUSE Manager

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1513,6 +1513,11 @@ DATA = {
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/debian/10/bootstrap/',
         'TYPE' : 'deb'
     },
+    'debian11-amd64' : {
+        'PDID' : [-32, 2410], 'BETAPDID' : [2411], 'PKGLIST' : PKGLISTDEBIAN11,
+        'DEST' : '/srv/www/htdocs/pub/repositories/debian/11/bootstrap/',
+        'TYPE' : 'deb'
+    },
     'debian9-amd64-uyuni' : {
          'BASECHANNEL' : 'debian-9-pool-amd64-uyuni', 'PKGLIST' : PKGLISTDEBIAN9,
          'DEST' : DOCUMENT_ROOT + '/pub/repositories/debian/9/bootstrap/',

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,4 +1,5 @@
-* Add missing dependencies for Salt 3004 into bootstrap repository
+- Enable bootstrapping for Debian11 for SUSE Manager 
+- Add missing dependencies for Salt 3004 into bootstrap repository
   for SLE15 family (bsc#1198221)
 - sort pg_hba.conf file (bsc#1198154)
 - delopy local CA under different name in the truststore to avoid


### PR DESCRIPTION
## What does this PR change?

Enable bootstrapping for Debian11 for SUSE Manager

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: According to @jcayouette Debian11 was enabled for the doc for SUSE Manager 4.3 already

- [x] **DONE**

## Test coverage
- No tests: Debian11 is not part of acceptance. But QE will need to do changes for BV (https://github.com/SUSE/spacewalk/issues/17549)
- 
- [x] **DONE**

## Links

Reference: https://github.com/SUSE/spacewalk/issues/15683

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
