### PR TITLE
Use the official URL for Debian11 security updates

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -2762,7 +2762,7 @@ archs    = amd64-deb
 repo_type = deb
 checksum = sha256
 base_channels = debian-11-pool-amd64-uyuni
-repo_url = http://security-cdn.debian.org/debian-security/dists/bullseye-security/updates/main/binary-amd64/
+repo_url = http://security.debian.org/debian-security/dists/bullseye-security/updates/main/binary-amd64/
 
 [debian-11-amd64-uyuni-client-devel]
 label    = debian-11-amd64-uyuni-client-devel

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- Use the official URL for Debian11 security updates
+
 -------------------------------------------------------------------
 Fri Mar 11 15:22:33 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Use the official URL for Debian11 security updates

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: Transparent for the user
- [x] **DONE**

## Test coverage
- No tests: Tool not covered by the tests

- [x] **DONE**

## Links

Related: https://github.com/SUSE/spacewalk/pull/17548

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
