### PR TITLE
QE: Fix flacky test on Ansible inventories

### DIFF
--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -51,7 +51,7 @@ Feature: Operate an Ansible control node in a normal minion
     And I follow "Inventories" in the content area
     And I wait until I see "/srv/playbooks/orion_dummy/hosts" text
     And I click on "/srv/playbooks/orion_dummy/hosts"
-    Then I should see a "myself" text
+    Then I wait until I see "myself" text
 
   Scenario: Discover playbooks and display them
     Given I am on the Systems overview page of this "sle_minion"

--- a/testsuite/features/secondary/minssh_ansible_control_node.feature
+++ b/testsuite/features/secondary/minssh_ansible_control_node.feature
@@ -53,7 +53,7 @@ Feature: Operate an Ansible control node in SSH minion
     And I follow "Inventories" in the content area
     And I wait until I see "/srv/playbooks/orion_dummy/hosts" text
     And I click on "/srv/playbooks/orion_dummy/hosts"
-    Then I should see a "myself" text
+    Then I wait until I see "myself" text
 
   Scenario: Discover playbooks and display them
     Given I am on the Systems overview page of this "ssh_minion"


### PR DESCRIPTION
## What does this PR change?

On Ansible tests, when looking at inventories, we need to wait a bit until the page is loaded.
We can do it waiting until the page is loaded or just using a "wait until I see" of the text we are expecting, both of them could be valid approaches. I took the change that not includes a additional step.

![image](https://user-images.githubusercontent.com/2827771/164014752-de853a73-b8d3-4d98-b95c-bb06b5051562.png)


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed
- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
