### PR TITLE
QE: Increase timeout to apply highstate after parametrize a formula

### DIFF
--- a/testsuite/features/secondary/min_salt_formulas.feature
+++ b/testsuite/features/secondary/min_salt_formulas.feature
@@ -59,7 +59,7 @@ Feature: Use salt formulas
      When I click on the "disabled" toggler
      And I click on "Apply Highstate"
      Then I should see a "Applying the highstate has been scheduled." text
-     And I wait until event "Apply highstate in test-mode scheduled by admin" is completed
+     And I wait at most 300 seconds until event "Apply highstate in test-mode scheduled" is completed
 
   Scenario: Apply the parametrized formula via the highstate
      And I follow "States" in the content area


### PR DESCRIPTION
## What does this PR change?

Increase timeout to apply highstate after parametrize a formula.
it actually only happen in Head CI, in Uyuni CI we are good, it could be the hardware below it.

![image](https://user-images.githubusercontent.com/2827771/164028576-a1fed195-731e-4f30-90ac-4e2a93c9cd50.png)


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
