### PR TITLE
QE: Log Cobbler output when scenario fails

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -105,6 +105,18 @@ After do |scenario|
   page.instance_variable_set(:@touched, false)
 end
 
+# get the Cobbler log output when it fails
+After('@scope_cobbler') do |scenario|
+  if scenario.failed?
+    STDOUT.puts '=> /var/log/cobbler/cobbler.log'
+    out, _code = $server.run("tail -n20 /var/log/cobbler/cobbler.log")
+    out.each_line do |line|
+      STDOUT.puts line.to_s
+    end
+    STDOUT.puts
+  end
+end
+
 AfterStep do
   if has_css?('.senna-loading', wait: 0)
     log 'WARN: Step ends with an ajax transition not finished, let\'s wait a bit!'


### PR DESCRIPTION
## What does this PR change?

This will log the output of `/var/log/cobbler/cobbler.log` in the output
when Cobbler fails.


## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- No tests: already covered

- [x] **DONE**

## Links

Manager 4.2
Manager 4.1

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
