### PR TITLE
Testsuite: improve test of docker image build

### DIFF
--- a/testsuite/features/secondary/buildhost_docker_auth_registry.feature
+++ b/testsuite/features/secondary/buildhost_docker_auth_registry.feature
@@ -37,6 +37,7 @@ Feature: Build image with authenticated registry
     When I wait at most 660 seconds until container "auth_registry_profile" with version "latest" is built successfully
     And I refresh the page
     Then table row for "auth_registry_profile" should contain "1"
+    And the list of packages of image "auth_registry_profile" with version "latest" is not empty
 
   Scenario: Cleanup: remove Docker profile for the authenticated image store
     When I follow the left menu "Images > Profiles"

--- a/testsuite/features/secondary/buildhost_docker_auth_registry.feature
+++ b/testsuite/features/secondary/buildhost_docker_auth_registry.feature
@@ -34,7 +34,7 @@ Feature: Build image with authenticated registry
     And I click on "submit-btn"
     Then I wait until I see "auth_registry_profile" text
     # Verify the status of images in the authenticated image store
-    When I wait at most 660 seconds until container "auth_registry_profile" is built successfully
+    When I wait at most 660 seconds until container "auth_registry_profile" with version "latest" is built successfully
     And I refresh the page
     Then table row for "auth_registry_profile" should contain "1"
 

--- a/testsuite/features/secondary/buildhost_docker_build_image.feature
+++ b/testsuite/features/secondary/buildhost_docker_build_image.feature
@@ -57,11 +57,13 @@ Feature: Build container images
     And I wait at most 660 seconds until event "Image Build suse_simple scheduled by admin" is completed
     And I schedule the build of image "suse_real_key" via XML-RPC calls
     And I wait at most 660 seconds until event "Image Build suse_real_key scheduled by admin" is completed
+    And I wait at most 60 seconds until all "3" container images are built correctly in the GUI
 
   Scenario: Build same images with different versions
     When I schedule the build of image "suse_key" with version "Latest_key-activation1" via XML-RPC calls
     And I schedule the build of image "suse_simple" with version "Latest_simple" via XML-RPC calls
-    And I wait at most 1000 seconds until all "5" container images are built correctly in the GUI
+    And I wait at most 660 seconds until container "suse_simple" with version "Latest_simple" is built successfully
+    And I wait at most 660 seconds until container "suse_key" with version "Latest_key-activation1" is built successfully
 
   Scenario: Delete image via XML-RPC calls
     When I delete the image "suse_key" with version "Latest_key-activation1" via XML-RPC calls
@@ -72,7 +74,8 @@ Feature: Build container images
   Scenario: Rebuild the images
     When I schedule the build of image "suse_simple" with version "Latest_simple" via XML-RPC calls
     And I schedule the build of image "suse_key" with version "Latest_key-activation1" via XML-RPC calls
-    And I wait at most 1000 seconds until all "5" container images are built correctly in the GUI
+    And I wait at most 660 seconds until container "suse_key" with version "Latest_key-activation1" is built successfully
+    And I wait at most 660 seconds until container "suse_simple" with version "Latest_simple" is built successfully
 
   Scenario: Build an image via the GUI
     When I follow the left menu "Images > Build"
@@ -81,6 +84,7 @@ Feature: Build container images
     And I select the hostname of "build_host" from "buildHostId"
     And I click on "submit-btn"
     Then I wait until I see "GUI_BUILT_IMAGE" text
+    And I wait at most 660 seconds until container "suse_real_key" with version "GUI_BUILT_IMAGE" is built successfully
 
   Scenario: Login as Docker image administrator and build an image
     Given I am authorized as "docker" with password "docker"
@@ -90,6 +94,7 @@ Feature: Build container images
     And I select the hostname of "build_host" from "buildHostId"
     And I click on "submit-btn"
     Then I wait until I see "GUI_DOCKERADMIN" text
+    And I wait at most 660 seconds until container "suse_real_key" with version "GUI_DOCKERADMIN" is built successfully
 
   Scenario: Cleanup: delete all images
     Given I am authorized as "admin" with password "admin"

--- a/testsuite/features/secondary/buildhost_docker_build_image.feature
+++ b/testsuite/features/secondary/buildhost_docker_build_image.feature
@@ -58,12 +58,17 @@ Feature: Build container images
     And I schedule the build of image "suse_real_key" via XML-RPC calls
     And I wait at most 660 seconds until event "Image Build suse_real_key scheduled by admin" is completed
     And I wait at most 60 seconds until all "3" container images are built correctly in the GUI
+    Then the list of packages of image "suse_key" with version "latest" is not empty
+    And the list of packages of image "suse_simple" with version "latest" is not empty
+    And the list of packages of image "suse_real_key" with version "latest" is not empty
 
   Scenario: Build same images with different versions
     When I schedule the build of image "suse_key" with version "Latest_key-activation1" via XML-RPC calls
     And I schedule the build of image "suse_simple" with version "Latest_simple" via XML-RPC calls
     And I wait at most 660 seconds until container "suse_simple" with version "Latest_simple" is built successfully
     And I wait at most 660 seconds until container "suse_key" with version "Latest_key-activation1" is built successfully
+    Then the list of packages of image "suse_key" with version "Latest_key-activation1" is not empty
+    And the list of packages of image "suse_simple" with version "Latest_simple" is not empty
 
   Scenario: Delete image via XML-RPC calls
     When I delete the image "suse_key" with version "Latest_key-activation1" via XML-RPC calls
@@ -76,6 +81,8 @@ Feature: Build container images
     And I schedule the build of image "suse_key" with version "Latest_key-activation1" via XML-RPC calls
     And I wait at most 660 seconds until container "suse_key" with version "Latest_key-activation1" is built successfully
     And I wait at most 660 seconds until container "suse_simple" with version "Latest_simple" is built successfully
+    Then the list of packages of image "suse_key" with version "Latest_key-activation1" is not empty
+    And the list of packages of image "suse_simple" with version "Latest_simple" is not empty
 
   Scenario: Build an image via the GUI
     When I follow the left menu "Images > Build"

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -131,7 +131,7 @@ Then(/^the list of packages of image "([^"]*)" with version "([^"]*)" is not emp
 
   idetails = cont_op.get_image_details(image_id)
   log "Image Details: #{idetails}"
-  raise 'the list of image packages is empty' if idetails['installedPackages'] == 0
+  raise 'the list of image packages is empty' if (idetails['installedPackages']).zero?
 end
 
 Then(/^the image "([^"]*)" with version "([^"]*)" doesn't exist via XML-RPC calls$/) do |image_non_exist, version|

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -36,13 +36,13 @@ When(/^I enter URI, username and password for registry$/) do
   )
 end
 
-When(/^I wait at most (\d+) seconds until container "([^"]*)" is built successfully$/) do |timeout, name|
+When(/^I wait at most (\d+) seconds until container "([^"]*)" with version "([^"]*)" is built successfully$/) do |timeout, name, version|
   cont_op.login('admin', 'admin')
   images_list = cont_op.list_images
   log "List of images: #{images_list}"
   image_id = 0
   images_list.each do |element|
-    if element['name'] == name
+    if element['name'] == name && element['version'] == version
       image_id = element['id']
       break
     end
@@ -59,6 +59,8 @@ When(/^I wait at most (\d+) seconds until container "([^"]*)" is built successfu
   end
 end
 
+# Warning: this can be confused by failures in previous scenarios
+# so it should be used only in the first image building scenario
 When(/^I wait at most (\d+) seconds until all "([^"]*)" container images are built correctly in the GUI$/) do |timeout, count|
   os_version, os_family = get_os_version($build_host)
   # don't run this for sles11 (docker feature is not there)

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -116,6 +116,24 @@ When(/^I delete the image "([^"]*)" with version "([^"]*)" via XML-RPC calls$/) 
   end
 end
 
+Then(/^the list of packages of image "([^"]*)" with version "([^"]*)" is not empty$/) do |name, version|
+  cont_op.login('admin', 'admin')
+  images_list = cont_op.list_images
+  log "List of images: #{images_list}"
+  image_id = 0
+  images_list.each do |element|
+    if element['name'] == name && element['version'] == version
+      image_id = element['id']
+      break
+    end
+  end
+  raise 'unable to find the image id' if image_id.zero?
+
+  idetails = cont_op.get_image_details(image_id)
+  log "Image Details: #{idetails}"
+  raise 'the list of image packages is empty' if idetails['installedPackages'] == 0
+end
+
 Then(/^the image "([^"]*)" with version "([^"]*)" doesn't exist via XML-RPC calls$/) do |image_non_exist, version|
   cont_op.login('admin', 'admin')
   images_list = cont_op.list_images


### PR DESCRIPTION
## What does this PR change?

The test "wait until all 5 container images are built" does not work correctly. It can be confused by failures in previous
scenarios. So if the first scenario failed, it made all the subsequent tests fail too.
Additionally, the failed tests did not wait until the scheduled build actions were finished, so they got queued on the
build host. This caused timeouts in subsequent scenarios.

The first commit changes the tests to wait for particular image name-version.

The "wait until all 3 container images are built" is still used once, because this is the only test which tests UI.


The second commit tests the number of image packages. It is not enough to rely on the result of inspect action:
https://github.com/uyuni-project/uyuni/blob/Manager-4.3-Beta2/java/code/src/com/suse/manager/utils/SaltUtils.java#L1207

It is currently failing because of 
https://github.com/SUSE/spacewalk/issues/17507

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
