### PR TITLE
QE: Fix Prometheus issues in the testsuite

### DIFF
--- a/testsuite/features/secondary/min_monitoring.feature
+++ b/testsuite/features/secondary/min_monitoring.feature
@@ -48,6 +48,16 @@ Feature: Monitor SUMA environment with Prometheus on a SLE Salt minion
     And I click on "Save"
     Then I should see a "Formula saved" text
 
+  @susemanager
+  Scenario: Apply highstate for Prometheus exporters
+    When I enable the repositories "tools_additional_repo tools_additional_repo" on this "sle_minion" without error control
+    When I follow "States" in the content area
+    And I click on "Apply Highstate"
+    Then I should see a "Applying the highstate has been scheduled." text
+    And I wait until event "Apply highstate scheduled by admin" is completed
+    Then I disable the repositories "tools_additional_repo tools_additional_repo" on this "sle_minion" without error control
+
+  @uyuni
   Scenario: Apply highstate for Prometheus exporters
     When I enable the repositories "tools_update_repo tools_pool_repo" on this "sle_minion" without error control
     When I follow "States" in the content area

--- a/testsuite/features/secondary/min_monitoring.feature
+++ b/testsuite/features/secondary/min_monitoring.feature
@@ -50,21 +50,21 @@ Feature: Monitor SUMA environment with Prometheus on a SLE Salt minion
 
   @susemanager
   Scenario: Apply highstate for Prometheus exporters
-    When I enable the repositories "tools_additional_repo tools_additional_repo" on this "sle_minion" without error control
+    When I enable the repositories "tools_additional_repo" on this "sle_minion" without error control
     When I follow "States" in the content area
     And I click on "Apply Highstate"
     Then I should see a "Applying the highstate has been scheduled." text
     And I wait until event "Apply highstate scheduled by admin" is completed
-    Then I disable the repositories "tools_additional_repo tools_additional_repo" on this "sle_minion" without error control
+    Then I disable the repositories "tools_additional_repo" on this "sle_minion" without error control
 
   @uyuni
   Scenario: Apply highstate for Prometheus exporters
-    When I enable the repositories "tools_update_repo tools_pool_repo" on this "sle_minion" without error control
+    When I enable the repositories "tools_update_repo" on this "sle_minion" without error control
     When I follow "States" in the content area
     And I click on "Apply Highstate"
     Then I should see a "Applying the highstate has been scheduled." text
     And I wait until event "Apply highstate scheduled by admin" is completed
-    Then I disable the repositories "tools_update_repo tools_pool_repo" on this "sle_minion" without error control
+    Then I disable the repositories "tools_update_repo" on this "sle_minion" without error control
 
   Scenario: Visit monitoring endpoints on the minion
     When I wait until "prometheus" service is active on "sle_minion"

--- a/testsuite/features/secondary/min_monitoring.feature
+++ b/testsuite/features/secondary/min_monitoring.feature
@@ -48,11 +48,17 @@ Feature: Monitor SUMA environment with Prometheus on a SLE Salt minion
     And I click on "Save"
     Then I should see a "Formula saved" text
 
+  Scenario: Enable tools update repository
+    When I enable the repositories "tools_update_repo tools_pool_repo" on this "sle_minion" without error control
+
   Scenario: Apply highstate for Prometheus exporters
     When I follow "States" in the content area
     And I click on "Apply Highstate"
     Then I should see a "Applying the highstate has been scheduled." text
     And I wait until event "Apply highstate scheduled by admin" is completed
+
+  Scenario: Disable tools update repository again
+    When I disable the repositories "tools_update_repo tools_pool_repo" on this "sle_minion" without error control
 
   Scenario: Visit monitoring endpoints on the minion
     When I wait until "prometheus" service is active on "sle_minion"

--- a/testsuite/features/secondary/min_monitoring.feature
+++ b/testsuite/features/secondary/min_monitoring.feature
@@ -48,17 +48,13 @@ Feature: Monitor SUMA environment with Prometheus on a SLE Salt minion
     And I click on "Save"
     Then I should see a "Formula saved" text
 
-  Scenario: Enable tools update repository
-    When I enable the repositories "tools_update_repo tools_pool_repo" on this "sle_minion" without error control
-
   Scenario: Apply highstate for Prometheus exporters
+    When I enable the repositories "tools_update_repo tools_pool_repo" on this "sle_minion" without error control
     When I follow "States" in the content area
     And I click on "Apply Highstate"
     Then I should see a "Applying the highstate has been scheduled." text
     And I wait until event "Apply highstate scheduled by admin" is completed
-
-  Scenario: Disable tools update repository again
-    When I disable the repositories "tools_update_repo tools_pool_repo" on this "sle_minion" without error control
+    Then I disable the repositories "tools_update_repo tools_pool_repo" on this "sle_minion" without error control
 
   Scenario: Visit monitoring endpoints on the minion
     When I wait until "prometheus" service is active on "sle_minion"


### PR DESCRIPTION
## What does this PR change?

This will enable (and afterwards disable) the tools update repository on the SLE minion in order to be able to install the Prometheus package (`golang-github-prometheus-prometheus`).

Fixes our Prometheus issue in the CI we see on Uyuni, head and 4.2.

![image](https://user-images.githubusercontent.com/12104291/164473702-5350f54d-6cc1-4e4c-b842-9a02bc6aa47e.png)


## GUI diff

No difference.


- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [x] **DONE**

- Cucumber tests were adjusted

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17512

Manager 4.2
Manager 4.1

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
