### PR TITLE
Testsuite: Do not match OS Images in container test

### DIFF
--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -68,8 +68,8 @@ When(/^I wait at most (\d+) seconds until all "([^"]*)" container images are bui
     repeat_until_timeout(timeout: timeout.to_i, message: 'at least one image was not built correctly') do
       step %(I follow the left menu "Images > Image List")
       step %(I wait until I do not see "There are no entries to show." text)
-      raise 'error detected while building images' if has_xpath?("//*[contains(@title, 'Failed')]")
-      break if has_xpath?("//*[contains(@title, 'Built')]", count: count)
+      raise 'error detected while building images' if has_xpath?("//tr[td[text()='Container Image']][td//*[contains(@title, 'Failed')]]")
+      break if has_xpath?("//tr[td[text()='Container Image']][td//*[contains(@title, 'Built')]]", count: count)
       sleep 5
     end
   end


### PR DESCRIPTION
## What does this PR change?

Make sure that the test for built container images does not match OS Images built by previous test.

Fixes the "And I wait at most 60 seconds until all "3" container images are built correctly in the GUI" failure.

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
