### PR TITLE
fix(susemanager-sls): Oracle Linux Bootstrap Issue

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -70,6 +70,8 @@ no_ssh_push_key_authorized:
     {%- set os_base = 'amzn' %}
   {%- elif 'alibaba' in grains['osfullname']|lower %}
     {%- set os_base = 'alibaba' %}
+  {%- elif 'oracle' in grains['osfullname']|lower %}
+    {%- set os_base = 'oracle' %}
   {%- endif %}
   #end of expections
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Fix bootstrap repository path resolution for Oracle Linux
+
 -------------------------------------------------------------------
 Tue Apr 19 12:13:41 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fix Error 'no match for argument: salt-minion' when bootstrapping Oracle Linux Clients due to missing oracle entry in 'RedHat OS Family'.

## GUI diff

No difference.

Before:

After:

- [X] **DONE**

## Documentation
- No documentation needed: Only Bugfix

- [x] **DONE**

## Test coverage
- No tests: Nothing changed on existing tests / no new tests added.

- [x] **DONE**

## Links

Fixes: https://github.com/uyuni-project/uyuni/issues/5061
Issue introduced in PR: https://github.com/uyuni-project/uyuni/pull/4249

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
