### PR TITLE
Remove old workaround

### DIFF
--- a/testsuite/features/core/proxy_branch_network.feature
+++ b/testsuite/features/core/proxy_branch_network.feature
@@ -15,7 +15,7 @@ Feature: Setup Uyuni for Retail branch network
 
 @proxy
 @private_net
-  Scenario: Remove dhcp packages on the proxy
+  Scenario: Remove DHCP packages on the proxy
     # WORKAROUND
     When I remove package "dhcp dhcp-client" from this "proxy"
     # End of WORKAROUND
@@ -225,9 +225,7 @@ Feature: Setup Uyuni for Retail branch network
 @proxy
 @private_net
   Scenario: Let the server know about the new IP and FQDN of the proxy
-    # WORKAROUND: bsc#1196050 - Hardware list refresh is not sufficient to detect a change in interface's IP address
-    When I restart salt-minion on "proxy"
-    And I follow "Details" in the content area
+    When I follow "Details" in the content area
     And I follow "Hardware" in the content area
     And I click on "Schedule Hardware Refresh"
     Then I should see a "You have successfully scheduled a hardware profile refresh" text


### PR DESCRIPTION
## What does this PR change?

Remove old workaround for bsc#1196050 - Hardware list refresh was not sufficient to detect a change in interface's IP address. Now the product problem is fixed, and we don't need to restart salt-minion on the proxy anymore.


## Links

Ports:
* 4.1: SUSE/spacewalk#17596
* 4.2: SUSE/spacewalk#17595


## Changelogs

- [x] No changelog needed
