### PR TITLE
Fix wrong parameter

### DIFF
--- a/testsuite/features/support/namespaces/system.rb
+++ b/testsuite/features/support/namespaces/system.rb
@@ -174,7 +174,7 @@ class NamespaceSystemSearch
     @test = api_test
   end
 
-  def hostname(hostname)
-    @test.call('system.search.hostname', sessionKey: @test.token, searchTerm: hostname)
+  def hostname(server)
+    @test.call('system.search.hostname', sessionKey: @test.token, searchTerm: server)
   end
 end


### PR DESCRIPTION
## What does this PR change?

Fix wrong API parameter


## Links

Ports:
* 4.1: SUSE/spacewalk#17601
* 4.2: SUSE/spacewalk#17599


## Changelogs

- [x] No changelog needed
