### PR TITLE
Fix method name

### DIFF
--- a/testsuite/features/support/namespaces/system.rb
+++ b/testsuite/features/support/namespaces/system.rb
@@ -96,7 +96,7 @@ class NamespaceSystemConfig
     @test = api_test
   end
 
-  def config_remove_channels(servers, channels)
+  def remove_channels(servers, channels)
     @test.call('system.config.removeChannels', sessionKey: @test.token, serverIds: servers, configChannelLabels: channels)
   end
 end


### PR DESCRIPTION
## What does this PR change?

Fix wrong HTTP API method name.


## Links

Ports:
* 4.1: SUSE/spacewalk#17602
* 4.2: SUSE/spacewalk#17599


## Changelogs

- [x] No changelog needed
