### PR TITLE
Fix the channel name for the Debian 11 client tools

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -2766,7 +2766,7 @@ repo_url = http://security.debian.org/debian-security/dists/bullseye-security/up
 
 [debian-11-amd64-uyuni-client-devel]
 label    = debian-11-amd64-uyuni-client-devel
-name     = Uyuni Client Tools for Debian 10 Buster AMD64 (Development)
+name     = Uyuni Client Tools for Debian 11 Bullseye AMD64 (Development)
 archs    = amd64-deb
 repo_type = deb
 checksum = sha256
@@ -2775,7 +2775,7 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 
 [debian-11-amd64-uyuni-client]
 label    = debian-11-amd64-uyuni-client
-name     = Uyuni Client Tools for Debian 10 Buster AMD64
+name     = Uyuni Client Tools for Debian 11 Bullseye AMD64
 archs    = amd64-deb
 repo_type = deb
 checksum = sha256

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- Fix the channel name for the Debian11 Client Tools
+
 -------------------------------------------------------------------
 Tue Apr 19 12:42:43 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fix the channel name for the Debian 11 client tools. It mentioned "Debian10'", which is wrong and caused conflicts, as reported at https://github.com/uyuni-project/uyuni/issues/5069

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfix

- [x] **DONE**

## Test coverage
- No tests: But again, we should consider build validation to catch such issues :-)

- [x] **DONE**

## Links

Fixes  https://github.com/uyuni-project/uyuni/issues/5069

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
