### PR TITLE
Fix API test name

### DIFF
--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -4,7 +4,7 @@
 require 'json'
 require 'socket'
 
-$api_test = $product == 'Uyuni' ? ApiTestHttp.new($server.full_hostname) : ApiTestXMLRPC.new($server.full_hostname)
+$api_test = $product == 'Uyuni' ? ApiTestHttp.new($server.full_hostname) : ApiTestXmlrpc.new($server.full_hostname)
 
 ## auth namespace
 


### PR DESCRIPTION
## What does this PR change?

Fix API test name in XML-RPC case


## Links

No ports, head only.


## Changelogs

- [x] No changelog needed
