### PR TITLE
QE: Fix wrong proxy name in terminal test

### DIFF
--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -325,7 +325,7 @@ Feature: PXE boot a Retail terminal
     When I follow "pxeboot" terminal
     And I follow "Details" in the content area
     And I follow "Connection" in the content area
-    Then I should see "proxy" short hostname
+    Then I should see a "proxy.example.org" text
 
   Scenario: Install a package on the bootstrapped terminal
     Given I am on the Systems page


### PR DESCRIPTION
## What does this PR change?

This will fix a wrong name when checking of the proxy of a bootstrapped
terminal exists. The issue was found in our Uyuni CI.

See https://github.com/SUSE/spacewalk/pull/17080 for an older PR that
did the fix in another place.

The PR is already building in [Jenkins](https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-prs-ci-tests/1296/).


## GUI diff

No difference.


- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/pull/17611
https://github.com/SUSE/spacewalk/pull/17612

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
