### PR TITLE
HTTP API fixes

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/XmlRpcServlet.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/XmlRpcServlet.java
@@ -45,8 +45,8 @@ public class XmlRpcServlet extends HttpServlet {
     private static Logger log = LogManager.getLogger(XmlRpcServlet.class);
 
     private RhnXmlRpcServer server;
-    private HandlerFactory handlerFactory;
-    private SerializerFactory serializerFactory;
+    private final HandlerFactory handlerFactory;
+    private final SerializerFactory serializerFactory;
 
     /**
      * Constructor which takes in HandlerFactory and SerializerFactory. The
@@ -90,9 +90,6 @@ public class XmlRpcServlet extends HttpServlet {
     }
 
     private void registerCustomSerializers(RhnXmlRpcServer srvr) {
-        if (serializerFactory == null) {
-            serializerFactory = new SerializerFactory();
-        }
         XmlRpcSerializer serializer = srvr.getSerializer();
         serializer.addCustomSerializer(new ObjectSerializer());
         serializer.addCustomSerializer(new BigDecimalSerializer());
@@ -102,20 +99,14 @@ public class XmlRpcServlet extends HttpServlet {
     }
 
     private void registerInvocationHandlers(RhnXmlRpcServer srvr) {
-        if (handlerFactory == null) {
-            handlerFactory = new HandlerFactory();
-        }
-
         // find the configured handlers...
         for (String namespace : handlerFactory.getKeys()) {
-            if (log.isDebugEnabled()) {
-                log.debug("registerInvocationHandler: namespace [" + namespace +
-                        "] handler [" + handlerFactory.getHandler(namespace).get() + "]");
-            }
-            srvr.addInvocationHandler(
-                    namespace,
-                    handlerFactory.getHandler(namespace).get()
-            );
+            handlerFactory.getHandler(namespace).ifPresent((handler) -> {
+                if (log.isDebugEnabled()) {
+                    log.debug("registerInvocationHandler: namespace [" + namespace + "] handler [" + handler + "]");
+                }
+                srvr.addInvocationHandler(namespace, handler);
+            });
         }
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/test/XmlRpcServletTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/test/XmlRpcServletTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.xmlrpc.XmlRpcServlet;
+import com.redhat.rhn.frontend.xmlrpc.serializer.SerializerFactory;
 import com.redhat.rhn.testing.MockObjectTestCase;
 import com.redhat.rhn.testing.UserTestUtils;
 
@@ -78,7 +79,7 @@ public class XmlRpcServletTest extends MockObjectTestCase {
         } });
 
         // ok run servlet
-        XmlRpcServlet xrs = new XmlRpcServlet(XmlRpcTestUtils.getTestHandlerFactory(), null);
+        XmlRpcServlet xrs = new XmlRpcServlet(XmlRpcTestUtils.getTestHandlerFactory(), new SerializerFactory());
         xrs.init();
         xrs.doPost(mockreq, mockresp);
 

--- a/java/code/src/com/suse/manager/api/ListDeserializer.java
+++ b/java/code/src/com/suse/manager/api/ListDeserializer.java
@@ -49,15 +49,20 @@ public class ListDeserializer implements JsonDeserializer<List<Object>> {
                 if (prim.isNumber()) {
                     Number num = null;
                     try {
-                        num = Long.parseLong(prim.getAsString());
+                        num = Integer.parseInt(prim.getAsString());
                     }
-                    catch (NumberFormatException eLong) {
+                    catch (NumberFormatException eInt) {
                         try {
-                            num = Double.parseDouble(prim.getAsString());
+                            num = Long.parseLong(prim.getAsString());
                         }
-                        catch (NumberFormatException eDouble) {
-                            // Not a valid number
-                            list.add(prim.getAsString());
+                        catch (NumberFormatException eLong) {
+                            try {
+                                num = Double.parseDouble(prim.getAsString());
+                            }
+                            catch (NumberFormatException eDouble) {
+                                // Not a valid number
+                                list.add(prim.getAsString());
+                            }
                         }
                     }
                     if (num != null) {

--- a/java/code/src/com/suse/manager/api/MapDeserializer.java
+++ b/java/code/src/com/suse/manager/api/MapDeserializer.java
@@ -48,15 +48,20 @@ public class MapDeserializer implements JsonDeserializer<Map<String, Object>> {
                 if (prim.isNumber()) {
                     Number num = null;
                     try {
-                        num = Long.parseLong(prim.getAsString());
+                        num = Integer.parseInt(prim.getAsString());
                     }
-                    catch (NumberFormatException eLong) {
+                    catch (NumberFormatException eInt) {
                         try {
-                            num = Double.parseDouble(prim.getAsString());
+                            num = Long.parseLong(prim.getAsString());
                         }
-                        catch (NumberFormatException eDouble) {
-                            // Not a valid number
-                            map.put(key, prim.getAsString());
+                        catch (NumberFormatException eLong) {
+                            try {
+                                num = Double.parseDouble(prim.getAsString());
+                            }
+                            catch (NumberFormatException eDouble) {
+                                // Not a valid number
+                                map.put(key, prim.getAsString());
+                            }
                         }
                     }
                     if (num != null) {

--- a/java/code/src/com/suse/manager/api/RouteFactory.java
+++ b/java/code/src/com/suse/manager/api/RouteFactory.java
@@ -15,14 +15,14 @@
 package com.suse.manager.api;
 
 import static com.suse.manager.webui.utils.SparkApplicationHelper.asJson;
-import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
 
 import com.redhat.rhn.FaultException;
 import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
 import com.redhat.rhn.frontend.xmlrpc.serializer.SerializerFactory;
+import com.redhat.rhn.manager.session.SessionManager;
 
-import com.suse.manager.webui.utils.RouteWithUser;
 import com.suse.manager.webui.utils.SparkApplicationHelper;
 
 import com.google.gson.Gson;
@@ -150,7 +150,7 @@ public class RouteFactory {
      * @return the {@link Route}
      */
     public Route createRoute(List<Method> methods, BaseHandler handler) {
-        RouteWithUser routeWithUser = (req, res, user) -> {
+        Route route = (req, res) -> {
             // Collect all the parameters from the query string and the body
             Map<String, JsonElement> requestParams;
             try {
@@ -162,9 +162,10 @@ public class RouteFactory {
                 throw Spark.halt(HttpStatus.SC_BAD_REQUEST, e.getMessage());
             }
 
+            String sessionKey = new RequestContext(req.raw()).getWebSession().getKey();
             try {
                 // Find an overload matching the parameter names and types
-                MethodCall call = findMethod(methods, requestParams, user);
+                MethodCall call = findMethod(methods, requestParams, sessionKey);
                 HttpApiResponse response = HttpApiResponse.success(call.invoke(handler));
                 return SparkApplicationHelper.json(gson, res, response);
             }
@@ -187,7 +188,7 @@ public class RouteFactory {
                 throw new RuntimeException(exceptionInMethod);
             }
         };
-        return asJson(withUser(routeWithUser));
+        return asJson(route);
     }
 
     /**
@@ -197,18 +198,20 @@ public class RouteFactory {
      * The parsed arguments are packed together with the chosen method and returned as a {@link MethodCall} object.
      * @param methods list of methods
      * @param jsonArgs the JSON arguments
-     * @param user the logged-in user
+     * @param sessionKey the session key
      * @return the matched method, if exists
      * @throws NoSuchMethodException if no match is found
      */
-    private MethodCall findMethod(List<Method> methods, Map<String, JsonElement> jsonArgs, User user)
+    private MethodCall findMethod(List<Method> methods, Map<String, JsonElement> jsonArgs, String sessionKey)
             throws NoSuchMethodException {
+        User user = SessionManager.loadSession(sessionKey).getUser();
         // Filter methods with parameter names that match the request parameters, excluding the User parameter
         return methods.stream()
                 .filter(m -> jsonArgs.keySet().equals(
                         Arrays.stream(m.getParameters())
                                 .filter(p -> !User.class.equals(p.getType()))
                                 .map(Parameter::getName)
+                                .filter(p -> !"sessionKey".equals(p))
                                 .collect(Collectors.toSet())))
                 // Try to parse arguments according to method parameter types
                 .map(method -> {
@@ -217,17 +220,21 @@ public class RouteFactory {
                         // If the method contains a User parameter, add the current user to the argument list
                         if (User.class.equals(param.getType())) {
                             args.add(user);
-                            continue;
                         }
-                        try {
-                            // Parse each value and add to the argument list
-                            args.add(requestParser.parseValue(jsonArgs.get(param.getName()), param.getType()));
+                        else if ("sessionKey".equals(param.getName())) {
+                            args.add(sessionKey);
                         }
-                        catch (ParseException e) {
-                            // Type mismatch, skip the method
-                            LOG.debug(MessageFormat.format("Cannot parse {0} into {1}. Skipping current method.",
-                                    param.getName(), param.getType().getSimpleName()));
-                            return null;
+                        else {
+                            try {
+                                // Parse each value and add to the argument list
+                                args.add(requestParser.parseValue(jsonArgs.get(param.getName()), param.getType()));
+                            }
+                            catch (ParseException e) {
+                                // Type mismatch, skip the method
+                                LOG.debug(MessageFormat.format("Cannot parse {0} into {1}. Skipping current method.",
+                                        param.getName(), param.getType().getSimpleName()));
+                                return null;
+                            }
                         }
                     }
                     return new MethodCall(method, args.toArray());

--- a/java/code/src/com/suse/manager/api/test/RouteFactoryTest.java
+++ b/java/code/src/com/suse/manager/api/test/RouteFactoryTest.java
@@ -158,7 +158,7 @@ public class RouteFactoryTest extends BaseControllerTestCase {
         Response res = createResponse();
         Map<String, Object> result = getResult((String) route.handle(req, res), Map.class);
 
-        assertEquals(1L, result.get("myInteger"));
+        assertEquals(1, result.get("myInteger"));
         assertEquals("$tr:ng", result.get("myString"));
         assertEquals(true, result.get("myBoolean"));
     }
@@ -176,7 +176,7 @@ public class RouteFactoryTest extends BaseControllerTestCase {
         Response res = createResponse();
         Map<String, Object> result = getResult((String) route.handle(req, res), Map.class);
 
-        assertEquals(1L, result.get("myInteger")); // gson prefers long when deserializing numbers
+        assertEquals(1, result.get("myInteger")); // gson prefers long when deserializing numbers
         assertEquals("-empty-", result.get("myString"));
         assertEquals(true, result.get("myBoolean"));
     }
@@ -195,7 +195,7 @@ public class RouteFactoryTest extends BaseControllerTestCase {
         Response res = createResponse();
         Map<String, Object> result = getResult((String) route.handle(req, res), Map.class);
 
-        assertEquals(1L, result.get("myInteger")); // gson prefers long when deserializing numbers
+        assertEquals(1, result.get("myInteger")); // gson prefers long when deserializing numbers
         assertEquals("bar", result.get("myString")); // value in body should take precedence
         assertEquals(true, result.get("myBoolean"));
     }
@@ -229,7 +229,7 @@ public class RouteFactoryTest extends BaseControllerTestCase {
         Response res = createResponse();
         Map<String, Object> result = getResult((String) route.handle(req, res), Map.class);
 
-        assertEquals(1L, result.get("myInteger")); // gson prefers long when deserializing numbers
+        assertEquals(1, result.get("myInteger")); // gson prefers long when deserializing numbers
         assertEquals("$tr:ng", result.get("myString"));
         assertEquals(true, result.get("myBoolean"));
     }
@@ -312,7 +312,7 @@ public class RouteFactoryTest extends BaseControllerTestCase {
         Response res = createResponse();
         List<?> result = getResult((String) route.handle(req, res), List.class);
 
-        assertEquals(List.of(2L, 3L, 5L), result);
+        assertEquals(List.of(2, 3, 5), result);
     }
 
     /**
@@ -329,7 +329,7 @@ public class RouteFactoryTest extends BaseControllerTestCase {
         List<Long> result = getResult((String) route.handle(req, res),
                 TypeToken.getParameterized(List.class, Long.class).getType());
 
-        assertEquals(List.of(2L, 3L, 5L), result);
+        assertEquals(List.of(2, 3, 5), result);
     }
 
     /**
@@ -423,7 +423,7 @@ public class RouteFactoryTest extends BaseControllerTestCase {
         Response res = createResponse();
 
         List<Object> result = getResult((String) route.handle(req, res), List.class);
-        assertTrue(result.containsAll(List.of(1L, "two", "3")));
+        assertTrue(result.containsAll(List.of(1, "two", "3")));
     }
 
     /**
@@ -503,7 +503,7 @@ public class RouteFactoryTest extends BaseControllerTestCase {
         Map<String, Object> result = getResult((String) route.handle(req, res), Map.class);
 
         assertFalse(result.containsKey("isCustomSerialized"));
-        assertEquals(1L, result.get("myInteger"));
+        assertEquals(1, result.get("myInteger"));
         assertEquals("foo", result.get("myString"));
         assertEquals(2, result.size());
     }
@@ -522,7 +522,7 @@ public class RouteFactoryTest extends BaseControllerTestCase {
         Map<String, Object> result = getResult((String) route.handle(req, res), Map.class);
 
         assertEquals(true, result.get("isCustomSerialized"));
-        assertEquals(1L, result.get("myInteger"));
+        assertEquals(1, result.get("myInteger"));
         assertEquals("foo", result.get("myString"));
         assertEquals(3, result.size());
     }
@@ -543,7 +543,7 @@ public class RouteFactoryTest extends BaseControllerTestCase {
         Map<String, Object> result = getResult((String) route.handle(req, res), Map.class);
 
         assertEquals(true, result.get("isCustomSerialized"));
-        assertEquals(1L, result.get("myInteger"));
+        assertEquals(1, result.get("myInteger"));
         assertEquals("foo", result.get("myString"));
         assertEquals(3, result.size());
     }
@@ -577,7 +577,7 @@ public class RouteFactoryTest extends BaseControllerTestCase {
         Map<String, Object> nested = (Map<String, Object>) result.get("myObject");
         assertEquals(true, nested.get("isCustomSerialized"));
         assertEquals("foo", nested.get("myString"));
-        assertEquals(3L, nested.get("myInteger"));
+        assertEquals(3, nested.get("myInteger"));
     }
 
     /**
@@ -595,9 +595,9 @@ public class RouteFactoryTest extends BaseControllerTestCase {
         List<Map<String, Object>> result = getResult((String) route.handle(req, res), List.class);
 
         assertTrue(result.stream().allMatch(i -> (boolean) i.get("isCustomSerialized")));
-        assertEquals(1L, result.get(0).get("myInteger"));
+        assertEquals(1, result.get(0).get("myInteger"));
         assertEquals("foo", result.get(0).get("myString"));
-        assertEquals(2L, result.get(1).get("myInteger"));
+        assertEquals(2, result.get(1).get("myInteger"));
         assertEquals("bar", result.get(1).get("myString"));
     }
 
@@ -617,9 +617,9 @@ public class RouteFactoryTest extends BaseControllerTestCase {
 
         assertEquals(2, result.size());
         assertTrue(result.values().stream().allMatch(i -> (boolean) i.get("isCustomSerialized")));
-        assertEquals(1L, result.get("1").get("myInteger"));
+        assertEquals(1, result.get("1").get("myInteger"));
         assertEquals("foo", result.get("1").get("myString"));
-        assertEquals(2L, result.get("2").get("myInteger"));
+        assertEquals(2, result.get("2").get("myInteger"));
         assertEquals("bar", result.get("2").get("myString"));
     }
 
@@ -637,7 +637,7 @@ public class RouteFactoryTest extends BaseControllerTestCase {
 
         List<Long> result = getResult((String) route.handle(req, res), List.class);
 
-        assertEquals(List.of(2L, 3L, 5L), result);
+        assertEquals(List.of(2, 3, 5), result);
     }
 
     /**

--- a/java/code/src/com/suse/manager/api/test/TestHandler.java
+++ b/java/code/src/com/suse/manager/api/test/TestHandler.java
@@ -184,7 +184,7 @@ public class TestHandler extends BaseHandler {
      */
     @ReadOnly
     public TestComplexResponse complexResponse(String myString, Map<String, Object> nestedObjProps) {
-        return new TestComplexResponse(myString, new TestResponse(((Long) nestedObjProps.get("myInteger")).intValue(),
+        return new TestComplexResponse(myString, new TestResponse((Integer) nestedObjProps.get("myInteger"),
                 (String) nestedObjProps.get("myString")));
     }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Prefer parsing numbers as ints in HTTP API for compatibility
+
 -------------------------------------------------------------------
 Tue Apr 19 12:01:05 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
This PR fixes various bugs in HTTP API

## Fixes

- `Long` to `Int` conversion in XMLRPC compatible handler methods
- Sonarqube errors
- Use raw session key for search endpoints in HTTP API


## Test coverage
- No tests: already covered


## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
