### PR TITLE
Bump Java `memoryMaximumSize`

### DIFF
--- a/java/manager-build.xml
+++ b/java/manager-build.xml
@@ -106,7 +106,7 @@
            nowarn="${nowarn}"
            encoding="utf-8"
            fork="yes"
-           memoryMaximumSize="256m"
+           memoryMaximumSize="512m"
            includeAntRuntime="false"
            classpathref="libjars"
     >


### PR DESCRIPTION
## What does this PR change?

Bumps the max memory size as discussed here https://suse.slack.com/archives/C02D78LLS04/p1650888140357749

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: build config update

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
