### PR TITLE
Add supportconfig data from proxy containers

### DIFF
--- a/susemanager-utils/supportutils-plugin-susemanager-client/supportutils-plugin-susemanager-client.changes
+++ b/susemanager-utils/supportutils-plugin-susemanager-client/supportutils-plugin-susemanager-client.changes
@@ -1,3 +1,5 @@
+- Add proxy containers config and logs
+
 -------------------------------------------------------------------
 Mon Aug 09 10:43:30 CEST 2021 - jgonzalez@suse.com
 

--- a/susemanager-utils/supportutils-plugin-susemanager-client/susemanagerclient
+++ b/susemanager-utils/supportutils-plugin-susemanager-client/susemanagerclient
@@ -42,6 +42,8 @@ osad
 zypp-plugin-spacewalk
 salt-minion
 salt
+podman
+uyuni-proxy-systemd-services
 "
 
 for THISRPM in $RPMLIST; do
@@ -65,7 +67,9 @@ pconf_files \
     /etc/sysconfig/rhn/systemid \
     /etc/salt/minion \
     /etc/salt/minion.d/susemanager.conf \
-    /etc/salt/minion.d/_schedule.conf
+    /etc/salt/minion.d/_schedule.conf \
+    /etc/uyuni/proxy/config.yaml \
+    /etc/sysconfig/uyuni-proxy-systemd-services
 
 
 section_header "SUSE Manager Client Capabilities"
@@ -87,3 +91,51 @@ plugin_command "zypper --no-refresh lr -u"
 plugin_command "salt-minion --versions-report"
 
 plugin_command "cp /var/log/zypper.log $LOG"
+
+section_header "Proxy Containers Configuration Files"
+
+plugin_command "ls -l /etc/uyuni/proxy/"
+
+
+section_header "Proxy Containers Systems Status"
+
+systemd_status() {
+    if systemctl list-unit-files $1 >/dev/null; then
+        plugin_command "systemctl status $1"
+    fi
+}
+
+SERVICES="
+    uyuni-proxy-pod
+    uyuni-proxy-httpd
+    uyuni-proxy-salt-broker
+    uyuni-proxy-squid
+    uyuni-proxy-ssh
+    uyuni-proxy-tftpd
+"
+
+for SERVICE in $SERVICES; do
+    systemd_status "$SERVICE.service"
+done
+
+CONTAINERS="
+    uyuni-proxy-httpd
+    uyuni-proxy-ssh
+    uyuni-proxy-squid
+    uyuni-proxy-tftpd
+    uyuni-proxy-salt-broker
+"
+
+if which podman >/dev/null 2>&1; then
+    section_header "Proxy Containers Inspects"
+
+    for CONTAINER in $CONTAINERS; do
+        plugin_command "podman inspect $CONTAINER"
+    done
+
+    section_header "Proxy Containers Logs"
+
+    for CONTAINER in $CONTAINERS; do
+        plugin_command "podman logs $CONTAINER"
+    done
+fi


### PR DESCRIPTION
## What does this PR change?

Dump config and logs of proxy containers in client supportconfig.

The rationale behind adding it in this plugin is that the host will need to be registered to install the `uyuni-proxy-systemd-services` package. However this may be reverted in a mid term to handle more OSes and potentially kubernetes deployments.

## GUI diff

No difference. 

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [X] **DONE**

## Test coverage
- No tests: supportconfig change
- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17520
- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
