### PR TITLE
Add real pkg update

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
@@ -820,6 +820,9 @@ public class ErrataFactory extends HibernateFactory {
      * @return pairs of package and server ids of packages that are retracted for a given server.
      */
     public static List<Tuple2<Long, Long>> retractedPackagesByNevra(List<String> nevras, List<Long> sids) {
+        if (nevras.isEmpty()) {
+            return new LinkedList<Tuple2<Long, Long>>();
+        }
         Map<String, Object> params = new HashMap<>();
         params.put("nevras", nevras);
         params.put("sids", sids);
@@ -1047,7 +1050,7 @@ public class ErrataFactory extends HibernateFactory {
     public static List<Errata> listErrata(Collection<Long> ids, Long orgId) {
         Map<String, Object> params = new HashMap<>();
         params.put("orgId", orgId);
-        return (List<Errata>) singleton.listObjectsByNamedQuery("Errata.listAvailableToOrgByIds",
+        return singleton.listObjectsByNamedQuery("Errata.listAvailableToOrgByIds",
                 params, ids, "eids");
     }
 

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -220,6 +220,7 @@ public class SaltServerActionService {
     /* Logger for this class */
     private static final Logger LOG = LogManager.getLogger(SaltServerActionService.class);
     public static final String PACKAGES_PKGINSTALL = "packages.pkginstall";
+    public static final String PACKAGES_PKGUPDATE = "packages.pkgupdate";
     private static final String PACKAGES_PKGDOWNLOAD = "packages.pkgdownload";
     public static final String PACKAGES_PATCHINSTALL = "packages.patchinstall";
     private static final String PACKAGES_PATCHDOWNLOAD = "packages.patchdownload";
@@ -1166,8 +1167,14 @@ public class SaltServerActionService {
                 .getDetails().stream().map(d -> Arrays.asList(d.getPackageName().getName(),
                         d.getArch().toUniversalArchString(), d.getEvr().toUniversalEvrString()))
                 .collect(Collectors.toList());
-        ret.put(State.apply(Arrays.asList(PACKAGES_PKGINSTALL),
-                Optional.of(singletonMap(PARAM_PKGS, pkgs))), filteredMinions);
+        if (pkgs.isEmpty()) {
+            // Full system package update using update state
+            ret.put(State.apply(Arrays.asList(PACKAGES_PKGUPDATE), Optional.empty()), filteredMinions);
+        }
+        else {
+            ret.put(State.apply(Arrays.asList(PACKAGES_PKGINSTALL),
+                    Optional.of(singletonMap(PARAM_PKGS, pkgs))), filteredMinions);
+        }
         return ret;
     }
 

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
@@ -125,7 +125,7 @@ public class SaltSSHService {
             "certs", "channels", "cleanup_ssh_minion", "configuration",
             "distupgrade", "hardware", "images", "packages/init.sls",
             "packages/patchdownload.sls", "packages/patchinstall.sls", "packages/pkgdownload.sls",
-            "packages/pkginstall.sls", "packages/pkgremove.sls", "packages/profileupdate.sls",
+            "packages/pkginstall.sls", "packages/pkgupdate.sls", "packages/pkgremove.sls", "packages/profileupdate.sls",
             "packages/redhatproductinfo.sls", "remotecommands", "scap", "services",
             "custom", "custom_groups", "custom_org", "util", "bootstrap", "formulas.sls");
 

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -211,6 +211,53 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         Map<LocalCall<?>, List<MinionSummary>> result = saltServerActionService.callsForAction(
                 updateAction, minionSummaries);
         assertEquals(1, result.values().size());
+        assertStateApplyWithPillar("packages.pkginstall", null, null, result.keySet().iterator().next());
+        MinionSummary minionSummary = result.values().iterator().next().iterator().next();
+        assertEquals(new MinionSummary(testMinionServer), minionSummary);
+    }
+
+    @Test
+    public void testPackageFullUpdate() throws Exception {
+        MinionServer testMinionServer = MinionServerFactoryTest.createTestMinionServer(user);
+        List<MinionServer> mins = new ArrayList<>();
+        mins.add(testMinionServer);
+
+        List<MinionSummary> minionSummaries = mins.stream().
+                map(MinionSummary::new).collect(Collectors.toList());
+
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        Package p64 = ErrataTestUtils.createTestPackage(user, channel, "x86_64");
+        Package p32 = ErrataTestUtils.createLaterTestPackage(user, null, channel, p64);
+        p32.setPackageEvr(p64.getPackageEvr());
+        p32.setPackageArch(PackageFactory.lookupPackageArchByLabel("i686"));
+        TestUtils.saveAndFlush(p32);
+
+        List<Map<String, Long>> packageMaps = new ArrayList<>();
+        Map<String, Long> pkg32map = new HashMap<>();
+        pkg32map.put("name_id", p32.getPackageName().getId());
+        pkg32map.put("evr_id", p32.getPackageEvr().getId());
+        pkg32map.put("arch_id", p32.getPackageArch().getId());
+        packageMaps.add(pkg32map);
+        Map<String, Long> pkg64map = new HashMap<>();
+        pkg64map.put("name_id", p64.getPackageName().getId());
+        pkg64map.put("evr_id", p64.getPackageEvr().getId());
+        pkg64map.put("arch_id", p64.getPackageArch().getId());
+        packageMaps.add(pkg64map);
+
+        final ZonedDateTime now = ZonedDateTime.now(ZoneId.systemDefault());
+        Action action = ActionManager.createAction(user, ActionFactory.TYPE_PACKAGES_UPDATE,
+                "test action", Date.from(now.toInstant()));
+
+        ActionFactory.addServerToAction(testMinionServer, action);
+
+        //ActionManager.addPackageActionDetails(Arrays.asList(action), packageMaps);
+        TestUtils.flushAndEvict(action);
+        Action updateAction = ActionFactory.lookupById(action.getId());
+
+        Map<LocalCall<?>, List<MinionSummary>> result = saltServerActionService.callsForAction(
+                updateAction, minionSummaries);
+        assertEquals(1, result.values().size());
+        assertStateApplyWithPillar("packages.pkgupdate", null, null, result.keySet().iterator().next());
         MinionSummary minionSummary = result.values().iterator().next().iterator().next();
         assertEquals(new MinionSummary(testMinionServer), minionSummary);
     }
@@ -478,7 +525,8 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         assertEquals("state", call.getModuleName());
         assertEquals("apply", call.getFunctionName());
         Map<String, Object> kwargs = ((Map<String, Object>)call.getPayload().get("kwarg"));
-        assertTrue(((List<String>)kwargs.get("mods")).contains(expectedState));
+        assertTrue(((List<String>)kwargs.get("mods")).contains(expectedState),
+                "State does not call: " + expectedState);
         if (pillarEntry != null) {
             assertEquals(pillarValue, ((Map<String, Object>)kwargs.get("pillar")).get(pillarEntry));
         }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- add schedulePackageUpdate() XMLRPC function (bsc#1197507)
 - Redesign the auto errata task to schedule combined actions (bsc#1197429)
 - Allow to add failed and completed servers to SSM
 - drop specialized SSL truststore for db connections in favor

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,5 @@
+- on full system update call schedulePackageUpdate API (bsc#1197507)
+
 -------------------------------------------------------------------
 Tue Apr 19 11:56:27 CEST 2022 - jgonzalez@suse.com
 

--- a/spacecmd/src/spacecmd/system.py
+++ b/spacecmd/src/spacecmd/system.py
@@ -1044,22 +1044,27 @@ def do_system_upgradepackage(self, args):
 
     # make a dictionary of each system and the package IDs to install
     jobs = {}
+    minions = {}
     for system in sorted(systems):
         system_id = self.get_system_id(system)
         if not system_id:
             continue
-
-        packages = \
-            self.client.system.listLatestUpgradablePackages(self.session,
-                                                            system_id)
-
-        if packages:
-            package_ids = [p.get('to_package_id') for p in packages]
-            jobs[system] = package_ids
+        details = self.client.system.getDetails(self.session, system_id)
+        if self.check_api_version('25.0') and \
+           details.get('base_entitlement', '') == 'salt_entitled':
+            minions[system] = system_id
         else:
-            logging.warning(_N('No upgrades available for %s') % system)
+            packages = \
+                self.client.system.listLatestUpgradablePackages(self.session,
+                                                                system_id)
 
-    if not jobs:
+            if packages:
+                package_ids = [p.get('to_package_id') for p in packages]
+                jobs[system] = package_ids
+            else:
+                logging.warning(_N('No upgrades available for %s') % system)
+
+    if not jobs and not minions:
         return 1
 
     add_separator = False
@@ -1084,10 +1089,21 @@ def do_system_upgradepackage(self, args):
 
         print('\n'.join(sorted(package_names)))
 
+    for system in minions:
+        if add_separator:
+            print(self.SEPARATOR)
+        add_separator = True
+
+        hdr = _('Full package update on systems:')
+        print(hdr)
+        print('-' * len(hdr))
+        print('- {}'.format(system))
+
+
     print('')
     print(_('Start Time: %s') % options.start_time)
 
-    if not self.user_confirm(_('Upgrade these packages [y/N]:')):
+    if not self.user_confirm(_('Upgrade these systems/packages [y/N]:')):
         return 1
 
     scheduled = 0
@@ -1103,6 +1119,17 @@ def do_system_upgradepackage(self, args):
             scheduled += 1
         except xmlrpclib.Fault:
             logging.error(_N('Failed to schedule %s') % system)
+
+    if minions:
+        try:
+            sids = list(minions.values())
+            self.client.system.schedulePackageUpdate(self.session,
+                                                     sids,
+                                                     options.start_time)
+            scheduled += len(sids)
+        except xmlrpclib.Fault:
+             logging.error(_N('Failed to schedule %s') % system)
+
 
     logging.info(_N('Scheduled %i system(s)') % scheduled)
 

--- a/susemanager-utils/susemanager-sls/salt/packages/pkgupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/pkgupdate.sls
@@ -1,0 +1,11 @@
+include:
+  - channels
+
+mgr_pkg_update:
+  pkg.uptodate:
+{%- if grains['os_family'] == 'Debian' %}
+    - skip_verify: {{ not pillar.get('mgr_metadata_signing_enabled', false) }}
+{%- endif %}
+    - diff_attr: ['epoch', 'version', 'release', 'arch', 'install_date_time_t']
+    - require:
+      - file: mgrchannels*

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- add packages.pkgupdate state (bsc#1197507)
 - Uninstall the products with no successors after migration
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

When doing a full system update it is better to call with salt `pkg.upgrade` and not `pkg.install` with defined version numbers.
This require a new API call and a new salt state.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/17587

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
