### PR TITLE
Make group TERMINALS optional for saltbooted machines

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -616,14 +616,16 @@ public class RegisterMinionEventMessageAction implements MessageAction {
         ManagedServerGroup branchIdGroup = ServerGroupFactory.lookupByNameAndOrg(branchIdGroupName, org);
         ManagedServerGroup hwGroup = ServerGroupFactory.lookupByNameAndOrg(hwTypeGroup, org);
 
-        if (terminalsGroup == null || branchIdGroup == null) {
-            throw new IllegalStateException("Missing required server groups (\"" + TERMINALS_GROUP_NAME + "\" or \"" +
-                    branchIdGroupName + "\")! Aborting registration.");
+        if (branchIdGroup == null) {
+            throw new IllegalStateException("Missing required server group (\"" + branchIdGroupName + "\")!" +
+                    " Aborting registration.");
         }
 
         SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON, saltApi);
-        systemManager.addServerToServerGroup(minion, terminalsGroup);
         systemManager.addServerToServerGroup(minion, branchIdGroup);
+        if (terminalsGroup != null) {
+            systemManager.addServerToServerGroup(minion, terminalsGroup);
+        }
         if (hwGroup != null) {
             // if the system is already assigned to some HWTYPE group, skip assignment and log this only
             if (minion.getManagedGroups().stream().anyMatch(g -> g.getName().startsWith(hwTypeGroupPrefix))) {

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -1533,12 +1533,11 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                                 with(any(String.class)));
                     }},
                     (contactMethod) -> null, // no AK
-                    (optMinion, machineId, key) -> assertFalse(optMinion.isPresent()), DEFAULT_CONTACT_METHOD);
+                    (optMinion, machineId, key) -> assertTrue(optMinion.isPresent()), DEFAULT_CONTACT_METHOD);
         }
         catch (RegisterMinionEventMessageAction.RegisterMinionException e) {
-            return;
+            fail("Unexpected Exception thrown");
         }
-        fail("Expected Exception not thrown");
     }
 
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Make TERMINALS group optional for saltbooted machines
 Fix outdated documentation and release notes links
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Saltbooted (Retail) terminals were made to always be part of TERMINALS group, but this was just to better organize them and was not really based on any business decision and turned out to be a nuisance.
This PR makes TERMINALS group optional. If exists, terminals will become a member on registration. Otherwise just continue onboarding.

This does not impact branch group which is still mandatory.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
