### PR TITLE
Ensure correct order of precedence with GSON serializers

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SystemSearchHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SystemSearchHelper.java
@@ -163,7 +163,7 @@ public class SystemSearchHelper {
      * @throws XmlRpcFault on xmlrpc error
      * @throws MalformedURLException on bad search server address
      */
-    public static DataResult systemSearch(RequestContext ctx,
+    public static DataResult<SystemSearchResult> systemSearch(RequestContext ctx,
                                           String searchString,
                                           String viewMode,
                                           Boolean invertResults,
@@ -189,7 +189,7 @@ public class SystemSearchHelper {
      * @throws XmlRpcFault on xmlrpc error
      * @throws MalformedURLException on bad search server address
      */
-    public static DataResult systemSearch(String sessionKey,
+    public static DataResult<SystemSearchResult> systemSearch(String sessionKey,
             String searchString,
             String viewMode,
             Boolean invertResults,
@@ -647,7 +647,7 @@ public class SystemSearchHelper {
         return serverIds;
     }
 
-    protected static DataResult processResultMap(User userIn, Map serverIds,
+    protected static DataResult<SystemSearchResult> processResultMap(User userIn, Map serverIds,
             String viewMode) {
         DataResult<SystemSearchResult> serverList =
             UserManager.visibleSystemsAsDtoFromList(userIn,

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/search/SystemSearchHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/search/SystemSearchHandler.java
@@ -17,6 +17,7 @@ package com.redhat.rhn.frontend.xmlrpc.system.search;
 import com.redhat.rhn.FaultException;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.frontend.action.systems.SystemSearchHelper;
+import com.redhat.rhn.frontend.dto.SystemSearchResult;
 import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
 import com.redhat.rhn.frontend.xmlrpc.SearchServerCommException;
 import com.redhat.rhn.frontend.xmlrpc.SearchServerQueryException;
@@ -41,12 +42,12 @@ import redstone.xmlrpc.XmlRpcFault;
 public class SystemSearchHandler extends BaseHandler {
     private static Logger log = LogManager.getLogger(SystemSearchHandler.class);
 
-    private List performSearch(String sessionKey, String searchString,
+    private List<SystemSearchResult> performSearch(String sessionKey, String searchString,
             String viewMode) throws FaultException {
         Boolean invertResults = false;
         String whereToSearch = ""; // if this is "system_list" it will search SSM only
 
-        DataResult dr = null;
+        DataResult<SystemSearchResult> dr;
         try {
             dr = SystemSearchHelper.systemSearch(sessionKey,
                     searchString,
@@ -73,10 +74,10 @@ public class SystemSearchHandler extends BaseHandler {
         // Connection error
 
         if (dr != null) {
-            dr.elaborate(Collections.EMPTY_MAP);
+            dr.elaborate(Collections.emptyMap());
             return dr;
         }
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     /**
@@ -94,10 +95,8 @@ public class SystemSearchHandler extends BaseHandler {
      *         $SystemSearchResultSerializer
      *     #array_end()
      */
-    public Object[] ip(String sessionKey, String searchTerm)
-        throws FaultException {
-        List result = performSearch(sessionKey, searchTerm, SystemSearchHelper.IP);
-        return result.toArray();
+    public List<SystemSearchResult> ip(String sessionKey, String searchTerm) throws FaultException {
+        return performSearch(sessionKey, searchTerm, SystemSearchHelper.IP);
     }
 
     /**
@@ -115,11 +114,8 @@ public class SystemSearchHandler extends BaseHandler {
      *         $SystemSearchResultSerializer
      *     #array_end()
      */
-    public Object[] hostname(String sessionKey, String searchTerm)
-        throws FaultException {
-        List result = performSearch(sessionKey, searchTerm,
-                SystemSearchHelper.HOSTNAME);
-        return result.toArray();
+    public List<SystemSearchResult> hostname(String sessionKey, String searchTerm) throws FaultException {
+        return performSearch(sessionKey, searchTerm, SystemSearchHelper.HOSTNAME);
     }
 
     /**
@@ -137,11 +133,8 @@ public class SystemSearchHandler extends BaseHandler {
      *         $SystemSearchResultSerializer
      *     #array_end()
      */
-    public Object[] deviceVendorId(String sessionKey, String searchTerm)
-        throws FaultException {
-        List result = performSearch(sessionKey, searchTerm,
-                SystemSearchHelper.HW_VENDOR_ID);
-        return result.toArray();
+    public List<SystemSearchResult> deviceVendorId(String sessionKey, String searchTerm) throws FaultException {
+        return performSearch(sessionKey, searchTerm, SystemSearchHelper.HW_VENDOR_ID);
     }
 
     /**
@@ -159,11 +152,8 @@ public class SystemSearchHandler extends BaseHandler {
      *         $SystemSearchResultSerializer
      *     #array_end()
      */
-    public Object[] deviceId(String sessionKey, String searchTerm)
-        throws FaultException {
-        List result =  performSearch(sessionKey, searchTerm,
-                SystemSearchHelper.HW_DEVICE_ID);
-        return result.toArray();
+    public List<SystemSearchResult> deviceId(String sessionKey, String searchTerm) throws FaultException {
+        return performSearch(sessionKey, searchTerm, SystemSearchHelper.HW_DEVICE_ID);
     }
 
     /**
@@ -181,11 +171,8 @@ public class SystemSearchHandler extends BaseHandler {
      *         $SystemSearchResultSerializer
      *     #array_end()
      */
-    public Object[] deviceDriver(String sessionKey, String searchTerm)
-        throws FaultException {
-        List result =  performSearch(sessionKey, searchTerm,
-                SystemSearchHelper.HW_DRIVER);
-        return result.toArray();
+    public List<SystemSearchResult> deviceDriver(String sessionKey, String searchTerm) throws FaultException {
+        return performSearch(sessionKey, searchTerm, SystemSearchHelper.HW_DRIVER);
     }
 
     /**
@@ -203,11 +190,8 @@ public class SystemSearchHandler extends BaseHandler {
      *         $SystemSearchResultSerializer
      *     #array_end()
      */
-    public Object[] deviceDescription(String sessionKey, String searchTerm)
-        throws FaultException {
-        List result = performSearch(sessionKey, searchTerm,
-                SystemSearchHelper.HW_DESCRIPTION);
-        return result.toArray();
+    public List<SystemSearchResult> deviceDescription(String sessionKey, String searchTerm) throws FaultException {
+        return performSearch(sessionKey, searchTerm, SystemSearchHelper.HW_DESCRIPTION);
     }
 
     /**
@@ -225,11 +209,8 @@ public class SystemSearchHandler extends BaseHandler {
      *         $SystemSearchResultSerializer
      *     #array_end()
      */
-    public Object[] nameAndDescription(String sessionKey, String searchTerm)
-        throws FaultException {
-        List result = performSearch(sessionKey, searchTerm,
-                SystemSearchHelper.NAME_AND_DESCRIPTION);
-        return result.toArray();
+    public List<SystemSearchResult> nameAndDescription(String sessionKey, String searchTerm) throws FaultException {
+        return performSearch(sessionKey, searchTerm, SystemSearchHelper.NAME_AND_DESCRIPTION);
     }
 
     /**
@@ -247,10 +228,7 @@ public class SystemSearchHandler extends BaseHandler {
      *         $SystemSearchResultSerializer
      *     #array_end()
      */
-    public Object[] uuid(String sessionKey, String searchTerm)
-        throws FaultException {
-        List result = performSearch(sessionKey, searchTerm,
-                SystemSearchHelper.UUID);
-        return result.toArray();
+    public List<SystemSearchResult> uuid(String sessionKey, String searchTerm) throws FaultException {
+        return performSearch(sessionKey, searchTerm, SystemSearchHelper.UUID);
     }
 }


### PR DESCRIPTION
Serializers that serialize classes in the same class hierarchy override each other in the order they are added. To ensure that subclass serializers take precedence, they must be added later than serializers of their parent classes.

This PR reorders serializers according to the hierarchy relationship between their supported classes to obey the mentioned rule.

## Test coverage
- Unit tests were added

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
