### PR TITLE
require netty build for uyuni to fix failing tomcat start

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- require uyuni netty build to fix failing tomcat start
+
 -------------------------------------------------------------------
 Mon Apr 25 15:04:59 CEST 2022 - jgonzalez@suse.com
 

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -137,7 +137,7 @@ BuildRequires:  libxml2-tools
 %endif
 BuildRequires:  log4j
 BuildRequires:  log4j-slf4j
-BuildRequires:  netty
+BuildRequires:  netty < 4.1.45
 BuildRequires:  objectweb-asm
 BuildRequires:  perl
 BuildRequires:  pgjdbc-ng
@@ -217,7 +217,7 @@ Requires:       jose4j
 Requires:       jpa-api
 Requires:       libsolv-tools
 Requires:       mgr-libmod
-Requires:       netty
+Requires:       netty < 4.1.45
 Requires:       objectweb-asm
 Requires:       pgjdbc-ng
 Requires:       prometheus-client-java


### PR DESCRIPTION
## What does this PR change?

Fix broken symlinks in webapp because of new netty version having the jar files at a different place.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/5278

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
