### PR TITLE
Disable HSTS headers by default (Uyuni-2022.04)

### DIFF
--- a/proxy/proxy/httpd-conf/spacewalk-proxy.conf
+++ b/proxy/proxy/httpd-conf/spacewalk-proxy.conf
@@ -66,5 +66,5 @@
 
 SSLProxyEngine on
 
-# Enable HSTS
-Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains"
+# Uncomment to enable HSTS
+# Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains"

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,5 @@
+- Disable HSTS headers by default
+
 -------------------------------------------------------------------
 Tue Apr 19 12:03:58 CEST 2022 - jgonzalez@suse.com
 

--- a/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
+++ b/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
@@ -165,8 +165,8 @@ Header set X-XSS-Protection "1; mode=block"
 Header set X-Content-Type-Options "nosniff"
 Header set X-Permitted-Cross-Domain-Policies "master-only"
 
-# Enable HSTS
-Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains"
+# Uncomment to enable HSTS
+# Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains"
 
 # make sure the js MIME is not x-js
 AddType "application/javascript" .js

--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,3 +1,5 @@
+- Disable HSTS headers by default
+
 -------------------------------------------------------------------
 Tue Apr 19 12:00:34 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This patch is disabling HSTS headers by default, but leaving the configuration for relatively easy enablement. This way we can gather some experience first and then consider enabling it by default in a future release.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- Documentation will be needed, I will create a PR with a paragraph on how to enable it and warn about required browser configuration (importing certificates)

- [ ] **DONE**

## Test coverage

- Testing might be considered in this issue: https://github.com/SUSE/spacewalk/issues/17576

- [X] **DONE**

## Links

Follow-up to #4981 

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
