### PR TITLE
Allow alternative location for byte-buddy

### DIFF
--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -52,6 +52,10 @@
   <!-- =================== jar dependencies ======================= -->
   <property name="commons-lang" value="commons-lang3"/>
 
+  <condition property="byte-buddy" value="byte-buddy/byte-buddy.jar" else="byte-buddy.jar">
+    <available file="${java.lib.dir}/byte-buddy/byte-buddy.jar"/>
+  </condition>
+
   <available file="${java.lib.dir}/hibernate/hibernate-commons-annotations.jar" type="file"
 	  property="hibernate-commons-annotations" value="hibernate/hibernate-commons-annotations"/>
   <available file="${java.lib.dir}/hibernate-commons-annotations/hibernate-commons-annotations.jar" type="file"
@@ -105,7 +109,7 @@
   <property name="jaxb" value="${jaxb-api} ${jaxb-core} ${jaxb-runtime} ${txw2} ${istack-commons}"/>
 
 
-  <property name="hibernate5deps" value="hibernate-ehcache-5 hibernate-c3p0-5 hibernate-core-5 ${hibernate-commons-annotations} slf4j/api jakarta-persistence-api byte-buddy jboss-logging javassist log4j/log4j-slf4j-impl ${ehcache} classmate statistics hibernate-types-52-2.12.1 jackson-databind jackson-core jackson-annotations"/>
+  <property name="hibernate5deps" value="hibernate-ehcache-5 hibernate-c3p0-5 hibernate-core-5 ${hibernate-commons-annotations} slf4j/api jakarta-persistence-api ${byte-buddy} jboss-logging javassist log4j/log4j-slf4j-impl ${ehcache} classmate statistics hibernate-types-52-2.12.1 jackson-databind jackson-core jackson-annotations"/>
 
   <available file="${java.lib.dir}/hibernate-core-5.jar" type="file" property="hibernate" value="${hibernate5deps}" />
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Allow alternative location for byte-buddy jar.
 - Allow migration where target products have no successor
 - require new salt-netapi-client version
 - Fix PXEEvent string comparision


### PR DESCRIPTION
## What does this PR change?

Allow byte-buddy.jar and byte-buddy/byte-buddy.jar as a location.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
