### PR TITLE
XMLRPC API ContentManagement createAppStreamFilters

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
@@ -652,12 +652,14 @@ public class ContentManagementHandler extends BaseHandler {
     }
 
     /**
+     * Create new {@link ContentFilter}s for all AppStream modules with default streams
      *
-     * @param loggedInUser
-     * @param prefix
-     * @param channelLabel
-     * @param projectLabel
-     * @return List of created Filter or null
+     * @param loggedInUser the logged in user
+     * @param prefix the filter name prefix
+     * @param channelLabel label of the modular channel
+     * @param projectLabel label of the Content Lifecycle Project
+     * @throws EntityExistsFaultException when Filter already exist
+     * @return List of created and successfully attached Filter
      */
     public List<ContentFilter> createAppStreamFilters(User loggedInUser, String prefix,
             String channelLabel, String projectLabel) throws ModulemdApiException {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
@@ -20,6 +20,7 @@ import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
 
+import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.common.validator.ValidatorException;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.contentmgmt.ContentEnvironment;
@@ -672,9 +673,9 @@ public class ContentManagementHandler extends BaseHandler {
             String channelLabel, String projectLabel) throws ModulemdApiException {
         ensureOrgAdmin(loggedInUser);
 
-        Channel channel = ChannelManager.lookupByLabelAndUser(channelLabel, loggedInUser);
-
         try {
+            Channel channel = ChannelManager.lookupByLabelAndUser(channelLabel, loggedInUser);
+
             List<ContentFilter> createdFilters = filterTemplateManager.createAppStreamFilters(
                     prefix, channel, loggedInUser);
 
@@ -688,6 +689,9 @@ public class ContentManagementHandler extends BaseHandler {
         }
         catch (EntityExistsException e) {
             throw new EntityExistsFaultException(e);
+        }
+        catch (LookupException | EntityNotExistsException e) {
+            throw new EntityNotExistsFaultException(e);
         }
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
@@ -660,6 +660,13 @@ public class ContentManagementHandler extends BaseHandler {
      * @param projectLabel label of the Content Lifecycle Project
      * @throws EntityExistsFaultException when Filter already exist
      * @return List of created and successfully attached Filter
+     *
+     * @xmlrpc.doc Create Filters for AppStream Modular Channel and attach them to CLM Project
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param #param_desc("string", "prefix", "Filter name prefix")
+     * @xmlrpc.param #param_desc("string", "channelLabel", "Modular Channel label")
+     * @xmlrpc.param #param_desc("string", "projectLabel", "Project label")
+     * @xmlrpc.returntype #return_array_begin() $ContentFilterSerializer #array_end()
      */
     public List<ContentFilter> createAppStreamFilters(User loggedInUser, String prefix,
             String channelLabel, String projectLabel) throws ModulemdApiException {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- add createAppStreamFilters() XMLRPC function
 - Display usertime instead of server time for clm issue date filter (bsc#1198429)
 - fix bootstrapping of ssh minions via proxy
 - check if file exists before sending it to xsendfile (bsc#1198191)


### PR DESCRIPTION
## What does this PR change?

Adds API Endpoint to create AppStreamFilters based on Template similar as the CLM Web UI functionality.
Re-use Classes and methods also used for the Web UI Implementation: https://github.com/uyuni-project/uyuni/pull/4147

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: API Documentation generated by javadoc

- [x] **DONE**

## Test coverage
- No tests: already covered in `java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java`

- [x] **DONE**

## Links

none

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
