### PR TITLE
Add a way to ignore known issues in audits

### DIFF
--- a/web/html/src/.auditignore.js
+++ b/web/html/src/.auditignore.js
@@ -1,0 +1,7 @@
+/**
+ * This file outlines known issues or grandfathered modules for audits
+ */
+module.exports = {
+  // We don't have the bandwidth to upgrade Bootstrap right now
+  bootstrap: "No bandwidth to upgrade",
+};

--- a/web/html/src/build/audit.js
+++ b/web/html/src/build/audit.js
@@ -3,7 +3,7 @@ const { exec } = require("child_process");
 const ignore = require("../.auditignore.js");
 
 // Yarn 1.x doesn't currently support muting known issues, see https://github.com/yarnpkg/yarn/issues/6669
-exec(`yarn audit --json --groups "dependencies"`, (error, stdout, stderr) => {
+exec(`yarn audit --json --groups "dependencies"`, (_, stdout) => {
   try {
     const lines = (stdout || "").split(/\r?\n/).filter((line) => line.trim() !== "");
     const results = lines.map((line) => JSON.parse(line));

--- a/web/html/src/build/audit.js
+++ b/web/html/src/build/audit.js
@@ -8,6 +8,10 @@ exec(`yarn audit --json --groups "dependencies"`, (error, stdout, stderr) => {
     const lines = (stdout || "").split(/\r?\n/).filter((line) => line.trim() !== "");
     const results = lines.map((line) => JSON.parse(line));
 
+    if (!results.some((item) => item.type === "auditSummary")) {
+      throw new TypeError("No audit result found");
+    }
+
     const advisories = results.filter((item) => item.type === "auditAdvisory");
     if (!advisories.length) {
       process.exitCode = 0;
@@ -38,6 +42,7 @@ exec(`yarn audit --json --groups "dependencies"`, (error, stdout, stderr) => {
     return;
   } catch (error) {
     process.exitCode = error.code || 1;
+    console.error(error);
     return;
   }
 });

--- a/web/html/src/build/audit.js
+++ b/web/html/src/build/audit.js
@@ -18,7 +18,7 @@ exec(`yarn audit --json --groups "dependencies"`, (error, stdout, stderr) => {
       return;
     }
 
-    const remainingAdvisories = advisories.filter((item) => {
+    const validAdvisories = advisories.filter((item) => {
       const { module_name: moduleName, id } = item.data.advisory;
       if (ignore[moduleName]) {
         console.info(`Ignoring advisory ${id} for module "${moduleName}": ${ignore[moduleName]}`);
@@ -27,14 +27,14 @@ exec(`yarn audit --json --groups "dependencies"`, (error, stdout, stderr) => {
       return true;
     });
 
-    if (remainingAdvisories.length) {
-      remainingAdvisories.forEach((item) => {
+    if (validAdvisories.length) {
+      process.exitCode = 1;
+      validAdvisories.forEach((item) => {
         const { module_name: moduleName, id, overview, recommendation } = item.data.advisory;
         console.error(
           `Error: Found advisory ${id} for module "${moduleName}"\nOverview: ${overview}\nRecommendation: ${recommendation}\n`
         );
       });
-      process.exitCode = 1;
       return;
     }
 

--- a/web/html/src/build/audit.js
+++ b/web/html/src/build/audit.js
@@ -1,0 +1,43 @@
+const { exec } = require("child_process");
+
+const ignore = require("../.auditignore.js");
+
+// Yarn 1.x doesn't currently support muting known issues, see https://github.com/yarnpkg/yarn/issues/6669
+exec(`yarn audit --json --groups "dependencies"`, (error, stdout, stderr) => {
+  try {
+    const lines = (stdout || "").split(/\r?\n/).filter((line) => line.trim() !== "");
+    const results = lines.map((line) => JSON.parse(line));
+
+    const advisories = results.filter((item) => item.type === "auditAdvisory");
+    if (!advisories.length) {
+      process.exitCode = 0;
+      return;
+    }
+
+    const remainingAdvisories = advisories.filter((item) => {
+      const { module_name: moduleName, id } = item.data.advisory;
+      if (ignore[moduleName]) {
+        console.info(`Ignoring advisory ${id} for module "${moduleName}": ${ignore[moduleName]}`);
+        return false;
+      }
+      return true;
+    });
+
+    if (remainingAdvisories.length) {
+      remainingAdvisories.forEach((item) => {
+        const { module_name: moduleName, id, overview, recommendation } = item.data.advisory;
+        console.error(
+          `Error: Found advisory ${id} for module "${moduleName}"\nOverview: ${overview}\nRecommendation: ${recommendation}\n`
+        );
+      });
+      process.exitCode = 1;
+      return;
+    }
+
+    process.exitCode = 0;
+    return;
+  } catch (error) {
+    process.exitCode = error.code || 1;
+    return;
+  }
+});

--- a/web/html/src/package.json
+++ b/web/html/src/package.json
@@ -5,7 +5,7 @@
   "license": "UNLICENSED",
   "scripts": {
     "all": "yarn install && npm-run-all -clps --aggregate-output build lint test tsc",
-    "audit-production-dependencies": "yarn audit --groups \"dependencies\"",
+    "audit-production-dependencies": "NODE_OPTIONS=\"--trace-warnings --trace-deprecation --unhandled-rejections=strict\" node build/audit.js",
     "dev": "NODE_OPTIONS=\"--trace-warnings --trace-deprecation --unhandled-rejections=strict\" webpack --config build/webpack.config.js --mode development",
     "watch": "NODE_OPTIONS=\"--trace-warnings --trace-deprecation --unhandled-rejections=strict\" webpack --config build/webpack.config.js --mode development --watch",
     "proxy": "NODE_OPTIONS=\"--trace-warnings --trace-deprecation --unhandled-rejections=strict\"; proxy () { webpack-dev-server --mode development --config build/webpack.config.js --env server=$*; }; proxy",


### PR DESCRIPTION
## What does this PR change?

Since we moved branding dependencies into web, we now also get security advisories for them. Right now we don't have the bandwidth to upgrade Bootstrap so I've ignored it in the audit results.  

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: tooling

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
