### PR TITLE
Use proper SSL terminology visible to the user

### DIFF
--- a/web/html/src/manager/proxy/container-config.tsx
+++ b/web/html/src/manager/proxy/container-config.tsx
@@ -238,14 +238,14 @@ export function ProxyConfig() {
           name="sslMode"
           label={t("SSL certificate")}
           title={t("SSL certificate")}
-          hint={"Whether to create an SSL certificate or reuse an existing one"}
+          hint={"Whether to generate an SSL certificate or reuse an existing one"}
           inline={true}
           required
           labelClass="col-md-3"
           divClass="col-md-6"
           defaultValue={SSLMode.CreateSSL}
           items={[
-            { label: t("Create"), value: SSLMode.CreateSSL },
+            { label: t("Generate"), value: SSLMode.CreateSSL },
             { label: t("Use existing"), value: SSLMode.UseSSL },
           ]}
         />

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Use proper SSL terminology visible to the user
 - Stylesheets and relevant assets are now provided by spacewalk-web
 - Fix outdated documentation and release notes links
 


### PR DESCRIPTION
## What does this PR change?

Simple string change to be consistent with the SSL terminology

## GUI diff

Before:
![before-ssl](https://user-images.githubusercontent.com/7080830/165726650-b0ca7870-89af-4f6e-87aa-6979f1a19dc9.png)


After:
![after-ssl](https://user-images.githubusercontent.com/7080830/165726687-a1ddbace-e7cf-438d-ae77-41f2eb1d1035.png)

- [x] **DONE**

## Documentation
- No documentation needed: 

- [x] **DONE**

## Test coverage
- No tests: 

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
