### PR TITLE
Added some views that were missing in the previous update scripts

### DIFF
--- a/schema/reportdb/upgrade/uyuni-reportdb-schema-4.3.2-to-uyuni-reportdb-schema-4.3.3/002-fix-system-group.sql
+++ b/schema/reportdb/upgrade/uyuni-reportdb-schema-4.3.2-to-uyuni-reportdb-schema-4.3.3/002-fix-system-group.sql
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS SystemGroupMember
     CONSTRAINT SystemGroupMember_pk PRIMARY KEY (mgm_id, system_group_id, system_id)
 );
 
+DROP VIEW IF EXISTS InventoryReport;
 CREATE OR REPLACE VIEW InventoryReport AS
     -- CTEs to group all one to many relationship joining values with ; as separator
     WITH Entitlements AS (

--- a/schema/reportdb/upgrade/uyuni-reportdb-schema-4.3.2-to-uyuni-reportdb-schema-4.3.3/003-additional-tables.sql
+++ b/schema/reportdb/upgrade/uyuni-reportdb-schema-4.3.2-to-uyuni-reportdb-schema-4.3.3/003-additional-tables.sql
@@ -176,6 +176,7 @@ CREATE TABLE IF NOT EXISTS SystemCustomInfo
 );
 
 -- Views
+DROP VIEW IF EXISTS ProxyOverviewReport;
 CREATE OR REPLACE VIEW ProxyOverviewReport AS
     SELECT prx.mgm_id
               , prx.system_id AS proxy_id
@@ -189,6 +190,7 @@ CREATE OR REPLACE VIEW ProxyOverviewReport AS
  ORDER BY prx.mgm_id, prx.system_id, sys.system_id
 ;
 
+DROP VIEW IF EXISTS ScapScanReport;
 CREATE OR REPLACE VIEW ScapScanReport AS
   SELECT XccdScan.mgm_id
             , XccdScan.scan_id
@@ -220,6 +222,7 @@ ORDER BY XccdScan.mgm_id
             , XccdScan.end_time
 ;
 
+DROP VIEW IF EXISTS ScapScanResultReport;
 CREATE OR REPLACE VIEW ScapScanResultReport AS
   SELECT XccdScanResult.mgm_id
             , XccdScanResult.scan_id
@@ -237,6 +240,7 @@ CREATE OR REPLACE VIEW ScapScanResultReport AS
 ORDER BY mgm_id, scan_id, rule_id
 ;
 
+DROP VIEW IF EXISTS SystemGroupsReport;
 CREATE OR REPLACE VIEW SystemGroupsReport AS
   SELECT mgm_id
             , system_group_id
@@ -248,6 +252,7 @@ CREATE OR REPLACE VIEW SystemGroupsReport AS
 ORDER BY mgm_id, system_group_id
 ;
 
+DROP VIEW IF EXISTS SystemGroupsSystemsReport;
 CREATE OR REPLACE VIEW SystemGroupsSystemsReport AS
    SELECT SystemGroupMember.mgm_id
               , SystemGroupMember.system_group_id AS group_id
@@ -260,6 +265,7 @@ CREATE OR REPLACE VIEW SystemGroupsSystemsReport AS
  ORDER BY SystemGroupMember.mgm_id, SystemGroupMember.system_group_id, SystemGroupMember.system_id
 ;
 
+DROP VIEW IF EXISTS SystemPackagesInstalledReport;
 CREATE OR REPLACE VIEW SystemPackagesInstalledReport AS
   SELECT SystemPackageInstalled.mgm_id
             , SystemPackageInstalled.system_id
@@ -275,6 +281,7 @@ CREATE OR REPLACE VIEW SystemPackagesInstalledReport AS
 ORDER BY SystemPackageInstalled.mgm_id, SystemPackageInstalled.system_id, SystemPackageInstalled.name
 ;
 
+DROP VIEW IF EXISTS SystemExtraPackagesReport;
 CREATE OR REPLACE VIEW SystemExtraPackagesReport AS
   WITH packages_from_channels AS (
     SELECT SystemPackageInstalled.mgm_id
@@ -321,6 +328,7 @@ CREATE OR REPLACE VIEW SystemExtraPackagesReport AS
 ORDER BY System.mgm_id, System.organization, System.system_id, SystemPackageInstalled.name
 ;
 
+DROP VIEW IF EXISTS PackagesUpdatesAllReport;
 CREATE OR REPLACE VIEW PackagesUpdatesAllReport AS
   SELECT System.mgm_id
             , System.system_id
@@ -340,6 +348,7 @@ CREATE OR REPLACE VIEW PackagesUpdatesAllReport AS
 ORDER BY System.mgm_id, System.organization, System.system_id, SystemPackageUpdate.name
 ;
 
+DROP VIEW IF EXISTS PackagesUpdatesNewestReport;
 CREATE OR REPLACE VIEW PackagesUpdatesNewestReport AS
   SELECT System.mgm_id
             , System.system_id
@@ -360,6 +369,7 @@ CREATE OR REPLACE VIEW PackagesUpdatesNewestReport AS
 ORDER BY System.mgm_id, System.organization, System.system_id, SystemPackageUpdate.name
 ;
 
+DROP VIEW IF EXISTS ClonedChannelsReport;
 CREATE OR REPLACE VIEW ClonedChannelsReport AS
   SELECT original.mgm_id
             , original.channel_id AS original_channel_id
@@ -374,6 +384,7 @@ CREATE OR REPLACE VIEW ClonedChannelsReport AS
 ORDER BY original.mgm_id, original.channel_id
 ;
 
+DROP VIEW IF EXISTS ChannelPackagesReport;
 CREATE OR REPLACE VIEW ChannelPackagesReport AS
   SELECT Channel.mgm_id
             , Channel.label AS channel_label
@@ -391,6 +402,7 @@ CREATE OR REPLACE VIEW ChannelPackagesReport AS
 ORDER BY Channel.mgm_id, Channel.label, Package.name, Package.version, Package.release, Package.epoch, Package.arch
 ;
 
+DROP VIEW IF EXISTS ErrataChannelsReport;
 CREATE OR REPLACE VIEW ErrataChannelsReport AS
   SELECT mgm_id
             , advisory_name
@@ -402,6 +414,7 @@ CREATE OR REPLACE VIEW ErrataChannelsReport AS
 ORDER BY mgm_id, advisory_name, errata_id, channel_label, channel_id
 ;
 
+DROP VIEW IF EXISTS AccountsReport;
 CREATE OR REPLACE VIEW AccountsReport AS
   SELECT Account.mgm_id
             , Account.organization
@@ -435,6 +448,7 @@ GROUP BY Account.mgm_id
 ORDER BY Account.mgm_id, Account.organization, Account.account_id
 ;
 
+DROP VIEW IF EXISTS AccountsSystemsReport;
 CREATE OR REPLACE VIEW AccountsSystemsReport AS
   WITH org_admins AS (
       SELECT mgm_id, account_id
@@ -480,6 +494,7 @@ CREATE OR REPLACE VIEW AccountsSystemsReport AS
 ORDER BY users_details.mgm_id, users_details.account_id, system_users.system_id
 ;
 
+DROP VIEW IF EXISTS CustomInfoReport;
 CREATE OR REPLACE VIEW CustomInfoReport AS
   SELECT SystemCustomInfo.mgm_id
             , SystemCustomInfo.system_id

--- a/schema/reportdb/upgrade/uyuni-reportdb-schema-4.3.2-to-uyuni-reportdb-schema-4.3.3/004-additional-views.sql
+++ b/schema/reportdb/upgrade/uyuni-reportdb-schema-4.3.2-to-uyuni-reportdb-schema-4.3.3/004-additional-views.sql
@@ -5,6 +5,7 @@ ALTER TABLE SystemAction
     ADD COLUMN IF NOT EXISTS action_name VARCHAR(128)
 ;
 
+DROP VIEW IF EXISTS ActionsReport;
 CREATE OR REPLACE VIEW ActionsReport AS
   SELECT DISTINCT SystemAction.mgm_id
              , SystemAction.action_id
@@ -49,6 +50,7 @@ CREATE TABLE IF NOT EXISTS Repository
     CONSTRAINT Repository_pk PRIMARY KEY (mgm_id, repository_id)
 );
 
+DROP VIEW IF EXISTS CustomChannelsReport;
 CREATE OR REPLACE VIEW CustomChannelsReport AS
   WITH repositories AS (
       SELECT mgm_id, channel_id, string_agg(repository_id || ' - ' || repository_label, ';')  AS channel_repositories
@@ -74,7 +76,6 @@ ORDER BY Channel.mgm_id, Channel.organization, Channel.channel_id
 ;
 
 DROP VIEW IF EXISTS ErrataListReport;
-
 CREATE OR REPLACE VIEW ErrataListReport AS
   SELECT Errata.mgm_id
             , Errata.errata_id
@@ -100,6 +101,7 @@ GROUP BY Errata.mgm_id
 ORDER BY Errata.mgm_id, Errata.advisory_name
 ;
 
+DROP VIEW IF EXISTS ErrataSystemsReport;
 CREATE OR REPLACE VIEW ErrataSystemsReport AS
   WITH V6Addresses AS (
           SELECT mgm_id, system_id, interface_id, string_agg(address || ' (' || scope || ')', ';') AS ip6_addresses
@@ -123,6 +125,7 @@ CREATE OR REPLACE VIEW ErrataSystemsReport AS
 ORDER BY SystemErrata.mgm_id, SystemErrata.errata_id, SystemErrata.system_id
 ;
 
+DROP VIEW IF EXISTS HostGuestsReport;
 CREATE OR REPLACE VIEW HostGuestsReport AS
   SELECT mgm_id
             , host_system_id AS host
@@ -134,6 +137,7 @@ CREATE OR REPLACE VIEW HostGuestsReport AS
 ORDER BY mgm_id, host_system_id, virtual_system_id
 ;
 
+DROP VIEW IF EXISTS SystemHistoryChannelsReport;
 CREATE OR REPLACE VIEW SystemHistoryChannelsReport AS
   SELECT mgm_id
               , system_id
@@ -148,6 +152,7 @@ CREATE OR REPLACE VIEW SystemHistoryChannelsReport AS
 ORDER BY mgm_id, system_id, history_id
 ;
 
+DROP VIEW IF EXISTS SystemHistoryConfigurationReport;
 CREATE OR REPLACE VIEW SystemHistoryConfigurationReport AS
   SELECT mgm_id
             , system_id
@@ -168,6 +173,7 @@ CREATE OR REPLACE VIEW SystemHistoryConfigurationReport AS
 ORDER BY mgm_id, system_id, action_id
 ;
 
+DROP VIEW IF EXISTS SystemHistoryEntitlementsReport;
 CREATE OR REPLACE VIEW SystemHistoryEntitlementsReport AS
   SELECT mgm_id
               , system_id
@@ -182,6 +188,7 @@ CREATE OR REPLACE VIEW SystemHistoryEntitlementsReport AS
 ORDER BY mgm_id, system_id, history_id
 ;
 
+DROP VIEW IF EXISTS SystemHistoryErrataReport;
 CREATE OR REPLACE VIEW SystemHistoryErrataReport AS
   SELECT mgm_id
             , system_id
@@ -197,6 +204,7 @@ CREATE OR REPLACE VIEW SystemHistoryErrataReport AS
 ORDER BY mgm_id, system_id, action_id
 ;
 
+DROP VIEW IF EXISTS SystemHistoryKickstartReport;
 CREATE OR REPLACE VIEW SystemHistoryKickstartReport AS
   SELECT mgm_id
             , system_id
@@ -212,6 +220,7 @@ CREATE OR REPLACE VIEW SystemHistoryKickstartReport AS
 ORDER BY mgm_id, system_id, action_id
 ;
 
+DROP VIEW IF EXISTS SystemHistoryPackagesReport;
 CREATE OR REPLACE VIEW SystemHistoryPackagesReport AS
   SELECT mgm_id
             , system_id
@@ -227,6 +236,7 @@ CREATE OR REPLACE VIEW SystemHistoryPackagesReport AS
 ORDER BY mgm_id, system_id, action_id
 ;
 
+DROP VIEW IF EXISTS SystemHistoryScapReport;
 CREATE OR REPLACE VIEW SystemHistoryScapReport AS
   SELECT mgm_id
             , system_id

--- a/schema/reportdb/upgrade/uyuni-reportdb-schema-4.3.3-to-uyuni-reportdb-schema-4.3.4/003-fixes-for-spacewalk-report-compatibility.sql
+++ b/schema/reportdb/upgrade/uyuni-reportdb-schema-4.3.3-to-uyuni-reportdb-schema-4.3.4/003-fixes-for-spacewalk-report-compatibility.sql
@@ -69,6 +69,9 @@ CREATE OR REPLACE VIEW SystemHistoryErrataReport AS
 ORDER BY mgm_id, system_id, action_id
 ;
 
+-- SystemHistoryKickstartReport might have been created by mistake due to a wrong update file
+DROP VIEW IF EXISTS SystemHistoryKickstartReport;
+
 DROP VIEW IF EXISTS SystemHistoryAutoinstallationReport;
 
 CREATE OR REPLACE VIEW SystemHistoryAutoinstallationReport AS

--- a/schema/reportdb/upgrade/uyuni-reportdb-schema-4.3.3-to-uyuni-reportdb-schema-4.3.4/003-fixes-for-spacewalk-report-compatibility.sql
+++ b/schema/reportdb/upgrade/uyuni-reportdb-schema-4.3.3-to-uyuni-reportdb-schema-4.3.4/003-fixes-for-spacewalk-report-compatibility.sql
@@ -1,11 +1,18 @@
 DO $$
 BEGIN
-  IF EXISTS(SELECT * FROM information_schema.columns WHERE table_name='actionsreport' and column_name='scheduled_by')
+  IF EXISTS(SELECT * FROM information_schema.columns WHERE table_name='systemaction' and column_name='scheduled_by')
   THEN
     DROP VIEW IF EXISTS ActionsReport;
 
-    ALTER TABLE SystemAction ADD COLUMN scheduler_id NUMERIC;
-    ALTER TABLE SystemAction RENAME COLUMN scheduled_by TO scheduler_username;
+    ALTER TABLE SystemAction ADD COLUMN IF NOT EXISTS scheduler_id NUMERIC;
+
+    IF EXISTS(SELECT * FROM information_schema.columns WHERE table_name='systemaction' and column_name='scheduler_username')
+    THEN
+      RAISE NOTICE 'The scheduler_username is already present. Dropping scheduled_by';
+      ALTER TABLE SystemAction DROP COLUMN scheduled_by;
+    ELSE
+      ALTER TABLE SystemAction RENAME COLUMN scheduled_by TO scheduler_username;
+    END IF;
 
     CREATE OR REPLACE VIEW ActionsReport AS
       SELECT DISTINCT SystemAction.mgm_id
@@ -24,7 +31,7 @@ BEGIN
     ORDER BY SystemAction.mgm_id, SystemAction.action_id;
 
   ELSE
-    RAISE NOTICE 'The scheduler_id is already available in ActionsReport';
+    RAISE NOTICE 'The scheduled_by has already been removed from ActionsReport';
   END IF;
 END $$;
 

--- a/schema/reportdb/upgrade/uyuni-reportdb-schema-4.3.3-to-uyuni-reportdb-schema-4.3.4/004-fix-missing-views.sql
+++ b/schema/reportdb/upgrade/uyuni-reportdb-schema-4.3.3-to-uyuni-reportdb-schema-4.3.4/004-fix-missing-views.sql
@@ -1,0 +1,14 @@
+-- ChannelsReport view was missing in previous update files
+CREATE OR REPLACE VIEW ChannelsReport AS
+  SELECT Channel.mgm_id
+            , Channel.channel_id
+            , Channel.label AS channel_label
+            , Channel.name AS channel_name
+            , COUNT(ChannelPackage.channel_id) AS number_of_packages
+            , Channel.organization
+            , Channel.synced_date
+    FROM Channel
+            LEFT JOIN ChannelPackage ON ( Channel.mgm_id = ChannelPackage.mgm_id AND Channel.channel_id = ChannelPackage.channel_id )
+GROUP BY Channel.mgm_id, Channel.channel_id, Channel.label, Channel.name, Channel.organization, Channel.synced_date
+ORDER BY Channel.mgm_id, Channel.channel_id
+;

--- a/schema/reportdb/upgrade/uyuni-reportdb-schema-4.3.3-to-uyuni-reportdb-schema-4.3.4/004-fix-missing-views.sql
+++ b/schema/reportdb/upgrade/uyuni-reportdb-schema-4.3.3-to-uyuni-reportdb-schema-4.3.4/004-fix-missing-views.sql
@@ -1,4 +1,5 @@
 -- ChannelsReport view was missing in previous update files
+DROP VIEW IF EXISTS ChannelsReport;
 CREATE OR REPLACE VIEW ChannelsReport AS
   SELECT Channel.mgm_id
             , Channel.channel_id


### PR DESCRIPTION
## What does this PR change?

This PR adds additional update scripts for the reporting database. In fact, a previous update file was missing a view (`ChannelsReport`) and created a view with a wrong name (`SystemHistoryKickstartReport` instead of `SystemHistoryAutoinstallationReport`). This PR addresses that by taking into account the wrong name in the update and by adding the possibly missing view.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
