### PR TITLE
HTTP API final adjustments

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/servlets/AuthFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/AuthFilter.java
@@ -114,7 +114,8 @@ public class AuthFilter implements Filter {
 
             // Ignore requests to the download and login endpoints
             if (servletRequest.getServletPath().startsWith("/manager/download/") ||
-                    servletRequest.getServletPath().equals("/manager/api/login")) {
+                    servletRequest.getServletPath().equals("/manager/api/login") ||
+                    servletRequest.getServletPath().equals("/manager/api/auth/login")) {
                 chain.doFilter(request, response);
             }
             // Send 401 for unauthorized API requests and senna SPA requests, else redirect to login

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandler.java
@@ -237,6 +237,7 @@ public class AnsibleHandler extends BaseHandler {
      * @xmlrpc.returntype
      * $AnsiblePathSerializer
      */
+    @ReadOnly
     public AnsiblePath lookupAnsiblePathById(User loggedInUser, Integer pathId) {
         try {
             return AnsibleManager.lookupAnsiblePathById(pathId, loggedInUser)

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/configchannel/ConfigChannelHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/configchannel/ConfigChannelHandler.java
@@ -430,6 +430,7 @@ public class ConfigChannelHandler extends BaseHandler {
      *  $ConfigChannelSerializer
      * #array_end()
      */
+    @ReadOnly
     public List<ConfigChannel> lookupChannelInfo(User loggedInUser,
                                                     List<String> labels) {
         XmlRpcConfigChannelHelper helper = XmlRpcConfigChannelHelper.getInstance();
@@ -671,10 +672,8 @@ public class ConfigChannelHandler extends BaseHandler {
      * $ConfigRevisionSerializer
      * #array_end()
      */
-    public List<ConfigRevision> lookupFileInfo(User loggedInUser,
-                                                String channelLabel,
-                                                List<String> paths
-                                                ) {
+    @ReadOnly
+    public List<ConfigRevision> lookupFileInfo(User loggedInUser, String channelLabel, List<String> paths) {
         XmlRpcConfigChannelHelper configHelper = XmlRpcConfigChannelHelper.getInstance();
         ConfigChannel channel = configHelper.lookupGlobal(loggedInUser,
                                                                 channelLabel);
@@ -713,11 +712,8 @@ public class ConfigChannelHandler extends BaseHandler {
      * @xmlrpc.returntype
      * $ConfigRevisionSerializer
      */
-    public ConfigRevision lookupFileInfo(User loggedInUser,
-                                                String channelLabel,
-                                                String path,
-                                                Integer revision
-                                                ) {
+    @ReadOnly
+    public ConfigRevision lookupFileInfo(User loggedInUser, String channelLabel, String path, Integer revision) {
         XmlRpcConfigChannelHelper configHelper = XmlRpcConfigChannelHelper.getInstance();
         ConfigChannel channel = configHelper.lookupGlobal(loggedInUser,
                                                                 channelLabel);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
@@ -110,6 +110,7 @@ public class ContentManagementHandler extends BaseHandler {
      * @xmlrpc.param #param_desc("string", "label", "Content Project label")
      * @xmlrpc.returntype $ContentProjectSerializer
      */
+    @ReadOnly
     public ContentProject lookupProject(User loggedInUser, String label) {
         return ContentManager.lookupProject(label, loggedInUser)
                 .orElseThrow(() -> new EntityNotExistsFaultException(label));
@@ -246,6 +247,7 @@ public class ContentManagementHandler extends BaseHandler {
      * @xmlrpc.param #param_desc("string", "envLabel", "Content Environment label")
      * @xmlrpc.returntype $ContentEnvironmentSerializer
      */
+    @ReadOnly
     public ContentEnvironment lookupEnvironment(User loggedInUser, String projectLabel, String envLabel) {
         try {
             return ContentManager.lookupEnvironment(envLabel, projectLabel, loggedInUser)
@@ -402,6 +404,7 @@ public class ContentManagementHandler extends BaseHandler {
      * @xmlrpc.param #param_desc("string", "sourceLabel", "Project Source label")
      * @xmlrpc.returntype $ContentProjectSourceSerializer
      */
+    @ReadOnly
     public ProjectSource lookupSource(User loggedInUser, String projectLabel, String sourceType,
             String sourceLabel) {
         Type type = Type.lookupByLabel(sourceType);
@@ -537,6 +540,7 @@ public class ContentManagementHandler extends BaseHandler {
      * @xmlrpc.param #param_desc("int", "id", "Filter id")
      * @xmlrpc.returntype $ContentFilterSerializer
      */
+    @ReadOnly
     public ContentFilter lookupFilter(User loggedInUser, Integer id) {
         return ContentManager.lookupFilterById(id.longValue(), loggedInUser)
                 .orElseThrow(() -> new EntityNotExistsFaultException(id));

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/packages/search/PackagesSearchHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/packages/search/PackagesSearchHandler.java
@@ -34,6 +34,8 @@ import com.redhat.rhn.manager.channel.ChannelManager;
 import com.redhat.rhn.manager.session.SessionManager;
 import com.redhat.rhn.manager.token.ActivationKeyManager;
 
+import com.suse.manager.api.ReadOnly;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -75,6 +77,7 @@ public class PackagesSearchHandler extends BaseHandler {
      *   $PackageOverviewSerializer
      * #array_end()
      *  */
+    @ReadOnly
     public List<PackageOverview> name(String sessionKey, String name)
         throws FaultException {
         return performSearch(sessionKey, name, BaseSearchAction.OPT_NAME_ONLY);
@@ -98,6 +101,7 @@ public class PackagesSearchHandler extends BaseHandler {
      *   $PackageOverviewSerializer
      * #array_end()
      *  */
+    @ReadOnly
     public List<PackageOverview> nameAndDescription(String sessionKey, String query)
         throws FaultException {
         return performSearch(sessionKey, query, BaseSearchAction.OPT_NAME_AND_DESC);
@@ -121,6 +125,7 @@ public class PackagesSearchHandler extends BaseHandler {
      *   $PackageOverviewSerializer
      * #array_end()
      *  */
+    @ReadOnly
     public List<PackageOverview> nameAndSummary(String sessionKey, String query)
         throws FaultException {
         return performSearch(sessionKey, query, BaseSearchAction.OPT_NAME_AND_SUMMARY);
@@ -155,6 +160,7 @@ public class PackagesSearchHandler extends BaseHandler {
      *      $PackageOverviewSerializer
      *   #array_end()
      *  */
+    @ReadOnly
     public List<PackageOverview> advanced(String sessionKey, String luceneQuery)
         throws FaultException {
 
@@ -198,6 +204,7 @@ public class PackagesSearchHandler extends BaseHandler {
      *      $PackageOverviewSerializer
      *   #array_end()
      *  */
+    @ReadOnly
     public List<PackageOverview> advancedWithChannel(String sessionKey,
             String luceneQuery, String channelLabel) throws FaultException {
         if (StringUtils.isBlank(channelLabel)) {
@@ -262,6 +269,7 @@ public class PackagesSearchHandler extends BaseHandler {
      *      $PackageOverviewSerializer
      *   #array_end()
      *  */
+    @ReadOnly
     public List<PackageOverview> advancedWithActKey(String sessionKey,
             String luceneQuery, String actKey) throws FaultException {
         if (StringUtils.isBlank(actKey)) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringActionHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringActionHandler.java
@@ -100,6 +100,7 @@ public class RecurringActionHandler extends BaseHandler {
      * @xmlrpc.param #param_desc("int", "actionId", "Id of the action")
      * @xmlrpc.returntype $RecurringActionSerializer
      */
+    @ReadOnly
     public RecurringAction lookupById(User loggedInUser, Integer actionId) {
         RecurringAction action = RecurringActionFactory.lookupById(actionId).orElseThrow(
                 () -> new EntityNotExistsFaultException("Action with id: " + actionId + " does not exist")

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/ServerConfigHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/ServerConfigHandler.java
@@ -319,6 +319,7 @@ public class ServerConfigHandler extends BaseHandler {
      *          $ConfigRevisionSerializer
      *      #array_end()
      */
+    @ReadOnly
     public List<ConfigRevision> lookupFileInfo(User loggedInUser,
             Integer sid, List<String> paths, Boolean searchLocal) {
         Server server = xmlRpcSystemHelper.lookupServer(loggedInUser, sid);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/search/SystemSearchHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/search/SystemSearchHandler.java
@@ -22,6 +22,8 @@ import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
 import com.redhat.rhn.frontend.xmlrpc.SearchServerCommException;
 import com.redhat.rhn.frontend.xmlrpc.SearchServerQueryException;
 
+import com.suse.manager.api.ReadOnly;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -95,6 +97,7 @@ public class SystemSearchHandler extends BaseHandler {
      *         $SystemSearchResultSerializer
      *     #array_end()
      */
+    @ReadOnly
     public List<SystemSearchResult> ip(String sessionKey, String searchTerm) throws FaultException {
         return performSearch(sessionKey, searchTerm, SystemSearchHelper.IP);
     }
@@ -114,6 +117,7 @@ public class SystemSearchHandler extends BaseHandler {
      *         $SystemSearchResultSerializer
      *     #array_end()
      */
+    @ReadOnly
     public List<SystemSearchResult> hostname(String sessionKey, String searchTerm) throws FaultException {
         return performSearch(sessionKey, searchTerm, SystemSearchHelper.HOSTNAME);
     }
@@ -133,6 +137,7 @@ public class SystemSearchHandler extends BaseHandler {
      *         $SystemSearchResultSerializer
      *     #array_end()
      */
+    @ReadOnly
     public List<SystemSearchResult> deviceVendorId(String sessionKey, String searchTerm) throws FaultException {
         return performSearch(sessionKey, searchTerm, SystemSearchHelper.HW_VENDOR_ID);
     }
@@ -152,6 +157,7 @@ public class SystemSearchHandler extends BaseHandler {
      *         $SystemSearchResultSerializer
      *     #array_end()
      */
+    @ReadOnly
     public List<SystemSearchResult> deviceId(String sessionKey, String searchTerm) throws FaultException {
         return performSearch(sessionKey, searchTerm, SystemSearchHelper.HW_DEVICE_ID);
     }
@@ -171,6 +177,7 @@ public class SystemSearchHandler extends BaseHandler {
      *         $SystemSearchResultSerializer
      *     #array_end()
      */
+    @ReadOnly
     public List<SystemSearchResult> deviceDriver(String sessionKey, String searchTerm) throws FaultException {
         return performSearch(sessionKey, searchTerm, SystemSearchHelper.HW_DRIVER);
     }
@@ -190,6 +197,7 @@ public class SystemSearchHandler extends BaseHandler {
      *         $SystemSearchResultSerializer
      *     #array_end()
      */
+    @ReadOnly
     public List<SystemSearchResult> deviceDescription(String sessionKey, String searchTerm) throws FaultException {
         return performSearch(sessionKey, searchTerm, SystemSearchHelper.HW_DESCRIPTION);
     }
@@ -209,6 +217,7 @@ public class SystemSearchHandler extends BaseHandler {
      *         $SystemSearchResultSerializer
      *     #array_end()
      */
+    @ReadOnly
     public List<SystemSearchResult> nameAndDescription(String sessionKey, String searchTerm) throws FaultException {
         return performSearch(sessionKey, searchTerm, SystemSearchHelper.NAME_AND_DESCRIPTION);
     }
@@ -228,6 +237,7 @@ public class SystemSearchHandler extends BaseHandler {
      *         $SystemSearchResultSerializer
      *     #array_end()
      */
+    @ReadOnly
     public List<SystemSearchResult> uuid(String sessionKey, String searchTerm) throws FaultException {
         return performSearch(sessionKey, searchTerm, SystemSearchHelper.UUID);
     }

--- a/java/code/src/com/suse/manager/webui/controllers/login/LoginController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/login/LoginController.java
@@ -67,6 +67,7 @@ public class LoginController {
     public static void initRoutes(JadeTemplateEngine jade) {
         get("/manager/login", withCsrfToken(LoginController::loginView), jade);
         post("/manager/api/login", LoginController::login);
+        // TODO: Use this endpoint with the "Logout" button
         get("/manager/api/logout", withUser(LoginController::logout));
     }
 


### PR DESCRIPTION
This PR addresses a couple of final issues with the HTTP API

- Move `login` and `logout` into `auth` namespace to be parallel with XMLRPC
- Make some endpoints read-only appropriately

## Test coverage
- No tests: already covered

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
