### PR TITLE
Set the classpath for running SchemaSpy depending on the Posgresql jdb driver version

### DIFF
--- a/susemanager-utils/testing/docker/scripts/generate-reportdb-docs.sh
+++ b/susemanager-utils/testing/docker/scripts/generate-reportdb-docs.sh
@@ -15,9 +15,9 @@
 # in this software or its documentation.
 #
 set -e
-SCRIPT=$(basename $0)
+SCRIPT=$(basename "$0")
 
-if [ -z $1 ];then
+if [ -z "$1" ];then
     echo "Missing parameters"
     echo "Usage: $SCRIPT brand_name"
 fi
@@ -28,23 +28,23 @@ if [ "$BRAND_NAME" == "unittest" ];then
     echo "Running just unit test"
 fi
 
-echo Using branding $BRAND_NAME
+echo "Using branding $BRAND_NAME"
 
 cd /manager/susemanager-utils/testing/docker/scripts/
 
 # Move Postgres database to tmpfs to speed initialization and testing up
-if [ ! -z $PG_TMPFS_DIR ]; then
+if [ -n "$PG_TMPFS_DIR" ]; then
     trap "umount $PG_TMPFS_DIR" EXIT INT TERM
-    ./docker-testing-pgsql-move-data-to-tmpfs.sh $PG_TMPFS_DIR
+    ./docker-testing-pgsql-move-data-to-tmpfs.sh "$PG_TMPFS_DIR"
 fi
 
-echo Going to reset pgsql database
+echo "Going to reset pgsql database"
 
 export PERLLIB=/manager/spacewalk/setup/lib/:/manager/web/modules/rhn/:/manager/web/modules/pxt/:/manager/schema/spacewalk/lib
 export PATH=/manager/schema/spacewalk/:/manager/spacewalk/setup/bin/:$PATH
 
 export SYSTEMD_NO_WRAP=1
-#sysctl -w kernel.shmmax=18446744073709551615
+
 su - postgres -c "/usr/lib/postgresql/bin/pg_ctl stop" ||:
 su - postgres -c "/usr/lib/postgresql/bin/pg_ctl start" ||:
 
@@ -55,26 +55,26 @@ pushd /tmp/schema/reportdb
 RPM_VERSION=$(rpm -q --qf "%{version}\n" --specfile uyuni-reportdb-schema.spec | head -n 1)
 NEXT_VERSION=$(echo "$RPM_VERSION" | awk '{ pre=post=$0; gsub("[0-9]+$","",pre); gsub(".*\\.","",post); print pre post+1 ; }')
 
-if [ -d upgrade/uyuni-reportdb-schema-$RPM_VERSION-to-uyuni-reportdb-schema-$NEXT_VERSION ]; then
+if [ -d "upgrade/uyuni-reportdb-schema-$RPM_VERSION-to-uyuni-reportdb-schema-$NEXT_VERSION" ]; then
     DB_VERSION=$NEXT_VERSION
 else
     DB_VERSION=$RPM_VERSION
 fi
 
 # Create the schema files
-echo Creating schema creation file
+echo "Creating schema creation file"
 make -s -f Makefile.schema SCHEMA=uyuni-reportdb-schema VERSION="$DB_VERSION" RELEASE=testing BRAND_NAME="$BRAND_NAME"
 # Create the documentation addons
-echo Creating schema documentation
+echo "Creating schema documentation"
 make -s -f Makefile.schema docs
 
 # Unit test for checking if reportdb schema and doc are aligned
 SCHEMA_DIFF=$(./check_reportdb_doc)
 popd
 
-if [ ! -z $SCHEMA_DIFF ]; then
+if [ -n "$SCHEMA_DIFF" ]; then
         echo "ReportDB schema and doc are misaligned"
-        echo $SCHEMA_DIFF
+        echo "$SCHEMA_DIFF"
         exit 1
 fi
 echo "ReportDB schema and doc are aligned"
@@ -99,21 +99,21 @@ CONFIG_FILE=/root/reportdb-docs.properties
 
 OUTPUT_FILE=reportdb-schema-docs.tar.xz
 if [ -f $OUTPUT_FILE ]; then
-    echo Removing previous generated tarball
+    echo "Removing previous generated tarball $OUTPUT_FILE"
     rm -f $OUTPUT_FILE
 fi
 
-OUTPUT_DIR=$(cat $CONFIG_FILE | grep schemaspy.o | cut -c 13-)
-if [ -d $OUTPUT_DIR ]; then
-    echo Removing previous generated docs at $OUTPUT_DIR
-    rm -rf $OUTPUT_DIR
+OUTPUT_DIR=$(grep schemaspy.o $CONFIG_FILE | cut -c 13-)
+if [ -d "$OUTPUT_DIR" ]; then
+    echo "Removing previous generated docs at $OUTPUT_DIR"
+    rm -rf "$OUTPUT_DIR"
 fi
 
 SCHEMASPY_REPO=mackdk/schemaspy
 SCHEMASPY_VERSION=6.1.1
 SCHEMASPY_JAR=/root/schemaspy.jar
 if [ ! -f $SCHEMASPY_JAR ]; then
-    echo Retrieving SchemaSpy version $SCHEMASPY_VERSION
+    echo "Retrieving SchemaSpy version $SCHEMASPY_VERSION"
     wget -q --show-progress "https://github.com/$SCHEMASPY_REPO/releases/download/v$SCHEMASPY_VERSION/schemaspy-$SCHEMASPY_VERSION.jar" -O $SCHEMASPY_JAR
 fi
 
@@ -127,13 +127,13 @@ fi
 
 java -jar $SCHEMASPY_JAR -configFile $CONFIG_FILE -dp "$DRIVER_PATH" -label "$BRAND_NAME Reporting"
 
-CSS_FILE=$(cat $CONFIG_FILE | grep schemaspy.css | cut -c 15-)
-if [ -n $CSS_FILE ] && [ -f $CSS_FILE ]; then
-    echo Copying CSS file $CSS_FILE
-    cp $CSS_FILE out/schemaSpy.css
+CSS_FILE=$(grep schemaspy.css $CONFIG_FILE | cut -c 15-)
+if [ -n "$CSS_FILE" ] && [ -f "$CSS_FILE" ]; then
+    echo "Copying CSS file $CSS_FILE"
+    cp "$CSS_FILE" out/schemaSpy.css
 fi
 
-echo Building docs distribution tarball
+echo "Building docs distribution tarball $OUTPUT_FILE"
 tar cJf $OUTPUT_FILE out/ --transform s/out/reportdb-schema/
 
-rm -rf $OUTPUT_DIR
+rm -rf "$OUTPUT_DIR"


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue that prevents the documentation tool to run correctly with the latest version of the jdbc postgresql driver. This version needs an additional classpath entry for ongres. The first commit sets the classpath dynamically based on the version of the postgresql-jdbc driver package installed inside the docker container. The seconds adds some minor code cleanup based on the suggestion of shellcheck.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: no code change

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
