### PR TITLE
store credentials when generating a new password

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -3880,6 +3880,7 @@ public class SystemManager extends BaseManager {
                         Credentials.TYPE_REPORT_CREDS, null));
         if (forcePwChange) {
             credentials.setPassword(RandomStringUtils.random(24, 0, 0, true, true, null, new SecureRandom()));
+            CredentialsFactory.storeCredentials(credentials);
         }
         mgrServerInfo.setReportDbCredentials(credentials);
         Map<String, Object> pillar = new HashMap<>();


### PR DESCRIPTION
## What does this PR change?

Store credentials correctly by calling store function.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
