### PR TITLE
HTTP API polishing

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -177,9 +177,9 @@ def get_client_type(name)
 end
 
 def repository_exist?(repo)
-  $api_test.login('admin', 'admin')
-  repo_list = $api_test.channel_software_repository_list_user_repos
-  $api_test.logout
+  $api_test.auth.login('admin', 'admin')
+  repo_list = $api_test.channel.software.list_user_repos
+  $api_test.auth.logout
   repo_list.include? repo
 end
 

--- a/testsuite/features/support/http_client.rb
+++ b/testsuite/features/support/http_client.rb
@@ -13,7 +13,9 @@ class HttpClient
   def prepare_call(name, params)
     short_name = name.split('.')[-1]
     call_type =
-      if short_name.start_with?('list', 'get', 'is', 'find') || ['logout', 'errata.applicableToChannels'].include?(name)
+      if short_name.start_with?('list', 'get', 'is', 'find') ||
+         name.start_with?('system.search.', 'packages.search.') ||
+         ['auth.logout', 'errata.applicableToChannels'].include?(name)
         'GET'
       else
         'POST'
@@ -32,8 +34,6 @@ class HttpClient
   end
 
   def call(name, params)
-    name.sub!('auth.', '') if ['auth.login', 'auth.logout'].include?(name)
-
     # Get session cookie from previous calls
     if params.nil?
       session_cookie = nil
@@ -63,7 +63,7 @@ class HttpClient
     end
 
     # Return either new session cookie or HTTP body
-    if name == 'login'
+    if name == 'auth.login'
       session_cookie = ''
       cookies = answer.headers['Set-cookie']
       cookies.split(',').each do |cookie|


### PR DESCRIPTION
## What does this PR change?

* Can fixed missing `auth` namespace, this PR removes the corresponding workarounds
* Can moved some more methods from POST to GET, this PR accomodates for it
* I forgot to use `channel.software` namespace in a call used for Build Validation, this PR fixes that

**TO BE MERGED ONLY ON 2022-04-30 AS CAN'S MODIFICATIONS ARE NOT YET ON REBUILT PACKAGES**


## Links

Ports:
* 4.1: SUSE/spacewalk#17676
* 4.2: SUSE/spacewalk#17678


## Changelogs

- [x] No changelog needed
