### PR TITLE
Fix react-select XPath selector

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -173,7 +173,7 @@ end
 
 When(/^I select "([^"]*)" from "([^"]*)"$/) do |option, field|
   xpath_option = ".//*[contains(@class, 'data-testid-#{field}-child__option') and contains(text(),'#{option}')]"
-  xpath_field = "//*[contains(@class, 'data-testid-#{field}-child__control')]/../*[@name='#{field}']/.."
+  xpath_field = "//*[contains(@class, 'data-testid-#{field}-child__control')]"
   if has_select?(field, with_options: [option], wait: 1)
     select(option, from: field)
   else


### PR DESCRIPTION
Fix failing react-select XPath selector as followup to https://github.com/uyuni-project/uyuni/pull/5078

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
