### PR TITLE
Deploy the formula so all fields are shown

### DIFF
--- a/testsuite/features/build_validation/init_clients/proxy.feature
+++ b/testsuite/features/build_validation/init_clients/proxy.feature
@@ -88,6 +88,7 @@ Feature: Setup SUSE Manager proxy
 @private_net
   Scenario: Parametrize the branch network
     When I follow first "Branch Network" in the content area
+    And I click on "Expand All Sections"
     And I uncheck enable route box
     And I uncheck enable NAT box
     And I click on "Save Formula"


### PR DESCRIPTION
## What does this PR change?

BV: the routing checbox cannot be accessed if the branch network formula is collapsed. Now it's the default due to SUSE/spacewalk#17148. This PR fixes that by expanding the formula.


## Links

Ports:
* 4.1: SUSE/spacewalk#17683
* 4.2: SUSE/spacewalk#17684


## Changelogs

- [x] No changelog needed
