### PR TITLE
Fix ubuntu errata package version selection

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
@@ -549,7 +549,8 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                       rhnPackageArch pa,
                       rhnPackageEVR pevr,
                       rhnPackageEVR spevr,
-                      rhnPackageName pn
+                      rhnPackageName pn,
+                      rhnChannelPackage pc
                  WHERE e.id in (:errataIds) AND
                       sc.server_id in (:serverIds) AND
                       e.id = ce.errata_id AND
@@ -563,7 +564,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                       pevr.evr > spevr.evr AND
                       p.package_arch_id = sp.package_arch_id AND
                       p.package_arch_id = pa.id AND
-                      p.name_id = pn.id
+                      p.name_id = pn.id AND
+                      pc.package_id = p.id AND
+                      pc.channel_id = sc.channel_id
                  GROUP BY sc.server_id, pn.name, pa.label) X]]>
     </sql-query>
 

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -1248,25 +1248,31 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
         baseChan.addErrata(e1);
         e1.getPackages().add(p1v2);
         e1.getPackages().add(p2v4);
+        baseChan.getPackages().add(p1v2);
+        baseChan.getPackages().add(p2v4);
 
         Errata e2 = ErrataFactoryTest.createTestErrata(user.getId());
         errataIds.add(e2.getId());
         baseChan.addErrata(e2);
         e2.getPackages().add(p1v3);
+        baseChan.getPackages().add(p1v3);
 
         Errata e3 = ErrataFactoryTest.createTestErrata(user.getId());
         errataIds.add(e3.getId());
         baseChan.addErrata(e3);
         e3.getPackages().add(p1v3arch2);
+        baseChan.getPackages().add(p1v3arch2);
 
         Errata e4 = ErrataFactoryTest.createTestErrata(user.getId());
         errataIds.add(e4.getId());
         childChan.addErrata(e4);
         e4.getPackages().add(p1v2);
+        childChan.getPackages().add(p1v2);
 
         Errata e5 = ErrataFactoryTest.createTestErrata(user.getId());
         childChan.addErrata(e4);
         e4.getPackages().add(p1v4);
+        childChan.getPackages().add(p1v4);
 
         ChannelFactory.save(baseChan);
         ChannelFactory.save(childChan);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix package selection for ubuntu errata install (bsc#1199049)
 - Add script examples for HTTP API
 - Refactor API docs for HTTP API
 - Branding updates


### PR DESCRIPTION
## What does this PR change?

Previously ubuntu errata installation would always try to install the latest package version even if that package is not available in the systems assigned channels. This fixes that by only considering packages from assigned channels.

## GUI diff

No difference.


- [ ] **DONE**

## Documentation
- No documentation needed

- [ ] **DONE**

## Test coverage
- No tests

- [ ] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/5023


- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
