### PR TITLE
prevent NPE when queueRun is not set due to errors

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/threaded/TaskQueue.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/threaded/TaskQueue.java
@@ -147,9 +147,14 @@ public class TaskQueue {
 
         if (isTaskQueueDone()) {
             // everything done
-            queueDriver.getLogger().debug("Finishing run {}", queueRun.getId());
-            queueRun.finished();
-            queueRun.saveStatus(TaskoRun.STATUS_FINISHED);
+            if (queueRun != null) {
+                queueDriver.getLogger().debug("Finishing run {}", queueRun.getId());
+                queueRun.finished();
+                queueRun.saveStatus(TaskoRun.STATUS_FINISHED);
+            }
+            else {
+                queueDriver.getLogger().debug("Finishing Task Queue");
+            }
             HibernateFactory.commitTransaction();
             HibernateFactory.closeSession();
             changeRun(null);


### PR DESCRIPTION
## What does this PR change?

Get an NPE when a hub reporting task cannot reach the reportdb to sync. E.g. due to SSL certificate exception

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **min**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
