### PR TITLE
Use container_images_path macro for proxy container images

### DIFF
--- a/containers/proxy-systemd-services/uyuni-proxy-systemd-services.changes
+++ b/containers/proxy-systemd-services/uyuni-proxy-systemd-services.changes
@@ -1,3 +1,5 @@
+- Default to SUSE Manager images only when installed from SUSE Manager
+
 -------------------------------------------------------------------
 Fri Apr 08 13:39:38 CEST 2022 - jgonzalez@suse.com
 

--- a/containers/proxy-systemd-services/uyuni-proxy-systemd-services.spec
+++ b/containers/proxy-systemd-services/uyuni-proxy-systemd-services.spec
@@ -49,9 +49,12 @@ install -d -m 755 %{buildroot}/%{_localstatedir}/lib/uyuni/proxy-rhn-cache
 install -d -m 755 %{buildroot}/%{_localstatedir}/lib/uyuni/proxy-tftpboot
 install -d -m 755 %{buildroot}%{_sbindir}
 
+%if "%{?container_images_path}" != ""
+sed 's|^NAMESPACE=.*$|NAMESPACE=%{container_images_path}|' -i uyuni-proxy-services.config
+%endif
+
 %if !0%{?is_opensuse}
 PRODUCT_VERSION=$(echo %{version} | sed 's/^\([0-9]\+\.[0-9]\+\).*$/\1/')
-sed "s/^NAMESPACE=.*$/NAMESPACE=registry.suse.com\/suse\/manager\/${PRODUCT_VERSION}/" -i uyuni-proxy-services.config
 %endif
 %if 0%{?rhel}
 install -D -m 644 uyuni-proxy-services.config %{buildroot}%{_sysconfdir}/sysconfig/uyuni-proxy-systemd-services.config


### PR DESCRIPTION
## What does this PR change?

Choosing the proxy images to use depending on the system OS doesn'work
since those need to depend from the server that is used.

In order to fix this, allow setting the containers_image_path variable
in the project settings like so:

    Macros:
    %container_images_path registry.suse.com/suse/manager/4.3
    :Macros

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: under construction

- [X] **DONE**

## Links

Fixes #5330 

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
