### PR TITLE
Typo in parameter name

### DIFF
--- a/testsuite/features/support/namespaces/system.rb
+++ b/testsuite/features/support/namespaces/system.rb
@@ -97,7 +97,7 @@ class NamespaceSystemConfig
   end
 
   def remove_channels(servers, channels)
-    @test.call('system.config.removeChannels', sessionKey: @test.token, sid: servers, configChannelLabels: channels)
+    @test.call('system.config.removeChannels', sessionKey: @test.token, sids: servers, configChannelLabels: channels)
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes a typo in previous PR #5334


## Links

Ports:
* 4.1: SUSE/spacewalk#17688
* 4.2: SUSE/spacewalk#17686


## Changelogs

- [x] No changelog needed
