### PR TITLE
move reportdb schema docs in en subdirectory and add item at About as well

### DIFF
--- a/java/code/src/com/suse/manager/webui/menu/MenuTree.java
+++ b/java/code/src/com/suse/manager/webui/menu/MenuTree.java
@@ -487,7 +487,7 @@ public class MenuTree {
                     .addChild(new MenuItem("Sample Scripts").withPrimaryUrl("/rhn/apidoc/scripts.jsp"))
             )
             .addChild(new MenuItem("Report Database Schema").withTarget("_blank")
-                    .withPrimaryUrl("/docs/reportdb-schema/index.html")
+                    .withPrimaryUrl("/docs/en/reportdb-schema/index.html")
             );
     }
 
@@ -511,6 +511,9 @@ public class MenuTree {
                             .withDir("/rhn/apidoc"))
                     .addChild(new MenuItem("FAQ").withPrimaryUrl("/rhn/apidoc/faqs.jsp"))
                     .addChild(new MenuItem("Sample Scripts").withPrimaryUrl("/rhn/apidoc/scripts.jsp"))
+            )
+            .addChild(new MenuItem("Report Database Schema").withTarget("_blank")
+                    .withPrimaryUrl("/docs/en/reportdb-schema/index.html")
             );
     }
 


### PR DESCRIPTION
## What does this PR change?

Move reportdb schema docs into en sub directory to prevent it gets detected as language.
Additionally add that menu item also for not logged-in users under "About" item.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
