### PR TITLE
Fixes for report files

### DIFF
--- a/reporting/reports/data/channel-packages
+++ b/reporting/reports/data/channel-packages
@@ -36,4 +36,4 @@ sql:
         FROM ChannelPackagesReport
   ) X
   -- where placeholder
-  ORDER BY mgm_id, channel_label
+  ORDER BY mgm_id, channel_label, name, version, release, epoch, arch

--- a/reporting/reports/data/channel-packages
+++ b/reporting/reports/data/channel-packages
@@ -26,11 +26,11 @@ sql:
       SELECT mgm_id
                 , channel_label
                 , channel_name
-                , package_name AS name
-                , package_version AS version
-                , package_release AS release
-                , package_epoch AS epoch
-                , package_arch AS arch
+                , name
+                , version
+                , release
+                , epoch
+                , arch
                 , full_package_name
                 , synced_date
         FROM ChannelPackagesReport

--- a/reporting/reports/data/channels
+++ b/reporting/reports/data/channels
@@ -30,4 +30,4 @@ sql:
         FROM ChannelsReport
   ) X
   -- where placeholder
-  ORDER BY mgm_id, channel_id
+  ORDER BY mgm_id, channel_label

--- a/reporting/reports/data/custom-channels
+++ b/reporting/reports/data/custom-channels
@@ -40,4 +40,4 @@ sql:
         FROM CustomChannelsReport
   ) X
   -- where placeholder
-  ORDER BY mgm_id, channel_id
+  ORDER BY mgm_id, channel_label

--- a/reporting/reports/data/custom-info
+++ b/reporting/reports/data/custom-info
@@ -11,8 +11,8 @@ columns:
 
   mgm_id The id of the management server instance that contains this data
   system_id The id of the system
-  system_name The unique descriptive name of the system
   organization The organization that owns this data
+  system_name The unique descriptive name of the system
   key The name of the custom information
   value The value of the custom information
   synced_date The timestamp of when this data was last refreshed.

--- a/reporting/reports/data/errata-channels
+++ b/reporting/reports/data/errata-channels
@@ -24,4 +24,4 @@ sql:
         FROM ErrataChannelsReport
   ) X
   -- where placeholder
-  ORDER BY mgm_id, channel_label, advisory
+  ORDER BY mgm_id, advisory, channel_label

--- a/reporting/reports/data/inventory
+++ b/reporting/reports/data/inventory
@@ -14,17 +14,17 @@ columns:
   profile_name The unique descriptive name of the system
   hostname The hostname that identifies this system
   ip_address The IPv4 address of the primary network interface of the system
-  ip6_addresses The list of IPv6 addresses and their scopes of the primary network interface of the system, separated by ;
+  ipv6_address The list of IPv6 addresses and their scopes of the primary network interface of the system, separated by ;
   registered_by The user account who onboarded this system
   registration_time When this system was onboarded
   last_checkin_time When this system was visible and reachable last time
   kernel_version The version of the kernel installed on this system
   packages_out_of_date The number of packages installed on the system that can be updated
   errata_out_of_date The number of patches that can be applied to the system
-  software_channels THe list of software channels the system is subscribed to, separated by ;
-  configuration_channels The list of configuration channels the system is subscribed to, separated by ;
+  software_channel THe list of software channels the system is subscribed to, separated by ;
+  configuration_channel The list of configuration channels the system is subscribed to, separated by ;
   entitlements The list of entitlements of the system, separated by ;
-  system_groups The list of groups of the system, separated by ;
+  system_group The list of groups of the system, separated by ;
   organization The organization that owns this data
   virtual_host The id of the host of the system, if any
   architecture The architecture of the system

--- a/reporting/reports/data/proxies-overview
+++ b/reporting/reports/data/proxies-overview
@@ -28,4 +28,4 @@ sql:
         FROM ProxyOverviewReport
   ) X
   -- where placeholder
-  ORDER BY mgm_id, proxy_id, system_id
+  ORDER BY mgm_id, proxy_name, system_name

--- a/reporting/reports/data/scap-scan
+++ b/reporting/reports/data/scap-scan
@@ -56,4 +56,4 @@ sql:
         FROM ScapScanReport
   ) X
   -- where placeholder
-  ORDER BY mgm_id, testresult_id, system_id
+  ORDER BY mgm_id, system_id, event_id

--- a/reporting/reports/data/scap-scan-results
+++ b/reporting/reports/data/scap-scan-results
@@ -34,4 +34,4 @@ sql:
         FROM ScapScanResultReport
   ) X
   -- where placeholder
-  ORDER BY mgm_id, testresult_id, ruleresult_id
+  ORDER BY mgm_id, testresult_id, ruleresult_id, system, system_id, ident

--- a/reporting/reports/data/system-extra-packages
+++ b/reporting/reports/data/system-extra-packages
@@ -36,4 +36,4 @@ sql:
         FROM SystemExtraPackagesReport
   ) X
   -- where placeholder
-  ORDER BY mgm_id, system_id, package_name
+  ORDER BY mgm_id, system_name, system_id, package_name

--- a/reporting/reports/data/system-history-configuration
+++ b/reporting/reports/data/system-history-configuration
@@ -11,7 +11,7 @@ columns:
 
   mgm_id The id of the management server instance that contains this data
   system_id The id of the system
-  event_id The id of the action
+  event_id The id of the history event
   earliest_action The earliest time this action was schedule for execution
   pickup_date When this action was picked up for execution
   completed_date When this action was completed

--- a/reporting/reports/data/system-history-errata
+++ b/reporting/reports/data/system-history-errata
@@ -11,7 +11,7 @@ columns:
 
   mgm_id The id of the management server instance that contains this data
   system_id The id of the system
-  action_id The id of the action
+  event_id The id of the history event
   earliest_action The earliest time this action was schedule for execution
   pickup_date When this action was picked up for execution
   completed_date When this action was completed

--- a/reporting/reports/data/system-history-kickstart
+++ b/reporting/reports/data/system-history-kickstart
@@ -11,7 +11,7 @@ columns:
 
   mgm_id The id of the management server instance that contains this data
   system_id The id of the system
-  action_id The id of the action
+  event_id The id of the history event
   earliest_action The earliest time this action was schedule for execution
   pickup_date When this action was picked up for execution
   completed_date When this action was completed

--- a/reporting/reports/data/system-history-packages
+++ b/reporting/reports/data/system-history-packages
@@ -11,7 +11,7 @@ columns:
 
   mgm_id The id of the management server instance that contains this data
   system_id The id of the system
-  action_id The id of the action
+  event_id The id of the history event
   earliest_action The earliest time this action was schedule for execution
   pickup_date When this action was picked up for execution
   completed_date When this action was completed

--- a/reporting/reports/data/system-history-scap
+++ b/reporting/reports/data/system-history-scap
@@ -11,7 +11,7 @@ columns:
 
   mgm_id The id of the management server instance that contains this data
   system_id The id of the system
-  event_id The id of the action
+  event_id The id of the history event
   earliest_action The earliest time this action was schedule for execution
   pickup_date When this action was picked up for execution
   completed_date When this action was completed

--- a/reporting/reports/data/users
+++ b/reporting/reports/data/users
@@ -17,7 +17,7 @@ columns:
   first_name The person first name(s)
   position The descriptive role of this user within the organization
   email The email address associated with this account
-  roles List of roles assigned to the user, separated by ;
+  role List of roles assigned to the user, separated by ;
   creation_time When this user account was created
   last_login_time When this user account logged in for the last time
   active Current status of the user. Possible values: enabled, disabled

--- a/reporting/reports/data/users-md5
+++ b/reporting/reports/data/users-md5
@@ -17,7 +17,7 @@ columns:
   first_name The person first name(s)
   position The descriptive role of this user within the organization
   email The email address associated with this account
-  roles List of roles assigned to the user, separated by ;
+  role List of roles assigned to the user, separated by ;
   creation_time When this user account was created
   last_login_time When this user account logged in for the last time
   active Current status of the user. Possible values: enabled, disabled

--- a/reporting/reports/data/users-systems
+++ b/reporting/reports/data/users-systems
@@ -30,7 +30,6 @@ sql:
                 , is_admin AS admin_access
                 , synced_date
         FROM AccountsSystemsReport
-       WHERE md5_encryption
   ) X
   -- where placeholder
   ORDER BY mgm_id, user_id, system_id

--- a/reporting/reports/data/users-systems
+++ b/reporting/reports/data/users-systems
@@ -32,4 +32,4 @@ sql:
         FROM AccountsSystemsReport
   ) X
   -- where placeholder
-  ORDER BY mgm_id, user_id, system_id
+  ORDER BY mgm_id, organization, user_id, system_id


### PR DESCRIPTION
## What does this PR change?

This PR fixes some wrong column names that prevent the affected report from being generated. It also improves the backward compatibility by matching the sorting of the old report version, when possible

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
