### PR TITLE
declare /manager directory as save

### DIFF
--- a/susemanager-utils/testing/docker/scripts/push-to-obs.sh
+++ b/susemanager-utils/testing/docker/scripts/push-to-obs.sh
@@ -57,6 +57,9 @@ if [ ! -f ${OSCRC} ]; then
   exit 1
 fi
 
+# declare /manager as "save"
+git config --global --add safe.directory /manager
+
 cd ${REL_ENG_FOLDER}
 
 # If we have more than one destinations, keep SRPMS so we don't


### PR DESCRIPTION
## What does this PR change?

With new git 2.35.2 and higher permissions of the git repos are checked.
This is a problem when the git repo comes from a mounted directory in a docker container.
In this case we need to declare that directory as "save", otherwise git fail with:

```
fatal: unsafe repository ('/manager' is owned by someone else)
To add an exception for this directory, call:

        git config --global --add safe.directory /manager
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
