### PR TITLE
Cosmetic fix for the default email used at rhn_web.conf

### DIFF
--- a/web/conf/rhn_web.conf
+++ b/web/conf/rhn_web.conf
@@ -78,7 +78,7 @@ web.buildtimestamp = _OBS_BUILD_TIMESTAMP_
 web.maximum_config_file_size = 131072
 
 # email address to send satellite emails from
-web.default_mail_from = Spacewalk <dev-null@localhost>
+web.default_mail_from = Uyuni <dev-null@localhost>
 
 # server configs needed for satellite installer
 server.satellite.http_proxy =


### PR DESCRIPTION
## What does this PR change?

Cosmetic fix for the default email used at rhn_web.conf

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Cosmetic fix.

- [x] **DONE**

## Test coverage
- No tests: I think this default value is not even used, as I think we instead always use the one from the YaST setup.

- [x] **DONE**

## Links

Nothing

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
