### PR TITLE
Fix log file name for legacy Kiwi (bsc#1199094)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
+++ b/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
@@ -109,14 +109,14 @@ mgr_kiwi_clear_cache:
 
 mgr_buildimage_kiwi_prepare:
   cmd.run:
-    - name: "{{ kiwi }} --nocolor --force-new-root --prepare {{ source_dir }} --root {{ chroot_dir }} {{ kiwi_params() }}"
+    - name: "{{ kiwi }} --logfile {{ root_dir }}/build.log --nocolor --force-new-root --prepare {{ source_dir }} --root {{ chroot_dir }} {{ kiwi_params() }}"
     - require:
       - mgrcompat: mgr_buildimage_prepare_source
       - file: mgr_buildimage_prepare_activation_key_in_source
 
 mgr_buildimage_kiwi_create:
   cmd.run:
-    - name: "{{ kiwi }} --nocolor --yes --create {{ chroot_dir }} --dest {{ dest_dir }} {{ kiwi_params() }}"
+    - name: "{{ kiwi }} --logfile {{ root_dir }}/build.log --nocolor --yes --create {{ chroot_dir }} --dest {{ dest_dir }} {{ kiwi_params() }}"
     - require:
       - cmd: mgr_buildimage_kiwi_prepare
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix log file name for legacy Kiwi (bsc#1199094)
 - Collect logs from docker.build
 - add packages.pkgupdate state (bsc#1197507)
 - Uninstall the products with no successors after migration


### PR DESCRIPTION
## What does this PR change?

Legacy Kiwi used incorrect log file name, so cp.push failed.
This adds an option with the correct name.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: bugfix
- [x] **DONE**

## Test coverage
- covered by openqa tests (which are not yet fully configured for 4.3)

## Links

https://bugzilla.suse.com/show_bug.cgi?id=1199094

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
