### PR TITLE
speedup system_available_packages query

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
@@ -804,46 +804,41 @@ SELECT P.id, P.summary, PP.name as provider
 
 <mode name="system_available_packages"  class="com.redhat.rhn.frontend.dto.PackageListItem">
   <query params="sid">
-    SELECT
-      rp.id AS package_id,
-      pn.name || '-' || evr_t_as_vre_simple(latest.evr) AS NVRE,
-      latest.arch_label as arch,
-      pn.id || '|' || rp.evr_id || '|' || latest.arch_id AS ID_COMBO
-    FROM
-      (
-            SELECT
-              p.name_id AS name_id,
-              max(pe.evr) AS evr,
-              pa.label AS arch_label,
-              pa.id AS arch_id
-            FROM
-              rhnPackageEVR PE
-                JOIN rhnPackage p ON p.evr_id = pe.id
-                JOIN rhnChannelPackage cp ON cp.package_id = p.id
-                JOIN rhnServerChannel sc ON sc.channel_id = cp.channel_id
-                JOIN rhnPackageArch pa ON pa.id = p.package_arch_id
-            WHERE
-              sc.server_id = :sid
-              AND NOT EXISTS (SELECT 1 FROM suseServerChannelsRetractedPackagesView WHERE sid = :sid AND pid = p.id)
-            GROUP BY
-              p.name_id,
-              pa.label,
-              pa.id
-          ) latest
-            JOIN rhnPackageName pn ON pn.id = latest.name_id
-            JOIN rhnPackage rp ON rp.name_id = latest.name_id
-            AND rp.evr_id =  lookup_evr((latest.evr).epoch, (latest.evr).version, (latest.evr).release, (latest.evr).type)
-            AND rp.package_arch_id = latest.arch_id
-            JOIN rhnChannelPackage rcp ON rcp.package_id = rp.id
-            JOIN rhnServerChannel rsc ON rsc.channel_id = rcp.channel_id
-        WHERE NOT EXISTS (
-          SELECT 1
-          FROM rhnServerPackage SP
-          WHERE SP.server_id = :sid
-            AND SP.name_id = latest.name_id
-            AND (SP.package_arch_id = latest.arch_id OR SP.package_arch_id IS NULL)
-        )
-        AND rsc.server_id = :sid
+SELECT rp.id AS package_id,
+       pn.name || '-' || evr_t_as_vre_simple(latest.evr) AS NVRE,
+       latest.arch_label as arch,
+       pn.id || '|' || rp.evr_id || '|' || latest.arch_id AS ID_COMBO
+  FROM (
+         SELECT p.name_id AS name_id,
+                max(pe.evr) AS evr,
+                pa.label AS arch_label,
+                pa.id AS arch_id
+           FROM
+                rhnPackageEVR PE
+           JOIN rhnPackage p ON p.evr_id = pe.id
+           JOIN rhnChannelNewestPackage cp ON cp.package_id = p.id
+           JOIN rhnServerChannel sc ON sc.channel_id = cp.channel_id
+           JOIN rhnPackageArch pa ON pa.id = p.package_arch_id
+          WHERE
+                sc.server_id = :sid
+            AND NOT EXISTS (
+                 SELECT 1
+                   FROM rhnServerPackage SP
+                  WHERE SP.server_id = :sid
+                    AND SP.name_id = p.name_id
+                    AND (SP.package_arch_id = pa.id OR SP.package_arch_id IS NULL)
+            )
+            AND NOT EXISTS (SELECT 1 FROM suseServerChannelsRetractedPackagesView WHERE sid = :sid AND pid = p.id)
+       GROUP BY p.name_id, pa.label, pa.id) latest
+           JOIN rhnPackageName pn ON pn.id = latest.name_id
+           JOIN rhnPackage rp ON rp.name_id = latest.name_id
+                             AND rp.evr_id =  lookup_evr((latest.evr).epoch, (latest.evr).version, (latest.evr).release, (latest.evr).type)
+                             AND rp.package_arch_id = latest.arch_id
+          WHERE EXISTS (
+                         SELECT 1 FROM rhnChannelPackage rcp
+                           JOIN rhnServerChannel rsc ON rsc.channel_id = rcp.channel_id
+                          WHERE rcp.package_id = rp.id
+                            AND rsc.server_id = :sid)
     ORDER BY UPPER(pn.name)
   </query>
 </mode>

--- a/java/code/src/com/redhat/rhn/manager/rhnpackage/test/PackageManagerRetractedTest.java
+++ b/java/code/src/com/redhat/rhn/manager/rhnpackage/test/PackageManagerRetractedTest.java
@@ -110,6 +110,10 @@ public class PackageManagerRetractedTest extends BaseTestCaseWithUser {
         PackageTestUtils.installPackageOnServer(oldPkg, server);
         SystemManager.subscribeServerToChannel(user, server, channel);
 
+        // refresh the newest package cache
+        ChannelFactory.refreshNewestPackageCache(channel, "java::test");
+        ChannelFactory.refreshNewestPackageCache(clonedChannel, "java::test");
+
         // verify the package is retracted
         DataResult<PackageListItem> pkgs = PackageManager.systemPackageList(server.getId(), null);
         pkgs.elaborate();
@@ -147,6 +151,11 @@ public class PackageManagerRetractedTest extends BaseTestCaseWithUser {
         // subscribe the system to the channel with the retracted patch
         // the newest installable package should be the "newerPkg", since the "newestPkg" is retracted
         SystemManager.subscribeServerToChannel(user, server, channel);
+
+        // refresh the newest package cache
+        ChannelFactory.refreshNewestPackageCache(channel, "java::test");
+        ChannelFactory.refreshNewestPackageCache(clonedChannel, "java::test");
+
         PackageListItem pkg = assertSingleAndGet(PackageManager.systemAvailablePackages(server.getId(), null));
         assertEquals(newerPkg.getId(), pkg.getPackageId());
 
@@ -175,6 +184,10 @@ public class PackageManagerRetractedTest extends BaseTestCaseWithUser {
 
         // set the patch in original to retracted
         vendorPatch.setAdvisoryStatus(AdvisoryStatus.RETRACTED);
+
+        // refresh the newest package cache
+        ChannelFactory.refreshNewestPackageCache(channel, "java::test");
+        ChannelFactory.refreshNewestPackageCache(clonedChannel, "java::test");
 
         // only the "newerPkg" is retracted in the original channel
         DataResult<PackageOverview> pkgsOriginal = PackageManager.listPackagesInChannelForList(channel.getId());
@@ -209,6 +222,10 @@ public class PackageManagerRetractedTest extends BaseTestCaseWithUser {
 
         // set the patch in original to retracted
         vendorPatch.setAdvisoryStatus(AdvisoryStatus.RETRACTED);
+
+        // refresh the newest package cache
+        ChannelFactory.refreshNewestPackageCache(channel, "java::test");
+        ChannelFactory.refreshNewestPackageCache(clonedChannel, "java::test");
 
         Map<Long, PackageDto> pkgsOriginalMap = ChannelManager.listAllPackages(channel).stream()
                 .collect(Collectors.toMap(PackageDto::getId, p -> p));
@@ -246,6 +263,10 @@ public class PackageManagerRetractedTest extends BaseTestCaseWithUser {
 
         PackageTestUtils.installPackageOnServer(oldPkg, server);
         SystemManager.subscribeServerToChannel(user, server, channel);
+
+        // refresh the newest package cache
+        ChannelFactory.refreshNewestPackageCache(channel, "java::test");
+        ChannelFactory.refreshNewestPackageCache(clonedChannel, "java::test");
 
         // list the possible package updates when subscribed to the original
         assertSingleAndGet(SystemManager.listPotentialSystemsForPackage(user, newerPkg.getId()));

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- faster display installable packages list (bsc#1187333)
 - fix package selection for ubuntu errata install (bsc#1199049)
 - Add script examples for HTTP API
 - Refactor API docs for HTTP API

--- a/web/conf/rhn_web.conf
+++ b/web/conf/rhn_web.conf
@@ -121,7 +121,7 @@ ssh_use_salt_thin = false
 web.spa.enable = true
 
 # Request timeout for the Single Page Application engine, in seconds.
-web.spa.timeout = 30
+web.spa.timeout = 60
 
 # default language to use in the web UI
 web.locale = en_US

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- increase web page default timeout (bsc#1187333)
 - Branding updates
 - Use proper SSL terminology visible to the user
 - Stylesheets and relevant assets are now provided by spacewalk-web


### PR DESCRIPTION
## What does this PR change?

Tested on our manager with ubuntu channel. This should speedup the query by 50% .
But the returned number of packages is still high and maybe jsp has also a problem with this.

But we should give it a try

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15201
Tracks 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
