### PR TITLE
Declare /manager directory as safe for nodejs tests

### DIFF
--- a/susemanager-utils/testing/docker/scripts/push-to-obs.sh
+++ b/susemanager-utils/testing/docker/scripts/push-to-obs.sh
@@ -57,7 +57,7 @@ if [ ! -f ${OSCRC} ]; then
   exit 1
 fi
 
-# declare /manager as "save"
+# declare /manager as "safe"
 git config --global --add safe.directory /manager
 
 cd ${REL_ENG_FOLDER}

--- a/web/html/src/scripts/docker-javascript-lint.sh
+++ b/web/html/src/scripts/docker-javascript-lint.sh
@@ -3,6 +3,9 @@ set -euxo pipefail
 
 zypper --non-interactive install git
 
+# declare /manager as "safe"
+git config --global --add safe.directory /manager
+
 cd /manager/web/html/src
 
 yarn install


### PR DESCRIPTION
## What does this PR change?

Replicate for https://github.com/uyuni-project/uyuni/pull/5348 for tne nodejs tests, as otherwise tests are failing with:

```
fatal: unsafe repository ('/manager' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /manager
error Command failed with exit code 128.
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Fix for tests

- [x] **DONE**

## Test coverage
- No tests: Fix for tests

- [x] **DONE**

## Links

https://github.com/uyuni-project/uyuni/pull/5348

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
