### PR TITLE
Limit byte-buddy to less than 1.10

### DIFF
--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -171,7 +171,7 @@ Requires:       apache-commons-jexl
 Requires:       apache-commons-lang3
 Requires:       apache-commons-logging
 Requires:       bcel
-Requires:       byte-buddy
+Requires:       byte-buddy < 1.10
 Requires:       c3p0 >= 0.9.1
 Requires:       cglib
 Requires:       (/sbin/unix2_chkpwd or /usr/sbin/unix2_chkpwd)
@@ -356,7 +356,7 @@ Requires:       apache-commons-codec
 Requires:       apache-commons-lang3
 Requires:       apache-commons-logging
 Requires:       bcel
-Requires:       byte-buddy
+Requires:       byte-buddy < 1.10
 Requires:       c3p0 >= 0.9.1
 Requires:       cglib
 Requires:       (/sbin/unix2_chkpwd or /usr/sbin/unix2_chkpwd)

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -83,7 +83,7 @@ BuildRequires:  apache-commons-jexl
 BuildRequires:  apache-commons-lang3 >= 3.4
 BuildRequires:  apache-commons-logging
 BuildRequires:  bcel
-BuildRequires:  byte-buddy
+BuildRequires:  byte-buddy < 1.10
 BuildRequires:  c3p0 >= 0.9.1
 BuildRequires:  cglib
 %if 0%{?suse_version}


### PR DESCRIPTION
## What does this PR change?

Limit byte-buddy requirement to less than 1.10. The Tomcat rhn context throws a class not found with version 1.10:

`java.lang.NoClassDefFoundError: net/bytebuddy/NamingStrategy$SuffixingRandom$BaseNameResolver`

According to the API doc, the class should be there. So it could also be a difference between the CentOS Stream 9 version 1.10 and the Uyuni:Master:Others version 1.8.

Build works just fine with 1.10.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
