### PR TITLE
fix contains check for salt function name array

### DIFF
--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -247,7 +247,10 @@ public class SaltUtils {
                 results -> results.entrySet().stream()
                     .anyMatch(result -> extractFunction(result.getKey())
                         .map(fn -> fn.equals("mgrcompat.module_run") ?
-                            PKG_EXECUTION_MODULES.contains(result.getValue().getName()) :
+                            result.getValue().getName()
+                                    .map(x -> x.fold(Arrays::asList, List::of))
+                                    .orElseGet(ArrayList::new)
+                                    .stream().anyMatch(PKG_EXECUTION_MODULES::contains) :
                             PKG_STATE_MODULES.contains(fn)
                         ).orElse(false) &&
                         !result.getValue().getChanges().isEmpty()
@@ -414,7 +417,12 @@ public class SaltUtils {
                                 new TypeToken<StateApplyResult<JsonElement>>() {
                                 }.getType()
                         );
-                        if (PKG_EXECUTION_MODULES.contains(ap.getName())) {
+                        if (
+                            ap.getName()
+                                    .map(x -> x.fold(Arrays::asList, List::of))
+                                    .orElseGet(ArrayList::new)
+                                    .stream().anyMatch(PKG_EXECUTION_MODULES::contains)
+                        ) {
                             return Stream.of(ap);
                         }
                         else {


### PR DESCRIPTION
## What does this PR change?

fixes a case where the contains check was not adjusted to handle salts function name arrays.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
