### PR TITLE
Testsuite: fixes for retail test

### DIFF
--- a/testsuite/features/core/proxy_branch_network.feature
+++ b/testsuite/features/core/proxy_branch_network.feature
@@ -25,7 +25,6 @@ Feature: Setup Uyuni for Retail branch network
     When I manually install the "branch-network" formula on the server
     And I manually install the "dhcpd" formula on the server
     And I manually install the "bind" formula on the server
-    And I synchronize all Salt dynamic modules on "proxy"
 
 @proxy
 @private_net
@@ -34,6 +33,7 @@ Feature: Setup Uyuni for Retail branch network
     When I refresh the metadata for "server"
     When I install pattern "suma_retail" on this "server"
     And I wait for "patterns-suma_retail" to be installed on "server"
+    And I synchronize all Salt dynamic modules on "proxy"
 
 @proxy
 @private_net
@@ -42,6 +42,12 @@ Feature: Setup Uyuni for Retail branch network
     When I refresh the metadata for "server"
     When I install pattern "uyuni_retail" on this "server"
     And I wait for "patterns-uyuni_retail" to be installed on "server"
+    And I synchronize all Salt dynamic modules on "proxy"
+
+@proxy
+@private_net
+  Scenario: Restart spacewalk services
+    When I restart the spacewalk service
 
 @proxy
 @private_net

--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -52,20 +52,6 @@ Feature: Build OS images
     And I am on the image store of the Kiwi image for organization "1"
     Then I should see the name of the image for "pxeboot_minion"
 
-@proxy
-@private_net
-  Scenario: Move the image to the branch server
-    When I manually install the "image-sync" formula on the server
-    And I enable repositories before installing branch server
-    And I synchronize all Salt dynamic modules on "proxy"
-    And I apply state "image-sync" to "proxy"
-    Then the image for "pxeboot_minion" should exist on the branch server
-
-@proxy
-@private_net
-  Scenario: Cleanup: Disable the repositories on branch server
-    When I disable repositories after installing branch server
-
   Scenario: Cleanup: remove remaining systems from SSM after OS image tests
     When I go to the home page
     And I click on "Clear"

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -28,7 +28,11 @@ Feature: PXE boot a Retail terminal
     And I manually install the "vsftpd" formula on the server
     And I manually install the "saltboot" formula on the server
     And I manually install the "pxe" formula on the server
+    And I manually install the "image-sync" formula on the server
     And I synchronize all Salt dynamic modules on "proxy"
+
+  Scenario: Restart spacewalk services to apply saltboot reactor configuration
+    When I restart the spacewalk service
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
@@ -128,6 +132,10 @@ Feature: PXE boot a Retail terminal
     And I enter "Terminal branch: example.org" as "description"
     And I click on "Create Group"
     Then I should see a "System group example created." text
+    When I follow "Target Systems"
+    And I check the "proxy" client
+    And I click on "Add Systems"
+    Then I should see a "1 systems were added to example server group." text
 
   Scenario: Create all terminals group
     When I follow the left menu "Systems > System Groups"
@@ -148,6 +156,12 @@ Feature: PXE boot a Retail terminal
     And I check the "proxy" client
     And I click on "Add Systems"
     Then I should see a "1 systems were added to SERVERS server group." text
+
+  Scenario: Move the image to the branch server
+    When I enable repositories before installing branch server
+    And I apply state "image-sync" to "proxy"
+    And I disable repositories after installing branch server
+    Then the image for "pxeboot_minion" should exist on the branch server
 
   Scenario: Enable Saltboot formula for hardware type group
     When I follow the left menu "Systems > System Groups"

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -23,17 +23,6 @@ Feature: PXE boot a Retail terminal
   I PXE boot one of the terminals
   I perform a mass import of several virtual terminals and one real minion
 
-  Scenario: Install or update PXE formulas on the server
-    When I manually install the "tftpd" formula on the server
-    And I manually install the "vsftpd" formula on the server
-    And I manually install the "saltboot" formula on the server
-    And I manually install the "pxe" formula on the server
-    And I manually install the "image-sync" formula on the server
-    And I synchronize all Salt dynamic modules on "proxy"
-
-  Scenario: Restart spacewalk services to apply saltboot reactor configuration
-    When I restart the spacewalk service
-
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 


### PR DESCRIPTION
## What does this PR change?

This fixes the setup of retail environment.

Before, the image-sync was called before the retail groups were created. As a result, the bug https://bugzilla.suse.com/show_bug.cgi?id=1199157 was not detected. This PR moves  image-sync to the right place.

Also, it adds the required restart after installation of saltboot formula and assigns the branch server to branch group.

The second commit increases the timeout for saltboot state to 600s. It took 400s at 
https://ci.suse.de/view/Manager/view/Manager-Head/job/manager-Head-dev-acceptance-tests-NUE/3237/


## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
