### PR TITLE
Fix reposync issue with DEB repos when using a local mirror (bsc#1199142)

### DIFF
--- a/python/spacewalk/common/repo.py
+++ b/python/spacewalk/common/repo.py
@@ -119,10 +119,9 @@ class DpkgRepo:
                             self._pkg_index = cnt_fname, f.read()
                             break
                     except FileNotFoundError as ex:
-                        logging.exception(
+                        logging.debug(
                             "File not found: {}".format(
                                 packages_url.replace("file://", "")), exc_info=True)
-                        raise ex
                 else:
                     resp = requests.get(packages_url, proxies=self.proxies)
                     if resp.status_code == http.HTTPStatus.OK:

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,3 +1,6 @@
+- Do not raise error on file:// based DEB repo when looking
+  for alternative Release files (bsc#1199142)
+
 -------------------------------------------------------------------
 Wed May 04 15:19:39 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes a problem when running reposync to sync a local DEB repository using `file://` as part of the URL.

In some situations, when there is no `Release.gz` file, but some others like `Release.xz`, the current mechanism was not trying the different alternatives but simply raising an error if the first one if not found:

This situation produces problems for example when syncing Debian 11 repos from a local mirror.

```console
2022/04/28 16:33:12 +02:00 Command: ['/usr/bin/spacewalk-repo-sync', '--channel', 'debian-11-main-updates-amd64', '--type', 'deb', '--non-interactive']
2022/04/28 16:33:12 +02:00 Sync of channel started.
2022/04/28 16:33:12 +02:00 Unhandled error occurred: [Errno 2] No such file or directory: '/mirror/deb.debian.org/debian/dists/bullseye-updates/main/binary-amd64/Packages.gz'
2022/04/28 16:33:12 +02:00 Unexpected error: <class 'FileNotFoundError'>
2022/04/28 16:33:12 +02:00 Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/reposync.py", line 594, in sync
    http_headers=source_url["http_headers"])
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/repo_plugins/deb_src.py", line 339, in __init__
    self.repo.verify()
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/repo_plugins/deb_src.py", line 183, in verify
    if not repo.DpkgRepo(self.url, self._get_proxies(), self.gpg_verify).verify_packages_index():
  File "/usr/lib/python3.6/site-packages/spacewalk/common/repo.py", line 430, in verify_packages_index
    name, data = self.get_pkg_index_raw()
  File "/usr/lib/python3.6/site-packages/spacewalk/common/repo.py", line 125, in get_pkg_index_raw
    raise ex
  File "/usr/lib/python3.6/site-packages/spacewalk/common/repo.py", line 118, in get_pkg_index_raw
    with open(packages_url.replace("file://", ""), "rb") as f:
FileNotFoundError: [Errno 2] No such file or directory: '/mirror/deb.debian.org/debian/dists/bullseye-updates/main/binary-amd64/Packages.gz'
``` 

With this PR, we allow the loop to continue iterating and evaluating the other possible alternatives for the `Release` file, so the reposync can run successfully in this case:

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **tested manually by QE during BV**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/17702

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
