### PR TITLE
QE: Prometheus formula must be tested only in SUSE Systems

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -162,25 +162,35 @@ Feature: Smoke tests for <client>
     When I force picking pending events on "<client>" if necessary
     And I wait until event "Package Install/Upgrade scheduled by admin" is completed
 
-@skip_for_traditional
-  Scenario: Test Prometheus and Prometheus exporter formulas
+@suse_minion
+  Scenario: Test Prometheus formula on the <client>
     Given I am on the Systems overview page of this "<client>"
     When I follow "Formulas" in the content area
     And I check the "prometheus" formula
-    And I check the "prometheus-exporters" formula
     And I click on "Save"
     Then I wait until I see "Formula saved" text
-    # Configure Prometheus formula
-    When I follow "Formulas" in the content area
-    And I follow "Prometheus" in the content area
+    When I follow "Prometheus" in the content area
     And I click on "Expand All Sections"
     And I enter "admin" as "Username"
     And I enter "admin" as "Password"
     And I click on "Save Formula"
     Then I should see a "Formula saved" text
-    # Configure Prometheus exporter formula
+    When I follow "States" in the content area
+    And I click on "Apply Highstate"
+    Then I should see a "Applying the highstate has been scheduled." text
+    And I wait until event "Apply highstate scheduled by admin" is completed
+    # Visit monitoring endpoints on the minion
+    When I wait until "prometheus" service is active on "<client>"
+    And I visit "Prometheus" endpoint of this "<client>"
+
+  Scenario: Test Prometheus exporter formula on the <client>
+    Given I am on the Systems overview page of this "<client>"
     When I follow "Formulas" in the content area
-    And I follow "Prometheus Exporters" in the content area
+    And I check the "prometheus-exporters" formula
+    And I click on "Save"
+    Then I wait until I see "Formula saved" text
+    # Configure Prometheus exporter formula
+    When I follow "Prometheus Exporters" in the content area
     And I click on "Expand All Sections"
     And I should see a "Enable and configure Prometheus exporters for managed systems." text
     And I check "node" exporter
@@ -194,9 +204,7 @@ Feature: Smoke tests for <client>
     Then I should see a "Applying the highstate has been scheduled." text
     And I wait until event "Apply highstate scheduled by admin" is completed
     # Visit monitoring endpoints on the minion
-    When I wait until "prometheus" service is active on "<client>"
-    And I visit "Prometheus" endpoint of this "<client>"
-    And I wait until "prometheus-node_exporter" service is active on "<client>"
+    When I wait until "prometheus-node_exporter" service is active on "<client>"
     And I visit "Prometheus node exporter" endpoint of this "<client>"
     And I wait until "prometheus-apache_exporter" service is active on "<client>"
     And I visit "Prometheus apache exporter" endpoint of this "<client>"

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -343,6 +343,12 @@ Before('@opensuse153arm_minion') do
   skip_this_scenario unless $opensuse153arm_minion
 end
 
+Before('@suse_minion') do |scenario|
+  filename = scenario.location.file
+  skip_this_scenario unless filename.include? 'minion'
+  skip_this_scenario unless (filename.include? 'sle') || (filename.include? 'suse')
+end
+
 Before('@skip_for_debianlike') do |scenario|
   filename = scenario.location.file
   skip_this_scenario if (filename.include? 'ubuntu') || (filename.include? 'debian')


### PR DESCRIPTION
## What does this PR change?

 Prometheus formula must be tested only in SUSE Systems

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
