### PR TITLE
Add SLE 15 SP4 to Build Validation

### DIFF
--- a/testsuite/features/build_validation/core/allcli_sanity.feature
+++ b/testsuite/features/build_validation/core/allcli_sanity.feature
@@ -184,6 +184,27 @@ Feature: Sanity checks
     And "sle15sp3_ssh_minion" should communicate with the server using public interface
     And the clock from "sle15sp3_ssh_minion" should be exact
 
+@sle15sp4_client
+  Scenario: The SLES 15 SP4 traditional client is healthy
+    Then "sle15sp4_client" should have a FQDN
+    And reverse resolution should work for "sle15sp4_client"
+    And "sle15sp4_client" should communicate with the server using public interface
+    And the clock from "sle15sp4_client" should be exact
+
+@sle15sp4_minion
+  Scenario: The SLES 15 SP4 minion is healthy
+    Then "sle15sp4_minion" should have a FQDN
+    And reverse resolution should work for "sle15sp4_minion"
+    And "sle15sp4_minion" should communicate with the server using public interface
+    And the clock from "sle15sp4_minion" should be exact
+
+@sle15sp4_ssh_minion
+  Scenario: The SLES 15 SP4 Salt SSH minion is healthy
+    Then "sle15sp4_ssh_minion" should have a FQDN
+    And reverse resolution should work for "sle15sp4_ssh_minion"
+    And "sle15sp4_ssh_minion" should communicate with the server using public interface
+    And the clock from "sle15sp4_ssh_minion" should be exact
+
 @ceos7_client
   Scenario: The CentOS 7 traditional client is healthy
     Then "ceos7_client" should have a FQDN

--- a/testsuite/features/build_validation/create_bootstrap_repositories/srv_create_bootstrap_repositories.feature
+++ b/testsuite/features/build_validation/create_bootstrap_repositories/srv_create_bootstrap_repositories.feature
@@ -98,6 +98,18 @@ Feature: Create bootstrap repositories
   Scenario: Create the bootstrap repository for a SLES 15 SP3 Salt SSH minion
     When I create the bootstrap repository for "sle15sp3_ssh_minion" on the server
 
+@sle15sp4_client
+  Scenario: Create the bootstrap repository for a SLES 15 SP4 traditional client
+    When I create the bootstrap repository for "sle15sp4_client" on the server
+
+@sle15sp4_minion
+  Scenario: Create the bootstrap repository for a SLES 15 SP4 minion
+    When I create the bootstrap repository for "sle15sp4_minion" on the server
+
+@sle15sp4_ssh_minion
+  Scenario: Create the bootstrap repository for a SLES 15 SP4 Salt SSH minion
+    When I create the bootstrap repository for "sle15sp4_ssh_minion" on the server
+
 @ceos7_client
   Scenario: Create the bootstrap repository for a CentOS 7 traditional client
     When I create the bootstrap repository for "ceos7_client" on the server

--- a/testsuite/features/build_validation/init_clients/sle15sp4_client.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp4_client.feature
@@ -1,0 +1,46 @@
+# Copyright (c) 2022 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@sle15sp4_client
+Feature: Bootstrap a SLES 15 SP4 traditional client
+
+  Scenario: Clean up sumaform leftovers on a SLES 15 SP4 traditional client
+    When I perform a full salt minion cleanup on "sle15sp4_client"
+
+  Scenario: Register a SLES 15 SP4 traditional client
+    When I bootstrap traditional client "sle15sp4_client" using bootstrap script with activation key "1-sle15sp4_client_key" from the proxy
+    And I install package "spacewalk-client-setup mgr-cfg-actions" on this "sle15sp4_client"
+    And I run "mgr-actions-control --enable-all" on "sle15sp4_client"
+    Then I should see "sle15sp4_client" via spacecmd
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: The onboarding of SLES 15 SP4 traditional client is completed
+    When I wait until onboarding is completed for "sle15sp4_client"
+
+  Scenario: Check registration values of SLES 15 SP4 traditional
+    Given I update the profile of "sle15sp4_client"
+    When I am on the Systems overview page of this "sle15sp4_client"
+    And I wait until I see "Software Updates Available" text or "System is up to date" text
+    Then I should see a "System Status" text
+    And I should see a "Edit These Properties" link
+    And I should see a "[Management]" text
+    And I should see a "Add to SSM" link
+    And I should see a "Delete System" link
+    And I should see a "Initial Registration Parameters:" text
+    And I should see a "OS: sles-release" text
+
+@proxy
+  Scenario: Check connection from SLES 15 SP4 traditional to proxy
+    Given I am on the Systems overview page of this "sle15sp4_client"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see "proxy" short hostname
+
+@proxy
+  Scenario: Check registration on proxy of SLES 15 SP4 traditional
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Details" in the content area
+    And I follow "Proxy" in the content area
+    Then I should see "sle15sp4_client" hostname

--- a/testsuite/features/build_validation/init_clients/sle15sp4_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp4_minion.feature
@@ -1,0 +1,47 @@
+# Copyright (c) 2022 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@sle15sp4_minion
+Feature: Bootstrap a SLES 15 SP4 Salt minion
+
+  Scenario: Clean up sumaform leftovers on a SLES 15 SP4 Salt minion
+    When I perform a full salt minion cleanup on "sle15sp4_minion"
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Bootstrap a SLES 15 SP4 minion
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I enter the hostname of "sle15sp4_minion" as "hostname"
+    And I enter "22" as "port"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I select "1-sle15sp4_minion_key" from "activationKeys"
+    And I select the hostname of "proxy" from "proxies"
+    And I click on "Bootstrap"
+    And I wait until I see "Successfully bootstrapped host!" text
+    And I wait until onboarding is completed for "sle15sp4_minion"
+
+  Scenario: Check the new bootstrapped SLES 15 SP4 minion in System Overview page
+    When I follow the left menu "Salt > Keys"
+    Then I should see a "accepted" text
+    And the Salt master can reach "sle15sp4_minion"
+
+@proxy
+  Scenario: Check connection from SLES 15 SP4 minion to proxy
+    Given I am on the Systems overview page of this "sle15sp4_minion"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see "proxy" short hostname
+
+@proxy
+  Scenario: Check registration on proxy of SLES 15 SP4 minion
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Details" in the content area
+    And I follow "Proxy" in the content area
+    Then I should see "sle15sp4_minion" hostname
+
+  Scenario: Check events history for failures on SLES 15 SP4 minion
+    Given I am on the Systems overview page of this "sle15sp4_minion"
+    Then I check for failed events on history event page

--- a/testsuite/features/build_validation/init_clients/sle15sp4_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp4_ssh_minion.feature
@@ -1,0 +1,41 @@
+# Copyright (c) 2022 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@sle15sp4_ssh_minion
+Feature: Bootstrap a SLES 15 SP4 Salt SSH minion
+
+  Scenario: Clean up sumaform leftovers on a SLES 15 SP4 Salt SSH minion
+    When I perform a full salt minion cleanup on "sle15sp4_ssh_minion"
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Bootstrap a SLES 15 SP4 system managed via salt-ssh
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I check "manageWithSSH"
+    And I enter the hostname of "sle15sp4_ssh_minion" as "hostname"
+    And I enter "linux" as "password"
+    And I select "1-sle15sp4_ssh_minion_key" from "activationKeys"
+    And I select the hostname of "proxy" from "proxies"
+    And I click on "Bootstrap"
+    And I wait until I see "Successfully bootstrapped host!" text
+    And I wait until onboarding is completed for "sle15sp4_ssh_minion"
+
+@proxy
+  Scenario: Check connection from SLES 15 SP4 SSH minion to proxy
+    Given I am on the Systems overview page of this "sle15sp4_ssh_minion"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see "proxy" short hostname
+
+@proxy
+  Scenario: Check registration on proxy of SLES 15 SP4 SSH minion
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Details" in the content area
+    And I follow "Proxy" in the content area
+    Then I should see "sle15sp4_ssh_minion" hostname
+
+  Scenario: Check events history for failures on SLES 15 SP4 SSH minion
+    Given I am on the Systems overview page of this "sle15sp4_ssh_minion"
+    Then I check for failed events on history event page

--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -116,6 +116,24 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
     And I wait until I see "SUSE Linux Enterprise Server 15 SP3 x86_64" product has been added
 
+@sle15sp4_minion
+  Scenario: Add SUSE Linux Enterprise Server 15 SP4
+    When I follow the left menu "Admin > Setup Wizard > Products"
+    And I wait until I do not see "Loading" text
+    And I enter "SUSE Linux Enterprise Server 15 SP4 x86_64 (BETA)" as the filtered product description
+    And I select "SUSE Linux Enterprise Server 15 SP4 x86_64 (BETA)" as a product
+    Then I should see the "SUSE Linux Enterprise Server 15 SP4 x86_64 (BETA)" selected
+    When I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP4 x86_64 (BETA)"
+    And I open the sub-list of the product "Basesystem Module 15 SP4 x86_64"
+    And I select "Desktop Applications Module 15 SP4 x86_64" as a product
+    Then I should see the "Desktop Applications Module 15 SP4 x86_64" selected
+    When I open the sub-list of the product "Desktop Applications Module 15 SP4 x86_64"
+    And I select "Development Tools Module 15 SP4 x86_64" as a product
+    Then I should see the "Development Tools Module 15 SP4 x86_64" selected
+    When I click the Add Product button
+    And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
+    And I wait until I see "SUSE Linux Enterprise Server 15 SP4 x86_64" product has been added
+
 @opensuse153arm_minion
   Scenario: Add openSUSE 15.3 for ARM
     When I follow the left menu "Admin > Setup Wizard > Products"

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -97,6 +97,9 @@ PACKAGE_BY_CLIENT = { 'sle_client' => 'bison',
                       'sle15sp3_client' => 'bison',
                       'sle15sp3_minion' => 'bison',
                       'sle15sp3_ssh_minion' => 'bison',
+                      'sle15sp4_client' => 'bison',
+                      'sle15sp4_minion' => 'bison',
+                      'sle15sp4_ssh_minion' => 'bison',
                       'ceos7_client' => 'autoconf',
                       'ceos7_minion' => 'autoconf',
                       'ceos7_ssh_minion' => 'autoconf',
@@ -145,6 +148,9 @@ BASE_CHANNEL_BY_CLIENT = { 'proxy' => 'SLE-Product-SUSE-Manager-Proxy-4.3-Pool',
                            'sle15sp3_client' => 'SLES15-SP3-Pool',
                            'sle15sp3_minion' => 'SLES15-SP3-Pool',
                            'sle15sp3_ssh_minion' => 'SLES15-SP3-Pool',
+                           'sle15sp4_client' => 'SLES15-SP4-Pool',
+                           'sle15sp4_minion' => 'SLES15-SP4-Pool',
+                           'sle15sp4_ssh_minion' => 'SLES15-SP4-Pool',
                            'sle15sp3_buildhost' => 'SLES15-SP3-Pool',
                            'sle15sp3_terminal' => 'SLES15-SP3-Pool',
                            'ceos7_client' => 'RHEL x86_64 Server 7',
@@ -173,6 +179,7 @@ LABEL_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.3-Pool' => 'sle-prod
                           'SLES15-SP1-Pool' => 'sle-product-sles15-sp1-pool-x86_64',
                           'SLES15-SP2-Pool' => 'sle-product-sles15-sp2-pool-x86_64',
                           'SLES15-SP3-Pool' => 'sle-product-sles15-sp3-pool-x86_64',
+                          'SLES15-SP4-Pool' => 'sle-product-sles15-sp4-pool-x86_64',
                           'RHEL x86_64 Server 7' => 'rhel-x86_64-server-7',
                           'no-appstream-result-RHEL8-Pool for x86_64' => 'no-appstream-result-rhel8-pool-x86_64',
                           'ubuntu-18.04-pool' => 'ubuntu-18.04-pool-amd64',
@@ -209,6 +216,7 @@ PARENT_CHANNEL_TO_SYNC_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.3-P
                                            'SLES15-SP1-Pool' => 'sle-product-sles15-sp1-pool-x86_64',
                                            'SLES15-SP2-Pool' => 'sle-product-sles15-sp2-pool-x86_64',
                                            'SLES15-SP3-Pool' => 'sle-product-sles15-sp3-pool-x86_64',
+                                           'SLES15-SP4-Pool' => 'sle-product-sles15-sp4-pool-x86_64',
                                            'RHEL x86_64 Server 7' => 'rhel-x86_64-server-7',
                                            'no-appstream-result-RHEL8-Pool for x86_64' => nil,
                                            'ubuntu-18.04-pool' => nil,
@@ -245,6 +253,9 @@ PKGARCH_BY_CLIENT = { 'proxy' => 'x86_64',
                       'sle15sp3_client' => 'x86_64',
                       'sle15sp3_minion' => 'x86_64',
                       'sle15sp3_ssh_minion' => 'x86_64',
+                      'sle15sp4_client' => 'x86_64',
+                      'sle15sp4_minion' => 'x86_64',
+                      'sle15sp4_ssh_minion' => 'x86_64',
                       'ceos7_client' => 'x86_64',
                       'ceos7_minion' => 'x86_64',
                       'ceos7_ssh_minion' => 'x86_64',
@@ -333,6 +344,21 @@ CHANNEL_TO_SYNCH_BY_OS_VERSION = {
     sle-module-containers15-sp3-updates-x86_64
     sle-module-basesystem15-sp3-updates-x86_64
     sle-module-server-applications15-sp3-updates-x86_64
+  ],
+  '15-SP4' =>
+  %w[
+    sle-product-sles15-sp4-pool-x86_64
+    sle-manager-tools15-pool-x86_64-sp4
+    sle-manager-tools15-beta-pool-x86_64-sp4
+    sle-module-containers15-sp4-pool-x86_64
+    sle-module-basesystem15-sp4-pool-x86_64
+    sle-module-server-applications15-sp4-pool-x86_64
+    sle-product-sles15-sp4-updates-x86_64
+    sle-manager-tools15-updates-x86_64-sp4
+    sle-manager-tools15-beta-updates-x86_64-sp4
+    sle-module-containers15-sp4-updates-x86_64
+    sle-module-basesystem15-sp4-updates-x86_64
+    sle-module-server-applications15-sp4-updates-x86_64
   ]
 }.freeze
 

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -315,6 +315,18 @@ Before('@sle15sp3_client') do
   skip_this_scenario unless $sle15sp3_client
 end
 
+Before('@sle15sp4_ssh_minion') do
+  skip_this_scenario unless $sle15sp4_ssh_minion
+end
+
+Before('@sle15sp4_minion') do
+  skip_this_scenario unless $sle15sp4_minion
+end
+
+Before('@sle15sp4_client') do
+  skip_this_scenario unless $sle15sp4_client
+end
+
 Before('@sle11sp4_buildhost') do
   skip_this_scenario unless $sle11sp4_buildhost
 end

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -57,6 +57,9 @@ if $build_validation
   $sle15sp3_client = twopence_init("ssh:#{ENV['SLE15SP3_CLIENT']}") if ENV['SLE15SP3_CLIENT']
   $sle15sp3_minion = twopence_init("ssh:#{ENV['SLE15SP3_MINION']}") if ENV['SLE15SP3_MINION']
   $sle15sp3_ssh_minion = twopence_init("ssh:#{ENV['SLE15SP3_SSHMINION']}") if ENV['SLE15SP3_SSHMINION']
+  $sle15sp4_client = twopence_init("ssh:#{ENV['SLE15SP4_CLIENT']}") if ENV['SLE15SP4_CLIENT']
+  $sle15sp4_minion = twopence_init("ssh:#{ENV['SLE15SP4_MINION']}") if ENV['SLE15SP4_MINION']
+  $sle15sp4_ssh_minion = twopence_init("ssh:#{ENV['SLE15SP4_SSHMINION']}") if ENV['SLE15SP4_SSHMINION']
   $ceos7_client = twopence_init("ssh:#{ENV['CENTOS7_CLIENT']}") if ENV['CENTOS7_CLIENT']
   $ceos7_minion = twopence_init("ssh:#{ENV['CENTOS7_MINION']}") if ENV['CENTOS7_MINION']
   $ceos7_ssh_minion = twopence_init("ssh:#{ENV['CENTOS7_SSHMINION']}") if ENV['CENTOS7_SSHMINION']
@@ -83,6 +86,7 @@ if $build_validation
              $sle15sp1_client, $sle15sp1_minion, $sle15sp1_ssh_minion,
              $sle15sp2_client, $sle15sp2_minion, $sle15sp2_ssh_minion,
              $sle15sp3_client, $sle15sp3_minion, $sle15sp3_ssh_minion,
+             $sle15sp4_client, $sle15sp4_minion, $sle15sp4_ssh_minion,
              $ceos7_client, $ceos7_minion, $ceos7_ssh_minion,
              $ceos8_minion, $ceos8_ssh_minion,
              $ubuntu1804_minion, $ubuntu1804_ssh_minion,
@@ -274,6 +278,9 @@ $node_by_host = { 'localhost'                 => $localhost,
                   'sle15sp3_client'           => $sle15sp3_client,
                   'sle15sp3_minion'           => $sle15sp3_minion,
                   'sle15sp3_ssh_minion'       => $sle15sp3_ssh_minion,
+                  'sle15sp4_client'           => $sle15sp4_client,
+                  'sle15sp4_minion'           => $sle15sp4_minion,
+                  'sle15sp4_ssh_minion'       => $sle15sp4_ssh_minion,
                   'ceos7_client'              => $ceos7_client,
                   'ceos7_minion'              => $ceos7_minion,
                   'ceos7_ssh_minion'          => $ceos7_ssh_minion,

--- a/testsuite/run_sets/build_validation_init_clients.yml
+++ b/testsuite/run_sets/build_validation_init_clients.yml
@@ -29,6 +29,9 @@
 - features/build_validation/init_clients/sle15sp3_client.feature
 - features/build_validation/init_clients/sle15sp3_minion.feature
 - features/build_validation/init_clients/sle15sp3_ssh_minion.feature
+- features/build_validation/init_clients/sle15sp4_client.feature
+- features/build_validation/init_clients/sle15sp4_minion.feature
+- features/build_validation/init_clients/sle15sp4_ssh_minion.feature
 
 - features/build_validation/init_clients/ubuntu1804_minion.feature
 - features/build_validation/init_clients/ubuntu1804_ssh_minion.feature


### PR DESCRIPTION
## What does this PR change?

Add support for SLE 15 SP4 to build validation.

I have run sanity checks with this PR to at least avoid obvious breakages.


## Links

Sibling PRs:
* Sumaform: uyuni-project/sumaform#1089
* Susemanager-ci: SUSE/susemanager-ci#537
* Infrastructure: https://gitlab.suse.de/galaxy/infrastructure/-/merge_requests/526

Ports:
* 4.1: SUSE/spacewalk#17751 (for code synchronization purposes only)
* 4.2: SUSE/spacewalk#17750


## Changelogs

- [x] No changelog needed
