### PR TITLE
update server needed cache after adding Ubuntu Errata

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManager.java
@@ -322,6 +322,11 @@ public class UbuntuErrataManager {
                         e -> e.getChannels().stream().map(c -> c.getId()).collect(Collectors.toList())
                         )
                 );
+        changedErrata.stream().flatMap(e -> e.getChannels().stream()).distinct()
+            .forEach(channel -> {
+                LOG.debug("Update NeededCache for Channel: " + channel.getLabel());
+                ErrataManager.insertErrataCacheTask(channel);
+        });
         ErrataManager.bulkErrataNotification(errataToChannels, new Date());
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- update server needed cache after adding Ubuntu Errata (bsc#1196977)
 - Fix ACL rules for config diff download for SLS files (bsc#1198914)
 - fix invalid link to action schedule
 


### PR DESCRIPTION
## What does this PR change?

Update the server needed cache after adding ubuntu errata. The errata mailer depends on correct data in the cache.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/17752

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
