### PR TITLE
Display usertime instead of server time for clm issue date filter

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/mappers/ResponseMappers.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/mappers/ResponseMappers.java
@@ -44,9 +44,6 @@ import com.suse.manager.webui.utils.ViewHelper;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
-import java.time.Instant;
-import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
@@ -237,19 +234,7 @@ public class ResponseMappers {
                     contentFilterResponse.setEntityType(filter.getEntityType().getLabel());
                     contentFilterResponse.setMatcher(filter.getCriteria().getMatcher().getLabel());
                     contentFilterResponse.setCriteriaKey(filter.getCriteria().getField());
-                    // If we have a date as a criteria value we need to format it with the current user timezone
-                    if (filter.getCriteria().getField().equals("issue_date")) {
-                        DateTimeFormatter timeFormatter = DateTimeFormatter.ISO_DATE_TIME;
-                        OffsetDateTime offsetDateTime = OffsetDateTime.parse(
-                                filter.getCriteria().getValue(), timeFormatter
-                        );
-                        Date criteriaValueDate = Date.from(Instant.from(offsetDateTime));
-
-                        contentFilterResponse.setCriteriaValue(ViewHelper.getInstance().renderDate(criteriaValueDate));
-                    }
-                    else {
-                        contentFilterResponse.setCriteriaValue(filter.getCriteria().getValue());
-                    }
+                    contentFilterResponse.setCriteriaValue(filter.getCriteria().getValue());
                     contentFilterResponse.setRule(filter.getRule().getLabel());
                     contentFilterResponse.setProjects(
                             projects.stream()

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/response/FilterResponse.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/response/FilterResponse.java
@@ -15,8 +15,14 @@
 package com.suse.manager.webui.controllers.contentmanagement.response;
 
 
+import com.suse.manager.webui.utils.ViewHelper;
+
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -49,7 +55,20 @@ public class FilterResponse {
         this.criteriaKey = criteriaKeyIn;
     }
 
+    /**
+     * Sets the criteria value
+     *
+     * @param criteriaValueIn the criteria value
+     */
     public void setCriteriaValue(String criteriaValueIn) {
+        // If we have a date as a criteria value we need to format it with the current user timezone
+        if (this.criteriaKey.equals("issue_date")) {
+            DateTimeFormatter timeFormatter = DateTimeFormatter.ISO_DATE_TIME;
+            OffsetDateTime offsetDateTime = OffsetDateTime.parse(
+                    criteriaValueIn, timeFormatter);
+            Date criteriaValueDate = Date.from(Instant.from(offsetDateTime));
+            criteriaValueIn = ViewHelper.getInstance().renderDate(criteriaValueDate);
+        }
         this.criteriaValue = criteriaValueIn;
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/response/ProjectFilterResponse.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/response/ProjectFilterResponse.java
@@ -14,6 +14,13 @@
  */
 package com.suse.manager.webui.controllers.contentmanagement.response;
 
+import com.suse.manager.webui.utils.ViewHelper;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
 /**
  * JSON response wrapper for a content filter resume.
  */
@@ -44,7 +51,20 @@ public class ProjectFilterResponse {
         this.criteriaKey = criteriaKeyIn;
     }
 
+    /**
+     * Sets the criteria value
+     *
+     * @param criteriaValueIn the criteria value
+     */
     public void setCriteriaValue(String criteriaValueIn) {
+        // If we have a date as a criteria value we need to format it with the current user timezone
+        if (this.criteriaKey.equals("issue_date")) {
+            DateTimeFormatter timeFormatter = DateTimeFormatter.ISO_DATE_TIME;
+            OffsetDateTime offsetDateTime = OffsetDateTime.parse(
+                    criteriaValueIn, timeFormatter);
+            Date criteriaValueDate = Date.from(Instant.from(offsetDateTime));
+            criteriaValueIn = ViewHelper.getInstance().renderDate(criteriaValueDate);
+        }
         this.criteriaValue = criteriaValueIn;
     }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Display usertime instead of server time for clm issue date filter (bsc#1198429)
 - fix bootstrapping of ssh minions via proxy
 - check if file exists before sending it to xsendfile (bsc#1198191)
 - update server needed cache after adding Ubuntu Errata (bsc#1196977)

--- a/web/html/src/components/datetime/DateTimePicker.tsx
+++ b/web/html/src/components/datetime/DateTimePicker.tsx
@@ -284,18 +284,6 @@ export class DateTimePicker extends React.Component<DateTimePickerProps, DateTim
     });
   };
 
-  toggleTimeZone = () => {
-    if (localizedMoment.serverTimeZone === localizedMoment.userTimeZone) {
-      return;
-    }
-    this.setState({
-      timeZone:
-        this.state.timeZone === localizedMoment.serverTimeZone
-          ? localizedMoment.userTimeZone
-          : localizedMoment.serverTimeZone,
-    });
-  };
-
   onDateChanged = (year: number, month: number, day: number) => {
     const newValue = localizedMoment(this.props.value)
       // The user made the choice in the given timezone
@@ -375,7 +363,7 @@ export class DateTimePicker extends React.Component<DateTimePickerProps, DateTim
             seconds={seconds}
             key="time-picker"
           />,
-          <span className="input-group-addon" key="tz" onClick={this.toggleTimeZone}>
+          <span className="input-group-addon" key="tz">
             {this.state.timeZone}
           </span>,
         ]}


### PR DESCRIPTION
## What does this PR change?

Display usertime instead of server time for clm issue date filter
Remove toggle timezone between user and server time for the datetimepicker

## Links

Tracks https://github.com/SUSE/spacewalk/issues/17511

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
