### PR TITLE
Check file exists

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
@@ -558,6 +558,10 @@ public class DownloadController {
      * @param file description of the file to send
      */
     private static Object downloadFile(Request request, Response response, File file) {
+        if (!file.exists()) {
+            log.info("404 - File not found: " + file.getAbsolutePath());
+            halt(HttpStatus.SC_NOT_FOUND, "File not found: " + request.url());
+        }
         response.header("Content-Type", "application/octet-stream");
         response.header("Content-Disposition", "attachment; filename=" + file.getName());
         response.header("X-Sendfile", file.getAbsolutePath());

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- check if file exists before sending it to xsendfile (bsc#1198191)
 - update server needed cache after adding Ubuntu Errata (bsc#1196977)
 - Fix ACL rules for config diff download for SLS files (bsc#1198914)
 - fix invalid link to action schedule


### PR DESCRIPTION
## What does this PR change?

Apache module xsendfile cause hanging AJP connections when the file does not exist which should be send.
This PR test the existence of the file before returning to xsendfile and raise a "404 Not Found" when the file does not exist.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/17679

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
