### PR TITLE
Fix bootstrap repository URL resolution for Yum based clients with preflight for Salt SSH

### DIFF
--- a/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
+++ b/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
@@ -168,8 +168,7 @@ function getA_CLIENT_CODE_BASE() {
 
 if [ "${INSTALLER}" = "yum" ]; then
     getY_CLIENT_CODE_BASE
-    CLIENT_REPO_PATH="${CLIENT_REPOS_ROOT}/${Y_CLIENT_CODE_BASE}/${Y_CLIENT_CODE_VERSION}"
-    CLIENT_REPO_URL="${CLIENT_REPOS_ROOT}/${CLIENT_REPO_PATH}/bootstrap"
+    CLIENT_REPO_URL="${CLIENT_REPOS_ROOT}/${Y_CLIENT_CODE_BASE}/${Y_CLIENT_CODE_VERSION}/bootstrap"
     # In case of CentOS, check is centos bootstrap repository is available, if not, fallback to res.
     if [ "$Y_CLIENT_CODE_BASE" == centos ]; then
         $FETCH $CLIENT_REPO_URL/repodata/repomd.xml &> /dev/null

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,6 @@
+- Fix bootstrap repository URL resolution for Yum based clients
+  with preflight script for Salt SSH
+
 -------------------------------------------------------------------
 Wed May 04 15:26:22 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Bootstrap repository URL on Yum based clients resolved wrong way. A part of the URL is doubled.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: testsuite is not reaching this part of the script

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/5372

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
