### PR TITLE
Testsuite: Test reboot of retail terminal

### DIFF
--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -220,6 +220,14 @@ Feature: PXE boot a Retail terminal
     Then I should see a "1 package install has been scheduled" text
     When I wait until event "Package Install/Upgrade scheduled by admin" is completed
 
+  Scenario: Check that the PXE boot minion stays configured after reboot
+    # salt key, channels and installed packages must survive reboot
+    When I reboot the Retail terminal "pxeboot_minion"
+    And I follow the left menu "Systems > System List > All"
+    And I follow this "pxeboot_minion" link
+    And I wait at most 350 seconds until event "Apply states [util.syncstates, saltboot] scheduled by (none)" is completed
+    Then the Salt master can reach "pxeboot_minion"
+
   Scenario: Cleanup: remove a package on the new Retail terminal
     Given I navigate to the Systems overview page of this "pxeboot_minion"
     When I follow "Software" in the content area

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -11,7 +11,7 @@ Given(/^the Salt master can reach "(.*?)"$/) do |minion|
   # 300 is the default 1st keepalive interval for the minion
   # where it realizes the connection is stuck
   repeat_until_timeout(timeout: 300, retries: 3, message: "Master can not communicate with #{minion}", report_result: true) do
-    out, _code = $server.run("salt #{system_name} test.ping")
+    out, _code = $server.run("salt #{system_name} test.ping", check_errors: false, timeout: 90)
     if out.include?(system_name) && out.include?('True')
       finished = Time.now
       log "Took #{finished.to_i - start.to_i} seconds to contact the minion"


### PR DESCRIPTION
## What does this PR change?

Add a test of retail terminal reboot.
This verifies that the terminal configuration (PXE files, salt key, additionally installed packages) is stored permanently.
The test takes 104s on my machine.

It requires the fixes from https://github.com/uyuni-project/uyuni/pull/5362
I created separate PR as this might be unstable at the beginning.



## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
