### PR TITLE
WIP: Investigate better test id integration

### DIFF
--- a/web/html/src/components/combobox.tsx
+++ b/web/html/src/components/combobox.tsx
@@ -80,7 +80,7 @@ export class Combobox extends React.Component<ComboboxProps, ComboboxState> {
       label: item.text,
     }));
 
-    const testAttributes = withTestAttributes(this.props["data-testid"], this.props.name);
+    const testAttributes = withTestAttributes(this.props["data-testid"]);
     return (
       <Creatable
         id={this.props.id}

--- a/web/html/src/components/input/Select.tsx
+++ b/web/html/src/components/input/Select.tsx
@@ -192,10 +192,12 @@ export function Select(props: Props) {
             isClearable: isClearable,
             styles: bootstrapStyles,
             isMulti: props.isMulti,
+            // NB! This is mandatory for Cucumber integration to work
+            openMenuOnFocus: true,
             // TODO: Create a separate div in body so we don't invalidate the layout every time, see https://github.com/SUSE/spacewalk/issues/17076
             menuPortalTarget: document.body,
           },
-          withTestAttributes(props["data-testid"], props.name)
+          withTestAttributes(props["data-testid"])
         );
 
         if (isAsync(props)) {

--- a/web/html/src/components/input/select-test-attributes.tsx
+++ b/web/html/src/components/input/select-test-attributes.tsx
@@ -1,29 +1,14 @@
 import { components as WrapperComponents } from "react-select";
 
-const TestIdContainer = function ({ children, ...props }) {
-  const innerProps = Object.assign(
-    {
-      "data-testid": props.selectProps["data-testid"],
-    },
-    props.innerProps
-  );
-  return (
-    <WrapperComponents.SelectContainer {...props} innerProps={innerProps}>
-      {children}
-    </WrapperComponents.SelectContainer>
-  );
+const Input = function (props) {
+  return <WrapperComponents.Input {...props} data-testid={props.selectProps["data-testid"]} />;
 };
 
-export default function withTestAttributes(testId: string | undefined, fallbackName: string | undefined) {
-  // The name-based fallback is used to keep compatibility with existing forms that use the `name` prop for binding to tests
-  const testClassName = testId || fallbackName || undefined;
-  const classNamePrefix = testClassName ? `data-testid-${testClassName}-child` : undefined;
-
+export default function withTestAttributes(testId: string | undefined) {
   return {
-    classNamePrefix,
     components: testId
       ? {
-          SelectContainer: TestIdContainer,
+          Input,
         }
       : undefined,
     "data-testid": testId,


### PR DESCRIPTION
## What does this PR change?

With this change, React dropdowns should be openable with whatever is XPath's equivalent of `document.querySelector('[data-testid="selectedBaseChannel"]').focus()`. If you want to test this out in your local browser, wrap it in a timeout and restore focus to the main browser area before the timeout fires, the browser won't give focus away if the focus is in the devtools instead.  

This change most definitely breaks whatever logic we had bound to the class names since I removed it, so I'm expecting this to break other tests too. I'm not sure if it's completely fine to remove the class name logic. Do we still use it to a-la select the correct item from the dropdown or something similar? I'm not sure if there's edge cases I haven't thought of or other things I've missed, so would appreciate your input Can.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: trying to fix existing tests

- [x] **DONE**

## Links

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
