### PR TITLE
create a roster for pending minions not yet in DB

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
@@ -212,8 +212,13 @@ public class SaltSSHService {
      */
     public <R> Map<String, Result<R>> callSyncSSH(LocalCall<R> call, MinionList target, Optional<String> extraFileRefs)
             throws SaltException {
+        // Using custom LocalCall timeout if included in the payload
+        Optional<Integer> sshTimeout = call.getPayload().containsKey("timeout") ?
+                Optional.ofNullable((Integer) call.getPayload().get("timeout")) :
+                    getSshPushTimeout();
+        Optional<SaltRoster> roster = prepareSaltRoster(target, sshTimeout);
         return unwrapSSHReturn(
-                callSyncSSHInternal(call, target, Optional.empty(), false, isSudoUser(getSSHUser()), extraFileRefs));
+                callSyncSSHInternal(call, target, roster, false, isSudoUser(getSSHUser()), extraFileRefs));
     }
 
     /**
@@ -233,13 +238,15 @@ public class SaltSSHService {
         return callSyncSSH(call, target, Optional.empty());
     }
 
-    private SaltRoster prepareSaltRoster(MinionList target, Optional<Integer> sshTimeout) {
+    private Optional<SaltRoster> prepareSaltRoster(MinionList target, Optional<Integer> sshTimeout) {
         SaltRoster roster = new SaltRoster();
+        boolean pendingMinion = false;
 
         // these values are mostly fixed, which should change when we allow configuring
         // per-minion server
         for (String mid : target.getTarget()) {
             if (MinionPendingRegistrationService.containsSSHMinion(mid)) {
+                pendingMinion = true;
                 MinionPendingRegistrationService.get(mid).ifPresent(minion -> {
                     String contactMethodLabel = minion.getContactMethod();
 
@@ -285,7 +292,9 @@ public class SaltSSHService {
                 }, () -> LOG.error("Minion id='{}' not found in the database", mid));
             }
         }
-        return roster;
+        // we only need a roster when we may contact pending minions which are not yet in DB
+        // otherwise the roster is generated from DB
+        return pendingMinion ? Optional.of(roster) : Optional.empty();
     }
 
     /**
@@ -313,7 +322,7 @@ public class SaltSSHService {
     public <R> Map<String, CompletionStage<Result<R>>> callAsyncSSH(
             LocalCall<R> call, MinionList target, CompletableFuture<GenericError> cancel,
             Optional<String> extraFilerefs) {
-        SaltRoster roster = prepareSaltRoster(target, getSshPushTimeout());
+        Optional<SaltRoster> roster = prepareSaltRoster(target, getSshPushTimeout());
         Map<String, CompletableFuture<Result<R>>> futures = new HashedMap();
         target.getTarget().forEach(minionId ->
                 futures.put(minionId, new CompletableFuture<>())
@@ -322,7 +331,7 @@ public class SaltSSHService {
                 CompletableFuture.supplyAsync(() -> {
                     try {
                         return unwrapSSHReturn(
-                                callSyncSSHInternal(call, target, Optional.of(roster),
+                                callSyncSSHInternal(call, target, roster,
                                         false, isSudoUser(getSSHUser()),
                                         extraFilerefs));
                     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix bootstrapping of ssh minions via proxy
 - check if file exists before sending it to xsendfile (bsc#1198191)
 - update server needed cache after adding Ubuntu Errata (bsc#1196977)
 - Fix ACL rules for config diff download for SLS files (bsc#1198914)

--- a/testsuite/features/secondary/minssh_bootstrap_api.feature
+++ b/testsuite/features/secondary/minssh_bootstrap_api.feature
@@ -17,6 +17,10 @@ Feature: Register a salt-ssh system via API
     And I wait until I see "has been deleted" text
     Then "ssh_minion" should not be registered
 
+@proxy
+  Scenario: block direct access from server to sshminion to test proxy as jumphost
+    Given I block connections from "server" on "ssh_minion"
+
   Scenario: Bootstrap a SLES SSH minion via API
     Given I am logged in API as user "admin" and password "admin"
     When I call system.bootstrap() on host "ssh_minion" and salt-ssh "enabled"
@@ -58,3 +62,7 @@ Feature: Register a salt-ssh system via API
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
     And I wait until event "Subscribe channels scheduled by admin" is completed
+
+@proxy
+  Scenario: cleanup and flush the firewall rules
+    When I flush firewall on "ssh_minion"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1706,3 +1706,15 @@ Then(/^I should find the updated "([^"]*)" property as "([^"]*)" on the "([^"]*)
   final_synced_date = Time.parse(query_result.tuple(0)[1])
   raise "Column synced_date not updated. Inital synced_date was #{$initial_synced_date} while current synced_date is #{final_synced_date}" unless final_synced_date > $initial_synced_date
 end
+
+Given(/^I block connections from "([^"]*)" on "([^"]*)"$/) do |blockhost, target|
+  blkhost = get_target(blockhost)
+  node = get_target(target)
+  node.run("iptables -A INPUT -s #{blkhost.public_ip} -j LOG")
+  node.run("iptables -A INPUT -s #{blkhost.public_ip} -j DROP")
+end
+
+Then(/^I flush firewall on "([^"]*)"$/) do |target|
+  node = get_target(target)
+  node.run("iptables -F INPUT")
+end


### PR DESCRIPTION
## What does this PR change?

When bootstrapping a ssh minion via a proxy and the server cannot reach the minion directly, we must use
the proxy as jump host also when getting the grains via salt-ssh after the first bootstrap call but before the client is
created in the database.
In this case we still must create a roster file as the autogenerated roster from DB will not yet find the minion.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber test added

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/5370
Fixes https://github.com/SUSE/spacewalk/issues/17762

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
