### PR TITLE
Fix CLM sources modal

### DIFF
--- a/testsuite/features/secondary/srv_content_lifecycle.feature
+++ b/testsuite/features/secondary/srv_content_lifecycle.feature
@@ -19,7 +19,7 @@ Feature: Content lifecycle
     And I enter "clp_name" as "name"
     And I enter "clp_desc" as "description"
     And I click on "Create"
-    Then I wait until I see "Content Lifecycle Project - clp_name" text
+    And I wait until I see "Content Lifecycle Project - clp_name" text
 
   Scenario: Verify the content lifecycle project page
     When I follow the left menu "Content Lifecycle > Projects"
@@ -38,21 +38,21 @@ Feature: Content lifecycle
     And I click on "Attach/Detach Sources"
     And I select "SLES12-SP5-Pool for x86_64" from "selectedBaseChannel"
     And I click on "Save"
-    Then I wait until I see "SLES12-SP5-Pool for x86_64" text
-    And I should see a "Version 1: (draft - not built) - Check the changes below" text
+    And I wait until I see "SLES12-SP5-Pool for x86_64" text
+    Then I should see a "Version 1: (draft - not built) - Check the changes below" text
 
 @uyuni
   Scenario: Verify added sources for Uyuni
     When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
-    And I should see a "SLES12-SP5-Updates for x86_64" text
+    Then I should see a "SLES12-SP5-Updates for x86_64" text
     And I should see a "Build (2)" text
 
 @susemanager
   Scenario: Verify added sources for SUSE Manager
     When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
-    And I should see a "SLE-Manager-Tools12-Updates for x86_64 SP5" text
+    Then I should see a "SLE-Manager-Tools12-Updates for x86_64 SP5" text
     And I should see a "SLES12-SP5-Updates for x86_64" text
     And I should see a "SLE-Manager-Tools12-Pool for x86_64 SP5" text
     And I should see a "Build (4)" text

--- a/testsuite/features/secondary/srv_content_lifecycle.feature
+++ b/testsuite/features/secondary/srv_content_lifecycle.feature
@@ -37,6 +37,7 @@ Feature: Content lifecycle
     And I follow "clp_name"
     And I click on "Attach/Detach Sources"
     And I select "SLES12-SP5-Pool for x86_64" from "selectedBaseChannel"
+    And I wait until I see "SLES12-SP5-Pool for x86_64" text
     And I click on "Save"
     And I wait until I see "SLES12-SP5-Pool for x86_64" text
     Then I should see a "Version 1: (draft - not built) - Check the changes below" text

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -172,12 +172,12 @@ When(/^I check "([^"]*)" if not checked$/) do |arg1|
 end
 
 When(/^I select "([^"]*)" from "([^"]*)"$/) do |option, field|
-  xpath_option = ".//*[contains(@class, 'data-testid-#{field}-child__option') and contains(text(),'#{option}')]"
-  xpath_field = "//*[contains(@class, 'data-testid-#{field}-child__control')]"
   if has_select?(field, with_options: [option], wait: 1)
     select(option, from: field)
   else
     # Custom React selector
+    xpath_field = "//*[contains(@class, 'data-testid-#{field}-child__control')]"
+    xpath_option = ".//*[contains(@class, 'data-testid-#{field}-child__option') and contains(text(), '#{option}')]"
     find(:xpath, xpath_field).click
     find(:xpath, xpath_option, match: :first).click
   end


### PR DESCRIPTION
## What does this PR change?

When we select a channel in the CLM "add sources" dialog box, a summary of the channel and its child channels appears, where the channel is selected via a checkbox.

If this summary has not the time to appear and we press the "Save" button too early, then the channel will not be selected in the sources.

This PR waits for the summary to appear, by waiting for the selected channel name to appear.

There are also cosmetical changes (in a separate commit).

Note: an unresolved problem in 4.2 is that the drop-down field is callled `undefined`. This should probably be fixed at product level.


## Links

Ports:
* 4.1: SUSE/spacewalk#17767
* 4.2: SUSE/spacewalk#17766


## Changelogs

- [x] No changelog needed
