### PR TITLE
Use registry.opensuse.org/uyuni namespace for proxy containers

### DIFF
--- a/containers/proxy-systemd-services/uyuni-proxy-services.config
+++ b/containers/proxy-systemd-services/uyuni-proxy-services.config
@@ -1,7 +1,7 @@
 # This file is expected to be found in `/etc/sysconfig/container-proxy-services.config`,
 # the EnvironmentFile services property is pointing there
 
-NAMESPACE=registry.opensuse.org/systemsmanagement/uyuni/stable/containers/uyuni
+NAMESPACE=registry.opensuse.org/uyuni
 CONFIG_DIR=/etc/uyuni/proxy
 SQUID_CACHE_DIR=/var/lib/uyuni/proxy-squid-cache
 RHN_CACHE_DIR=/var/lib/uyuni/proxy-rhn-cache

--- a/containers/proxy-systemd-services/uyuni-proxy-systemd-services.changes
+++ b/containers/proxy-systemd-services/uyuni-proxy-systemd-services.changes
@@ -1,3 +1,5 @@
+- Fix containers namespaces in configuration
+
 -------------------------------------------------------------------
 Wed May 04 15:26:57 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

The longer
registry.opensuse.org/systemsmanagement/uyuni/stable/containers/uyuni
namspace is no longer provided.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: not ready yet

- [X] **DONE**

## Links

Fixes #5387 

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
