### PR TITLE
[4.3 RC1] Remove the port from the proxy path given to preflight script

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
@@ -259,7 +259,7 @@ public class SaltSSHService {
                             Optional.of(Arrays.asList(
                                     proxyPath.isEmpty() ?
                                             ConfigDefaults.get().getCobblerHost() :
-                                            proxyPath.get(proxyPath.size() - 1),
+                                            proxyPath.get(proxyPath.size() - 1).split(":")[0],
                                     ContactMethodUtil.SSH_PUSH_TUNNEL.equals(contactMethodLabel) ?
                                             getSshPushRemotePort() : SSL_PORT,
                                     getSSHUseSaltThin() ? 1 : 0
@@ -529,7 +529,7 @@ public class SaltSSHService {
                     Optional.of(Arrays.asList(
                             bootstrapProxyPath.isEmpty() ?
                                     ConfigDefaults.get().getCobblerHost() :
-                                    bootstrapProxyPath.get(bootstrapProxyPath.size() - 1),
+                                    bootstrapProxyPath.get(bootstrapProxyPath.size() - 1).split(":")[0],
                             ContactMethodUtil.SSH_PUSH_TUNNEL.equals(contactMethod) ?
                                     getSshPushRemotePort() : SSL_PORT,
                             getSSHUseSaltThin() ? 1 : 0,

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Remove the SSH proxy port from the path passed to preflight script
+
 -------------------------------------------------------------------
 Wed May 04 15:20:24 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
The preflight script doesn't care about the SSH port, remove it from the
proxy path or we end up with URLs like https://server:8022:443/ with
both SSH and TLS ports.

## What does this PR change?

Ensure we don't have the SSH proxy port in the pre flight script host parameter

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: testing the `SaltRoster` generation is not easy

- [X] **DONE**

## Links

Fixes #5389 

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
