### PR TITLE
QE: Update the Docker profiles in CI to use SLES15 images

### DIFF
--- a/testsuite/features/profiles/Docker/Dockerfile
+++ b/testsuite/features/profiles/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.mgr.suse.de/toaster-sles12sp3-products
+FROM registry.mgr.suse.de/toaster-sles15sp2-products
 MAINTAINER Admin User "noemail@example.com"
 
 ARG repo
@@ -10,7 +10,7 @@ RUN echo "$repo" > /etc/zypp/repos.d/susemanager:dockerbuild.repo
 
 ADD nsswitch.conf /etc/nsswitch.conf
 ADD avahi-daemon.conf /root/avahi-daemon.conf
-ADD sles12sp4.repo /etc/zypp/repos.d/sles12sp4.repo
+ADD sles15sp2.repo /etc/zypp/repos.d/sles15sp2.repo
 
 ADD add_packages.sh /root/add_packages.sh
 RUN /root/add_packages.sh

--- a/testsuite/features/profiles/Docker/add_packages.sh
+++ b/testsuite/features/profiles/Docker/add_packages.sh
@@ -12,7 +12,7 @@ cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Test-Channel-x86_64 || :
-zypper rr sles12sp4
+zypper rr sles15sp2
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref

--- a/testsuite/features/profiles/Docker/authprofile/Dockerfile
+++ b/testsuite/features/profiles/Docker/authprofile/Dockerfile
@@ -14,7 +14,7 @@ RUN echo "$repo" > /etc/zypp/repos.d/susemanager:dockerbuild.repo
 
 ADD nsswitch.conf /etc/nsswitch.conf
 ADD avahi-daemon.conf /root/avahi-daemon.conf
-ADD sles12sp4.repo /etc/zypp/repos.d/sles12sp4.repo
+ADD sles15sp4.repo /etc/zypp/repos.d/sles15sp4.repo
 
 ADD add_packages.sh /root/add_packages.sh
 RUN /root/add_packages.sh

--- a/testsuite/features/profiles/Docker/authprofile/add_packages.sh
+++ b/testsuite/features/profiles/Docker/authprofile/add_packages.sh
@@ -15,7 +15,7 @@ zypper --non-interactive in python3 python3-xml
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Test-Channel-x86_64 || :
-zypper rr sles12sp4
+zypper rr sles15sp4
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref

--- a/testsuite/features/profiles/Docker/authprofile/sles12sp4.repo
+++ b/testsuite/features/profiles/Docker/authprofile/sles12sp4.repo
@@ -1,6 +1,0 @@
-[sles12sp4]
-name=sles12sp4
-enabled=1
-autorefresh=0
-baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product/
-type=rpm-md

--- a/testsuite/features/profiles/Docker/authprofile/sles15sp4.repo
+++ b/testsuite/features/profiles/Docker/authprofile/sles15sp4.repo
@@ -1,0 +1,6 @@
+[sles15sp4]
+name=sles15sp4
+enabled=1
+autorefresh=0
+baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP4/x86_64/product/
+type=rpm-md

--- a/testsuite/features/profiles/Docker/serverhost/Dockerfile
+++ b/testsuite/features/profiles/Docker/serverhost/Dockerfile
@@ -14,7 +14,7 @@ RUN echo "$repo" > /etc/zypp/repos.d/susemanager:dockerbuild.repo
 
 ADD nsswitch.conf /etc/nsswitch.conf
 ADD avahi-daemon.conf /root/avahi-daemon.conf
-ADD sles12sp4.repo /etc/zypp/repos.d/sles12sp4.repo
+ADD sles15sp4.repo /etc/zypp/repos.d/sles15sp4.repo
 
 ADD add_packages.sh /root/add_packages.sh
 RUN /root/add_packages.sh

--- a/testsuite/features/profiles/Docker/serverhost/add_packages.sh
+++ b/testsuite/features/profiles/Docker/serverhost/add_packages.sh
@@ -15,7 +15,7 @@ zypper --non-interactive in python3 python3-xml
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Test-Channel-x86_64 || :
-zypper rr sles12sp4
+zypper rr sles15sp4
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref

--- a/testsuite/features/profiles/Docker/serverhost/sles12sp4.repo
+++ b/testsuite/features/profiles/Docker/serverhost/sles12sp4.repo
@@ -1,6 +1,0 @@
-[sles12sp4]
-name=sles12sp4
-enabled=1
-autorefresh=0
-baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product/
-type=rpm-md

--- a/testsuite/features/profiles/Docker/serverhost/sles15sp4.repo
+++ b/testsuite/features/profiles/Docker/serverhost/sles15sp4.repo
@@ -1,0 +1,6 @@
+[sles15sp4]
+name=sles15sp4
+enabled=1
+autorefresh=0
+baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP4/x86_64/product/
+type=rpm-md

--- a/testsuite/features/profiles/Docker/sles12sp4.repo
+++ b/testsuite/features/profiles/Docker/sles12sp4.repo
@@ -1,6 +1,0 @@
-[sles12sp4]
-name=sles12sp4
-enabled=1
-autorefresh=0
-baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product/
-type=rpm-md

--- a/testsuite/features/profiles/Docker/sles15sp2.repo
+++ b/testsuite/features/profiles/Docker/sles15sp2.repo
@@ -1,0 +1,6 @@
+[sles15sp2]
+name=sles15sp2
+enabled=1
+autorefresh=0
+baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product/
+type=rpm-md


### PR DESCRIPTION
## What does this PR change?

**Card**: https://github.com/SUSE/spacewalk/issues/17619

Update the docker profiles in CI to use SLES15 images, so we match Docker profiles with Build Host OS (SLES15SP4)

**Note:** For now we don't have an image for SLE15 available in the registry, I'm discussing it with @agraul , once we have one, we can merge this. We might for now use SLES15SP2 image and then I will make the changes in that PR to use it instead of SP4.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Docker profiles

- [x] **DONE**

## Links

No ports.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
