### PR TITLE
QE: Add system presence tags for init client features

### DIFF
--- a/testsuite/features/init_clients/sle_client.feature
+++ b/testsuite/features/init_clients/sle_client.feature
@@ -1,6 +1,7 @@
 # Copyright (c) 2015-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@sle_client
 Feature: Register a traditional client
   In order to register a traditional client to the Uyuni server
   I want to create, parametrize and run boostrap script from proxy

--- a/testsuite/features/init_clients/sle_minion.feature
+++ b/testsuite/features/init_clients/sle_minion.feature
@@ -1,6 +1,7 @@
 # Copyright (c) 2016-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@sle_minion
 Feature: Bootstrap a Salt minion via the GUI
 
   Scenario: Log in as admin user


### PR DESCRIPTION
## What does this PR change?

Adding tags for system presence, so when we don't deploy a `sle_minion` or a `sle_client` VM, we don't try to init clients for them.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were improved

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
