### PR TITLE
On upgrade, create LOCAL-RHN-ORG-TRUSTED-SSL-CERT (bsc#1199376)

### DIFF
--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,4 +1,4 @@
-- on upgrade, create LOCAL-RHN-ORG-TRUSTED-SSL-CERT (bsc#1199376)
+- create LOCAL-RHN-ORG-TRUSTED-SSL-CERT if not exist (bsc#1199376)
 
 -------------------------------------------------------------------
 Thu Apr 28 10:14:10 CEST 2022 - jgonzalez@suse.com

--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,3 +1,5 @@
+- on upgrade, create LOCAL-RHN-ORG-TRUSTED-SSL-CERT (bsc#1199376)
+
 -------------------------------------------------------------------
 Thu Apr 28 10:14:10 CEST 2022 - jgonzalez@suse.com
 

--- a/spacewalk/config/spacewalk-config.spec
+++ b/spacewalk/config/spacewalk-config.spec
@@ -62,6 +62,7 @@ BuildRequires:  openssl
 BuildRequires:  sudo
 %endif
 Requires:       (apache2-mod_xsendfile or mod_xsendfile)
+Requires: diff
 
 %description
 Common Spacewalk configuration files and templates.
@@ -206,5 +207,12 @@ if [ -e /etc/pki/tls/private/uyuni.key ]; then
   fi
 fi
 
+if [[ ! -f /etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT ]] ; then
+    if diff -qs /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT /srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT ; then
+        mv /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT /etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT
+    else
+        cp /srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT /etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT
+    fi
+fi
 
 %changelog

--- a/spacewalk/config/spacewalk-config.spec
+++ b/spacewalk/config/spacewalk-config.spec
@@ -62,7 +62,7 @@ BuildRequires:  openssl
 BuildRequires:  sudo
 %endif
 Requires:       (apache2-mod_xsendfile or mod_xsendfile)
-Requires: diff
+Requires:       diffutils
 
 %description
 Common Spacewalk configuration files and templates.

--- a/spacewalk/config/spacewalk-config.spec
+++ b/spacewalk/config/spacewalk-config.spec
@@ -207,7 +207,7 @@ if [ -e /etc/pki/tls/private/uyuni.key ]; then
   fi
 fi
 
-if [[ ! -f /etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT ]] ; then
+if [ ! -f /etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT ] ; then
     if diff -qs /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT /srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT ; then
         mv /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT /etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT
     else


### PR DESCRIPTION
## What does this PR change?

`/usr/lib/susemanager/bin/pg-migrate-13-to-14.sh` fails with this error:
```
spacewalk-startup-helper[3420]: The SSL CA Certificate (/etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT) is required to setup the reporting database
 spacewalk-startup-helper[3334]: Report Database creation has failed. Please check the logs.
```

on upgrade, create `LOCAL-RHN-ORG-TRUSTED-SSL-CERT`.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17780

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
