### PR TITLE
Drop handling container version in changelog

### DIFF
--- a/rel-eng/push-packages-to-obs.sh
+++ b/rel-eng/push-packages-to-obs.sh
@@ -270,13 +270,6 @@ while read PKG_NAME; do
       # to lowercase with ",," and replace spaces " " with "-"
       PRODUCT_VERSION=$(echo ${PRODUCT_VERSION,,} | sed -r 's/ /-/g')
       sed "s/%PKG_VERSION%/${PRODUCT_VERSION}/g" -i $SRPM_PKG_DIR/Dockerfile
-
-      # if obs vs local version is different, add changelog about the bumping version
-      OSC_PKG_VERSION=$(${OSC} cat ${OBS_PROJ}/${PKG_NAME}/Dockerfile | grep '^LABEL org.opencontainers.image.version=')
-      OSC_PKG_VERSION=$(echo ${OSC_PKG_VERSION} | sed -n 's/.*=\"\(.*\)\"/\1/p')
-      if [ "${OSC_PKG_VERSION}" != "${PRODUCT_VERSION}" ]; then
-        ${OSC} vc ${SRPM_PKG_DIR} -m "Bump version to ${PRODUCT_VERSION}"
-      fi
   fi
 
   # update from obs (create missing package on the fly)


### PR DESCRIPTION
## What does this PR change?

$subject

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed:  rel-eng stuff

- [x] **DONE**

## Test coverage
- No tests: rel-eng stuff

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
