### PR TITLE
cleanup leftovers

### DIFF
--- a/python/spacewalk/server/handlers/sat/__init__.py
+++ b/python/spacewalk/server/handlers/sat/__init__.py
@@ -17,11 +17,9 @@
 __all__ = []
 
 from . import auth
-from . import cert
 
 rpcClasses = {
     'authentication':   auth.Authentication,
-    'certificate':   cert.Certificate,
 }
 
 getHandler = None

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- cleanup leftovers from removing unused xmlrpc endpoint
+
 -------------------------------------------------------------------
 Thu May 05 13:40:49 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Cleanup some leftovers from removal of an unused xmlrpc endpoint.

Follow up on commit ec7cd9f3bf70b3109d74d91e173f10a4f21370d7

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes #

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
