### PR TITLE
convert Basic Auth into token auth to make caching possible

### DIFF
--- a/proxy/proxy/broker/rhnBroker.py
+++ b/proxy/proxy/broker/rhnBroker.py
@@ -169,9 +169,12 @@ class BrokerHandler(SharedHandler):
             # we need to remove Basic Auth, otherwise squid does not cache the package
             # so we convert it into token auth
             # The token is the login. So it is not secret
-            lpw = ustr(base64.b64decode(self.req.headers_in['Authorization'][6:])) # "Basic " == 6 characters
-            self.authToken = lpw[:lpw.find(':')]
-            del self.req.headers_in['Authorization']
+            try:
+                lpw = ustr(base64.b64decode(self.req.headers_in['Authorization'][6:])) # "Basic " == 6 characters
+                self.authToken = lpw[:lpw.find(':')]
+                del self.req.headers_in['Authorization']
+            except Exception as e:
+                log_error("Unable to decode Authorization header.", e)
         elif 'X-RHN-Auth' not in self.req.headers_in:
             self.authToken = effectiveURI_parts.query
 

--- a/proxy/proxy/broker/rhnBroker.py
+++ b/proxy/proxy/broker/rhnBroker.py
@@ -168,7 +168,9 @@ class BrokerHandler(SharedHandler):
         elif 'Authorization' in self.req.headers_in and effectiveURI_parts.path.startswith('/rhn/manager/download/'):
             # we need to remove Basic Auth, otherwise squid does not cache the package
             # so we convert it into token auth
-            self.authToken = ustr(base64.b64decode(self.req.headers_in['Authorization'][6:]))[:-1] # "Basic " == 6 characters
+            # The token is the login. So it is not secret
+            lpw = ustr(base64.b64decode(self.req.headers_in['Authorization'][6:])) # "Basic " == 6 characters
+            self.authToken = lpw[:lpw.find(':')]
             del self.req.headers_in['Authorization']
         elif 'X-RHN-Auth' not in self.req.headers_in:
             self.authToken = effectiveURI_parts.query

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,5 @@
+- fix caching of debian packages in the proxy (bsc#1199401)
+
 -------------------------------------------------------------------
 Thu Apr 28 10:13:40 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Debians "apt" does not work with token auth. As a workaround we configured basic auth and use the token as "login" (username). The password is empty.
But squid does not cache files recieved via an authenticated transaction which make the use of the proxy useless.

To solve this problem, this PR convert the basic auth into token auth. With token auth we have a solution to get
the files cached.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- TBD

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17776
Fixes https://github.com/uyuni-project/uyuni/issues/5241
Tracks https://github.com/SUSE/spacewalk/pull/17831

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
