### PR TITLE
XMLRPC: authenticate in listChannels as it may not have been done yet

### DIFF
--- a/python/spacewalk/server/handlers/xmlrpc/up2date.py
+++ b/python/spacewalk/server/handlers/xmlrpc/up2date.py
@@ -124,28 +124,9 @@ class Up2date(rhnHandler):
 
     def listChannels(self, system_id):
         """ Clients v2+ """
-        log_debug(5, system_id)
-        # Authenticate the system certificate
-        self.auth_system('listChannels', system_id)
-        # log the entry
-        log_debug(1, self.server_id)
+        self.login(system_id)
+
         channelList = rhnChannel.channels_for_server(self.server_id)
-
-        loginDict = {
-            'X-RHN-Server-Id': self.server_id,
-            'X-RHN-Auth-Channels': rhnChannel.getSubscribedChannels(self.server_id),
-        }
-
-        # Duplicate these values in the headers so that the proxy can
-        # intercept and cache them without parseing the xmlrpc.
-        transport = rhnFlags.get('outputTransportOptions')
-        for k, v in list(loginDict.items()):
-            # Special case for channels
-            if k.lower() == 'x-rhn-auth-channels'.lower():
-                # Concatenate the channel information column-separated
-                transport[k] = [':'.join(x) for x in v]
-            else:
-                transport[k] = v
         return channelList
 
     def subscribeChannels(self, system_id, channelNames, username, passwd):

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Authenticate when listing channels (bsc#1197963)
+
 -------------------------------------------------------------------
 Thu May 05 13:40:49 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

zypper spacewalk plugin seems to first list the channels and then login
on the server... When using a proxy, the broker checks the
authentication token to handle the listChannels and we don't have it.

Doing a full login on the server side ensures the proxy has the token
when expected.

## GUI diff

No difference.
- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [X] **DONE**

## Test coverage
- No tests: covered, just that now there won't be backtraces in apache proxy logs

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17432

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
