### PR TITLE
Fix ACL rules for config diff download for SLS files (bsc#1198914)

### DIFF
--- a/java/code/webapp/WEB-INF/struts-config.xml
+++ b/java/code/webapp/WEB-INF/struts-config.xml
@@ -7049,7 +7049,7 @@
         input="/WEB-INF/pages/configuration/files/diff.jsp"
         type="com.redhat.rhn.frontend.action.configuration.files.DownloadDiffAction"
         className="com.redhat.rhn.frontend.struts.RhnActionMapping">
-        <set-property property="acls" value="is_file()"/>
+        <set-property property="acls" value="is_file() or is_sls()"/>
         <set-property property="mixins" value="com.redhat.rhn.common.security.acl.ConfigAclHandler" />
         <forward name="default"
                  path="/configuration/file/Diff.do"/>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix ACL rules for config diff download for SLS files (bsc#1198914)
 - fix invalid link to action schedule
 
 -------------------------------------------------------------------


### PR DESCRIPTION
The config file diff output cannot be downloaded for SLS files because of a missing ACL rule. This PR adds the rule to ensure access.

https://bugzilla.suse.com/show_bug.cgi?id=1198914

Port of: https://github.com/SUSE/spacewalk/pull/17729

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
