### PR TITLE
payg taskomatic task for updating certificates (#17783)

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygUpdateHostsTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygUpdateHostsTask.java
@@ -45,7 +45,7 @@ public class PaygUpdateHostsTask extends RhnJavaJob {
 
     @Override
     public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
-        log.debug("Running CloudRmUpdateHostsTaksc");
+        log.debug("Running CloudRmUpdateHostsTask");
         List<CloudRmtHost> hostToUpdate = CloudRmtHostFactory.lookupCloudRmtHostsToUpdate();
         loadHttpsCertificates(hostToUpdate);
         updateHost(hostToUpdate);
@@ -64,8 +64,17 @@ public class PaygUpdateHostsTask extends RhnJavaJob {
             log.error("error when writing the hosts file", e);
         }
         finally {
-            String[] cmd = {"/usr/share/rhn/certs/update-ca-cert-trust.sh"};
-            executeExtCmd(cmd);
+            if (hostToUpdate.size() > 0) {
+                try {
+                    String[] cmd = {"systemctl", "is-active", "--quiet", "ca-certificates.path"};
+                    executeExtCmd(cmd);
+                }
+                catch (Exception e) {
+                    log.debug("ca-certificates.path service is not active, we will call 'update-ca-certificates' tool");
+                    String[] cmd = {"/usr/share/rhn/certs/update-ca-cert-trust.sh"};
+                    executeExtCmd(cmd);
+                }
+            }
         }
     }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Correct concurrency error on payg taskomatic task
+  for updating certificates (#17783)
 - Display usertime instead of server time for clm issue date filter (bsc#1198429)
 - fix bootstrapping of ssh minions via proxy
 - check if file exists before sending it to xsendfile (bsc#1198191)


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

Implementation of: https://github.com/SUSE/spacewalk/issues/17783

We now do a two-step process:
 - check if `ca-certificates.path` service is running
 - if not running call `/usr/sbin/update-ca-certificates`
 
Before this change the script `/usr/share/rhn/certs/update-ca-cert-trust.sh` was always called, and was causing some concurrency errors.

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
