### PR TITLE
Regenerated "internal_prv" and "internal_nue" with "make" command

### DIFF
--- a/testsuite/features/profiles/internal_nue/Docker/Dockerfile
+++ b/testsuite/features/profiles/internal_nue/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.mgr.suse.de/toaster-sles12sp3-products
+FROM registry.mgr.suse.de/toaster-sles15sp2-products
 MAINTAINER Admin User "noemail@example.com"
 
 ARG repo
@@ -10,7 +10,7 @@ RUN echo "$repo" > /etc/zypp/repos.d/susemanager:dockerbuild.repo
 
 ADD nsswitch.conf /etc/nsswitch.conf
 ADD avahi-daemon.conf /root/avahi-daemon.conf
-ADD sles12sp4.repo /etc/zypp/repos.d/sles12sp4.repo
+ADD sles15sp2.repo /etc/zypp/repos.d/sles15sp2.repo
 
 ADD add_packages.sh /root/add_packages.sh
 RUN /root/add_packages.sh

--- a/testsuite/features/profiles/internal_nue/Docker/add_packages.sh
+++ b/testsuite/features/profiles/internal_nue/Docker/add_packages.sh
@@ -12,7 +12,7 @@ cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Test-Channel-x86_64 || :
-zypper rr sles12sp4
+zypper rr sles15sp2
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref

--- a/testsuite/features/profiles/internal_nue/Docker/authprofile/Dockerfile
+++ b/testsuite/features/profiles/internal_nue/Docker/authprofile/Dockerfile
@@ -14,7 +14,7 @@ RUN echo "$repo" > /etc/zypp/repos.d/susemanager:dockerbuild.repo
 
 ADD nsswitch.conf /etc/nsswitch.conf
 ADD avahi-daemon.conf /root/avahi-daemon.conf
-ADD sles12sp4.repo /etc/zypp/repos.d/sles12sp4.repo
+ADD sles15sp4.repo /etc/zypp/repos.d/sles15sp4.repo
 
 ADD add_packages.sh /root/add_packages.sh
 RUN /root/add_packages.sh

--- a/testsuite/features/profiles/internal_nue/Docker/authprofile/add_packages.sh
+++ b/testsuite/features/profiles/internal_nue/Docker/authprofile/add_packages.sh
@@ -15,7 +15,7 @@ zypper --non-interactive in python3 python3-xml
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Test-Channel-x86_64 || :
-zypper rr sles12sp4
+zypper rr sles15sp4
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref

--- a/testsuite/features/profiles/internal_nue/Docker/authprofile/sles12sp4.repo
+++ b/testsuite/features/profiles/internal_nue/Docker/authprofile/sles12sp4.repo
@@ -1,6 +1,0 @@
-[sles12sp4]
-name=sles12sp4
-enabled=1
-autorefresh=0
-baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product/
-type=rpm-md

--- a/testsuite/features/profiles/internal_nue/Docker/authprofile/sles15sp4.repo
+++ b/testsuite/features/profiles/internal_nue/Docker/authprofile/sles15sp4.repo
@@ -1,0 +1,6 @@
+[sles15sp4]
+name=sles15sp4
+enabled=1
+autorefresh=0
+baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP4/x86_64/product/
+type=rpm-md

--- a/testsuite/features/profiles/internal_nue/Docker/serverhost/Dockerfile
+++ b/testsuite/features/profiles/internal_nue/Docker/serverhost/Dockerfile
@@ -14,7 +14,7 @@ RUN echo "$repo" > /etc/zypp/repos.d/susemanager:dockerbuild.repo
 
 ADD nsswitch.conf /etc/nsswitch.conf
 ADD avahi-daemon.conf /root/avahi-daemon.conf
-ADD sles12sp4.repo /etc/zypp/repos.d/sles12sp4.repo
+ADD sles15sp4.repo /etc/zypp/repos.d/sles15sp4.repo
 
 ADD add_packages.sh /root/add_packages.sh
 RUN /root/add_packages.sh

--- a/testsuite/features/profiles/internal_nue/Docker/serverhost/add_packages.sh
+++ b/testsuite/features/profiles/internal_nue/Docker/serverhost/add_packages.sh
@@ -15,7 +15,7 @@ zypper --non-interactive in python3 python3-xml
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Test-Channel-x86_64 || :
-zypper rr sles12sp4
+zypper rr sles15sp4
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref

--- a/testsuite/features/profiles/internal_nue/Docker/serverhost/sles12sp4.repo
+++ b/testsuite/features/profiles/internal_nue/Docker/serverhost/sles12sp4.repo
@@ -1,6 +1,0 @@
-[sles12sp4]
-name=sles12sp4
-enabled=1
-autorefresh=0
-baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product/
-type=rpm-md

--- a/testsuite/features/profiles/internal_nue/Docker/serverhost/sles15sp4.repo
+++ b/testsuite/features/profiles/internal_nue/Docker/serverhost/sles15sp4.repo
@@ -1,0 +1,6 @@
+[sles15sp4]
+name=sles15sp4
+enabled=1
+autorefresh=0
+baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP4/x86_64/product/
+type=rpm-md

--- a/testsuite/features/profiles/internal_nue/Docker/sles12sp4.repo
+++ b/testsuite/features/profiles/internal_nue/Docker/sles12sp4.repo
@@ -1,6 +1,0 @@
-[sles12sp4]
-name=sles12sp4
-enabled=1
-autorefresh=0
-baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product/
-type=rpm-md

--- a/testsuite/features/profiles/internal_nue/Docker/sles15sp2.repo
+++ b/testsuite/features/profiles/internal_nue/Docker/sles15sp2.repo
@@ -1,0 +1,6 @@
+[sles15sp2]
+name=sles15sp2
+enabled=1
+autorefresh=0
+baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product/
+type=rpm-md

--- a/testsuite/features/profiles/internal_prv/Docker/Dockerfile
+++ b/testsuite/features/profiles/internal_prv/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.mgr.prv.suse.net/toaster-sles12sp3-products
+FROM registry.mgr.prv.suse.net/toaster-sles15sp2-products
 MAINTAINER Admin User "noemail@example.com"
 
 ARG repo
@@ -10,7 +10,7 @@ RUN echo "$repo" > /etc/zypp/repos.d/susemanager:dockerbuild.repo
 
 ADD nsswitch.conf /etc/nsswitch.conf
 ADD avahi-daemon.conf /root/avahi-daemon.conf
-ADD sles12sp4.repo /etc/zypp/repos.d/sles12sp4.repo
+ADD sles15sp2.repo /etc/zypp/repos.d/sles15sp2.repo
 
 ADD add_packages.sh /root/add_packages.sh
 RUN /root/add_packages.sh

--- a/testsuite/features/profiles/internal_prv/Docker/add_packages.sh
+++ b/testsuite/features/profiles/internal_prv/Docker/add_packages.sh
@@ -12,7 +12,7 @@ cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Test-Channel-x86_64 || :
-zypper rr sles12sp4
+zypper rr sles15sp2
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref

--- a/testsuite/features/profiles/internal_prv/Docker/authprofile/Dockerfile
+++ b/testsuite/features/profiles/internal_prv/Docker/authprofile/Dockerfile
@@ -14,7 +14,7 @@ RUN echo "$repo" > /etc/zypp/repos.d/susemanager:dockerbuild.repo
 
 ADD nsswitch.conf /etc/nsswitch.conf
 ADD avahi-daemon.conf /root/avahi-daemon.conf
-ADD sles12sp4.repo /etc/zypp/repos.d/sles12sp4.repo
+ADD sles15sp4.repo /etc/zypp/repos.d/sles15sp4.repo
 
 ADD add_packages.sh /root/add_packages.sh
 RUN /root/add_packages.sh

--- a/testsuite/features/profiles/internal_prv/Docker/authprofile/add_packages.sh
+++ b/testsuite/features/profiles/internal_prv/Docker/authprofile/add_packages.sh
@@ -15,7 +15,7 @@ zypper --non-interactive in python3 python3-xml
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Test-Channel-x86_64 || :
-zypper rr sles12sp4
+zypper rr sles15sp4
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref

--- a/testsuite/features/profiles/internal_prv/Docker/authprofile/sles12sp4.repo
+++ b/testsuite/features/profiles/internal_prv/Docker/authprofile/sles12sp4.repo
@@ -1,6 +1,0 @@
-[sles12sp4]
-name=sles12sp4
-enabled=1
-autorefresh=0
-baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product/
-type=rpm-md

--- a/testsuite/features/profiles/internal_prv/Docker/authprofile/sles15sp4.repo
+++ b/testsuite/features/profiles/internal_prv/Docker/authprofile/sles15sp4.repo
@@ -1,0 +1,6 @@
+[sles15sp4]
+name=sles15sp4
+enabled=1
+autorefresh=0
+baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP4/x86_64/product/
+type=rpm-md

--- a/testsuite/features/profiles/internal_prv/Docker/serverhost/Dockerfile
+++ b/testsuite/features/profiles/internal_prv/Docker/serverhost/Dockerfile
@@ -14,7 +14,7 @@ RUN echo "$repo" > /etc/zypp/repos.d/susemanager:dockerbuild.repo
 
 ADD nsswitch.conf /etc/nsswitch.conf
 ADD avahi-daemon.conf /root/avahi-daemon.conf
-ADD sles12sp4.repo /etc/zypp/repos.d/sles12sp4.repo
+ADD sles15sp4.repo /etc/zypp/repos.d/sles15sp4.repo
 
 ADD add_packages.sh /root/add_packages.sh
 RUN /root/add_packages.sh

--- a/testsuite/features/profiles/internal_prv/Docker/serverhost/add_packages.sh
+++ b/testsuite/features/profiles/internal_prv/Docker/serverhost/add_packages.sh
@@ -15,7 +15,7 @@ zypper --non-interactive in python3 python3-xml
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Test-Channel-x86_64 || :
-zypper rr sles12sp4
+zypper rr sles15sp4
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref

--- a/testsuite/features/profiles/internal_prv/Docker/serverhost/sles12sp4.repo
+++ b/testsuite/features/profiles/internal_prv/Docker/serverhost/sles12sp4.repo
@@ -1,6 +1,0 @@
-[sles12sp4]
-name=sles12sp4
-enabled=1
-autorefresh=0
-baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product/
-type=rpm-md

--- a/testsuite/features/profiles/internal_prv/Docker/serverhost/sles15sp4.repo
+++ b/testsuite/features/profiles/internal_prv/Docker/serverhost/sles15sp4.repo
@@ -1,0 +1,6 @@
+[sles15sp4]
+name=sles15sp4
+enabled=1
+autorefresh=0
+baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP4/x86_64/product/
+type=rpm-md

--- a/testsuite/features/profiles/internal_prv/Docker/sles12sp4.repo
+++ b/testsuite/features/profiles/internal_prv/Docker/sles12sp4.repo
@@ -1,6 +1,0 @@
-[sles12sp4]
-name=sles12sp4
-enabled=1
-autorefresh=0
-baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product/
-type=rpm-md

--- a/testsuite/features/profiles/internal_prv/Docker/sles15sp2.repo
+++ b/testsuite/features/profiles/internal_prv/Docker/sles15sp2.repo
@@ -1,0 +1,6 @@
+[sles15sp2]
+name=sles15sp2
+enabled=1
+autorefresh=0
+baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product/
+type=rpm-md


### PR DESCRIPTION
## What does this PR change?

Regenerated "internal_prv" and "internal_nue" with "make" command after switch from 12sp3 to 15sp2 for docker images.


## Links

None, no ports.


## Changelogs

- [x] No changelog needed
