### PR TITLE
fix NoSuchElementException when pkg install date is missing

### DIFF
--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -1558,7 +1558,9 @@ public class SaltUtils {
                                                            Pkg.Info pkgInfo, Server server) {
         InstalledPackage pkg = new InstalledPackage();
         pkg.setEvr(packageEvr);
-        pkg.setInstallTime(new Date(pkgInfo.getInstallDateUnixTime().get() * 1000));
+        pkg.setInstallTime(pkgInfo.getInstallDateUnixTime()
+                .map(time -> new Date((time * 1000)))
+                .orElse(null));
         pkg.setName(packageName);
         pkg.setServer(server);
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix NoSuchElementException when pkg install date is missing
 - Fix error message in Kubernetes VHM creation dialog
 - Add createAppStreamFilters() XMLRPC function
 - Correct concurrency error on payg taskomatic task


### PR DESCRIPTION
## What does this PR change?

Fix exception when package install date is not reported.

```
2022-03-11 10:11:28,787 [salt-event-thread-2] ERROR com.suse.manager.webui.services.SaltServerActionService - Error processing Salt job return
java.util.NoSuchElementException: No value present
        at java.base/java.util.Optional.get(Optional.java:148)
        at com.suse.manager.utils.SaltUtils.createInstalledPackage(SaltUtils.java:1492)
        at com.suse.manager.utils.SaltUtils.lambda$createPackagesFromSalt$96(SaltUtils.java:1472)
...
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/4996
Tracks https://github.com/SUSE/spacewalk/pull/17809

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
