### PR TITLE
Wait for inspect action before checking image packages

### DIFF
--- a/testsuite/features/secondary/buildhost_docker_auth_registry.feature
+++ b/testsuite/features/secondary/buildhost_docker_auth_registry.feature
@@ -37,7 +37,7 @@ Feature: Build image with authenticated registry
     And I click on "submit-btn"
     Then I wait until I see "auth_registry_profile" text
     # Verify the status of images in the authenticated image store
-    When I wait at most 660 seconds until container "auth_registry_profile" with version "latest" is built successfully
+    When I wait at most 660 seconds until image "auth_registry_profile" with version "latest" is built and inspected successfully via API
     And I refresh the page
     Then table row for "auth_registry_profile" should contain "1"
     And the list of packages of image "auth_registry_profile" with version "latest" is not empty

--- a/testsuite/features/secondary/buildhost_docker_build_image.feature
+++ b/testsuite/features/secondary/buildhost_docker_build_image.feature
@@ -59,6 +59,11 @@ Feature: Build container images
     And I schedule the build of image "suse_real_key" via API calls
     And I wait at most 660 seconds until event "Image Build suse_real_key scheduled by admin" is completed
     And I wait at most 60 seconds until all "3" container images are built correctly in the GUI
+    # We should see the same result via API.
+    # Also, check that all inspect actions are finished:
+    And I wait at most 660 seconds until container "suse_key" with version "latest" is built successfully
+    And I wait at most 660 seconds until container "suse_simple" with version "latest" is built successfully
+    And I wait at most 660 seconds until container "suse_real_key" with version "latest" is built successfully
     Then the list of packages of image "suse_key" with version "latest" is not empty
     And the list of packages of image "suse_simple" with version "latest" is not empty
     And the list of packages of image "suse_real_key" with version "latest" is not empty

--- a/testsuite/features/secondary/buildhost_docker_build_image.feature
+++ b/testsuite/features/secondary/buildhost_docker_build_image.feature
@@ -58,12 +58,12 @@ Feature: Build container images
     And I wait at most 660 seconds until event "Image Build suse_simple scheduled by admin" is completed
     And I schedule the build of image "suse_real_key" via API calls
     And I wait at most 660 seconds until event "Image Build suse_real_key scheduled by admin" is completed
-    And I wait at most 60 seconds until all "3" container images are built correctly in the GUI
+    And I wait at most 60 seconds until all "3" container images are built correctly on the Image List page
     # We should see the same result via API.
     # Also, check that all inspect actions are finished:
-    And I wait at most 660 seconds until container "suse_key" with version "latest" is built successfully
-    And I wait at most 660 seconds until container "suse_simple" with version "latest" is built successfully
-    And I wait at most 660 seconds until container "suse_real_key" with version "latest" is built successfully
+    And I wait at most 660 seconds until image "suse_key" with version "latest" is built and inspected successfully via API
+    And I wait at most 660 seconds until image "suse_simple" with version "latest" is built and inspected successfully via API
+    And I wait at most 660 seconds until image "suse_real_key" with version "latest" is built and inspected successfully via API
     Then the list of packages of image "suse_key" with version "latest" is not empty
     And the list of packages of image "suse_simple" with version "latest" is not empty
     And the list of packages of image "suse_real_key" with version "latest" is not empty
@@ -71,8 +71,8 @@ Feature: Build container images
   Scenario: Build same images with different versions
     When I schedule the build of image "suse_key" with version "Latest_key-activation1" via API calls
     And I schedule the build of image "suse_simple" with version "Latest_simple" via API calls
-    And I wait at most 660 seconds until container "suse_simple" with version "Latest_simple" is built successfully
-    And I wait at most 660 seconds until container "suse_key" with version "Latest_key-activation1" is built successfully
+    And I wait at most 660 seconds until image "suse_simple" with version "Latest_simple" is built and inspected successfully via API
+    And I wait at most 660 seconds until image "suse_key" with version "Latest_key-activation1" is built and inspected successfully via API
     Then the list of packages of image "suse_key" with version "Latest_key-activation1" is not empty
     And the list of packages of image "suse_simple" with version "Latest_simple" is not empty
 
@@ -85,8 +85,8 @@ Feature: Build container images
   Scenario: Rebuild the images
     When I schedule the build of image "suse_simple" with version "Latest_simple" via API calls
     And I schedule the build of image "suse_key" with version "Latest_key-activation1" via API calls
-    And I wait at most 660 seconds until container "suse_key" with version "Latest_key-activation1" is built successfully
-    And I wait at most 660 seconds until container "suse_simple" with version "Latest_simple" is built successfully
+    And I wait at most 660 seconds until image "suse_key" with version "Latest_key-activation1" is built and inspected successfully via API
+    And I wait at most 660 seconds until image "suse_simple" with version "Latest_simple" is built and inspected successfully via API
     Then the list of packages of image "suse_key" with version "Latest_key-activation1" is not empty
     And the list of packages of image "suse_simple" with version "Latest_simple" is not empty
 
@@ -97,7 +97,7 @@ Feature: Build container images
     And I select the hostname of "build_host" from "buildHostId"
     And I click on "submit-btn"
     Then I wait until I see "GUI_BUILT_IMAGE" text
-    And I wait at most 660 seconds until container "suse_real_key" with version "GUI_BUILT_IMAGE" is built successfully
+    And I wait at most 660 seconds until image "suse_real_key" with version "GUI_BUILT_IMAGE" is built and inspected successfully via API
 
   Scenario: Login as Docker image administrator and build an image
     Given I am authorized as "docker" with password "docker"
@@ -107,7 +107,7 @@ Feature: Build container images
     And I select the hostname of "build_host" from "buildHostId"
     And I click on "submit-btn"
     Then I wait until I see "GUI_DOCKERADMIN" text
-    And I wait at most 660 seconds until container "suse_real_key" with version "GUI_DOCKERADMIN" is built successfully
+    And I wait at most 660 seconds until image "suse_real_key" with version "GUI_DOCKERADMIN" is built and inspected successfully via API
 
   Scenario: Cleanup: delete all images
     Given I am authorized as "admin" with password "admin"

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -30,7 +30,7 @@ When(/^I enter URI, username and password for registry$/) do
   )
 end
 
-When(/^I wait at most (\d+) seconds until container "([^"]*)" with version "([^"]*)" is built successfully$/) do |timeout, name, version|
+When(/^I wait at most (\d+) seconds until image "([^"]*)" with version "([^"]*)" is built and inspected successfully via API$/) do |timeout, name, version|
   images_list = $api_test.image.list_images
   log "List of images: #{images_list}"
   image_id = 0
@@ -54,7 +54,7 @@ end
 
 # Warning: this can be confused by failures in previous scenarios
 # so it should be used only in the first image building scenario
-When(/^I wait at most (\d+) seconds until all "([^"]*)" container images are built correctly in the GUI$/) do |timeout, count|
+When(/^I wait at most (\d+) seconds until all "([^"]*)" container images are built correctly on the Image List page$/) do |timeout, count|
   os_version, os_family = get_os_version($build_host)
   # don't run this for sles11 (docker feature is not there)
   unless os_family =~ /^sles/ && os_version =~ /^11/


### PR DESCRIPTION
## What does this PR change?

The image packages list is valid after the successful end of inspect action.
The GUI test for finished build checked only build action. API test checks both build and inspect actions.

This PR makes sure that the API test is called before the test for image packages.


## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
