### PR TITLE
Added a property to avoid automatic cleaning before each ant compilation

### DIFF
--- a/java/buildconf/manager-developer-build.properties.example
+++ b/java/buildconf/manager-developer-build.properties.example
@@ -4,6 +4,9 @@ deploy.host = d52.suse.de
 # Uncomment to use .class files from the build/classes directory directly to avoid calling javac
 #precompiled = true
 
+# Uncomment to avoid performing a clean before each compilation
+#build.incremental.compile = true
+
 # Uncomment to get javascript sourcemaps in Reactjs pages
 #javascript.devel = true
 

--- a/java/manager-build.xml
+++ b/java/manager-build.xml
@@ -58,6 +58,10 @@
     <delete dir="${test.results.dir}" />
   </target>
 
+  <target name="maybe-clean" unless="build.incremental.compile">
+    <antcall target="clean" />
+  </target>
+
   <target name="obs-to-maven" description="Updates local maven repository with OBS jars">
     <exec failonerror="true" executable="obs-to-maven">
       <arg line="-d ${basedir}/buildconf/ivy/obs-maven-config.yaml ${basedir}/buildconf/ivy/repository" />
@@ -68,7 +72,7 @@
     <ivy-retrieve sync="true" type="jar,bundle"/>
   </target>
 
-  <target name="refresh-branding-jar" depends="clean" description="Compiles and builds the SUSE branding jar">
+  <target name="refresh-branding-jar" depends="maybe-clean" description="Compiles and builds the SUSE branding jar">
     <mkdir dir="${build.dir}/java-branding" />
 
     <javac destdir="${build.dir}/java-branding"
@@ -88,7 +92,7 @@
   </target>
 
   <target name="compile"
-          depends="clean"
+          depends="maybe-clean"
           unless="precompiled"
           description="Compiles the main codebase"
   >


### PR DESCRIPTION
## What does this PR change?

This PR makes a small change in the ant `manager-build.xml` file. It allows to skip the `clean` step performed currently before each `compile`. In order to enable it, a new property `build.incremental.compile` needs to be defined inside the custom properties file `manager-developer-build.properties`. Without it, the build process maintains the old behaviour. 

When the property is enabled, the `clean` step will work as expected if invoked directly. So the old behaviour can still be obtained by chaining the tasks:

```
ant -f manager-build.xml clean webapp
```

This change is meant only as a developer convenience, to save time during build and deploy. 

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: change only affect the build process

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
