### PR TITLE
autorefresh and keeppackages flags only known on SUSE systems

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/bootstrap.repo
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/bootstrap.repo
@@ -9,9 +9,10 @@ type=rpm-md
 baseurl={{bootstrap_repo_url}}
 gpgcheck=0
 enabled=1
-autorefresh=1
-keeppackages=0
 {%- if grains['os_family'] == 'RedHat' and grains['osmajorrelease'] >= 8 %}
 module_hotfixes=1
+{%- elif grains['os_family'] == 'Suse' %}
+autorefresh=1
+keeppackages=0
 {%- endif %}
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- remove unknown repository flags on EL
+
 -------------------------------------------------------------------
 Fri May 06 16:30:23 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Some repository flags are only known on SUSE systems. Do not set them when bootstrapping EL systems.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/4988
Tracks https://github.com/SUSE/spacewalk/pull/17825

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
