### PR TITLE
store create-bootstrap logs in spacewalk-debug

### DIFF
--- a/python/spacewalk/satellite_tools/spacewalk-debug
+++ b/python/spacewalk/satellite_tools/spacewalk-debug
@@ -206,6 +206,11 @@ if [ -d /var/log/rhn ]; then
     if [ -d /var/log/rhn/search ]; then
         cp -fapRd /var/log/rhn/search $DIR/rhn-logs/rhn
     fi
+
+    # check mgr-create-bootstrap-repo dir
+    if [ -d /var/log/rhn/mgr-create-bootstrap-repo ]; then
+        cp -fapRd /var/log/rhn/mgr-create-bootstrap-repo $DIR/rhn-logs/rhn
+    fi
 fi
 
 DB_INSTALL_LOG=/var/log/rhn/rhn-database-installation.log

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- store create-bootstrap logs in spacewalk-debug
 - Fix traceback on calling spacewalk-repo-sync --show-packages
 - cleanup leftovers from removing unused xmlrpc endpoint
 


### PR DESCRIPTION
## What does this PR change?

The create-bootstrap logfiles are not part of spacewalk-debug collection.
As these are important logfiles, we better collect them.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **for debugging**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/17830

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
