### PR TITLE
Exits mgr-sync if properties are duplicated in conf files (bsc#1182742)

### DIFF
--- a/susemanager/src/mgr-sync
+++ b/susemanager/src/mgr-sync
@@ -31,6 +31,12 @@ except socket.error as ex:
         raise
     else:
         sys.exit(1)
+except SyntaxError as ex:
+    sys.stderr.write("Syntax error: {0}\n".format(ex))
+    if options.verbose:
+        raise
+    else:
+        sys.exit(1)
 except KeyboardInterrupt as ex:
     sys.stdout.write("\n")
 except Exception as ex:

--- a/susemanager/src/mgr_sync/config.py
+++ b/susemanager/src/mgr_sync/config.py
@@ -65,11 +65,17 @@ class Config(object):
 
         # Read /etc/rhn/rhn.conf if any
         if os.access(Config.RHNFILE, os.R_OK):
-            self._config.merge(ConfigObj(Config.RHNFILE))
+            try:
+                self._config.merge(ConfigObj(Config.RHNFILE))
+            except SyntaxError as ex:
+                raise SyntaxError("Error while parsing file {0}: {1}".format(Config.RHNFILE, ex)) from ex
 
         # Read ~/.mgr-sync if any and override
         if os.access(Config.DOTFILE, os.R_OK):
-            self._config.merge(ConfigObj(Config.DOTFILE))
+            try:
+                self._config.merge(ConfigObj(Config.DOTFILE))
+            except SyntaxError as ex:
+                raise SyntaxError("Error while parsing file{0}: {1}".format(Config.DOTFILE, ex)) from ex
 
         # Remove unnesessary items
         for key in list(self._config.keys()):

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- mgr-sync: Raise a proper exception when duplicated lines exist in a config file (bsc#1182742)
 - Add openSUSE Leap 15.4 bootstrap repositories
 - add SLED 12 SP3 bootstrap repo definition (bsc#1199438)
 - Add RHEL 7 and 8 bootstrap repositories for Uyuni


### PR DESCRIPTION
## What does this PR change?

mgr-sync was exiting abruptly when a duplicated property existed in a configuration file. Now it shows an error message.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed:  user invisible changes

- [X] **DONE**

## Test coverage
- No tests: bugfix

- [X] **DONE**

## Links

Fixes #[1182742](https://bugzilla.suse.com/show_bug.cgi?id=1182742)
Tracks https://github.com/SUSE/spacewalk/issues/14113

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
