### PR TITLE
Add Basesystem repo

### DIFF
--- a/testsuite/features/profiles/Docker/serverhost/Dockerfile
+++ b/testsuite/features/profiles/Docker/serverhost/Dockerfile
@@ -15,6 +15,7 @@ RUN echo "$repo" > /etc/zypp/repos.d/susemanager:dockerbuild.repo
 ADD nsswitch.conf /etc/nsswitch.conf
 ADD avahi-daemon.conf /root/avahi-daemon.conf
 ADD sles15sp4.repo /etc/zypp/repos.d/sles15sp4.repo
+ADD sles15sp4-base.repo /etc/zypp/repos.d/sles15sp4-base.repo
 
 ADD add_packages.sh /root/add_packages.sh
 RUN /root/add_packages.sh

--- a/testsuite/features/profiles/Docker/serverhost/sles15sp4-base.repo
+++ b/testsuite/features/profiles/Docker/serverhost/sles15sp4-base.repo
@@ -1,0 +1,6 @@
+[sles15sp4-base]
+name=sles15sp4-base
+enabled=1
+autorefresh=0
+baseurl=http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP4/x86_64/update/
+type=rpm-md

--- a/testsuite/features/profiles/internal_nue/Docker/serverhost/Dockerfile
+++ b/testsuite/features/profiles/internal_nue/Docker/serverhost/Dockerfile
@@ -15,6 +15,7 @@ RUN echo "$repo" > /etc/zypp/repos.d/susemanager:dockerbuild.repo
 ADD nsswitch.conf /etc/nsswitch.conf
 ADD avahi-daemon.conf /root/avahi-daemon.conf
 ADD sles15sp4.repo /etc/zypp/repos.d/sles15sp4.repo
+ADD sles15sp4-base.repo /etc/zypp/repos.d/sles15sp4-base.repo
 
 ADD add_packages.sh /root/add_packages.sh
 RUN /root/add_packages.sh

--- a/testsuite/features/profiles/internal_nue/Docker/serverhost/sles15sp4-base.repo
+++ b/testsuite/features/profiles/internal_nue/Docker/serverhost/sles15sp4-base.repo
@@ -1,0 +1,6 @@
+[sles15sp4-base]
+name=sles15sp4-base
+enabled=1
+autorefresh=0
+baseurl=http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP4/x86_64/update/
+type=rpm-md

--- a/testsuite/features/profiles/internal_prv/Docker/serverhost/Dockerfile
+++ b/testsuite/features/profiles/internal_prv/Docker/serverhost/Dockerfile
@@ -15,6 +15,7 @@ RUN echo "$repo" > /etc/zypp/repos.d/susemanager:dockerbuild.repo
 ADD nsswitch.conf /etc/nsswitch.conf
 ADD avahi-daemon.conf /root/avahi-daemon.conf
 ADD sles15sp4.repo /etc/zypp/repos.d/sles15sp4.repo
+ADD sles15sp4-base.repo /etc/zypp/repos.d/sles15sp4-base.repo
 
 ADD add_packages.sh /root/add_packages.sh
 RUN /root/add_packages.sh

--- a/testsuite/features/profiles/internal_prv/Docker/serverhost/sles15sp4-base.repo
+++ b/testsuite/features/profiles/internal_prv/Docker/serverhost/sles15sp4-base.repo
@@ -1,0 +1,6 @@
+[sles15sp4-base]
+name=sles15sp4-base
+enabled=1
+autorefresh=0
+baseurl=http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP4/x86_64/update/
+type=rpm-md


### PR DESCRIPTION
## What does this PR change?

This PR adds the missing basesystem repo to the Docker profile now we switched Docker builds to sle 15 sp2.

PLEASE CHECK THE REPO URL. IT IS PROBABLY WRONG.

(and yeah, it's using sle 15 sp4 repos on sle 15 sp2 images... but do we really want to fix that?)

## Links

No ports.


## Changelogs

- [x] No changelog needed
