### PR TITLE
do not install products and gpg keys in dryrun

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/init.sls
@@ -132,7 +132,8 @@ mgrchannels_yum_clean_all:
 {%- endif %}
 {%- endif %}
 
-{%- if grains['os_family'] == 'Suse' and grains['osmajorrelease']|int > 11 and not grains['oscodename'] == 'openSUSE Leap 15.3'%}
+{%- if not salt['pillar.get']('susemanager:distupgrade:dryrun', False) %}
+{%- if grains['os_family'] == 'Suse' and grains['osmajorrelease']|int > 11 and not grains['oscodename'] == 'openSUSE Leap 15.3' %}
 mgrchannels_install_products:
   product.all_installed:
     - require:
@@ -145,3 +146,4 @@ mgrchannels_install_products:
 {%- endif %}
 
 {% include 'channels/gpg-keys.sls' %}
+{%- endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- do not install products and gpg keys when performing distupgrade
+  dry-run (bsc#1199466)
 - remove unknown repository flags on EL
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

When performing a distupgrade Dry Run, we should not install / update the products or gpg keys.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: manual

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17828
Tracks https://github.com/SUSE/spacewalk/pull/17839

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
