### PR TITLE
don't try to remove known_hosts entry if hostname is null

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -776,13 +776,15 @@ public class SystemManager extends BaseManager {
     }
 
     private void removeSaltSSHKnownHosts(Server server) {
-        Optional<MgrUtilRunner.RemoveKnowHostResult> result =
-                saltApi.removeSaltSSHKnownHost(server.getHostname());
-        boolean removed = result.map(r -> "removed".equals(r.getStatus())).orElse(false);
-        if (!removed) {
-            log.warn("Hostname {} could not be removed from /var/lib/salt/.ssh/known_hosts: {}", server.getHostname(),
-                    result.map(MgrUtilRunner.RemoveKnowHostResult::getComment).orElse(""));
-        }
+        Optional.ofNullable(server.getHostname()).ifPresent(hostname -> {
+            Optional<MgrUtilRunner.RemoveKnowHostResult> result =
+                    saltApi.removeSaltSSHKnownHost(hostname);
+            boolean removed = result.map(r -> "removed".equals(r.getStatus())).orElse(false);
+            if (!removed) {
+                log.warn("Hostname " + hostname + " could not be removed from " +
+                        "/var/lib/salt/.ssh/known_hosts: " + result.map(r -> r.getComment()).orElse(""));
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
## What does this PR change?

don't try to remove known_hosts entry if hostname is null

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
