### PR TITLE
Fix issue removing duplicated packages names in the same action (bsc#1198686)

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -1181,12 +1181,28 @@ public class SaltServerActionService {
     private Map<LocalCall<?>, List<MinionSummary>> packagesRemoveAction(
             List<MinionSummary> minionSummaries, PackageRemoveAction action) {
         Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
-        List<List<String>> pkgs = action
+        List<List<String>> pkgsAll = action
                 .getDetails().stream().map(d -> Arrays.asList(d.getPackageName().getName(),
                         d.getArch().toUniversalArchString(), d.getEvr().toUniversalEvrString()))
                 .collect(Collectors.toList());
+
+        List<List<String>> uniquePkgs = new ArrayList<>();
+        pkgsAll.stream().forEach(d -> {
+                if (!uniquePkgs.stream().map(p -> p.get(0))
+                        .collect(Collectors.toList())
+                        .contains(d.get(0))) {
+                                uniquePkgs.add(d);
+                }
+        });
+        List<List<String>> duplicatedPkgs = pkgsAll.stream()
+                .filter(p -> !uniquePkgs.contains(p)).collect(Collectors.toList());
+
+        Map<String, Object> params = new HashMap<>();
+        params.put(PARAM_PKGS, uniquePkgs);
+        params.put("param_pkgs_duplicates", duplicatedPkgs);
+
         ret.put(State.apply(Arrays.asList(PACKAGES_PKGREMOVE),
-                Optional.of(singletonMap(PARAM_PKGS, pkgs))), minionSummaries);
+                Optional.of(params)), minionSummaries);
         return ret;
     }
 

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -418,9 +418,9 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void testPackageRemoveDuplicates() throws Exception {
-        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        MinionServer testMinion = MinionServerFactoryTest.createTestMinionServer(user);
         List<MinionServer> mins = new ArrayList<>();
-        mins.add(minion);
+        mins.add(testMinion);
 
         List<MinionSummary> minionSummaries = mins.stream().
                 map(MinionSummary::new).collect(Collectors.toList());
@@ -449,13 +449,14 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         Action action = ActionManager.createAction(user, ActionFactory.TYPE_PACKAGES_REMOVE,
                 "test remove action", Date.from(now.toInstant()));
 
-        ActionFactory.addServerToAction(minion, action);
+        ActionFactory.addServerToAction(testMinion, action);
 
         ActionManager.addPackageActionDetails(Arrays.asList(action), packageMaps);
         TestUtils.flushAndEvict(action);
         Action removeAction = ActionFactory.lookupById(action.getId());
 
-        Map<LocalCall<?>, List<MinionSummary>> result = saltServerActionService.callsForAction(removeAction, minionSummaries);
+        Map<LocalCall<?>, List<MinionSummary>> result =
+                saltServerActionService.callsForAction(removeAction, minionSummaries);
         assertEquals(1, result.values().size());
         LocalCall<?> resultCall = result.keySet().iterator().next();
         List<List<String>> resultPkgs1 = (List<List<String>>) ((Map) ((Map) resultCall.getPayload().get("kwarg")).get(

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -470,10 +470,13 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
                 resultPkgs2.stream().filter(pkg -> p2.getPackageName().getName().equals(pkg.get(0))).findFirst().get();
 
         // Assert packages are sent to Salt correctly
+        assertEquals(1, resultPkgs1.size());
+        assertEquals(1, resultPkgs2.size());
         assertEquals("x86_64", resultPkg1.get(1));
-        assertEquals("1.0.1", resultPkg1.get(2));
         assertEquals("x86_64", resultPkg2.get(1));
-        assertEquals("1.0.0", resultPkg2.get(2));
+        assertTrue(Arrays.asList("1.0.0", "1.0.1").contains(resultPkg1.get(2)));
+        assertTrue(Arrays.asList("1.0.0", "1.0.1").contains(resultPkg2.get(2)));
+        assertTrue(resultPkg1.get(2) != resultPkg2.get(2));
     }
 
     @Test

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -417,6 +417,65 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
     }
 
     @Test
+    public void testPackageRemoveDuplicates() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        List<MinionServer> mins = new ArrayList<>();
+        mins.add(minion);
+
+        List<MinionSummary> minionSummaries = mins.stream().
+                map(MinionSummary::new).collect(Collectors.toList());
+
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        Package p1 = ErrataTestUtils.createTestPackage(user, channel, "x86_64");
+        Package p2 = ErrataTestUtils.createTestPackage(user, channel, "x86_64");
+        p1.getPackageName().setName("test-package-duplicated-name");
+        p2.setPackageName(p1.getPackageName());
+        p1.setPackageEvr(PackageEvrFactoryTest.createTestPackageEvr(null, "1.0.0", "X", PackageType.RPM));
+        p2.setPackageEvr(PackageEvrFactoryTest.createTestPackageEvr(null, "1.0.1", "X", PackageType.RPM));
+
+        List<Map<String, Long>> packageMaps = new ArrayList<>();
+        Map<String, Long> p1map = new HashMap<>();
+        p1map.put("name_id", p1.getPackageName().getId());
+        p1map.put("evr_id", p1.getPackageEvr().getId());
+        p1map.put("arch_id", p1.getPackageArch().getId());
+        packageMaps.add(p1map);
+        Map<String, Long> p2map = new HashMap<>();
+        p2map.put("name_id", p2.getPackageName().getId());
+        p2map.put("evr_id", p2.getPackageEvr().getId());
+        p2map.put("arch_id", p2.getPackageArch().getId());
+        packageMaps.add(p2map);
+
+        final ZonedDateTime now = ZonedDateTime.now(ZoneId.systemDefault());
+        Action action = ActionManager.createAction(user, ActionFactory.TYPE_PACKAGES_REMOVE,
+                "test remove action", Date.from(now.toInstant()));
+
+        ActionFactory.addServerToAction(minion, action);
+
+        ActionManager.addPackageActionDetails(Arrays.asList(action), packageMaps);
+        TestUtils.flushAndEvict(action);
+        Action removeAction = ActionFactory.lookupById(action.getId());
+
+        Map<LocalCall<?>, List<MinionSummary>> result = saltServerActionService.callsForAction(removeAction, minionSummaries);
+        assertEquals(1, result.values().size());
+        LocalCall<?> resultCall = result.keySet().iterator().next();
+        List<List<String>> resultPkgs1 = (List<List<String>>) ((Map) ((Map) resultCall.getPayload().get("kwarg")).get(
+                "pillar")).get("param_pkgs");
+        List<List<String>> resultPkgs2 = (List<List<String>>) ((Map) ((Map) resultCall.getPayload().get("kwarg")).get(
+                "pillar")).get("param_pkgs_duplicates");
+
+        List<String> resultPkg1 =
+                resultPkgs1.stream().filter(pkg -> p1.getPackageName().getName().equals(pkg.get(0))).findFirst().get();
+        List<String> resultPkg2 =
+                resultPkgs2.stream().filter(pkg -> p2.getPackageName().getName().equals(pkg.get(0))).findFirst().get();
+
+        // Assert packages are sent to Salt correctly
+        assertEquals("x86_64", resultPkg1.get(1));
+        assertEquals("1.0.1", resultPkg1.get(2));
+        assertEquals("x86_64", resultPkg2.get(1));
+        assertEquals("1.0.0", resultPkg2.get(2));
+    }
+
+    @Test
     public void testDeployFiles() throws Exception {
         MinionServer minion1 = MinionServerFactoryTest.createTestMinionServer(user);
         MinionServer minion2 = MinionServerFactoryTest.createTestMinionServer(user);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Allow removing duplicated packages names in the same Salt action (bsc#1198686)
 - Styling fixes for new branding
 - fix NoSuchElementException when pkg install date is missing
 - Fix error message in Kubernetes VHM creation dialog

--- a/susemanager-utils/susemanager-sls/salt/packages/pkgremove.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/pkgremove.sls
@@ -15,5 +15,23 @@ pkg_removed:
         - file: mgrchannels*
 {% endif %}
 
+{% if pillar.get('param_pkgs_duplicates') %}
+{% for pkg, arch, version in pillar["param_pkgs_duplicates"] %}
+pkg_removed_dup_{{ loop.index0 }}:
+  pkg.removed:
+    -   pkgs:
+    {%- if grains['os_family'] == 'Debian' %}
+        - {{ pkg }}:{{ arch }}: {{ version }}
+    {%- elif grains.get('__suse_reserved_pkg_all_versions_support', False) %}
+        - {{ pkg }}.{{ arch }}: {{ version }}
+    {%- else %}
+        - {{ pkg }}: {{ version }}
+    {%- endif %}
+    -   require:
+        - file: mgrchannels*
+
+{% endfor %}
+{% endif %}
+
 include:
   - channels

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Add support to packages.pkgremove to deal with duplicated pkg names (bsc#1198686)
 - do not install products and gpg keys when performing distupgrade
   dry-run (bsc#1199466)
 - remove unknown repository flags on EL


### PR DESCRIPTION
## What does this PR change?

This PR fixes and issue happening when scheduling a package remove action targeting multiple versions of the same package name. For example: `kernel-devel` or `kernel-source` packages, which we can have multiple versions installed at the same time on a system. 

The problem is that Salt is not able to process duplicates packages names as part of the same `pkg.removed` state execution. So, in case we are under this situation, and we schedule the removal of these packages from the Uyuni UI, the generated `packages.pkgremove` state would be something like:

```yaml
pkg_removed:
  pkg.removed:
    -   pkgs:
        - kernel-source.noarch: 4.12.14-122.80.1
        - kernel-source.noarch: 4.12.14-122.60.1
    -   require:
        - file: mgrchannels*
```

Notice the duplicated packages names as part of `pkgs`.

Now, when this state is proceesed by Salt, only one of the duplicaed items in `pkgs` will remain and used for the execution, producing unconsistent results (as it is not taking all the specified packages into consideration). Fixing this behavior in the Salt side to allow duplicates packages in this context is not really straight forward. This has to do with Salt internals structures and data are organized and it would require time and some considerable refactoring.

For now, I've pushed a fix to Salt (here: https://github.com/saltstack/salt/pull/62019) in order to produce an error message and failed state execution and not cause inconsistent results when the user is passing duplicated packages names as above.

So in order to fix this situation, this PR is making Uyuni to generate the `packages.pkgremove` state in a way that is able to be consumed by Salt in case of additional packages.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/17591

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
