### PR TITLE
fix bootstrap repo handling for SLE Micro

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -544,6 +544,7 @@ elif [ "$INSTALLER" == zypper ]; then
             if [ "$BASE" != "sle" ]; then
                 grep -q 'openSUSE' /etc/os-release && BASE='opensuse'
             fi
+            grep -q 'Enterprise Micro' /etc/os-release && BASE='slemicro'
             VERSION="$(grep '^\(VERSION_ID\)' /etc/os-release | sed -n 's/.*"\([[:digit:]]\+\).*/\\1/p')"
             PATCHLEVEL="$(grep '^\(VERSION_ID\)' /etc/os-release | sed -n 's/.*\.\([[:digit:]]*\).*/\\1/p')"
         fi

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,5 @@
+- change bootstrap script generator to detect SLE Micro
+
 -------------------------------------------------------------------
 Tue Apr 19 11:59:08 CEST 2022 - jgonzalez@suse.com
 

--- a/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
+++ b/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
@@ -138,6 +138,7 @@ function getZ_CLIENT_CODE_BASE() {
         if [ "$BASE" != "sle" ]; then
             grep -q 'openSUSE' /etc/os-release && BASE='opensuse'
         fi
+        grep -q 'Enterprise Micro' /etc/os-release && BASE='slemicro'
         VERSION="$(grep '^\(VERSION_ID\)' /etc/os-release | sed -n 's/.*"\([[:digit:]]\+\).*/\1/p')"
         PATCHLEVEL="$(grep '^\(VERSION_ID\)' /etc/os-release | sed -n 's/.*\.\([[:digit:]]*\).*/\1/p')"
     fi

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -23,6 +23,9 @@ no_ssh_push_key_authorized:
 # SUSE OS Family
 {%- if grains['os_family'] == 'Suse' %}
   {% set os_base = 'sle' %}
+  {%- if 'sle micro' in grains['osfullname']|lower  %}
+    {%- set os_base = 'slemicro' %}
+  {% endif %}
   {% set osrelease_major = grains['osrelease_info'][0] %}
   #exceptions to the family rule
   {%- if "opensuse" in grains['oscodename']|lower %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- detect bootstrap repository path for SLE Micro
 - do not install products and gpg keys when performing distupgrade
   dry-run (bsc#1199466)
 - remove unknown repository flags on EL

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1261,6 +1261,30 @@ DATA = {
         'PDID' : [2299, 2384], 'BETAPDID' : [], 'PKGLIST' : PKGLIST15_TRAD + ONLYSLE15 + PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/sle/15/4/bootstrap/'
     },
+    'SLE-MICRO-5.1-aarch64' : {
+        'PDID' : [2282], 'BETAPDID' : [1925], 'PKGLIST' : PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/slemicro/5/1/bootstrap/'
+    },
+    'SLE-MICRO-5.1-s390x' : {
+        'PDID' : [2287], 'BETAPDID' : [1927], 'PKGLIST' : PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/slemicro/5/1/bootstrap/'
+    },
+    'SLE-MICRO-5.1-x86_64' : {
+        'PDID' : [2283], 'BETAPDID' : [1928], 'PKGLIST' : PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/slemicro/5//bootstrap/'
+    },
+    'SLE-MICRO-5.2-aarch64' : {
+        'PDID' : [2399], 'BETAPDID' : [1925], 'PKGLIST' : PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/slemicro/5/2/bootstrap/'
+    },
+    'SLE-MICRO-5.2-s390x' : {
+        'PDID' : [2400], 'BETAPDID' : [1927], 'PKGLIST' : PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/slemicro/5/2/bootstrap/'
+    },
+    'SLE-MICRO-5.2-x86_64' : {
+        'PDID' : [2401], 'BETAPDID' : [1928], 'PKGLIST' : PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/slemicro/5/2/bootstrap/'
+    },
     'openSUSE-Leap-42.3-x86_64' : {
         'BASECHANNEL' : 'opensuse_leap42_3-x86_64', 'PKGLIST' : PKGLIST12 + ONLYOPENSUSE42 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensuse/42/3/bootstrap/'

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- add bootstrap repository definitions for SLE-Micro 5.1 and 5.2
+
 -------------------------------------------------------------------
 Wed May 04 15:24:41 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

SLE Micro was using not existing bootstrap repo path. Detect SLE Micro properly and define an own path for it.
Also define bootstrap repo definitions and package list (no traditional tools)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage
- No tests: **manual**

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17793
Tracks 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
