### PR TITLE
Add RHEL 7 and 8 bootstrap repositories for Uyuni

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1425,6 +1425,10 @@ DATA = {
         'PDID' : [-7, 1683], 'BETAPDID' : [2065], 'PKGLIST' : RES7 + RES7_X86,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/res/7/bootstrap/'
     },
+    'RHEL7-x86_64-uyuni' : {
+        'BASECHANNEL' : 'rhel7-pool-x86_64', 'PKGLIST' : RES7 + RES7_X86,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/res/7/bootstrap/'
+    },
     'SLE-ES8-x86_64' : {
         'PDID' : [-8, 1921, 2007], 'BETAPDID' : [2066], 'PKGLIST' : RES8 + RES8_X86,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/res/8/bootstrap/'
@@ -1433,6 +1437,10 @@ DATA = {
         'PDID' : [-8, 2007], 'BETAPDID' : [2066], 'PKGLIST' : RES8 + RES8_X86,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/res/8/bootstrap/'
     },
+    'RHEL8-x86_64-uyuni' : {
+        'BASECHANNEL' : 'rhel8-pool-x86_64', 'PKGLIST' : RES8 + RES8_X86,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/res/8/bootstrap/'
+    },    
     'alibaba-2-x86_64-uyuni': {
         'BASECHANNEL': 'alibaba-2-x86_64', 'PKGLIST': RES7 + RES7_X86,
         'DEST': DOCUMENT_ROOT + '/pub/repositories/alibaba/2/bootstrap/'

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- Add RHEL 7 and 8 bootstrap repositories for Uyuni
+
 -------------------------------------------------------------------
 Wed May 04 15:24:41 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Add RHEL 7 and 8 bootstrap repositories for Uyuni

My guess is that nobody noticed yet, because the bootstrap repository is common with centos/alma/rocky, so as long as the user has one of those other OS, bootstrapping RHEL would work.

This happens only happens for users that are only managing RHEL.

The fix on this PR was tested by @HerrmannMax (https://github.com/uyuni-project/uyuni/issues/5376#issuecomment-1127315017)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: This was supposed to work.

- [ ] **DONE**

## Test coverage
- No tests: At this point we can't automatically test RHEL

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/5376

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
