### PR TITLE
Add openSUSE Leap 15.4 bootstrap repositories

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1313,6 +1313,22 @@ DATA = {
         'BASECHANNEL' : 'opensuse_leap15_3-aarch64', 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15SP0SP1_SALT + PKGLIST15_X86_ARM,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensuse/15/3/bootstrap/'
     },
+    'openSUSE-Leap-15.4-x86_64' : {
+        'PDID' : [2409], 'PKGLIST' : PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensuse/15/4/bootstrap/'
+    },
+    'openSUSE-Leap-15.4-aarch64' : {
+        'PDID' : [2406], 'PKGLIST' : PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensuse/15/4/bootstrap/'
+    },
+    'openSUSE-Leap-15.4-x86_64-uyuni' : {
+        'BASECHANNEL' : 'opensuse_leap15_4-x86_64', 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15SP0SP1_SALT + PKGLIST15_X86_ARM,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensuse/15/4/bootstrap/'
+    },
+    'openSUSE-Leap-15.4-aarch64-uyuni' : {
+        'BASECHANNEL' : 'opensuse_leap15_4-aarch64', 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15SP0SP1_SALT + PKGLIST15_X86_ARM,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensuse/15/4/bootstrap/'
+    },    
     'centos-6-x86_64' : {
         'PDID' : [-11, 1682], 'BETAPDID' : [2064], 'PKGLIST' : RES6,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/centos/6/bootstrap/'

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Add openSUSE Leap 15.4 bootstrap repositories
 - add SLED 12 SP3 bootstrap repo definition (bsc#1199438)
 - Add RHEL 7 and 8 bootstrap repositories for Uyuni
 


### PR DESCRIPTION
## What does this PR change?

Add openSUSE Leap 15.4 bootstrap repositories

Tested:
- [x] Bootstrap creation works
- [x] Bootstrap (WebUI) a salt minion, remote command, package install, package removal, apply state
- [x] Bootstrap (WebUI) a salt-ssh minion , remote command, package install, package removal, apply state
- [x] Bootstrap (Script) a sal minion,

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- PR: https://github.com/uyuni-project/uyuni-docs/pull/1560 (issue https://github.com/SUSE/spacewalk/issues/17541)

- [ ] **DONE**

## Test coverage
- No tests: Will be tested later, by sumaform and the testsuite

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17542

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
