### PR TITLE
Add channel to sync for SLE 15 SP4

### DIFF
--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -198,6 +198,7 @@ CHANNEL_TO_SYNC_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.3-Pool' =>
                                     'SLES15-SP1-Pool' => 'SLE-15-SP1-x86_64',
                                     'SLES15-SP2-Pool' => 'SLE-15-SP2-x86_64',
                                     'SLES15-SP3-Pool' => 'SLE-15-SP3-x86_64',
+                                    'SLES15-SP4-Pool' => 'SLE-15-SP4-x86_64',
                                     'RHEL x86_64 Server 7' => 'RES7-x86_64',
                                     'no-appstream-result-RHEL8-Pool for x86_64' => 'SLE-ES8-x86_64',
                                     'ubuntu-18.04-pool' => 'ubuntu-18.04-amd64',


### PR DESCRIPTION
## What does this PR change?

This PR adds a missing constant that defines the channel of the bootstrap reposiory to create for SLE 15 SP4.


## Links

Ports:
* 4.1: SUSE/spacewalk#17861
* 4.2: SUSE/spacewalk#17860


## Changelogs

- [x] No changelog needed
