### PR TITLE
Fix VM changes on traditional virtual hosts

### DIFF
--- a/client/tools/mgr-virtualization/mgr-virtualization.changes
+++ b/client/tools/mgr-virtualization/mgr-virtualization.changes
@@ -1,3 +1,5 @@
+- Report all VMs in poller, not only running ones. (bsc#1199528)
+
 -------------------------------------------------------------------
 Tue Apr 19 11:54:25 CEST 2022 - jgonzalez@suse.com
 

--- a/client/tools/mgr-virtualization/virtualization/poller.py
+++ b/client/tools/mgr-virtualization/virtualization/poller.py
@@ -91,31 +91,11 @@ def poll_hypervisor():
         # No connection to hypervisor made
         return {}
 
-    domainIDs = conn.listDomainsID()
-
-    if not domainIDs:
-        domainIDs = []
-    if len(domainIDs) == 0:
-        domainIDs.extend(conn.listDefinedDomains())
+    domains = conn.listAllDomains()
 
     state = {}
 
-    for domainID in domainIDs:
-        if type(domainID) == int:
-            try:
-                domain = conn.lookupByID(domainID)
-            except libvirt.libvirtError:
-                lve = sys.exc_info()[1]
-                raise_with_tb(VirtualizationException("Failed to obtain handle to domain %d: %s" % (domainID, repr(lve)),
-                                                      sys.exc_info()[2]))
-        else:
-            try:
-                domain = conn.lookupByName(domainID)
-            except libvirt.libvirtError:
-                lve = sys.exc_info()[1]
-                raise_with_tb(VirtualizationException("Failed to obtain handle to domain %d: %s" % (domainID, repr(lve)),
-                                                      sys.exc_info()[2]))
-
+    for domain in domains:
         uuid = binascii.hexlify(domain.UUID())
         # SEE: http://libvirt.org/html/libvirt-libvirt.html#virDomainInfo
         # for more info.

--- a/python/spacewalk/server/rhnVirtualization.py
+++ b/python/spacewalk/server/rhnVirtualization.py
@@ -538,7 +538,7 @@ class VirtualizationEventHandler:
             SELECT s.id
             FROM rhnServer s
             LEFT JOIN rhnVirtualInstance vi on vi.virtual_system_id = s.id
-            WHERE s.machine_id = ':uuid' and vi.virtual_system_id IS NULL
+            WHERE s.machine_id = :uuid and vi.virtual_system_id IS NULL
         """
         query = rhnSQL.prepare(get_system_id_sql)
         query.execute(uuid=uuid)

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Fix virt_notify SQL syntax error (bsc#1199528)
 - store create-bootstrap logs in spacewalk-debug
 - Fix traceback on calling spacewalk-repo-sync --show-packages
 - cleanup leftovers from removing unused xmlrpc endpoint


### PR DESCRIPTION
## What does this PR change?

The fix is composed of a client and server side fix. This requires
libvirt 0.9.13 or older, which should be fine on RHEL7 and SLE 12SP3+
clients.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [X] **DONE**

## Test coverage
- No tests: traditional virtualization stack

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17852

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
