### PR TITLE
Do not allow creating path if nonexistent user or group in fileutils

### DIFF
--- a/python/uyuni/uyuni-common-libs.changes
+++ b/python/uyuni/uyuni-common-libs.changes
@@ -1,3 +1,5 @@
+- Do not allow creating path if nonexistent user or group in fileutils.
+
 -------------------------------------------------------------------
 Tue Apr 19 12:14:45 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fixes the function `makedirs` in `uyuni.common.fileutils` that was creating the required path even if the specified user/group did not exist, and then failing to chown. Now it does not create the path and raises an exception.

## GUI diff

No difference.


- [X] **DONE**

## Documentation
- No documentation needed:  user invisible changes

- [X] **DONE**

## Test coverage
- No tests:  bugfix

- [X] **DONE**

## Links

Fixes #5106 
Tracks https://github.com/SUSE/spacewalk/issues/17730

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
