### PR TITLE
change default theme to susemanager-light for SUSE Manager

### DIFF
--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- change default theme to susemanager-light for SUSE Manager
+  installations (bsc#1199586)
 - Styling fixes for new branding
 - Fix mimetype in kubeconfig validation request (bsc#1199019)
 

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -214,6 +214,12 @@ cp -pR img %{buildroot}/%{www_path}
 cp -pR javascript %{buildroot}/%{www_path}
 popd
 
+# Adjust default theme for SUSE Manager
+%if 0%{?sle_version}
+sed -i -e 's/^web.theme_default =.*$/web.theme_default = susemanager-light/' $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_web.conf
+%endif
+
+
 %find_lang spacewalk-web
 
 %files -n spacewalk-base


### PR DESCRIPTION
## What does this PR change?

When installing SUSE Manager we should use a susemanager theme.
The uyuni theme stays for Uyuni installations on openSUSE

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17867
Fixes https://github.com/SUSE/spacewalk/issues/17779

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
