### PR TITLE
Fix Internal Server Error when URI contains invalid sysid

### DIFF
--- a/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
@@ -239,6 +239,9 @@ public class AccessTest extends BaseTestCaseWithUser {
         context.put("sid", new String[] {s.getId().toString()});
         assertFalse(acl.evalAcl(context, "system_has_management_entitlement()"));
 
+        // Intentionally invalid sysid
+        context.put("sid", new String[] { "999900099900" });
+        assertFalse(acl.evalAcl(context, "system_has_management_entitlement()"));
 
     }
 
@@ -269,6 +272,10 @@ public class AccessTest extends BaseTestCaseWithUser {
         s = ServerFactoryTest.createUnentitledTestServer(user, true,
                 ServerFactoryTest.TYPE_SERVER_NORMAL, new Date());
         context.put("sid", new String[] {s.getId().toString()});
+        assertFalse(acl.evalAcl(context, "system_has_salt_entitlement()"));
+
+        // Intentionally invalid sysid
+        context.put("sid", new String[] { "999900099900" });
         assertFalse(acl.evalAcl(context, "system_has_salt_entitlement()"));
     }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix Intenal Server Error when URI contains invalid sysid (bsc#1186011)
 - Fix containerized proxy configuration machine name
 - Improve CLM channel cloning performance (bsc#1199523)
 - Keep the websocket connections alive with ping/pong frames (bsc#1199874)


### PR DESCRIPTION
## What does this PR change?

When the URL is a valid path but contains an invalid sysid, the system was trying to lookup the server based on that wrong sysid
generating a LookupException.

The LookupException was captured and logged as a warning leading to a permission error to the user instead of an Internal Server Error.

## GUI diff

No difference. Bug fix.

- [x] **DONE**

## Documentation
- No documentation needed: bug fix.

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17216

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
