### PR TITLE
Use basesystem repo

### DIFF
--- a/testsuite/features/profiles/Docker/authprofile/sles15sp2.repo
+++ b/testsuite/features/profiles/Docker/authprofile/sles15sp2.repo
@@ -2,5 +2,5 @@
 name=sles15sp2
 enabled=1
 autorefresh=0
-baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product/
+baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product/
 type=rpm-md

--- a/testsuite/features/profiles/Docker/serverhost/sles15sp2.repo
+++ b/testsuite/features/profiles/Docker/serverhost/sles15sp2.repo
@@ -2,5 +2,5 @@
 name=sles15sp2
 enabled=1
 autorefresh=0
-baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product/
+baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product/
 type=rpm-md

--- a/testsuite/features/profiles/Docker/sles15sp2.repo
+++ b/testsuite/features/profiles/Docker/sles15sp2.repo
@@ -2,5 +2,5 @@
 name=sles15sp2
 enabled=1
 autorefresh=0
-baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product/
+baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product/
 type=rpm-md

--- a/testsuite/features/profiles/internal_nue/Docker/authprofile/sles15sp2.repo
+++ b/testsuite/features/profiles/internal_nue/Docker/authprofile/sles15sp2.repo
@@ -2,5 +2,5 @@
 name=sles15sp2
 enabled=1
 autorefresh=0
-baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product/
+baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product/
 type=rpm-md

--- a/testsuite/features/profiles/internal_nue/Docker/serverhost/sles15sp2.repo
+++ b/testsuite/features/profiles/internal_nue/Docker/serverhost/sles15sp2.repo
@@ -2,5 +2,5 @@
 name=sles15sp2
 enabled=1
 autorefresh=0
-baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product/
+baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product/
 type=rpm-md

--- a/testsuite/features/profiles/internal_nue/Docker/sles15sp2.repo
+++ b/testsuite/features/profiles/internal_nue/Docker/sles15sp2.repo
@@ -2,5 +2,5 @@
 name=sles15sp2
 enabled=1
 autorefresh=0
-baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product/
+baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product/
 type=rpm-md

--- a/testsuite/features/profiles/internal_prv/Docker/authprofile/sles15sp2.repo
+++ b/testsuite/features/profiles/internal_prv/Docker/authprofile/sles15sp2.repo
@@ -2,5 +2,5 @@
 name=sles15sp2
 enabled=1
 autorefresh=0
-baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product/
+baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product/
 type=rpm-md

--- a/testsuite/features/profiles/internal_prv/Docker/serverhost/sles15sp2.repo
+++ b/testsuite/features/profiles/internal_prv/Docker/serverhost/sles15sp2.repo
@@ -2,5 +2,5 @@
 name=sles15sp2
 enabled=1
 autorefresh=0
-baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product/
+baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product/
 type=rpm-md

--- a/testsuite/features/profiles/internal_prv/Docker/sles15sp2.repo
+++ b/testsuite/features/profiles/internal_prv/Docker/sles15sp2.repo
@@ -2,5 +2,5 @@
 name=sles15sp2
 enabled=1
 autorefresh=0
-baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product/
+baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product/
 type=rpm-md


### PR DESCRIPTION
## What does this PR change?

Use the basesystem module for sle15sp2

Another PR to move back to SP4 will follow once we get the registry issue fixed


## Links

No ports, Uyuni only.


## Changelogs

- [x] No changelog needed
