### PR TITLE
Change Lock Menu Name

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -7331,7 +7331,7 @@ organization. You may grant or remove the organization administrator role in the
         </context-group>
       </trans-unit>
       <trans-unit id="pkg.lock.menu" xml:space="preserve">
-        <source>Lock</source>
+        <source>Lock / Unlock</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/details/packages/LockPackages.do</context>
         </context-group>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Change system details lock tab name to lock/unlock (bsc#1193032)
 - Added a notification to inform the administrators about the product end-of-life
 - Set profile tag has no-mandatory in XCCDF result (bsc#1194262)
 - provisioning thought proxy should use proxy for self_update (bsc#1199036)

--- a/testsuite/features/secondary/min_salt_lock_packages.feature
+++ b/testsuite/features/secondary/min_salt_lock_packages.feature
@@ -16,20 +16,20 @@ Feature: Lock packages on SLES salt minion
   Scenario: Lock a package on the client
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
-    And I follow "Lock"
+    And I follow "Lock / Unlock"
     And I check row with "hoag-dummy-1.1-1.1" and arch of "sle_minion"
     And I click on "Lock"
     Then I should see a "Packages has been requested for being locked." text
     When I wait until event "Lock packages scheduled by admin" is completed
     Then "hoag-dummy-1.1-1.1" is locked on "sle_minion"
     When I follow "Software" in the content area
-    And I follow "Lock"
+    And I follow "Lock / Unlock"
     Then package "hoag-dummy-1.1-1.1" is reported as locked
 
   Scenario: Attempt to install a locked package on the client
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
-    And I follow "Lock"
+    And I follow "Lock / Unlock"
     And package "hoag-dummy-1.1-1.1" is reported as locked
     And I follow "Install"
     And I check row with "hoag-dummy-1.1-1.1" and arch of "sle_minion"
@@ -46,7 +46,7 @@ Feature: Lock packages on SLES salt minion
   Scenario: Unlock a package on the client
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
-    And I follow "Lock"
+    And I follow "Lock / Unlock"
     And package "hoag-dummy-1.1-1.1" is reported as locked
     And I check row with "hoag-dummy-1.1-1.1" and arch of "sle_minion"
     And I click on "Unlock"
@@ -54,13 +54,13 @@ Feature: Lock packages on SLES salt minion
     When I wait until event "Lock packages scheduled by admin" is completed
     Then "hoag-dummy-1.1-1.1" is unlocked on "sle_minion"
     When I follow "Software" in the content area
-    And I follow "Lock"
+    And I follow "Lock / Unlock"
     Then package "hoag-dummy-1.1-1.1" is reported as unlocked
 
   Scenario: Schedule a package lock
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
-    And I follow "Lock"
+    And I follow "Lock / Unlock"
     And I check row with "hoag-dummy-1.1-1.1" and arch of "sle_minion"
     And I click on "Lock"
     Then I should see a "Packages has been requested for being locked." text
@@ -69,7 +69,7 @@ Feature: Lock packages on SLES salt minion
   Scenario: Schedule another package lock
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
-    And I follow "Lock"
+    And I follow "Lock / Unlock"
     When I check row with "milkyway-dummy-2.0-1.1" and arch of "sle_minion"
     And I click on "Lock"
     Then I should see a "Packages has been requested for being locked." text
@@ -77,20 +77,20 @@ Feature: Lock packages on SLES salt minion
     Then "hoag-dummy-1.1-1.1" is locked on "sle_minion"
     And "milkyway-dummy-2.0-1.1" is locked on "sle_minion"
     When I follow "Software" in the content area
-    And I follow "Lock"
+    And I follow "Lock / Unlock"
     Then package "hoag-dummy-1.1-1.1" is reported as locked
     And package "milkyway-dummy-2.0-1.1" is reported as locked
 
   Scenario: Mix package locks and unlock events
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
-    And I follow "Lock"
+    And I follow "Lock / Unlock"
     And package "hoag-dummy-1.1-1.1" is reported as locked
     And package "milkyway-dummy-2.0-1.1" is reported as locked
     When I check row with "orion-dummy-1.1-1.1" and arch of "sle_minion"
     And I click on "Lock"
     Then I should see a "Packages has been requested for being locked." text
-    When I follow "Lock"
+    When I follow "Lock / Unlock"
     And I check row with "milkyway-dummy-2.0-1.1" and arch of "sle_minion"
     And I uncheck row with "hoag-dummy-1.1-1.1" and arch of "sle_minion"
     And I click on "Unlock"
@@ -100,7 +100,7 @@ Feature: Lock packages on SLES salt minion
     And "milkyway-dummy-2.0-1.1" is unlocked on "sle_minion"
     And "orion-dummy-1.1-1.1" is locked on "sle_minion"
     When I follow "Software" in the content area
-    And I follow "Lock"
+    And I follow "Lock / Unlock"
     Then package "hoag-dummy-1.1-1.1" is reported as locked
     And package "milkyway-dummy-2.0-1.1" is reported as unlocked
     And package "orion-dummy-1.1-1.1" is reported as locked
@@ -108,7 +108,7 @@ Feature: Lock packages on SLES salt minion
   Scenario: Mix package locks and unlock events part 2
     Given I am on the Systems overview page of this "sle_minion"
     And I follow "Software" in the content area
-    And I follow "Lock"
+    And I follow "Lock / Unlock"
     When I click on "Select All"
     And I click on "Unlock"
     Then I should see a "Packages has been requested for being unlocked." text
@@ -117,7 +117,7 @@ Feature: Lock packages on SLES salt minion
     Then "hoag-dummy-1.1-1.1" is unlocked on "sle_minion"
     And "orion-dummy-1.1-1.1" is unlocked on "sle_minion"
     When I follow "Software" in the content area
-    And I follow "Lock"
+    And I follow "Lock / Unlock"
     Then package "hoag-dummy-1.1-1.1" is reported as unlocked
     And package "orion-dummy-1.1-1.1" is reported as unlocked
 

--- a/testsuite/features/secondary/trad_lock_packages.feature
+++ b/testsuite/features/secondary/trad_lock_packages.feature
@@ -17,7 +17,7 @@ Feature: Lock packages on traditional client
 
   Scenario: Lock a package on the client
     When I follow "Software" in the content area
-    And I follow "Lock"
+    And I follow "Lock / Unlock"
     And I check row with "hoag-dummy-1.1-1.1" and arch of "sle_client"
     And I click on "Lock"
     And I run "rhn_check -vvv" on "sle_client"
@@ -28,7 +28,7 @@ Feature: Lock packages on traditional client
 
   Scenario: Attempt to install a locked package on the client
     When I follow "Software" in the content area
-    And I follow "Lock"
+    And I follow "Lock / Unlock"
     And package "hoag-dummy-1.1-1.1" is reported as locked
     And I follow "Install"
     And I check row with "hoag-dummy-1.1-1.1" and arch of "sle_client"
@@ -45,7 +45,7 @@ Feature: Lock packages on traditional client
 
   Scenario: Unlock a package on the client
     When I follow "Software" in the content area
-    And I follow "Lock"
+    And I follow "Lock / Unlock"
     And package "hoag-dummy-1.1-1.1" is reported as locked
     And I check row with "hoag-dummy-1.1-1.1" and arch of "sle_client"
     And I click on "Unlock"
@@ -57,7 +57,7 @@ Feature: Lock packages on traditional client
 
   Scenario: Schedule a package lock
     When I follow "Software" in the content area
-    And I follow "Lock"
+    And I follow "Lock / Unlock"
     And I check row with "hoag-dummy-1.1-1.1" and arch of "sle_client"
     And I click on "Lock"
     Then I should see a "Packages has been requested for being locked." text
@@ -65,13 +65,13 @@ Feature: Lock packages on traditional client
 
   Scenario: Schedule another package lock
     And I follow "Software" in the content area
-    And I follow "Lock"
+    And I follow "Lock / Unlock"
     And package "hoag-dummy-1.1-1.1" is reported as pending to be locked
     And package "hoag-dummy-1.1-1.1" cannot be selected
     When I check row with "milkyway-dummy-2.0-1.1" and arch of "sle_client"
     And I click on "Lock"
     Then I should see a "Packages has been requested for being locked." text
-    When I follow "Lock"
+    When I follow "Lock / Unlock"
     Then package "hoag-dummy-1.1-1.1" is reported as pending to be locked
     And package "hoag-dummy-1.1-1.1" cannot be selected
     And package "milkyway-dummy-2.0-1.1" is reported as pending to be locked
@@ -79,13 +79,13 @@ Feature: Lock packages on traditional client
     When I run "rhn_check -vvv" on "sle_client"
     Then "hoag-dummy-1.1-1.1" is locked on "sle_client"
     And "milkyway-dummy-2.0-1.1" is locked on "sle_client"
-    When I follow "Lock"
+    When I follow "Lock / Unlock"
     Then package "hoag-dummy-1.1-1.1" is reported as locked
     And package "milkyway-dummy-2.0-1.1" is reported as locked
 
   Scenario: Mix package locks and unlock events
     And I follow "Software" in the content area
-    And I follow "Lock"
+    And I follow "Lock / Unlock"
     And package "hoag-dummy-1.1-1.1" is reported as locked
     And package "milkyway-dummy-2.0-1.1" is reported as locked
     When I check row with "orion-dummy-1.1-1.1" and arch of "sle_client"
@@ -99,7 +99,7 @@ Feature: Lock packages on traditional client
     And I uncheck row with "hoag-dummy-1.1-1.1" and arch of "sle_client"
     And I click on "Unlock"
     Then I should see a "Packages has been requested for being unlocked." text
-    When I follow "Lock"
+    When I follow "Lock / Unlock"
     Then package "hoag-dummy-1.1-1.1" is reported as locked
     And package "milkyway-dummy-2.0-1.1" is reported as pending to be unlocked
     And package "orion-dummy-1.1-1.1" is reported as pending to be locked
@@ -107,21 +107,21 @@ Feature: Lock packages on traditional client
     Then "hoag-dummy-1.1-1.1" is locked on "sle_client"
     And "milkyway-dummy-2.0-1.1" is unlocked on "sle_client"
     And "orion-dummy-1.1-1.1" is locked on "sle_client"
-    When I follow "Lock"
+    When I follow "Lock / Unlock"
     Then package "hoag-dummy-1.1-1.1" is reported as locked
     And package "milkyway-dummy-2.0-1.1" is reported as unlocked
     And package "orion-dummy-1.1-1.1" is reported as locked
 
   Scenario: Mix package locks and unlock events part 2
     And I follow "Software" in the content area
-    And I follow "Lock"
+    And I follow "Lock / Unlock"
     When I click on "Select All"
     And I click on "Unlock"
     Then I should see a "Packages has been requested for being unlocked." text
     When I follow "Lock"
     Then only packages "hoag-dummy-1.1-1.1, orion-dummy-1.1-1.1" are reported as pending to be unlocked
     When I run "rhn_check -vvv" on "sle_client"
-    And I follow "Lock"
+    And I follow "Lock / Unlock"
     Then package "hoag-dummy-1.1-1.1" is reported as unlocked
     And package "orion-dummy-1.1-1.1" is reported as unlocked
 


### PR DESCRIPTION
Port of spacewalk PR : https://github.com/SUSE/spacewalk/pull/17868

Changes the Lock tab name to Lock / Unlock.
https://bugzilla.suse.com/show_bug.cgi?id=1193032
#17239 

## GUI diff
Before:

![image](https://user-images.githubusercontent.com/729087/168757355-36d03e12-e4ca-4e61-a8ff-8c9157cdc763.png)

After:
![image](https://user-images.githubusercontent.com/729087/168756537-de4bdd4f-4d02-4f5c-8c45-a049bf7e8432.png)

- [ ] **DONE**

## Documentation
- No documentation needed: 
@jcayouette  Screen shots should be updated

- [ ] **DONE**

## Test coverage
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"