### PR TITLE
WIP: Add support for smtp port, auth and ssl/tls config in rhn.cfg

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -9,7 +9,7 @@
         <dependency org="suse" name="c3p0" rev="0.9.5.5" />
         <dependency org="suse" name="cglib" rev="3.2.4" />
         <dependency org="suse" name="classmate" rev="1.3.4" />
-        <dependency org="suse" name="classpathx-mail-1.3.1-monolithic" rev="1.1.2" />
+        <dependency org="suse" name="javax.mail" rev="1.5.2" />
         <dependency org="suse" name="client" rev="1.0.0~beta.2" />
         <dependency org="suse" name="common" rev="1.0.0~beta.2" />
         <dependency org="suse" name="commons-beanutils" rev="1.9.4" />

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -27,8 +27,9 @@ artifacts:
     repository: Leap
   - artifact: classmate
     repository: Uyuni_Other
-  - artifact: classpathx-mail-1.3.1-monolithic
-    package: classpathx-mail
+  - artifact: javax.mail
+    jar: javax.mail.jar
+    package: javamail
     repository: Leap
   - artifact: commons-beanutils
     package: apache-commons-beanutils

--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -56,6 +56,13 @@ public class ConfigDefaults {
     public static final String WEB_SESSION_SWAP_SECRET_4 = "web.session_swap_secret_4";
 
     public static final String WEB_SMTP_SERVER = "java.smtp_server";
+    public static final String WEB_SMTP_PORT = "java.smtp_port";
+    public static final String WEB_SMTP_AUTH = "java.smtp_auth";
+    public static final String WEB_SMTP_SSL = "java.smtp_ssl";
+    public static final String WEB_SMTP_STARTTLS = "java.smtp_starttls";
+    public static final String WEB_SMTP_USER = "java.smtp_user";
+    public static final String WEB_SMTP_PASS = "java.smtp_pass";
+
     public static final String ERRATA_CACHE_COMPUTE_THRESHOLD
     = "errata_cache_compute_threshold";
 

--- a/java/code/src/com/redhat/rhn/common/messaging/SmtpMail.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/SmtpMail.java
@@ -29,6 +29,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
 
+import javax.mail.Address;
 import javax.mail.Message;
 import javax.mail.Message.RecipientType;
 import javax.mail.MessagingException;

--- a/java/code/src/com/redhat/rhn/common/messaging/SmtpMail.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/SmtpMail.java
@@ -17,21 +17,26 @@ package com.redhat.rhn.common.messaging;
 
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
+
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import javax.mail.*;
-import javax.mail.Message.RecipientType;
-import javax.mail.internet.AddressException;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
 import java.io.IOException;
 import java.util.Enumeration;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
+
+import javax.mail.Message;
+import javax.mail.Message.RecipientType;
+import javax.mail.MessagingException;
+import javax.mail.Session;
+import javax.mail.Transport;
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
 
 /**
  * A simple wrapper around javamail to allow us to send e-mail quickly.

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add support in rhn.cfg for smtp port, auth, ssl/tls config
 - Change system details lock tab name to lock/unlock (bsc#1193032)
 - Added a notification to inform the administrators about the product end-of-life
 - Set profile tag has no-mandatory in XCCDF result (bsc#1194262)


### PR DESCRIPTION
## What does this PR change?

Add new parameter for `rhn.cfg` to allow individual configuration of SMTP Port, Authentication, Username, Password, SSL and STARTTLS.

Requires replacement of the quite old `classpathx-mail-1.3.1-monolithic` with `javamail/javax.mail 1.5.2` (https://build.opensuse.org/package/show/openSUSE:Leap:15.3/javamail) package to support SSL/TLS and definition of the Protocol Version to be used.

Based on the Feature Request https://github.com/uyuni-project/uyuni/issues/5343

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- Documentation issue was created: https://github.com/uyuni-project/uyuni-docs/issues/1568

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/5343

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
