### PR TITLE
Fix the changelog entry with missing bsc#1199528 ref

### DIFF
--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,6 +1,7 @@
 - Fix virt_notify SQL syntax error (bsc#1199528)
 - store create-bootstrap logs in spacewalk-debug
 - Fix traceback on calling spacewalk-repo-sync --show-packages
+  (bsc#1193238)
 - cleanup leftovers from removing unused xmlrpc endpoint
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Fix the changelog entry with missing bsc#1199528 ref

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
