### PR TITLE
fix exception when trying to forward data to scc without credentials

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/ForwardRegistrationTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ForwardRegistrationTask.java
@@ -34,6 +34,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
 
@@ -57,6 +58,16 @@ public class ForwardRegistrationTask extends RhnJavaJob {
         try {
             if (Config.get().getString(ContentSyncManager.RESOURCE_PATH) == null) {
 
+                List<Credentials> credentials = CredentialsFactory.lookupSCCCredentials();
+                Optional<Credentials> optPrimCred = credentials.stream()
+                        .filter(Credentials::isPrimarySCCCredential)
+                        .findFirst();
+                if (optPrimCred.isEmpty()) {
+                    // We cannot update SCC without credentials
+                    // Standard Uyuni case
+                    log.debug("No SCC Credentials - skipping forwarding registration");
+                    return;
+                }
                 int waitTime = ThreadLocalRandom.current().nextInt(0, 15 * 60);
                 if (log.isDebugEnabled()) {
                     // no waiting when debug is on
@@ -75,20 +86,19 @@ public class ForwardRegistrationTask extends RhnJavaJob {
                 log.debug("{} RegCacheItems found to forward", forwardRegistration.size());
                 List<SCCRegCacheItem> deregister = SCCCachingFactory.listDeregisterItems();
                 log.debug("{} RegCacheItems found to delete", deregister.size());
-                List<Credentials> credentials = CredentialsFactory.lookupSCCCredentials();
                 SCCConfig sccConfig = new SCCConfig(url, "", "", uuid);
                 SCCClient sccClient = new SCCWebClient(sccConfig);
                 SCCSystemRegistrationManager sccRegManager = new SCCSystemRegistrationManager(sccClient);
                 sccRegManager.deregister(deregister, false);
-                credentials.stream()
-                    .filter(Credentials::isPrimarySCCCredential)
-                    .findFirst()
-                    .ifPresent(primaryCredentials -> sccRegManager.register(forwardRegistration, primaryCredentials));
+                optPrimCred.ifPresent(primaryCredentials ->
+                    sccRegManager.register(forwardRegistration, primaryCredentials));
                 if (LocalDateTime.now().isAfter(nextLastSeenUpdateRun)) {
-                    sccRegManager.updateLastSeen();
-                    // next run in 22 - 26 hours
-                    nextLastSeenUpdateRun = nextLastSeenUpdateRun.plusMinutes(
-                            ThreadLocalRandom.current().nextInt(22 * 60, 26 * 60));
+                    optPrimCred.ifPresent(primaryCredentials -> {
+                        sccRegManager.updateLastSeen(primaryCredentials);
+                        // next run in 22 - 26 hours
+                        nextLastSeenUpdateRun = nextLastSeenUpdateRun.plusMinutes(
+                                ThreadLocalRandom.current().nextInt(22 * 60, 26 * 60));
+                    });
                 }
             }
         }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ForwardRegistrationTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ForwardRegistrationTask.java
@@ -55,56 +55,62 @@ public class ForwardRegistrationTask extends RhnJavaJob {
             log.debug("Forwarding registrations disabled");
             return;
         }
-        try {
-            if (Config.get().getString(ContentSyncManager.RESOURCE_PATH) == null) {
+        if (Config.get().getString(ContentSyncManager.RESOURCE_PATH) == null) {
 
-                List<Credentials> credentials = CredentialsFactory.lookupSCCCredentials();
-                Optional<Credentials> optPrimCred = credentials.stream()
-                        .filter(Credentials::isPrimarySCCCredential)
-                        .findFirst();
-                if (optPrimCred.isEmpty()) {
-                    // We cannot update SCC without credentials
-                    // Standard Uyuni case
-                    log.debug("No SCC Credentials - skipping forwarding registration");
-                    return;
-                }
-                int waitTime = ThreadLocalRandom.current().nextInt(0, 15 * 60);
-                if (log.isDebugEnabled()) {
-                    // no waiting when debug is on
-                    waitTime = 1;
-                }
-                try {
-                    Thread.sleep(waitTime * 1000);
-                }
-                catch (InterruptedException e) {
-                    log.debug("Sleep interrupted", e);
-                }
-                URI url = new URI(Config.get().getString(ConfigDefaults.SCC_URL));
-                String uuid = ContentSyncManager.getUUID();
-                SCCCachingFactory.initNewSystemsToForward();
-                List<SCCRegCacheItem> forwardRegistration = SCCCachingFactory.findSystemsToForwardRegistration();
-                log.debug("{} RegCacheItems found to forward", forwardRegistration.size());
-                List<SCCRegCacheItem> deregister = SCCCachingFactory.listDeregisterItems();
-                log.debug("{} RegCacheItems found to delete", deregister.size());
-                SCCConfig sccConfig = new SCCConfig(url, "", "", uuid);
-                SCCClient sccClient = new SCCWebClient(sccConfig);
-                SCCSystemRegistrationManager sccRegManager = new SCCSystemRegistrationManager(sccClient);
-                sccRegManager.deregister(deregister, false);
-                optPrimCred.ifPresent(primaryCredentials ->
-                    sccRegManager.register(forwardRegistration, primaryCredentials));
-                if (LocalDateTime.now().isAfter(nextLastSeenUpdateRun)) {
-                    optPrimCred.ifPresent(primaryCredentials -> {
-                        sccRegManager.updateLastSeen(primaryCredentials);
-                        // next run in 22 - 26 hours
-                        nextLastSeenUpdateRun = nextLastSeenUpdateRun.plusMinutes(
-                                ThreadLocalRandom.current().nextInt(22 * 60, 26 * 60));
-                    });
-                }
+            List<Credentials> credentials = CredentialsFactory.lookupSCCCredentials();
+            Optional<Credentials> optPrimCred = credentials.stream()
+                    .filter(Credentials::isPrimarySCCCredential)
+                    .findFirst();
+            if (optPrimCred.isEmpty()) {
+                // We cannot update SCC without credentials
+                // Standard Uyuni case
+                log.debug("No SCC Credentials - skipping forwarding registration");
+                return;
             }
-        }
-        catch (URISyntaxException e) {
-           log.error(e);
+            int waitTime = ThreadLocalRandom.current().nextInt(0, 15 * 60);
+            if (log.isDebugEnabled()) {
+                // no waiting when debug is on
+                waitTime = 1;
+            }
+            try {
+                Thread.sleep(waitTime * 1000);
+            }
+            catch (InterruptedException e) {
+                log.debug("Sleep interrupted", e);
+            }
+            optPrimCred.ifPresent(primaryCredentials -> executeSCCTasks(primaryCredentials));
         }
     }
 
+    /*
+     * Do SCC related tasks like insert, update and delete system in SCC
+     */
+    private void executeSCCTasks(Credentials primaryCredentials) {
+        try {
+            URI url = new URI(Config.get().getString(ConfigDefaults.SCC_URL));
+            String uuid = ContentSyncManager.getUUID();
+            SCCCachingFactory.initNewSystemsToForward();
+            SCCConfig sccConfig = new SCCConfig(url, "", "", uuid);
+            SCCClient sccClient = new SCCWebClient(sccConfig);
+
+            SCCSystemRegistrationManager sccRegManager = new SCCSystemRegistrationManager(sccClient);
+            List<SCCRegCacheItem> forwardRegistration = SCCCachingFactory.findSystemsToForwardRegistration();
+            log.debug("{} RegCacheItems found to forward", forwardRegistration.size());
+
+            List<SCCRegCacheItem> deregister = SCCCachingFactory.listDeregisterItems();
+            log.debug("{} RegCacheItems found to delete", deregister.size());
+
+            sccRegManager.deregister(deregister, false);
+            sccRegManager.register(forwardRegistration, primaryCredentials);
+            if (LocalDateTime.now().isAfter(nextLastSeenUpdateRun)) {
+                sccRegManager.updateLastSeen(primaryCredentials);
+                // next run in 22 - 26 hours
+                nextLastSeenUpdateRun = nextLastSeenUpdateRun.plusMinutes(
+                        ThreadLocalRandom.current().nextInt(22 * 60, 26 * 60));
+            }
+        }
+        catch (URISyntaxException e) {
+            log.error(e);
+        }
+    }
 }

--- a/java/code/src/com/suse/scc/SCCSystemRegistrationManager.java
+++ b/java/code/src/com/suse/scc/SCCSystemRegistrationManager.java
@@ -19,7 +19,6 @@ import static java.util.Optional.ofNullable;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.credentials.Credentials;
-import com.redhat.rhn.domain.credentials.CredentialsFactory;
 import com.redhat.rhn.domain.product.SUSEProduct;
 import com.redhat.rhn.domain.scc.SCCCachingFactory;
 import com.redhat.rhn.domain.scc.SCCRegCacheItem;
@@ -68,13 +67,10 @@ public class SCCSystemRegistrationManager {
 
     /**
      * Update last_seen field in SCC for all registered clients
+     * @param primaryCredential the primary scc credential
      */
-    public void updateLastSeen() {
-        List<Credentials> credentials = CredentialsFactory.lookupSCCCredentials();
-        Credentials primCred = credentials.stream()
-                .filter(c -> c.isPrimarySCCCredential())
-                .findFirst().orElseThrow();
-        List<Map<String, Object>> candidates = SCCCachingFactory.listUpdateLastSeenCandidates(primCred);
+    public void updateLastSeen(Credentials primaryCredential) {
+        List<Map<String, Object>> candidates = SCCCachingFactory.listUpdateLastSeenCandidates(primaryCredential);
 
         List<SCCUpdateSystemJson> sysList = candidates.stream()
                 .map(c -> new SCCUpdateSystemJson(
@@ -90,7 +86,7 @@ public class SCCSystemRegistrationManager {
                                 )).values());
         for (List<SCCUpdateSystemJson> batch: batches) {
             try {
-                sccClient.updateBulkLastSeen(batch, primCred.getUsername(), primCred.getPassword());
+                sccClient.updateBulkLastSeen(batch, primaryCredential.getUsername(), primaryCredential.getPassword());
             }
             catch (SCCClientException e) {
                 LOG.error("SCC error while updating systems", e);

--- a/java/code/src/com/suse/scc/test/SCCSystemRegistrationManagerTest.java
+++ b/java/code/src/com/suse/scc/test/SCCSystemRegistrationManagerTest.java
@@ -181,7 +181,7 @@ public class SCCSystemRegistrationManagerTest {
         CredentialsFactory.storeCredentials(credentials);
         sccSystemRegistrationManager.register(testSystems, credentials);
 
-        sccSystemRegistrationManager.updateLastSeen();
+        sccSystemRegistrationManager.updateLastSeen(credentials);
     }
 
     @Test
@@ -248,6 +248,6 @@ public class SCCSystemRegistrationManagerTest {
         CredentialsFactory.storeCredentials(credentials);
         sccSystemRegistrationManager.register(testSystems, credentials);
 
-        sccSystemRegistrationManager.updateLastSeen();
+        sccSystemRegistrationManager.updateLastSeen(credentials);
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- skip forwarding data to scc if no credentials are available
 - add python3 example for HTTP API
 - Improved handling of error messages during bootstrapping
 - Fix the confirm message on the refresh action by adding a link


### PR DESCRIPTION
## What does this PR change?

Skip forwarding data to SCC when we do not have SCC credentials like in the Uyuni case

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were changed

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17877
Fixes https://github.com/uyuni-project/uyuni/issues/5459
Tracks https://github.com/SUSE/spacewalk/pull/17906

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
