### PR TITLE
Fixed duplication of XccdScanResult table by retrieving the ident_id

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/ScapReport_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/ScapReport_queries.xml
@@ -63,6 +63,7 @@
         )
         SELECT rhnxccdfruleresult.testresult_id AS scan_id
                    , rhnxccdfruleresult.id AS rule_id
+                   , COALESCE(rhnxccdfruleidentmap.ident_id, ruleresult_idrefs.ident_id) AS ident_id
                    , ruleresult_idrefs.identifier AS idref
                    , rhnxccdfidentsystem.system as rulesystem
                    , rhnxccdftestresult.server_id as system_id
@@ -75,7 +76,7 @@
                    LEFT JOIN rhnxccdfruleidentmap ON rhnxccdfruleidentmap.rresult_id = ruleresult_idrefs.rresult_id AND rhnxccdfruleidentmap.ident_id != ruleresult_idrefs.ident_id
                    LEFT JOIN rhnxccdfident on rhnxccdfruleidentmap.ident_id = rhnxccdfident.id
                    LEFT JOIN rhnxccdfidentsystem on rhnxccdfident.identsystem_id = rhnxccdfidentsystem.id
-        ORDER BY rhnxccdfruleresult.testresult_id OFFSET :offset LIMIT :limit
+        ORDER BY scan_id, rule_id, ident_id OFFSET :offset LIMIT :limit
     </query>
 </mode>
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fixed query to populate the XccdScanResult reporting table
 - skip forwarding data to scc if no credentials are available
 - add python3 example for HTTP API
 - Improved handling of error messages during bootstrapping

--- a/java/tito.props
+++ b/java/tito.props
@@ -6,4 +6,4 @@ salt-netapi-client=0.20
 
 [conf/rhn_java.conf]
 java.min_schema_version=4.3.11
-java.min_report_schema_version=4.3.4
+java.min_report_schema_version=4.3.5

--- a/schema/reportdb/common/tables/XccdScanResult.sql
+++ b/schema/reportdb/common/tables/XccdScanResult.sql
@@ -14,6 +14,7 @@ CREATE TABLE XccdScanResult
     mgm_id              NUMERIC NOT NULL,
     scan_id             NUMERIC NOT NULL,
     rule_id             NUMERIC NOT NULL,
+    ident_id            NUMERIC NOT NULL,
     idref               VARCHAR(255),
     rulesystem          VARCHAR(80),
     system_id           NUMERIC NOT NULL,
@@ -23,4 +24,4 @@ CREATE TABLE XccdScanResult
 );
 
 ALTER TABLE XccdScanResult
-  ADD CONSTRAINT XccdScanResult_pk PRIMARY KEY (mgm_id, scan_id, rule_id);
+  ADD CONSTRAINT XccdScanResult_pk PRIMARY KEY (mgm_id, scan_id, rule_id, ident_id);

--- a/schema/reportdb/postgres/docs/tables/XccdScanResult.pre
+++ b/schema/reportdb/postgres/docs/tables/XccdScanResult.pre
@@ -17,6 +17,8 @@ COMMENT ON COLUMN XccdScanResult.mgm_id
 COMMENT ON COLUMN XccdScanResult.scan_id
   IS 'The id of the security scan';
 COMMENT ON COLUMN XccdScanResult.rule_id
+  IS 'The id of the rule result';
+COMMENT ON COLUMN XccdScanResult.ident_id
   IS 'The id of the rule';
 COMMENT ON COLUMN XccdScanResult.idref
   IS 'The reference of the rule';
@@ -25,7 +27,7 @@ COMMENT ON COLUMN XccdScanResult.rulesystem
 COMMENT ON COLUMN XccdScanResult.system_id
   IS 'The id of the system';
 COMMENT ON COLUMN XccdScanResult.ident
-  IS 'The CCE v5 id of this rule';
+  IS 'The identifier of this rule';
 COMMENT ON COLUMN XccdScanResult.result
   IS 'The result of the scan for this rule';
 COMMENT ON COLUMN XccdScanResult.synced_date

--- a/schema/reportdb/upgrade/uyuni-reportdb-schema-4.3.4-to-uyuni-reportdb-schema-4.3.5/001-fix-scan-result-duplication.sql
+++ b/schema/reportdb/upgrade/uyuni-reportdb-schema-4.3.4-to-uyuni-reportdb-schema-4.3.5/001-fix-scan-result-duplication.sql
@@ -1,0 +1,29 @@
+DO $$
+  BEGIN
+    IF NOT EXISTS (SELECT 1 FROM information_schema."columns" WHERE table_name = 'xccdscanresult' AND column_name = 'ident_id') THEN
+
+      -- Temporary sequence to fill the missing ident_id and allow it to be not null
+      CREATE SEQUENCE IF NOT EXISTS ident_id_seq;
+
+      ALTER TABLE XccdScanResult ADD COLUMN ident_id NUMERIC NOT NULL DEFAULT nextval('ident_id_seq');
+
+      -- Drop the default value and the sequence
+      ALTER TABLE XccdScanResult ALTER COLUMN ident_id DROP DEFAULT;
+
+      DROP SEQUENCE IF EXISTS ident_id_seq;
+
+    ELSE
+      RAISE NOTICE 'xccdscanresult already contains the column ident_id';
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM information_schema.key_column_usage WHERE constraint_name = 'xccdscanresult_pk' AND column_name = 'ident_id') THEN
+
+      ALTER TABLE XccdScanResult DROP CONSTRAINT IF EXISTS XccdScanResult_pk;
+
+      ALTER TABLE XccdScanResult ADD CONSTRAINT XccdScanResult_pk PRIMARY KEY (mgm_id, scan_id, rule_id, ident_id);
+
+    ELSE
+      RAISE NOTICE 'xccdscanresult primary key already contains the column ident_id';
+    END IF;
+  END;
+$$;

--- a/schema/reportdb/uyuni-reportdb-schema.changes
+++ b/schema/reportdb/uyuni-reportdb-schema.changes
@@ -1,3 +1,5 @@
+- Fixed duplication of XccdScanResult table
+
 -------------------------------------------------------------------
 Wed May 04 15:27:38 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR addresses an issue in the primary key of  the table `XccdScanResult` that prevent to fill the table due to wrong data duplication.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- Documentation for report db updated

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17881 https://github.com/uyuni-project/uyuni/issues/5458

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
