### PR TITLE
Container systemd fixes

### DIFF
--- a/containers/proxy-systemd-services/README.md
+++ b/containers/proxy-systemd-services/README.md
@@ -1,33 +1,15 @@
-# Creating systemd services
+# General usage
+
+In order to run the containers, generate a configuration using one of:
+
+* `spacecmd proxy_container_config` command,
+* `spacecmd proxy_container_config_generate_cert` command
+* or the web UI
+
+Unpack the configuration file in `/etc/uyuni/proxy` and start the services by running `systemctl start pod-proxy-pod.service`.
 
 
-## First things first
+# Advanced options
 
-Create the pod; create containers and add them to the pod.
-
-
-## Generate systemd services
-
-```
-mkdir systemd-services-generation
-cd systemd-services-generation
-
-podman generate systemd --files --name --new proxy-pod
-
-# replace KillMode=none with TimeoutStopSec=60 as per https://github.com/containers/podman/pull/8889
-sed -i 's/KillMode=none/TimeoutStopSec=60/' *-proxy-*.service
-
-mv *-proxy-*.service /etc/systemd/system/.
-```
-
-
-## Start services
-```
-systemctl daemon-reload
-systemctl start pod-proxy-pod.service
-```
-
-
-## NOTE
-
-Remember to customize and parameterize values that are meant to be, because `podman generate systemd` will create services with the output value of each parameter based on the created/running instances.
+In order to change the default images registry, namespace and tag, edit the `NAMESPACE` and `TAG` variables in `/etc/sysconfig/uyuni-proxy-systemd-services` file.
+Restart the `uyuni-proxy-pod` service is required to apply the change.

--- a/containers/proxy-systemd-services/uyuni-proxy-httpd.service
+++ b/containers/proxy-systemd-services/uyuni-proxy-httpd.service
@@ -14,7 +14,7 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=/etc/sysconfig/uyuni-proxy-systemd-services
 Restart=on-failure
 ExecStartPre=/bin/rm -f %t/uyuni-proxy-httpd.pid %t/uyuni-proxy-httpd.ctr-id
-ExecStart=/usr/bin/podman run --conmon-pidfile %t/uyuni-proxy-httpd.pid --cidfile %t/uyuni-proxy-httpd.ctr-id --cgroups=no-conmon --pod-id-file %t/uyuni-proxy-pod.pod-id -d --replace -dt -v ${CONFIG_DIR}:/etc/uyuni:ro -v ${RHN_CACHE_DIR}:/var/cache/rhn -v ${TFTPBOOT_DIR}:/srv/tftpboot --name uyuni-proxy-httpd ${NAMESPACE}/proxy-httpd
+ExecStart=/usr/bin/podman run --conmon-pidfile %t/uyuni-proxy-httpd.pid --cidfile %t/uyuni-proxy-httpd.ctr-id --cgroups=no-conmon --pod-id-file %t/uyuni-proxy-pod.pod-id -d --replace -dt -v ${CONFIG_DIR}:/etc/uyuni:ro -v ${RHN_CACHE_DIR}:/var/cache/rhn -v ${TFTPBOOT_DIR}:/srv/tftpboot --name uyuni-proxy-httpd ${NAMESPACE}/proxy-httpd:${TAG}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/uyuni-proxy-httpd.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/uyuni-proxy-httpd.ctr-id
 PIDFile=%t/uyuni-proxy-httpd.pid

--- a/containers/proxy-systemd-services/uyuni-proxy-salt-broker.service
+++ b/containers/proxy-systemd-services/uyuni-proxy-salt-broker.service
@@ -14,7 +14,7 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=/etc/sysconfig/uyuni-proxy-systemd-services
 Restart=on-failure
 ExecStartPre=/bin/rm -f %t/uyuni-proxy-salt-broker.pid %t/uyuni-proxy-salt-broker.ctr-id
-ExecStart=/usr/bin/podman run --conmon-pidfile %t/uyuni-proxy-salt-broker.pid --cidfile %t/uyuni-proxy-salt-broker.ctr-id --cgroups=no-conmon --pod-id-file %t/uyuni-proxy-pod.pod-id -d --replace -dt -v ${CONFIG_DIR}:/etc/uyuni:ro --name uyuni-proxy-salt-broker ${NAMESPACE}/proxy-salt-broker
+ExecStart=/usr/bin/podman run --conmon-pidfile %t/uyuni-proxy-salt-broker.pid --cidfile %t/uyuni-proxy-salt-broker.ctr-id --cgroups=no-conmon --pod-id-file %t/uyuni-proxy-pod.pod-id -d --replace -dt -v ${CONFIG_DIR}:/etc/uyuni:ro --name uyuni-proxy-salt-broker ${NAMESPACE}/proxy-salt-broker:${TAG}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/uyuni-proxy-salt-broker.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/uyuni-proxy-salt-broker.ctr-id
 PIDFile=%t/uyuni-proxy-salt-broker.pid

--- a/containers/proxy-systemd-services/uyuni-proxy-services.config
+++ b/containers/proxy-systemd-services/uyuni-proxy-services.config
@@ -1,7 +1,13 @@
 # This file is expected to be found in `/etc/sysconfig/container-proxy-services.config`,
 # the EnvironmentFile services property is pointing there
 
+# Where to get the images from.
+# It should contain the registry FQDN and path to the proxy-* images without trailing slash 
 NAMESPACE=registry.opensuse.org/uyuni
+
+# Tag of the images to pull
+TAG=latest
+
 CONFIG_DIR=/etc/uyuni/proxy
 SQUID_CACHE_DIR=/var/lib/uyuni/proxy-squid-cache
 RHN_CACHE_DIR=/var/lib/uyuni/proxy-rhn-cache

--- a/containers/proxy-systemd-services/uyuni-proxy-squid.service
+++ b/containers/proxy-systemd-services/uyuni-proxy-squid.service
@@ -14,7 +14,7 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=/etc/sysconfig/uyuni-proxy-systemd-services
 Restart=on-failure
 ExecStartPre=/bin/rm -f %t/uyuni-proxy-squid.pid %t/uyuni-proxy-squid.ctr-id
-ExecStart=/usr/bin/podman run --conmon-pidfile %t/uyuni-proxy-squid.pid --cidfile %t/uyuni-proxy-squid.ctr-id --cgroups=no-conmon --pod-id-file %t/uyuni-proxy-pod.pod-id --replace -d -v ${CONFIG_DIR}:/etc/uyuni:ro -v ${SQUID_CACHE_DIR}:/var/cache/squid --name uyuni-proxy-squid ${NAMESPACE}/proxy-squid
+ExecStart=/usr/bin/podman run --conmon-pidfile %t/uyuni-proxy-squid.pid --cidfile %t/uyuni-proxy-squid.ctr-id --cgroups=no-conmon --pod-id-file %t/uyuni-proxy-pod.pod-id --replace -d -v ${CONFIG_DIR}:/etc/uyuni:ro -v ${SQUID_CACHE_DIR}:/var/cache/squid --name uyuni-proxy-squid ${NAMESPACE}/proxy-squid:${TAG}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/uyuni-proxy-squid.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/uyuni-proxy-squid.ctr-id
 PIDFile=%t/uyuni-proxy-squid.pid

--- a/containers/proxy-systemd-services/uyuni-proxy-ssh.service
+++ b/containers/proxy-systemd-services/uyuni-proxy-ssh.service
@@ -14,7 +14,7 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=/etc/sysconfig/uyuni-proxy-systemd-services
 Restart=on-failure
 ExecStartPre=/bin/rm -f %t/uyuni-proxy-ssh.pid %t/uyuni-proxy-ssh.ctr-id
-ExecStart=/usr/bin/podman run --conmon-pidfile %t/uyuni-proxy-ssh.pid --cidfile %t/uyuni-proxy-ssh.ctr-id --cgroups=no-conmon --pod-id-file %t/uyuni-proxy-pod.pod-id -d --replace -dt -v ${CONFIG_DIR}:/etc/uyuni:ro --name uyuni-proxy-ssh ${NAMESPACE}/proxy-ssh
+ExecStart=/usr/bin/podman run --conmon-pidfile %t/uyuni-proxy-ssh.pid --cidfile %t/uyuni-proxy-ssh.ctr-id --cgroups=no-conmon --pod-id-file %t/uyuni-proxy-pod.pod-id -d --replace -dt -v ${CONFIG_DIR}:/etc/uyuni:ro --name uyuni-proxy-ssh ${NAMESPACE}/proxy-ssh:${TAG}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/uyuni-proxy-ssh.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/uyuni-proxy-ssh.ctr-id
 PIDFile=%t/uyuni-proxy-ssh.pid

--- a/containers/proxy-systemd-services/uyuni-proxy-systemd-services.changes
+++ b/containers/proxy-systemd-services/uyuni-proxy-systemd-services.changes
@@ -1,3 +1,5 @@
+- Add TAG variable in configuration 
+
 -------------------------------------------------------------------
 Tue May 10 10:02:30 CEST 2022 - jgonzalez@suse.com
 

--- a/containers/proxy-systemd-services/uyuni-proxy-systemd-services.spec
+++ b/containers/proxy-systemd-services/uyuni-proxy-systemd-services.spec
@@ -15,7 +15,7 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
-%define SERVICES proxy-httpd proxy-salt-broker proxy-squid proxy-ssh proxy-tftpd proxy-pod
+%define SERVICES uyuni-proxy-httpd uyuni-proxy-salt-broker uyuni-proxy-squid uyuni-proxy-ssh uyuni-proxy-tftpd uyuni-proxy-pod
 
 Name:           uyuni-proxy-systemd-services
 Summary:        Uyuni proxy server systemd services containers
@@ -63,48 +63,47 @@ install -D -m 644 uyuni-proxy-services.config %{buildroot}%{_fillupdir}/sysconfi
 %endif
 
 for service in %{SERVICES}; do
-    install -D -m 644 uyuni-${service}.service %{buildroot}%{_unitdir}/uyuni-${service}.service
-    ln -s /usr/sbin/service %{buildroot}%{_sbindir}/rcuyuni-${service}
+    install -D -m 644 ${service}.service %{buildroot}%{_unitdir}/${service}.service
+    ln -s /usr/sbin/service %{buildroot}%{_sbindir}/rc${service}
 done
 
 %check
 
 %pre
 %if !0%{?rhel}
-for service in %{SERVICES}; do
-    %service_add_pre uyuni-${service}.service
-done
+%service_add_pre %{SERVICES}
 %endif
 
 %post
 %if 0%{?suse_version}
 %fillup_only
 %endif
+
+%if 0%{?rhel}
 for service in %{SERVICES}; do
-    %if 0%{?rhel}
-        %systemd_post uyuni-${service}.service
-    %else
-    %service_add_post uyuni-${service}.service
-    %endif
+    %systemd_post ${service}.service
 done
+%else
+%service_add_post %{SERVICES}
+%endif
 
 %preun
+%if 0%{?rhel}
 for service in %{SERVICES}; do
-    %if 0%{?rhel}
-        %systemd_preun uyuni-${service}.service
-    %else
-        %service_del_preun uyuni-${service}.service
-    %endif
+    %systemd_preun ${service}.service
 done
+%else
+%service_del_preun %{SERVICES}
+%endif
 
 %postun
+%if 0%{?rhel}
 for service in %{SERVICES}; do
-    %if 0%{?rhel}
-        %systemd_postun uyuni-${service}.service
-    %else
-        %service_del_postun uyuni-${service}.service
-    %endif
+    %systemd_postun ${service}.service
 done
+%else
+%service_del_postun %{SERVICES}
+%endif
 
 %files
 %defattr(-,root,root)

--- a/containers/proxy-systemd-services/uyuni-proxy-systemd-services.spec
+++ b/containers/proxy-systemd-services/uyuni-proxy-systemd-services.spec
@@ -107,6 +107,7 @@ done
 
 %files
 %defattr(-,root,root)
+%doc README.md
 %{_unitdir}/*.service
 %{_sbindir}/rcuyuni-*
 %if 0%{?rhel}

--- a/containers/proxy-systemd-services/uyuni-proxy-tftpd.service
+++ b/containers/proxy-systemd-services/uyuni-proxy-tftpd.service
@@ -14,7 +14,7 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=/etc/sysconfig/uyuni-proxy-systemd-services
 Restart=on-failure
 ExecStartPre=/bin/rm -f %t/uyuni-proxy-tftpd.pid %t/uyuni-proxy-tftpd.ctr-id
-ExecStart=/usr/bin/podman run --conmon-pidfile %t/uyuni-proxy-tftpd.pid --cidfile %t/uyuni-proxy-tftpd.ctr-id --cgroups=no-conmon --pod-id-file %t/uyuni-proxy-pod.pod-id -d --replace -dt -v ${CONFIG_DIR}:/etc/uyuni:ro -v ${TFTPBOOT_DIR}:/srv/tftpboot:ro --name uyuni-proxy-tftpd ${NAMESPACE}/proxy-tftpd
+ExecStart=/usr/bin/podman run --conmon-pidfile %t/uyuni-proxy-tftpd.pid --cidfile %t/uyuni-proxy-tftpd.ctr-id --cgroups=no-conmon --pod-id-file %t/uyuni-proxy-pod.pod-id -d --replace -dt -v ${CONFIG_DIR}:/etc/uyuni:ro -v ${TFTPBOOT_DIR}:/srv/tftpboot:ro --name uyuni-proxy-tftpd ${NAMESPACE}/proxy-tftpd:${TAG}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/uyuni-proxy-tftpd.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/uyuni-proxy-tftpd.ctr-id
 PIDFile=%t/uyuni-proxy-tftpd.pid


### PR DESCRIPTION
## What does this PR change?

* Proxy: add image tag configuration to systemd service
* Add comments to the config file and improve the README.md
* Remove `for` loops in `%service_{add|del}_{pre|post}` calls
  
## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: work in progress

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17788

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
