### PR TITLE
Remove BETA client tools, no longer exists

### DIFF
--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -46,7 +46,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I select the addon "Legacy Module 12 x86_64"
     Then I should see the "Legacy Module 12 x86_64" selected
     # Comment following 1 line if you wish to re-enable testing with beta client tools for SLE12
-    And I deselect "SUSE Manager Client Tools Beta for SLE 12 x86_64 (BETA)" as a SUSE Manager product
+    # And I deselect "SUSE Manager Client Tools Beta for SLE 12 x86_64 (BETA)" as a SUSE Manager product
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 12 SP5 x86_64" product has been added
     Then the SLE12 SP5 product should be added


### PR DESCRIPTION
## What does this PR change?

Remove BETA client tools, no longer exists https://suse.slack.com/archives/C02D78LLS04/p1652691105459709?thread_ts=1652690616.916259&cid=C02D78LLS04

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes no issue, directly for HEAD testsuite review
Tracks: I think this only affects HEAD. 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
