### PR TITLE
Move cert deps from proxy-broker to proxy package

### DIFF
--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,5 @@
+- Move certificates dependencies from broker to proxy package
+
 -------------------------------------------------------------------
 Fri May 20 00:09:53 CEST 2022 - jgonzalez@suse.com
 

--- a/proxy/proxy/spacewalk-proxy.spec
+++ b/proxy/proxy/spacewalk-proxy.spec
@@ -29,6 +29,8 @@ BuildRequires:  python3
 BuildArch:      noarch
 Requires:       httpd
 Requires:       python3-uyuni-common-libs
+Requires:       spacewalk-certs-tools
+Requires:       spacewalk-ssl-cert-check
 BuildRequires:  mgr-push >= 4.0.0
 BuildRequires:  python3-mgr-push
 BuildRequires:  spacewalk-backend >= 1.7.24
@@ -80,9 +82,7 @@ This package require all needed packages for Spacewalk Proxy Server.
 Summary:        The Broker component for the Spacewalk Proxy Server
 Group:          Applications/Internet
 Requires:       httpd
-Requires:       spacewalk-certs-tools
 Requires:       spacewalk-proxy-package-manager
-Requires:       spacewalk-ssl-cert-check
 %if 0%{?suse_version}
 Requires:       apache2-prefork
 Requires:       apache2-mod_wsgi-python3


### PR DESCRIPTION
## What does this PR change?

The proxy broker is not using any of the certs and cert-check tools and
these are pulling a lot of packages. In order to help slimming down
container images, move these requires to the proxy package so they are
still installed on regular proxies.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
