### PR TITLE
create CA symlink on SUMA/Uyuni Proxies

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/certs/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/init.sls
@@ -7,3 +7,9 @@ mgr_absent_ca_package:
 {%- endmacro %}
 {% set sls = includesls(grains['os_family']|lower) -%}
 {{ sls }}
+
+mgr_proxy_ca_cert_symlink:
+  file.symlink:
+    - name: /usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT
+    - target: /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT
+    - onlyif: grep -Eq "^proxy.rhn_parent *= *[a-zA-Z0-9]+" /etc/rhn/rhn.conf && -e /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,6 @@
+- create CA certificate symlink on Proxies which might get lost due
+  to de-installation of the ca package
+
 -------------------------------------------------------------------
 Fri May 20 00:14:13 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

When a Proxy change the CA certificate from package to file deployment, it can happen that the CA
is not available anymore under `/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT` .
This change add a state which create the symlink when it's missing.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17931
Tracks 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
