### PR TITLE
Fix numerous branding bugs

### DIFF
--- a/web/html/src/branding/css/base/tables.less
+++ b/web/html/src/branding/css/base/tables.less
@@ -53,29 +53,6 @@ th button.btn-link{
   font-weight: bold;
 }
 
-.table-striped > tbody > tr:nth-child(odd) > td, .table-striped > tbody > tr:nth-child(odd) > th {
-    background-color: #f9f9f9;
-}
-.list-row-odd, .list-row-odd td.sortedCol {
-    background-color: #f9f9f9 !important;
-}
-
-.list-row-even td.sortedCol {
-  background-color: transparent !important;
-}
-
-.list-row-odd,
-.list-row-odd td.sortedCol {
-  background-color: @table-bg-accent !important;
-}
-
-.list-row-even:hover td,
-.list-row-odd:hover td,
-.list-row-even:hover td.sortedCol,
-.list-row-odd:hover td.sortedCol  {
-  background-color: darken(@gray-lighter, 2%) !important;
-}
-
 .compare-list {
   border: 1px solid #DDDDDD;
   width: 100%;

--- a/web/html/src/branding/css/base/theme.less
+++ b/web/html/src/branding/css/base/theme.less
@@ -1074,11 +1074,10 @@ a time:hover {
 .spacewalk-section-toolbar.fixed {
   position: fixed;
   z-index: 900;
-  border-bottom: 1px solid #ccc;
-  box-shadow: 0px 2px 1px 0px #eee;
   padding-left: 1em;
   padding-right: 1em;
   margin-top: 0px;
+
   .form-group {
     margin-bottom: 0;
   }

--- a/web/html/src/branding/css/base/theme.less
+++ b/web/html/src/branding/css/base/theme.less
@@ -356,11 +356,15 @@ header, nav.navbar-pf {
       border-style: solid;
       border-radius: 0;
       border-width: 0 0 1px 0;
-      // TODO: Update this to dark
-      color: @eos-bc-gray-900;
       padding-right: 3em;
       height: 3em;
+      color: @eos-bc-gray-1000;
+
+      &::placeholder {
+        color: @eos-bc-gray-900;
+      }
     }
+
     input:focus {
       box-shadow: none;
     }

--- a/web/html/src/branding/css/susemanager/components/buttons.less
+++ b/web/html/src/branding/css/susemanager/components/buttons.less
@@ -34,7 +34,7 @@
   }
 
   // Branding hover effect
-  &:not(:disabled):not(.disabled):hover::after {
+  &:not(:disabled):not(.disabled):not(.text-muted):hover::after {
     // background: #686565;
     border: 2px solid transparent;
     bottom: -2px;
@@ -57,7 +57,7 @@
   }
 
   &.text-muted {
-    color: inherit;
+    color: inherit !important;
   }
 }
 
@@ -79,7 +79,7 @@
       border-color: @eos-bc-pine-500;
       color: @eos-bc-pine-500;
 
-      &:not(:disabled):not(.disabled):hover::after {
+      &:not(:disabled):not(.disabled):not(.text-muted):hover::after {
         background: @eos-bc-pine-500;
       }
     }
@@ -93,7 +93,7 @@
       border-color: @eos-bc-persimmon-500;
       color: @eos-bc-gray-1000;
 
-      &:not(:disabled):not(.disabled):hover::after {
+      &:not(:disabled):not(.disabled):not(.text-muted):hover::after {
         background: @eos-bc-gray-900;
       }
     }
@@ -107,7 +107,7 @@
       border-color: @eos-bc-persimmon-500;
       color: @eos-bc-gray-1000;
 
-      &:not(:disabled):not(.disabled):hover::after {
+      &:not(:disabled):not(.disabled):not(.text-muted):hover::after {
         background: @eos-bc-persimmon-500;
       }
     }
@@ -128,7 +128,7 @@
         border-color: @eos-bc-red-900;
       }
 
-      &:not(:disabled):not(.disabled):hover::after {
+      &:not(:disabled):not(.disabled):not(.text-muted):hover::after {
         background: @eos-bc-gray-900;
       }
     }
@@ -140,7 +140,7 @@
   padding: 6px 12px;
   z-index: 100;
 
-  &:not(:disabled):not(.disabled):hover::after {
+  &:not(:disabled):not(.disabled):not(.text-muted):hover::after {
     border-width: 1px;
     bottom: -1px;
     left: -1px;

--- a/web/html/src/branding/css/susemanager/components/buttons.less
+++ b/web/html/src/branding/css/susemanager/components/buttons.less
@@ -62,11 +62,15 @@
 }
 
 .btn-link {
-  color: @link-color;
-  font-weight: normal;
+  &, &:active, &:focus, &:disabled, &.disabled {
+    &, &:hover {
+      color: @link-color;
+      font-weight: normal;
+    }
 
-  &:hover {
-    text-decoration: underline;
+    &:not(:disabled):not(.disabled):not(.text-muted):hover {
+      text-decoration: underline;
+    }
   }
 }
 
@@ -123,7 +127,7 @@
       border-color: @eos-bc-red-500;
       color: @eos-bc-white;
 
-      &:not(:disabled):not(.disabled):hover {
+      &:not(:disabled):not(.disabled):not(.text-muted):hover {
         background: @eos-bc-red-900;
         border-color: @eos-bc-red-900;
       }

--- a/web/html/src/branding/css/susemanager/components/buttons.less
+++ b/web/html/src/branding/css/susemanager/components/buttons.less
@@ -73,7 +73,7 @@
 // TODO: Add :active and :focus states for green etc
 // NB! Here and below, these are not nested because they're not used consistently along with .btn
 .btn-default {
-  &, &:disabled, &.disabled {
+  &, &:active, &:focus, &:disabled, &.disabled {
     &, &:hover {
       background: transparent;
       border-color: @eos-bc-pine-500;
@@ -87,7 +87,7 @@
 }
 
 .btn-primary {
-  &, &:disabled, &.disabled {
+  &, &:active, &:focus, &:disabled, &.disabled {
     &, &:hover {
       background: @eos-bc-persimmon-500;
       border-color: @eos-bc-persimmon-500;
@@ -101,7 +101,7 @@
 }
 
 .btn-success {
-  &, &:disabled, &.disabled {
+  &, &:active, &:focus, &:disabled, &.disabled {
     &, &:hover {
       background: transparent;
       border-color: @eos-bc-persimmon-500;
@@ -117,7 +117,7 @@
 // Warning shouldn't currently be used anywhere, but cover it just in case
 .btn-warning,
 .btn-danger {
-  &, &:disabled, &.disabled {
+  &, &:active, &:focus, &:disabled, &.disabled {
     &, &:hover {
       background: @eos-bc-red-500;
       border-color: @eos-bc-red-500;

--- a/web/html/src/branding/css/susemanager/components/nav.less
+++ b/web/html/src/branding/css/susemanager/components/nav.less
@@ -6,6 +6,7 @@
       border-color: @eos-bc-green-500;
       padding-bottom: 1px;
       border-bottom-width: 5px;
+      text-decoration: none !important;
     }
 
     &:active, &:focus {
@@ -19,7 +20,7 @@
   &.active {
     a {
       &, &:hover, &:active, &:focus {
-      color: @eos-bc-gray-1000;
+        color: @eos-bc-gray-1000;
       }
     }
   }

--- a/web/html/src/branding/css/susemanager/components/panels.less
+++ b/web/html/src/branding/css/susemanager/components/panels.less
@@ -37,10 +37,6 @@
     .list-group-item {
       background: transparent;
       border-color: @eos-bc-gray-100;
-
-      &:last-child {
-        border: none;
-      }
     }
   }
 }

--- a/web/html/src/branding/css/susemanager/components/panels.less
+++ b/web/html/src/branding/css/susemanager/components/panels.less
@@ -34,6 +34,10 @@
       padding: 1.25rem;
     }
 
+    .list-group:last-child {
+      margin-bottom: 0;
+    }
+
     .list-group-item {
       background: transparent;
       border-color: @eos-bc-gray-100;

--- a/web/html/src/branding/css/susemanager/components/tables.less
+++ b/web/html/src/branding/css/susemanager/components/tables.less
@@ -1,3 +1,24 @@
+.spacewalk-list-head-addons {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  label {
+    cursor: pointer;
+  }
+}
+
+.table-search-wrapper {
+  flex: 1;
+}
+
+.table-input-search {
+  width: 60%;
+  max-width: 500px;
+  display: inline-block;
+  margin-right: 10px;
+}
+
 thead tr {
   background: transparent !important;
   color: @eos-bc-gray-700 !important;

--- a/web/html/src/branding/css/susemanager/components/tables.less
+++ b/web/html/src/branding/css/susemanager/components/tables.less
@@ -1,7 +1,7 @@
 .spacewalk-list-head-addons {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
 
   label {
     cursor: pointer;
@@ -26,6 +26,7 @@ thead tr {
   .btn-link {
     padding: 0 !important;
     border-width: 0 !important;
+    color: @eos-bc-gray-1000 !important;
   }
 }
 

--- a/web/html/src/branding/css/susemanager/components/toolbar.less
+++ b/web/html/src/branding/css/susemanager/components/toolbar.less
@@ -2,4 +2,9 @@
   background: transparent;
   padding: 0;
   border: none;
+
+  &.fixed {
+    background: @eos-bc-white;
+    border-bottom: 1px solid @eos-bc-gray-300;
+  }
 }

--- a/web/html/src/branding/css/uyuni/legacy-mixins.less
+++ b/web/html/src/branding/css/uyuni/legacy-mixins.less
@@ -50,6 +50,7 @@ i.no-margin {
   max-width: 500px;
   display: inline-block;
   margin-right: 10px;
+  margin-bottom: 0.5em;
 }
 
 th a.orderBy{

--- a/web/html/src/components/table/SearchField.tsx
+++ b/web/html/src/components/table/SearchField.tsx
@@ -26,7 +26,7 @@ export class SearchField extends React.Component<SearchFieldProps> {
     const props = this.props;
     return (
       <input
-        className="form-control table-input-search with-bottom-margin"
+        className="form-control table-input-search"
         value={props.criteria || ""}
         placeholder={props.placeholder}
         type="text"

--- a/web/html/src/core/debug/index.ts
+++ b/web/html/src/core/debug/index.ts
@@ -1,0 +1,45 @@
+type Theme = "susemanager-light" | "susemanager-dark" | "uyuni";
+
+class Debug {
+  public toggleTheme(toTheme?: Theme) {
+    const lightTheme = document.querySelector('link[href^="/css/susemanager-light"]');
+    if (lightTheme) {
+      lightTheme.setAttribute(
+        "href",
+        toTheme || lightTheme.getAttribute("href")!.replace("susemanager-light", "uyuni")
+      );
+      return;
+    }
+
+    const darkTheme = document.querySelector('link[href^="/css/susemanager-dark"]');
+    if (darkTheme) {
+      darkTheme.setAttribute("href", toTheme || darkTheme.getAttribute("href")!.replace("susemanager-dark", "uyuni"));
+      return;
+    }
+
+    const uyuniTheme = document.querySelector('link[href^="/css/uyuni"]');
+    if (uyuniTheme) {
+      uyuniTheme.setAttribute(
+        "href",
+        toTheme || uyuniTheme.getAttribute("href")!.replace("uyuni", "susemanager-light")
+      );
+      return;
+    }
+  }
+}
+
+declare global {
+  interface Window {
+    debug?: Debug;
+  }
+}
+
+const bindDebugHelpers = () => {
+  window.debug = new Debug();
+};
+
+if (window.location.host.startsWith("localhost")) {
+  bindDebugHelpers();
+}
+
+export default {};

--- a/web/html/src/manager/admin/setup/products/products-scc-dialog.tsx
+++ b/web/html/src/manager/admin/setup/products/products-scc-dialog.tsx
@@ -162,7 +162,7 @@ class SCCDialog extends React.Component<Props> {
                         : "fa fa-li fa-circle-o text-muted"
                     }
                   />
-                  <span className={s.success == null ? "text-muted" : ""}>{s.label}</span>
+                  <span>{s.label}</span>
                 </li>
               );
             })}

--- a/web/html/src/manager/images/image-view.tsx
+++ b/web/html/src/manager/images/image-view.tsx
@@ -613,13 +613,13 @@ class ImageViewList extends React.Component<ImageViewListProps, ImageViewListSta
     }
 
     const obsoleteFilter = (
-      <label>
+      <label className="btn-link">
         <input
           name="obsoleteFilter"
           type="checkbox"
           checked={this.state.showObsolete}
           onChange={this.showObsoleteChanged}
-        />
+        />{" "}
         <span>{t("Show obsolete")}</span>
       </label>
     );

--- a/web/html/src/manager/index.ts
+++ b/web/html/src/manager/index.ts
@@ -8,6 +8,7 @@ import "./polyfills";
 import "react-hot-loader";
 import "core/spa/spa-engine";
 import "core/log";
+import "core/debug";
 import "./legacy";
 
 import SpaRenderer from "core/spa/spa-renderer";

--- a/web/html/src/manager/salt/keys/key-management.tsx
+++ b/web/html/src/manager/salt/keys/key-management.tsx
@@ -151,7 +151,7 @@ class KeyManagement extends React.Component<Props, State> {
             identifier={this.rowKey}
             initialSortColumnKey="id"
             loading={this.state.loading}
-            searchField={<SearchField filter={this.searchData} />}
+            searchField={<SearchField filter={this.searchData} placeholder={t("Search by name or fingerprint")} />}
           >
             <Column
               columnKey="id"

--- a/web/html/src/manager/state/highstate-summary.tsx
+++ b/web/html/src/manager/state/highstate-summary.tsx
@@ -101,7 +101,6 @@ function HighstateOutput({ minionId }) {
         icon="fa-file-text-o"
         text={t("Show full highstate output")}
         action={() => requestHighstate(minionId).then(setHighstate)}
-        defaultType="btn-link"
       />
     );
   }

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Fix miscellaneous small branding mismatches
+
 -------------------------------------------------------------------
 Fri May 20 00:13:32 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fix numerous style bugs in the new branding.

## GUI diff

Before:

<img width="1643" alt="Screenshot 2022-05-20 at 11 53 37" src="https://user-images.githubusercontent.com/3171718/169526155-b014c420-fcf9-43cc-b3b1-07ae40bc1ff3.png">

After:

<img width="1641" alt="Screenshot 2022-05-20 at 11 53 43" src="https://user-images.githubusercontent.com/3171718/169526175-d268aadd-2587-46ae-91ef-80af450b946b.png">

Before:

<img width="1621" alt="Screenshot 2022-05-20 at 11 54 43" src="https://user-images.githubusercontent.com/3171718/169526198-b7ded140-41ca-4cd8-b024-7fcce8d58dd1.png">

After:

<img width="1627" alt="Screenshot 2022-05-20 at 12 01 26" src="https://user-images.githubusercontent.com/3171718/169526216-59ce2d0e-9951-445f-88c0-794041a261ba.png">

Before:

<img width="151" alt="Screenshot 2022-05-20 at 13 40 50" src="https://user-images.githubusercontent.com/3171718/169526236-ec718834-88b9-42a5-855e-4a37b0aab414.png">

After:

<img width="140" alt="Screenshot 2022-05-20 at 13 40 54" src="https://user-images.githubusercontent.com/3171718/169526264-a3adb0d7-cab5-4f5e-b42e-ece009802ce4.png">

Before:

<img width="261" alt="Screenshot 2022-05-20 at 13 53 15" src="https://user-images.githubusercontent.com/3171718/169526306-57a7833c-cb1f-473a-ae0b-897a54cf99b6.png">

After:

<img width="265" alt="Screenshot 2022-05-20 at 13 53 20" src="https://user-images.githubusercontent.com/3171718/169526316-452ee5e3-a1ec-4fc3-8141-f60beb20642a.png">

Before:

<img width="273" alt="Screenshot 2022-05-20 at 14 05 27" src="https://user-images.githubusercontent.com/3171718/169526336-c955c21f-3d4a-42aa-87be-ff6a23a09915.png">

After:

<img width="207" alt="Screenshot 2022-05-20 at 14 05 49" src="https://user-images.githubusercontent.com/3171718/169526353-c0ec58cf-6cbc-4406-9ceb-aaa782cafa7f.png">

Before:

<img width="791" alt="Screenshot 2022-05-20 at 14 12 02" src="https://user-images.githubusercontent.com/3171718/169526365-5d3dacc4-61e0-4b03-87cb-20a371854e49.png">

After:

<img width="786" alt="Screenshot 2022-05-20 at 14 12 23" src="https://user-images.githubusercontent.com/3171718/169526385-babf1b87-e2f0-4641-acba-946619be23ac.png">


- [x] **DONE**

## Documentation
- Documentation issue already exists

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17882
Fixes https://github.com/SUSE/spacewalk/issues/17887
Fixes https://github.com/SUSE/spacewalk/issues/17884
Fixes https://github.com/SUSE/spacewalk/issues/17883
Fixes https://github.com/SUSE/spacewalk/issues/17880

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
