### PR TITLE
Hide authentication data in PAYG UI (bsc#1199679)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/PaygSshDataSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/PaygSshDataSerializer.java
@@ -32,15 +32,9 @@ import com.suse.manager.api.SerializedApiResponse;
  *              #prop("string", "hostname")
  *              #prop("int", "port")
  *              #prop("string", "username")
- *              #prop("string", "password")
- *              #prop("string", "key")
- *              #prop("string", "key_password")
  *              #prop("string", "bastion_hostname")
  *              #prop("int", "bastion_port")
  *              #prop("string", "bastion_username")
- *              #prop("string", "bastion_password")
- *              #prop("string", "bastion_key")
- *              #prop("string", "bastion_key_password")
  *      #struct_end()
  */
 public class PaygSshDataSerializer extends ApiResponseSerializer<PaygSshData> {
@@ -57,15 +51,9 @@ public class PaygSshDataSerializer extends ApiResponseSerializer<PaygSshData> {
                 .add("hostname", src.getHost())
                 .add("port", src.getPort())
                 .add("username", src.getUsername())
-                .add("password", src.getPassword())
-                .add("key", src.getKey())
-                .add("key_password", src.getKeyPassword())
                 .add("bastion_hostname", src.getBastionHost())
                 .add("bastion_port", src.getBastionPort())
                 .add("bastion_username", src.getBastionUsername())
-                .add("bastion_password", src.getBastionPassword())
-                .add("bastion_key", src.getBastionKey())
-                .add("bastion_key_password", src.getBastionKeyPassword())
                 .build();
     }
 }

--- a/java/code/src/com/suse/manager/admin/PaygAdminManager.java
+++ b/java/code/src/com/suse/manager/admin/PaygAdminManager.java
@@ -168,38 +168,48 @@ public class PaygAdminManager {
         Integer port = null;
         Integer bastionPort = null;
 
-        if (!StringUtils.isEmpty(paygProperties.getPort())) {
-            try {
-                port = Integer.parseInt(paygProperties.getPort());
-            }
-            catch (NumberFormatException e) {
-                result.addFieldError(PaygAdminFields.port.name(), "payg.port_invalid");
-            }
-        }
-        if (!StringUtils.isEmpty(paygProperties.getBastionPort())) {
-            try {
-                bastionPort = Integer.parseInt(paygProperties.getBastionPort());
-            }
-            catch (NumberFormatException e) {
-                result.addFieldError(PaygAdminFields.bastion_port.name(), "payg.bastion_port_invalid");
+        if (paygProperties.isInstanceEdit()) {
+            if (!StringUtils.isEmpty(paygProperties.getPort())) {
+                try {
+                    port = Integer.parseInt(paygProperties.getPort());
+                }
+                catch (NumberFormatException e) {
+                    result.addFieldError(PaygAdminFields.port.name(), "payg.port_invalid");
+                }
             }
         }
-
+        else {
+            port = paygSshData.getPort();
+        }
+        if (paygProperties.isBastionEdit()) {
+            if (!StringUtils.isEmpty(paygProperties.getBastionPort())) {
+                try {
+                    bastionPort = Integer.parseInt(paygProperties.getBastionPort());
+                }
+                catch (NumberFormatException e) {
+                    result.addFieldError(PaygAdminFields.bastion_port.name(), "payg.bastion_port_invalid");
+                }
+            }
+        }
+        else {
+            bastionPort = paygSshData.getBastionPort();
+        }
 
         return setDetails(paygSshData,
                 paygProperties.getDescription(),
                 paygSshData.getHost(),
                 port,
-                paygProperties.getUsername(),
-                paygProperties.getPassword(),
-                paygProperties.getKey(),
-                paygProperties.getKeyPassword(),
-                paygProperties.getBastionHost(),
+                paygProperties.isInstanceEdit() ? paygProperties.getUsername() : paygSshData.getUsername(),
+                paygProperties.isInstanceEdit() ? paygProperties.getPassword() : paygSshData.getPassword(),
+                paygProperties.isInstanceEdit() ? paygProperties.getKey() : paygSshData.getKey(),
+                paygProperties.isInstanceEdit() ? paygProperties.getKeyPassword() : paygSshData.getKeyPassword(),
+                paygProperties.isBastionEdit() ? paygProperties.getBastionHost() : paygSshData.getBastionHost(),
                 bastionPort,
-                paygProperties.getBastionUsername(),
-                paygProperties.getBastionPassword(),
-                paygProperties.getBastionKey(),
-                paygProperties.getBastionKeyPassword());
+                paygProperties.isBastionEdit() ? paygProperties.getBastionUsername() : paygSshData.getBastionUsername(),
+                paygProperties.isBastionEdit() ? paygProperties.getBastionPassword() : paygSshData.getBastionPassword(),
+                paygProperties.isBastionEdit() ? paygProperties.getBastionKey() : paygSshData.getBastionKey(),
+                paygProperties.isBastionEdit() ? paygProperties.getBastionKeyPassword() :
+                        paygSshData.getBastionKeyPassword());
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/admin/beans/PaygProperties.java
+++ b/java/code/src/com/suse/manager/webui/controllers/admin/beans/PaygProperties.java
@@ -38,6 +38,10 @@ public class PaygProperties {
     private String bastionKey;
     @SerializedName("bastion_key_password")
     private String bastionKeyPassword;
+    @SerializedName("instance_edit")
+    private Boolean instanceEdit;
+    @SerializedName("bastion_edit")
+    private Boolean bastionEdit;
 
     /**
      * default constructor
@@ -60,6 +64,8 @@ public class PaygProperties {
      * @param bastionPasswordIn
      * @param bastionKeyIn
      * @param bastionKeyPasswordIn
+     * @param instanceEditIn
+     * @param bastionEditIn
      */
     public PaygProperties(String descriptionIn,
                           String hostIn, String portIn,
@@ -67,7 +73,8 @@ public class PaygProperties {
                           String keyIn, String keyPasswordIn,
                           String bastionHostIn, String bastionPortIn,
                           String bastionUsernameIn, String bastionPasswordIn,
-                          String bastionKeyIn, String bastionKeyPasswordIn) {
+                          String bastionKeyIn, String bastionKeyPasswordIn,
+                          Boolean instanceEditIn, Boolean bastionEditIn) {
         this.description = descriptionIn;
         this.host = hostIn;
         this.port = portIn;
@@ -81,6 +88,8 @@ public class PaygProperties {
         this.bastionPassword = bastionPasswordIn;
         this.bastionKey = bastionKeyIn;
         this.bastionKeyPassword = bastionKeyPasswordIn;
+        this.instanceEdit = instanceEditIn;
+        this.bastionEdit = bastionEditIn;
     }
 
     public String getDescription() {
@@ -185,5 +194,21 @@ public class PaygProperties {
 
     public void setBastionKeyPassword(String bastionKeyPasswordIn) {
         this.bastionKeyPassword = bastionKeyPasswordIn;
+    }
+
+    public Boolean isInstanceEdit() {
+        return instanceEdit;
+    }
+
+    public void setInstanceEdit(Boolean instanceEditIn) {
+        instanceEdit = instanceEditIn;
+    }
+
+    public Boolean isBastionEdit() {
+        return bastionEdit;
+    }
+
+    public void setBastionEdit(Boolean bastionEditIn) {
+        bastionEdit = bastionEditIn;
     }
 }

--- a/java/code/src/com/suse/manager/webui/controllers/admin/handlers/test/PaygApiControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/admin/handlers/test/PaygApiControllerTest.java
@@ -166,7 +166,7 @@ public class PaygApiControllerTest extends BaseControllerTestCase {
         PaygSshData paygInfo = createPaygSshData();
         PaygProperties properties = new PaygProperties("d", "h", "8001",
                 "u", "p", "k", "kp",
-                "bh", "8002", "bu", "bp", "bk", "bkp");
+                "bh", "8002", "bu", "bp", "bk", "bkp", true, true);
 
         String dataJson = PaygApiContoller.updatePayg(
                 getPostRequestWithCsrfAndBody("/manager/api/admin/config/payg/:id",
@@ -181,16 +181,18 @@ public class PaygApiControllerTest extends BaseControllerTestCase {
         assertEquals(paygInfo.getHost(), returnData.getData().getProperties().getHost());
         assertEquals(properties.getPort(), returnData.getData().getProperties().getPort());
         assertEquals(properties.getUsername(), returnData.getData().getProperties().getUsername());
-        assertEquals(properties.getPassword(), returnData.getData().getProperties().getPassword());
-        assertEquals(properties.getKey(), returnData.getData().getProperties().getKey());
-        assertEquals(properties.getKeyPassword(), returnData.getData().getProperties().getKeyPassword());
+        assertEquals("", returnData.getData().getProperties().getPassword());
+        assertEquals("", returnData.getData().getProperties().getKey());
+        assertEquals("", returnData.getData().getProperties().getKeyPassword());
 
         assertEquals(properties.getBastionHost(), returnData.getData().getProperties().getBastionHost());
         assertEquals(properties.getBastionPort(), returnData.getData().getProperties().getBastionPort());
         assertEquals(properties.getBastionUsername(), returnData.getData().getProperties().getBastionUsername());
-        assertEquals(properties.getBastionPassword(), returnData.getData().getProperties().getBastionPassword());
-        assertEquals(properties.getBastionKey(), returnData.getData().getProperties().getBastionKey());
-        assertEquals(properties.getBastionKeyPassword(), returnData.getData().getProperties().getBastionKeyPassword());
+        assertEquals("", returnData.getData().getProperties().getBastionPassword());
+        assertEquals("", returnData.getData().getProperties().getBastionKey());
+        assertEquals("", returnData.getData().getProperties().getBastionKeyPassword());
+
+        //FIXME check data in the database
 
         context.assertIsSatisfied();
     }
@@ -220,7 +222,7 @@ public class PaygApiControllerTest extends BaseControllerTestCase {
 
         PaygProperties properties = new PaygProperties("d", "h", "8001",
                 "u", "p", "k", "kp",
-                "bh", "8002", "bu", "bp", "bk", "bkp");
+                "bh", "8002", "bu", "bp", "bk", "bkp", true, true);
 
         String dataJson = PaygApiContoller.createPayg(
                 getPostRequestWithCsrfAndBody("/manager/api/admin/config/payg",

--- a/java/code/src/com/suse/manager/webui/controllers/admin/mappers/PaygResponseMappers.java
+++ b/java/code/src/com/suse/manager/webui/controllers/admin/mappers/PaygResponseMappers.java
@@ -69,12 +69,16 @@ public class PaygResponseMappers {
                 new PaygProperties(paygSshData.getDescription(),
                         paygSshData.getHost(),
                         paygSshData.getPort() != null ? String.valueOf(paygSshData.getPort()) : null,
-                        paygSshData.getUsername(), paygSshData.getPassword(),
-                        paygSshData.getKey(), paygSshData.getKeyPassword(),
+                        paygSshData.getUsername(),
+                        "",
+                        "",
+                        "",
                         paygSshData.getBastionHost(),
                         paygSshData.getBastionPort() != null ? String.valueOf(paygSshData.getBastionPort()) : null,
-                        paygSshData.getBastionUsername(), paygSshData.getBastionPassword(),
-                        paygSshData.getBastionKey(), paygSshData.getBastionKeyPassword()
+                        paygSshData.getBastionUsername(),
+                        "",
+                        "",
+                        "", false, false
                         ));
         return paygResponse;
     }

--- a/java/code/src/com/suse/manager/xmlrpc/admin/test/AdminPaygHandlerTest.java
+++ b/java/code/src/com/suse/manager/xmlrpc/admin/test/AdminPaygHandlerTest.java
@@ -320,6 +320,14 @@ public class AdminPaygHandlerTest extends BaseHandlerTestCase {
         assertNull(payg.get().getPassword());
         assertNull(payg.get().getKey());
         assertNull(payg.get().getKeyPassword());
+
+        assertNull(payg.get().getBastionHost());
+        assertNull(payg.get().getBastionPort());
+        assertNull(payg.get().getBastionUsername());
+        assertNull(payg.get().getBastionPassword());
+        assertNull(payg.get().getBastionKey());
+        assertNull(payg.get().getBastionKeyPassword());
+
         assertEquals(payg.get().getStatus(), PaygSshData.Status.P);
         assertNull(payg.get().getErrorMessage());
         assertNullBastion(payg.get());

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Hide authentication data in PAYG UI (bsc#1199679)
 - Clean grub2 reinstall entry in autoyast snippet (bsc#1199950)
 - Show reboot alert message on all system detail pages (bsc#1199779)
 - Show patch as installed in CVE Audit even if successor patch affects

--- a/testsuite/features/secondary/srv_payg_ssh_connection.feature
+++ b/testsuite/features/secondary/srv_payg_ssh_connection.feature
@@ -44,15 +44,15 @@ Feature: Pay as you go
     And I should see a "my-host-full.local" text in element "Instance-panel-wrapper"
     And I should see a "21" text in element "Instance-panel-wrapper"
     And I should see a "rootFull" text in element "Instance-panel-wrapper"
-    And I should see a "passwordFull" text in element "Instance-panel-wrapper"
-    And I should see a "keyFull" text in element "Instance-panel-wrapper"
-    And I should see a "keyPasswordFull" text in element "Instance-panel-wrapper"
+    And I should not see a "passwordFull" text in element "Instance-panel-wrapper"
+    And I should not see a "keyFull" text in element "Instance-panel-wrapper"
+    And I should not see a "keyPasswordFull" text in element "Instance-panel-wrapper"
     And I should see a "my-bastion.local" text in element "Bastion-panel-wrapper"
     And I should see a "22" text in element "Bastion-panel-wrapper"
     And I should see a "b_rootFull" text in element "Bastion-panel-wrapper"
-    And I should see a "b_passwordFull" text in element "Bastion-panel-wrapper"
-    And I should see a "b_keyFull" text in element "Bastion-panel-wrapper"
-    And I should see a "b_keyPasswordFull" text in element "Bastion-panel-wrapper"
+    And I should not see a "b_passwordFull" text in element "Bastion-panel-wrapper"
+    And I should not see a "b_keyFull" text in element "Bastion-panel-wrapper"
+    And I should not see a "b_keyPasswordFull" text in element "Bastion-panel-wrapper"
     And I should see a "Delete" button
 
   Scenario: Check pay-as-you-go list
@@ -84,9 +84,9 @@ Feature: Pay as you go
     Then I should see a "Pay-as-you-go properties updated successfully" text
     And I should see a "221" text in element "Instance-panel-wrapper"
     And I should see a "NewRootFull" text in element "Instance-panel-wrapper"
-    And I should see a "NewPasswordFull" text in element "Instance-panel-wrapper"
-    And I should see a "newKeyFull" text in element "Instance-panel-wrapper"
-    And I should see a "newKeyPasswordFull" text in element "Instance-panel-wrapper"
+    And I should not see a "NewPasswordFull" text in element "Instance-panel-wrapper"
+    And I should not see a "newKeyFull" text in element "Instance-panel-wrapper"
+    And I should not see a "newKeyPasswordFull" text in element "Instance-panel-wrapper"
 
   Scenario: Edit bastion ssh connection data
     When I follow the left menu "Admin > Setup Wizard > Pay-as-you-go"
@@ -103,9 +103,9 @@ Feature: Pay as you go
     And I should see a "my-new-bastion.local" text in element "Bastion-panel-wrapper"
     And I should see a "222" text in element "Bastion-panel-wrapper"
     And I should see a "b_new_rootFull" text in element "Bastion-panel-wrapper"
-    And I should see a "b_new_passwordFull" text in element "Bastion-panel-wrapper"
-    And I should see a "b_new_keyFull" text in element "Bastion-panel-wrapper"
-    And I should see a "b_new_keyPasswordFull" text in element "Bastion-panel-wrapper"
+    And I should not see a "b_new_passwordFull" text in element "Bastion-panel-wrapper"
+    And I should not see a "b_new_keyFull" text in element "Bastion-panel-wrapper"
+    And I should not see a "b_new_keyPasswordFull" text in element "Bastion-panel-wrapper"
 
   Scenario: Cleanup: delete minimal information for payg ssh connection data
     When I follow the left menu "Admin > Setup Wizard > Pay-as-you-go"

--- a/web/html/src/manager/admin/create-payg/create-payg.tsx
+++ b/web/html/src/manager/admin/create-payg/create-payg.tsx
@@ -29,6 +29,8 @@ const CreateProject = () => {
       bastion_password: "",
       bastion_key: "",
       bastion_key_password: "",
+      instance_edit: false,
+      bastion_edit: false,
     },
     errors: {},
   });

--- a/web/html/src/manager/admin/payg-shared/sshData/payg-ssh-data-edit.tsx
+++ b/web/html/src/manager/admin/payg-shared/sshData/payg-ssh-data-edit.tsx
@@ -22,6 +22,11 @@ const PaygSshDataEdit = (props: Props) => {
   const { onAction, cancelAction, isLoading } = useLifecyclePaygActionsApi();
 
   const saveAction = ({ item, closeDialog, setErrors }) => {
+    if (props.isInstance) {
+      item.instance_edit = true;
+    } else {
+      item.bastion_edit = true;
+    }
     onAction(item, "update", props.paygId)
       .then((data) => {
         closeDialog();

--- a/web/html/src/manager/admin/payg-shared/sshData/payg-ssh-data-form.tsx
+++ b/web/html/src/manager/admin/payg-shared/sshData/payg-ssh-data-form.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { paygProperties } from "manager/admin/payg/payg";
 
-import { Form, Text } from "components/input";
+import { Form, Password, Text } from "components/input";
 import { InputBase } from "components/input/InputBase";
 
 type PropsForm = {
@@ -39,6 +39,11 @@ export const PaygSshDataFormFields = (props: PropsFields) => {
   let prefix = props.isInstance ? "" : "bastion_";
   return (
     <React.Fragment>
+      {props.editing && (
+        <div className="alert alert-info" style={{ marginTop: "0px" }}>
+          {t("When editing the SSH connection all needed credentials must be re-provided.")}
+        </div>
+      )}
       <div className="row">
         <Text
           required={props.isInstance}
@@ -69,7 +74,7 @@ export const PaygSshDataFormFields = (props: PropsFields) => {
         />
       </div>
       <div className="row">
-        <Text name={prefix + "password"} label={t("Password")} labelClass="col-md-2" divClass="col-md-10" />
+        <Password name={prefix + "password"} label={t("Password")} labelClass="col-md-2" divClass="col-md-10" />
       </div>
       <div className="row">
         <InputBase name={prefix + "key"} label={t("SSH Private Key")} labelClass="col-md-2" divClass="col-md-10">
@@ -92,7 +97,7 @@ export const PaygSshDataFormFields = (props: PropsFields) => {
         </InputBase>
       </div>
       <div className="row">
-        <Text
+        <Password
           name={prefix + "key_password"}
           label={t("SSH Private Key Passphrase")}
           labelClass="col-md-2"

--- a/web/html/src/manager/admin/payg-shared/sshData/payg-ssh-data-view.tsx
+++ b/web/html/src/manager/admin/payg-shared/sshData/payg-ssh-data-view.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import { paygProperties } from "manager/admin/payg/payg";
 
+const passHidden = "*****";
 type Props = {
   payg: paygProperties;
   isInstance: boolean;
@@ -24,17 +25,21 @@ const PaygShhDataView = (props: Props) => {
       </dl>
       <dl className="row">
         <dt className="col-xs-2">{t("Password")}</dt>
-        <dd className="col-xs-10">{props.isInstance ? props.payg.password : props.payg.bastion_password}</dd>
+        <dd className="col-xs-10">
+          {(props.isInstance ? props.payg.password : props.payg.bastion_password) || passHidden}
+        </dd>
       </dl>
       <dl className="row">
         <dt className="col-xs-2">{t("SSH Private Key")}</dt>
         <dd className="col-xs-10" style={{ whiteSpace: "pre-wrap" }}>
-          {props.isInstance ? props.payg.key : props.payg.bastion_key}
+          {(props.isInstance ? props.payg.key : props.payg.bastion_key) || passHidden}
         </dd>
       </dl>
       <dl className="row">
         <dt className="col-xs-2">{t("SSH Private Key Passphrase")}</dt>
-        <dd className="col-xs-10">{props.isInstance ? props.payg.key_password : props.payg.bastion_key_password}</dd>
+        <dd className="col-xs-10">
+          {(props.isInstance ? props.payg.key_password : props.payg.bastion_key_password) || passHidden}
+        </dd>
       </dl>
     </div>
   );

--- a/web/html/src/manager/admin/payg/payg.tsx
+++ b/web/html/src/manager/admin/payg/payg.tsx
@@ -27,6 +27,8 @@ export type paygProperties = {
   bastion_password: string;
   bastion_key: string;
   bastion_key_password: string;
+  instance_edit: boolean;
+  bastion_edit: boolean;
 };
 
 export type PaygFullType = {

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Hide authentication data in PAYG UI (bsc#1199679)
 - add textarea to formulas
 
 -------------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

For security reasons, we should hide the authentication data on the webUI. 
Also in the create form, password fields should be of type password.

When editing the ssh connection user should re-provide the authentication data, otherwise, the existing one will be removed.

## GUI diff

Before:

![image](https://user-images.githubusercontent.com/2996004/169614892-5afcac1f-81fa-4f9c-98d5-7dacfd89979a.png)

![image](https://user-images.githubusercontent.com/2996004/169614933-6056be63-9c36-4229-b3a8-996dae36520c.png)

![image](https://user-images.githubusercontent.com/2996004/169614963-e28dc623-c84d-4ead-9755-39bef828984f.png)



After:

![image](https://user-images.githubusercontent.com/2996004/169614198-576aad89-d6a7-4981-b656-444498598670.png)

![image](https://user-images.githubusercontent.com/2996004/169614505-f488c62b-4215-41e0-8724-873ba83ca14f.png)

![image](https://user-images.githubusercontent.com/2996004/169614655-21d0f0c5-28e3-41fd-9e7f-4f198d1158ef.png)


- [ ] **DONE**

## Documentation
- No documentation needed: We are hiding data on the details page, and how to change data is not documented.


- [ ] **DONE**

## Test coverage
- tests already exists and were adapted to this change

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17903
Tracks:
- needs 4.2 backport

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
