### PR TITLE
python3-psutil is needed for container verification

### DIFF
--- a/testsuite/features/profiles/Docker/add_packages.sh
+++ b/testsuite/features/profiles/Docker/add_packages.sh
@@ -16,7 +16,7 @@ zypper rr sles15sp2
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref
-zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar python3
+zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar python3 python3-psutil
 
 # kill avahi
 /usr/sbin/avahi-daemon -k

--- a/testsuite/features/profiles/Docker/authprofile/add_packages.sh
+++ b/testsuite/features/profiles/Docker/authprofile/add_packages.sh
@@ -10,8 +10,8 @@ zypper --non-interactive in avahi
 cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
-# install python3 on the container
-zypper --non-interactive in python3
+# install python3 and python3-psutil in the container
+zypper --non-interactive in python3 python3-psutil
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Test-Channel-x86_64 || :

--- a/testsuite/features/profiles/Docker/serverhost/add_packages.sh
+++ b/testsuite/features/profiles/Docker/serverhost/add_packages.sh
@@ -10,8 +10,8 @@ zypper --non-interactive in avahi
 cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
-# install python3 on the container
-zypper --non-interactive in python3
+# install python3 and python3-psutil in the container
+zypper --non-interactive in python3 python3-psutil
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Test-Channel-x86_64 || :

--- a/testsuite/features/profiles/internal_nue/Docker/add_packages.sh
+++ b/testsuite/features/profiles/internal_nue/Docker/add_packages.sh
@@ -16,7 +16,7 @@ zypper rr sles15sp2
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref
-zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar python3
+zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar python3 python3-psutil
 
 # kill avahi
 /usr/sbin/avahi-daemon -k

--- a/testsuite/features/profiles/internal_nue/Docker/authprofile/add_packages.sh
+++ b/testsuite/features/profiles/internal_nue/Docker/authprofile/add_packages.sh
@@ -10,8 +10,8 @@ zypper --non-interactive in avahi
 cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
-# install python3 on the container
-zypper --non-interactive in python3
+# install python3 and python3-psutil in the container
+zypper --non-interactive in python3 python3-psutil
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Test-Channel-x86_64 || :

--- a/testsuite/features/profiles/internal_nue/Docker/serverhost/add_packages.sh
+++ b/testsuite/features/profiles/internal_nue/Docker/serverhost/add_packages.sh
@@ -10,8 +10,8 @@ zypper --non-interactive in avahi
 cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
-# install python3 on the container
-zypper --non-interactive in python3
+# install python3 and python3-psutil in the container
+zypper --non-interactive in python3 python3-psutil
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Test-Channel-x86_64 || :

--- a/testsuite/features/profiles/internal_prv/Docker/add_packages.sh
+++ b/testsuite/features/profiles/internal_prv/Docker/add_packages.sh
@@ -16,7 +16,7 @@ zypper rr sles15sp2
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref
-zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar python3
+zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar python3 python3-psutil
 
 # kill avahi
 /usr/sbin/avahi-daemon -k

--- a/testsuite/features/profiles/internal_prv/Docker/authprofile/add_packages.sh
+++ b/testsuite/features/profiles/internal_prv/Docker/authprofile/add_packages.sh
@@ -10,8 +10,8 @@ zypper --non-interactive in avahi
 cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
-# install python3 on the container
-zypper --non-interactive in python3
+# install python3 and python3-psutil in the container
+zypper --non-interactive in python3 python3-psutil
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Test-Channel-x86_64 || :

--- a/testsuite/features/profiles/internal_prv/Docker/serverhost/add_packages.sh
+++ b/testsuite/features/profiles/internal_prv/Docker/serverhost/add_packages.sh
@@ -10,8 +10,8 @@ zypper --non-interactive in avahi
 cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
-# install python3 on the container
-zypper --non-interactive in python3
+# install python3 and python3-psutil in the container
+zypper --non-interactive in python3 python3-psutil
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Test-Channel-x86_64 || :


### PR DESCRIPTION
## What does this PR change?

This PR adds python3-psutil to the Docker profiles. It is needed for the container verification after building.

According to Vladimir, the package is missing only in `Docker/authprofile` and `Docker/serverhost`, but I added it also to `Docker` to have more consistent code.


## Links

No backports to 4.1 and 4.2.

Port to Manager-4.3-GMC: SUSE/spacewalk#17941


## Changelogs

- [x] No changelog needed
