### PR TITLE
Correct default path handling for Cobbler part of spacewalk-hostname-rename

### DIFF
--- a/spacewalk/setup/bin/spacewalk-setup-cobbler
+++ b/spacewalk/setup/bin/spacewalk-setup-cobbler
@@ -22,12 +22,12 @@ from shutil import copyfile
 parser = argparse.ArgumentParser(description='Setup Cobbler for Uyuni.')
 parser.add_argument('--cobbler-config-directory', '-c', dest='cobbler_config_directory', default="/etc/cobbler/",
                     help='The directory where "settings" and "modules.conf" are in.')
-parser.add_argument('--apache2-config-directory', '-a', dest='httpd_config_directory', default="/etc/httpd",
+parser.add_argument('--apache2-config-directory', '-a', dest='httpd_config_directory', default="/etc/apache2/conf.d",
                     help='The directory where the Apache config file "cobbler.conf" is in.')
 
 COBBLER_CONFIG_DIRECTORY = "/etc/cobbler/"
 COBBLER_CONFIG_FILES = ["modules.conf", "settings"]
-HTTPD_CONFIG_DIRECTORY = "/etc/httpd/conf.d/"
+HTTPD_CONFIG_DIRECTORY = "/etc/apache2/conf.d/"
 COBBLER_HTTP_CONFIG = "cobbler.conf"
 
 

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,5 @@
+- spacewalk-setup-cobbler assumes /etc/apache2/conf.d now as a
+  default instead of /etc/httpd/conf.d (bsc#1198356)
 - Allow alternative usage of perl-Net-LibIDN2.
 
 -------------------------------------------------------------------

--- a/utils/spacewalk-hostname-rename
+++ b/utils/spacewalk-hostname-rename
@@ -447,7 +447,8 @@ else
     fi
 fi
 
-OLD_HOSTNAME=$(grep ^redhat_management_server /etc/cobbler/settings | awk '{print $2}')
+# This awk command can read a single line yaml value which may optionally be double or single quoted.
+OLD_HOSTNAME=$(awk -F ':' '/redhat_management_server/{sub(/^[[:blank:]]+/,"", $2); gsub(/["'\'']/, "", $2); print $2}' /etc/cobbler/settings)
 
 echo "=============================================" | tee -a $LOG
 echo "hostname: $HOSTNAME" | tee -a $LOG
@@ -535,7 +536,11 @@ EOS
 print_status 0  # just simulate end
 
 echo -n "Changing cobbler settings ... " | tee -a $LOG
-/usr/bin/spacewalk-setup-cobbler >> $LOG 2>&1
+APACHE2_CONF_DIR_DEFAULT_CONF=$(awk -F '=' '/httpd_config_dir/{sub(/^[[:blank:]]+/,"", $2); print $2}' /usr/share/rhn/config-defaults/rhn.conf)
+if [ -z "$APACHE2_CONF_DIR_DEFAULT_CONF" ]; then
+  print_status 1 'Apache 2 config directory could not be found. Please add it to "/usr/share/rhn/config-defaults/rhn.conf"!'
+fi
+/usr/bin/spacewalk-setup-cobbler --apache2-config-directory "$APACHE2_CONF_DIR_DEFAULT_CONF" >> $LOG 2>&1
 print_status $?
 
 echo -n "Changing kernel_options ... " | tee -a $LOG

--- a/utils/spacewalk-hostname-rename
+++ b/utils/spacewalk-hostname-rename
@@ -594,8 +594,8 @@ print_status $?
 # change /root/.mgr-sync
 if [ -e $MGR_SYNC_CONF ]; then
     backup_file $MGR_SYNC_CONF
-    sed -i "s/$OLD_HOSTNAME/$HOSTNAME/g" $MGR_SYNC_CONF
-    sed -i "s/^\(mgrsync.session.token \?=\).*$/\1/g" $MGR_SYNC_CONF
+    sed -i "s/^mgrsync.host\s\{0,1\}=\s\{0,1\}.*/mgrsync.host = $HOSTNAME/g" $MGR_SYNC_CONF
+    sed -i "s/^mgrsync.session.token\s\{0,1\}=\s\{0,1\}.*/mgrsync.session.token = \"\"/g" $MGR_SYNC_CONF
 fi
 print_status 0  # just simulate end
 

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- spacewalk-hostname-rename now correctly replaces the hostname for
+  the mgr-sync configuration file (bsc#1198356)
 - spacewalk-hostname-rename now utilizes the "--apache2-conf-dir"
   flag for spacewalk-setup-cobbler
 - Add repositories for Ubuntu 22.04 LTS

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- spacewalk-hostname-rename now utilizes the "--apache2-conf-dir"
+  flag for spacewalk-setup-cobbler
 - Add repositories for Ubuntu 22.04 LTS
 - Add AlmaLinux 9 and Oracle Linux 9 to spacewalk-common-channels
 - Add missing SLES 15 SP4 client tools repositories to
@@ -14,7 +16,7 @@ Tue Jun 21 18:31:46 CEST 2022 - jgonzalez@suse.com
 Fri May 20 00:12:42 CEST 2022 - jgonzalez@suse.com
 
 - version 4.3.11-1
-  * openSUSE Leap 15.4 repositories 
+  * openSUSE Leap 15.4 repositories
 
 -------------------------------------------------------------------
 Wed May 04 15:23:36 CEST 2022 - jgonzalez@suse.com


### PR DESCRIPTION
## What does this PR change?

This PR corrects the behaviour of two things in `spacewalk-hostname-rename`:

1. Fix the default path handling for the Cobbler Apache directory.
2. Fix the `sed` expression which replaced data in `/root/.mgr-sync`

## GUI diff

No difference.

- [ ] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage

- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17506
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
