### PR TITLE
Fix eclipse compilation errors

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -90,7 +90,6 @@
         <dependency org="suse" name="spark-template-jade" rev="2.3" />
         <dependency org="suse" name="spy" rev="0.8.7" />
         <dependency org="suse" name="statistics" rev="1.0.2" />
-        <dependency org="suse" name="stax-api" rev="1.0.1" />
         <dependency org="suse" name="stax2-api" rev="3.1.4" />
         <dependency org="suse" name="stringtree-json" rev="2.0.9" />
         <dependency org="suse" name="struts" rev="1.2.9" />

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -251,9 +251,6 @@ artifacts:
     repository: Uyuni_Other
   - artifact: statistics
     repository: Uyuni_Other
-  - artifact: stax-api
-    package: woodstox
-    repository: Uyuni_Other
   - artifact: stax2-api
     package: woodstox
     repository: Uyuni_Other


### PR DESCRIPTION
## What does this PR change?

This PR fixes the compilation errors generated when compiling with the Eclipse compiler ECJ.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed: no functional changes

- [X] **DONE**

## Test coverage
- No tests: no functional changes

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
