### PR TITLE
Change the base image for all proxy containers to 15.4

### DIFF
--- a/containers/proxy-httpd-image/Dockerfile
+++ b/containers/proxy-httpd-image/Dockerfile
@@ -1,6 +1,6 @@
 #!BuildTag: uyuni/proxy-httpd:latest uyuni/proxy-httpd:%PKG_VERSION% uyuni/proxy-httpd:%PKG_VERSION%.%RELEASE%
 
-ARG BASE=registry.suse.com/bci/bci-base:15.3
+ARG BASE=registry.suse.com/bci/bci-base:15.4
 FROM $BASE
 
 

--- a/containers/proxy-httpd-image/proxy-httpd-image.changes
+++ b/containers/proxy-httpd-image/proxy-httpd-image.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue May 24 13:27:51 UTC 2022 - Julio González Gil <jgonzalez@suse.com>
+
+- Change the default base image to 15.4 
+
+-------------------------------------------------------------------
 Fri May 13 07:33:23 UTC 2022 - Julio González Gil <jgonzalez@suse.com>
 
 - Update the image version to 4.3.0

--- a/containers/proxy-salt-broker-image/Dockerfile
+++ b/containers/proxy-salt-broker-image/Dockerfile
@@ -1,6 +1,6 @@
 #!BuildTag: uyuni/proxy-salt-broker:latest uyuni/proxy-salt-broker:%PKG_VERSION% uyuni/proxy-salt-broker:%PKG_VERSION%.%RELEASE%
 
-ARG BASE=registry.suse.com/bci/bci-base:15.3
+ARG BASE=registry.suse.com/bci/bci-base:15.4
 FROM $BASE AS fat
 
 ARG PRODUCT_REPO
@@ -21,7 +21,7 @@ COPY prepare_target.sh .
 RUN sh prepare_target.sh
 
 # Define slim image
-ARG BASE=registry.suse.com/bci/bci-base:15.3
+ARG BASE=registry.suse.com/bci/bci-base:15.4
 FROM $BASE AS slim
 
 ARG PRODUCT=Uyuni

--- a/containers/proxy-salt-broker-image/proxy-salt-broker-image.changes
+++ b/containers/proxy-salt-broker-image/proxy-salt-broker-image.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue May 24 13:27:51 UTC 2022 - Julio González Gil <jgonzalez@suse.com>
+
+- Change the default base image to 15.4
+
+-------------------------------------------------------------------
 Fri May 13 07:33:42 UTC 2022 - Julio González Gil <jgonzalez@suse.com>
 
 - Update the image version to 4.3.0

--- a/containers/proxy-squid-image/Dockerfile
+++ b/containers/proxy-squid-image/Dockerfile
@@ -1,6 +1,6 @@
 #!BuildTag: uyuni/proxy-squid:latest uyuni/proxy-squid:%PKG_VERSION% uyuni/proxy-squid:%PKG_VERSION%.%RELEASE%
 
-ARG BASE=registry.suse.com/bci/bci-base:15.3
+ARG BASE=registry.suse.com/bci/bci-base:15.4
 FROM $BASE
 
 ARG PRODUCT_REPO

--- a/containers/proxy-squid-image/proxy-squid-image.changes
+++ b/containers/proxy-squid-image/proxy-squid-image.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue May 24 13:27:51 UTC 2022 - Julio González Gil <jgonzalez@suse.com>
+
+- Change the default base image to 15.4
+
+-------------------------------------------------------------------
 Fri May 13 07:33:58 UTC 2022 - Julio González Gil <jgonzalez@suse.com>
 
 - Update the image version to 4.3.0

--- a/containers/proxy-ssh-image/Dockerfile
+++ b/containers/proxy-ssh-image/Dockerfile
@@ -1,6 +1,6 @@
 #!BuildTag: uyuni/proxy-ssh:latest uyuni/proxy-ssh:%PKG_VERSION% uyuni/proxy-ssh:%PKG_VERSION%.%RELEASE%
 
-ARG BASE=registry.suse.com/bci/bci-base:15.3
+ARG BASE=registry.suse.com/bci/bci-base:15.4
 FROM $BASE
 
 ARG PRODUCT_REPO

--- a/containers/proxy-ssh-image/proxy-ssh-image.changes
+++ b/containers/proxy-ssh-image/proxy-ssh-image.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue May 24 13:27:51 UTC 2022 - Julio González Gil <jgonzalez@suse.com>
+
+- Change the default base image to 15.4
+
+-------------------------------------------------------------------
 Fri May 13 07:34:38 UTC 2022 - Julio González Gil <jgonzalez@suse.com>
 
 - Update the image version to 4.3.0

--- a/containers/proxy-tftpd-image/Dockerfile
+++ b/containers/proxy-tftpd-image/Dockerfile
@@ -1,6 +1,6 @@
 #!BuildTag: uyuni/proxy-tftpd:latest uyuni/proxy-tftpd:%PKG_VERSION% uyuni/proxy-tftpd:%PKG_VERSION%.%RELEASE%
 
-ARG BASE=registry.suse.com/bci/bci-base:15.3
+ARG BASE=registry.suse.com/bci/bci-base:15.4
 FROM $BASE
 
 ARG PRODUCT_REPO

--- a/containers/proxy-tftpd-image/proxy-tftpd-image.changes
+++ b/containers/proxy-tftpd-image/proxy-tftpd-image.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue May 24 13:27:51 UTC 2022 - Julio González Gil <jgonzalez@suse.com>
+
+- Change the default base image to 15.4
+
+-------------------------------------------------------------------
 Fri May 13 07:34:53 UTC 2022 - Julio González Gil <jgonzalez@suse.com>
 
 - Update the image version to 4.3.0


### PR DESCRIPTION
## What does this PR change?

Change the base image for all proxy containers to 15.4

So we can remove the `BuildFlags` from https://build.opensuse.org/projects/systemsmanagement:Uyuni:Master/prjconf

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- The change to Leap 15.4 as base OS (SLE15SP4 for the proxy images) is already part of  https://github.com/SUSE/spacewalk/issues/17541

- [x] **DONE**

## Test coverage
- No tests: Managed by the acceptance testsuite

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/17491

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
