### PR TITLE
deprecation warning for spacewalk-clone-by-date

### DIFF
--- a/utils/spacewalk-clone-by-date
+++ b/utils/spacewalk-clone-by-date
@@ -38,7 +38,9 @@ if _LIBPATH not in sys.path:
 
 from utils import cloneByDate
 from utils.cloneByDate import UserError
+from warnings import warn
 
+warn(f'The module {__name__} is DEPRECATED. Please use Content Lifecycle Management Tool.', DeprecationWarning, stacklevel=2)
 
 SAMPLE_CONFIG = """
 {

--- a/utils/spacewalk-clone-by-date.sgml
+++ b/utils/spacewalk-clone-by-date.sgml
@@ -9,6 +9,7 @@
 <RefNameDiv>
 <RefName><command>spacewalk-clone-by-date</command></RefName>
 <RefPurpose>
+The module <emphasis>spacewalk-clone-by-date</emphasis> is DEPRECATED. Please use Content Lifecycle Management Tool.
 Utility for cloning errata by date (For RHEL5 and above).
 </RefPurpose>
 </RefNameDiv>
@@ -89,7 +90,9 @@ Utility for cloning errata by date (For RHEL5 and above).
 </RefSynopsisDiv>
 
 <RefSect1><Title>Description</Title>
-
+    <para>
+        The module <emphasis>spacewalk-clone-by-date</emphasis> is DEPRECATED. Please use Content Lifecycle Management Tool.
+    </para>
     <para>
         <emphasis>spacewalk-clone-by-date</emphasis> tool, clones all the errata belonging to a specified channel, as of a specific date.
     </para>

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- add deprecation warning for spacewalk-clone-by-date
+
 -------------------------------------------------------------------
 Fri May 20 00:12:42 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

deprecation warning for spacewalk-clone-by-date 

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
