### PR TITLE
Fix refresh action confirmation message when no system is selected

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SSMUpdateHardwareProfileConfirm.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SSMUpdateHardwareProfileConfirm.java
@@ -89,7 +89,7 @@ public class SSMUpdateHardwareProfileConfirm extends RhnAction implements Listab
                 ActionMessages msgs = new ActionMessages();
                 ActionMessage msg = new ActionMessage("ssm.hw.systems.confirmmessage");
 
-                if (set.size() > 1) {
+                if (set.size() != 1) {
                     msg = new ActionMessage("ssm.hw.systems.confirmmessage.multiple", set.size());
                 }
                 msgs.add(ActionMessages.GLOBAL_MESSAGE, msg);

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SSMUpdateSoftwareProfileConfirm.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SSMUpdateSoftwareProfileConfirm.java
@@ -89,7 +89,7 @@ public class SSMUpdateSoftwareProfileConfirm extends RhnAction implements Listab
                 ActionMessages msgs = new ActionMessages();
                 ActionMessage msg = new ActionMessage("ssm.sw.systems.confirmmessage");
 
-                if (set.size() > 1) {
+                if (set.size() != 1) {
                     msg = new ActionMessage("ssm.sw.systems.confirmmessage.multiple", set.size());
                 }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix refresh action confirmation message when no system is selected
 - Fix containerized proxy configuration machine name
 - Improve CLM channel cloning performance (bsc#1199523)
 - Keep the websocket connections alive with ping/pong frames (bsc#1199874)


### PR DESCRIPTION
## What does this PR change?

Fix refresh action confirmation message when no system is selected showing 0 profiles are scheduled to be refreshed instead of 1 profile is scheduled.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bug fix.

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
