### PR TITLE
Update dependencies to be resolved from Leap 15.4

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -10,8 +10,8 @@
         <dependency org="suse" name="cglib" rev="3.2.4" />
         <dependency org="suse" name="classmate" rev="1.3.4" />
         <dependency org="suse" name="classpathx-mail-1.3.1-monolithic" rev="1.1.2" />
-        <dependency org="suse" name="client" rev="1.0.0~beta.2" />
-        <dependency org="suse" name="common" rev="1.0.0~beta.2" />
+        <dependency org="suse" name="client" rev="2.1" />
+        <dependency org="suse" name="common" rev="2.1" />
         <dependency org="suse" name="commons-beanutils" rev="1.9.4" />
         <dependency org="suse" name="commons-cli" rev="1.4" />
         <dependency org="suse" name="commons-codec" rev="1.11" />
@@ -50,14 +50,14 @@
         <dependency org="suse" name="jakarta-persistence-api" rev="2.2.2" />
         <dependency org="suse" name="java-saml" rev="2.4.0" />
         <dependency org="suse" name="java-saml-core" rev="2.4.0" />
-        <dependency org="suse" name="javassist" rev="3.20.0" />
-        <dependency org="suse" name="jboss-logging" rev="3.3.0" />
+        <dependency org="suse" name="javassist" rev="3.23.1" />
+        <dependency org="suse" name="jboss-logging" rev="3.4.1" />
         <dependency org="suse" name="jcommon" rev="1.0.16" />
         <dependency org="suse" name="jdom" rev="1.1.3" />
         <dependency org="suse" name="joda-time" rev="2.10.1" />
         <dependency org="suse" name="jose4j" rev="0.5.1" />
-        <dependency org="suse" name="log4j-api" rev="2.13.0" />
-        <dependency org="suse" name="log4j-core" rev="2.13.0" />
+        <dependency org="suse" name="log4j-api" rev="2.17.1" />
+        <dependency org="suse" name="log4j-core" rev="2.17.1" />
         <dependency org="suse" name="jsch" rev="0.1.55" />
         <dependency org="suse" name="mchange-commons-java" rev="0.2.20" />
         <dependency org="suse" name="netty-buffer" rev="4.1.44.Final" />
@@ -69,7 +69,7 @@
         <dependency org="suse" name="netty-transport-native-unix-common" rev="4.1.44.Final" />
         <dependency org="suse" name="oro" rev="2.0.8" />
         <dependency org="suse" name="pgjdbc-ng" rev="0.8.7" />
-        <dependency org="suse" name="postgresql-jdbc" rev="42.2.16" />
+        <dependency org="suse" name="postgresql-jdbc" rev="42.2.25" />
         <dependency org="suse" name="quartz" rev="2.3.0" />
         <dependency org="suse" name="redstone-xmlrpc" rev="1.1_20071120" />
         <dependency org="suse" name="redstone-xmlrpc-client" rev="1.1_20071120" />
@@ -82,7 +82,7 @@
         <dependency org="suse" name="simple-xml" rev="2.6.2" />
         <dependency org="suse" name="sitemesh" rev="2.1" />
         <dependency org="suse" name="slf4j-api" rev="1.7.30" />
-        <dependency org="suse" name="log4j-slf4j-impl" rev="2.13.0" />
+        <dependency org="suse" name="log4j-slf4j-impl" rev="2.17.1" />
         <dependency org="suse" name="snakeyaml" rev="1.28" />
         <dependency org="suse" name="spark-core" rev="2.7.2" />
         <dependency org="suse" name="spark-template-jade" rev="2.3" />

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -12,6 +12,8 @@
         <dependency org="suse" name="classpathx-mail-1.3.1-monolithic" rev="1.1.2" />
         <dependency org="suse" name="client" rev="2.1" />
         <dependency org="suse" name="common" rev="2.1" />
+        <dependency org="suse" name="stringprep" rev="1.1" />
+        <dependency org="suse" name="saslprep" rev="1.1" />
         <dependency org="suse" name="commons-beanutils" rev="1.9.4" />
         <dependency org="suse" name="commons-cli" rev="1.4" />
         <dependency org="suse" name="commons-codec" rev="1.11" />

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -1,13 +1,13 @@
 repositories:
   Leap:
-    project: openSUSE:Leap:15.3
+    project: openSUSE:Leap:15.4
     repository: standard
   Uyuni_Other:
     project: systemsmanagement:Uyuni:Master:Other
-    repository: openSUSE_Leap_15.3
+    repository: openSUSE_Leap_15.4
   Uyuni:
     project: systemsmanagement:Uyuni:Master
-    repository: openSUSE_Leap_15.3
+    repository: openSUSE_Leap_15.4
 artifacts:
   - artifact: asm
     package: asm3
@@ -21,7 +21,7 @@ artifacts:
   - artifact: byte-buddy
     repository: Uyuni_Other
   - artifact: c3p0
-    repository: Uyuni_Other
+    repository: Leap
   - artifact: cglib
     jar: cglib.jar
     repository: Leap
@@ -111,7 +111,7 @@ artifacts:
   - artifact: httpasyncclient
     package: httpcomponents-asyncclient
     jar: httpasyncclient-[0-9.]+
-    repository: Uyuni_Other
+    repository: Leap
   - artifact: httpclient
     package: httpcomponents-client
     repository: Leap
@@ -137,7 +137,7 @@ artifacts:
     package: java-saml
     repository: Uyuni_Other
   - artifact: javassist
-    repository: Uyuni_Other
+    repository: Leap
   - artifact: jboss-logging
     repository: Leap
   - artifact: jcommon
@@ -161,10 +161,10 @@ artifacts:
     package: log4j-slf4j
     repository: Leap
   - artifact: jsch
-    repository: Uyuni_Other
+    repository: Leap
   - artifact: mchange-commons-java
     package: mchange-commons
-    repository: Uyuni_Other
+    repository: Leap
   - artifact: netty-buffer
     package: netty
     repository: Uyuni_Other

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -193,6 +193,12 @@ artifacts:
   - artifact: common
     package: ongres-scram
     repository: Leap
+  - artifact: stringprep
+    package: ongres-stringprep
+    repository: Leap
+  - artifact: saslprep
+    package: ongres-stringprep-saslprep
+    repository: Leap
   - artifact: oro
     repository: Leap
   - artifact: pgjdbc-ng

--- a/java/code/src/com/redhat/rhn/common/finder/test/JarFinderTest.java
+++ b/java/code/src/com/redhat/rhn/common/finder/test/JarFinderTest.java
@@ -32,12 +32,12 @@ public class JarFinderTest {
     // Sigh.
     // At least make it clear what we're looking for...
 
-    // Currently used jarfile: postgresql-jdbc-42.2.16.jar
+    // Currently used jarfile: postgresql-jdbc-42.2.25.jar
     // (previously redstone.xmlrpc could find either redstone-xmlrpc.jar or
     //  redstone-xmlrpc-client.jar, making test-results indeterminate)
     private static final String TESTJAR = "org.postgresql";
-    private static final int NUM_CLASSES_IN_TESTJAR = 375;
-    private static final int NUM_SUBDIRS_IN_TESTJAR = 375;
+    private static final int NUM_CLASSES_IN_TESTJAR = 377;
+    private static final int NUM_SUBDIRS_IN_TESTJAR = 377;
 
     @Test
     public void testGetFinder() throws Exception {

--- a/java/code/src/com/redhat/rhn/testing/RhnMockHttpServletRequest.java
+++ b/java/code/src/com/redhat/rhn/testing/RhnMockHttpServletRequest.java
@@ -128,6 +128,7 @@ public class RhnMockHttpServletRequest extends MockHttpServletRequest {
     /**
      * Override to return 'null' if the requested param doesn't exist
      * (Mock throws an AssertionError in this case :(
+     * This requires old junit4 as this class is not defined anymore in junit5
      * @param paramName name of param to look up
      * @return value of paramName, or 'null' if paramName isn't in the request
      */

--- a/java/code/src/com/suse/manager/saltboot/test/PXEEventTest.java
+++ b/java/code/src/com/suse/manager/saltboot/test/PXEEventTest.java
@@ -18,8 +18,8 @@ package com.suse.manager.saltboot.test;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static java.util.Optional.empty;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 


### PR DESCRIPTION
## What does this PR change?

Uyuni builds on top of Leap 15.4 now, so we need to change buildfiles used for local compilation, but also CI, in order to resolve dependencies from the corresponding repositories. This patch also adds two new required dependencies needed from XXX:

* `ongres-stringprep`
* `ongres-stringprep-saslprep`

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed.

- [X] **DONE**

## Test coverage

- No tests: only dependency resolution is changed.

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
