### PR TITLE
CVE audit installed successor

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/audit/CVEAuditManager.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/CVEAuditManager.java
@@ -963,6 +963,7 @@ public class CVEAuditManager {
                     .filter(Matcher::matches).map(m -> "kernel-" + m.group(1)).collect(Collectors.toSet());
 
             AtomicBoolean patchInSuccessorProduct = new AtomicBoolean(false);
+            AtomicBoolean patchesInstalled = new AtomicBoolean(false);
             Set<ErrataIdAdvisoryPair> successorErratas = new HashSet<>();
 
             // Loop through affected packages one by one
@@ -976,7 +977,7 @@ public class CVEAuditManager {
                 // or empty if the package is already patched
                 Optional<CVEPatchStatus> patchCandidateResult = getPatchCandidateResult(packageResults.getValue());
 
-                patchCandidateResult.ifPresent(result -> {
+                patchCandidateResult.ifPresentOrElse(result -> {
                     // The package is not patched. Keep a list of the missing patch and the top candidate channel
                     AuditChannelInfo channel = new AuditChannelInfo(result.getChannelId().get(),
                             result.getChannelName(), result.getChannelLabel(), result.getChannelRank().orElse(0L));
@@ -992,24 +993,34 @@ public class CVEAuditManager {
                         patchInSuccessorProduct.set(true);
                         successorErratas.add(errata);
                     }
+                }, () -> {
+                    patchesInstalled.set(true);
                 });
             }
 
             boolean allChannelsForOneErrataAssigned = assignedChannels.containsAll(system.getChannels());
             // Filter out channels that are part of a successor or predecessor product. This is to make sure the
-            // current product is chosen as the most suitable candidate if there is a patch available for it, even
-            // though it might not contain a patch for all the packages e.g. because some versions are to old to be
-            // affected.
-            if (patchInSuccessorProduct.get() && system.getChannels().size() > 1) {
+            // current product is chosen as the most suitable candidate if there is a patch available for it or
+            // a patch is already installed, even though it might not contain a patch for all the packages e.g.
+            // because some versions are to old to be affected.
+            if (patchInSuccessorProduct.get()) {
+                Set<ErrataIdAdvisoryPair> erratasNotInSuccessor = system.getErratas().stream().filter(errata ->
+                                !successorErratas.contains(errata)).collect(Collectors.toSet());
                 Set<AuditChannelInfo> filteredChannels = system.getChannels().stream().filter(channel ->
                         channel.getRank() < SUCCESSOR_PRODUCT_RANK_BOUNDARY).collect(Collectors.toSet());
-                if (!filteredChannels.isEmpty()) {
+
+                // If there are no erratas found that are not part of a successor product and there are already
+                // patches installed we assume that the system is already patched
+                if (erratasNotInSuccessor.isEmpty() && patchesInstalled.get()) {
+                    system.setChannels(Collections.emptySet());
+                    system.setErratas(Collections.emptySet());
+                }
+                else if (!filteredChannels.isEmpty()) {
                     allChannelsForOneErrataAssigned = assignedChannels.containsAll(filteredChannels);
                     if (allChannelsForOneErrataAssigned) {
                         // Don't display the patches and channels that belong to successor products
                         system.setChannels(filteredChannels);
-                        system.setErratas(system.getErratas().stream().filter(errata ->
-                                !successorErratas.contains(errata)).collect(Collectors.toSet()));
+                        system.setErratas(erratasNotInSuccessor);
                     }
                 }
             }

--- a/java/code/src/com/redhat/rhn/manager/audit/test/CVEAuditManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/test/CVEAuditManagerTest.java
@@ -1351,6 +1351,77 @@ public class CVEAuditManagerTest extends RhnBaseTestCase {
     }
 
     /**
+     * Test that successor products and service packs are considered *only* if there is no patch
+     * installed in a current product. Even if the current products patch does not contain all the
+     * packages available in a patch for a successor product, since packages might be to old to be affected.
+     *
+     * See also here: https://bugzilla.suse.com/show_bug.cgi?id=1199646
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testIgnoreSuccessorProductsWhenCurrentPatchInstalled() throws Exception {
+        // Create a CVE number
+        String cveName = TestUtils.randomString().substring(0, 13);
+        Cve cve = createTestCve(cveName);
+        Set<Cve> cves = new HashSet<>();
+        cves.add(cve);
+
+        // Create SP2 and SP3 products + upgrade path
+        ChannelFamily channelFamily = createTestChannelFamily();
+        SUSEProduct productSP2 = createTestSUSEProduct(channelFamily);
+        SUSEProduct productSP3 = createTestSUSEProduct(channelFamily);
+        createTestSUSEUpgradePath(productSP2, productSP3);
+
+        // Create channels for the products
+        ChannelProduct channelProductSP2 = createTestChannelProduct();
+        ChannelProduct channelProductSP3 = createTestChannelProduct();
+        Channel baseChannelSP2 = createTestVendorBaseChannel(channelFamily, channelProductSP2);
+        Channel updateChannelSP2 = createTestVendorChildChannel(baseChannelSP2, channelProductSP2);
+        Channel baseChannelSP3 = createTestVendorBaseChannel(channelFamily, channelProductSP3);
+        Channel updateChannelSP3 = createTestVendorChildChannel(baseChannelSP3, channelProductSP3);
+
+        // Assign channels to products
+        createTestSUSEProductChannel(baseChannelSP2, productSP2, true);
+        createTestSUSEProductChannel(updateChannelSP2, productSP2, true);
+        createTestSUSEProductChannel(baseChannelSP3, productSP3, true);
+        createTestSUSEProductChannel(updateChannelSP3, productSP3, true);
+
+        // Create two errata: one in the SP2 updates and one in SP3 updates
+        User user = createTestUser();
+        Errata errataSP2 = createTestErrata(user, cves);
+        updateChannelSP2.addErrata(errataSP2);
+        TestUtils.saveAndFlush(updateChannelSP2);
+        Errata errataSP3 = createTestErrata(user, cves);
+        updateChannelSP3.addErrata(errataSP3);
+        TestUtils.saveAndFlush(updateChannelSP3);
+
+        // Create packages for SP2 and SP3, but SP3 has an update not available in SP2 patch
+        Package basePackage1 = createTestPackage(user, null, baseChannelSP2, "noarch");
+        Package basePackage2 = createTestPackage(user, null, baseChannelSP2, "noarch");
+        Package updatePackage1SP2 = createLaterTestPackage(user, errataSP2, updateChannelSP2, basePackage1);
+        Package updatePackage1SP3 = createLaterTestPackage(user, errataSP3, updateChannelSP3, basePackage1);
+        Package updatePackage2SP3 = createLaterTestPackage(user, errataSP3, updateChannelSP3, basePackage2);
+
+        // Create server: patch is installed
+        Set<Channel> channelsSP2 = new HashSet<>();
+        channelsSP2.add(baseChannelSP2);
+        channelsSP2.add(updateChannelSP2);
+        Server server = createTestServer(user, channelsSP2);
+        createTestInstalledPackage(updatePackage1SP2, server);
+        createTestInstalledPackage(basePackage2, server);
+        installSUSEProductOnServer(productSP2, server);
+
+        // Show the patch as available in the currently installed product version
+        CVEAuditManager.populateCVEChannels();
+        EnumSet<PatchStatus> filter = EnumSet.allOf(PatchStatus.class);
+        List<CVEAuditServer> results = CVEAuditManager.listSystemsByPatchStatus(user, cveName, filter);
+        assertSystemPatchStatus(server, PatchStatus.PATCHED, results);
+        // Make sure the errata and channel for the successor product is filtered out
+        assertEquals(0, results.stream().findFirst().get().getErratas().size());
+        assertEquals(0, results.stream().findFirst().get().getChannels().size());
+    }
+
+    /**
      * Test the SDK scenario: one errata with two packages in different channels.
      *
      * @throws Exception if anything goes wrong

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Show patch as installed in CVE Audit even if successor patch affects
+  additional packages (bsc#1199646)
 - Fix containerized proxy configuration machine name
 - Improve CLM channel cloning performance (bsc#1199523)
 - Keep the websocket connections alive with ping/pong frames (bsc#1199874)


### PR DESCRIPTION
## What does this PR change?

Display patch as correctly installed in the currently installed product in CVE-Audit even though there might be a patch in a successor product that has updates for additional packages.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed

- [x] **DONE**

## Test coverage

- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/17892

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
