### PR TITLE
Prefer the Salt Bundle with Cobbler snippets

### DIFF
--- a/java/conf/cobbler/snippets/minion_script
+++ b/java/conf/cobbler/snippets/minion_script
@@ -3,7 +3,13 @@
     <filename>uyuni-minion.sh</filename>
     <source>
         <![CDATA[
-cat <<EOF >"/etc/salt/minion.d/susemanager.conf"
+SALT_MINION_CONF_DIR="/etc/venv-salt-minion/minion.d"
+SALT_MINION_SERVICE="venv-salt-minion"
+if [ ! -d "$SALT_MINION_CONF_DIR" ]; then
+  SALT_MINION_CONF_DIR="/etc/salt/minion.d"
+  SALT_MINION_SERVICE="salt-minion"
+fi
+cat <<EOF >"$SALT_MINION_CONF_DIR/susemanager.conf"
 master: $redhat_management_server
 server_id_use_crc: adler32
 enable_legacy_startup_events: False
@@ -29,18 +35,18 @@ EOF
 #end if
 
 #if $activation_keys or $management_key
-cat <<EOF >>"/etc/salt/minion.d/susemanager.conf"
+cat <<EOF >>"$SALT_MINION_CONF_DIR/susemanager.conf"
 grains:
     susemanager:
 EOF
 #end if
 #if $management_key
-cat <<EOF >>"/etc/salt/minion.d/susemanager.conf"
+cat <<EOF >>"$SALT_MINION_CONF_DIR/susemanager.conf"
         management_key: "$management_key"
 EOF
 #end if
 #if $activation_keys
-cat <<EOF >>"/etc/salt/minion.d/susemanager.conf"
+cat <<EOF >>"$SALT_MINION_CONF_DIR/susemanager.conf"
         activation_key: "$activation_keys"
 EOF
 #end if
@@ -48,8 +54,8 @@ EOF
 #if not $varExists('dont_register')
 # if you don't want to register, set the 'dont_register' variable
 
-systemctl restart salt-minion
-systemctl enable salt-minion
+systemctl restart "$SALT_MINION_SERVICE"
+systemctl enable "$SALT_MINION_SERVICE"
 #end if
 
 #if not $varExists('dont_disable_automatic_onlineupdate')

--- a/java/conf/cobbler/snippets/redhat_register_using_salt
+++ b/java/conf/cobbler/snippets/redhat_register_using_salt
@@ -1,5 +1,11 @@
 # begin SUSE Manager registration
-cat <<EOF >"/etc/salt/minion.d/susemanager.conf"
+SALT_MINION_CONF_DIR="/etc/venv-salt-minion/minion.d"
+SALT_MINION_SERVICE="venv-salt-minion"
+if [ ! -d "$SALT_MINION_CONF_DIR" ]; then
+  SALT_MINION_CONF_DIR="/etc/salt/minion.d"
+  SALT_MINION_SERVICE="salt-minion"
+fi
+cat <<EOF >"$SALT_MINION_CONF_DIR/susemanager.conf"
 master: $redhat_management_server
 server_id_use_crc: adler32
 enable_legacy_startup_events: False
@@ -25,18 +31,18 @@ EOF
 #end if
 
 #if $activation_keys or $management_key
-cat <<EOF >>"/etc/salt/minion.d/susemanager.conf"
+cat <<EOF >>"$SALT_MINION_CONF_DIR/susemanager.conf"
 grains:
     susemanager:
 EOF
 #end if
 #if $management_key
-cat <<EOF >>"/etc/salt/minion.d/susemanager.conf"
+cat <<EOF >>"$SALT_MINION_CONF_DIR/susemanager.conf"
         management_key: "$management_key"
 EOF
 #end if
 #if $activation_keys
-cat <<EOF >>"/etc/salt/minion.d/susemanager.conf"
+cat <<EOF >>"$SALT_MINION_CONF_DIR/susemanager.conf"
         activation_key: "$activation_keys"
 EOF
 #end if
@@ -44,8 +50,8 @@ EOF
 #if not $varExists('dont_register')
 # if you don't want to register, set the 'dont_register' variable
 
-systemctl restart salt-minion
-systemctl enable salt-minion
+systemctl restart "$SALT_MINION_SERVICE"
+systemctl enable "$SALT_MINION_SERVICE"
 #end if
 
 #if not $varExists('dont_disable_automatic_onlineupdate')

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,6 @@
+- Prefer the Salt Bundle with Cobbler snippets configuration
+  (minion_script and redhat_register_using_salt) (bsc#1198646)
+
 -------------------------------------------------------------------
 Mon May 23 10:57:23 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Change the Salt Bundle configs in case of using venv-salt-minion package on the deployed system with Cobbler snippets.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17573

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
