### PR TITLE
Block parallel_tests Gem version

### DIFF
--- a/testsuite/Gemfile
+++ b/testsuite/Gemfile
@@ -17,7 +17,7 @@ gem 'minitest'
 gem 'websocket'
 gem 'websocket-driver'
 gem 'syntax'
-gem 'parallel_tests'
+gem 'parallel_tests', '3.8.1'
 gem 'simplecov'
 gem 'rubocop'
 # Pre-requisite:

--- a/testsuite/Gemfile
+++ b/testsuite/Gemfile
@@ -17,7 +17,7 @@ gem 'minitest'
 gem 'websocket'
 gem 'websocket-driver'
 gem 'syntax'
-gem 'parallel_tests', '3.8.1'
+gem 'parallel_tests', '3.1.0'
 gem 'simplecov'
 gem 'rubocop'
 # Pre-requisite:


### PR DESCRIPTION
## What does this PR change?

Some recent versions of parallel_tests are failing.
Let's keep an older stable release.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
