### PR TITLE
QE: Show details on errors in bootstrapping

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -90,6 +90,8 @@ After do |scenario|
     begin
       Dir.mkdir("screenshots") unless File.directory?("screenshots")
       path = "screenshots/#{scenario.name.tr(' ./', '_')}.png"
+      # only click on Details when we have errors during bootstrapping and more Details available
+      click_button('Details') if has_content?('Bootstrap Minions') && has_content?('Details')
       page.driver.browser.save_screenshot(path)
       attach path, 'image/png'
       attach current_url, 'text/plain'


### PR DESCRIPTION
## What does this PR change?

This will show more details in the saved screenshot if a scenario during bootstrapping failed and there is an option to show more details. This is due to adjustments of showing the errors made by https://github.com/uyuni-project/uyuni/pull/5395.

Only necessary for Uyuni/HEAD.

## GUI diff

No difference.


- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were adjusted

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17948


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
