### PR TITLE
send notifications as email

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/notification/NotificationMessage.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/NotificationMessage.java
@@ -152,7 +152,8 @@ public class NotificationMessage implements Serializable {
             case StateApplyFailed: return "State apply failed";
             case PaygAuthenticationUpdateFailed: return "Pay-as-you-go refresh authentication data failed";
             case EndOfLifePeriod: return "End of Life Period";
-            default: throw new RuntimeException("should not happen!");
+            case SubscriptionWarning: return "Subscription Warning";
+            default: return getType().name();
         }
     }
 

--- a/java/code/src/com/redhat/rhn/domain/notification/NotificationMessage.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/NotificationMessage.java
@@ -139,6 +139,24 @@ public class NotificationMessage implements Serializable {
     }
 
     /**
+     * Return the Notification Type as human readable string
+     * @return the notification type as string
+     */
+    @Transient
+    public String getTypeAsString() {
+        switch (getType()) {
+            case OnboardingFailed: return "Onboarding failed";
+            case ChannelSyncFailed: return "Channel sync failed";
+            case ChannelSyncFinished: return "Channel sync finished";
+            case CreateBootstrapRepoFailed: return "Creating Bootstrap Repository failed";
+            case StateApplyFailed: return "State apply failed";
+            case PaygAuthenticationUpdateFailed: return "Pay-as-you-go refresh authentication data failed";
+            case EndOfLifePeriod: return "End of Life Period";
+            default: throw new RuntimeException("should not happen!");
+        }
+    }
+
+    /**
      * @param dataIn The description to set.
      */
     public void setData(String dataIn) {

--- a/java/code/src/com/redhat/rhn/domain/notification/UserNotificationFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/UserNotificationFactory.java
@@ -151,16 +151,13 @@ public class UserNotificationFactory extends HibernateFactory {
         // We want to disable out the notifications defined on parameter: java.notifications_type_disabled
         // They are still added to the SuseNotificationTable but not associated with any user
         if (!isNotificationTypeDisabled(notificationMessageIn)) {
-            Set<User> notifyUsers = users.stream()
-                    .filter(u -> !u.isDisabled())
-                    .collect(Collectors.toSet());
-            notifyUsers
-                    .forEach(user -> UserNotificationFactory.store(new UserNotification(user, notificationMessageIn)));
-
-            String[] receipients = notifyUsers.stream()
-                    .filter(u -> u.getEmailNotify() == 1)
-                    .map(u -> u.getEmail())
-                    .toArray(size -> new String[size]);
+            String[] receipients = users.stream()
+                                        .filter(user -> !user.isDisabled())
+                                        .peek(user -> UserNotificationFactory.store(
+                                                new UserNotification(user, notificationMessageIn)))
+                                        .filter(user -> user.getEmailNotify() == 1)
+                                        .map(User::getEmail)
+                                        .toArray(String[]::new);
             if (receipients.length > 0) {
                 String subject = String.format("%s Notification from %s: %s",
                         MailHelper.PRODUCT_PREFIX,

--- a/java/code/src/com/redhat/rhn/domain/notification/UserNotificationFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/UserNotificationFactory.java
@@ -66,9 +66,8 @@ public class UserNotificationFactory extends HibernateFactory {
             return;
         }
         try {
-            Class cobj = Class.forName(clazz);
-            mailer = (Mail) cobj.newInstance();
-            return;
+            Class<? extends Mail> cobj = Class.forName(clazz).asSubclass(Mail.class);
+            mailer = cobj.getDeclaredConstructor().newInstance();
         }
         catch (Exception e) {
             mailer = new SmtpMail();

--- a/java/code/src/com/redhat/rhn/domain/notification/test/NotificationFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/test/NotificationFactoryTest.java
@@ -19,6 +19,7 @@ import static java.util.Optional.empty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.common.messaging.test.MockMail;
 import com.redhat.rhn.domain.notification.NotificationMessage;
 import com.redhat.rhn.domain.notification.UserNotification;
 import com.redhat.rhn.domain.notification.UserNotificationFactory;
@@ -27,6 +28,7 @@ import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.TestUtils;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -38,9 +40,17 @@ import java.util.List;
 
 public class NotificationFactoryTest extends BaseTestCaseWithUser {
 
+    private MockMail mailer;
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        mailer = new MockMail();
+    }
 
     @Test
     public final void testVisibilityForNoRoles() {
+        mailer.setExpectedSendCount(1);
+        UserNotificationFactory.setMailer(mailer);
         assertEquals(0, UserNotificationFactory.unreadUserNotificationsSize(user));
         NotificationMessage msg = UserNotificationFactory.createNotificationMessage(new OnboardingFailed("minion1"));
         UserNotificationFactory.storeNotificationMessageFor(msg, Collections.emptySet(), empty());
@@ -48,10 +58,29 @@ public class NotificationFactoryTest extends BaseTestCaseWithUser {
         assertEquals(1, UserNotificationFactory.unreadUserNotificationsSize(user));
         assertEquals(1, UserNotificationFactory.listUnreadByUser(user).size());
         assertEquals(1, UserNotificationFactory.listAllByUser(user).size());
+        mailer.verify();
+    }
+
+    @Test
+    public final void testUserOptOutForMail() {
+        mailer.setExpectedSendCount(0);
+        UserNotificationFactory.setMailer(mailer);
+        user.setEmailNotify(0);
+
+        assertEquals(0, UserNotificationFactory.unreadUserNotificationsSize(user));
+        NotificationMessage msg = UserNotificationFactory.createNotificationMessage(new OnboardingFailed("minion1"));
+        UserNotificationFactory.storeNotificationMessageFor(msg, Collections.emptySet(), empty());
+
+        assertEquals(1, UserNotificationFactory.unreadUserNotificationsSize(user));
+        assertEquals(1, UserNotificationFactory.listUnreadByUser(user).size());
+        assertEquals(1, UserNotificationFactory.listAllByUser(user).size());
+        mailer.verify();
     }
 
     @Test
     public final void testVisibilityForWrongRoles() {
+        mailer.setExpectedSendCount(0);
+        UserNotificationFactory.setMailer(mailer);
         assertEquals(0, UserNotificationFactory.unreadUserNotificationsSize(user));
         NotificationMessage msg = UserNotificationFactory.createNotificationMessage(new OnboardingFailed("minion1"));
         UserNotificationFactory.storeNotificationMessageFor(
@@ -60,10 +89,12 @@ public class NotificationFactoryTest extends BaseTestCaseWithUser {
         assertEquals(0, UserNotificationFactory.unreadUserNotificationsSize(user));
         assertEquals(0, UserNotificationFactory.listUnreadByUser(user).size());
         assertEquals(0, UserNotificationFactory.listAllByUser(user).size());
+        mailer.verify();
     }
 
     @Test
     public final void testUpdateReadFlag() {
+        UserNotificationFactory.setMailer(mailer);
         assertEquals(0, UserNotificationFactory.unreadUserNotificationsSize(user));
         NotificationMessage msg = UserNotificationFactory.createNotificationMessage(new OnboardingFailed("minion1"));
         UserNotificationFactory.storeNotificationMessageFor(msg, Collections.emptySet(), empty());
@@ -89,6 +120,7 @@ public class NotificationFactoryTest extends BaseTestCaseWithUser {
 
     @Test
     public final void testDeleteNotificationMessagesBefore() {
+        UserNotificationFactory.setMailer(mailer);
         // Clean up all notifications that might be present
         if (UserNotificationFactory.listAllNotificationMessages().size() > 0) {
             UserNotificationFactory.deleteNotificationMessagesBefore(Date.from(Instant.now()));
@@ -117,6 +149,7 @@ public class NotificationFactoryTest extends BaseTestCaseWithUser {
 
     @Test
     public final void testDeleteNotificationMessages() {
+        UserNotificationFactory.setMailer(mailer);
         // Clean up all notifications that might be present
         if (UserNotificationFactory.listAllNotificationMessages().size() > 0) {
             UserNotificationFactory.deleteNotificationMessagesBefore(Date.from(Instant.now()));

--- a/java/code/src/com/redhat/rhn/domain/user/test/UserFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/user/test/UserFactoryTest.java
@@ -294,7 +294,7 @@ public class UserFactoryTest extends RhnBaseTestCase {
                             availablePrefixes().toArray()[0];
         usr.setPrefix(prefix);
 
-        usr.setEmail("redhatJavaTest@redhat.com");
+        usr.setEmail("javaTest@example.com");
 
         Address addr1 = UserFactory.createAddress();
         addr1.setAddress1("444 Castro");

--- a/java/code/src/com/redhat/rhn/frontend/events/test/NewUserEventTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/test/NewUserEventTest.java
@@ -62,7 +62,7 @@ public class NewUserEventTest extends RhnBaseTestCase {
         assertContains(eventText, "A SUSE Manager login has been created for you");
         assertContains(eventText,
                 "SUSE Manager login, in combination with an active SUSE subscription,");
-        assertContains(eventText, "e-mail: redhatJavaTest@redhat.com");
+        assertContains(eventText, "e-mail: javaTest@example.com");
 
     }
 
@@ -85,9 +85,9 @@ public class NewUserEventTest extends RhnBaseTestCase {
         assertTrue(mailer.getBody().contains("Your SUSE Manager login:         testUser") ||
                    mailer.getBody().contains("Your RHN login:         testUser"));
         assertTrue(mailer.getBody().contains("Your SUSE Manager email address: " +
-                    "redhatJavaTest@redhat.com") ||
+                    "javaTest@example.com") ||
                    mailer.getBody().contains("Your RHN email address: " +
-                "redhatJavaTest@redhat.com"));
+                "javaTest@example.com"));
     }
 
     private NewUserEvent createTestEvent() {

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoXmlRpcHandler.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoXmlRpcHandler.java
@@ -16,6 +16,10 @@ package com.redhat.rhn.taskomatic;
 
 import static org.quartz.TriggerKey.triggerKey;
 
+import com.redhat.rhn.domain.notification.NotificationMessage;
+import com.redhat.rhn.domain.notification.UserNotificationFactory;
+import com.redhat.rhn.domain.notification.types.CreateBootstrapRepoFailed;
+import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.taskomatic.core.SchedulerKernel;
 import com.redhat.rhn.taskomatic.domain.TaskoBunch;
 import com.redhat.rhn.taskomatic.domain.TaskoRun;
@@ -29,9 +33,11 @@ import org.quartz.Trigger;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 
 /**
@@ -256,7 +262,7 @@ public class TaskoXmlRpcHandler {
      * @throws InvalidParamException shall not be thrown
      */
     public Date scheduleSingleSatBunchRun(String bunchName, String jobLabel,
-            Map<?, ?> params, Date start)
+                                          Map<?, ?> params, Date start)
         throws NoSuchBunchTaskException, InvalidParamException {
         return scheduleSingleBunchRun(null, bunchName, jobLabel, params, start);
     }
@@ -651,5 +657,19 @@ public class TaskoXmlRpcHandler {
             return false;
         }
         return true;
+    }
+
+    /**
+     * Create a BootstrapRepoFailed Notification and assign it to SUSE Manager administrators
+     * @param identifier bootstrap repo identifier label
+     * @param details error details
+     * @return 1 when finished
+     */
+    public int createBootstrapRepoFailedNotification(String identifier, String details) {
+        NotificationMessage notificationMessage = UserNotificationFactory.createNotificationMessage(
+                new CreateBootstrapRepoFailed(identifier, details));
+        UserNotificationFactory.storeNotificationMessageFor(notificationMessage,
+                Collections.singleton(RoleFactory.SAT_ADMIN), Optional.empty());
+        return 1;
     }
 }

--- a/java/code/src/com/redhat/rhn/testing/UserTestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/UserTestUtils.java
@@ -118,7 +118,7 @@ public class UserTestUtils  {
         String prefix = (String) LocalizationService.getInstance().
         availablePrefixes().toArray()[0];
         usr.setPrefix(prefix);
-        usr.setEmail("redhatJavaTest@redhat.com");
+        usr.setEmail("javaTest@example.com");
 
         return usr;
     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- send notifications also as email if email notifications are enabled
 - remove jabberd and osa-dispatcher
 - Add subscription warning notification to overview page
 - Fix CLM to not remove necessary packages when filtering erratas (bsc#1195979)

--- a/python/uyuni/common/notificationUtils.py
+++ b/python/uyuni/common/notificationUtils.py
@@ -1,6 +1,16 @@
 from spacewalk.common.rhnConfig import initCFG, CFG
+from spacewalk.common.rhnLog import log_debug
 from spacewalk.server import rhnSQL
 import json
+
+try:
+    import xmlrpc.client as xmlrpc_client
+except ImportError:
+    import xmlrpclib as xmlrpc_client
+
+# see TaskoXmlRpcHandler.java for available methods
+TASKOMATIC_XMLRPC_URL = 'http://localhost:2829/RPC2'
+
 
 def getNotificationsTypeDisabled():
     """Return list of types which are disabled"""
@@ -23,49 +33,9 @@ class CreateBootstrapRepoFailed:
         if self.type in getNotificationsTypeDisabled():
             return
 
-        i = rhnSQL.prepare("""
-          SELECT users.id
-            FROM (
-                  SELECT wc.id,
-                         (CASE WHEN (SELECT 1
-                                       FROM rhnwebcontactchangelog wccl
-                                       JOIN (
-                                             SELECT web_contact_id, max(id) current_state
-                                               FROM rhnwebcontactchangelog uch
-                                           GROUP BY web_contact_id
-                                            ) X ON X.current_state = wccl.id
-                                       JOIN rhnwebcontactchangestate wcsc ON wccl.change_state_id = wcsc.id
-                                      WHERE wcsc.label = 'disabled'
-                                        AND X.web_contact_id = wc.id) = 1
-                               THEN 1
-                               ELSE 0
-                           END) disabled
-                    FROM rhnusergrouptype ugt
-                    JOIN rhnusergroup ug ON ug.group_type = ugt.id
-                    JOIN rhnusergroupmembers ugm ON ugm.user_group_id = ug.id
-                    JOIN web_contact wc ON wc.id = ugm.user_id
-                   WHERE ugt.label = 'satellite_admin'
-                 ) users
-           WHERE users.disabled = 0;
-        """)
-        i.execute()
-        affected_user = i.fetchall_dict() or None
-        if not affected_user:
-            return
+        return self._create_bootstrap_repo_failed_notification()
 
-        mid = rhnSQL.Sequence('suse_notif_message_id_seq')()
-
-        h = rhnSQL.prepare("""
-          INSERT INTO suseNotificationMessage (id, type, data)
-          VALUES (:mid, :type, :data)
-        """)
-        h.execute(mid=mid, type=self.type, data=json.dumps(self.__dict__))
-
-        j = rhnSQL.prepare("""
-          INSERT INTO suseUserNotification (id, user_id, message_id)
-          VALUES (sequence_nextval('suse_user_notif_id_seq'), :uid, :mid)
-        """)
-
-        for user in affected_user:
-            j.execute(uid=user['id'], mid=mid)
-        rhnSQL.commit()
+    def _create_bootstrap_repo_failed_notification(self):
+        client = xmlrpc_client.Server(TASKOMATIC_XMLRPC_URL)
+        log_debug(2, "Calling createBootstrapRepoFailedNotification({0}, {1})".format(self.identifier, self.details))
+        return client.tasko.createBootstrapRepoFailedNotification(self.identifier, self.details)

--- a/python/uyuni/uyuni-common-libs.changes
+++ b/python/uyuni/uyuni-common-libs.changes
@@ -1,3 +1,5 @@
+- unify user notification code on java side
+
 -------------------------------------------------------------------
 Wed Sep 28 11:05:47 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

The notifications shown in the WebUI are not so usefull for people who not login very often.
Send them also as email if email notifications in the user preferences is enabled.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- not needed

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/19751

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
