### PR TITLE
Remove manual removal of bootstrap repos in testsuite

### DIFF
--- a/testsuite/features/build_validation/create_bootstrap_repositories/srv_create_bootstrap_repositories.feature
+++ b/testsuite/features/build_validation/create_bootstrap_repositories/srv_create_bootstrap_repositories.feature
@@ -6,10 +6,6 @@ Feature: Create bootstrap repositories
   As the system administrator
   I create all bootstrap repos with --custom-repos option
 
-# WORKAROUND: --flush option does not seem to work in case of hash mismatch with same version
-  Scenario: Clean up all bootstrap repositories on the server
-    When I clean up all bootstrap repositories on the server
-
 @proxy
   Scenario: Create the bootstrap repository for the SUSE Manager proxy
     When I create the bootstrap repository for "proxy" on the server

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -971,11 +971,6 @@ When(/^I wait until the package "(.*?)" has been cached on this "(.*?)"$/) do |p
   end
 end
 
-# WORKAROUND: --flush option does not seem to work in case of hash mismatch with same version
-When(/^I clean up all bootstrap repositories on the server$/) do
-  $server.run('rm -rf /srv/www/htdocs/pub/repositories/*')
-end
-
 When(/^I create the bootstrap repository for "([^"]*)" on the server$/) do |host|
   base_channel = BASE_CHANNEL_BY_CLIENT[host]
   channel = CHANNEL_TO_SYNC_BY_BASE_CHANNEL[base_channel]


### PR DESCRIPTION
## What does this PR change?

Remove manual removal of bootstrap repos in testsuite because it removes content installed and needed by a package. See https://bugzilla.suse.com/show_bug.cgi?id=1195845#c6

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18019
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
