### PR TITLE
Fix loading filebased pillars for minions

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
@@ -405,6 +405,20 @@ public class FormulaFactory {
                 .filter(pillar -> pillar.getCategory().startsWith(PREFIX))
                 .map(pillar -> pillar.getCategory().substring(PREFIX.length()))
                 .collect(Collectors.toList()));
+
+        // Still try the legacy way since the formula data may not be converted yet
+        File serverDataFile = new File(getServerDataFile());
+        if (formulas.isEmpty() && serverDataFile.exists()) {
+            try {
+                Map<String, List<String>> serverFormulas =
+                        GSON.fromJson(new BufferedReader(new FileReader(serverDataFile)),
+                                Map.class);
+                return orderFormulas(serverFormulas.getOrDefault(minion.getMinionId(),
+                        Collections.emptyList()));
+            }
+            catch (FileNotFoundException e) {
+            }
+        }
         return orderFormulas(formulas);
     }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix loading filebased pillars for minions (bsc#1199979)
 -------------------------------------------------------------------
 Mon May 23 10:57:23 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

4.3 now uses database pillars and migration is supposed to be automatic. However loading old files for migration got lost. This PR fixes it.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18016

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
