### PR TITLE
spacewalk-java: Set Cobbler 3.2.1 as exact requirement

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Add specific requirement for Cobbler 3.2.1 to not conflict with Leap 15.4
+
 -------------------------------------------------------------------
 Mon May 23 10:57:23 CEST 2022 - jgonzalez@suse.com
 

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -179,7 +179,7 @@ Requires:       (/sbin/unix2_chkpwd or /usr/sbin/unix2_chkpwd)
 Requires:       classmate
 %endif
 Requires:       %{ehcache}
-Requires:       cobbler >= 3.0.0
+Requires:       cobbler = 3.1.2
 Requires:       concurrent
 Requires:       dwr >= 3
 Requires:       (gnu-jaf or jakarta-activation)


### PR DESCRIPTION
## What does this PR change?

Fixes a bug for new installations of Uyuni where the version of Cobbler is taken from openSUSE Leap 15.4 and not `Uyuni:Master`.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- No tests: already covered

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
