### PR TITLE
Fix download CSV links

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/CachedStatement.java
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/CachedStatement.java
@@ -918,6 +918,7 @@ public class CachedStatement implements Serializable {
      * @return what the previous query returned or null.
      */
     public DataResult<?> restartQuery() {
+        restoreSessionIfClosed();
         return restartData == null ? null :
                 (DataResult<?>) internalExecute(restartData.getParameters(),
                         restartData.getInClause(), restartData.getMode());
@@ -968,5 +969,17 @@ public class CachedStatement implements Serializable {
         finally {
             HibernateHelper.cleanupDB(ps);
         }
+    }
+
+    /**
+     * Restore the linked hibernate session if it is closed
+     */
+    public void restoreSessionIfClosed() {
+        if (session.isOpen()) {
+            return;
+        }
+
+        session = session.getSessionFactory().openSession();
+        session.beginTransaction();
     }
 }

--- a/java/code/src/com/redhat/rhn/common/db/datasource/SelectMode.java
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/SelectMode.java
@@ -133,6 +133,7 @@ public class SelectMode extends BaseMode implements Serializable {
     public void elaborate(List resultList, Map<String, ?> parameters) {
         // find the requested elaborator.
         for (CachedStatement cs : elaborators) {
+            cs.restoreSessionIfClosed();
             Collection elaborated = cs.executeElaborator(resultList, this, parameters);
             resultList.clear();
             resultList.addAll(elaborated);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix download CSV
 - Clean grub2 reinstall entry in autoyast snippet (bsc#1199950)
 - Show reboot alert message on all system detail pages (bsc#1199779)
 - Show patch as installed in CVE Audit even if successor patch affects


### PR DESCRIPTION
## What does this PR change?

Since 2022.02, when CachedStatement started to store hibernate session,
all the pages using `rl:csv` custom JSP tag stopped working.

The reason is when CSVDownloadAction executes, the hibernate session linked
to the CachedStatements is closed.

To fix this, the method restoreSessionIfClosed was added and called in the
buggy points.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bug fix.

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17725

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
