### PR TITLE
Let LazyLoader do its job in mgrcompat to prevent tracebacks

### DIFF
--- a/susemanager-utils/susemanager-sls/src/states/mgrcompat.py
+++ b/susemanager-utils/susemanager-sls/src/states/mgrcompat.py
@@ -13,7 +13,6 @@ from __future__ import absolute_import
 
 # Import salt libs
 from salt.utils.odict import OrderedDict
-from salt.states import module
 
 import logging
 
@@ -26,12 +25,6 @@ def __virtual__():
     '''
     This module is always enabled while 'module.run' is available.
     '''
-    module.__salt__ = __salt__
-    module.__opts__ = __opts__
-    module.__pillar__ = __pillar__
-    module.__grains__ = __grains__
-    module.__context__ = __context__
-    module.__utils__ = __utils__
     return __virtualname__
 
 def _tailor_kwargs_to_new_syntax(name, **kwargs):
@@ -82,7 +75,7 @@ def module_run(**kwargs):
     else:
         new_kwargs = kwargs
 
-    ret = module.run(**new_kwargs)
+    ret = __states__['module.run'](**new_kwargs)
     if use_new_syntax:
         if ret['changes']:
             changes = ret['changes'].pop(old_name)

--- a/susemanager-utils/susemanager-sls/src/tests/test_state_mgrcompat.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_state_mgrcompat.py
@@ -18,109 +18,129 @@ mgrcompat.log = MagicMock()
 mgrcompat.OrderedDict = dict
 mgrcompat.__opts__ = {}
 mgrcompat.__grains__ = {}
+mgrcompat.__states__ = {}
 
 
 def test_module_run_on_phosphorous():
     mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})
-    mgrcompat.module.run = mock
-    with patch.dict(mgrcompat.__grains__, {'saltversioninfo': [3005, None, None, None]}):
+    with patch.dict(
+        mgrcompat.__grains__, {'saltversioninfo': [3005, None, None, None]}
+    ), patch.dict(mgrcompat.__states__, {'module.run': mock}):
         mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
         mock.assert_called_once_with(**TAILORED_MODULE_RUN_KWARGS)
 
 def test_module_run_on_silicon():
     mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})
-    mgrcompat.module.run = mock
-    with patch.dict(mgrcompat.__grains__, {'saltversioninfo': [3004, None, None, None]}):
+    with patch.dict(
+        mgrcompat.__grains__, {'saltversioninfo': [3004, None, None, None]}
+    ), patch.dict(mgrcompat.__states__, {'module.run': mock}):
         mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
         mock.assert_called_once_with(**MGRCOMPAT_MODULE_RUN_KWARGS)
 
 def test_module_run_on_silicon_use_superseded():
     mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})
-    mgrcompat.module.run = mock
-    with patch.dict(mgrcompat.__grains__, {'saltversioninfo': [3004, None, None, None]}):
-        with patch.dict(mgrcompat.__opts__, {'use_superseded': ['module.run']}):
-            mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
-            mock.assert_called_once_with(**TAILORED_MODULE_RUN_KWARGS)
+    with patch.dict(
+        mgrcompat.__grains__, {'saltversioninfo': [3004, None, None, None]}
+    ), patch.dict(
+        mgrcompat.__opts__, {'use_superseded': ['module.run']}
+    ), patch.dict(mgrcompat.__states__, {'module.run': mock}):
+        mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
+        mock.assert_called_once_with(**TAILORED_MODULE_RUN_KWARGS)
 
 def test_module_run_on_aluminum():
     mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})
-    mgrcompat.module.run = mock
-    with patch.dict(mgrcompat.__grains__, {'saltversioninfo': [3003, None, None, None]}):
+    with patch.dict(
+        mgrcompat.__grains__, {'saltversioninfo': [3003, None, None, None]}
+    ), patch.dict(mgrcompat.__states__, {'module.run': mock}):
         mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
         mock.assert_called_once_with(**MGRCOMPAT_MODULE_RUN_KWARGS)
 
 def test_module_run_on_aluminum_use_superseded():
     mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})
-    mgrcompat.module.run = mock
-    with patch.dict(mgrcompat.__grains__, {'saltversioninfo': [3003, None, None, None]}):
-        with patch.dict(mgrcompat.__opts__, {'use_superseded': ['module.run']}):
-            mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
-            mock.assert_called_once_with(**TAILORED_MODULE_RUN_KWARGS)
+    with patch.dict(
+        mgrcompat.__grains__, {'saltversioninfo': [3003, None, None, None]}
+    ), patch.dict(
+        mgrcompat.__opts__, {'use_superseded': ['module.run']}
+    ), patch.dict(mgrcompat.__states__, {'module.run': mock}):
+        mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
+        mock.assert_called_once_with(**TAILORED_MODULE_RUN_KWARGS)
 
 def test_module_run_on_magnesium():
     mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})
-    mgrcompat.module.run = mock
-    with patch.dict(mgrcompat.__grains__, {'saltversioninfo': [3002, None, None, None]}):
+    with patch.dict(
+        mgrcompat.__grains__, {'saltversioninfo': [3002, None, None, None]}
+    ), patch.dict(mgrcompat.__states__, {'module.run': mock}):
         mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
         mock.assert_called_once_with(**MGRCOMPAT_MODULE_RUN_KWARGS)
 
 def test_module_run_on_magnesium_use_superseded():
     mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})
-    mgrcompat.module.run = mock
-    with patch.dict(mgrcompat.__grains__, {'saltversioninfo': [3002, None, None, None]}):
-        with patch.dict(mgrcompat.__opts__, {'use_superseded': ['module.run']}):
-            mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
-            mock.assert_called_once_with(**TAILORED_MODULE_RUN_KWARGS)
+    with patch.dict(
+        mgrcompat.__grains__, {'saltversioninfo': [3002, None, None, None]}
+    ), patch.dict(
+        mgrcompat.__opts__, {'use_superseded': ['module.run']}
+    ), patch.dict(mgrcompat.__states__, {'module.run': mock}):
+        mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
+        mock.assert_called_once_with(**TAILORED_MODULE_RUN_KWARGS)
 
 def test_module_run_on_sodium():
     mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})
-    mgrcompat.module.run = mock
-    with patch.dict(mgrcompat.__grains__, {'saltversioninfo': [3001, None, None, None]}):
+    with patch.dict(
+        mgrcompat.__grains__, {'saltversioninfo': [3001, None, None, None]}
+    ), patch.dict(mgrcompat.__states__, {'module.run': mock}):
         mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
         mock.assert_called_once_with(**MGRCOMPAT_MODULE_RUN_KWARGS)
 
 def test_module_run_on_sodium_use_superseded():
     mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})
-    mgrcompat.module.run = mock
-    with patch.dict(mgrcompat.__grains__, {'saltversioninfo': [3001, None, None, None]}):
-        with patch.dict(mgrcompat.__opts__, {'use_superseded': ['module.run']}):
-            mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
-            mock.assert_called_once_with(**TAILORED_MODULE_RUN_KWARGS)
+    with patch.dict(
+        mgrcompat.__grains__, {'saltversioninfo': [3001, None, None, None]}
+    ), patch.dict(
+        mgrcompat.__opts__, {'use_superseded': ['module.run']}
+    ), patch.dict(mgrcompat.__states__, {'module.run': mock}):
+        mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
+        mock.assert_called_once_with(**TAILORED_MODULE_RUN_KWARGS)
 
 def test_module_run_on_neon():
     mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})
-    mgrcompat.module.run = mock
-    with patch.dict(mgrcompat.__grains__, {'saltversioninfo': [3000, None, None, None]}):
+    with patch.dict(
+        mgrcompat.__grains__, {'saltversioninfo': [3000, None, None, None]}
+    ), patch.dict(mgrcompat.__states__, {'module.run': mock}):
         mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
         mock.assert_called_once_with(**MGRCOMPAT_MODULE_RUN_KWARGS)
 
 def test_module_run_on_neon_use_superseded():
     mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})
-    mgrcompat.module.run = mock
-    with patch.dict(mgrcompat.__grains__, {'saltversioninfo': [3000, None, None, None]}):
-        with patch.dict(mgrcompat.__opts__, {'use_superseded': ['module.run']}):
-            mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
-            mock.assert_called_once_with(**TAILORED_MODULE_RUN_KWARGS)
+    with patch.dict(
+        mgrcompat.__grains__, {'saltversioninfo': [3000, None, None, None]}
+    ), patch.dict(
+        mgrcompat.__opts__, {'use_superseded': ['module.run']}
+    ), patch.dict(mgrcompat.__states__, {'module.run': mock}):
+        mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
+        mock.assert_called_once_with(**TAILORED_MODULE_RUN_KWARGS)
 
 def test_module_run_on_2019_2_0_use_superseded():
     mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})
-    mgrcompat.module.run = mock
-    with patch.dict(mgrcompat.__grains__, {'saltversioninfo': [2019, 2, 0, 0]}):
-        with patch.dict(mgrcompat.__opts__, {'use_superseded': ['module.run']}):
-            mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
-            mock.assert_called_once_with(**TAILORED_MODULE_RUN_KWARGS)
+    with patch.dict(
+        mgrcompat.__grains__, {'saltversioninfo': [2019, 2, 0, 0]}
+    ), patch.dict(
+        mgrcompat.__opts__, {'use_superseded': ['module.run']}
+    ), patch.dict(mgrcompat.__states__, {'module.run': mock}):
+        mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
+        mock.assert_called_once_with(**TAILORED_MODULE_RUN_KWARGS)
 
 def test_module_run_on_2019_2_0_without_use_superseded():
     mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})
-    mgrcompat.module.run = mock
-    with patch.dict(mgrcompat.__grains__, {'saltversioninfo': [2019, 2, 0, 0]}):
-        with patch.dict(mgrcompat.__opts__, {}):
-            mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
-            mock.assert_called_once_with(**MGRCOMPAT_MODULE_RUN_KWARGS)
+    with patch.dict(
+        mgrcompat.__grains__, {'saltversioninfo': [2019, 2, 0, 0]}
+    ), patch.dict(mgrcompat.__states__, {'module.run': mock}):
+        mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
+        mock.assert_called_once_with(**MGRCOMPAT_MODULE_RUN_KWARGS)
 
 def test_module_run_on_2016_11_4():
     mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})
-    mgrcompat.module.run = mock
-    with patch.dict(mgrcompat.__grains__, {'saltversioninfo': [2016, 11, 4, 0]}):
-       mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
-       mock.assert_called_once_with(**MGRCOMPAT_MODULE_RUN_KWARGS)
+    with patch.dict(
+        mgrcompat.__grains__, {'saltversioninfo': [2016, 11, 4, 0]}
+    ), patch.dict(mgrcompat.__states__, {'module.run': mock}):
+        mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
+        mock.assert_called_once_with(**MGRCOMPAT_MODULE_RUN_KWARGS)

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,6 @@
+- Prevent possible tracebacks on calling module.run from mgrcompat
+  by setting proper globals with using LazyLoader
+
 -------------------------------------------------------------------
 Tue Jun 21 18:39:32 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Prevents traceback with undefined `__low__` as `mgrcompat` doesn't respect to LazyLoader and not passing `__low__` to `module.run`.

After discussion with @agraul the better solution was found.

Superseeds https://github.com/uyuni-project/uyuni/pull/5494

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- Unit tests were added

## Links

Tracks # https://github.com/SUSE/spacewalk/issues/17838

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
