### PR TITLE
Rename QA tp QE in labeler and issue

### DIFF
--- a/.github/Maintenance_Update.md
+++ b/.github/Maintenance_Update.md
@@ -7,7 +7,7 @@ List of bigger changes:
 - [ ] Increase version number in web/conf/rhn_web.conf (x.y.z+1)
 - [ ] check salt package if all patches in testing are also available for the update
 - [ ] ~Allocate time for manual testing of new features~
-- [ ] Ask maintenance / QA if an update is ok
+- [ ] Ask maintenance / QE if an update is ok
 - [ ] check all testsuites - everything should be green
 
 ----
@@ -15,7 +15,7 @@ List of bigger changes:
 - [ ] tag all packages
 - [ ] Submit according to https://github.com/SUSE/spacewalk/wiki/Maintenance-Update%3A-the-whole-new-procedure
 - [ ] Send patchinfo (link) to kkaempf for release notes
-- [ ] write testmatrix for QA
+- [ ] write testmatrix for QE
 
 ## Things not to forget
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -63,7 +63,7 @@ xmlrpc:
 - java/code/src/com/redhat/rhn/frontend/xmlrpc/*
 - java/code/src/com/redhat/rhn/frontend/xmlrpc/**/*
 
-#QA Labels
+#QE Labels
 testing:
 - testsuite/*
 - testsuite/**/*


### PR DESCRIPTION
## What does this PR change?

Rename QA tp QE in labeler and Maintenance_Update.md

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes part of https://github.com/SUSE/spacewalk/issues/17331
Tracks no other PR, this is for .github only on master

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
