### PR TITLE
Show reboot alert message on all system detail pages (SLE Micro system)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemOverviewAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemOverviewAction.java
@@ -131,12 +131,6 @@ public class SystemOverviewAction extends RhnAction {
             createErrorMessage(request, "packagelist.jsp.modulespresent", null);
         }
 
-        s.asMinionServer().ifPresent(minion -> {
-            if (minion.doesOsSupportsTransactionalUpdate()) {
-                createErrorMessage(request, "overview.jsp.transactionalupdate.reboot", null);
-            }
-        });
-
         request.setAttribute("rebootRequired", rebootRequired);
         request.setAttribute("unentitled", s.getEntitlements().isEmpty());
         request.setAttribute("entitlements", entitlements);

--- a/java/code/src/com/redhat/rhn/frontend/servlets/TransactionalUpdateRebootMessageFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/TransactionalUpdateRebootMessageFilter.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.frontend.servlets;
+
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.struts.RequestContext;
+import com.redhat.rhn.frontend.struts.StrutsDelegate;
+import com.redhat.rhn.manager.system.SystemManager;
+
+import org.apache.struts.Globals;
+import org.apache.struts.action.ActionErrors;
+import org.apache.struts.action.ActionMessage;
+import org.apache.struts.action.ActionMessages;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * This class implements a WebFilter that applies to all system details pages and adds the transactional update reboot
+ * alert if necessary, considering whether the system supports Transactional Update.
+ */
+@WebFilter("/systems/details/*")
+public class TransactionalUpdateRebootMessageFilter implements Filter {
+
+    private static final String MESSAGE_KEY = "overview.jsp.transactionalupdate.reboot";
+
+    @Override
+    public void doFilter(
+        ServletRequest request,
+        ServletResponse response,
+        FilterChain chain
+    ) throws ServletException, IOException {
+        chain.doFilter(request, response);
+        HttpServletRequest req = (HttpServletRequest) request;
+        if (!isMessageAlreadyPresent(req)) {
+            RequestContext rctx = new RequestContext(req);
+            Long sid = rctx.getRequiredParam("sid");
+            User user = rctx.getCurrentUser();
+            Server s  = SystemManager.lookupByIdAndUser(sid, user);
+            s.asMinionServer().ifPresent(minion -> {
+                if (minion.doesOsSupportsTransactionalUpdate()) {
+                    ActionErrors errs = new ActionErrors();
+                    errs.add(
+                        ActionMessages.GLOBAL_MESSAGE,
+                        new ActionMessage(MESSAGE_KEY)
+                    );
+                    StrutsDelegate.getInstance().saveMessages(req, errs);
+                }
+            });
+        }
+    }
+
+    /**
+     * Checks if the message is already present in the session, to avoid duplicate alerts
+     */
+    private boolean isMessageAlreadyPresent(HttpServletRequest request) {
+        Object sessionErrs = request.getSession().getAttribute(Globals.ERROR_KEY);
+        if (sessionErrs != null) {
+            Iterator<ActionMessage> i = ((ActionMessages) sessionErrs).get(ActionMessages.GLOBAL_MESSAGE);
+            while (i.hasNext()) {
+                if (i.next().getKey().equals(MESSAGE_KEY)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Show reboot alert message on all system detail pages (bsc#1199779)
 - Show patch as installed in CVE Audit even if successor patch affects
   additional packages (bsc#1199646)
 - Fix refresh action confirmation message when no system is selected


### PR DESCRIPTION
## What does this PR change?

Add WebFilter to show reboot alert message on all system detail pages for SLE Micro system. Without this filter the alert is only shown on the main system profile page, while the requirements are to shown it on all pages.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bug fix.

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17954

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
