### PR TITLE
Fix table header selection detection

### DIFF
--- a/web/html/src/components/table/TableDataHandler.tsx
+++ b/web/html/src/components/table/TableDataHandler.tsx
@@ -344,6 +344,7 @@ export class TableDataHandler extends React.Component<Props, State> {
 
     const emptyText = this.props.emptyText || t("There are no entries to show.");
     const loadingText = this.props.loadingText || t("Loading...");
+    const isSelectable = typeof this.props.selectable !== "undefined" && this.props.selectable !== false;
 
     return (
       <div className="spacewalk-list">
@@ -360,7 +361,7 @@ export class TableDataHandler extends React.Component<Props, State> {
                   onClear={handleSearchPanelClear}
                   onSelectAll={handleSearchPanelSelectAll}
                   selectedCount={selectedItems.length}
-                  selectable={this.props.selectable != null}
+                  selectable={isSelectable}
                 >
                   {this.props.searchField}
                   {this.props.additionalFilters?.map((filter, i) => (

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Fix table header layout for unselectable tables
+
 -------------------------------------------------------------------
 Mon May 23 10:57:53 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

The table header logic for detecting selectable tables was slightly buggy and the "Select All" button was still shown when `selectable = false`. This PR fixes the issue.

## GUI diff

No "Select All" button for tables that can't be selected.

- [x] **DONE**

## Documentation
- No documentation needed: Small bugfix.

- [x] **DONE**

## Test coverage
- No tests: Visual bug fix.

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18040

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
