### PR TITLE
Process date values in spacecmd api calls (bsc#1198903)

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Process date values in spacecmd api calls (bsc#1198903)
 - Improve Proxy FQDN hint message
 
 -------------------------------------------------------------------

--- a/spacecmd/src/spacecmd/utils.py
+++ b/spacecmd/src/spacecmd/utils.py
@@ -51,6 +51,7 @@ from difflib import unified_diff
 from tempfile import mkstemp
 from textwrap import wrap
 from subprocess import Popen, PIPE
+from dateutil.parser import parse as parse_datetime, ParserError
 
 try:
     import json
@@ -682,7 +683,17 @@ def parse_api_args(args, sep=','):
     except ValueError:
         ret = [parse_str(a) for a in parse_list_str(args, sep)]
 
+    datetime_parser_lst(ret)
     return ret
+
+
+def datetime_parser_lst(lst):
+    for i, l in enumerate(lst):
+        if isinstance(l, str):
+            try:
+                lst[i] = parse_datetime(l)
+            except ParserError:
+                pass
 
 
 def json_dump(obj, fp, indent=4, **kwargs):

--- a/spacecmd/tests/test_api.py
+++ b/spacecmd/tests/test_api.py
@@ -5,6 +5,7 @@ Test suite for spacecmd.api
 from mock import MagicMock, patch, mock_open
 from spacecmd import api
 import helpers
+import datetime
 
 
 class TestSCAPI:
@@ -79,4 +80,44 @@ class TestSCAPI:
             api.do_api(shell, "call -A first,second,123 -o /tmp/spacecmd.log")
         assert shell.client.call.called
         assert shell.client.call.call_args_list[0][0] == ('session', 'first', 'second', 123)
+        assert out._closed
+
+    def test_args_datetime(self):
+        """
+        Test args option.
+        """
+        shell = MagicMock()
+        shell.help_api = MagicMock()
+        shell.client = MagicMock()
+        shell.client.call = MagicMock(return_value=["one", "two", "three"])
+        shell.session = "session"
+
+        log = MagicMock()
+        out = helpers.FileHandleMock()
+        with patch("spacecmd.api.open", out, create=True) as mop, \
+                patch("spacecmd.api.logging", log) as mlog:
+            api.do_api(shell, "call -A first,second,2022-05-05 -o /tmp/spacecmd.log")
+        assert shell.client.call.called
+        assert shell.client.call.call_args_list[0][0] == ('session', 'first', 'second',
+                                                          datetime.datetime(2022, 5, 5, 0, 0))
+        assert out._closed
+
+    def test_args_json(self):
+        """
+        Test args option.
+        """
+        shell = MagicMock()
+        shell.help_api = MagicMock()
+        shell.client = MagicMock()
+        shell.client.call = MagicMock(return_value=["one", "two", "three"])
+        shell.session = "session"
+
+        log = MagicMock()
+        out = helpers.FileHandleMock()
+        with patch("spacecmd.api.open", out, create=True) as mop, \
+                patch("spacecmd.api.logging", log) as mlog:
+            api.do_api(shell, "call -A '[\"first\",\"second\",\"2022-05-05\",4]' -o /tmp/spacecmd.log")
+        assert shell.client.call.called
+        assert shell.client.call.call_args_list[0][0] == ('session', 'first', 'second',
+                                                          datetime.datetime(2022, 5, 5, 0, 0),4)
         assert out._closed


### PR DESCRIPTION
## What does this PR change?

Inside the `spacecmd` command-line interface the `api` function was showing an error when trying to pass dates with the `-A` argument. Now it parses the dates and calls the API endpoint with a suitable parameter type.

An example:

`api -A "sle-product-sles15-sp3-pool-x86_64,2022-05-20,2022-05-25" channel.software.listAllPackages`

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: bugfix

- [x] **DONE**

## Links

Fixes [#1198903](https://bugzilla.suse.com/show_bug.cgi?id=1198903)
Tracks  https://github.com/SUSE/spacewalk/issues/17671

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
