### PR TITLE
Clean up the grub2 reinstall entries in autoyast minion snippet

### DIFF
--- a/java/conf/cobbler/snippets/minion_script
+++ b/java/conf/cobbler/snippets/minion_script
@@ -77,6 +77,10 @@ zypper mr -d --all
 zypper mr -e --medium-type plugin
 #end if
 
+# Clean up the reinstallation boot entry
+rm -rf /etc/grub.d/42_uyuni_reinstall
+rm -rf /boot/uyuni-reinstall-kernel /boot/uyuni-reinstall-initrd
+/usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg
         ]]>
     </source>
 </script>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Clean grub2 reinstall entry in autoyast snippet (bsc#1199950)
 - Show reboot alert message on all system detail pages (bsc#1199779)
 - Show patch as installed in CVE Audit even if successor patch affects
   additional packages (bsc#1199646)


### PR DESCRIPTION
## What does this PR change?

See title

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: reinstallation autoyast is not easy to automatically test

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
