### PR TITLE
use URI class for URL decoding

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
@@ -47,10 +47,8 @@ import org.jose4j.jwt.consumer.JwtConsumer;
 import org.jose4j.jwt.consumer.JwtConsumerBuilder;
 
 import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.security.Key;
 import java.util.Arrays;
 import java.util.Base64;
@@ -378,11 +376,13 @@ public class DownloadController {
         String channel = request.params(":channel");
         String path = "";
         try {
-            URL url = new URL(request.url());
+            URI uri = new URI(request.url());
             // URL decode the path to support ^ in package versions
-            path = URLDecoder.decode(url.getPath(), StandardCharsets.UTF_8);
+            path = uri.getPath();
+
         }
-        catch (MalformedURLException e) {
+        catch (URISyntaxException e) {
+            log.error(String.format("Unable to parse: %s", request.url()));
             halt(HttpStatus.SC_INTERNAL_SERVER_ERROR,
                     String.format("url '%s' is malformed", request.url()));
         }
@@ -399,6 +399,7 @@ public class DownloadController {
                 pkgInfo.getVersion(), pkgInfo.getRelease(), pkgInfo.getEpoch(), pkgInfo.getArch(),
                 pkgInfo.getChecksum());
         if (pkg == null) {
+            log.error(String.format("%s: Package not found in channel: %s", path, channel));
             halt(HttpStatus.SC_NOT_FOUND,
                  String.format("%s not found in %s", basename, channel));
         }

--- a/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
@@ -382,7 +382,7 @@ public class DownloadController {
 
         }
         catch (URISyntaxException e) {
-            log.error(String.format("Unable to parse: %s", request.url()));
+            log.error("Unable to parse: {}", request.url());
             halt(HttpStatus.SC_INTERNAL_SERVER_ERROR,
                     String.format("url '%s' is malformed", request.url()));
         }

--- a/java/code/src/com/suse/manager/webui/controllers/test/DownloadControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/DownloadControllerTest.java
@@ -65,8 +65,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
+import java.net.URI;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -130,11 +129,11 @@ public class DownloadControllerTest extends BaseTestCaseWithUser {
         this.uriFile = String.format("%s.rpm", nvra);
 
         this.pkg2 = ErrataTestUtils.createLaterTestPackage(user, null, channel, pkg,
-                null, "1000^20220524", pkg.getPackageEvr().getRelease());
+                null, "1000+git001^20220524", pkg.getPackageEvr().getRelease());
         final String nvra2 = String.format("%s-%s-%s.%s",
                 pkg2.getPackageName().getName(), pkg2.getPackageEvr().getVersion(),
                 pkg2.getPackageEvr().getRelease(), pkg2.getPackageArch().getLabel());
-        this.uriFile2 = URLEncoder.encode(String.format("%s.rpm", nvra2), StandardCharsets.UTF_8);
+        this.uriFile2 = new URI(String.format("%s.rpm", nvra2.replace("^", "%5e"))).toString();
 
         Tuple3<Package, File, String> dpkg = createDebPkg(channel, "1", "1", "0", "all-deb");
         this.debPkg = dpkg.getA();


### PR DESCRIPTION
## What does this PR change?

Use the URI class for URL decoding as the URLdecoder mess around with the `+` sign.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fix problems with https://github.com/uyuni-project/uyuni/pull/5496
Tracks https://github.com/SUSE/spacewalk/pull/18082

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
