### PR TITLE
Add "python3-gnupg" to bootstrap repo definition for Ubuntu 20.04 (bsc#1200212)

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -631,6 +631,7 @@ PKGLISTUBUNTU2004 = [
     "python3-psutil",
     "python3-pycryptodome",
     "python3-zmq",
+    "python3-gnupg",
     "salt-common",
     "salt-minion",
     "gnupg",

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Add python3-gnupg to bootstrap repo definition for Ubuntu 20.04 (bsc#1200212)
 - Update server-migrator to dist-upgrade to openSUSE 15.4
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

This PR adds the missing`python3-gnupg` package to the bootstrap repository definition for Ubuntu 20.04.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/18080

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
