### PR TITLE
Fixed badge color

### DIFF
--- a/web/html/src/branding/css/susemanager/variables.less
+++ b/web/html/src/branding/css/susemanager/variables.less
@@ -108,6 +108,7 @@
 @link-color:             @eos-bc-blue-500;
 // TODO: This should be selection green instead?
 @table-row-selected:     lighten(@eos-bc-yellow-100, 5%);
+@badge-bg: @eos-bc-gray-1000;
  
 /**
 * FONTS

--- a/web/html/src/branding/css/uyuni/variables.less
+++ b/web/html/src/branding/css/uyuni/variables.less
@@ -24,6 +24,7 @@
 @footer:       #030303;
 @aside:        @gray-light;
 @spacewalk-section:     #f7f7f7;
+@badge-bg: @gray-dark;
 
 /* Colours for the menu in the first column on the left */
 @aside-border: lighten(@aside, 8%);


### PR DESCRIPTION
## What does this PR change?

It overrides the value of the variable `@bade-bg` from its default bootstrap value to `@gray-dark` to increase the contrast with the text and make it easier to read.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: just a small fix.

- [x] **DONE**

## Test coverage
- No tests: CSS change.

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/12592

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
