### PR TITLE
Fixed date format on scheduler related messages

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/ssm/ProvisioningRemoteCommand.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/ssm/ProvisioningRemoteCommand.java
@@ -243,7 +243,7 @@ public class ProvisioningRemoteCommand extends RhnAction implements
                 if (actionChain == null) {
                     infoMessages.add(ActionMessages.GLOBAL_MESSAGE, new ActionMessage(
                         "ssm.operations.provisioning.remotecommand.form.schedule.succeed",
-                        label, LocalizationService.getInstance().formatDate(scheduleDate)));
+                        label, LocalizationService.getInstance().formatCustomDate(scheduleDate)));
                 }
                 else {
                     infoMessages.add(ActionMessages.GLOBAL_MESSAGE, new ActionMessage(

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SystemRemoteCommandAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SystemRemoteCommandAction.java
@@ -327,7 +327,7 @@ public class SystemRemoteCommandAction extends RhnAction implements MaintenanceW
                             new ActionMessage("ssm.overview.provisioning" +
                                 ".remotecommand.succeed", server.getId().toString(),
                                 action.getId().toString(), LocalizationService
-                                    .getInstance().formatDate(action.getEarliestAction())));
+                                    .getInstance().formatCustomDate(action.getEarliestAction())));
                     }
                     else {
                         infoMessages.add(ActionMessages.GLOBAL_MESSAGE,

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fixed date format on scheduler related messages (bsc#1195455)
 - Clean grub2 reinstall entry in autoyast snippet (bsc#1199950)
 - Show reboot alert message on all system detail pages (bsc#1199779)
 - Show patch as installed in CVE Audit even if successor patch affects


### PR DESCRIPTION
## What does this PR change?

It changes the format of the dates shown in alert messages to be consistent with the format filled in the scheduler component.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: small adjust on alert messages.

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/16860

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
