### PR TITLE
Fixed FormulaForm component

### DIFF
--- a/web/html/src/components/FormulaForm.tsx
+++ b/web/html/src/components/FormulaForm.tsx
@@ -201,14 +201,9 @@ class FormulaForm extends React.Component<Props, State> {
 
   getMessageText = (msg) => {
     if (!this.props.messageTexts[msg] && defaultMessageTexts[msg]) {
-      return t(defaultMessageTexts[msg]);
+      return defaultMessageTexts[msg];
     }
-    /**
-     * TODO: There is a bug here, in some uses messageTexts can also contain elements,
-     * a-la in group-formula.renderer.tsx. This case is not accounted for and needs
-     * separate consideration.
-     */
-    return this.props.messageTexts[msg] ? t(this.props.messageTexts[msg]) : msg;
+    return this.props.messageTexts[msg] ? this.props.messageTexts[msg] : msg;
   };
 
   render() {


### PR DESCRIPTION
## What does this PR change?

It removes unsafe use of `t()` function in messages that could have elements on it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bug fix.

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14111

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
