### PR TITLE
compare authorityKeyIdentifier with CAs subjectKeyIdentifier

### DIFF
--- a/spacewalk/certs-tools/mgr_ssl_cert_setup.py
+++ b/spacewalk/certs-tools/mgr_ssl_cert_setup.py
@@ -234,6 +234,7 @@ def getCertData(cert):
             "-issuer",
             "-issuer_hash",
             "-modulus",
+            "-ext", "subjectKeyIdentifier,authorityKeyIdentifier"
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -244,7 +245,10 @@ def getCertData(cert):
             "Unable to parse the certificate: {}".format(out.stderr.decode("utf-8"))
         )
         return None
+    nextval = ""
     for line in out.stdout.decode("utf-8").splitlines():
+        if line.strip() == "":
+            continue
         if line.startswith("subject="):
             data["subject"] = line[8:].strip()
         elif line.startswith("issuer="):
@@ -255,9 +259,20 @@ def getCertData(cert):
             data["enddate"] = line[9:].strip()
         elif line.startswith("Modulus="):
             data["modulus"] = line[8:].strip()
+        elif line.startswith("X509v3 Subject Key Identifier"):
+            nextval = "subjectKeyIdentifier"
+        elif line.startswith("X509v3 Authority Key Identifier"):
+            nextval = "authorityKeyIdentifier"
+        elif line.startswith("    "):
+            if nextval == "subjectKeyIdentifier":
+                data["subjectKeyIdentifier"] = line.strip().upper()
+            elif nextval == "authorityKeyIdentifier" and line.startswith("    keyid:"):
+                data["authorityKeyIdentifier"] = line[10:].strip().upper()
         elif "subject_hash" not in data:
+            # subject_hash comes first without key to identify it
             data["subject_hash"] = line.strip()
         else:
+            # second issue_hash without key to identify this value
             data["issuer_hash"] = line.strip()
     data["isca"] = isCA(cert)
     data["content"] = cert
@@ -339,6 +354,8 @@ def checkCompleteCAChain(server_cert_content, certData):
 
     subject = certData[serverCertHash]["subject"]
     ihash = certData[serverCertHash]["issuer_hash"]
+    issuerKeyId = certData[serverCertHash]["authorityKeyIdentifier"]
+
     if not ihash or ihash not in certData:
         raise CertCheckError("No CA found for server certificate")
 
@@ -353,11 +370,17 @@ def checkCompleteCAChain(server_cert_content, certData):
     )
 
     while ihash in certData:
+        keyId = certData[ihash]["subjectKeyIdentifier"]
+        if not (keyId and issuerKeyId and keyId == issuerKeyId):
+            raise CertCheckError(
+                "Incomplete CA Chain. Key Identifiers do not match. Unable to find issuer of '{}'".format(subject)
+            )
         if not certData[ihash]["isca"]:
             raise CertCheckError("CA missing basic constraints extension")
 
         subject = certData[ihash]["subject"]
         nexthash = certData[ihash]["issuer_hash"]
+        issuerKeyId = certData[ihash]["authorityKeyIdentifier"]
         isValid(certData[ihash]["startdate"], certData[ihash]["enddate"], subject)
 
         if nexthash == ihash:

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,6 @@
+- improve CA Chain checking by comparing authorityKeyIdentifier
+  with subjectKeyIdentifier
+
 -------------------------------------------------------------------
 Thu Jun 09 13:43:22 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

improve checking of the CA chain before deploying certificates on Server or Proxy

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
