### PR TITLE
Update junit5 jar files to their latest versions

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -124,6 +124,7 @@
         <dependency org="suse" name="junit" rev="4.12" transitive="false"/>
         <dependency org="org.junit.jupiter" name="junit-jupiter-api" rev="5.8.2" transitive="false"/>
         <dependency org="org.junit.platform" name="junit-platform-commons" rev="1.8.2" transitive="false" />
+        <dependency org="org.junit.platform" name="junit-platform-console-standalone" rev="1.8.2" transitive="false" />
         <dependency org="org.opentest4j" name="opentest4j" rev="1.2.0" transitive="false"/>
         <dependency org="org.apiguardian" name="apiguardian-api" rev="1.1.0" transitive="false"/>
         <dependency org="org.jmock" name="jmock" rev="2.12.0" transitive="false"/>

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -122,8 +122,8 @@
         <dependency org="com.sun.xml.bind" name="jaxb-core" rev="2.3.0" transitive="false"/>
         <dependency org="com.sun.xml.bind" name="jaxb-impl" rev="2.3.0" transitive="false"/>
         <dependency org="suse" name="junit" rev="4.12" transitive="false"/>
-        <dependency org="org.junit.jupiter" name="junit-jupiter-api" rev="5.6.3" transitive="false"/>
-        <dependency org="org.junit.platform" name="junit-platform-commons" rev="1.6.3" transitive="false" />
+        <dependency org="org.junit.jupiter" name="junit-jupiter-api" rev="5.8.2" transitive="false"/>
+        <dependency org="org.junit.platform" name="junit-platform-commons" rev="1.8.2" transitive="false" />
         <dependency org="org.opentest4j" name="opentest4j" rev="1.2.0" transitive="false"/>
         <dependency org="org.apiguardian" name="apiguardian-api" rev="1.1.0" transitive="false"/>
         <dependency org="org.jmock" name="jmock" rev="2.12.0" transitive="false"/>


### PR DESCRIPTION
## What does this PR change?

This is only a small patch to update the junit5 jars to their latest version. Also the [console launcher](https://junit.org/junit5/docs/current/user-guide/#running-tests-console-launcher) is added, that is required to run the unit tests from VS Code.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed, only a minor update of test dependencies.

- [X] **DONE**

## Test coverage

- No tests, this is an update to the unit test framework

- [X] **DONE**

## Links

No links.

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
