### PR TITLE
Remove `nodejs-packaging` as a build requirement

### DIFF
--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Remove nodejs-packaging as a build requirement
 - Update translation strings
 
 -------------------------------------------------------------------

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -47,7 +47,6 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 Requires(pre):  uyuni-base-common
 BuildRequires:  gettext
-BuildRequires:  nodejs-packaging
 BuildRequires:  uyuni-base-common
 BuildRequires:  perl(ExtUtils::MakeMaker)
 


### PR DESCRIPTION
## What does this PR change?

This PR removes the build-time dependency on `nodejs-packaging`. The version we're using relies on Python 2 which is EOL.

If I understood correctly, this package was used to add provides etc information into packages in the past for security audits (perhaps @SchoolGuy can chime in with a more correct description), however it seems we currently don't use it as far as I could see and find when testing builds.  
The frontend build itself does not rely on this package, as we don't use `nodejs-less` etc anymore (Webpack handles those things instead now).

Using `rel-eng/build-packages-local-obs.sh`, `spacewalk-web` builds fine with `BuildRequires:  nodejs-packaging` removed.  

From the security side, frontend dependencies are covered by both Github's Dependabot, as well as a Github action (`frontend-dependency-audit.yml`). If we want to add information about frontend dependencies into packages, we could update or augment the way we wrap those dependencies up in the future (currently we make a tarball via `yarn zip`). The information is readily available, we just need to agree on if and how we want to approach this.  

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: build tooling.

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13521

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
