### PR TITLE
Introduced logging in the HTTP API

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/XmlRpcServlet.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/XmlRpcServlet.java
@@ -86,7 +86,7 @@ public class XmlRpcServlet extends HttpServlet {
         // enhancement: if we ever need more than one InvocationProcessor
         // we should use the ManifestFactory like we did above for the
         // handlers.
-        server.addInvocationInterceptor(new LoggingInvocationProcessor());
+        server.addInvocationInterceptor(new XmlRpcLoggingInvocationProcessor());
     }
 
     private void registerCustomSerializers(RhnXmlRpcServer srvr) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -121,7 +121,6 @@ import com.redhat.rhn.frontend.xmlrpc.InvalidPackageException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidParameterException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidProfileLabelException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidSystemException;
-import com.redhat.rhn.frontend.xmlrpc.LoggingInvocationProcessor;
 import com.redhat.rhn.frontend.xmlrpc.MethodInvalidParamException;
 import com.redhat.rhn.frontend.xmlrpc.ModulesNotAllowedException;
 import com.redhat.rhn.frontend.xmlrpc.NoActionInScheduleException;
@@ -147,6 +146,7 @@ import com.redhat.rhn.frontend.xmlrpc.TaskomaticApiException;
 import com.redhat.rhn.frontend.xmlrpc.UndefinedCustomFieldsException;
 import com.redhat.rhn.frontend.xmlrpc.UnrecognizedCountryException;
 import com.redhat.rhn.frontend.xmlrpc.UnsupportedOperationException;
+import com.redhat.rhn.frontend.xmlrpc.XmlRpcLoggingInvocationProcessor;
 import com.redhat.rhn.frontend.xmlrpc.kickstart.XmlRpcKickstartHelper;
 import com.redhat.rhn.frontend.xmlrpc.user.XmlRpcUserHelper;
 import com.redhat.rhn.manager.MissingCapabilityException;
@@ -8010,7 +8010,7 @@ public class SystemHandler extends BaseHandler {
     /**
      * Bootstrap a system for management via either Salt (minion/master) or Salt SSH.
      *
-     * NOTE: Arguments contain sensitive data, which is hidden from logging in {@link LoggingInvocationProcessor}
+     * NOTE: Arguments contain sensitive data, which is hidden from logging in {@link XmlRpcLoggingInvocationProcessor}
      *
      * @param user the current user
      * @param host hostname or IP address of the target machine
@@ -8045,7 +8045,7 @@ public class SystemHandler extends BaseHandler {
      * Bootstrap a system for management via either Salt (minion/master) or Salt SSH.
      * Use SSH private key for authentication.
      *
-     * NOTE: Arguments contain sensitive data, which is hidden from logging in {@link LoggingInvocationProcessor}
+     * NOTE: Arguments contain sensitive data, which is hidden from logging in {@link XmlRpcLoggingInvocationProcessor}
      *
      * @param user the current user
      * @param host hostname or IP address of the target machine
@@ -8082,7 +8082,7 @@ public class SystemHandler extends BaseHandler {
     /**
      * Bootstrap a system for management via either Salt (minion/master) or Salt SSH.
      *
-     * NOTE: Arguments contain sensitive data, which is hidden from logging in {@link LoggingInvocationProcessor}
+     * NOTE: Arguments contain sensitive data, which is hidden from logging in {@link XmlRpcLoggingInvocationProcessor}
      *
      * @param user the current user
      * @param host hostname or IP address of the target machine
@@ -8119,7 +8119,7 @@ public class SystemHandler extends BaseHandler {
      * Bootstrap a system for management via either Salt (minion/master) or Salt SSH.
      * Use SSH private key for authentication.
      *
-     * NOTE: Arguments contain sensitive data, which is hidden from logging in {@link LoggingInvocationProcessor}
+     * NOTE: Arguments contain sensitive data, which is hidden from logging in {@link XmlRpcLoggingInvocationProcessor}
      *
      * @param user the current user
      * @param host hostname or IP address of the target machine
@@ -8158,7 +8158,7 @@ public class SystemHandler extends BaseHandler {
     /**
      * Bootstrap a system for management via either Salt (minion/master) or Salt SSH.
      *
-     * NOTE: Arguments contain sensitive data, which is hidden from logging in {@link LoggingInvocationProcessor}
+     * NOTE: Arguments contain sensitive data, which is hidden from logging in {@link XmlRpcLoggingInvocationProcessor}
      *
      * @param user the current user
      * @param host hostname or IP address of the target machine
@@ -8195,7 +8195,7 @@ public class SystemHandler extends BaseHandler {
      * Bootstrap a system for management via either Salt (minion/master) or Salt SSH.
      * Use SSH private key for authentication.
      *
-     * NOTE: Arguments contain sensitive data, which is hidden from logging in {@link LoggingInvocationProcessor}
+     * NOTE: Arguments contain sensitive data, which is hidden from logging in {@link XmlRpcLoggingInvocationProcessor}
      *
      * @param user the current user
      * @param host hostname or IP address of the target machine
@@ -8235,7 +8235,7 @@ public class SystemHandler extends BaseHandler {
     /**
      * Bootstrap a system for management via either Salt (minion/master) or Salt SSH.
      *
-     * NOTE: Arguments contain sensitive data, which is hidden from logging in {@link LoggingInvocationProcessor}
+     * NOTE: Arguments contain sensitive data, which is hidden from logging in {@link XmlRpcLoggingInvocationProcessor}
      *
      * @param user the current user
      * @param host hostname or IP address of the target machine
@@ -8275,7 +8275,7 @@ public class SystemHandler extends BaseHandler {
      * Bootstrap a system for management via either Salt (minion/master) or Salt SSH.
      * Use SSH private key for authentication.
      *
-     * NOTE: Arguments contain sensitive data, which is hidden from logging in {@link LoggingInvocationProcessor}
+     * NOTE: Arguments contain sensitive data, which is hidden from logging in {@link XmlRpcLoggingInvocationProcessor}
      *
      * @param user the current user
      * @param host hostname or IP address of the target machine

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/test/XmlRpcLoggingInvocationProcessorTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/test/XmlRpcLoggingInvocationProcessorTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.redhat.rhn.domain.session.WebSession;
 import com.redhat.rhn.domain.session.WebSessionFactory;
 import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.frontend.xmlrpc.LoggingInvocationProcessor;
+import com.redhat.rhn.frontend.xmlrpc.XmlRpcLoggingInvocationProcessor;
 import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.UserTestUtils;
 
@@ -37,14 +37,14 @@ import redstone.xmlrpc.XmlRpcInvocation;
 /**
  * LoggingInvocationProcessorTest
  */
-public class LoggingInvocationProcessorTest extends RhnBaseTestCase {
+public class XmlRpcLoggingInvocationProcessorTest extends RhnBaseTestCase {
 
-    private LoggingInvocationProcessor lip;
+    private XmlRpcLoggingInvocationProcessor lip;
     private Writer writer;
 
     @BeforeEach
     public void setUp() throws Exception {
-        lip = new LoggingInvocationProcessor();
+        lip = new XmlRpcLoggingInvocationProcessor();
         writer = new StringWriter();
     }
 

--- a/java/code/src/com/suse/manager/api/HttpApiLoggingInvocationProcessor.java
+++ b/java/code/src/com/suse/manager/api/HttpApiLoggingInvocationProcessor.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.api;
+
+import com.redhat.rhn.common.hibernate.LookupException;
+import com.redhat.rhn.common.translation.Translator;
+import com.redhat.rhn.domain.session.InvalidSessionIdException;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.servlets.PxtCookieManager;
+import com.redhat.rhn.manager.session.SessionManager;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import spark.Request;
+import spark.Spark;
+
+/**
+ * HttpApiLoggingInvocationProcessor defines Spark filters (after and before)
+ * to log method calls in the context of the HTTP API.
+ */
+public class HttpApiLoggingInvocationProcessor extends LoggingInvocationProcessor {
+
+    // The pattern to capture everything starting with HTTP_API_ROOT
+    public static final String HTTP_API_URL_PATTERN = HttpApiRegistry.HTTP_API_ROOT + "*";
+    private final ApiRequestParser apiRequestParser = new ApiRequestParser(new Gson());
+
+    private static ThreadLocal<User> caller = new ThreadLocal<>();
+
+    /**
+     * Register before and after filters in Spark
+     */
+    public void register() {
+
+        // Reset the timer and set the caller (the caller is set here, instead of in after, to capture logout caller)
+        Spark.before(HTTP_API_URL_PATTERN, (request, response) -> {
+            getStopWatch().reset();
+            getStopWatch().start();
+            caller.set(getCaller(request));
+        });
+
+        Spark.after(HTTP_API_URL_PATTERN, (request, response) -> {
+            String[] urlTokens = request.pathInfo().split(HttpApiRegistry.HTTP_API_ROOT)[1].split("/");
+
+            // To be HTTP API related, the URL needs to have at least two parts (handler and method names)
+            if (urlTokens.length < 2) {
+                return;
+            }
+            String handler = getHandlerName(urlTokens);
+            String methodName = urlTokens[urlTokens.length - 1];
+
+            afterProcess(
+                handler,
+                methodName,
+                processParams(request, handler, methodName),
+                request.ip()
+            );
+        });
+    }
+
+    /**
+     * Extracts params from request.queryMap() and request.body()
+     *
+     * @param request - the spark request being processed
+     * @param handler - the name of the handler
+     * @param methodName - the name of the method
+     * @return the params as a StringBuffer ready to be logged
+     */
+    public StringBuffer processParams(Request request, String handler, String methodName) {
+        Map<String, String> paramsMap = getQueryMapParams(request);
+        paramsMap.putAll(parseBody(request.body()));
+        return processParams(paramsMap, handler, methodName);
+    }
+
+    /**
+     * Convert the params from a Map to a StringBuffer with format of a method call
+     * @param paramsMap the Map containing the parameters
+     * @param handler name of the handler
+     * @param methodName name of the method
+     * @return the params as a StringBuffer ready to be logged
+     */
+    public StringBuffer processParams(Map<String, String> paramsMap, String handler, String methodName) {
+        StringBuffer params = new StringBuffer();
+        for (String key : paramsMap.keySet()) {
+            params.append(key);
+            params.append("=");
+            params.append(getParamValueToLog(handler, methodName, key, paramsMap.get(key)));
+            params.append(", ");
+        }
+
+        // Removes trailing comma
+        if (params.length() > 1) {
+            params.delete(params.length() - 2, params.length());
+        }
+        return params;
+    }
+
+    /**
+     * Extract the params from request.queryMap()
+     *
+     * @param request - the Spark request being processed
+     * @return a map with the param names as keys and param values as values
+     */
+    public Map<String, String> getQueryMapParams(Request request) {
+        return request.queryMap().toMap().entrySet().stream().collect(
+            Collectors.toMap(
+                Map.Entry::getKey,
+                e -> e.getValue().length == 1 ? e.getValue()[0] : Arrays.toString(e.getValue())
+            )
+        );
+    }
+
+    /**
+     * Converts the request body in a map of params
+     * @param body request body as String
+     * @return the map of parameters extracted from the body
+     */
+    public Map<String, String> parseBody(String body) {
+        try {
+            Map<String, JsonElement> bodyParams = apiRequestParser.parseBody(body);
+            return bodyParams.entrySet().stream().collect(
+                    Collectors.toMap(
+                            Map.Entry::getKey,
+                            e -> e.getValue().toString()
+                    )
+            );
+        }
+        catch (ParseException e) {
+            return Collections.emptyMap();
+        }
+    }
+
+    /**
+     * Translate the param value and hide it if necessary
+     * @param handler - the name of the handler
+     * @param methodName - the name of the method
+     * @param key is the param name
+     * @param value param value
+     * @return param value ready to be logged
+     */
+    public String getParamValueToLog(String handler, String methodName, String key, String value) {
+        if (preventValueLogging(handler, methodName, key)) {
+            return "******";
+        }
+        else {
+            return (String) Translator.convert(value, String.class);
+        }
+    }
+
+    /**
+     * Extracts the handler name from URL tokens.
+     * Basically, it concatenates all the tokens, except the last one
+     * that is the methodName, connecting them through a dot.
+     *
+     * @param urlTokens - the parts of the URL after splitting it
+     * @return the handler name
+     */
+    public String getHandlerName(String[] urlTokens) {
+        StringBuilder handlerName = new StringBuilder();
+        for (int i = 0; i < urlTokens.length - 1; i++) {
+            handlerName.append(urlTokens[i]);
+            handlerName.append(".");
+        }
+        handlerName.deleteCharAt(handlerName.length() - 1);
+        return handlerName.toString();
+    }
+
+    /**
+     * Extracts the logged user from session
+     * @param request - the Spark request being processed
+     * @return the logged user or null
+     */
+    public User getCaller(Request request) {
+        try {
+            String sessionKey = request.cookie(PxtCookieManager.PXT_SESSION_COOKIE_NAME);
+            return SessionManager.loadSession(sessionKey).getUser();
+        }
+        catch (InvalidSessionIdException | LookupException e) {
+            // As this code is just for logging, it could keep going when no session is found.
+            return null;
+        }
+    }
+
+    @Override
+    public String getCallerLogin() {
+        return getCallerLogin(caller.get());
+    }
+
+}

--- a/java/code/src/com/suse/manager/api/HttpApiRegistry.java
+++ b/java/code/src/com/suse/manager/api/HttpApiRegistry.java
@@ -73,6 +73,7 @@ public class HttpApiRegistry {
      */
     public void initRoutes() {
         final int[] methodCount = {0};
+        new HttpApiLoggingInvocationProcessor().register();
 
         handlerFactory.getKeys().forEach(namespace -> {
             BaseHandler handler = handlerFactory.getHandler(namespace).get();

--- a/java/code/src/com/suse/manager/api/LoggingInvocationProcessor.java
+++ b/java/code/src/com/suse/manager/api/LoggingInvocationProcessor.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.api;
+
+import com.redhat.rhn.domain.user.User;
+
+import org.apache.commons.lang3.time.StopWatch;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Base logic for processing logs.
+ */
+public abstract class LoggingInvocationProcessor {
+
+    private static final Logger LOGGER = LogManager.getLogger(LoggingInvocationProcessor.class);
+
+    private static ThreadLocal timer = new ThreadLocal() {
+        protected synchronized Object initialValue() {
+            return new StopWatch();
+        }
+    };
+
+    /**
+     * This map contains the method args whose value is sensible and should not be logged.
+     *
+     * The key follows the pattern handler.methodName and the value is a map containing
+     * the restricted args, arg position as key and arg name as value.
+     */
+    private static final Map<String, Map<Integer, String>> RESTRICTED_ARGS = new HashMap<>();
+
+    static {
+        RESTRICTED_ARGS.put("auth.login", Map.of(1, "password"));
+        RESTRICTED_ARGS.put("system.bootstrap", Map.of(4, "sshPassword"));
+        RESTRICTED_ARGS.put(
+            "system.bootstrapWithPrivateKey",
+            Map.of(4, "sshPrivKey", 5, "sshPrivKeyPass")
+        );
+        RESTRICTED_ARGS.put(
+            "admin.payg.create",
+            Map.of(
+                5, "password",
+                6, "key",
+                7, "keyPassword",
+                11, "bastionPassword",
+                12, "bastionKey",
+                13, "bastionKeyPassword"
+            )
+        );
+        RESTRICTED_ARGS.put("admin.payg.setDetails", Map.of(2, "details"));
+        RESTRICTED_ARGS.put(
+            "proxy.container_config",
+            Map.of(
+                6, "caCrt",
+                7, "caKey",
+                8, "caPassword"
+            )
+        );
+    }
+
+    /**
+     * Makes the after hook processing logic agnostic, taking as parameters all data to be logged and
+     * the processingTimer to be stopped.
+     *
+     * @param handlerName the handler of the request
+     * @param methodName the method called
+     * @param arguments the string representation of the arguments passed to the method
+     * @param ip the request's ip
+     */
+    public void afterProcess(
+        String handlerName,
+        String methodName,
+        StringBuffer arguments,
+        String ip
+    ) {
+        try {
+            // Create the call in a separate buffer for reuse
+            StringBuffer buf = new StringBuffer();
+            buf.append("REQUESTED FROM: ");
+            buf.append(ip);
+            buf.append(" CALL: ");
+            buf.append(handlerName);
+            buf.append(".");
+            buf.append(methodName);
+            buf.append("(");
+            buf.append(arguments);
+            buf.append(")");
+            buf.append(" CALLER: (");
+            buf.append(getCallerLogin());
+            buf.append(") TIME: ");
+
+            buf.append(stopTimer() / 1000.00);
+            buf.append(" seconds");
+
+            LOGGER.info(buf);
+        }
+        catch (RuntimeException e) {
+            LOGGER.error("postProcess error CALL: {} {}", handlerName, methodName, e);
+        }
+    }
+
+    protected abstract String getCallerLogin();
+
+    /**
+     * Stop the timer
+     * @return the time registered in this timer.
+     */
+    private long stopTimer() {
+        getStopWatch().stop();
+        return getStopWatch().getTime();
+    }
+
+    // determines whether the value should be hidden from logging based on argPosition
+    protected static boolean preventValueLogging(String handler, String method, int argPosition) {
+        String handlerAndMethod = handler + "." + method;
+        return RESTRICTED_ARGS.containsKey(handlerAndMethod) &&
+                RESTRICTED_ARGS.get(handlerAndMethod).containsKey(argPosition);
+    }
+
+    /**
+     * @param handler - name of the handler
+     * @param method - name of the method
+     * @param argName - name of the argument
+     * @return - whether the value should be hidden from logging based on argName
+     */
+    protected static boolean preventValueLogging(String handler, String method, String argName) {
+        String handlerAndMethod = handler + "." + method;
+        return RESTRICTED_ARGS.containsKey(handlerAndMethod) &&
+                RESTRICTED_ARGS.get(handlerAndMethod).containsValue(argName);
+    }
+
+    protected static StopWatch getStopWatch() {
+        return (StopWatch) timer.get();
+    }
+
+    /**
+     * Extracts the login of the caller
+     * @param caller - the user
+     * @return the login of the user or "none" if no user is present
+     */
+    public String getCallerLogin(User caller) {
+        String ret = "none";
+        if (caller != null) {
+            ret = caller.getLogin();
+        }
+        return ret;
+    }
+}

--- a/java/code/src/com/suse/manager/api/test/HttpApiLoggingInvocationProcessorTest.java
+++ b/java/code/src/com/suse/manager/api/test/HttpApiLoggingInvocationProcessorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.api.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.domain.user.legacy.UserImpl;
+
+import com.suse.manager.api.HttpApiLoggingInvocationProcessor;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class HttpApiLoggingInvocationProcessorTest {
+
+    private final HttpApiLoggingInvocationProcessor processor = new HttpApiLoggingInvocationProcessor();
+
+    @Test
+    public void testGetHandlerAndMethodNames() {
+        String url = "system/provisioning/powermanagement/listTypes";
+        String[] urlTokens = url.split("/");
+        String handlerName = processor.getHandlerName(urlTokens);
+        assertEquals("system.provisioning.powermanagement", handlerName);
+    }
+
+    @Test
+    public void testGetCallerLogin() {
+        String login = "userLoginTest";
+        User user = new UserImpl();
+        user.setLogin(login);
+        assertEquals("none", processor.getCallerLogin(null));
+        assertEquals(login, processor.getCallerLogin(user));
+    }
+
+    @Test
+    public void getParamValueToLog() {
+        String value = "testValue";
+        String valueToLog = processor.getParamValueToLog("system", "login", "username", value);
+        assertEquals(value, valueToLog);
+
+        valueToLog = processor.getParamValueToLog("auth", "login", "password", value);
+        assertEquals("******", valueToLog);
+    }
+
+    @Test
+    public void testParseBody() {
+        String body = "[\"not object json body\"]";
+        Map<String, String> parsed = processor.parseBody(body);
+        assertTrue(parsed.isEmpty());
+
+        body = "{ \"var1\": \"value1\", \"var2\": \"value2\" }";
+        parsed = processor.parseBody(body);
+        assertTrue(parsed.containsKey("var1"));
+        assertTrue(parsed.containsKey("var2"));
+        assertEquals("\"value1\"", parsed.get("var1"));
+        assertEquals("\"value2\"", parsed.get("var2"));
+    }
+
+    @Test
+    public void testProcessParams() {
+        Map<String, String> params = new HashMap<>();
+        params.put("sid", "100001");
+        params.put("user", "userTest");
+        StringBuffer result = processor.processParams(
+            params, "system.provisioning.powermanagement", "getDetails"
+        );
+        assertEquals("user=userTest, sid=100001", result.toString());
+    }
+}

--- a/java/code/src/log4j2.xml
+++ b/java/code/src/log4j2.xml
@@ -6,7 +6,7 @@
             <SizeBasedTriggeringPolicy size="10MB" />
             <DefaultRolloverStrategy max="5" />
         </RollingFile>
-        <RollingFile name="xmlRpcFileAppender" fileName="/var/log/rhn/rhn_web_api.log" filePattern="rhn_web_api-%i.log">
+        <RollingFile name="apiLogFileAppender" fileName="/var/log/rhn/rhn_web_api.log" filePattern="rhn_web_api-%i.log">
             <PatternLayout pattern="[%d] %-5p - %m%n" />
             <SizeBasedTriggeringPolicy size="10MB" />
             <DefaultRolloverStrategy max="5" />
@@ -29,7 +29,7 @@
             <PatternLayout pattern="[%d] %-5p - %m%n" />
         </File>
         -->
-        <FailOver name="xmlRpcFailOverAppender" primary="xmlRpcFileAppender">
+        <FailOver name="xmlRpcFailOverAppender" primary="apiLogFileAppender">
             <FailOvers>
                 <AppenderRef ref="rootAppender" />
             </FailOvers>
@@ -64,8 +64,12 @@
         <Logger name="com.redhat.rhn.common.security.acl" level="warn" />
 
         <!-- XML-RPC logging -->
-        <Logger name="com.redhat.rhn.frontend.xmlrpc.LoggingInvocationProcessor" level="info" additivity="false">
+        <Logger name="com.redhat.rhn.frontend.xmlrpc.XmlRpcLoggingInvocationProcessor" level="info" additivity="false">
             <AppenderRef ref="xmlRpcFailOverAppender" />
+        </Logger>
+
+        <Logger name="com.suse.manager.api.LoggingInvocationProcessor" level="info" additivity="false">
+            <AppenderRef ref="apiLogFileAppender" />
         </Logger>
 
         <!-- Frontend logs -->

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Improved log handling in HTTP API (bsc#1199662)
 - set Channel GPG Key info from SCC data
 - set GPG Key Url as channel pillar data (bsc#1199984)
 - new API endpoint for addErrataUpdate, that take 


### PR DESCRIPTION
## What does this PR change?

It introduces a solution for logging HTTP API calls in a similar way to what is done on XML RPC.

The solution is based on Spark filters to capture which methods were called, which user called them and how long it took to process this request.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17890

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
