### PR TITLE
QE: Add step to check for open/closed ports

### DIFF
--- a/testsuite/features/secondary/srv_monitoring.feature
+++ b/testsuite/features/secondary/srv_monitoring.feature
@@ -26,17 +26,13 @@ Feature: Disable and re-enable monitoring of the server
     And I should see a list item with text "Tomcat (Java JMX)" and a failing bullet
     And I should see a "Restarting Tomcat and Taskomatic is needed for the configuration changes to take effect." text
     And file "/etc/rhn/rhn.conf" should contain "prometheus_monitoring_enabled = 0" on server
-    And port "3333" should be closed
-    And port "3334" should be closed
     And file "/usr/lib/systemd/system/tomcat.service.d/jmx.conf" should not exist on server
     And file "/usr/lib/systemd/system/taskomatic.service.d/jmx.conf" should not exist on server
-    And port "5556" should be closed
-    And port "5557" should be closed
 
   Scenario: Restart spacewalk services to apply config changes after disabling monitoring
     When I restart the spacewalk service
 
-  Scenario: Check that monitoring is disabled using the UI
+  Scenario: Check that monitoring is disabled
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Manager Configuration > Monitoring"
     And I wait until I see "Server self monitoring" text
@@ -48,6 +44,10 @@ Feature: Disable and re-enable monitoring of the server
     And I should see a list item with text "Taskomatic (Java JMX)" and a failing bullet
     And I should see a list item with text "Tomcat (Java JMX)" and a failing bullet
     And I should not see a "Restarting Tomcat and Taskomatic is needed for the configuration changes to take effect." text
+    And port "3333" should be closed
+    And port "3334" should be closed
+    And port "5556" should be closed
+    And port "5557" should be closed
 
   Scenario: Enable monitoring from the UI
     When I follow the left menu "Admin > Manager Configuration > Monitoring"
@@ -62,17 +62,13 @@ Feature: Disable and re-enable monitoring of the server
     And I should see a list item with text "Tomcat (Java JMX)" and a pending bullet
     And I should see a "Restarting Tomcat and Taskomatic is needed for the configuration changes to take effect." text
     And file "/etc/rhn/rhn.conf" should contain "prometheus_monitoring_enabled = 1" on server
-    And port "3333" should be closed
-    And port "3334" should be closed
     And file "/usr/lib/systemd/system/tomcat.service.d/jmx.conf" should contain "jmx_prometheus_javaagent.jar=5556" on server
     And file "/usr/lib/systemd/system/taskomatic.service.d/jmx.conf" should contain "jmx_prometheus_javaagent.jar=5557" on server
-    And port "5556" should be open
-    And port "5557" should be open
 
   Scenario: Restart spacewalk services to apply config changes after enabling monitoring
     When I restart the spacewalk service
 
-  Scenario: Check that monitoring is enabled using the UI
+  Scenario: Check that monitoring is enabled
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Manager Configuration > Monitoring"
     And I wait until I see "Server self monitoring" text
@@ -84,3 +80,7 @@ Feature: Disable and re-enable monitoring of the server
     And I should see a list item with text "Taskomatic (Java JMX)" and a success bullet
     And I should see a list item with text "Tomcat (Java JMX)" and a success bullet
     And I should not see a "Restarting Tomcat and Taskomatic is needed for the configuration changes to take effect." text
+    And port "3333" should be closed
+    And port "3334" should be closed
+    And port "5556" should be open
+    And port "5557" should be open

--- a/testsuite/features/secondary/srv_monitoring.feature
+++ b/testsuite/features/secondary/srv_monitoring.feature
@@ -26,8 +26,8 @@ Feature: Disable and re-enable monitoring of the server
     And I should see a list item with text "Tomcat (Java JMX)" and a failing bullet
     And I should see a "Restarting Tomcat and Taskomatic is needed for the configuration changes to take effect." text
     And file "/etc/rhn/rhn.conf" should contain "prometheus_monitoring_enabled = 0" on server
-    And file "/etc/sysconfig/tomcat" should not contain "Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=" on server
-    And file "/etc/rhn/taskomatic.conf" should not contain "Dcom.sun.management.jmxremote.port=3334 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=" on server
+    And port "3333" should be closed
+    And port "3334" should be closed
     And file "/usr/lib/systemd/system/tomcat.service.d/jmx.conf" should not exist on server
     And file "/usr/lib/systemd/system/taskomatic.service.d/jmx.conf" should not exist on server
 
@@ -60,8 +60,8 @@ Feature: Disable and re-enable monitoring of the server
     And I should see a list item with text "Tomcat (Java JMX)" and a pending bullet
     And I should see a "Restarting Tomcat and Taskomatic is needed for the configuration changes to take effect." text
     And file "/etc/rhn/rhn.conf" should contain "prometheus_monitoring_enabled = 1" on server
-    And file "/etc/sysconfig/tomcat" should not contain "Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=" on server
-    And file "/etc/rhn/taskomatic.conf" should not contain "Dcom.sun.management.jmxremote.port=3334 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=" on server
+    And port "3333" should be closed
+    And port "3334" should be closed
     And file "/usr/lib/systemd/system/tomcat.service.d/jmx.conf" should contain "jmx_prometheus_javaagent.jar=5556" on server
     And file "/usr/lib/systemd/system/taskomatic.service.d/jmx.conf" should contain "jmx_prometheus_javaagent.jar=5557" on server
 

--- a/testsuite/features/secondary/srv_monitoring.feature
+++ b/testsuite/features/secondary/srv_monitoring.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021 SUSE LLC
+# Copyright (c) 2019-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 # This feature is a dependency for:
 # - features/secondary/min_monitoring.feature : If this feature fails could let monitoring feature disabled for SLE minion

--- a/testsuite/features/secondary/srv_monitoring.feature
+++ b/testsuite/features/secondary/srv_monitoring.feature
@@ -25,9 +25,6 @@ Feature: Disable and re-enable monitoring of the server
     And I should see a list item with text "Taskomatic (Java JMX)" and a failing bullet
     And I should see a list item with text "Tomcat (Java JMX)" and a failing bullet
     And I should see a "Restarting Tomcat and Taskomatic is needed for the configuration changes to take effect." text
-    And file "/etc/rhn/rhn.conf" should contain "prometheus_monitoring_enabled = 0" on server
-    And file "/usr/lib/systemd/system/tomcat.service.d/jmx.conf" should not exist on server
-    And file "/usr/lib/systemd/system/taskomatic.service.d/jmx.conf" should not exist on server
 
   Scenario: Restart spacewalk services to apply config changes after disabling monitoring
     When I restart the spacewalk service
@@ -44,6 +41,9 @@ Feature: Disable and re-enable monitoring of the server
     And I should see a list item with text "Taskomatic (Java JMX)" and a failing bullet
     And I should see a list item with text "Tomcat (Java JMX)" and a failing bullet
     And I should not see a "Restarting Tomcat and Taskomatic is needed for the configuration changes to take effect." text
+    And file "/etc/rhn/rhn.conf" should contain "prometheus_monitoring_enabled = 0" on server
+    And file "/usr/lib/systemd/system/tomcat.service.d/jmx.conf" should not exist on server
+    And file "/usr/lib/systemd/system/taskomatic.service.d/jmx.conf" should not exist on server
     And port "3333" should be closed
     And port "3334" should be closed
     And port "5556" should be closed
@@ -61,9 +61,6 @@ Feature: Disable and re-enable monitoring of the server
     And I should see a list item with text "Taskomatic (Java JMX)" and a pending bullet
     And I should see a list item with text "Tomcat (Java JMX)" and a pending bullet
     And I should see a "Restarting Tomcat and Taskomatic is needed for the configuration changes to take effect." text
-    And file "/etc/rhn/rhn.conf" should contain "prometheus_monitoring_enabled = 1" on server
-    And file "/usr/lib/systemd/system/tomcat.service.d/jmx.conf" should contain "jmx_prometheus_javaagent.jar=5556" on server
-    And file "/usr/lib/systemd/system/taskomatic.service.d/jmx.conf" should contain "jmx_prometheus_javaagent.jar=5557" on server
 
   Scenario: Restart spacewalk services to apply config changes after enabling monitoring
     When I restart the spacewalk service
@@ -80,6 +77,9 @@ Feature: Disable and re-enable monitoring of the server
     And I should see a list item with text "Taskomatic (Java JMX)" and a success bullet
     And I should see a list item with text "Tomcat (Java JMX)" and a success bullet
     And I should not see a "Restarting Tomcat and Taskomatic is needed for the configuration changes to take effect." text
+    And file "/etc/rhn/rhn.conf" should contain "prometheus_monitoring_enabled = 1" on server
+    And file "/usr/lib/systemd/system/tomcat.service.d/jmx.conf" should contain "jmx_prometheus_javaagent.jar=5556" on server
+    And file "/usr/lib/systemd/system/taskomatic.service.d/jmx.conf" should contain "jmx_prometheus_javaagent.jar=5557" on server
     And port "3333" should be closed
     And port "3334" should be closed
     And port "5556" should be open

--- a/testsuite/features/secondary/srv_monitoring.feature
+++ b/testsuite/features/secondary/srv_monitoring.feature
@@ -30,6 +30,8 @@ Feature: Disable and re-enable monitoring of the server
     And port "3334" should be closed
     And file "/usr/lib/systemd/system/tomcat.service.d/jmx.conf" should not exist on server
     And file "/usr/lib/systemd/system/taskomatic.service.d/jmx.conf" should not exist on server
+    And port "5556" should be closed
+    And port "5557" should be closed
 
   Scenario: Restart spacewalk services to apply config changes after disabling monitoring
     When I restart the spacewalk service
@@ -64,6 +66,8 @@ Feature: Disable and re-enable monitoring of the server
     And port "3334" should be closed
     And file "/usr/lib/systemd/system/tomcat.service.d/jmx.conf" should contain "jmx_prometheus_javaagent.jar=5556" on server
     And file "/usr/lib/systemd/system/taskomatic.service.d/jmx.conf" should contain "jmx_prometheus_javaagent.jar=5557" on server
+    And port "5556" should be open
+    And port "5557" should be open
 
   Scenario: Restart spacewalk services to apply config changes after enabling monitoring
     When I restart the spacewalk service

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1342,3 +1342,13 @@ When(/^I schedule a task to update ReportDB$/) do
     And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
   )
 end
+
+Then(/^port "([^"]*)" should be (open|closed)$/) do |port, selection|
+  output, _code = $server.run("ss -l --numeric | grep #{port}  || echo 'closed'", check_errors: false)
+  case selection
+  when 'open'
+    raise "Port '#{port}' not open although it should be!" if output == "closed\n"
+  when 'closed'
+    raise "Port '#{port}' open although it should not be!" if output != "closed\n"
+  end
+end

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1344,7 +1344,7 @@ When(/^I schedule a task to update ReportDB$/) do
 end
 
 Then(/^port "([^"]*)" should be (open|closed)$/) do |port, selection|
-  output, _code = $server.run("ss -l --numeric | grep #{port}  || echo 'closed'", check_errors: false)
+  output, _code = $server.run("ss --listening --numeric | grep #{port}  || echo 'closed'", check_errors: false)
   case selection
   when 'open'
     raise "Port '#{port}' not open although it should be!" if output == "closed\n"


### PR DESCRIPTION
## What does this PR change?

This will add a step to be able to check if ports are open/closed.
Furthermore it will address one issue found in the testsuite regarding
checking the Taskomatic/Tomcat configuration file for a configuration
line for monitoring via JMX that is always present.
Now we only check if the desired ports for Taskomatic (3334) and Tomacat
(3333) are open or not instead of grepping for contents in their
configuration files.

@renner did the changes in sumaform already: https://github.com/uyuni-project/sumaform/pull/1109


## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links

Manager 4.2
Manager 4.1
Sumaform changes: https://github.com/uyuni-project/sumaform/pull/1109
PR CI test: https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-prs-ci-tests/1348/#showFailuresLink

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
