### PR TITLE
Add python3-contextvars and python3-immutables to missing bootstrap repos (bsc#1200606)

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -388,6 +388,8 @@ RES8 = [
     "python3-pytz",
     "python3-setuptools",
     "python3-distro",
+    "python3-immutables",
+    "python3-contextvars",
     "venv-salt-minion",
 ]
 
@@ -614,6 +616,8 @@ PKGLISTUBUNTU1804 = [
     "python3-distro",
     "python3-gnupg",
     "gnupg",
+    "python3-immutables",
+    "python3-contextvars",
     "venv-salt-minion",
 ]
 
@@ -634,6 +638,8 @@ PKGLISTUBUNTU2004 = [
     "salt-common",
     "salt-minion",
     "gnupg",
+    "python3-immutables",
+    "python3-contextvars",
     "venv-salt-minion",
 ]
 
@@ -756,6 +762,8 @@ PKGLISTDEBIAN10 = [
     "salt-common",
     "salt-minion",
     "gnupg",
+    "python3-immutables",
+    "python3-contextvars",
     "venv-salt-minion",
 ]
 

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -638,8 +638,6 @@ PKGLISTUBUNTU2004 = [
     "salt-common",
     "salt-minion",
     "gnupg",
-    "python3-immutables",
-    "python3-contextvars",
     "venv-salt-minion",
 ]
 
@@ -762,8 +760,6 @@ PKGLISTDEBIAN10 = [
     "salt-common",
     "salt-minion",
     "gnupg",
-    "python3-immutables",
-    "python3-contextvars",
     "venv-salt-minion",
 ]
 

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Add python3-contextvars and python3-immutables to missing bootstrap repos (bsc#1200606)
 - Update server-migrator to dist-upgrade to openSUSE 15.4
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

This PR adds missing `python3-immutables` and `python3-contextvars` to bootstrap repository definition of RES8 and Ubuntu 18.04, as all those OSes will get Salt 3004 as new Salt version.

**NOTE: These two dependencies are not required for OS with Python version higher than 3.7, like Ubuntu 20.04 and Debian 10**

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/18152

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
