### PR TITLE
QE: Fixup for #5566 for open/closed ports

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1344,7 +1344,7 @@ When(/^I schedule a task to update ReportDB$/) do
 end
 
 Then(/^port "([^"]*)" should be (open|closed)$/) do |port, selection|
-  output, _code = $server.run("ss --listening --numeric | grep #{port}  || echo 'closed'", check_errors: false)
+  output, _code = $server.run("lsof -i -P -n  | grep #{port}  || echo 'closed'", check_errors: false)
   case selection
   when 'open'
     raise "Port '#{port}' not open although it should be!" if output == "closed\n"


### PR DESCRIPTION
## What does this PR change?

With the `lsof` command we get a better result/detection of open/closed port compared to `ss` with our Ruby code.

This was a run on the Uyuni CI controller. 
```bash
 Scenario: Check that monitoring is enabled                                                                                      # features/secondary/srv_monitoring.feature:
(...)
    And file "/usr/lib/systemd/system/tomcat.service.d/jmx.conf" should contain "jmx_prometheus_javaagent.jar=5556" on server     # features/step_definitions/command_steps.rb:410
    And file "/usr/lib/systemd/system/taskomatic.service.d/jmx.conf" should contain "jmx_prometheus_javaagent.jar=5557" on server # features/step_definitions/command_steps.rb:410
    And port "3333" should be closed                                                                                              # features/step_definitions/common_steps.rb:1346
    And port "3334" should be closed                                                                                              # features/step_definitions/common_steps.rb:1346
    And port "5556" should be open                                                                                                # features/step_definitions/common_steps.rb:1346
    And port "5557" should be open                                                                                                # features/step_definitions/common_steps.rb:1346
      This scenario took: 10 seconds
```

## GUI diff

No difference.


- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links

Previous PR: https://github.com/uyuni-project/uyuni/pull/5566
Manager 4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
