### PR TITLE
QE: Use the same timeout for XML-RPC and HTTP

### DIFF
--- a/testsuite/features/support/http_client.rb
+++ b/testsuite/features/support/http_client.rb
@@ -7,7 +7,7 @@ require 'faraday'
 class HttpClient
   def initialize(host)
     puts 'Activating HTTP API'
-    @http_client = Faraday.new('https://' + host)
+    @http_client = Faraday.new('https://' + host, request: { timeout: DEFAULT_TIMEOUT })
   end
 
   def prepare_call(name, params)


### PR DESCRIPTION
## What does this PR change?

Actions like reboot can take a lot of time. See https://bugzilla.suse.com/show_bug.cgi?id=1200506 .

This PR aligns the timeout for the HTTP API with the one for XML-RPC.


## Links

No backports, head only.
Fixes: https://github.com/SUSE/spacewalk/issues/18133


## Changelogs

- [x] No changelog needed
