### PR TITLE
Fix bootstrapping for Ubuntu 18.04 with classic Salt package (bsc#1200707)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -144,6 +144,9 @@ salt-minion-package:
     - require:
       - file: bootstrap_repo
 
+{# These two dependencies are only needed on DEB based distros with Python version < 3.7 #}
+{# We cannot make these packages as hard depedendencies for Salt package because this is only needed for Ubuntu 18.04 #}
+{# and we only maintain a single DEB package for all DEB based distros #}
 {% if salt_minion_name == 'salt-minion' and grains['os_family'] == 'Debian' and grains['pythonversion'][0] >= 3 and grains['pythonversion'][1] < 7 %}
 salt-install-contextvars:
   pkg.installed:

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -144,6 +144,16 @@ salt-minion-package:
     - require:
       - file: bootstrap_repo
 
+{% if salt_minion_name == 'salt-minion' and grains['os_family'] == 'Debian' and grains['pythonversion'][0] >= 3 and grains['pythonversion'][1] < 7 %}
+salt-install-contextvars:
+  pkg.installed:
+    - name: python3-contextvars
+    - install_recommends: False
+    - require:
+      - file: bootstrap_repo
+      - pkg: salt-minion-package
+{% endif %}
+
 {{ salt_config_dir }}/minion.d/susemanager.conf:
   file.managed:
     - source:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix bootstrapping for Ubuntu 18.04 with classic Salt package (bsc#1200707)
 - create CA certificate symlink on Proxies which might get lost due
   to de-installation of the ca package
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue on bootstrapping with classic Salt 3004 package for Ubuntu 18.04 caused by missing `python3-contextvars` and `python3-immutables`not being installed during bootstrapping.

These packages are set as "Recommends" in the Salt DEB package, because we have only a single DEB package we build for all OSes based distros. These two dependencies are supposed to get installed automatically during bootstrapping (as recommends are installed by default), but this is not happening because bootstrapping explicitely disabling adding recommended packages.

In the end, since we cannot add these two packages as hard dependencies for Salt in DEB based distros as those packages are not existing in, i.a., Ubuntu 20.04, what we are doing with this PR is to make boostrapping to also explicitely install the two dependencies if we are installing `salt-minion` (classic package) in a DEB based distro with Python version < 3.7 (where these deps are expected).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/18177

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
