### PR TITLE
Move ImageSync pillars to database

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/image/ImageInfoFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/image/ImageInfoFactory.java
@@ -498,6 +498,28 @@ public class ImageInfoFactory extends HibernateFactory {
     }
 
     /**
+     * Lookup an image info by name, version, revision and org.
+     *
+     * @param name             the name
+     * @param version          the version/tag
+     * @param revision         the revision number
+     * @param org              the organization
+     * @return the optional ImageInfo
+     */
+    public static Optional<ImageInfo> lookupByName(String name, String version, long revision, Org org) {
+        CriteriaBuilder builder = getSession().getCriteriaBuilder();
+        CriteriaQuery<ImageInfo> query = builder.createQuery(ImageInfo.class);
+
+        Root<ImageInfo> root = query.from(ImageInfo.class);
+        query.where(builder.and(
+                builder.equal(root.get("name"), name),
+                builder.equal(root.get("version"), version),
+                builder.equal(root.get("revisionNumber"), revision),
+                builder.equal(root.get("org"), org)));
+        return getSession().createQuery(query).uniqueResultOptional();
+    }
+
+    /**
      * List all image overviews from a given organization
      * @param org the organization
      * @return Returns a list of ImageProfiles

--- a/java/code/src/com/redhat/rhn/domain/server/Pillar.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Pillar.java
@@ -330,7 +330,7 @@ public class Pillar implements Identifiable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, minion, org, group, category, pillar);
+        return Objects.hash(minion, org, group, category);
     }
 }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Move ImageSync pillars to database (bsc#1199157)
 - Convert formula integer values when upgrading (bsc#1200347)
 - Cleanup salt known_hosts when generating proxy containers config
 - Modify proxy containers configuration files set output

--- a/schema/spacewalk/postgres/triggers/suseImageInfo.sql
+++ b/schema/spacewalk/postgres/triggers/suseImageInfo.sql
@@ -27,6 +27,7 @@ execute procedure suse_imginfo_mod_trig_fun();
 CREATE OR REPLACE FUNCTION suse_image_info_image_removed_trig_fun() RETURNS TRIGGER AS $$
 BEGIN
   DELETE FROM suseSaltPillar WHERE id = OLD.pillar_id;
+  DELETE FROM suseSaltPillar WHERE category = concat('SyncedImage', OLD.id);
   RETURN OLD;
 END $$ LANGUAGE PLPGSQL;
 

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,5 @@
+- Move ImageSync pillars to database (bsc#1199157)
+
 -------------------------------------------------------------------
 Mon May 30 14:59:28 CEST 2022 - jgonzalez@suse.com
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.12-to-susemanager-schema-4.3.13/110-suseImageInfo_del_pillar.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.12-to-susemanager-schema-4.3.13/110-suseImageInfo_del_pillar.sql
@@ -1,0 +1,6 @@
+CREATE OR REPLACE FUNCTION suse_image_info_image_removed_trig_fun() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM suseSaltPillar WHERE id = OLD.pillar_id;
+  DELETE FROM suseSaltPillar WHERE category = concat('SyncedImage', OLD.id);
+  RETURN OLD;
+END $$ LANGUAGE PLPGSQL;


### PR DESCRIPTION
## What does this PR change?

This PR moves image sync pillars to database. 
It creates/deletes the pillar for given group according to events sent by the branch server. Before, the pillars were created as files, now they are in DB.

For normal images it uses category `"SyncedImage" + ID`. The pillar is deleted with the image by a trigger.

There can be also legacy images which are not referenced in the database. For such images it uses category  `"LegacySyncedImage" - Name - Version`.

The second commit fixes the hashCode method of Pillar class.
When the hash was calculated from ID and pillar, it could change during object lifetime and patterns like this do not work:
```
  branch.getPillarByCategory(category).orElseGet(() -> {
                Pillar pillar = new Pillar(category, Collections.emptyMap(), branch);
                branch.getPillars().add(pillar);
                return pillar;
            }).setPillar(topPillar);

...
   branch.getPillarByCategory(category).ifPresent(pillar -> branch.getPillars().remove(pillar));
```

## GUI diff

No difference.

## Documentation
- No documentation needed: not an user visible change

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17715

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
