### PR TITLE
Pass Profile and build host Id as a number (bsc#1199659)

### DIFF
--- a/java/code/src/com/suse/manager/webui/templates/content_management/build.jade
+++ b/java/code/src/com/suse/manager/webui/templates/content_management/build.jade
@@ -4,8 +4,8 @@ include ../common.jade
 
 script(type='text/javascript').
     window.csrfToken = "#{csrf_token}";
-    window.profileId = "#{profileId}";
-    window.hostId = "#{hostId}";
+    window.profileId = #{profileId ? profileId : "null"};
+    window.hostId = #{hostId ? hostId : "null"};
     window.version = "#{version}";
     window.timezone = "#{h.renderTimezone()}";
     window.localTime = "#{h.renderLocalTime()}";

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix initial profile and build host on Image Build page (bsc#1199659)
 - Convert formula integer values when upgrading (bsc#1200347)
 - Cleanup salt known_hosts when generating proxy containers config
 - Modify proxy containers configuration files set output

--- a/web/html/src/manager/images/image-build.tsx
+++ b/web/html/src/manager/images/image-build.tsx
@@ -20,8 +20,8 @@ import Network from "utils/network";
 // See java/code/src/com/suse/manager/webui/templates/content_management/build.jade
 declare global {
   interface Window {
-    profileId?: any;
-    hostId?: any;
+    profileId?: number;
+    hostId?: number;
     version?: any;
     timezone?: any;
     localTime?: any;
@@ -48,8 +48,8 @@ type State = {
   model: {
     version: string;
     earliest: moment.Moment;
-    profileId?: any;
-    buildHostId?: any;
+    profileId?: number;
+    buildHostId?: number;
     actionChain?: any;
   };
   profile: any;

--- a/web/html/src/manager/images/image-profile-edit.tsx
+++ b/web/html/src/manager/images/image-profile-edit.tsx
@@ -20,7 +20,7 @@ import Network from "utils/network";
 // See java/code/src/com/suse/manager/webui/templates/content_management/edit-profile.jade
 declare global {
   interface Window {
-    profileId?: any;
+    profileId?: number;
     activationKeys?: any;
     customDataKeys?: any;
     imageTypesDataFromTheServer?: any;

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix initial profile and build host on Image Build page (bsc#1199659)
 - Handle multi line error messages in proxy containers config creation
 - Hide authentication data in PAYG UI (bsc#1199679)
 - add textarea to formulas


### PR DESCRIPTION
## What does this PR change?

Profile ID and Host ID  were passed to javascript as strings in jade template, but the API returns numbers.
As a result, the comparison === in Select component did not match.

With this PR it uses numbers consistently.

## GUI diff

No difference.

## Documentation
- No documentation needed: bugfix

## Test coverage
- No tests: 

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17901

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
