### PR TITLE
QE: Fixup for checking open/closed ports

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1332,11 +1332,11 @@ When(/^I schedule a task to update ReportDB$/) do
 end
 
 Then(/^port "([^"]*)" should be (open|closed)$/) do |port, selection|
-  output, _code = $server.run("lsof -i -P -n  | grep #{port}  || echo 'closed'", check_errors: false)
-  case selection
-  when 'open'
-    raise "Port '#{port}' not open although it should be!" if output == "closed\n"
-  when 'closed'
-    raise "Port '#{port}' open although it should not be!" if output != "closed\n"
+  _output, code = $server.run("ss --listening --numeric | grep :#{port}", check_errors: false, verbose: true)
+  port_opened = code.zero?
+  if selection == 'closed'
+    raise "Port '#{port}' open although it should not be!" if port_opened
+  else
+    raise "Port '#{port}' not open although it should be!" unless port_opened
   end
 end


### PR DESCRIPTION
## What does this PR change?

`ss` gives the better output than `lsof`, especially when we have a small port number in a higher one:

```bash
head-srv:~ # lsof -i -P -n | grep 3333
postgres  13333   postgres   10u  IPv6 174132      0t0  UDP [::1]:50162->[::1]:50162 
postgres  13333   postgres   11u  IPv4 593821      0t0  TCP 127.0.0.1:5432->127.0.0.1:34556 (ESTABLISHED)


head-srv:~ # ss --listening --numeric | grep 3333

```

- CI PR run: https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-prs-ci-tests/1460/
- Issue: https://github.com/SUSE/spacewalk/issues/18314

## GUI diff

No difference.


- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18314
Needs: https://github.com/SUSE/spacewalk/issues/18459
Manager 4.1
Manager 4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
