### PR TITLE
pg-migrate-x-to-y.sh migration without creating backup use -f option

### DIFF
--- a/susemanager/bin/pg-migrate-x-to-y.sh
+++ b/susemanager/bin/pg-migrate-x-to-y.sh
@@ -103,7 +103,7 @@ else
         echo "$(timestamp)   A fast migration does not need this additional diskspace, because"
         echo "$(timestamp)   database files will be hardlinked instead of copied."
         echo
-        echo "$(timestamp)   If you have a backup of the database, run \"$0 fast\""
+        echo "$(timestamp)   If you have a backup of the database, run \"$0 -f\""
         echo
         exit 1
     else

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,6 @@
+- fix pg-migrate-x-to-y.sh comment: migration without creating backup 
+  use -f option
+
 -------------------------------------------------------------------
 Tue Jun 21 18:32:40 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

`pg-migrate-x-to-y.sh` suggests to use the `fast` mode if the disk does not have enough space to store the db backup.  The fast mode can be running `/usr/lib/susemanager/bin/pg-migrate-x-to-y.sh -f` instead of `/usr/lib/susemanager/bin/pg-migrate-x-to-y.sh fast` as suggested by the comment.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Doc PR: https://github.com/uyuni-project/uyuni-docs/pull/1621

- [x] **DONE**

## Test coverage

- [x] **DONE**

## Links


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
