### PR TITLE
Back to 12 SP4 as SP5 conflicts with later tests

### DIFF
--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -26,20 +26,20 @@ Feature: Be able to list available channels and enable them
 @susemanager
   Scenario: List products
     When I execute mgr-sync "list products"
-    Then I should get "[ ] SUSE Linux Enterprise Server 12 SP5 x86_64"
+    Then I should get "[ ] SUSE Linux Enterprise Server 12 SP4 x86_64"
     And I should get "[ ] SUSE Manager Proxy 4.1 x86_64"
 
 @susemanager
   Scenario: List all products for SUSE Manager
     When I execute mgr-sync "list products --expand"
-    Then I should get "[ ] SUSE Linux Enterprise Server 12 SP5 x86_64"
+    Then I should get "[ ] SUSE Linux Enterprise Server 12 SP4 x86_64"
     And I should get "[ ] SUSE Manager Proxy 4.1 x86_64"
     And I should get "  [ ] (R) SUSE Manager Client Tools for RHEL and ES 7 x86_64"
     And I should get "  [ ] (R) SUSE Manager Client Tools for SLE 15 x86_64"
 
   Scenario: List products with filter
     When I execute mgr-sync "list products --expand --filter x86_64"
-    Then I should get "[ ] SUSE Linux Enterprise Server 12 SP5 x86_64"
+    Then I should get "[ ] SUSE Linux Enterprise Server 12 SP4 x86_64"
     And I shouldn't get "ppc64"
     And I shouldn't get "s390x"
 
@@ -51,18 +51,18 @@ Feature: Be able to list available channels and enable them
     And I should see "Repo URL:" in the output
 
   Scenario: Enable a real base channel
-    When I execute mgr-sync "add channel sles12-sp5-pool-x86_64"
+    When I execute mgr-sync "add channel sles12-sp4-pool-x86_64"
     And I execute mgr-sync "list channels"
-    Then I should get "[I] SLES12-SP5-Pool for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 [sles12-sp5-pool-x86_64]"
-    And I should get "    [I] SLES12-SP5-Updates for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 [sles12-sp5-updates-x86_64]"
-    And I should get "    [ ] SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp5]"
+    Then I should get "[I] SLES12-SP4-Pool for x86_64 SUSE Linux Enterprise Server 12 SP4 x86_64 [sles12-sp4-pool-x86_64]"
+    And I should get "    [I] SLES12-SP4-Updates for x86_64 SUSE Linux Enterprise Server 12 SP4 x86_64 [sles12-sp4-updates-x86_64]"
+    And I should get "    [ ] SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp4]"
 
   Scenario: Enable a real child channel
-    When I execute mgr-sync "add channel sle-module-containers12-pool-x86_64-sp5"
+    When I execute mgr-sync "add channel sle-module-containers12-pool-x86_64-sp4"
     And I execute mgr-sync "list channels"
-    Then I should get "[I] SLES12-SP5-Pool for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 [sles12-sp5-pool-x86_64]"
-    And I should get "    [I] SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp5]"
-    And I should get "    [I] SLE-Module-Containers12-Updates for x86_64 Containers Module 12 x86_64 [sle-module-containers12-updates-x86_64-sp5]"
+    Then I should get "[I] SLES12-SP4-Pool for x86_64 SUSE Linux Enterprise Server 12 SP4 x86_64 [sles12-sp4-pool-x86_64]"
+    And I should get "    [I] SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp4]"
+    And I should get "    [I] SLE-Module-Containers12-Updates for x86_64 Containers Module 12 x86_64 [sle-module-containers12-updates-x86_64-sp4]"
 
   Scenario: Let mgr-sync time out
     When I remove the mgr-sync cache file


### PR DESCRIPTION
## What does this PR change?

Partial revert of previous PR.

We can't add SP5 twice - and we add it in later tests :disappointed: .


## Links

Ports:
* 4.2:
* 4.1:


## Changelogs

- [x] No changelog needed
