### PR TITLE
Mirror the complete pub folder in containerized proxy

### DIFF
--- a/containers/proxy-httpd-image/proxy-httpd-image.changes
+++ b/containers/proxy-httpd-image/proxy-httpd-image.changes
@@ -1,3 +1,4 @@
+- Mirror the whole server pub folder (bsc#1199802)
 - Modify proxy containers configuration files set output
 
 -------------------------------------------------------------------

--- a/containers/proxy-httpd-image/uyuni-configure.py
+++ b/containers/proxy-httpd-image/uyuni-configure.py
@@ -139,6 +139,9 @@ with open(config_path + "httpd.yaml") as httpdSource:
 WSGIScriptAlias /tftpsync/add /srv/www/tftpsync/add
 WSGIScriptAlias /tftpsync/delete /srv/www/tftpsync/delete''')
 
+    with open("/etc/apache2/conf.d/susemanager-pub.conf", "w") as file:
+        file.write("WSGIScriptAlias /pub /usr/share/rhn/wsgi/xmlrpc.py")
+
     with open("/etc/apache2/conf.d/saltboot.conf", "w") as file:
         # Saltboot uses the same URL regardles containerized or normal proxy
         # here we rewrite URL so upstream server understands it


### PR DESCRIPTION
## What does this PR change?

Since the user cannot call mgr-bootstrap on the containerized proxies,
mirror the complete /pub folder to get the server SSL cert and the
/pub/bootstrap folder content. (bsc#1199802)

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: proxy containers are not yet tested automatically

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17942

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
