### PR TITLE
Fixed unexpected unauthorized when using HTTP API

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/session/SessionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/session/SessionManager.java
@@ -85,6 +85,7 @@ public class SessionManager extends BaseManager {
 
         s.setExpires(TimeUtils.currentTimeSeconds() + duration);
         WebSessionFactory.save(s);
+        WebSessionFactory.getSession().flush();
         return s;
     }
 


### PR DESCRIPTION
## What does this PR change?

It adds a `commitTransaction` call just after saving the WebSession during user authentication.

Without this, in some random situations, [this call](https://github.com/uyuni-project/uyuni/blob/master/java/code/src/com/redhat/rhn/domain/session/WebSessionFactory.java#L63) to get WebSession by its id returned null, even this WebSession being saved just some fractions of second before.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18176

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_pgsql_tests"    
- [ ] Re-run test "schema_migration_test_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "susemanager_unittests" (Test skipped, there are no changes to test)
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
