### PR TITLE
Fix typo and ordering of HTTP API example scripts

### DIFF
--- a/java/buildconf/apidoc/asciidoc/scripts.txt
+++ b/java/buildconf/apidoc/asciidoc/scripts.txt
@@ -1,5 +1,144 @@
 = Sample Scripts
 
+== JSON over HTTP API scripts
+
+=== HTTP login with Curl
+
+Below is an example of the login process using an authentication token with the JSON over HTTP API.
+
+The JSON over HTTP API uses authentication tokens for access. The token is sent in a
+cookie called `pxt-session-cookie` in a response to a call to the `auth.login` endpoint.
+The `auth.login` endpoint accepts a POST request with a JSON body that has `login` and
+`password` properties in a top-level object.
+
+[source,bash]
+----
+$ API=https://manager.example.com/rhn/manager/api
+$ curl -H "Content-Type: application/json" -d '{"login": "myusername", "password": "mypass"}' -i $API/auth/login
+
+HTTP/1.1 200 200
+...
+Set-Cookie: pxt-session-cookie=&lt;tokenhash&gt;; ...
+...
+{"success":true,"messages":[]}
+----
+
+Once the login is successful, the retrieved cookie must be added to each subsequent request for authenticated access.
+
+
+=== HTTP GET example
+
+Below is an example of an HTTP GET call to the `contentmanagement.lookupProject` API.
+In a GET request, method parameters must be sent as query string key-value pairs.
+
+_The JSON output is pretty-printed for clarity._
+
+[source,bash]
+----
+$ API=https://manager.example.com/rhn/manager/api
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
+> $API/contentmanagement/lookupProject?projectLabel=myproject
+{
+  "success": true,
+  "result": {
+    "name": "My Project",
+    "description": "My CLM project",
+    "id": 1,
+    "label": "myproject",
+    "orgId": 1
+  }
+}
+----
+
+
+=== HTTP POST example
+
+Below is an example of an HTTP POST call to the `contentmanagement.createProject` API.
+In a POST request, method parameters can be sent as query string key-value pairs, as a JSON object in the request body, or a mix of both. `object` type parameters cannot be represented as a query string element and therefore must be sent in the request body.
+The following examples show both approaches.
+
+_The JSON output is pretty-printed for clarity._
+
+==== Using the query string
+
+[source,bash]
+----
+$ API=https://manager.example.com/rhn/manager/api
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" -X POST \
+> "$API/contentmanagement/createProject?projectLabel=myproject&name=My%20Project&description="
+{
+  "success": true,
+  "result": {
+    "name": "My Project",
+    "id": 1,
+    "label": "myproject",
+    "orgId": 1
+  }
+}
+----
+
+==== Using the request body
+
+The request body must be a top-level JSON object that contains all the parameters as its properties.
+
+[source,bash]
+----
+$ API=https://manager.example.com/rhn/manager/api
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
+> -d '{"projectLabel":"myproject","name":"My Project","description":""}' \
+> $API/contentmanagement/createProject
+{
+  "success": true,
+  "result": {
+    "name": "My Project",
+    "id": 1,
+    "label": "myproject",
+    "orgId": 1
+  }
+}
+----
+
+
+===Python 3 example
+
+Below is an example of the `system.listActiveSystems` call being used.
+
+[source,python]
+----
+#!/usr/bin/env python3
+import requests
+import pprint
+
+MANAGER_URL = "https://manager.example.com/rhn/manager/api"
+MANAGER_LOGIN = "username"
+MANAGER_PASSWORD = "password"
+SSLVERIFY = "/path/to/CA" # or False to disable verify;
+
+data = {"login": MANAGER_LOGIN, "password": MANAGER_PASSWORD}
+response = requests.post(MANAGER_URL + '/auth/login', json=data, verify=SSLVERIFY)
+print("LOGIN: {}:{}".format(response.status_code, response.json()))
+
+cookies = response.cookies
+res2 = requests.get(MANAGER_URL + '/system/listActiveSystems', cookies=cookies, verify=SSLVERIFY)
+print("RETCODE: {}".format(res2.status_code))
+pprint.pprint(res2.json())
+
+sysinfo = res2.json()['result'][0]
+
+note = {"sid": sysinfo['id'], "subject": "Title", "body": "Content of the Note"}
+res2 = requests.post(MANAGER_URL + '/system/addNote', json=note, cookies=cookies, verify=SSLVERIFY)
+print("RETCODE: {}".format(res2.status_code))
+pprint.pprint(res2.json())
+
+res2 = requests.get(MANAGER_URL + '/system/listNotes?sid={}'.format(sysinfo['id']), cookies=cookies, verify=SSLVERIFY)
+print("RETCODE: {}".format(res2.status_code))
+pprint.pprint(res2.json())
+
+res2 = requests.post(MANAGER_URL + '/auth/logout', cookies=cookies, verify=SSLVERIFY)
+print("RETCODE: {}".format(res2.status_code))
+pprint.pprint(res2.json())
+----
+
 == XMLRPC Scripts
 
 === Perl Example
@@ -146,144 +285,4 @@ for channel in channels do
 end
 
 @client.call('auth.logout', @key)
-----
-
-
-== HTTP over JSON API scripts
-
-=== HTTP login with Curl
-
-Below is an example of the login process using an authentication token with the HTTP over JSON API.
-
-The HTTP over JSON API uses authentication tokens for access. The token is sent in a
-cookie called `pxt-session-cookie` in a response to a call to the `auth.login` endpoint.
-The `auth.login` endpoint accepts a POST request with a JSON body that has `login` and
-`password` properties in a top-level object.
-
-[source,bash]
-----
-$ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" -d '{"login": "myusername", "password": "mypass"}' -i $API/auth/login
-
-HTTP/1.1 200 200
-...
-Set-Cookie: pxt-session-cookie=&lt;tokenhash&gt;; ...
-...
-{"success":true,"messages":[]}
-----
-
-Once the login is successful, the retrieved cookie must be added to each subsequent request for authenticated access.
-
-
-=== HTTP GET example
-
-Below is an example of an HTTP GET call to the `contentmanagement.lookupProject` API.
-In a GET request, method parameters must be sent as query string key-value pairs.
-
-_The JSON output is pretty-printed for clarity._
-
-[source,bash]
-----
-$ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
-> $API/contentmanagement/lookupProject?projectLabel=myproject
-{
-  "success": true,
-  "result": {
-    "name": "My Project",
-    "description": "My CLM project",
-    "id": 1,
-    "label": "myproject",
-    "orgId": 1
-  }
-}
-----
-
-
-=== HTTP POST example
-
-Below is an example of an HTTP POST call to the `contentmanagement.createProject` API.
-In a POST request, method parameters can be sent as query string key-value pairs, as a JSON object in the request body, or a mix of both. `object` type parameters cannot be represented as a query string element and therefore must be sent in the request body.
-The following examples show both approaches.
-
-_The JSON output is pretty-printed for clarity._
-
-==== Using the query string
-
-[source,bash]
-----
-$ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" -X POST \
-> "$API/contentmanagement/createProject?projectLabel=myproject&name=My%20Project&description="
-{
-  "success": true,
-  "result": {
-    "name": "My Project",
-    "id": 1,
-    "label": "myproject",
-    "orgId": 1
-  }
-}
-----
-
-==== Using the request body
-
-The request body must be a top-level JSON object that contains all the parameters as its properties.
-
-[source,bash]
-----
-$ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
-> -d '{"projectLabel":"myproject","name":"My Project","description":""}' \
-> $API/contentmanagement/createProject
-{
-  "success": true,
-  "result": {
-    "name": "My Project",
-    "id": 1,
-    "label": "myproject",
-    "orgId": 1
-  }
-}
-----
-
-
-===Python 3 example
-
-Below is an example of the `system.listActiveSystems` call being used.
-
-[source,python]
-----
-#!/usr/bin/env python3
-import requests
-import pprint
-
-MANAGER_URL = "https://manager.example.com/rhn/manager/api"
-MANAGER_LOGIN = "username"
-MANAGER_PASSWORD = "password"
-SSLVERIFY = "/path/to/CA" # or False to disable verify;
-
-data = {"login": MANAGER_LOGIN, "password": MANAGER_PASSWORD}
-response = requests.post(MANAGER_URL + '/auth/login', json=data, verify=SSLVERIFY)
-print("LOGIN: {}:{}".format(response.status_code, response.json()))
-
-cookies = response.cookies
-res2 = requests.get(MANAGER_URL + '/system/listActiveSystems', cookies=cookies, verify=SSLVERIFY)
-print("RETCODE: {}".format(res2.status_code))
-pprint.pprint(res2.json())
-
-sysinfo = res2.json()['result'][0]
-
-note = {"sid": sysinfo['id'], "subject": "Title", "body": "Content of the Note"}
-res2 = requests.post(MANAGER_URL + '/system/addNote', json=note, cookies=cookies, verify=SSLVERIFY)
-print("RETCODE: {}".format(res2.status_code))
-pprint.pprint(res2.json())
-
-res2 = requests.get(MANAGER_URL + '/system/listNotes?sid={}'.format(sysinfo['id']), cookies=cookies, verify=SSLVERIFY)
-print("RETCODE: {}".format(res2.status_code))
-pprint.pprint(res2.json())
-
-res2 = requests.post(MANAGER_URL + '/auth/logout', cookies=cookies, verify=SSLVERIFY)
-print("RETCODE: {}".format(res2.status_code))
-pprint.pprint(res2.json())
 ----

--- a/java/buildconf/apidoc/docbook/scripts.txt
+++ b/java/buildconf/apidoc/docbook/scripts.txt
@@ -4,136 +4,12 @@
 <preface>
 <title>Sample Scripts</title>
 <section>
-<title>XMLRPC Scripts</title>
-<example>
-    <title>Perl Example</title>
-    <para>This Perl example shows the <function>system.listUserSystems</function> call being used to get a
-list of systems a user has access to. In the example below, the name of each system will be printed.</para>
-    <programlisting>#!/usr/bin/perl
-use Frontier::Client;
-
-my $HOST = 'manager.example.com';
-my $user = 'username';
-my $pass = 'password';
-
-my $client = new Frontier::Client(url => "http://$HOST/rpc/api");
-my $session = $client->call('auth.login',$user, $pass);
-
-my $systems = $client->call('system.listUserSystems', $session);
-foreach my $system (@$systems) {
-   print $system->{'name'}."\n";
-}
-$client->call('auth.logout', $session);</programlisting>
-</example>
-
-<example>
-    <title>Python 2 Example</title>
-    <para>Below is an example of the <function>user.listUsers</function> call being used. Only the login of each
-user is printed.</para>
-    <programlisting>#!/usr/bin/python
-import xmlrpclib
-
-MANAGER_URL = "http://manager.example.com/rpc/api"
-MANAGER_LOGIN = "username"
-MANAGER_PASSWORD = "password"
-
-client = xmlrpclib.Server(MANAGER_URL, verbose=0)
-
-key = client.auth.login(MANAGER_LOGIN, MANAGER_PASSWORD)
-list = client.user.list_users(key)
-for user in list:
-  print user.get('login')
-
-client.auth.logout(key)</programlisting>
-    <para>The following code shows how to use date-time parameters. This code will schedule immediate installation of package rhnlib-2.5.22.9.el6.noarch to system with id 1000000001.</para>
-    <programlisting>#!/usr/bin/python
-from datetime import datetime
-import time
-import xmlrpclib
-
-MANAGER_URL = "http://manager.example.com/rpc/api"
-MANAGER_LOGIN = "username"
-MANAGER_PASSWORD = "password"
-
-client = xmlrpclib.Server(MANAGER_URL, verbose=0)
-
-key = client.auth.login(MANAGER_LOGIN, MANAGER_PASSWORD)
-package_list = client.packages.findByNvrea(key, 'rhnlib', '2.5.22', '9.el6', '', 'noarch')
-today = datetime.today()
-earliest_occurrence = xmlrpclib.DateTime(today)
-client.system.schedulePackageInstall(key, 1000000001, package_list[0]['id'], earliest_occurrence)
-
-client.auth.logout(key)</programlisting>
-</example>
-
-<example>
-    <title>Python 3 with SSL Example</title>
-    <para>Below is an example of the <function>user.listUsers</function> call being called.</para>
-    <programlisting>#!/usr/bin/env python3
-from xmlrpc.client import ServerProxy
-import ssl
-
-MANAGER_URL = "https://manager.example.com/rpc/api"
-MANAGER_LOGIN = "username"
-MANAGER_PASSWORD = "password"
-
-# You might need to set to set other options depending on your
-# server SSL configuartion and your local SSL configuration
-context = ssl.create_default_context()
-client = ServerProxy(MANAGER_URL, context=context)
-key = client.auth.login(MANAGER_LOGIN, MANAGER_PASSWORD)
-
-print(client.user.list_users(key))
-
-client.auth.logout(key)</programlisting>
-</example>
-
-<example>
-    <title>Python 3 Example</title>
-    <para>Below is an example of the <function>user.listUsers</function> call being called.</para>
-    <programlisting>#!/usr/bin/env python3
-from xmlrpc.client import ServerProxy
-
-MANAGER_URL = "http://manager.example.com/rpc/api"
-MANAGER_LOGIN = "username"
-MANAGER_PASSWORD = "password"
-
-client = ServerProxy(MANAGER_URL)
-key = client.auth.login(MANAGER_LOGIN, MANAGER_PASSWORD)
-
-print(client.user.list_users(key))
-
-client.auth.logout(key)</programlisting>
-</example>
-
-<example>
-    <title>Ruby Example</title>
-    <para>Below is an example of the <function>channel.listAllChannels</function> API call. List of channel labels is printed.</para>
-    <programlisting>#!/usr/bin/ruby
-require "xmlrpc/client"
-
-@MANAGER_URL = "http://manager.example.com/rpc/api"
-@MANAGER_LOGIN = "username"
-@MANAGER_PASSWORD = "password"
-
-@client = XMLRPC::Client.new2(@MANAGER_URL)
-
-@key = @client.call('auth.login', @MANAGER_LOGIN, @MANAGER_PASSWORD)
-channels = @client.call('channel.listAllChannels', @key)
-for channel in channels do
-   p channel["label"]
-end
-
-@client.call('auth.logout', @key)</programlisting>
-</example>
-</section>
-<section>
-<title>HTTP over JSON API scripts</title>
+<title>JSON over HTTP API scripts</title>
 
 <example>
     <title>HTTP login with Curl</title>
-    <para>Below is an example of the login process using an authentication token with the HTTP over JSON API.</para>
-    <para>The HTTP over JSON API uses authentication tokens for access. The token is sent
+    <para>Below is an example of the login process using an authentication token with the JSON over HTTP API.</para>
+    <para>The JSON over HTTP API uses authentication tokens for access. The token is sent
     in a cookie called <function>pxt-session-cookie</function> in a response to a call to
     the <function>auth.login</function> endpoint. The <function>auth.login</function> endpoint
     accepts a POST request with a JSON body that has <function>login</function> and
@@ -260,6 +136,130 @@ pprint.pprint(res2.json())
 ]]>
     </programlisting>
 </example>
+</section>
 
+<section>
+<title>XMLRPC Scripts</title>
+<example>
+    <title>Perl Example</title>
+    <para>This Perl example shows the <function>system.listUserSystems</function> call being used to get a
+list of systems a user has access to. In the example below, the name of each system will be printed.</para>
+    <programlisting>#!/usr/bin/perl
+use Frontier::Client;
+
+my $HOST = 'manager.example.com';
+my $user = 'username';
+my $pass = 'password';
+
+my $client = new Frontier::Client(url => "http://$HOST/rpc/api");
+my $session = $client->call('auth.login',$user, $pass);
+
+my $systems = $client->call('system.listUserSystems', $session);
+foreach my $system (@$systems) {
+   print $system->{'name'}."\n";
+}
+$client->call('auth.logout', $session);</programlisting>
+</example>
+
+<example>
+    <title>Python 2 Example</title>
+    <para>Below is an example of the <function>user.listUsers</function> call being used. Only the login of each
+user is printed.</para>
+    <programlisting>#!/usr/bin/python
+import xmlrpclib
+
+MANAGER_URL = "http://manager.example.com/rpc/api"
+MANAGER_LOGIN = "username"
+MANAGER_PASSWORD = "password"
+
+client = xmlrpclib.Server(MANAGER_URL, verbose=0)
+
+key = client.auth.login(MANAGER_LOGIN, MANAGER_PASSWORD)
+list = client.user.list_users(key)
+for user in list:
+  print user.get('login')
+
+client.auth.logout(key)</programlisting>
+    <para>The following code shows how to use date-time parameters. This code will schedule immediate installation of package rhnlib-2.5.22.9.el6.noarch to system with id 1000000001.</para>
+    <programlisting>#!/usr/bin/python
+from datetime import datetime
+import time
+import xmlrpclib
+
+MANAGER_URL = "http://manager.example.com/rpc/api"
+MANAGER_LOGIN = "username"
+MANAGER_PASSWORD = "password"
+
+client = xmlrpclib.Server(MANAGER_URL, verbose=0)
+
+key = client.auth.login(MANAGER_LOGIN, MANAGER_PASSWORD)
+package_list = client.packages.findByNvrea(key, 'rhnlib', '2.5.22', '9.el6', '', 'noarch')
+today = datetime.today()
+earliest_occurrence = xmlrpclib.DateTime(today)
+client.system.schedulePackageInstall(key, 1000000001, package_list[0]['id'], earliest_occurrence)
+
+client.auth.logout(key)</programlisting>
+</example>
+
+<example>
+    <title>Python 3 with SSL Example</title>
+    <para>Below is an example of the <function>user.listUsers</function> call being called.</para>
+    <programlisting>#!/usr/bin/env python3
+from xmlrpc.client import ServerProxy
+import ssl
+
+MANAGER_URL = "https://manager.example.com/rpc/api"
+MANAGER_LOGIN = "username"
+MANAGER_PASSWORD = "password"
+
+# You might need to set to set other options depending on your
+# server SSL configuartion and your local SSL configuration
+context = ssl.create_default_context()
+client = ServerProxy(MANAGER_URL, context=context)
+key = client.auth.login(MANAGER_LOGIN, MANAGER_PASSWORD)
+
+print(client.user.list_users(key))
+
+client.auth.logout(key)</programlisting>
+</example>
+
+<example>
+    <title>Python 3 Example</title>
+    <para>Below is an example of the <function>user.listUsers</function> call being called.</para>
+    <programlisting>#!/usr/bin/env python3
+from xmlrpc.client import ServerProxy
+
+MANAGER_URL = "http://manager.example.com/rpc/api"
+MANAGER_LOGIN = "username"
+MANAGER_PASSWORD = "password"
+
+client = ServerProxy(MANAGER_URL)
+key = client.auth.login(MANAGER_LOGIN, MANAGER_PASSWORD)
+
+print(client.user.list_users(key))
+
+client.auth.logout(key)</programlisting>
+</example>
+
+<example>
+    <title>Ruby Example</title>
+    <para>Below is an example of the <function>channel.listAllChannels</function> API call. List of channel labels is printed.</para>
+    <programlisting>#!/usr/bin/ruby
+require "xmlrpc/client"
+
+@MANAGER_URL = "http://manager.example.com/rpc/api"
+@MANAGER_LOGIN = "username"
+@MANAGER_PASSWORD = "password"
+
+@client = XMLRPC::Client.new2(@MANAGER_URL)
+
+@key = @client.call('auth.login', @MANAGER_LOGIN, @MANAGER_PASSWORD)
+channels = @client.call('channel.listAllChannels', @key)
+for channel in channels do
+   p channel["label"]
+end
+
+@client.call('auth.logout', @key)</programlisting>
+</example>
 </section>
 </preface>

--- a/java/buildconf/apidoc/html/scripts.txt
+++ b/java/buildconf/apidoc/html/scripts.txt
@@ -5,6 +5,139 @@
 </head>
 <body>
 <h1><i class="fa fa-gears"><a href="../scripts.html">Sample Scripts</a></h1>
+
+<h2>JSON over HTTP API scripts</h2>
+<h3>HTTP login with Curl:</h3>
+Below is an example of the login process using an authentication token with the JSON over HTTP API.<br/>
+<br/>
+The JSON over HTTP API uses authentication tokens for access. The token is sent in a cookie called
+<code>pxt-session-cookie</code> in a response to a call to the <code>auth.login</code> endpoint. The <code>auth.login</code>
+endpoint accepts a POST request with a JSON body that has <code>login</code> and <code>password</code> properties in a top-level object.<br/>
+<p/>
+
+<pre>
+$ API=https://manager.example.com/rhn/manager/api
+$ curl -H "Content-Type: application/json" -d '{"login": "myusername", "password": "mypass"}' -i $API/auth/login
+
+HTTP/1.1 200 200
+...
+Set-Cookie: pxt-session-cookie=&lt;tokenhash&gt;; ...
+...
+{"success":true,"messages":[]}
+</pre>
+<p/>
+Once the login is successful, the retrieved cookie must be added to each subsequent request for authenticated access.<br/>
+<hr/>
+<p/>
+<h3>HTTP GET example:</h3>
+Below is an example of an HTTP GET call to the <code>contentmanagement.lookupProject</code> API.
+In a GET request, method parameters must be sent as query string key-value pairs.<br/>
+<br/>
+<em>The JSON output is pretty-printed for clarity.</em>
+<p/>
+<pre>
+$ API=https://manager.example.com/rhn/manager/api
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
+> $API/contentmanagement/lookupProject?projectLabel=myproject
+{
+  "success": true,
+  "result": {
+    "name": "My Project",
+    "description": "My CLM project",
+    "id": 1,
+    "label": "myproject",
+    "orgId": 1
+  }
+}
+</pre>
+<hr/>
+<p/>
+<h3>HTTP POST example:</h3>
+Below is an example of an HTTP POST call to the <code>contentmanagement.createProject</code> API.
+In a POST request, method parameters can be sent as query string key-value pairs, as a JSON
+object in the request body, or a mix of both. <code>object</code> type parameters cannot be
+represented as a query string element and therefore must be sent in the request body.
+The following examples show both approaches.<br/>
+<br/>
+<em>The JSON output is pretty-printed for clarity.</em>
+<p/>
+<h4>Using the query string</h4>
+<pre>
+$ API=https://manager.example.com/rhn/manager/api
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" -X POST \
+> "$API/contentmanagement/createProject?projectLabel=myproject&name=My%20Project&description="
+{
+  "success": true,
+  "result": {
+    "name": "My Project",
+    "id": 1,
+    "label": "myproject",
+    "orgId": 1
+  }
+}
+</pre>
+<p/>
+<h4>Using the request body</h4>
+The request body must be a top-level JSON object that contains all the parameters as its
+properties.
+<p/>
+<pre>
+$ API=https://manager.example.com/rhn/manager/api
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
+> -d '{"projectLabel":"myproject","name":"My Project","description":""}' \
+> $API/contentmanagement/createProject
+{
+  "success": true,
+  "result": {
+    "name": "My Project",
+    "id": 1,
+    "label": "myproject",
+    "orgId": 1
+  }
+}
+</pre>
+<hr/>
+<p/>
+<h3>Python 3 example</h3>
+Below is an example of the <code>system.listActiveSystems</code> call being used.
+<p/>
+<pre>
+#!/usr/bin/env python3
+import requests
+import pprint
+
+MANAGER_URL = "https://manager.example.com/rhn/manager/api"
+MANAGER_LOGIN = "username"
+MANAGER_PASSWORD = "password"
+SSLVERIFY = "/path/to/CA" # or False to disable verify;
+
+data = {"login": MANAGER_LOGIN, "password": MANAGER_PASSWORD}
+response = requests.post(MANAGER_URL + '/auth/login', json=data, verify=SSLVERIFY)
+print("LOGIN: {}:{}".format(response.status_code, response.json()))
+
+cookies = response.cookies
+res2 = requests.get(MANAGER_URL + '/system/listActiveSystems', cookies=cookies, verify=SSLVERIFY)
+print("RETCODE: {}".format(res2.status_code))
+pprint.pprint(res2.json())
+
+sysinfo = res2.json()['result'][0]
+
+note = {"sid": sysinfo['id'], "subject": "Title", "body": "Content of the Note"}
+res2 = requests.post(MANAGER_URL + '/system/addNote', json=note, cookies=cookies, verify=SSLVERIFY)
+print("RETCODE: {}".format(res2.status_code))
+pprint.pprint(res2.json())
+
+res2 = requests.get(MANAGER_URL + '/system/listNotes?sid={}'.format(sysinfo['id']), cookies=cookies, verify=SSLVERIFY)
+print("RETCODE: {}".format(res2.status_code))
+pprint.pprint(res2.json())
+
+res2 = requests.post(MANAGER_URL + '/auth/logout', cookies=cookies, verify=SSLVERIFY)
+print("RETCODE: {}".format(res2.status_code))
+pprint.pprint(res2.json())
+</pre>
+<hr/>
+<p/>
+
 <h2>XMLRPC Scripts</h2>
 <h3>Perl example:</h3>
 This Perl example shows the <code>system.listUserSystems</code> call being used to get a list of systems a user has access to. In the example below, the name of each system will be printed.
@@ -145,138 +278,6 @@ for channel in channels do
 end
 
 @client.call('auth.logout', @key)
-</pre>
-<hr/>
-<p/>
-
-<h2>HTTP over JSON API scripts</h2>
-<h3>HTTP login with Curl:</h3>
-Below is an example of the login process using an authentication token with the HTTP over JSON API.<br/>
-<br/>
-The HTTP over JSON API uses authentication tokens for access. The token is sent in a cookie called
-<code>pxt-session-cookie</code> in a response to a call to the <code>auth.login</code> endpoint. The <code>auth.login</code>
-endpoint accepts a POST request with a JSON body that has <code>login</code> and <code>password</code> properties in a top-level object.<br/>
-<p/>
-
-<pre>
-$ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" -d '{"login": "myusername", "password": "mypass"}' -i $API/auth/login
-
-HTTP/1.1 200 200
-...
-Set-Cookie: pxt-session-cookie=&lt;tokenhash&gt;; ...
-...
-{"success":true,"messages":[]}
-</pre>
-<p/>
-Once the login is successful, the retrieved cookie must be added to each subsequent request for authenticated access.<br/>
-<hr/>
-<p/>
-<h3>HTTP GET example:</h3>
-Below is an example of an HTTP GET call to the <code>contentmanagement.lookupProject</code> API.
-In a GET request, method parameters must be sent as query string key-value pairs.<br/>
-<br/>
-<em>The JSON output is pretty-printed for clarity.</em>
-<p/>
-<pre>
-$ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
-> $API/contentmanagement/lookupProject?projectLabel=myproject
-{
-  "success": true,
-  "result": {
-    "name": "My Project",
-    "description": "My CLM project",
-    "id": 1,
-    "label": "myproject",
-    "orgId": 1
-  }
-}
-</pre>
-<hr/>
-<p/>
-<h3>HTTP POST example:</h3>
-Below is an example of an HTTP POST call to the <code>contentmanagement.createProject</code> API.
-In a POST request, method parameters can be sent as query string key-value pairs, as a JSON
-object in the request body, or a mix of both. <code>object</code> type parameters cannot be
-represented as a query string element and therefore must be sent in the request body.
-The following examples show both approaches.<br/>
-<br/>
-<em>The JSON output is pretty-printed for clarity.</em>
-<p/>
-<h4>Using the query string</h4>
-<pre>
-$ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" -X POST \
-> "$API/contentmanagement/createProject?projectLabel=myproject&name=My%20Project&description="
-{
-  "success": true,
-  "result": {
-    "name": "My Project",
-    "id": 1,
-    "label": "myproject",
-    "orgId": 1
-  }
-}
-</pre>
-<p/>
-<h4>Using the request body</h4>
-The request body must be a top-level JSON object that contains all the parameters as its
-properties.
-<p/>
-<pre>
-$ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
-> -d '{"projectLabel":"myproject","name":"My Project","description":""}' \
-> $API/contentmanagement/createProject
-{
-  "success": true,
-  "result": {
-    "name": "My Project",
-    "id": 1,
-    "label": "myproject",
-    "orgId": 1
-  }
-}
-</pre>
-<hr/>
-<p/>
-<h3>Python 3 example</h3>
-Below is an example of the <code>system.listActiveSystems</code> call being used.
-<p/>
-<pre>
-#!/usr/bin/env python3
-import requests
-import pprint
-
-MANAGER_URL = "https://manager.example.com/rhn/manager/api"
-MANAGER_LOGIN = "username"
-MANAGER_PASSWORD = "password"
-SSLVERIFY = "/path/to/CA" # or False to disable verify;
-
-data = {"login": MANAGER_LOGIN, "password": MANAGER_PASSWORD}
-response = requests.post(MANAGER_URL + '/auth/login', json=data, verify=SSLVERIFY)
-print("LOGIN: {}:{}".format(response.status_code, response.json()))
-
-cookies = response.cookies
-res2 = requests.get(MANAGER_URL + '/system/listActiveSystems', cookies=cookies, verify=SSLVERIFY)
-print("RETCODE: {}".format(res2.status_code))
-pprint.pprint(res2.json())
-
-sysinfo = res2.json()['result'][0]
-
-note = {"sid": sysinfo['id'], "subject": "Title", "body": "Content of the Note"}
-res2 = requests.post(MANAGER_URL + '/system/addNote', json=note, cookies=cookies, verify=SSLVERIFY)
-print("RETCODE: {}".format(res2.status_code))
-pprint.pprint(res2.json())
-
-res2 = requests.get(MANAGER_URL + '/system/listNotes?sid={}'.format(sysinfo['id']), cookies=cookies, verify=SSLVERIFY)
-print("RETCODE: {}".format(res2.status_code))
-pprint.pprint(res2.json())
-
-res2 = requests.post(MANAGER_URL + '/auth/logout', cookies=cookies, verify=SSLVERIFY)
-print("RETCODE: {}".format(res2.status_code))
-pprint.pprint(res2.json())
 </pre>
 <p/>
 

--- a/java/buildconf/apidoc/jsp/scripts.txt
+++ b/java/buildconf/apidoc/jsp/scripts.txt
@@ -10,6 +10,139 @@ ul.apidoc {
 </head>
 <body>
 <h1><i class="fa fa-gears"></i>Sample Scripts</h1>
+
+<h2>JSON over HTTP API scripts</h2>
+<h3>HTTP login with Curl:</h3>
+Below is an example of the login process using an authentication token with the JSON over HTTP API.<br/>
+<br/>
+The JSON over HTTP API uses authentication tokens for access. The token is sent in a cookie called
+<code>pxt-session-cookie</code> in a response to a call to the <code>auth.login</code> endpoint. The <code>auth.login</code>
+endpoint accepts a POST request with a JSON body that has <code>login</code> and <code>password</code> properties in a top-level object.<br/>
+<p/>
+
+<pre>
+$ API=https://manager.example.com/rhn/manager/api
+$ curl -H "Content-Type: application/json" -d '{"login": "myusername", "password": "mypass"}' -i $API/auth/login
+
+HTTP/1.1 200 200
+...
+Set-Cookie: pxt-session-cookie=&lt;tokenhash&gt;; ...
+...
+{"success":true,"messages":[]}
+</pre>
+<p/>
+Once the login is successful, the retrieved cookie must be added to each subsequent request for authenticated access.<br/>
+<hr/>
+<p/>
+<h3>HTTP GET example:</h3>
+Below is an example of an HTTP GET call to the <code>contentmanagement.lookupProject</code> API.
+In a GET request, method parameters must be sent as query string key-value pairs.<br/>
+<br/>
+<em>The JSON output is pretty-printed for clarity.</em>
+<p/>
+<pre>
+$ API=https://manager.example.com/rhn/manager/api
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
+> $API/contentmanagement/lookupProject?projectLabel=myproject
+{
+  "success": true,
+  "result": {
+    "name": "My Project",
+    "description": "My CLM project",
+    "id": 1,
+    "label": "myproject",
+    "orgId": 1
+  }
+}
+</pre>
+<hr/>
+<p/>
+<h3>HTTP POST example:</h3>
+Below is an example of an HTTP POST call to the <code>contentmanagement.createProject</code> API.
+In a POST request, method parameters can be sent as query string key-value pairs, as a JSON
+object in the request body, or a mix of both. <code>object</code> type parameters cannot be
+represented as a query string element and therefore must be sent in the request body.
+The following examples show both approaches.<br/>
+<br/>
+<em>The JSON output is pretty-printed for clarity.</em>
+<p/>
+<h4>Using the query string</h4>
+<pre>
+$ API=https://manager.example.com/rhn/manager/api
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" -X POST \
+> "$API/contentmanagement/createProject?projectLabel=myproject&name=My%20Project&description="
+{
+  "success": true,
+  "result": {
+    "name": "My Project",
+    "id": 1,
+    "label": "myproject",
+    "orgId": 1
+  }
+}
+</pre>
+<p/>
+<h4>Using the request body</h4>
+The request body must be a top-level JSON object that contains all the parameters as its
+properties.
+<p/>
+<pre>
+$ API=https://manager.example.com/rhn/manager/api
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
+> -d '{"projectLabel":"myproject","name":"My Project","description":""}' \
+> $API/contentmanagement/createProject
+{
+  "success": true,
+  "result": {
+    "name": "My Project",
+    "id": 1,
+    "label": "myproject",
+    "orgId": 1
+  }
+}
+</pre>
+<hr/>
+<p/>
+<h3>Python 3 example</h3>
+Below is an example of the <code>system.listActiveSystems</code> call being used.
+<p/>
+<pre>
+#!/usr/bin/env python3
+import requests
+import pprint
+
+MANAGER_URL = "https://manager.example.com/rhn/manager/api"
+MANAGER_LOGIN = "username"
+MANAGER_PASSWORD = "password"
+SSLVERIFY = "/path/to/CA" # or False to disable verify;
+
+data = {"login": MANAGER_LOGIN, "password": MANAGER_PASSWORD}
+response = requests.post(MANAGER_URL + '/auth/login', json=data, verify=SSLVERIFY)
+print("LOGIN: {}:{}".format(response.status_code, response.json()))
+
+cookies = response.cookies
+res2 = requests.get(MANAGER_URL + '/system/listActiveSystems', cookies=cookies, verify=SSLVERIFY)
+print("RETCODE: {}".format(res2.status_code))
+pprint.pprint(res2.json())
+
+sysinfo = res2.json()['result'][0]
+
+note = {"sid": sysinfo['id'], "subject": "Title", "body": "Content of the Note"}
+res2 = requests.post(MANAGER_URL + '/system/addNote', json=note, cookies=cookies, verify=SSLVERIFY)
+print("RETCODE: {}".format(res2.status_code))
+pprint.pprint(res2.json())
+
+res2 = requests.get(MANAGER_URL + '/system/listNotes?sid={}'.format(sysinfo['id']), cookies=cookies, verify=SSLVERIFY)
+print("RETCODE: {}".format(res2.status_code))
+pprint.pprint(res2.json())
+
+res2 = requests.post(MANAGER_URL + '/auth/logout', cookies=cookies, verify=SSLVERIFY)
+print("RETCODE: {}".format(res2.status_code))
+pprint.pprint(res2.json())
+</pre>
+<hr/>
+<p/>
+
 <h2>XMLRPC Scripts</h2>
 <h3>Perl example:</h3>
 This Perl example shows the <code>system.listUserSystems</code> call being used to get a list of systems a user has access to. In the example below, the name of each system will be printed.
@@ -150,138 +283,6 @@ for channel in channels do
 end
 
 @client.call('auth.logout', @key)
-</pre>
-<hr/>
-<p/>
-
-<h2>HTTP over JSON API scripts</h2>
-<h3>HTTP login with Curl:</h3>
-Below is an example of the login process using an authentication token with the HTTP over JSON API.<br/>
-<br/>
-The HTTP over JSON API uses authentication tokens for access. The token is sent in a cookie called
-<code>pxt-session-cookie</code> in a response to a call to the <code>auth.login</code> endpoint. The <code>auth.login</code>
-endpoint accepts a POST request with a JSON body that has <code>login</code> and <code>password</code> properties in a top-level object.<br/>
-<p/>
-
-<pre>
-$ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" -d '{"login": "myusername", "password": "mypass"}' -i $API/auth/login
-
-HTTP/1.1 200 200
-...
-Set-Cookie: pxt-session-cookie=&lt;tokenhash&gt;; ...
-...
-{"success":true,"messages":[]}
-</pre>
-<p/>
-Once the login is successful, the retrieved cookie must be added to each subsequent request for authenticated access.<br/>
-<hr/>
-<p/>
-<h3>HTTP GET example:</h3>
-Below is an example of an HTTP GET call to the <code>contentmanagement.lookupProject</code> API.
-In a GET request, method parameters must be sent as query string key-value pairs.<br/>
-<br/>
-<em>The JSON output is pretty-printed for clarity.</em>
-<p/>
-<pre>
-$ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
-> $API/contentmanagement/lookupProject?projectLabel=myproject
-{
-  "success": true,
-  "result": {
-    "name": "My Project",
-    "description": "My CLM project",
-    "id": 1,
-    "label": "myproject",
-    "orgId": 1
-  }
-}
-</pre>
-<hr/>
-<p/>
-<h3>HTTP POST example:</h3>
-Below is an example of an HTTP POST call to the <code>contentmanagement.createProject</code> API.
-In a POST request, method parameters can be sent as query string key-value pairs, as a JSON
-object in the request body, or a mix of both. <code>object</code> type parameters cannot be
-represented as a query string element and therefore must be sent in the request body.
-The following examples show both approaches.<br/>
-<br/>
-<em>The JSON output is pretty-printed for clarity.</em>
-<p/>
-<h4>Using the query string</h4>
-<pre>
-$ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" -X POST \
-> "$API/contentmanagement/createProject?projectLabel=myproject&name=My%20Project&description="
-{
-  "success": true,
-  "result": {
-    "name": "My Project",
-    "id": 1,
-    "label": "myproject",
-    "orgId": 1
-  }
-}
-</pre>
-<p/>
-<h4>Using the request body</h4>
-The request body must be a top-level JSON object that contains all the parameters as its
-properties.
-<p/>
-<pre>
-$ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
-> -d '{"projectLabel":"myproject","name":"My Project","description":""}' \
-> $API/contentmanagement/createProject
-{
-  "success": true,
-  "result": {
-    "name": "My Project",
-    "id": 1,
-    "label": "myproject",
-    "orgId": 1
-  }
-}
-</pre>
-<hr/>
-<p/>
-<h3>Python 3 example</h3>
-Below is an example of the <code>system.listActiveSystems</code> call being used.
-<p/>
-<pre>
-#!/usr/bin/env python3
-import requests
-import pprint
-
-MANAGER_URL = "https://manager.example.com/rhn/manager/api"
-MANAGER_LOGIN = "username"
-MANAGER_PASSWORD = "password"
-SSLVERIFY = "/path/to/CA" # or False to disable verify;
-
-data = {"login": MANAGER_LOGIN, "password": MANAGER_PASSWORD}
-response = requests.post(MANAGER_URL + '/auth/login', json=data, verify=SSLVERIFY)
-print("LOGIN: {}:{}".format(response.status_code, response.json()))
-
-cookies = response.cookies
-res2 = requests.get(MANAGER_URL + '/system/listActiveSystems', cookies=cookies, verify=SSLVERIFY)
-print("RETCODE: {}".format(res2.status_code))
-pprint.pprint(res2.json())
-
-sysinfo = res2.json()['result'][0]
-
-note = {"sid": sysinfo['id'], "subject": "Title", "body": "Content of the Note"}
-res2 = requests.post(MANAGER_URL + '/system/addNote', json=note, cookies=cookies, verify=SSLVERIFY)
-print("RETCODE: {}".format(res2.status_code))
-pprint.pprint(res2.json())
-
-res2 = requests.get(MANAGER_URL + '/system/listNotes?sid={}'.format(sysinfo['id']), cookies=cookies, verify=SSLVERIFY)
-print("RETCODE: {}".format(res2.status_code))
-pprint.pprint(res2.json())
-
-res2 = requests.post(MANAGER_URL + '/auth/logout', cookies=cookies, verify=SSLVERIFY)
-print("RETCODE: {}".format(res2.status_code))
-pprint.pprint(res2.json())
 </pre>
 <p/>
 

--- a/java/buildconf/apidoc/singlepage/scripts.txt
+++ b/java/buildconf/apidoc/singlepage/scripts.txt
@@ -5,6 +5,139 @@
 </head>
 <body>
 <h1><i class="fa fa-gears"><a href="../scripts.html">Sample Scripts</a></h1>
+
+<h2>JSON over HTTP API scripts</h2>
+<h3>HTTP login with Curl:</h3>
+Below is an example of the login process using an authentication token with the JSON over HTTP API.<br/>
+<br/>
+The JSON over HTTP API uses authentication tokens for access. The token is sent in a cookie called
+<code>pxt-session-cookie</code> in a response to a call to the <code>auth.login</code> endpoint. The <code>auth.login</code>
+endpoint accepts a POST request with a JSON body that has <code>login</code> and <code>password</code> properties in a top-level object.<br/>
+<p/>
+
+<pre>
+$ API=https://manager.example.com/rhn/manager/api
+$ curl -H "Content-Type: application/json" -d '{"login": "myusername", "password": "mypass"}' -i $API/auth/login
+
+HTTP/1.1 200 200
+...
+Set-Cookie: pxt-session-cookie=&lt;tokenhash&gt;; ...
+...
+{"success":true,"messages":[]}
+</pre>
+<p/>
+Once the login is successful, the retrieved cookie must be added to each subsequent request for authenticated access.<br/>
+<hr/>
+<p/>
+<h3>HTTP GET example:</h3>
+Below is an example of an HTTP GET call to the <code>contentmanagement.lookupProject</code> API.
+In a GET request, method parameters must be sent as query string key-value pairs.<br/>
+<br/>
+<em>The JSON output is pretty-printed for clarity.</em>
+<p/>
+<pre>
+$ API=https://manager.example.com/rhn/manager/api
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
+> $API/contentmanagement/lookupProject?projectLabel=myproject
+{
+  "success": true,
+  "result": {
+    "name": "My Project",
+    "description": "My CLM project",
+    "id": 1,
+    "label": "myproject",
+    "orgId": 1
+  }
+}
+</pre>
+<hr/>
+<p/>
+<h3>HTTP POST example:</h3>
+Below is an example of an HTTP POST call to the <code>contentmanagement.createProject</code> API.
+In a POST request, method parameters can be sent as query string key-value pairs, as a JSON
+object in the request body, or a mix of both. <code>object</code> type parameters cannot be
+represented as a query string element and therefore must be sent in the request body.
+The following examples show both approaches.<br/>
+<br/>
+<em>The JSON output is pretty-printed for clarity.</em>
+<p/>
+<h4>Using the query string</h4>
+<pre>
+$ API=https://manager.example.com/rhn/manager/api
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" -X POST \
+> "$API/contentmanagement/createProject?projectLabel=myproject&name=My%20Project&description="
+{
+  "success": true,
+  "result": {
+    "name": "My Project",
+    "id": 1,
+    "label": "myproject",
+    "orgId": 1
+  }
+}
+</pre>
+<p/>
+<h4>Using the request body</h4>
+The request body must be a top-level JSON object that contains all the parameters as its
+properties.
+<p/>
+<pre>
+$ API=https://manager.example.com/rhn/manager/api
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
+> -d '{"projectLabel":"myproject","name":"My Project","description":""}' \
+> $API/contentmanagement/createProject
+{
+  "success": true,
+  "result": {
+    "name": "My Project",
+    "id": 1,
+    "label": "myproject",
+    "orgId": 1
+  }
+}
+</pre>
+<hr/>
+<p/>
+<h3>Python 3 example</h3>
+Below is an example of the <code>system.listActiveSystems</code> call being used.
+<p/>
+<pre>
+#!/usr/bin/env python3
+import requests
+import pprint
+
+MANAGER_URL = "https://manager.example.com/rhn/manager/api"
+MANAGER_LOGIN = "username"
+MANAGER_PASSWORD = "password"
+SSLVERIFY = "/path/to/CA" # or False to disable verify;
+
+data = {"login": MANAGER_LOGIN, "password": MANAGER_PASSWORD}
+response = requests.post(MANAGER_URL + '/auth/login', json=data, verify=SSLVERIFY)
+print("LOGIN: {}:{}".format(response.status_code, response.json()))
+
+cookies = response.cookies
+res2 = requests.get(MANAGER_URL + '/system/listActiveSystems', cookies=cookies, verify=SSLVERIFY)
+print("RETCODE: {}".format(res2.status_code))
+pprint.pprint(res2.json())
+
+sysinfo = res2.json()['result'][0]
+
+note = {"sid": sysinfo['id'], "subject": "Title", "body": "Content of the Note"}
+res2 = requests.post(MANAGER_URL + '/system/addNote', json=note, cookies=cookies, verify=SSLVERIFY)
+print("RETCODE: {}".format(res2.status_code))
+pprint.pprint(res2.json())
+
+res2 = requests.get(MANAGER_URL + '/system/listNotes?sid={}'.format(sysinfo['id']), cookies=cookies, verify=SSLVERIFY)
+print("RETCODE: {}".format(res2.status_code))
+pprint.pprint(res2.json())
+
+res2 = requests.post(MANAGER_URL + '/auth/logout', cookies=cookies, verify=SSLVERIFY)
+print("RETCODE: {}".format(res2.status_code))
+pprint.pprint(res2.json())
+</pre>
+<hr/>
+<p/>
+
 <h2>XMLRPC Scripts</h2>
 <h3>Perl example:</h3>
 This Perl example shows the <code>system.listUserSystems</code> call being used to get a list of systems a user has access to. In the example below, the name of each system will be printed.
@@ -145,138 +278,6 @@ for channel in channels do
 end
 
 @client.call('auth.logout', @key)
-</pre>
-<hr/>
-<p/>
-
-<h2>HTTP over JSON API scripts</h2>
-<h3>HTTP login with Curl:</h3>
-Below is an example of the login process using an authentication token with the HTTP over JSON API.<br/>
-<br/>
-The HTTP over JSON API uses authentication tokens for access. The token is sent in a cookie called
-<code>pxt-session-cookie</code> in a response to a call to the <code>auth.login</code> endpoint. The <code>auth.login</code>
-endpoint accepts a POST request with a JSON body that has <code>login</code> and <code>password</code> properties in a top-level object.<br/>
-<p/>
-
-<pre>
-$ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" -d '{"login": "myusername", "password": "mypass"}' -i $API/auth/login
-
-HTTP/1.1 200 200
-...
-Set-Cookie: pxt-session-cookie=&lt;tokenhash&gt;; ...
-...
-{"success":true,"messages":[]}
-</pre>
-<p/>
-Once the login is successful, the retrieved cookie must be added to each subsequent request for authenticated access.<br/>
-<hr/>
-<p/>
-<h3>HTTP GET example:</h3>
-Below is an example of an HTTP GET call to the <code>contentmanagement.lookupProject</code> API.
-In a GET request, method parameters must be sent as query string key-value pairs.<br/>
-<br/>
-<em>The JSON output is pretty-printed for clarity.</em>
-<p/>
-<pre>
-$ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
-> $API/contentmanagement/lookupProject?projectLabel=myproject
-{
-  "success": true,
-  "result": {
-    "name": "My Project",
-    "description": "My CLM project",
-    "id": 1,
-    "label": "myproject",
-    "orgId": 1
-  }
-}
-</pre>
-<hr/>
-<p/>
-<h3>HTTP POST example:</h3>
-Below is an example of an HTTP POST call to the <code>contentmanagement.createProject</code> API.
-In a POST request, method parameters can be sent as query string key-value pairs, as a JSON
-object in the request body, or a mix of both. <code>object</code> type parameters cannot be
-represented as a query string element and therefore must be sent in the request body.
-The following examples show both approaches.<br/>
-<br/>
-<em>The JSON output is pretty-printed for clarity.</em>
-<p/>
-<h4>Using the query string</h4>
-<pre>
-$ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" -X POST \
-> "$API/contentmanagement/createProject?projectLabel=myproject&name=My%20Project&description="
-{
-  "success": true,
-  "result": {
-    "name": "My Project",
-    "id": 1,
-    "label": "myproject",
-    "orgId": 1
-  }
-}
-</pre>
-<p/>
-<h4>Using the request body</h4>
-The request body must be a top-level JSON object that contains all the parameters as its
-properties.
-<p/>
-<pre>
-$ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
-> -d '{"projectLabel":"myproject","name":"My Project","description":""}' \
-> $API/contentmanagement/createProject
-{
-  "success": true,
-  "result": {
-    "name": "My Project",
-    "id": 1,
-    "label": "myproject",
-    "orgId": 1
-  }
-}
-</pre>
-<hr/>
-<p/>
-<h3>Python 3 example</h3>
-Below is an example of the <code>system.listActiveSystems</code> call being used.
-<p/>
-<pre>
-#!/usr/bin/env python3
-import requests
-import pprint
-
-MANAGER_URL = "https://manager.example.com/rhn/manager/api"
-MANAGER_LOGIN = "username"
-MANAGER_PASSWORD = "password"
-SSLVERIFY = "/path/to/CA" # or False to disable verify;
-
-data = {"login": MANAGER_LOGIN, "password": MANAGER_PASSWORD}
-response = requests.post(MANAGER_URL + '/auth/login', json=data, verify=SSLVERIFY)
-print("LOGIN: {}:{}".format(response.status_code, response.json()))
-
-cookies = response.cookies
-res2 = requests.get(MANAGER_URL + '/system/listActiveSystems', cookies=cookies, verify=SSLVERIFY)
-print("RETCODE: {}".format(res2.status_code))
-pprint.pprint(res2.json())
-
-sysinfo = res2.json()['result'][0]
-
-note = {"sid": sysinfo['id'], "subject": "Title", "body": "Content of the Note"}
-res2 = requests.post(MANAGER_URL + '/system/addNote', json=note, cookies=cookies, verify=SSLVERIFY)
-print("RETCODE: {}".format(res2.status_code))
-pprint.pprint(res2.json())
-
-res2 = requests.get(MANAGER_URL + '/system/listNotes?sid={}'.format(sysinfo['id']), cookies=cookies, verify=SSLVERIFY)
-print("RETCODE: {}".format(res2.status_code))
-pprint.pprint(res2.json())
-
-res2 = requests.post(MANAGER_URL + '/auth/logout', cookies=cookies, verify=SSLVERIFY)
-print("RETCODE: {}".format(res2.status_code))
-pprint.pprint(res2.json())
 </pre>
 <p/>
 

--- a/java/manager-build.xml
+++ b/java/manager-build.xml
@@ -424,6 +424,15 @@
     <delete dir="${report.dir}/apidocs/${template.dir}/handlers/" />
   </target>
 
+  <target name="apidoc-validate" description="Validate the API documentation" depends="apidoc-docbook">
+      <exec executable="/usr/bin/xmllint" failonerror="true">
+          <arg value="--xinclude"/>
+          <arg value="--postvalid"/>
+          <arg value="${report.dir}/apidocs/docbook/book.xml"/>
+      </exec>
+      <echo message="${line.separator}The generated API documentation is valid."/>
+  </target>
+
   <target name="apidoc" description="Generate the api documentation" depends="compile">
     <path id="javadocpath">
       <pathelement location="build/classes" />

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix typo and ordering of JSON over HTTP API example scripts
 - set Channel GPG Key info from SCC data
 - set GPG Key Url as channel pillar data (bsc#1199984)
 - new API endpoint for addErrataUpdate, that take 


### PR DESCRIPTION
- Fixes the typo "HTTP over JSON" -> "JSON over HTTP"
- Puts the HTTP API examples on top of the page
- Adds an Ant target `apidoc-validate` to validate the API docs locally:
```bash
$ ant -f manager-build.xml apidoc-validate
```

Uyuni wiki has been updated with [instructions to use the new target](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API#validating-your-changes-locally).

## GUI diff

Typo fixes

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18237

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
