### PR TITLE
Fix bootstrap repo definitions to make the Bundle optional for Debian 9 and Proxy 4.2

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -431,7 +431,7 @@ AMAZONLINUX2 = [
     "zip"
 ]
 
-PKGLIST15_SALT = [
+PKGLIST15_SALT_NO_BUNDLE = [
     "libpgm-5_2-0",
     "libsodium23",
     "libzmq5",
@@ -461,7 +461,14 @@ PKGLIST15_SALT = [
     "salt",
     "python3-salt",
     "salt-minion",
+]
+
+PKGLIST15_SALT = PKGLIST15_SALT_NO_BUNDLE + [
     "venv-salt-minion",
+]
+
+PKGLIST15_SALT_OPT_BUNDLE = PKGLIST15_SALT_NO_BUNDLE + [
+    "venv-salt-minion*",
 ]
 
 PKGLIST15SP0SP1_SALT = [
@@ -701,7 +708,7 @@ PKGLISTDEBIAN9 = [
     "dmidecode",
     "gnupg",
     "gnupg1",
-    "venv-salt-minion",
+    "venv-salt-minion*",
 ]
 
 
@@ -1247,7 +1254,7 @@ DATA = {
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/sle/15/3/bootstrap/'
     },
     'SUMA-42-PROXY-x86_64' : {
-        'PDID' : [2145, 2225], 'BETAPDID' : [], 'PKGLIST' : PKGLIST15_TRAD + ONLYSLE15 + PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'PDID' : [2145, 2225], 'BETAPDID' : [], 'PKGLIST' : PKGLIST15_TRAD + ONLYSLE15 + PKGLIST15_SALT_OPT_BUNDLE + PKGLIST15_X86_ARM,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/sle/15/3/bootstrap/'
     },
     'SLE-15-SP4-aarch64' : {

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,6 @@
+- Make the Salt Bundle optional for bootstrap repositories
+  for Debian 9 and SUSE Manager Proxy 4.2
+
 -------------------------------------------------------------------
 Wed Jun 22 11:16:33 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fix the definitions for creating bootstrap repos for Debian 9 and Proxy 4.2 to make the bundle optional for these products.

## GUI diff

No difference.

## Documentation
- No documentation needed: just prevent failings on creating bootstrap repos for Debian 9 and Proxy 4.2

## Test coverage
- No tests for this part

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
