### PR TITLE
Update ivy config for google-gson-2.8.9

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -33,7 +33,7 @@
         <dependency org="suse" name="dwr" rev="3.0.2" />
         <dependency org="suse" name="ehcache-core" rev="2.10.1" />
         <dependency org="suse" name="geronimo-jta-1.1-api" rev="1.2" />
-        <dependency org="suse" name="google-gson" rev="2.8.5" />
+        <dependency org="suse" name="google-gson" rev="2.8.9" />
         <dependency org="suse" name="hibernate-c3p0" rev="5.3.25" />
         <dependency org="suse" name="hibernate-commons-annotations" rev="5.0.4" />
         <dependency org="suse" name="hibernate-core" rev="5.3.25" />

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -8,6 +8,8 @@ repositories:
   Uyuni:
     project: systemsmanagement:Uyuni:Master
     repository: openSUSE_Leap_15.4
+  Leap_sle:
+    url: https://download.opensuse.org/update/leap/15.4/sle
 artifacts:
   - artifact: asm
     package: asm3
@@ -87,7 +89,8 @@ artifacts:
     package: geronimo-jta-1_1-api
     repository: Leap
   - artifact: google-gson
-    repository: Leap
+    jar: gson.jar
+    repository: Leap_sle
   - artifact: hibernate-c3p0
     package: hibernate5
     jar: hibernate-c3p0


### PR DESCRIPTION
- Add Leap/SLE repository to `obs-to-maven` config (requires `obs-to-maven-1.1.1`)
- Update gson from `2.8.5` to `2.8.9` in ivy config
- Explicitly specify JAR name which is different from the artifact name for `google-gson`.

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
