### PR TITLE
Fixes for Retail in BV

### DIFF
--- a/testsuite/features/build_validation/retail/sle12sp5_buildhost_build_kiwi_image.feature
+++ b/testsuite/features/build_validation/retail/sle12sp5_buildhost_build_kiwi_image.feature
@@ -62,6 +62,7 @@ Feature: Prepare buildhost and build OS image for SLES 12 SP5
     Given I am on the Systems overview page of this "sle12sp5_buildhost"
     Then I should see a "[OS Image Build Host]" text
     When I wait until the image build "suse_os_image_12" is completed
+    And I wait until the image inspection for "sle12sp5_terminal" is completed
     And I am on the image store of the Kiwi image for organization "1"
     Then I should see the name of the image for "sle12sp5_terminal"
 

--- a/testsuite/features/build_validation/retail/sle15sp3_buildhost_build_kiwi_image.feature
+++ b/testsuite/features/build_validation/retail/sle15sp3_buildhost_build_kiwi_image.feature
@@ -62,6 +62,7 @@ Feature: Prepare buildhost and build OS image for SLES 15 SP3
     Given I am on the Systems overview page of this "sle15sp3_buildhost"
     Then I should see a "[OS Image Build Host]" text
     When I wait until the image build "suse_os_image_15" is completed
+    And I wait until the image inspection for "sle15sp3_terminal" is completed
     And I am on the image store of the Kiwi image for organization "1"
     Then I should see the name of the image for "sle15sp3_terminal"
 

--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -47,6 +47,7 @@ Feature: Build OS images
     Given I am on the Systems overview page of this "build_host"
     Then I should see a "[OS Image Build Host]" text
     When I wait until the image build "suse_os_image" is completed
+    And I wait until the image inspection for "pxeboot_minion" is completed
     And I am on the image store of the Kiwi image for organization "1"
     Then I should see the name of the image for "pxeboot_minion"
 

--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -83,7 +83,7 @@ Feature: PXE boot a terminal with Cobbler
 
   Scenario: PXE boot the PXE boot minion
     Given I set the default PXE menu entry to the "target profile" on the "proxy"
-    When I reboot the PXE boot minion
+    When I reboot the terminal "pxeboot_minion"
     And I wait for "60" seconds
     And I set the default PXE menu entry to the "local boot" on the "proxy"
     And I wait at most 1200 seconds until Salt master sees "pxeboot_minion" as "unaccepted"


### PR DESCRIPTION
## What does this PR change?

This PR fixes #4522:
* the step `I reboot the PXE boot minion` now accepts an argument (the name of the terminal to reboot)
* on head, images get renamed once they are built


## Links

No ports, 4.2 fixes directly integrated into SUSE/spacewalk#18256


## Changelogs

- [x] No changelog needed
