### PR TITLE
display messages to restart services after certificate change

### DIFF
--- a/spacewalk/certs-tools/mgr_ssl_cert_setup.py
+++ b/spacewalk/certs-tools/mgr_ssl_cert_setup.py
@@ -460,6 +460,9 @@ def deployApache(apache_cert_content, server_key_content):
         f.write(apache_cert_content)
     # exists on server and proxy
     os.system("/usr/bin/spacewalk-setup-httpd")
+    log(
+"""After changing the server certificate please execute:
+$> spacewalk-service stop """)
 
 
 def deployJabberd(jabber_cert_content):
@@ -485,6 +488,7 @@ def deployPg(server_key_content):
         os.chmod(PG_KEY_FILE, int("0600", 8))
         os.chown(PG_KEY_FILE, pg_uid, pg_gid)
 
+        log("""$> systemctl restart postgresql.service """)
 
 def deployCAUyuni(certData):
     for h, ca in certData.items():
@@ -504,6 +508,11 @@ def deployCAUyuni(certData):
     # in case a systemd timer try to do the same
     time.sleep(3)
     os.system("/usr/share/rhn/certs/update-ca-cert-trust.sh")
+    log(
+"""$> spacewalk-service start
+
+As the CA certificate has been changed, please deploy the CA to all registered clients.
+On salt-managed clients, you can do this by applying the highstate.""")
 
 
 def checks(server_key_content,server_cert_content, certData):

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,4 @@
+- display messages to restart services after certificate change
 - improve CA Chain checking by comparing authorityKeyIdentifier
   with subjectKeyIdentifier
 


### PR DESCRIPTION
## What does this PR change?

mgr-ssl-cert-setup tool should show instructions what need to be restarted when the certificate change.


## GUI diff

```
# mgr-ssl-cert-setup -r ssl-build/RHN-ORG-TRUSTED-SSL-CERT -s ssl-build/suma-refhead-srv.mgr/server.crt -k ssl-build/suma-refhead-srv.mgr/server.key 
After changing the server certificate please execute:
$> spacewalk-service stop 
$> systemctl restart postgresql.service 
$> spacewalk-service start

As the CA certificate changed, please deploy the CA to all registered clients.
You can apply a highstate when the clients are salt managed.
```

- [x] **DONE**

## Documentation
- https://github.com/uyuni-project/uyuni-docs/pull/1638

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18120


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
