### PR TITLE
fix posttrans error "RHN-ORG-TRUSTED-SSL-CERT" not found

### DIFF
--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,3 +1,5 @@
+- fix posttrans error "RHN-ORG-TRUSTED-SSL-CERT" not found
+
 -------------------------------------------------------------------
 Fri May 20 00:08:47 CEST 2022 - jgonzalez@suse.com
 

--- a/spacewalk/config/spacewalk-config.spec
+++ b/spacewalk/config/spacewalk-config.spec
@@ -207,12 +207,14 @@ if [ -e /etc/pki/tls/private/uyuni.key ]; then
   fi
 fi
 
-if [ ! -f /etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT ] ; then
+if [ -f /srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT ] ; then
+  if [ ! -f /etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT ] ; then
     if diff -qs /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT /srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT ; then
-        mv /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT /etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT
+      mv /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT /etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT
     else
-        cp /srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT /etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT
+      cp /srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT /etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT
     fi
+  fi
 fi
 
 %changelog


### PR DESCRIPTION
## What does this PR change?

While installing the pattern:
```
diff: /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT: No such file or directory
diff: /srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT: No such file or directory
cp: cannot stat '/srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT': No such file or directory
warning: %posttrans(spacewalk-config-4.3.8-1.9.uyuni2.noarch.rpm) scriptlet failed, exit status 1
```

The error was caused by a typo in the `if` statement.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/5606

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
