### PR TITLE
Prepare push-to-obs for MFA

### DIFF
--- a/susemanager-utils/testing/docker/scripts/push-to-obs.sh
+++ b/susemanager-utils/testing/docker/scripts/push-to-obs.sh
@@ -9,13 +9,14 @@ help() {
   echo ""
   echo "Syntax: "
   echo ""
-  echo "${SCRIPT} -d <API1|PROJECT1>[,<API2|PROJECT2>...] -c OSC_CFG_FILE [-p PACKAGE1,PACKAGE2,...,PACKAGEN] [-v] [-t] [-n PROJECT]"
+  echo "${SCRIPT} -d <API1|PROJECT1>[,<API2|PROJECT2>...] -c OSC_CFG_FILE -s SSH_PRIVATE_KEY [-p PACKAGE1,PACKAGE2,...,PACKAGEN] [-v] [-t] [-n PROJECT]"
   echo ""
   echo "Where: "
   echo "  -d  Comma separated list of destionations in the format API/PROJECT,"
   echo "      for example https://api.opensuse.org|systemsmanagement:Uyuni:Master"
   echo "  -p  Comma separated list of packages. If absent, all packages are submitted"
   echo "  -c  Path to the OSC credentials (usually ~/.osrc)"
+  echo "  -s  Path to the private key used for MFA"
   echo "  -v  Verbose mode"
   echo "  -t  For tito, use current branch HEAD instead of latest package tag"
   echo "  -n  If used, update PROJECT instead of the projects specified with -d"
@@ -25,11 +26,12 @@ help() {
 
 OSC_EXPAND="FALSE"
 
-while getopts ":d:c:p:n:vthe" opts; do
+while getopts ":d:c:s:p:n:vthe" opts; do
   case "${opts}" in
     d) DESTINATIONS=${OPTARG};;
     p) PACKAGES="$(echo ${OPTARG}|tr ',' ' ')";;
     c) export OSCRC=${OPTARG};;
+    s) export SSHKEY=${OPTARG};;
     v) export VERBOSE=1;;
     t) export TEST=1;;
     n) export OBS_TEST_PROJECT=${OPTARG};;


### PR DESCRIPTION
## What does this PR change?

Prepare push-to-obs for MFA.

This will require:
- The MFA enabled for the user zypper-team
- `osc` updated to at least 0.178
- Backport to other branches
- Reconfiguration of the Jenkins jobs, so we provide the path to the key.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: CI stuff.

- [x] **DONE**

## Test coverage
- No tests: CI stuff

- [x] **DONE**

## Links

Related: https://github.com/SUSE/spacewalk/issues/18180

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
