### PR TITLE
Changed the logout method to POST on HTTP API

### DIFF
--- a/java/code/src/com/suse/manager/api/HttpApiRegistry.java
+++ b/java/code/src/com/suse/manager/api/HttpApiRegistry.java
@@ -122,7 +122,7 @@ public class HttpApiRegistry {
      */
     private void registerAuthEndpoints() {
         registrationHelper.addPostRoute(HTTP_API_ROOT + "auth/login", LoginController::login);
-        registrationHelper.addGetRoute(HTTP_API_ROOT + "auth/logout", withUser(LoginController::logout));
+        registrationHelper.addPostRoute(HTTP_API_ROOT + "auth/logout", withUser(LoginController::logout));
     }
 
     /**

--- a/java/code/src/com/suse/manager/api/test/HttpApiRegistryTest.java
+++ b/java/code/src/com/suse/manager/api/test/HttpApiRegistryTest.java
@@ -65,7 +65,7 @@ public class HttpApiRegistryTest extends RhnJmockBaseTestCase {
         context().checking(new Expectations() {{
             // Auth routes are added in all cases
             oneOf(helper).addPostRoute(with("/manager/api/auth/login"), with(any(Route.class)));
-            oneOf(helper).addGetRoute(with("/manager/api/auth/logout"), with(any(Route.class)));
+            oneOf(helper).addPostRoute(with("/manager/api/auth/logout"), with(any(Route.class)));
 
             // Test routes
             oneOf(helper).addGetRoute(with("/manager/api/test/path/myFirstEndpoint"), with(any(Route.class)));

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Changed logout method to POST on HTTP API (bsc#1199663)
 - set Channel GPG Key info from SCC data
 - set GPG Key Url as channel pillar data (bsc#1199984)
 - new API endpoint for addErrataUpdate, that take 


### PR DESCRIPTION
## What does this PR change?

It changes the logout method from GET to POST on HTTP API.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: the change makes the code conform to the documentation.

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17889

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
