### PR TITLE
QE: Enable temporarily disabled features again

### DIFF
--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -29,8 +29,7 @@
 - features/secondary/min_centos_remote-command.feature
 - features/secondary/min_centos_ssh.feature
 - features/secondary/trad_centos_client.feature
-# temporarily disabled by the RRTGs
-#- features/secondary/trad_centos_migrate_to_min.feature
+- features/secondary/trad_centos_migrate_to_min.feature
 - features/secondary/min_ubuntu_openscap_audit.feature
 - features/secondary/min_ubuntu_remote-command.feature
 - features/secondary/min_ubuntu_ssh.feature
@@ -51,8 +50,7 @@
 - features/secondary/min_empty_system_profiles.feature
 - features/secondary/trad_need_reboot.feature
 - features/secondary/trad_action_chain.feature
-# temporarily disabled by the RRTGs
-#- features/secondary/trad_deleted_migrate_to_minion.feature
+- features/secondary/trad_deleted_migrate_to_minion.feature
 - features/secondary/min_action_chain.feature
 - features/secondary/minssh_action_chain.feature
 - features/secondary/allcli_action_chain.feature


### PR DESCRIPTION
## What does this PR change?

We disabled 2 features in February since we had issues with those. We
have more time to look into those failures now.


## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Manager 4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
