### PR TITLE
Add missing SLES 15 SP4 client tools repositories to spacewalk-common-channels.ini

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1429,6 +1429,46 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
 
+[sles15-sp4-uyuni-client]
+name     = Uyuni Client Tools for SLES15 SP4 %(arch)s
+archs    =  x86_64, s390x, aarch64, ppc64le
+base_channels = sle-product-sles15-sp4-pool-%(arch)s
+checksum = sha256
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLE15-Uyuni-Client-Tools/SLE_15/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLE15-Uyuni-Client-Tools/SLE_15/
+
+[sles15-sp4-devel-uyuni-client]
+name     = Uyuni Client Tools for SLES15 SP4 %(arch)s (Development)
+archs    =  x86_64, s390x, aarch64, ppc64le
+base_channels = sle-product-sles15-sp4-pool-%(arch)s
+checksum = sha256
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
+
+[sles15-sap-sp4-uyuni-client]
+name     = Uyuni Client Tools for SLES15 SP4 %(arch)s
+archs    =  x86_64, s390x, aarch64, ppc64le
+base_channels = sle-product-sles_sap15-sp4-pool-%(arch)s
+checksum = sha256
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLE15-Uyuni-Client-Tools/SLE_15/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLE15-Uyuni-Client-Tools/SLE_15/
+
+[sles15-sap-sp4-devel-uyuni-client]
+name     = Uyuni Client Tools for SLES15 SP4 %(arch)s (Development)
+archs    =  x86_64, s390x, aarch64, ppc64le
+base_channels = sle-product-sles_sap15-sp4-pool-%(arch)s
+checksum = sha256
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
+
 [oraclelinux8]
 archs    = x86_64, aarch64
 name     = Oracle Linux 8 (%(arch)s)

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,6 @@
+- Add missing SLES 15 SP4 client tools repositories to
+  spacewalk-common-channels.ini
+
 -------------------------------------------------------------------
 Tue Jun 21 18:31:46 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Seems we added everything except the client tools to spacewalk-common-channels.ini

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: Already documented

- [x] **DONE**

## Test coverage
- No tests: We need a BV for Uyuni, but that's still WIP :-)

- [x] **DONE**

## Links

Reported by @v0rtex9 at Gitter.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
