### PR TITLE
Switch to using pg_roles instead of pg_authid

### DIFF
--- a/schema/reportdb/postgres/end.sql
+++ b/schema/reportdb/postgres/end.sql
@@ -47,7 +47,7 @@ begin
         and a.attrelid in (
             select c.oid from pg_catalog.pg_class c
             where relkind = 'r' and pg_catalog.pg_table_is_visible(c.oid) and relowner = (
-                select oid from pg_catalog.pg_authid where rolname = current_user
+                select oid from pg_catalog.pg_roles where rolname = current_user
             )
         ) loop
         begin

--- a/schema/reportdb/uyuni-reportdb-schema.changes
+++ b/schema/reportdb/uyuni-reportdb-schema.changes
@@ -1,3 +1,5 @@
+- improve schema compatibility with Amazon RDS
+
 -------------------------------------------------------------------
 Fri May 20 00:15:22 CEST 2022 - jgonzalez@suse.com
 

--- a/schema/spacewalk/postgres/end.sql
+++ b/schema/spacewalk/postgres/end.sql
@@ -47,7 +47,7 @@ begin
         and a.attrelid in (
             select c.oid from pg_catalog.pg_class c
             where relkind = 'r' and pg_catalog.pg_table_is_visible(c.oid) and relowner = (
-                select oid from pg_catalog.pg_authid where rolname = current_user
+                select oid from pg_catalog.pg_roles where rolname = current_user
             )
         ) loop
         begin

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,5 @@
+- improve schema compatibility with Amazon RDS
+
 -------------------------------------------------------------------
 Mon May 30 14:59:28 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR switches two sql queries to use the pg_roles table instead of pg_authid.   When using a Cloud Based "RDS"  such as AWS, access to the pg_authid user is restricted as the cloud provider does not expose this. 

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage
- No tests: already covered

- [ ] **DONE**

## Links

[AWS limits access to pg_authid ](https://stackoverflow.com/questions/55143544/aws-rds-postgresql-access-to-pg-catalog-pg-authid-forbidden-in-all-contexts)

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ X] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
