### PR TITLE
Revert "QE: Enable temporarily disabled features again"

### DIFF
--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -29,7 +29,8 @@
 - features/secondary/min_centos_remote-command.feature
 - features/secondary/min_centos_ssh.feature
 - features/secondary/trad_centos_client.feature
-- features/secondary/trad_centos_migrate_to_min.feature
+# temporarily disabled by the RRTGs
+#- features/secondary/trad_centos_migrate_to_min.feature
 - features/secondary/min_ubuntu_openscap_audit.feature
 - features/secondary/min_ubuntu_remote-command.feature
 - features/secondary/min_ubuntu_ssh.feature
@@ -50,7 +51,8 @@
 - features/secondary/min_empty_system_profiles.feature
 - features/secondary/trad_need_reboot.feature
 - features/secondary/trad_action_chain.feature
-- features/secondary/trad_deleted_migrate_to_minion.feature
+# temporarily disabled by the RRTGs
+#- features/secondary/trad_deleted_migrate_to_minion.feature
 - features/secondary/min_action_chain.feature
 - features/secondary/minssh_action_chain.feature
 - features/secondary/allcli_action_chain.feature


### PR DESCRIPTION
Reverts uyuni-project/uyuni#5625. This did cause too much trouble in the testsuite. We have to enable and investigate this later on.