### PR TITLE
Check reposync logs after custom channels repo-sync

### DIFF
--- a/testsuite/features/build_validation/add_custom_repositories/srv_wait_for_custom_reposync.feature
+++ b/testsuite/features/build_validation/add_custom_repositories/srv_wait_for_custom_reposync.feature
@@ -5,3 +5,6 @@ Feature: Wait for reposync activity to finish after adding custom channels
 
   Scenario: Wait for running reposyncs to finish after adding custom channels
     When I wait until all spacewalk-repo-sync finished
+
+  Scenario: Verify the reposync went fine after adding custom channels
+    Then the reposync logs should not report errors

--- a/testsuite/features/build_validation/reposync/srv_wait_for_product_reposync.feature
+++ b/testsuite/features/build_validation/reposync/srv_wait_for_product_reposync.feature
@@ -16,5 +16,5 @@ Feature: Wait for reposync activity to finish after adding products
   Scenario: Wait for running reposyncs to finish after adding products
     When I wait until all spacewalk-repo-sync finished
 
-  Scenario: Verify the reposync went fine
+  Scenario: Verify the reposync went fine after adding products
     Then the reposync logs should not report errors


### PR DESCRIPTION
## What does this PR change?

Adds a scenario to check reposync logs after repository syncing for custom channels is complete.

## GUI diff

No difference.



- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were added

- [x] **DONE**

## Links

 - 4.2 backport : https://github.com/SUSE/spacewalk/pull/18322

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
