### PR TITLE
Uyuni-2022.06: Fix changelog entry

### DIFF
--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,5 +1,3 @@
-- Fix reposync issue about 'rpm.hdr' object has no attribute 'get' (#5630)
-
 -------------------------------------------------------------------
 Tue Jun 21 18:30:19 CEST 2022 - jgonzalez@suse.com
 

--- a/python/uyuni/uyuni-common-libs.changes
+++ b/python/uyuni/uyuni-common-libs.changes
@@ -1,3 +1,5 @@
+- Fix reposync issue about 'rpm.hdr' object has no attribute 'get' (#5630)
+
 -------------------------------------------------------------------
 Tue Apr 19 12:14:45 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR moves a changelog entry introduced by https://github.com/uyuni-project/uyuni/pull/5639 to the proper file.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/18317

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
