### PR TITLE
Import formula values as int rather than doubles when migrating

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/FormulaController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/FormulaController.java
@@ -211,26 +211,6 @@ public class FormulaController {
     }
 
     /**
-     * Convert the doubles that could be integers into integers: this is critical for formulas
-     * Since we don't serialize the values anymore.
-     *
-     * @param map the map to iterate on.
-     */
-    private void convertIntegers(Map<String, Object> map) {
-        for (String key : map.keySet()) {
-            Object value = map.get(key);
-            if (value instanceof Double) {
-                if (((Double)value) % 1 == 0) {
-                    map.put(key, ((Double)value).intValue());
-                }
-            }
-            else if (value instanceof Map) {
-                convertIntegers((Map<String, Object>) value);
-            }
-        }
-    }
-
-    /**
      * Save formula data for group or server
      * @param request the http request
      * @param response the http response
@@ -240,7 +220,7 @@ public class FormulaController {
     public String saveFormula(Request request, Response response, User user) {
         // Get data from request
         Map<String, Object> map = GSON.fromJson(request.body(), new TypeToken<Map<String, Object>>() { }.getType());
-        convertIntegers(map);
+        FormulaFactory.convertIntegers(map);
         Long id = Long.valueOf((String) map.get("id"));
         String formulaName = (String) map.get("formula_name");
         StateTargetType type = StateTargetType.valueOf((String) map.get("type"));

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Convert formula integer values when upgrading (bsc#1200347)
 - Cleanup salt known_hosts when generating proxy containers config
 - Modify proxy containers configuration files set output
 - Change proxy containers config to tarball with yaml files


### PR DESCRIPTION
## What does this PR change?

When converting the formulas data from files to DB, don't cast to doubles, but int. This is a hacky workaround due to GSON parser being clueless about number types.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: migration only
- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18102

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
