### PR TITLE
Fix httpd container image build

### DIFF
--- a/containers/proxy-httpd-image/remove_unused.sh
+++ b/containers/proxy-httpd-image/remove_unused.sh
@@ -4,23 +4,12 @@
 set -xe
 
 # remove rpm-build and its dependencies
-rpm -e rpm-build --nodeps
-rpm -e dwz make gcc patch diffutils python-rpm-macros systemd-rpm-macros glibc-locale
+rpm -e diffutils
 
 # remove perl and its dependencies
-rpm -e --nodeps perl spacewalk-base-minimal
-rpm -e perl-DBI perl-Module-Implementation perl-Module-Runtime perl-Params-Validate perl-Try-Tiny
+rpm -e --nodeps perl
 
 # remove locale data
 rm -rf /usr/share/locale
-
-# remove other packages
-zypper --non-interactive rm \
-  binutils \
-  cpp7 \
-  glibc-locale-base
-
-# remove packages with a -devel suffix
-zypper --non-interactive rm *-devel
 
 zypper clean --all


### PR DESCRIPTION
## What does this PR change?

Remove now useless cleanup when building the httpd container image to fix its build.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: container proxy

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
