### PR TITLE
Fix tracebacks on spacecmd kickstart_export (bsc#1200591)

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Fix tracebacks on spacecmd kickstart_export (bsc#1200591)
 - Change proxy container config default filename to end with tar.gz
 
 -------------------------------------------------------------------

--- a/spacecmd/src/spacecmd/kickstart.py
+++ b/spacecmd/src/spacecmd/kickstart.py
@@ -2326,7 +2326,13 @@ def export_kickstart_getdetails(self, profile, kickstarts):
     # and now sort all the lists
     for i in details.keys():
         if isinstance(details[i], list):
-            details[i].sort()
+            # Use `name` value of the dict on sorting list of the dicts
+            # advanced_opts is a list of dicts with `name` and `arguments` keys
+            details[i].sort(
+                key=lambda elem: elem["name"]
+                if isinstance(elem, dict) and "name" in elem
+                else elem
+            )
 
     return details
 

--- a/spacecmd/tests/test_kickstart.py
+++ b/spacecmd/tests/test_kickstart.py
@@ -6,6 +6,7 @@ NOTE: This module is quite rarely used within Uyuni/SLE,
       only mostly for cloning, manual editing of the cobbler profiles
       and then deleting them.
 """
+import copy
 import os
 from unittest.mock import MagicMock, patch
 from helpers import shell, assert_expect, assert_list_args_expect, assert_args_expect
@@ -808,3 +809,28 @@ echo 'some more hello'
         assert not shell.help_kickstart_removeactivationkeys.called
         assert not shell.user_confirm.called
         assert shell.client.kickstart.profile.keys.removeActivationKey.called
+
+    def test_export_kickstart_getdetails_sort_all_lists(self, shell):
+        """
+        Test export_kickstart_getdetails for sorting list of dicts
+
+        :return:
+        """
+        advanced_opts = [
+            {"name": "keyboard", "arguments": "us"},
+            {"name": "install"},
+            {"name": "firewall", "arguments": "--disabled"},
+        ]
+        expected = [
+            {"name": "firewall", "arguments": "--disabled"},
+            {"name": "install"},
+            {"name": "keyboard", "arguments": "us"},
+        ]
+        shell.client.kickstart.profile.getAdvancedOptions = MagicMock(
+            return_value=copy.deepcopy(advanced_opts)
+        )
+        shell.kickstart_getcontents = MagicMock(return_value="")
+        details = spacecmd.kickstart.export_kickstart_getdetails(shell, "testing-testing", [{
+            "label": "testing-testing",
+        }])
+        assert details["advanced_opts"] == expected


### PR DESCRIPTION
## What does this PR change?

There was a traceback on calling `spacecmd kickstart_export`:
```
Traceback (most recent call last):
  File "/usr/bin/spacecmd", line 244, in <module>
    shell.cmdloop()
  File "/usr/lib64/python3.6/cmd.py", line 138, in cmdloop
    stop = self.onecmd(line)
  File "/usr/lib64/python3.6/cmd.py", line 217, in onecmd
    return func(arg)
  File "/usr/lib/python3.6/site-packages/spacecmd/kickstart.py", line 2302, in do_kickstart_export
    ksdetails_list.append(self.export_kickstart_getdetails(p, kickstarts))
  File "/usr/lib/python3.6/site-packages/spacecmd/kickstart.py", line 2251, in export_kickstart_getdetails
    details[i].sort()
TypeError: '<' not supported between instances of 'dict' and 'dict'
```

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- Unit test was added

## Links

Tracks https://github.com/SUSE/spacewalk/issues/18154

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
