### PR TITLE
Show correct help for kickstart_importjson

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Show correct help on calling kickstart_importjson with no arguments
 - Fix tracebacks on spacecmd kickstart_export (bsc#1200591)
 - Change proxy container config default filename to end with tar.gz
 

--- a/spacecmd/src/spacecmd/kickstart.py
+++ b/spacecmd/src/spacecmd/kickstart.py
@@ -2414,7 +2414,7 @@ def do_kickstart_importjson(self, args):
 
     if not args:
         logging.error(_N("Error, no filename passed"))
-        self.help_kickstart_import()
+        self.help_kickstart_importjson()
         return 1
 
     for filename in args:

--- a/spacecmd/tests/test_kickstart.py
+++ b/spacecmd/tests/test_kickstart.py
@@ -834,3 +834,15 @@ echo 'some more hello'
             "label": "testing-testing",
         }])
         assert details["advanced_opts"] == expected
+
+    def test_help_kickstart_importjson(self, shell):
+        """
+        Test do_kickstart_importjson showing proper help if no arguments
+
+        :param shell:
+        :return:
+        """
+        spacecmd.kickstart.do_kickstart_importjson(shell, "")
+
+        assert shell.help_kickstart_importjson.called
+        assert not shell.help_kickstart_import.called


### PR DESCRIPTION
## What does this PR change?

`spacecmd` is showing help for `kickstart_import` instead of help for `kickstart_importjson` in case of calling `kickstart_importjson` with no arguments.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- Unit test was added

## Links

Tracks https://github.com/SUSE/spacewalk/issues/18154 (not related to the issue directly, but was found during fixing the bug for this issue)

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
