### PR TITLE
Automatic sync of custom channels

### DIFF
--- a/java/code/src/com/redhat/rhn/common/conf/Config.java
+++ b/java/code/src/com/redhat/rhn/common/conf/Config.java
@@ -377,19 +377,28 @@ public class Config {
      * @return the value
      */
     public boolean getBoolean(String s) {
+        return getBoolean(s, false);
+    }
+
+    /**
+     * get the config entry for string s
+     *
+     * @param s string to get the value of
+     * @param defaultValue the default value
+     * @return the value
+     */
+    public boolean getBoolean(String s, boolean defaultValue) {
         String value = getString(s);
         if (logger.isDebugEnabled()) {
             logger.debug("getBoolean() - {} is : {}", s, value);
         }
         if (value == null) {
-            return false;
+            return defaultValue;
         }
 
         //need to check the possible true values
         // tried to use BooleanUtils, but that didn't
         // get the job done for an integer as a String.
-
-
         for (String trueValue : TRUE_VALUES) {
             if (trueValue.equalsIgnoreCase(value)) {
                 if (logger.isDebugEnabled()) {

--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -355,6 +355,11 @@ public class ConfigDefaults {
      */
     public static final String DEFAULT_DOCS_LOCALE = "web.docs_locale";
 
+    /**
+     * Specify if custom channels are synced together with vendor channels
+     */
+    public static final String UNIFY_CUSTOM_CHANNEL_MANAGEMENT = "java.unify_custom_channel_management";
+
     private ConfigDefaults() {
     }
 
@@ -1098,4 +1103,14 @@ public class ConfigDefaults {
     public boolean isForwardRegistrationEnabled() {
         return Config.get().getBoolean(FORWARD_REGISTRATION);
     }
+
+    /**
+     * Returns true if custom channel are synced automatically with vendor channels
+     *
+     * @return true if automatic sync is active, false otherwise
+     */
+    public boolean isCustomChannelManagementUnificationEnabled() {
+        return Config.get().getBoolean(UNIFY_CUSTOM_CHANNEL_MANAGEMENT);
+    }
+
 }

--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -1110,7 +1110,7 @@ public class ConfigDefaults {
      * @return true if automatic sync is active, false otherwise
      */
     public boolean isCustomChannelManagementUnificationEnabled() {
-        return Config.get().getBoolean(UNIFY_CUSTOM_CHANNEL_MANAGEMENT);
+        return Config.get().getBoolean(UNIFY_CUSTOM_CHANNEL_MANAGEMENT, true);
     }
 
 }

--- a/java/code/src/com/redhat/rhn/common/util/RecurringEventPicker.java
+++ b/java/code/src/com/redhat/rhn/common/util/RecurringEventPicker.java
@@ -17,6 +17,8 @@ package com.redhat.rhn.common.util;
 import com.redhat.rhn.frontend.context.Context;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.text.DateFormatSymbols;
 import java.util.Calendar;
@@ -47,6 +49,8 @@ import javax.servlet.http.HttpServletRequest;
  *
  */
 public class RecurringEventPicker {
+
+    private static final Logger LOGGER = LogManager.getLogger(RecurringEventPicker.class);
 
     private static final String STATUS_DISABLED = "disabled";
 
@@ -275,7 +279,9 @@ public class RecurringEventPicker {
         else if (cronEntry != null) {
             if (cronEntry.split(WHITE_SPACE).length < 6) {
                 //The Cron Entry is too short
-                return null;
+                LOGGER.warn("Error while loading picker: ignoring invalid expression cron '{}'", cronEntry);
+                p.setStatus(STATUS_DISABLED);
+                return p;
             }
 
             // here do it the other way around, set the time pickers from
@@ -406,9 +412,7 @@ public class RecurringEventPicker {
      */
     public String getDayOfWeekString() {
         String num = getCronValue(5);
-        if (num == null || !StringUtils.isNumeric(num) ||
-                getDayNames().length  < Integer.parseInt(num) ||
-                Integer.parseInt(num) < 1) {
+        if (!StringUtils.isNumeric(num) || getDayNames().length < Integer.parseInt(num) || Integer.parseInt(num) < 1) {
             return null;
         }
         return getDayNames()[Integer.parseInt(num) - 1];

--- a/java/code/src/com/redhat/rhn/domain/channel/Channel.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/Channel.hbm.xml
@@ -642,6 +642,11 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <![CDATA[select distinct c.channelArch.label from com.redhat.rhn.domain.channel.Channel as c]]>
     </query>
 
+    <query name="Channel.findCustomChannelsWithRepositories">
+        <![CDATA[from com.redhat.rhn.domain.channel.Channel as c
+                where c.org is not null and c.sources is not empty]]>
+    </query>
+
     <query name="Channel.findVendorChannels">
         <![CDATA[from com.redhat.rhn.domain.channel.Channel as c
                  where c.org is null]]>

--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
@@ -1308,17 +1308,28 @@ public class ChannelFactory extends HibernateFactory {
      * List all vendor channels (org is null)
      * @return list of vendor channels
      */
-    @SuppressWarnings("unchecked")
     public static List<Channel> listVendorChannels() {
-        Map<String, Object> params = new HashMap<>();
-        List<Channel> result = singleton.listObjectsByNamedQuery(
-                "Channel.findVendorChannels", params);
+        @SuppressWarnings("unchecked")
+        List<Channel> result = singleton.listObjectsByNamedQuery("Channel.findVendorChannels", Collections.emptyMap());
         if (result != null) {
             return result;
         }
         return new ArrayList<>();
     }
 
+    /**
+     * List all custom channels (org is not null) with at least one repository
+     * @return list of vendor channels
+     */
+    public static List<Channel> listCustomChannelsWithRepositories() {
+        @SuppressWarnings("unchecked")
+        List<Channel> result =
+            singleton.listObjectsByNamedQuery("Channel.findCustomChannelsWithRepositories", Collections.emptyMap());
+        if (result != null) {
+            return result;
+        }
+        return new ArrayList<>();
+    }
     /**
      * List all vendor content sources (org is null)
      * @return list of vendor content sources

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -23468,6 +23468,12 @@ given channel.</source>
           <context context-type="sourcefile">/rhn/channels/manage/Sync.do</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="channel.manage.sync.scheduledisabled.jsp" xml:space="preserve">
+        <source>Automatic synchronization of custom channels is enabled. This channel will be automatically synced together with vendor channels.</source>
+            <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/channels/manage/Sync.do</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="extauth.org.message" xml:space="preserve">
         <source>Even externally authenticated users need to be created within @@PRODUCT_NAME@@. You may specify, in what organization new users shall be created. An option is to use the Org. Unit set on IPA server that has to match the organization name. Another option is to set a default organization, where all the newly created users will be created.</source>
         <context-group name="ctx">

--- a/java/code/webapp/WEB-INF/pages/channel/manage/syncrepos.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/manage/syncrepos.jsp
@@ -108,17 +108,32 @@
 
         <br/>
 
-        <jsp:include page="/WEB-INF/pages/common/fragments/repeat-task-picker.jspf">
-            <jsp:param name="widget" value="date"/>
-        </jsp:include>
+        <c:if test='${scheduleEditable}'>
+            <jsp:include page="/WEB-INF/pages/common/fragments/repeat-task-picker.jspf">
+                <jsp:param name="widget" value="date"/>
+            </jsp:include>
 
-        <div class="text-right">
-            <button type="submit" value="<bean:message key='schedule.button'/>" class="btn btn-default"
-                    name="dispatch" ${inactive ? 'disabled' : ''}>
-                <rhn:icon type="repo-schedule-sync"/>
-                <bean:message key="schedule.button"/>
-            </button>
-        </div>
+            <div class="text-right">
+                <button type="submit" value="<bean:message key='schedule.button'/>" class="btn btn-default"
+                        name="dispatch" ${inactive ? 'disabled' : ''}>
+                    <rhn:icon type="repo-schedule-sync"/>
+                    <bean:message key="schedule.button"/>
+                </button>
+            </div>
+        </c:if>
+
+        <c:if test='${not scheduleEditable}'>
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h4><bean:message key="schedule.header"/></h4>
+                </div>
+
+              <div class="panel-body">
+                  <bean:message key="channel.manage.sync.scheduledisabled.jsp"/>
+              </div>
+            </div>
+        </c:if>
+
 
     </rl:listset>
 

--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -128,6 +128,11 @@ java.non_expirable_package_urls =
 # Size of the thread pool used for the message queue
 java.message_queue_thread_pool_size = 5
 
+# Unify management of custom and vendor channels.
+# When true, custom channels are synced automatically after creation and scheduled together with vendor channels
+# Otherwise, any synchronization on custom channel must be issued manually
+java.unify_custom_channel_management = true
+
 # The duration, in hours, of the time window for Salt minions to stage
 # packages in advance of scheduled installations or upgrades.
 #

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Added a new configuration property to allow custom channels to
+  be synced together with vendor channels.
 - add onlyRelevant argument to addErrataUpdate API
 - fix taskomatic task remain in progress
 

--- a/utils/spacewalk-common-channels
+++ b/utils/spacewalk-common-channels
@@ -19,6 +19,7 @@ import fnmatch
 from optparse import OptionParser, Option
 import re
 from uyuni.common.cli import getUsernamePassword, xmlrpc_login, xmlrpc_logout
+from uyuni.common.context_managers import cfg_component
 
 try:
     import xmlrpclib
@@ -245,6 +246,14 @@ Create everything as well as unlimited activation key for every channel:
                action="store_true"),
     ]
 
+    # Read the configuration to figure out if channel should be synced automatically on creation
+    sync_channels = False
+    with cfg_component("java") as CFG:
+        try:
+            sync_channels = CFG.unify_custom_channel_management.lower() in ["1", "y", "true", "yes", "on"]
+        except (AttributeError, ValueError):
+            pass
+
     parser = ExtOptionParser(usage=usage, option_list=option_list, examples=examples)
     (options, args) = parser.parse_args()
     config = ConfigParser.ConfigParser()
@@ -322,7 +331,7 @@ Create everything as well as unlimited activation key for every channel:
 
     existing_repo_urls = get_existing_repos(client)
     if existing_repo_urls is None:
-        sys.stderr.write("Unable to get exsiting repositories from server.\n")
+        sys.stderr.write("Unable to get existing repositories from server.\n")
         sys.exit(2)
 
     for (base_channel_label, create_channel) in sorted(base_channels.items()):
@@ -361,6 +370,9 @@ Create everything as well as unlimited activation key for every channel:
                                                            base_info['repo_url'])
                         client.channel.software.associateRepo(key,
                                                               base_info['label'], base_info['yum_repo_label'])
+
+                    if sync_channels:
+                        client.channel.software.syncRepo(key, base_info['label'])
                 except xmlrpclib.Fault as e:
                     if e.faultCode == 1200:  # ignore if channel exists
                         sys.stdout.write("INFO: %s exists\n" % base_info['label'])
@@ -442,6 +454,8 @@ Create everything as well as unlimited activation key for every channel:
                                                            child_info['repo_url'])
                         client.channel.software.associateRepo(key,
                                                               child_info['label'], child_info['yum_repo_label'])
+                    if sync_channels:
+                        client.channel.software.syncRepo(key, child_info['label'])
                 except xmlrpclib.Fault as e:
                     if e.faultCode == 1200:  # ignore if channel exists
                         sys.stderr.write("WARNING: %s: %s\n" % (

--- a/utils/spacewalk-common-channels
+++ b/utils/spacewalk-common-channels
@@ -247,7 +247,7 @@ Create everything as well as unlimited activation key for every channel:
     ]
 
     # Read the configuration to figure out if channel should be synced automatically on creation
-    sync_channels = False
+    sync_channels = True
     with cfg_component("java") as CFG:
         try:
             sync_channels = CFG.unify_custom_channel_management.lower() in ["1", "y", "true", "yes", "on"]

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,7 @@
+- spacewalk-common-channels now syncs the channels automatically
+  on creation, if the new configuration property named
+  'unify_custom_channel_management' is enabled
+
 -------------------------------------------------------------------
 Wed Jul 27 14:09:58 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR add a new configuration property to unify the management of custom and vendor channels. In particular when the property is set to true:

1) custom channel are synced together with vendor channels
2) when a custom channel is added using `spacewalk-common-channels` it is automatically synced
3) the UI to set up scheduled syncronization is disabled

## GUI diff

After - Only when the configuration parameter is set to true:

![Screenshot from 2022-07-12 14-21-25](https://user-images.githubusercontent.com/2292684/178488452-46c3a500-4906-40fe-9db3-6a46cbdd07bb.png)

- [X] **DONE**

## Documentation

- Documentation PR WIP

- [ ] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18138

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
