### PR TITLE
log4j migration search server fix

### DIFF
--- a/search-server/spacewalk-search/build.xml
+++ b/search-server/spacewalk-search/build.xml
@@ -18,6 +18,10 @@
         <fileset dir="${java.lib.dir}" includes="**/*.jar" />
     </path>
 
+    <condition property="java_libdir" value="${JAVA_LIBDIR}" else="/usr/share/java">
+      <isset property="JAVA_LIBDIR"/>
+    </condition>
+
     <path id="test.classpath">
         <pathelement location="${build.dir}" />
         <path refid="project.classpath" />

--- a/search-server/spacewalk-search/buildconf/build-props.xml
+++ b/search-server/spacewalk-search/buildconf/build-props.xml
@@ -1,7 +1,7 @@
 <project name="build-props">
 
-  <available file="${java.lib.dir}/log4j/log4j-core.jar" type="file" property="log4j-core" value="log4j/log4j-core" />
-  <available file="${java.lib.dir}/log4j/log4j-api.jar" type="file" property="log4j-api" value="log4j/log4j-api" />
+  <available file="/usr/share/java/log4j/log4j-core.jar" type="file" property="log4j-core" value="log4j/log4j-core" />
+  <available file="/usr/share/java/log4j/log4j-api.jar" type="file" property="log4j-api" value="log4j/log4j-api" />
   <property name="log4j-jars" value="${log4j-core} ${log4j-api}"/>
 
   <property name="ivy.settings.file" value="buildconf/ivyconf.xml" />

--- a/search-server/spacewalk-search/buildconf/build-props.xml
+++ b/search-server/spacewalk-search/buildconf/build-props.xml
@@ -1,13 +1,13 @@
 <project name="build-props">
 
-  <available file="/usr/share/java/log4j/log4j-core.jar" type="file" property="log4j-core" value="log4j/log4j-core" />
-  <available file="/usr/share/java/log4j/log4j-api.jar" type="file" property="log4j-api" value="log4j/log4j-api" />
+  <available file="${java_libdir}/log4j/log4j-core.jar" type="file" property="log4j-core" value="log4j/log4j-core" />
+  <available file="${java_libdir}/log4j/log4j-api.jar" type="file" property="log4j-api" value="log4j/log4j-api" />
   <property name="log4j-jars" value="${log4j-core} ${log4j-api}"/>
 
   <property name="ivy.settings.file" value="buildconf/ivyconf.xml" />
 
   <property name="c3p0" value="c3p0"/>
-  <available file="/usr/share/java/mchange-commons/mchange-commons-java.jar" type="file" property="c3p0" value="${c3p0} mchange-commons/mchange-commons-java"/>
+  <available file="${java_libdir}/mchange-commons/mchange-commons-java.jar" type="file" property="c3p0" value="${c3p0} mchange-commons/mchange-commons-java"/>
 
   <property name="jpackage.jars"
       value="${c3p0} cglib commons-cli commons-codec commons-lang3


### PR DESCRIPTION
## What does this PR change?

Fixes the class path for the log4j jar in the search-server package

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- No tests: already covered

- [x] **DONE**

## Links

Fixes #

- [x] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests" (Test skipped, there are no changes to test)
- [x] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests" (Test skipped, there are no changes to test)
