### PR TITLE
search: set the JAVA_LIBDIR variable before imports use it

### DIFF
--- a/search-server/spacewalk-search/build.xml
+++ b/search-server/spacewalk-search/build.xml
@@ -1,4 +1,8 @@
 <project name="search-server" basedir="." default="all">
+    <condition property="java_libdir" value="${JAVA_LIBDIR}" else="/usr/share/java">
+      <isset property="JAVA_LIBDIR"/>
+    </condition>
+
     <import file="buildconf/build-utils.xml" />
     <import file="buildconf/build-props.xml" />
 
@@ -17,10 +21,6 @@
     <path id="project.classpath">
         <fileset dir="${java.lib.dir}" includes="**/*.jar" />
     </path>
-
-    <condition property="java_libdir" value="${JAVA_LIBDIR}" else="/usr/share/java">
-      <isset property="JAVA_LIBDIR"/>
-    </condition>
 
     <path id="test.classpath">
         <pathelement location="${build.dir}" />


### PR DESCRIPTION
## What does this PR change?

Fixes `spacewalk-search` package build

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered
- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
