### PR TITLE
Adapting cucumber tests relative to the About link in 4.3 mainpage

### DIFF
--- a/testsuite/features/secondary/srv_mainpage.feature
+++ b/testsuite/features/secondary/srv_mainpage.feature
@@ -10,14 +10,7 @@ Feature: Main landing page options and preferences
   Scenario: Access the Login page
     Given I am not authorized
     When I go to the home page
-    Then I should see something
-
-@susemanager
-  Scenario: Access the About page
-    Given I am not authorized
-    When I go to the home page
-    And I follow "About"
-    Then I should see a "About SUSE Manager" text
+    Then I should see a "Sign In" text
 
 @uyuni
   Scenario: Access the About page


### PR DESCRIPTION
## What does this PR change?

Adapt and remove cucumber tests related to the `About` link not present anymore on the main landing page (when signed out) since 4.3.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were added : change `I see something` into `I see "Sign In"`and remove the section testing the `About` link for suse manager. 

- [x] **DONE**

## Links

Fixes: https://github.com/SUSE/spacewalk/issues/18323
No backport

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
