### PR TITLE
Fix deploy of SLE Micro CA Certificate (bsc#1200276)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/certs/suse.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/suse.sls
@@ -31,6 +31,10 @@ update-ca-certificates:
     - runas: root
     - onchanges:
       - file: mgr_ca_cert
+    - retry:
+        attempts: 5
+        interval: 5
+        until: True
 {%- if grains['saltversioninfo'][0] >= 3002 %} # Workaround for bsc#1188641
     - unless:
       - fun: service.status

--- a/susemanager-utils/susemanager-sls/salt/certs/suse.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/suse.sls
@@ -35,10 +35,4 @@ update-ca-certificates:
         attempts: 5
         interval: 5
         until: True
-{%- if grains['saltversioninfo'][0] >= 3002 %} # Workaround for bsc#1188641
-    - unless:
-      - fun: service.status
-        args:
-          - ca-certificates.path
-{%- endif %}
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix deploy of SLE Micro CA Certificate (bsc#1200276)
 - disable local repos before bootstrap and at highstate (bsc#1191925)
 - deploy GPG keys to the clients and define trust in channels (bsc#1199984)
 - Enable basic support for Ubuntu 22.04


### PR DESCRIPTION
## What does this PR change?

Currently the deploy of SLE Micro CA Certificate is not working, because `update-ca-certificates` is never executed.
```
update-ca-certificates:
  cmd.run:
    - name: /usr/sbin/update-ca-certificates
    - runas: root
    - onchanges:
      - file: mgr_ca_cert
{%- if grains['saltversioninfo'][0] >= 3002 %} # Workaround for bsc#1188641
    - unless:
      - fun: service.status
        args:
          - ca-certificates.path
{%- endif %}
```
This happens because SLE Micro has a false positive when checking `service.status` . To workaround the issue, we would check if an ca-certificates update is already running by checking `/var/lib/ca-certificates/ca-bundle.pem.tmp` file. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage


- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18093

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
