### PR TITLE
The SSH public key is also required for OBS MFA

### DIFF
--- a/susemanager-utils/testing/automation/push-to-obs.sh
+++ b/susemanager-utils/testing/automation/push-to-obs.sh
@@ -17,7 +17,8 @@ help() {
   echo "  -d  Comma separated list of destionations in the format API/PROJECT,"
   echo "      for example https://api.opensuse.org|systemsmanagement:Uyuni:Master"
   echo "  -c  Path to the OSC credentials (usually ~/.osrc)"
-  echo "  -s  Path to the private key used for MFA"
+  echo "  -s  Path to the private key used for MFA, a file ending with .pub must also"
+  echo "      exist, containing the public key"
   echo "  -p  Comma separated list of packages. If absent, all packages are submitted"
   echo "  -v  Verbose mode"
   echo "  -t  For tito, use current branch HEAD instead of latest package tag"
@@ -88,7 +89,7 @@ if [ "${SSHKEY}" != "" ]; then
     echo "ERROR: File ${SSHKEY} does not exist!"
     exit 1
   fi
-  MOUNTSSHKEY="--mount type=bind,source=${SSHKEY},target=/root/.ssh/id_rsa"
+  MOUNTSSHKEY="--mount type=bind,source=${SSHKEY},target=/root/.ssh/id_rsa --mount type=bind,source=${SSHKEY}.pub,target=/root/.ssh/id_rsa.pub"
   USESSHKEY="-s /root/.ssh/id_rsa"
 fi
 


### PR DESCRIPTION
## What does this PR change?

Other wise we get the following error at the 2obs jobs:

```
*************** PUSHING TO Devel:Galaxy:Manager:Head ***************
dnf-plugin-spacewalk
Going to update Devel:Galaxy:Manager:Head from SRPMS...
=== Processing package [dnf-plugin-spacewalk]
Try: 1
Try: 2
Try: 3
Couldn't load public key /root/.ssh/id_rsa: No such file or directory
ssh-keygen signature creation failed: 255
*** FAILED (checkout) [dnf-plugin-spacewalk]
```

As you an see, the error is wrong, as this gets fixed by having ` /root/.ssh/id_rsa.pub`.

Anyway, I tested this fix at Head, and now the script is able to submit,

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Submission jobs

- [x] **DONE**

## Test coverage
- No tests: Tested by running it.

- [x] **DONE**

## Links

Related: https://github.com/SUSE/spacewalk/issues/18180

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
