### PR TITLE
Some extra checks for MFA

### DIFF
--- a/susemanager-utils/testing/automation/push-to-obs.sh
+++ b/susemanager-utils/testing/automation/push-to-obs.sh
@@ -89,6 +89,10 @@ if [ "${SSHKEY}" != "" ]; then
     echo "ERROR: File ${SSHKEY} does not exist!"
     exit 1
   fi
+  if [ ! -f ${SSHKEY}.pub ]; then
+    echo "ERROR: File ${SSHKEY}.pub does not exist!"
+    exit 1
+  fi
   MOUNTSSHKEY="--mount type=bind,source=${SSHKEY},target=/root/.ssh/id_rsa --mount type=bind,source=${SSHKEY}.pub,target=/root/.ssh/id_rsa.pub"
   USESSHKEY="-s /root/.ssh/id_rsa"
 fi

--- a/susemanager-utils/testing/docker/scripts/push-to-obs.sh
+++ b/susemanager-utils/testing/docker/scripts/push-to-obs.sh
@@ -16,7 +16,8 @@ help() {
   echo "      for example https://api.opensuse.org|systemsmanagement:Uyuni:Master"
   echo "  -p  Comma separated list of packages. If absent, all packages are submitted"
   echo "  -c  Path to the OSC credentials (usually ~/.osrc)"
-  echo "  -s  Path to the private key used for MFA"
+  echo "  -s  Path to the private key used for MFA, a file ending with .pub must also"
+  echo "      exist, containing the public key"
   echo "  -v  Verbose mode"
   echo "  -t  For tito, use current branch HEAD instead of latest package tag"
   echo "  -n  If used, update PROJECT instead of the projects specified with -d"
@@ -57,6 +58,17 @@ fi
 if [ ! -f ${OSCRC} ]; then
   echo "ERROR: File ${OSCRC} does not exist!"
   exit 1
+fi
+
+if [ "${SSHKEY}" != "" ]; then
+  if [ ! -f ${SSHKEY} ]; then
+    echo "ERROR: File ${SSHKEY} does not exist!"
+    exit 1
+  fi
+  if [ ! -f ${SSHKEY}.pub ]; then
+    echo "ERROR: File ${SSHKEY}.pub does not exist!"
+    exit 1
+  fi
 fi
 
 # declare /manager as "safe"


### PR DESCRIPTION
## What does this PR change?

Basically check that the both files for private and public key exist both before we create the container, and *inside* the container.

It will help us if we ever remove any of the files, by mistake.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Submission job

- [x] **DONE**

## Test coverage
- No tests: Tested by running it.

- [x] **DONE**

## Links

Related: https://github.com/SUSE/spacewalk/issues/18180

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
