### PR TITLE
Remove XML files from sonarqube scanning

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,5 +5,5 @@ sonar.java.libraries=java/lib/*.jar
 sonar.junit.reportPaths=java/test-results/
 sonar.coverage.jacoco.xmlReportPaths=java/test-results/coverage/report.xml
 sonar.tests=.
-sonar.exclusions=*.c,java/buildconf/**/*,**/*.jsp*,java/scripts/**/*
+sonar.exclusions=*.c,java/buildconf/**/*,**/*.jsp*,java/scripts/**/*,**/*.xml
 sonar.test.inclusions=testsuite/**/*,**/test/**/*,**/tests/**/*,**/*test.ts,**/*test.tsx,**/testing/**/*,java/**/*Test.java


### PR DESCRIPTION
## What does this PR change?

Remove the XML files from the counted lines of code: Those are adding about 1 million lines of code that we don't want to analyze for (Java localization, hibernate queries, struts config, etc)

## GUI diff

No difference.
- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: tooling config

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
