### PR TITLE
Add Rocky Linux 9 support

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
@@ -173,7 +173,7 @@ public class MinionServer extends Server implements SaltConfigurable {
     public boolean doesOsSupportsMonitoring() {
         return isSLES12() || isSLES15() || isLeap15() || isUbuntu1804() || isUbuntu2004() || isUbuntu2204() ||
                 isRedHat6() || isRedHat7() || isRedHat8() || isAlibaba2() || isAmazon2() || isRocky8() ||
-                isDebian11() || isDebian10();
+                isRocky9() || isDebian11() || isDebian10();
     }
 
     /**
@@ -260,6 +260,10 @@ public class MinionServer extends Server implements SaltConfigurable {
 
     private boolean isRocky8() {
         return ServerConstants.ROCKY.equals(getOs()) && getRelease().startsWith("8.");
+    }
+
+    private boolean isRocky9() {
+        return ServerConstants.ROCKY.equals(getOs()) && getRelease().startsWith("9.");
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Enable Rocky Linux 9 for monitoring
 - Added a new configuration property to allow custom channels to
   be synced together with vendor channels.
 - add onlyRelevant argument to addErrataUpdate API

--- a/schema/spacewalk/common/data/rhnPackageKey.sql
+++ b/schema/spacewalk/common/data/rhnPackageKey.sql
@@ -155,8 +155,10 @@ insert into rhnPackageKey (id, key_id, key_type_id, provider_id) (select sequenc
 insert into rhnPackageKey (id, key_id, key_type_id, provider_id) (select sequence_nextval('rhn_pkey_id_seq'), '3b49df2a0608b895', lookup_package_key_type('gpg'), lookup_package_provider('EPEL') from dual where not exists (select 1 from rhnPackageKey where key_id = '3b49df2a0608b895'));
 -- EPEL 7
 insert into rhnPackageKey (id, key_id, key_type_id, provider_id) (select sequence_nextval('rhn_pkey_id_seq'), '6a2faea2352c64e5', lookup_package_key_type('gpg'), lookup_package_provider('EPEL') from dual where not exists (select 1 from rhnPackageKey where key_id = '6a2faea2352c64e5'));
---EPEL 8
+-- EPEL 8
 insert into rhnPackageKey (id, key_id, key_type_id, provider_id) (select sequence_nextval('rhn_pkey_id_seq'), '21ea45ab2f86d6a1', lookup_package_key_type('gpg'), lookup_package_provider('EPEL') from dual where not exists (select 1 from rhnPackageKey where key_id = '21ea45ab2f86d6a1'));
+-- EPEL 9
+insert into rhnPackageKey (id, key_id, key_type_id, provider_id) (select sequence_nextval('rhn_pkey_id_seq'), '8a3872bf3228467c', lookup_package_key_type('gpg'), lookup_package_provider('EPEL') from dual where not exists (select 1 from rhnPackageKey where key_id = '8a3872bf3228467c'));
 
 -- Aliyun Linux 2.1903
 insert into rhnPackageKey (id, key_id, key_type_id, provider_id) (select sequence_nextval('rhn_pkey_id_seq'), 'eb801c41873141a8', lookup_package_key_type('gpg'), lookup_package_provider('Alibaba') from dual where not exists (select 1 from rhnPackageKey where key_id = 'eb801c41873141a8'));
@@ -172,6 +174,8 @@ insert into rhnPackageKey (id, key_id, key_type_id, provider_id) (select sequenc
 
 -- Rocky Linux 8
 insert into rhnPackageKey (id, key_id, key_type_id, provider_id) (select sequence_nextval('rhn_pkey_id_seq'), '15af5dac6d745a60', lookup_package_key_type('gpg'), lookup_package_provider('Rocky Linux') from dual where not exists (select 1 from rhnPackageKey where key_id = '15af5dac6d745a60'));
+-- Rocky Linux 9
+insert into rhnPackageKey (id, key_id, key_type_id, provider_id) (select sequence_nextval('rhn_pkey_id_seq'), '702d426d350d275d', lookup_package_key_type('gpg'), lookup_package_provider('Rocky Linux') from dual where not exists (select 1 from rhnPackageKey where key_id = '702d426d350d275d'));
 
 commit;
 

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Add Rocky Linux 9 and EPEL 9 key
 - improve schema compatibility with Amazon RDS
 
 -------------------------------------------------------------------

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.0-to-susemanager-schema-4.4.1/100-rocky-epel.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.0-to-susemanager-schema-4.4.1/100-rocky-epel.sql
@@ -1,0 +1,11 @@
+-- Rocky Linux 9
+insert into rhnPackageKey (id, key_id, key_type_id, provider_id)
+    (select sequence_nextval('rhn_pkey_id_seq'), '702d426d350d275d', lookup_package_key_type('gpg'),
+    lookup_package_provider('Rocky Linux') from dual
+    where not exists (select 1 from rhnPackageKey where key_id = '702d426d350d275d'));
+
+-- EPEL 9
+insert into rhnPackageKey (id, key_id, key_type_id, provider_id)
+    (select sequence_nextval('rhn_pkey_id_seq'), '8a3872bf3228467c', lookup_package_key_type('gpg'),
+    lookup_package_provider('EPEL') from dual
+    where not exists (select 1 from rhnPackageKey where key_id = '8a3872bf3228467c'));

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1550,6 +1550,22 @@ DATA = {
         'BASECHANNEL' : 'rockylinux8-aarch64', 'PKGLIST' : RES8,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/rockylinux/8/bootstrap/'
     },
+    'rockylinux-9-x86_64-uyuni' : {
+        'BASECHANNEL' : 'rockylinux9-x86_64', 'PKGLIST' : RES9,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/rockylinux/9/bootstrap/'
+    },
+    'rockylinux-9-aarch64-uyuni' : {
+        'BASECHANNEL' : 'rockylinux9-aarch64', 'PKGLIST' : RES9,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/rockylinux/9/bootstrap/'
+    },
+    'rockylinux-9-ppc64le-uyuni' : {
+        'BASECHANNEL' : 'rockylinux9-ppc64le', 'PKGLIST' : RES9,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/rockylinux/9/bootstrap/'
+    },
+    'rockylinux-9-s390x-uyuni' : {
+        'BASECHANNEL' : 'rockylinux9-s390x', 'PKGLIST' : RES9,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/rockylinux/9/bootstrap/'
+    },
     'ubuntu-16.04-amd64' : {
         'PDID' : [-2, 1917], 'BETAPDID' : [2061], 'PKGLIST' : PKGLISTUBUNTU1604,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/ubuntu/16/4/bootstrap/',

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Add Rocky Linux 9 bootstrap repositories for Uyuni
 - mgr-create-bootstrap-repo: flush directory also when called
   for a specific label (bsc#1200573)
 - pg-migrate-x-to-y.sh: improve output (bsc#1201260)

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -3505,7 +3505,8 @@ repo_url = http://mirrors.fedoraproject.org/mirrorlist?repo=epel-9&arch=%(arch)s
 
 [rockylinux8]
 archs    = x86_64, aarch64
-name     = RockyLinux 8 (%(arch)s)
+checksum = sha256
+name     = Rocky Linux 8 (%(arch)s)
 gpgkey_url = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rockyofficial
 gpgkey_id = 6D745A60
 gpgkey_fingerprint = 7051 C470 A929 F454 CEBE 37B7 15AF 5DAC 6D74 5A60
@@ -3515,6 +3516,7 @@ dist_map_release = 8
 [rockylinux8-appstream]
 label    = %(base_channel)s-appstream
 archs    = x86_64, aarch64
+checksum = sha256
 name     = Rocky Linux 8 - AppStream (%(arch)s)
 base_channels = rockylinux8-%(arch)s
 repo_url = https://mirrors.rockylinux.org/mirrorlist?repo=AppStream-8&arch=%(arch)s
@@ -3522,6 +3524,7 @@ repo_url = https://mirrors.rockylinux.org/mirrorlist?repo=AppStream-8&arch=%(arc
 [rockylinux8-extras]
 label    = %(base_channel)s-extras
 archs    = x86_64, aarch64
+checksum = sha256
 name     = Rocky Linux 8 - Extras (%(arch)s)
 base_channels = rockylinux8-%(arch)s
 repo_url = https://mirrors.rockylinux.org/mirrorlist?repo=extras-8&arch=%(arch)s
@@ -3529,6 +3532,7 @@ repo_url = https://mirrors.rockylinux.org/mirrorlist?repo=extras-8&arch=%(arch)s
 [rockylinux8-powertools]
 label    = %(base_channel)s-powertools
 archs    = x86_64, aarch64
+checksum = sha256
 name     = Rocky Linux 8 - PowerTools (%(arch)s)
 base_channels = rockylinux8-%(arch)s
 repo_url = https://mirrors.rockylinux.org/mirrorlist?repo=PowerTools-8&arch=%(arch)s
@@ -3536,6 +3540,7 @@ repo_url = https://mirrors.rockylinux.org/mirrorlist?repo=PowerTools-8&arch=%(ar
 [rockylinux8-ha]
 label    = %(base_channel)s-ha
 archs    = x86_64, aarch64
+checksum = sha256
 name     = Rocky Linux 8 - High Availability (%(arch)s)
 base_channels = rockylinux8-%(arch)s
 repo_url = https://mirrors.rockylinux.org/mirrorlist?repo=HighAvailability-8&arch=%(arch)s
@@ -3543,6 +3548,7 @@ repo_url = https://mirrors.rockylinux.org/mirrorlist?repo=HighAvailability-8&arc
 [rockylinux8-uyuni-client]
 name     = Uyuni Client Tools for %(base_channel_name)s
 archs    = %(_x86_archs)s, aarch64
+checksum = sha256
 base_channels = rockylinux8-%(arch)s
 gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s
@@ -3552,6 +3558,7 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 [rockylinux8-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
 archs    = %(_x86_archs)s, aarch64
+checksum = sha256
 base_channels = rockylinux8-%(arch)s
 gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s
@@ -3562,8 +3569,152 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 label    = epel8-%(base_channel)s
 name     = EPEL 8 for %(base_channel_name)s
 archs    = x86_64, ppc64le, aarch64
+checksum = sha256
 base_channels = rockylinux8-%(arch)s
 gpgkey_url = http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
 gpgkey_id = 2F86D6A1
 gpgkey_fingerprint = 94E2 79EB 8D8F 25B2 1810 ADF1 21EA 45AB 2F86 D6A1
 repo_url = http://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=%(arch)s
+
+[rockylinux9]
+archs    = x86_64, aarch64, ppc64le, s390x
+checksum = sha256
+name     = Rocky Linux 9 (%(arch)s)
+gpgkey_url = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9
+gpgkey_id = 350D275D
+gpgkey_fingerprint = 21CB 256A E16F C54C 6E65  2949 702D 426D 350D 275D
+repo_url = https://mirrors.rockylinux.org/mirrorlist?repo=BaseOS-9&arch=%(arch)s
+dist_map_release = 9
+
+[rockylinux9-appstream]
+label    = %(base_channel)s-appstream
+archs    = x86_64, aarch64, ppc64le, s390x
+checksum = sha256
+name     = Rocky Linux 9 AppStream (%(arch)s)
+base_channels = rockylinux9-%(arch)s
+repo_url = https://mirrors.rockylinux.org/mirrorlist?repo=AppStream-9&arch=%(arch)s
+
+[rockylinux9-extras]
+label    = %(base_channel)s-extras
+archs    = x86_64, aarch64, ppc64le, s390x
+checksum = sha256
+name     = Rocky Linux 9 Extras (%(arch)s)
+base_channels = rockylinux9-%(arch)s
+repo_url = https://mirrors.rockylinux.org/mirrorlist?repo=extras-9&arch=%(arch)s
+
+[rockylinux9-crb]
+label    = %(base_channel)s-crb
+archs    = x86_64, aarch64, ppc64le, s390x
+checksum = sha256
+name     = Rocky Linux 9 CRB (%(arch)s)
+base_channels = rockylinux9-%(arch)s
+repo_url = https://mirrors.rockylinux.org/mirrorlist?repo=CRB-9&arch=%(arch)s
+
+[rockylinux9-highavailability]
+label    = %(base_channel)s-highavailability
+archs    = x86_64, aarch64, ppc64le, s390x
+checksum = sha256
+name     = Rocky Linux 9 High Availability (%(arch)s)
+base_channels = rockylinux9-%(arch)s
+repo_url = https://mirrors.rockylinux.org/mirrorlist?repo=HighAvailability-9&arch=%(arch)s
+
+[rockylinux9-nfv]
+label    = %(base_channel)s-nfv
+archs    = x86_64, aarch64, ppc64le, s390x
+checksum = sha256
+name     = Rocky Linux 9 NFV (%(arch)s)
+base_channels = rockylinux9-%(arch)s
+repo_url = https://mirrors.rockylinux.org/mirrorlist?repo=NFV-9&arch=%(arch)s
+
+[rockylinux9-plus]
+label    = %(base_channel)s-plus
+archs    = x86_64, aarch64, ppc64le, s390x
+checksum = sha256
+name     = Rocky Linux 9 Plus (%(arch)s)
+base_channels = rockylinux9-%(arch)s
+repo_url = https://mirrors.rockylinux.org/mirrorlist?repo=plus-9&arch=%(arch)s
+
+[rockylinux9-resilientstorage]
+label    = %(base_channel)s-resilientstorage
+archs    = x86_64, aarch64, ppc64le, s390x
+checksum = sha256
+name     = Rocky Linux 9 ResilientStorage (%(arch)s)
+base_channels = rockylinux9-%(arch)s
+repo_url = https://mirrors.rockylinux.org/mirrorlist?repo=ResilientStorage-9&arch=%(arch)s
+
+[rockylinux9-rt]
+label    = %(base_channel)s-rt
+archs    = x86_64, aarch64, ppc64le, s390x
+checksum = sha256
+name     = Rocky Linux 9 RT (%(arch)s)
+base_channels = rockylinux9-%(arch)s
+repo_url = https://mirrors.rockylinux.org/mirrorlist?repo=RT-9&arch=%(arch)s
+
+[rockylinux9-saphana]
+label    = %(base_channel)s-saphana
+archs    = x86_64, aarch64, ppc64le, s390x
+checksum = sha256
+name     = Rocky Linux 9 SAPHANA (%(arch)s)
+base_channels = rockylinux9-%(arch)s
+repo_url = https://mirrors.rockylinux.org/mirrorlist?repo=SAP-9&arch=%(arch)s
+
+[rockylinux9-sap]
+label    = %(base_channel)s-sap
+archs    = x86_64, aarch64, ppc64le, s390x
+checksum = sha256
+name     = Rocky Linux 9 SAP (%(arch)s)
+base_channels = rockylinux9-%(arch)s
+repo_url = https://mirrors.rockylinux.org/mirrorlist?repo=SAPHANA-9&arch=%(arch)s
+
+[rockylinux9-altarch-common]
+label    = %(base_channel)s-altarch-common
+archs    = aarch64
+checksum = sha256
+name     = Rocky Linux 9 SIG AltArch Common (%(arch)s)
+gpgkey_url = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-SIG-AltArch
+gpgkey_id = 121A7A26
+gpgkey_fingerprint = F00C 8F0C 8082 E9F4 8675  C30A 51A8 2D3E 121A 7A26
+base_channels = rockylinux9-%(arch)s
+repo_url = https://mirrors.rockylinux.org/mirrorlist?repo=rocky-sig-altarch-common-9&arch=%(arch)s
+
+[rockylinux9-altarch-rockyrpi]
+label    = %(base_channel)s-altarch-rockyrpi
+archs    = aarch64
+checksum = sha256
+name     = Rocky Linux 9 Rasperry Pi (%(arch)s)
+gpgkey_url = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-SIG-AltArch
+gpgkey_id = 121A7A26
+gpgkey_fingerprint = F00C 8F0C 8082 E9F4 8675  C30A 51A8 2D3E 121A 7A26
+base_channels = rockylinux9-%(arch)s
+repo_url = https://mirrors.rockylinux.org/mirrorlist?repo=rocky-sig-altarch-rockyrpi-9&arch=%(arch)s
+
+[rockylinux9-uyuni-client]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = %(_x86_archs)s, aarch64, ppc64le, s390x
+checksum = sha256
+base_channels = rockylinux9-%(arch)s
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL9-Uyuni-Client-Tools/EL_9/
+
+[rockylinux9-uyuni-client-devel]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = %(_x86_archs)s, aarch64, ppc64le, s390x
+checksum = sha256
+base_channels = rockylinux9-%(arch)s
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL9-Uyuni-Client-Tools/EL_9/
+
+[rockylinux9-epel9]
+label    = epel9-%(base_channel)s
+name     = EPEL 9 for %(base_channel_name)s
+archs    = x86_64, aarch64, ppc64le, s390x
+checksum = sha256
+base_channels = rockylinux9-%(arch)s
+gpgkey_url = https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9
+gpgkey_id = 3228467C
+gpgkey_fingerprint = FF8A D134 4597 106E CE81 3B91 8A38 72BF 3228 467C
+repo_url = https://mirrors.fedoraproject.org/mirrorlist?repo=epel-9&arch=%(arch)s

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- Add Rocky Linux 9 to spacewalk-common-channels
 - spacewalk-common-channels now syncs the channels automatically
   on creation, if the new configuration property named
   'unify_custom_channel_management' is enabled


### PR DESCRIPTION
## What does this PR change?

This PR should make Rocky Linux 9 work completely.

I hope I didn't miss something took me a while to get through all parts of the application.

The only thing I didn't add are the parts in the 2 `additional_products.json` files and the referencing repo templates in `mgr-bootstrap-data.py`, as I didn't know which IDs I would have had to set.
If you could tell me which I should set there I can of course also add this right away 🙂 

It also adds the EPEL 9 key to the schema as this hasn't been done up to now, as far as I can see.

## GUI diff

No difference.

## Documentation
- Documentation issue was created: [uyuni-docs#1661](https://github.com/uyuni-project/uyuni-docs/issues/1661)
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: already covered

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

- [x] **DONE**

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

I don't really know which tests to run.

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
