### PR TITLE
QE: Wait until all valid channels has been synced in CI

### DIFF
--- a/testsuite/features/reposync/srv_wait_for_reposync.feature
+++ b/testsuite/features/reposync/srv_wait_for_reposync.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021 SUSE LLC
+# Copyright (c) 2019-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Wait for reposync activity to finish in CI context
@@ -15,3 +15,6 @@ Feature: Wait for reposync activity to finish in CI context
 
   Scenario: Kill running reposyncs or wait for them to finish
     When I kill all running spacewalk-repo-sync, excepted the ones needed to bootstrap
+
+  Scenario: Wait until all synchronized channels have finished
+    When I wait until all synchronized channels have finished

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -4,6 +4,7 @@
 require 'timeout'
 require 'nokogiri'
 require 'pg'
+require 'set'
 
 # Sanity checks
 
@@ -339,7 +340,7 @@ end
 # This function is written as a state machine. It bails out if no process is seen during
 # 60 seconds in a row, or if the whitelisted reposyncs last more than 7200 seconds in a row.
 When(/^I kill all running spacewalk\-repo\-sync, excepted the ones needed to bootstrap$/) do
-  do_not_kill = compute_list_to_leave_running
+  do_not_kill = compute_channels_to_leave_running
   reposync_not_running_streak = 0
   reposync_left_running_streak = 0
   while reposync_not_running_streak <= 60 && reposync_left_running_streak <= 7200
@@ -355,6 +356,7 @@ When(/^I kill all running spacewalk\-repo\-sync, excepted the ones needed to boo
     process = command_output.split("\n")[0]
     channel = process.split(' ')[5]
     if do_not_kill.include? channel
+      $channels_synchronized.add(channel)
       log "Reposync of channel #{channel} left running" if (reposync_left_running_streak % 60).zero?
       reposync_left_running_streak += 1
       sleep 1
@@ -384,12 +386,29 @@ end
 When(/^I wait until the channel "([^"]*)" has been synced$/) do |channel|
   begin
     repeat_until_timeout(timeout: 7200, message: 'Channel not fully synced') do
-      _result, code = $server.run("test -f /var/cache/rhn/repodata/#{channel}/repomd.xml", check_errors: false)
+      _result, code = $server.run("test -f /var/cache/rhn/repodata/#{channel}/products.xml", check_errors: false)
       break if code.zero?
       sleep 10
     end
   rescue StandardError => e
     log e.message # It might be that the MU repository is wrong, but we want to continue in any case
+  end
+end
+
+When(/I wait until all synchronized channels have finished$/) do
+  $channels_synchronized.each do |channel|
+    repeat_until_timeout(timeout: 7200, message: "Channel '#{channel}' not fully synced") do
+      # products.xml is the last file to be written when the server synchronize a channel,
+      # therefore we wait until it exist
+      _result, code = $server.run("test -f /var/cache/rhn/repodata/#{channel}/products.xml", check_errors: false)
+      if code.zero?
+        # We want to check if no .new files exists.
+        # On a re-sync, the old files stay, the new one have this suffix until it's ready.
+        _result, new_code = $server.run("test -f /var/cache/rhn/repodata/#{channel}/products.xml.new", check_errors: false)
+        break unless new_code.zero?
+      end
+      sleep 10
+    end
   end
 end
 

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -26,7 +26,7 @@ end
 # This function computes a list of reposyncs to avoid killing, because they might be involved in bootstrapping.
 #
 # This is a safety net only, the best thing to do is to not start the reposync at all.
-def compute_list_to_leave_running
+def compute_channels_to_leave_running
   # keep the repos needed for the auto-installation tests
   do_not_kill = CHANNEL_TO_SYNCH_BY_OS_VERSION['default']
   [$minion, $build_host, $sshminion].each do |node|

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -13,12 +13,16 @@ require 'minitest/autorun'
 require 'securerandom'
 require 'selenium-webdriver'
 require 'multi_test'
+require 'set'
 
 ## code coverage analysis
 # SimpleCov.start
 
 server = ENV['SERVER']
 $debug_mode = true if ENV['DEBUG']
+
+# Channels triggered by our tests to be synchronized
+$channels_synchronized = Set[]
 
 # maximal wait before giving up
 # the tests return much before that delay in case of success


### PR DESCRIPTION
## What does this PR change?

Wait until all valid channels has been synced in CI.
For that purpose, we monitor the file `products.xml` until it exist in the channels folder (`/var/cache/rhn/repodata/#{channel}`).

CI run: https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-prs-ci-tests/1447/console

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.2 https://github.com/SUSE/spacewalk/pull/18423

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
