### PR TITLE
Delta Image related fixes

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/image/ImageInfo.java
+++ b/java/code/src/com/redhat/rhn/domain/image/ImageInfo.java
@@ -304,13 +304,13 @@ public class ImageInfo extends BaseDomainHelper {
     }
 
     @OneToMany
-    @JoinColumn(name = "source_image_id")
+    @JoinColumn(name = "source_image_id", updatable = false)
     public Set<DeltaImageInfo> getDeltaSourceFor() {
         return deltaSourceFor;
     }
 
     @OneToMany
-    @JoinColumn(name = "target_image_id")
+    @JoinColumn(name = "target_image_id", updatable = false)
     public Set<DeltaImageInfo> getDeltaTargetFor() {
         return deltaTargetFor;
     }

--- a/java/code/src/com/redhat/rhn/domain/image/ImageInfoFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/image/ImageInfoFactory.java
@@ -651,6 +651,7 @@ public class ImageInfoFactory extends HibernateFactory {
         CriteriaBuilder builder = getSession().getCriteriaBuilder();
         CriteriaQuery<DeltaImageInfo> criteria = builder.createQuery(DeltaImageInfo.class);
         Root<DeltaImageInfo> root = criteria.from(DeltaImageInfo.class);
+        criteria.where(builder.equal(root.get("sourceImageInfo").get("org"), org));
         return getSession().createQuery(criteria).getResultList();
     }
 

--- a/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
@@ -625,7 +625,9 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
         assertEquals(3, ImageInfoFactory.listImageInfos(org).size());
         assertEquals(2, ImageInfoFactory.listDeltaImageInfos(org).size());
         assertEquals(2, org.getPillars().size()); //each delta has a pillar
+        HibernateFactory.getSession().clear();
 
+        img3 = TestUtils.reload(img3);
         // deleting a target image should delete also the delta
         ImageInfoFactory.delete(img3, saltApiMock);
 
@@ -636,6 +638,7 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
         assertEquals(1, ImageInfoFactory.listDeltaImageInfos(org).size());
         assertEquals(1, org.getPillars().size());
 
+        delta1 = TestUtils.reload(delta1);
         // deleting a delta should not delete the images
         ImageInfoFactory.deleteDeltaImage(delta1, saltApiMock);
 
@@ -646,6 +649,7 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
         assertEquals(0, ImageInfoFactory.listDeltaImageInfos(org).size());
         assertEquals(0, org.getPillars().size());
 
+        img1 = TestUtils.reload(img1);
         // deleting a source image should delete also the delta
         ImageInfoFactory.delete(img1, saltApiMock);
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix hibernate error on deleting an image with delta
 - Changed logout method to POST on HTTP API (bsc#1199663)
 - Turned API information endpoints public (bsc#1199817)
 - Fix typo and ordering of JSON over HTTP API example scripts


### PR DESCRIPTION
## What does this PR change?

The first commit makes sure that the listDeltaImageInfos method returns only delta images from given org.

The second commit fixes a problem with deleting an image and related delta image in one transaction - it tried to set `target_image_id` to `null` and that failed on not null constraint. Using `updatable=false` prevents this behavior.
It also adjusts the unit test to catch this problem.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Unit tests were updated

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
