### PR TITLE
Container proxy autoinstallation fixes

### DIFF
--- a/containers/proxy-httpd-image/proxy-httpd-image.changes
+++ b/containers/proxy-httpd-image/proxy-httpd-image.changes
@@ -1,3 +1,4 @@
+- Add missing cobbler proxy configuration (bsc#1200142)
 - Do not print console messages, use python logging instead
 - Mirror the whole server pub folder (bsc#1199802)
 - Modify proxy containers configuration files set output

--- a/containers/proxy-httpd-image/uyuni-configure.py
+++ b/containers/proxy-httpd-image/uyuni-configure.py
@@ -141,6 +141,17 @@ with open(config_path + "httpd.yaml") as httpdSource:
 WSGIScriptAlias /tftpsync/add /srv/www/tftpsync/add
 WSGIScriptAlias /tftpsync/delete /srv/www/tftpsync/delete''')
 
+    with open("/etc/apache2/conf.d/cobbler-proxy.conf", "w") as file:
+        file.write(f'''ProxyPass /cobbler_api https://{config['server']}/download/cobbler_api
+ProxyPassReverse /cobbler_api https://{config['server']}/download/cobbler_api
+RewriteRule ^/cblr/svc/op/ks/(.*)$ /download/$0 [P,L]
+RewriteRule ^/cblr/svc/op/autoinstall/(.*)$ /download/$0 [P,L]
+ProxyPass /cblr https://{config['server']}/cblr
+ProxyPassReverse /cblr https://{config['server']}/cblr
+ProxyPass /cobbler https://{config['server']}/cobbler
+ProxyPassReverse /cobbler https://{config['server']}/cobbler
+        ''')
+
     with open("/etc/apache2/conf.d/susemanager-pub.conf", "w") as file:
         file.write("WSGIScriptAlias /pub /usr/share/rhn/wsgi/xmlrpc.py")
 

--- a/containers/proxy-systemd-services/uyuni-proxy-pod.service
+++ b/containers/proxy-systemd-services/uyuni-proxy-pod.service
@@ -14,7 +14,7 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=/etc/sysconfig/uyuni-proxy-systemd-services
 Restart=on-failure
 ExecStartPre=/bin/rm -f %t/uyuni-proxy-pod.pid %t/uyuni-proxy-pod.pod-id
-ExecStartPre=/usr/bin/podman pod create --infra-conmon-pidfile %t/uyuni-proxy-pod.pid --pod-id-file %t/uyuni-proxy-pod.pod-id --name proxy-pod --publish 8022:22 --publish 69:69/udp --publish 8080:8080 --publish 443:443 --publish 4505:4505 --publish 4506:4506 --replace $EXTRA_POD_ARGS
+ExecStartPre=/usr/bin/podman pod create --infra-conmon-pidfile %t/uyuni-proxy-pod.pid --pod-id-file %t/uyuni-proxy-pod.pod-id --name proxy-pod --publish 8022:22 --publish 69:69/udp --publish 8080:8080 --publish 443:443 --publish 80:80 --publish 4505:4505 --publish 4506:4506 --replace $EXTRA_POD_ARGS
 ExecStart=/usr/bin/podman pod start --pod-id-file %t/uyuni-proxy-pod.pod-id
 ExecStop=/usr/bin/podman pod stop --ignore --pod-id-file %t/uyuni-proxy-pod.pod-id -t 10
 ExecStopPost=/usr/bin/podman pod rm --ignore -f --pod-id-file %t/uyuni-proxy-pod.pod-id

--- a/containers/proxy-systemd-services/uyuni-proxy-systemd-services.changes
+++ b/containers/proxy-systemd-services/uyuni-proxy-systemd-services.changes
@@ -1,3 +1,4 @@
+- Expose port 80 (bsc#1200142)
 - Use volumes rather than bind mounts
 - TFTPD to listen on udp port (bsc#1200968)
 - Add TAG variable in configuration 


### PR DESCRIPTION
## What does this PR change?

Adds the cobbler proxy config to the httpd container and exposes the port 80 in the systemd services. No need to change the helm charts services since it's already there.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: auto-installation is not automatically tested

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18063
- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
