### PR TITLE
Aws customization

### DIFF
--- a/testsuite/features/core/allcli_sanity.feature
+++ b/testsuite/features/core/allcli_sanity.feature
@@ -93,6 +93,7 @@ Feature: Sanity checks
     And "xen_server" should communicate with the server using public interface
     And the clock from "xen_server" should be exact
 
+@skip_if_cloud
   Scenario: The external resources can be reached
     Then it should be possible to reach the test packages
     And it should be possible to reach the build sources

--- a/testsuite/features/core/proxy_register_as_minion_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_script.feature
@@ -74,6 +74,7 @@ Feature: Setup Uyuni proxy
     # When I wait until I see "Uyuni Proxy" text, refreshing the page
     Then I should see a "Proxy" link in the content area
 
+@skip_if_cloud
   Scenario: Install expect package on proxy for bootstrapping minion via script
     When I enable repositories before installing branch server
     And I install package "expect" on this "proxy"

--- a/testsuite/features/reposync/srv_enable_sync_products.feature
+++ b/testsuite/features/reposync/srv_enable_sync_products.feature
@@ -30,14 +30,6 @@ Feature: Be able to list available products and enable them
     And I should get "- sle-product-we15-sp4-pool-x86_64-sled"
     And I should get "Product successfully added"
 
-  @cloud
-  Scenario: Enable "Public Cloud Module 15 SP4 x86_64" for migration on cloud
-    When I enable product "Public Cloud Module 15 SP4 x86_64"
-    Then I should get "Adding channels required by 'Public Cloud Module 15 SP4 x86_64' product"
-    And I should get "- sle-module-public-cloud15-sp4-pool-x86_64"
-    And I should get "- sle-module-public-cloud15-sp4-updates-x86_64"
-    And I should get "Product successfully added"
-
   Scenario: Enable "SUSE Linux Enterprise Server for SAP Applications 15 x86_64" without recommended modules
     When I enable product "SUSE Linux Enterprise Server for SAP Applications 15 x86_64" without recommended
     Then I should get "Adding channels required by 'SUSE Linux Enterprise Server for SAP Applications 15 x86_64' product"

--- a/testsuite/features/reposync/srv_enable_sync_products.feature
+++ b/testsuite/features/reposync/srv_enable_sync_products.feature
@@ -32,10 +32,10 @@ Feature: Be able to list available products and enable them
 
   @cloud
   Scenario: Enable "Public Cloud Module 15 SP3 x86_64" for migration on cloud
-    When I enable product "Public Cloud Module 15 SP3 x86_64"
-    Then I should get "Adding channels required by 'Public Cloud Module 15 SP3 x86_64' product"
-    And I should get "- sle-module-public-cloud15-sp3-pool-x86_64"
-    And I should get "- sle-module-public-cloud15-sp3-updates-x86_64"
+    When I enable product "Public Cloud Module 15 SP4 x86_64"
+    Then I should get "Adding channels required by 'Public Cloud Module 15 SP4 x86_64' product"
+    And I should get "- sle-module-public-cloud15-sp4-pool-x86_64"
+    And I should get "- sle-module-public-cloud15-sp4-updates-x86_64"
     And I should get "Product successfully added"
 
   Scenario: Enable "SUSE Linux Enterprise Server for SAP Applications 15 x86_64" without recommended modules

--- a/testsuite/features/reposync/srv_enable_sync_products.feature
+++ b/testsuite/features/reposync/srv_enable_sync_products.feature
@@ -30,6 +30,14 @@ Feature: Be able to list available products and enable them
     And I should get "- sle-product-we15-sp4-pool-x86_64-sled"
     And I should get "Product successfully added"
 
+  @cloud
+  Scenario: Enable "Public Cloud Module 15 SP3 x86_64" for migration on cloud
+    When I enable product "Public Cloud Module 15 SP3 x86_64"
+    Then I should get "Adding channels required by 'Public Cloud Module 15 SP3 x86_64' product"
+    And I should get "- sle-module-public-cloud15-sp3-pool-x86_64"
+    And I should get "- sle-module-public-cloud15-sp3-updates-x86_64"
+    And I should get "Product successfully added"
+
   Scenario: Enable "SUSE Linux Enterprise Server for SAP Applications 15 x86_64" without recommended modules
     When I enable product "SUSE Linux Enterprise Server for SAP Applications 15 x86_64" without recommended
     Then I should get "Adding channels required by 'SUSE Linux Enterprise Server for SAP Applications 15 x86_64' product"

--- a/testsuite/features/reposync/srv_enable_sync_products.feature
+++ b/testsuite/features/reposync/srv_enable_sync_products.feature
@@ -31,7 +31,7 @@ Feature: Be able to list available products and enable them
     And I should get "Product successfully added"
 
   @cloud
-  Scenario: Enable "Public Cloud Module 15 SP3 x86_64" for migration on cloud
+  Scenario: Enable "Public Cloud Module 15 SP4 x86_64" for migration on cloud
     When I enable product "Public Cloud Module 15 SP4 x86_64"
     Then I should get "Adding channels required by 'Public Cloud Module 15 SP4 x86_64' product"
     And I should get "- sle-module-public-cloud15-sp4-pool-x86_64"

--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -13,6 +13,7 @@
 # This feature leaves an JeOS image built
 # The image is used in proxy_retail_pxeboot_and_mass_import.feature
 
+@skip_if_cloud
 @buildhost
 @scope_retail
 @scope_building_container_images

--- a/testsuite/features/secondary/min_deblike_remote_command.feature
+++ b/testsuite/features/secondary/min_deblike_remote_command.feature
@@ -13,7 +13,7 @@ Feature: Remote command on Debian-like Salt minion
     When I follow the left menu "Salt > Remote Commands"
     Then I should see a "Remote Commands" text in the content area
     When I enter command "cat /etc/os-release"
-    And I enter target "*ubuntu*"
+    And I enter target "ubuntu_minion"
     And I click on preview
     And I click on run
     Then I should see "deblike_minion" hostname

--- a/testsuite/features/secondary/min_deblike_ssh.feature
+++ b/testsuite/features/secondary/min_deblike_ssh.feature
@@ -69,7 +69,7 @@ Feature: Bootstrap a SSH-managed Debian-like minion and do some basic operations
     When I follow the left menu "Salt > Remote Commands"
     Then I should see a "Remote Commands" text in the content area
     When I enter command "cat /etc/os-release"
-    And I enter target "*ubuntu*"
+    And I enter target "ubuntu_minion"
     And I click on preview
     And I click on run
     Then I should see "deblike_minion" hostname

--- a/testsuite/features/secondary/min_rhlike_remote_command.feature
+++ b/testsuite/features/secondary/min_rhlike_remote_command.feature
@@ -13,7 +13,7 @@ Feature: Remote command on the Red Hat-like Salt minion
     When I follow the left menu "Salt > Remote Commands"
     Then I should see a "Remote Commands" text in the content area
     When I enter command "cat /etc/os-release"
-    And I enter target "*centos*"
+    And I enter target "ceos_minion"
     And I click on preview
     And I click on run
     Then I should see "rhlike_minion" hostname

--- a/testsuite/features/secondary/min_rhlike_ssh.feature
+++ b/testsuite/features/secondary/min_rhlike_ssh.feature
@@ -68,7 +68,7 @@ Feature: Bootstrap a SSH-managed Red Hat-like minion and do some basic operation
     When I follow the left menu "Salt > Remote Commands"
     Then I should see a "Remote Commands" text in the content area
     When I enter command "cat /etc/os-release"
-    And I enter target "*centos*"
+    And I enter target "ceos_minion"
     And I click on preview
     And I click on run
     Then I should see "rhlike_minion" hostname

--- a/testsuite/features/secondary/srv_virtual_host_manager.feature
+++ b/testsuite/features/secondary/srv_virtual_host_manager.feature
@@ -1,6 +1,7 @@
 # Copyright (c) 2017-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@skip_if_cloud
 @scope_virtual_host_manager
 Feature: Virtual host manager web UI
 

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -792,7 +792,7 @@ When(/^I register this client for SSH push via tunnel$/) do
            "while {1} {\n" \
            "  expect {\n" \
            "    eof                                                        {break}\n" \
-	   "    -re \"Are you sure you want to continue connecting.*\" {send \"yes\r\"}\n" \
+	   "    -re -nocase \"Are you sure you want to continue connecting.*\" {send \"yes\r\"}\n" \
            "    \"Password:\"                                              {send \"linux\r\"}\n" \
            "  }\n" \
            "}\n"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -353,13 +353,15 @@ When(/^I kill all running spacewalk\-repo\-sync, excepted the ones needed to boo
   while reposync_not_running_streak <= 60
     command_output, _code = $server.run('ps axo pid,cmd | grep spacewalk-repo-sync | grep -v grep', check_errors: false)
     if command_output.empty?
+      log "In empty command with #{reposync_not_running_streak} try"
       reposync_not_running_streak += 1
       reposync_left_running_streak = 0
-      sleep 1
+      sleep 2
+      log "Stop waiting not running streak"
       next
     end
     reposync_not_running_streak = 0
-
+    log "New sync started, #{reposync_not_running_streak} reset ?"
     process = command_output.split("\n")[0]
     channel = process.split(' ')[5]
     if do_not_kill.include? channel

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -217,9 +217,7 @@ end
 When(/^I query latest Salt changes on Debian-like system "(.*?)"$/) do |host|
   node = get_target(host)
   salt =
-    if $is_cloud_provider
-      "salt-common"
-    elsif $use_salt_bundle
+    if $use_salt_bundle
       "venv-salt-minion"
     else
       "salt"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -512,7 +512,7 @@ When(/^I (deselect|select) "([^\"]*)" as a product$/) do |select, product|
 end
 
 When(/^I (deselect|select) "([^\"]*)" as a (SUSE Manager|Uyuni) product$/) do |select, product, product_version|
-  if $product == product_version
+  if $product == product_version && !$is_cloud_provider
     step %(I #{select} "#{product}" as a product)
   end
 end
@@ -542,7 +542,7 @@ When(/^I wait at most (\d+) seconds until the tree item "([^"]+)" contains "([^"
 end
 
 When(/^I open the sub-list of the product "(.*?)" on (SUSE Manager|Uyuni)$/) do |product, product_version|
-  if $product == product_version
+  if $product == product_version && !$is_cloud_provider
     step %(I open the sub-list of the product "#{product}")
   end
 end
@@ -783,23 +783,25 @@ When(/^I enable repositories before installing Docker$/) do
   os_version, os_family = get_os_version($build_host)
 
   # Distribution
-  repos = "os_pool_repo os_update_repo"
+  repos = $is_cloud_provider ? OS_REPOS_BY_OS_VERSION[os_version].join(' ') : "os_pool_repo os_update_repo"
   log $build_host.run("zypper mr --enable #{repos}")
 
   # Tools
-  repos, _code = $build_host.run('zypper lr | grep "tools" | cut -d"|" -f2')
-  log $build_host.run("zypper mr --enable #{repos.gsub(/\s/, ' ')}")
+  unless $is_cloud_provider
+    repos, _code = $build_host.run('zypper lr | grep "tools" | cut -d"|" -f2')
+    log $build_host.run("zypper mr --enable #{repos.gsub(/\s/, ' ')}")
+  end
 
   # Development and Desktop Applications (required)
   # (we do not install Python 2 repositories in this branch
   #  because they are not needed anymore starting with version 4.1)
-  if os_family =~ /^sles/ && os_version =~ /^15/
+  if (os_family =~ /^sles/ && os_version =~ /^15/) && !$is_cloud_provider
     repos = "devel_pool_repo devel_updates_repo desktop_pool_repo desktop_updates_repo"
     log $build_host.run("zypper mr --enable #{repos}")
   end
 
   # Containers
-  unless os_family =~ /^opensuse/ || os_version =~ /^11/
+  unless os_family =~ /^opensuse/ || os_version =~ /^11/ || $is_cloud_provider
     repos = "containers_pool_repo containers_updates_repo"
     log $build_host.run("zypper mr --enable #{repos}")
   end
@@ -811,23 +813,25 @@ When(/^I disable repositories after installing Docker$/) do
   os_version, os_family = get_os_version($build_host)
 
   # Distribution
-  repos = "os_pool_repo os_update_repo"
+  repos = $is_cloud_provider ? OS_REPOS_BY_OS_VERSION[os_version].join(' ') : "os_pool_repo os_update_repo"
   log $build_host.run("zypper mr --disable #{repos}")
 
   # Tools
-  repos, _code = $build_host.run('zypper lr | grep "tools" | cut -d"|" -f2')
-  log $build_host.run("zypper mr --disable #{repos.gsub(/\s/, ' ')}")
+  unless $is_cloud_provider
+    repos, _code = $build_host.run('zypper lr | grep "tools" | cut -d"|" -f2')
+    log $build_host.run("zypper mr --disable #{repos.gsub(/\s/, ' ')}")
+  end
 
   # Development and Desktop Applications (required)
   # (we do not install Python 2 repositories in this branch
   #  because they are not needed anymore starting with version 4.1)
-  if os_family =~ /^sles/ && os_version =~ /^15/
+  if (os_family =~ /^sles/ && os_version =~ /^15/) && !$is_cloud_provider
     repos = "devel_pool_repo devel_updates_repo desktop_pool_repo desktop_updates_repo"
     log $build_host.run("zypper mr --disable #{repos}")
   end
 
   # Containers
-  unless os_family =~ /^opensuse/ || os_version =~ /^11/
+  unless os_family =~ /^opensuse/ || os_version =~ /^11/ || $is_cloud_provider
     repos = "containers_pool_repo containers_updates_repo"
     log $build_host.run("zypper mr --disable #{repos}")
   end

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -787,7 +787,7 @@ When(/^I enable repositories before installing Docker$/) do
   log $build_host.run("zypper mr --enable #{repos}")
 
   # Tools
-  unless $is_cloud_provider
+  if !$is_cloud_provider
     repos, _code = $build_host.run('zypper lr | grep "tools" | cut -d"|" -f2')
     log $build_host.run("zypper mr --enable #{repos.gsub(/\s/, ' ')}")
   end
@@ -817,7 +817,7 @@ When(/^I disable repositories after installing Docker$/) do
   log $build_host.run("zypper mr --disable #{repos}")
 
   # Tools
-  unless $is_cloud_provider
+  if !$is_cloud_provider
     repos, _code = $build_host.run('zypper lr | grep "tools" | cut -d"|" -f2')
     log $build_host.run("zypper mr --disable #{repos.gsub(/\s/, ' ')}")
   end

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -787,7 +787,7 @@ When(/^I enable repositories before installing Docker$/) do
   log $build_host.run("zypper mr --enable #{repos}")
 
   # Tools
-  if !$is_cloud_provider
+  unless $is_cloud_provider
     repos, _code = $build_host.run('zypper lr | grep "tools" | cut -d"|" -f2')
     log $build_host.run("zypper mr --enable #{repos.gsub(/\s/, ' ')}")
   end
@@ -817,7 +817,7 @@ When(/^I disable repositories after installing Docker$/) do
   log $build_host.run("zypper mr --disable #{repos}")
 
   # Tools
-  if !$is_cloud_provider
+  unless $is_cloud_provider
     repos, _code = $build_host.run('zypper lr | grep "tools" | cut -d"|" -f2')
     log $build_host.run("zypper mr --disable #{repos.gsub(/\s/, ' ')}")
   end

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -346,6 +346,8 @@ CHANNEL_TO_SYNCH_BY_OS_VERSION = {
     sle-module-containers15-sp3-updates-x86_64
     sle-module-basesystem15-sp3-updates-x86_64
     sle-module-server-applications15-sp3-updates-x86_64
+    sle-module-public-cloud15-sp3-updates-x86_64
+    sle-module-public-cloud15-sp3-pool-x86_64
   ],
   '15-SP4' =>
   %w[

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -362,7 +362,7 @@ CHANNEL_TO_SYNCH_BY_OS_VERSION = {
     sle-module-basesystem15-sp4-updates-x86_64
     sle-module-server-applications15-sp4-updates-x86_64
     sle-module-public-cloud15-sp4-updates-x86_64
-    sle-module-public-cloud15-sp4-pool-x86_64Q
+    sle-module-public-cloud15-sp4-pool-x86_64
   ]
 }.freeze
 

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -366,3 +366,59 @@ CHANNEL_TO_SYNCH_BY_OS_VERSION = {
 
 MIGRATE_SSH_MINION_FROM = '15-SP3'.freeze
 MIGRATE_SSH_MINION_TO = '15-SP4'.freeze
+
+OS_REPOS_BY_OS_VERSION = {
+  '11-SP4' =>
+  %w[
+    SLE-Module-Basesystem11-SP4-Pool
+    SLE-Module-Basesystem11-SP4-Updates
+    SLE-Module-Containers11-SP4-Pool
+    SLE-Module-Containers11-SP4-Updates
+  ],
+  '12-SP3' =>
+  %w[
+    SLE-Module-Basesystem12-SP3-Pool
+    SLE-Module-Basesystem12-SP3-Updates
+  ],
+  '12-SP4' =>
+  %w[
+    SLE-Module-Basesystem12-SP4-Pool
+    SLE-Module-Basesystem12-SP4-Updates
+  ],
+  '15-SP1' =>
+  %w[
+    SLE-Module-Basesystem15-SP1-Pool
+    SLE-Module-Basesystem15-SP1-Updates
+    SLE-Module-DevTools15-SP1-Pool
+    SLE-Module-DevTools15-SP1-Updates
+    SLE-Module-Desktop-Applications15-SP1-Pool
+    SLE-Module-Desktop-Applications15-SP1-Updates
+  ],
+  '15-SP2' =>
+  %w[
+    SLE-Module-Basesystem15-SP2-Pool
+    SLE-Module-Basesystem15-SP2-Updates
+    SLE-Module-DevTools15-SP2-Pool
+    SLE-Module-DevTools15-SP2-Updates
+    SLE-Module-Desktop-Applications15-SP2-Pool
+    SLE-Module-Desktop-Applications15-SP2-Updates
+  ],
+  '15-SP3' =>
+  %w[
+    SLE-Module-Basesystem15-SP3-Pool
+    SLE-Module-Basesystem15-SP3-Updates
+    SLE-Module-DevTools15-SP3-Pool
+    SLE-Module-DevTools15-SP3-Updates
+    SLE-Module-Desktop-Applications15-SP3-Pool
+    SLE-Module-Desktop-Applications15-SP3-Updates
+  ],
+  '15-SP4' =>
+  %w[
+    SLE-Module-Basesystem15-SP4-Pool
+    SLE-Module-Basesystem15-SP4-Updates
+    SLE-Module-DevTools15-SP4-Pool
+    SLE-Module-DevTools15-SP4-Updates
+    SLE-Module-Desktop-Applications15-SP4-Pool
+    SLE-Module-Desktop-Applications15-SP4-Updates
+  ]
+}.freeze

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -346,8 +346,6 @@ CHANNEL_TO_SYNCH_BY_OS_VERSION = {
     sle-module-containers15-sp3-updates-x86_64
     sle-module-basesystem15-sp3-updates-x86_64
     sle-module-server-applications15-sp3-updates-x86_64
-    sle-module-public-cloud15-sp3-updates-x86_64
-    sle-module-public-cloud15-sp3-pool-x86_64
   ],
   '15-SP4' =>
   %w[
@@ -363,6 +361,8 @@ CHANNEL_TO_SYNCH_BY_OS_VERSION = {
     sle-module-containers15-sp4-updates-x86_64
     sle-module-basesystem15-sp4-updates-x86_64
     sle-module-server-applications15-sp4-updates-x86_64
+    sle-module-public-cloud15-sp4-updates-x86_64
+    sle-module-public-cloud15-sp4-pool-x86_64Q
   ]
 }.freeze
 

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -361,8 +361,6 @@ CHANNEL_TO_SYNCH_BY_OS_VERSION = {
     sle-module-containers15-sp4-updates-x86_64
     sle-module-basesystem15-sp4-updates-x86_64
     sle-module-server-applications15-sp4-updates-x86_64
-    sle-module-public-cloud15-sp4-updates-x86_64
-    sle-module-public-cloud15-sp4-pool-x86_64
   ]
 }.freeze
 

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -425,11 +425,6 @@ Before('@skip_if_cloud') do
   skip_this_scenario if $is_cloud_provider
 end
 
-# do test only if in cloud
-Before('@cloud') do
-  skip_this_scenario unless $is_cloud_provider
-end
-
 # have more infos about the errors
 def debug_server_on_realtime_failure
   STDOUT.puts '=> /var/log/rhn/rhn_web_ui.log'

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -425,6 +425,11 @@ Before('@skip_if_cloud') do
   skip_this_scenario if $is_cloud_provider
 end
 
+# do test only if in cloud
+Before('@cloud') do
+  skip_this_scenario unless $is_cloud_provider
+end
+
 # have more infos about the errors
 def debug_server_on_realtime_failure
   STDOUT.puts '=> /var/log/rhn/rhn_web_ui.log'

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -30,6 +30,8 @@ STDOUT.sync = true
 STARTTIME = Time.new.to_i
 Capybara.default_max_wait_time = ENV['CAPYBARA_TIMEOUT'] ? ENV['CAPYBARA_TIMEOUT'].to_i : 10
 DEFAULT_TIMEOUT = ENV['DEFAULT_TIMEOUT'] ? ENV['DEFAULT_TIMEOUT'].to_i : 250
+$is_cloud_provider = ENV["PROVIDER"].include? 'aws'
+$is_using_build_image = ENV.fetch('IS_USING_BUILD_IMAGE') { false }
 
 # QAM and Build Validation pipelines will provide a json file including all custom (MI) repositories
 custom_repos_path = File.dirname(__FILE__) + '/../upload_files/' + 'custom_repositories.json'
@@ -416,6 +418,11 @@ end
 # do test only if the registry with authentication is available
 Before('@auth_registry') do
   skip_this_scenario unless $auth_registry
+end
+
+# skip tests if executed in cloud environment
+Before('@skip_if_cloud') do
+  skip_this_scenario if $is_cloud_provider
 end
 
 # have more infos about the errors


### PR DESCRIPTION
## What does this PR change?

This PR add changes to run the testsuite on AWS with a classic SUMA deployment ( using sles as server and proxy ) : 
- create a tag pair : `skip_if_cloud` and `cloud` to skip specifics scenario ( some docker scenarios, virtual host scenario, ...)
- change the way to select target when running remote commands
- add constants to manage repository names when added using SCC activation
- add cloud repositories synchronization to migrate sles minion and client


## GUI diff

No difference.


- [x] **DONE**

## Documentation

- [x] **DONE**

## Test coverage

- Add compatibility with AWS provider

- [x] **DONE**

## Links

https://github.com/uyuni-project/sumaform/pull/1126
https://github.com/SUSE/susemanager-ci/pull/612
https://github.com/SUSE/spacewalk/issues/17243

- [x] **DONE**

## Changelogs


- [x] No changelog needed


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
