### PR TITLE
Fix helm chart push to IBS and OBS

### DIFF
--- a/containers/proxy-helm/Chart.yaml
+++ b/containers/proxy-helm/Chart.yaml
@@ -7,5 +7,5 @@ description: Uyuni proxy containers.
 type: application
 home: https://www.uyuni-project.org/
 icon: https://www.uyuni-project.org/img/uyuni-logo.svg
-version: 0.0.0 # Only increase the patch number when changing, the rest is replaced when pushing to OBS
+version: 0.0.0
 appVersion: "%PKG_VERSION%"

--- a/containers/proxy-helm/values.yaml
+++ b/containers/proxy-helm/values.yaml
@@ -1,5 +1,5 @@
 
-repository: registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni
+repository: registry.opensuse.org/uyuni
 version: latest
 
 ## Ref: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy


### PR DESCRIPTION
## What does this PR change?

Adjust helm charts versions and default values depending whether we push to OBS or IBS

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: helm charts tooling

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
