### PR TITLE
add onlyRelevant argument to addErrataUpdate API

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/chain/ActionChainHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/chain/ActionChainHandler.java
@@ -291,9 +291,42 @@ public class ActionChainHandler extends BaseHandler {
      * @apidoc.returntype #param_desc("int", "actionId", "The action id of the scheduled action")
      */
     public Integer addErrataUpdate(User loggedInUser,
+                                   List<Integer> sids,
+                                   List<Integer> errataIds,
+                                   String chainLabel) {
+
+        return addErrataUpdate(loggedInUser, sids, errataIds, chainLabel, false);
+    }
+
+    /**
+     * Schedule Errata update.
+     *
+     * @param loggedInUser The current user
+     * @param sids a list of Server IDs
+     * @param errataIds a list of erratas IDs
+     * @param chainLabel Label of the action chain
+     * @param onlyRelevant If true not all 
+     *        erratas are applied to all systems. Systems get only the erratas relevant for them.
+     *        If false, InvalidErrataException is thrown if an errata does not apply
+     *        to a system.
+     * @return action id if successful, exception otherwise
+     *
+     * @apidoc.doc Adds Errata update to an Action Chain.
+     * @apidoc.param #session_key()
+     * @apidoc.param #array_single_desc("int", "sids", "System IDs")
+     * @apidoc.param #array_single_desc("int", "errataIds", "Errata ID")
+     * @apidoc.param #param_desc("string", "chainLabel", "Label of the chain")
+     * @apidoc.param #param_desc("boolean", "onlyRelevant", "If true not all 
+     *        erratas are applied to all systems. Systems get only the erratas relevant for them.
+     *        If false, InvalidErrataException is thrown if an errata does not apply
+     *        to a system.")
+     * @apidoc.returntype #param_desc("int", "actionId", "The action ID of the scheduled action")
+     */
+    public Integer addErrataUpdate(User loggedInUser,
                                     List<Integer> sids,
                                     List<Integer> errataIds,
-                                    String chainLabel) {
+                                    String chainLabel,
+                                    Boolean onlyRelevant) {
         if (errataIds.isEmpty()) {
             throw new InvalidParameterException("No specified Erratas.");
         }
@@ -305,7 +338,7 @@ public class ActionChainHandler extends BaseHandler {
 
             actionIds = ActionChainManager.scheduleErrataUpdate(loggedInUser,
                     serverIds,
-                    errataIds, new Date(), this.acUtil.getActionChainByLabel(loggedInUser, chainLabel));
+                    errataIds, new Date(), this.acUtil.getActionChainByLabel(loggedInUser, chainLabel), onlyRelevant);
         }
         catch (com.redhat.rhn.taskomatic.TaskomaticApiException e) {
             // this err should never be thrown

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/chain/ActionChainHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/chain/ActionChainHandler.java
@@ -305,10 +305,8 @@ public class ActionChainHandler extends BaseHandler {
      * @param sids a list of Server IDs
      * @param errataIds a list of erratas IDs
      * @param chainLabel Label of the action chain
-     * @param onlyRelevant If true not all 
-     *        erratas are applied to all systems. Systems get only the erratas relevant for them.
-     *        If false, InvalidErrataException is thrown if an errata does not apply
-     *        to a system.
+     * @param onlyRelevant If true, InvalidErrataException
+     * is thrown if an errata does not apply to a system.
      * @return action id if successful, exception otherwise
      *
      * @apidoc.doc Adds Errata update to an Action Chain.
@@ -316,7 +314,7 @@ public class ActionChainHandler extends BaseHandler {
      * @apidoc.param #array_single_desc("int", "sids", "System IDs")
      * @apidoc.param #array_single_desc("int", "errataIds", "Errata ID")
      * @apidoc.param #param_desc("string", "chainLabel", "Label of the chain")
-     * @apidoc.param #param_desc("boolean", "onlyRelevant", "If true, InvalidErrataException 
+     * @apidoc.param #param_desc("boolean", "onlyRelevant", "If true, InvalidErrataException
      * is thrown if an errata does not apply to a system.")
      * @apidoc.returntype #param_desc("int", "actionId", "The action ID of the scheduled action")
      */

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/chain/ActionChainHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/chain/ActionChainHandler.java
@@ -316,10 +316,8 @@ public class ActionChainHandler extends BaseHandler {
      * @apidoc.param #array_single_desc("int", "sids", "System IDs")
      * @apidoc.param #array_single_desc("int", "errataIds", "Errata ID")
      * @apidoc.param #param_desc("string", "chainLabel", "Label of the chain")
-     * @apidoc.param #param_desc("boolean", "onlyRelevant", "If true not all 
-     *        erratas are applied to all systems. Systems get only the erratas relevant for them.
-     *        If false, InvalidErrataException is thrown if an errata does not apply
-     *        to a system.")
+     * @apidoc.param #param_desc("boolean", "onlyRelevant", "If true, InvalidErrataException 
+     * is thrown if an errata does not apply to a system.")
      * @apidoc.returntype #param_desc("int", "actionId", "The action ID of the scheduled action")
      */
     public Integer addErrataUpdate(User loggedInUser,

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -3623,7 +3623,7 @@ public class SystemHandler extends BaseHandler {
     public List<Long> scheduleApplyErrata(User loggedInUser, List<Integer> sids, List<Integer> errataIds,
                                           Date earliestOccurrence, Boolean allowModules) {
 
-        return scheduleApplyErrata(loggedInUser, sids, errataIds, earliestOccurrence, allowModules, false);
+        return scheduleApplyErrata(loggedInUser, sids, errataIds, earliestOccurrence, allowModules, true);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/action/ActionChainManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionChainManager.java
@@ -525,10 +525,36 @@ public class ActionChainManager {
                 errataIds.stream().map(Integer::longValue).collect(Collectors.toList()),
                 earliest,
                 actionChain,
-                servers.stream().map(Server::getId).collect(Collectors.toList())
+                servers.stream().map(Server::getId).collect(Collectors.toList()), true, false
         );
 
     }
+
+    /**
+     * Schedules an Errata update on a server.
+     * @param user the user scheduling actions
+     * @param servers the affected servers
+     * @param errataIds a list of erratas IDs
+     * @param earliest the earliest execution date
+     * @param actionChain the action chain
+     * @param onlyRelevant If true, InvalidErrataException is thrown if an errata
+     * does not apply to a system.
+     * @return list of scheduled action ids
+     * @throws TaskomaticApiException if there was a Taskomatic error
+     * (typically: Taskomatic is down)
+     */
+    public static List<Long> scheduleErrataUpdate(User user, List<Server> servers, List<Integer> errataIds,
+                                              Date earliest, ActionChain actionChain, boolean onlyRelevant)
+                                                      throws TaskomaticApiException  {
+
+        // This won't actually apply the errata because we're passing in an action chain
+        return ErrataManager.applyErrata(user,
+                errataIds.stream().map(Integer::longValue).collect(Collectors.toList()),
+                earliest,
+                actionChain,
+                servers.stream().map(Server::getId).collect(Collectors.toList()), onlyRelevant, false);
+    }
+
 
     /**
      * Schedules one or more package installation actions on one or more servers.

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -1711,7 +1711,7 @@ public class ErrataManager extends BaseManager {
     public static List<Long> applyErrata(User user, List errataIds, Date earliest,
             ActionChain actionChain, List<Long> serverIds)
         throws TaskomaticApiException {
-        return applyErrata(user, errataIds, earliest, actionChain, serverIds, true, false);
+        return applyErrata(user, errataIds, earliest, actionChain, serverIds, false, false);
     }
 
     /**
@@ -1725,10 +1725,8 @@ public class ErrataManager extends BaseManager {
      * @param earliest schedule time
      * @param actionChain the action chain to add the action to or null
      * @param serverIds server ids
-     * @param onlyRelevant If true not all erratas are applied to all systems.
-     *        Systems get only the erratas relevant for them.
-     *        If false, InvalidErrataException is thrown if an errata does not apply
-     *        to a system.
+     * @param onlyRelevant If true, InvalidErrataException is thrown if an errata
+     * does not apply to a system.
      * @param allowVendorChange true if vendor change allowed
      * @return list of action ids
      * @throws TaskomaticApiException if there was a Taskomatic error
@@ -1744,7 +1742,7 @@ public class ErrataManager extends BaseManager {
 
         // if required, check that all specified errata ids are applicable
         // throw Exception if that's not the case
-        if (!onlyRelevant) {
+        if (onlyRelevant) {
             boolean allRelevant = errataIds.isEmpty() ||
                     (errataIds.stream()
                     .allMatch(eid -> serverApplicableErrataMap.values().stream()

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- add onlyRelevant argument to addErrataUpdate API
+
 -------------------------------------------------------------------
 Wed Jul 27 14:18:34 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

add onlyRelevant argument to addErrataUpdate API

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
- No tests
- 
- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17895

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "susemanager_unittests" (Test skipped, there are no changes to test)
- [x] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests" (Test skipped, there are no changes to test)
