### PR TITLE
QE: Use 15 SP4 as default for channel sync

### DIFF
--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -273,12 +273,18 @@ CHANNEL_TO_SYNCH_BY_OS_VERSION = {
   # 'default' is required for auto-installation tests.
   'default' =>
   %w[
-    sle-product-sles15-sp2-pool-x86_64
-    sle-manager-tools15-pool-x86_64-sp2
-    sle-module-basesystem15-sp2-pool-x86_64
-    sle-product-sles15-sp2-updates-x86_64
-    sle-manager-tools15-updates-x86_64-sp2
-    sle-module-basesystem15-sp2-updates-x86_64
+    sle-product-sles15-sp4-pool-x86_64
+    sle-manager-tools15-pool-x86_64-sp4
+    sle-manager-tools15-beta-pool-x86_64-sp4
+    sle-module-containers15-sp4-pool-x86_64
+    sle-module-basesystem15-sp4-pool-x86_64
+    sle-module-server-applications15-sp4-pool-x86_64
+    sle-product-sles15-sp4-updates-x86_64
+    sle-manager-tools15-updates-x86_64-sp4
+    sle-manager-tools15-beta-updates-x86_64-sp4
+    sle-module-containers15-sp4-updates-x86_64
+    sle-module-basesystem15-sp4-updates-x86_64
+    sle-module-server-applications15-sp4-updates-x86_64
   ],
   '12-SP4' =>
   %w[


### PR DESCRIPTION
## What does this PR change?

This updates the CHANNEL_TO_SYNCH_BY_OS_VERSION constant to not use
SLE15SP2 since we do not use it in the CI any longer. This also fixes the issue `Timeout after 7200 seconds (Timeout.timeout): Channel 'sle-product-sles15-sp2-pool-x86_64' not fully synced (RuntimeError)` seen in the CI.


## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- No tests: already covered


- [x] **DONE**

## Links


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
