### PR TITLE
Changed logout method to use post

### DIFF
--- a/testsuite/features/support/http_client.rb
+++ b/testsuite/features/support/http_client.rb
@@ -15,7 +15,7 @@ class HttpClient
     call_type =
       if short_name.start_with?('list', 'get', 'is', 'find') ||
          name.start_with?('system.search.', 'packages.search.') ||
-         ['auth.logout', 'errata.applicableToChannels'].include?(name)
+         ['errata.applicableToChannels'].include?(name)
         'GET'
       else
         'POST'


### PR DESCRIPTION
## What does this PR change?

Fixed the HTTP method to use POST instead of GET, according with the last change in the API.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: fix on testsuit

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
