### PR TITLE
QE: Using official 15.4 base images in our Docker Profiles

### DIFF
--- a/testsuite/features/profiles/Docker/authprofile/Dockerfile
+++ b/testsuite/features/profiles/Docker/authprofile/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION               1.0.0
 
-FROM registry.mgr.suse.de:5000/cucutest/suma-head-testsuite
+FROM registry.mgr.suse.de/suse/sle15:15.4
 MAINTAINER Michael Calmer "mc@suse.com"
 
 ARG repo

--- a/testsuite/features/profiles/Docker/serverhost/Dockerfile
+++ b/testsuite/features/profiles/Docker/serverhost/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION               1.0.0
 
-FROM registry.mgr.suse.de/suma-head-testsuite
+FROM registry.mgr.suse.de/suse/sle15:15.4
 MAINTAINER Michael Calmer "mc@suse.com"
 
 ARG repo

--- a/testsuite/features/profiles/internal_nue/Docker/authprofile/Dockerfile
+++ b/testsuite/features/profiles/internal_nue/Docker/authprofile/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION               1.0.0
 
-FROM registry.mgr.suse.de:5000/cucutest/suma-head-testsuite
+FROM registry.mgr.suse.de/suse/sle15:15.4
 MAINTAINER Michael Calmer "mc@suse.com"
 
 ARG repo

--- a/testsuite/features/profiles/internal_nue/Docker/serverhost/Dockerfile
+++ b/testsuite/features/profiles/internal_nue/Docker/serverhost/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION               1.0.0
 
-FROM registry.mgr.suse.de/suma-head-testsuite
+FROM registry.mgr.suse.de/suse/sle15:15.4
 MAINTAINER Michael Calmer "mc@suse.com"
 
 ARG repo

--- a/testsuite/features/profiles/internal_prv/Docker/authprofile/Dockerfile
+++ b/testsuite/features/profiles/internal_prv/Docker/authprofile/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION               1.0.0
 
-FROM registry.mgr.prv.suse.net:5000/cucutest/suma-head-testsuite
+FROM registry.mgr.prv.suse.net/suse/sle15:15.4
 MAINTAINER Michael Calmer "mc@suse.com"
 
 ARG repo

--- a/testsuite/features/profiles/internal_prv/Docker/serverhost/Dockerfile
+++ b/testsuite/features/profiles/internal_prv/Docker/serverhost/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION               1.0.0
 
-FROM registry.mgr.prv.suse.net/suma-head-testsuite
+FROM registry.mgr.prv.suse.net/suse/sle15:15.4
 MAINTAINER Michael Calmer "mc@suse.com"
 
 ARG repo


### PR DESCRIPTION
## What does this PR change?

This PR tries to fix an issue in our CI caused by the upgrade of repositorie from SLES 15.2 to SLES 15.4 in our Docker Profiles.
We suspect that the base image  registry.mgr.suse.de/suma-head-testsuite must be upgraded to use 15.4. https://github.com/SUSE/spacewalk/issues/18450

But we will try to use the official image in this PR.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

No need ports, as we don't upgraded from 15.2 to 15.4 in Manager-4.2
@nodeg Please confirm :) ^^^ 

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
