### PR TITLE
Fix bootstrap issue in Debian 9 with classic minion because missing python3-contextvars (bsc#1201782)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -145,10 +145,19 @@ salt-minion-package:
     - require:
       - file: bootstrap_repo
 
-{# These dependencies are only needed on DEB based distros, running Salt 3004, with Python version < 3.7 #}
-{# We cannot make these packages as hard depedendencies for Salt package because this is only needed for Ubuntu 18.04 #}
-{# and we only maintain a single DEB package for all DEB based distros #}
-{% if salt_minion_name == 'salt-minion' and grains['os_family'] == 'Debian' and grains['saltversioninfo'][0] >= 3004 and grains['pythonversion'][0] >= 3 and grains['pythonversion'][1] < 7 %}
+{# We must install "python3-contextvars" on DEB based distros, running Salt 3004, with Python version < 3.7, like Ubuntu 18.04 #}
+{# We cannot make this package a hard depedendency for Salt DEB package because this is only needed in Ubuntu 18.04 #}
+{# DEB based distros with Python version >= 3.7 does not need this package - package is not existing in such cases #}
+{# Since we only maintain a single DEB package for all DEB based distros, we need to explicitely install the package here #}
+{%- if salt_minion_name == 'salt-minion' and grains['os_family'] == 'Debian' and grains['pythonversion'][0] >= 3 and grains['pythonversion'][1] < 7 %}
+  {%- if not (grains['os'] == 'Ubuntu' and grains['osrelease_info'][0] == 16) and not (grains['os'] == 'Debian' and grains['osrelease_info'][0] == 9) %}
+    {%- set contextvars_needed = True %}
+  {% else %}
+    {%- set contextvars_needed = False %}
+  {%- endif %}
+{%- endif %}
+
+{% if contextvars_needed %}
 salt-install-contextvars:
   pkg.installed:
     - name: python3-contextvars

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -149,12 +149,10 @@ salt-minion-package:
 {# We cannot make this package a hard depedendency for Salt DEB package because this is only needed in Ubuntu 18.04 #}
 {# DEB based distros with Python version >= 3.7 does not need this package - package is not existing in such cases #}
 {# Since we only maintain a single DEB package for all DEB based distros, we need to explicitely install the package here #}
+{%- set contextvars_needed = False %}
 {%- if salt_minion_name == 'salt-minion' and grains['os_family'] == 'Debian' and grains['pythonversion'][0] >= 3 and grains['pythonversion'][1] < 7 %}
   {%- if not (grains['os'] == 'Ubuntu' and grains['osrelease_info'][0] == 16) and not (grains['os'] == 'Debian' and grains['osrelease_info'][0] == 9) %}
     {%- set contextvars_needed = True %}
-  {% else %}
-    {%- set contextvars_needed = False %}
-  {%- endif %}
 {%- endif %}
 
 {% if contextvars_needed %}

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -145,10 +145,10 @@ salt-minion-package:
     - require:
       - file: bootstrap_repo
 
-{# These two dependencies are only needed on DEB based distros with Python version < 3.7 #}
+{# These dependencies are only needed on DEB based distros, running Salt 3004, with Python version < 3.7 #}
 {# We cannot make these packages as hard depedendencies for Salt package because this is only needed for Ubuntu 18.04 #}
 {# and we only maintain a single DEB package for all DEB based distros #}
-{% if salt_minion_name == 'salt-minion' and grains['os_family'] == 'Debian' and grains['pythonversion'][0] >= 3 and grains['pythonversion'][1] < 7 %}
+{% if salt_minion_name == 'salt-minion' and grains['os_family'] == 'Debian' and grains['saltversioninfo'][0] >= 3004 and grains['pythonversion'][0] >= 3 and grains['pythonversion'][1] < 7 %}
 salt-install-contextvars:
   pkg.installed:
     - name: python3-contextvars

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -153,6 +153,7 @@ salt-minion-package:
 {%- if salt_minion_name == 'salt-minion' and grains['os_family'] == 'Debian' and grains['pythonversion'][0] >= 3 and grains['pythonversion'][1] < 7 %}
   {%- if not (grains['os'] == 'Ubuntu' and grains['osrelease_info'][0] == 16) and not (grains['os'] == 'Debian' and grains['osrelease_info'][0] == 9) %}
     {%- set contextvars_needed = True %}
+  {%- endif %}
 {%- endif %}
 
 {% if contextvars_needed %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix issue bootstrap issue with Debian 9 because missing python3-contextvars (bsc#1201782)
 - Fix deploy of SLE Micro CA Certificate (bsc#1200276)
 - disable local repos before bootstrap and at highstate (bsc#1191925)
 - deploy GPG keys to the clients and define trust in channels (bsc#1199984)


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue happening when bootstrapping a Debian 9 system using the "classic" Salt minion package:

```console
Apply States failed during bootstrap (retcode=2). Details:

pkg_|-salt-install-contextvars_|-python3-contextvars_|-installed: Problem encountered installing package(s). Additional info follows:

errors:
    - Running scope as unit: run-rd65abbb383994fdb8d268b384a1ca046.scope
      E: Unable to locate package python3-contextvars
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: manually tested

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/18452

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
