### PR TITLE
Add "python3-gnupg" to Debian10 bootstrap repo (bsc#1201842)

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -777,6 +777,7 @@ PKGLISTDEBIAN10 = [
     "salt-minion",
     "gnupg",
     "venv-salt-minion",
+    "python3-gnupg",
 ]
 
 PKGLISTDEBIAN11 = [

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Add missing python3-gnupg to Debian10 bootstrap repo (bsc#1201842)
 - Add clients tool product to generate 
   bootstrap repo on OpenSUSE 15.x (bsc#1201189)
 - Add Oracle Linux 9 bootstrap repositories for Uyuni


### PR DESCRIPTION
## What does this PR change?

This PR adds `python3-gnupg` to Debian 10 bootstrap repository as this is a dependency needed to install classic Salt 3004 minion package in Debian 10:

```
The following packages have unmet dependencies:
 salt-common : Depends: python3-gnupg but it is not installable
               Recommends: python3-contextvars but it is not installable
               Recommends: python3-croniter but it is not going to be installed
```
## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
