### PR TITLE
QE: Log when we wait to finish a sync. of a channel

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -397,6 +397,7 @@ end
 
 When(/I wait until all synchronized channels have finished$/) do
   $channels_synchronized.each do |channel|
+    log "I wait until '#{channel}' synchronized channel has finished"
     repeat_until_timeout(timeout: 7200, message: "Channel '#{channel}' not fully synced") do
       # products.xml is the last file to be written when the server synchronize a channel,
       # therefore we wait until it exist


### PR DESCRIPTION
## What does this PR change?

Log when we wait to finish a sync. of a channel

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.2

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
