### PR TITLE
QE: Use solv file to wait until a channel is sync

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -401,11 +401,11 @@ When(/I wait until all synchronized channels have finished$/) do
     repeat_until_timeout(timeout: 7200, message: "Channel '#{channel}' not fully synced") do
       # products.xml is the last file to be written when the server synchronize a channel,
       # therefore we wait until it exist
-      _result, code = $server.run("test -f /var/cache/rhn/repodata/#{channel}/products.xml", check_errors: false)
+      _result, code = $server.run("test -f /var/cache/rhn/repodata/#{channel}/solv", check_errors: false)
       if code.zero?
         # We want to check if no .new files exists.
         # On a re-sync, the old files stay, the new one have this suffix until it's ready.
-        _result, new_code = $server.run("test -f /var/cache/rhn/repodata/#{channel}/products.xml.new", check_errors: false)
+        _result, new_code = $server.run("test -f /var/cache/rhn/repodata/#{channel}/solv.new", check_errors: false)
         break unless new_code.zero?
       end
       sleep 10


### PR DESCRIPTION
## What does this PR change?

Use solv file to wait until a channel is sync.
As products.xml is an optional file.

```
        // Optional files
        if (updateinfoData != null) {
            createdFiles.add(organizer.move(UPDATEINFO_FILE, "updateinfo.xml.gz", updateinfoData.getChecksum()));
        }
        if (productsData != null) {
            createdFiles.add(organizer.move(PRODUCTS_FILE, "products.xml", productsData.getChecksum()));
        }
``` 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
