### PR TITLE
Adding channels required in constants.rb

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -19,6 +19,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I open the sub-list of the product "SUSE Linux Enterprise Server 12 SP4 x86_64"
     And I select "SUSE Linux Enterprise Server LTSS 12 SP4 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server LTSS 12 SP4 x86_64" selected
+    And I select "Containers Module 12 x86_64" as a product
+    Then I should see the "Containers Module 12 x86_64" selected
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 12 SP4 x86_64" product has been added
 
@@ -29,6 +31,9 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I enter "SUSE Linux Enterprise Server 12 SP5" as the filtered product description
     And I select "SUSE Linux Enterprise Server 12 SP5 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server 12 SP5 x86_64" selected
+    When I open the sub-list of the product "SUSE Linux Enterprise Server 12 SP4 x86_64"
+    And I select "Containers Module 12 x86_64" as a product
+    Then I should see the "Containers Module 12 x86_64" selected
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 12 SP5 x86_64" product has been added
 
@@ -56,6 +61,9 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP1 x86_64"
     And I select "SUSE Linux Enterprise Server LTSS 15 SP1 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server LTSS 15 SP1 x86_64" selected
+    And I open the sub-list of the product "Basesystem Module 15 SP1 x86_64"
+    And I select "Containers Module 15 SP1 x86_64" as a product
+    Then I should see the "Containers Module 15 SP1 x86_64" selected
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 15 SP1 x86_64" product has been added
 
@@ -70,6 +78,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I open the sub-list of the product "Basesystem Module 15 SP2 x86_64"
     And I select "Desktop Applications Module 15 SP2 x86_64" as a product
     Then I should see the "Desktop Applications Module 15 SP2 x86_64" selected
+    And I select "Containers Module 15 SP2 x86_64" as a product
+    Then I should see the "Containers Module 15 SP2 x86_64" selected
     When I open the sub-list of the product "Desktop Applications Module 15 SP2 x86_64"
     And I select "Development Tools Module 15 SP2 x86_64" as a product
     Then I should see the "Development Tools Module 15 SP2 x86_64" selected
@@ -87,6 +97,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I open the sub-list of the product "Basesystem Module 15 SP3 x86_64"
     And I select "Desktop Applications Module 15 SP3 x86_64" as a product
     Then I should see the "Desktop Applications Module 15 SP3 x86_64" selected
+    And I select "Containers Module 15 SP3 x86_64" as a product
+    Then I should see the "Containers Module 15 SP3 x86_64" selected
     When I open the sub-list of the product "Desktop Applications Module 15 SP3 x86_64"
     And I select "Development Tools Module 15 SP3 x86_64" as a product
     Then I should see the "Development Tools Module 15 SP3 x86_64" selected
@@ -105,6 +117,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I open the sub-list of the product "Basesystem Module 15 SP4 x86_64"
     And I select "Desktop Applications Module 15 SP4 x86_64" as a product
     Then I should see the "Desktop Applications Module 15 SP4 x86_64" selected
+    And I select "Containers Module 15 SP4 x86_64" as a product
+    Then I should see the "Containers Module 15 SP4 x86_64" selected
     When I open the sub-list of the product "Desktop Applications Module 15 SP4 x86_64"
     And I select "Development Tools Module 15 SP4 x86_64" as a product
     Then I should see the "Development Tools Module 15 SP4 x86_64" selected


### PR DESCRIPTION
## What does this PR change?

Enabling additional channels in the testsuite required by the list of necessary channels to bootstrap minions.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were added : additional channels are selected for synchronization

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
