### PR TITLE
Generate new token for each channel (bsc#1201220)

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Reduce the length of image channel URL (bsc#1201220)
 - Fixed system search
 - update java dependencies
 - Enable Rocky Linux 9 for monitoring


### PR DESCRIPTION
## What does this PR change?

For image building, the download token contained list of all channels. The token was appended to each channel url.
In the end, the size of kiwi command line grew quadratically with the number of channels.

This commit generates new token for each channel.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: not an user visible change

- [x] **DONE**

## Test coverage
- covered by Cucumber tests

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18309
https://bugzilla.suse.com/show_bug.cgi?id=1201220
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
