### PR TITLE
Wait for solv instead of products.xml and add some logs to timeout loops

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -398,7 +398,7 @@ When(/^I wait until the channel "([^"]*)" has been synced$/) do |channel|
         # On a re-sync, the old files stay, the new one have this suffix until it's ready.
         _result, new_code = $server.run("test -f /var/cache/rhn/repodata/#{channel}/solv.new", check_errors: false)
         break unless new_code.zero?
-      break if code.zero?
+      end
       log "I am still waiting for '#{channel}' channel to be synchronized."
       sleep 10
     end

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -393,6 +393,11 @@ When(/^I wait until the channel "([^"]*)" has been synced$/) do |channel|
       # solv is the last file to be written when the server synchronizes a channel,
       # therefore we wait until it exist
       _result, code = $server.run("test -f /var/cache/rhn/repodata/#{channel}/solv", check_errors: false)
+      if code.zero?
+        # We want to check if no .new files exists.
+        # On a re-sync, the old files stay, the new one have this suffix until it's ready.
+        _result, new_code = $server.run("test -f /var/cache/rhn/repodata/#{channel}/solv.new", check_errors: false)
+        break unless new_code.zero?
       break if code.zero?
       log "I am still waiting for '#{channel}' channel to be synchronized."
       sleep 10

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -390,8 +390,9 @@ end
 When(/^I wait until the channel "([^"]*)" has been synced$/) do |channel|
   begin
     repeat_until_timeout(timeout: 7200, message: 'Channel not fully synced') do
-      _result, code = $server.run("test -f /var/cache/rhn/repodata/#{channel}/products.xml", check_errors: false)
+      _result, code = $server.run("test -f /var/cache/rhn/repodata/#{channel}/solv", check_errors: false)
       break if code.zero?
+      log "I am still waiting for '#{channel}' channel to be synchronized."
       sleep 10
     end
   rescue StandardError => e
@@ -403,8 +404,6 @@ When(/I wait until all synchronized channels have finished$/) do
   $channels_synchronized.each do |channel|
     log "I wait until '#{channel}' synchronized channel has finished"
     repeat_until_timeout(timeout: 7200, message: "Channel '#{channel}' not fully synced") do
-      # products.xml is the last file to be written when the server synchronize a channel,
-      # therefore we wait until it exist
       _result, code = $server.run("test -f /var/cache/rhn/repodata/#{channel}/solv", check_errors: false)
       if code.zero?
         # We want to check if no .new files exists.
@@ -412,6 +411,7 @@ When(/I wait until all synchronized channels have finished$/) do
         _result, new_code = $server.run("test -f /var/cache/rhn/repodata/#{channel}/solv.new", check_errors: false)
         break unless new_code.zero?
       end
+      log "I am still waiting for '#{channel}' channel to be synchronized."
       sleep 10
     end
   end


### PR DESCRIPTION
## What does this PR change?

Fix a step awaiting `products.xml` and wait for `solv` instead.
Add some logs in the channel-sync-waiting steps to keep some activity. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage


- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
