### PR TITLE
containerized broker logs

### DIFF
--- a/containers/proxy-helm/proxy-helm.changes
+++ b/containers/proxy-helm/proxy-helm.changes
@@ -1,3 +1,5 @@
+- Added the log level value to the config.yaml
+
 -------------------------------------------------------------------
 Tue Apr 26 15:09:11 UTC 2022 - Cédric Bosdonnat <cbosdonnat@suse.com>
 

--- a/containers/proxy-helm/proxy-helm.changes
+++ b/containers/proxy-helm/proxy-helm.changes
@@ -1,4 +1,4 @@
-- Added the log level value to the config.yaml
+- Add the log level value to the config.yaml
 
 -------------------------------------------------------------------
 Tue Apr 26 15:09:11 UTC 2022 - Cédric Bosdonnat <cbosdonnat@suse.com>

--- a/containers/proxy-helm/templates/config.yaml
+++ b/containers/proxy-helm/templates/config.yaml
@@ -10,7 +10,7 @@ data:
     proxy_fqdn: {{ .Values.proxy_fqdn }}
     email: {{ .Values.email }}
     max_cache_size_mb: {{ .Values.max_cache_size_mb }}
-    debug_log_level: {{ .Values.debug_log_level }}
+    log_level: {{ .Values.log_level }}
     ca_crt: |
 {{ .Values.ca_crt | indent 6 }}
 ---

--- a/containers/proxy-helm/templates/config.yaml
+++ b/containers/proxy-helm/templates/config.yaml
@@ -10,6 +10,7 @@ data:
     proxy_fqdn: {{ .Values.proxy_fqdn }}
     email: {{ .Values.email }}
     max_cache_size_mb: {{ .Values.max_cache_size_mb }}
+    debug_log_level: {{ .Values.debug_log_level }}
     ca_crt: |
 {{ .Values.ca_crt | indent 6 }}
 ---

--- a/containers/proxy-httpd-image/Dockerfile
+++ b/containers/proxy-httpd-image/Dockerfile
@@ -24,6 +24,7 @@ RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-li
     sh remove_unused.sh
 
 # Additional material
+COPY conf/ /usr/bin/conf/
 COPY uyuni-configure.py /usr/bin/uyuni-configure.py
 RUN chmod +x /usr/bin/uyuni-configure.py
 

--- a/containers/proxy-httpd-image/conf/mod_log_config.conf
+++ b/containers/proxy-httpd-image/conf/mod_log_config.conf
@@ -1,0 +1,29 @@
+LogFormat "%{HANDLER_TYPE}e %h %l %u %t \"%r\" %>s %b"                      common
+LogFormat "%{HANDLER_TYPE}e %v %h %l %u %t \"%r\" %>s %b"                   vhost_common
+LogFormat "%{HANDLER_TYPE}e %{Referer}i -> %U"                              referer
+LogFormat "%{HANDLER_TYPE}e %{User-agent}i"                                 agent
+LogFormat "%{HANDLER_TYPE}e %h %l %u %t \"%r\" %>s %b \
+\"%{Referer}i\" \"%{User-Agent}i\""                                         combined
+LogFormat "%{HANDLER_TYPE}e %v %h %l %u %t \"%r\" %>s %b \
+\"%{Referer}i\" \"%{User-Agent}i\""                                         vhost_combined
+
+# To use %I and %O, you need to enable mod_logio
+<IfModule mod_logio.c>
+LogFormat "%{HANDLER_TYPE}e %h %l %u %t \"%r\" %>s %b \
+\"%{Referer}i\" \"%{User-Agent}i\" %I %O"               combinedio
+</IfModule>
+
+# Use one of these when you want a compact non-error SSL logfile on a virtual
+# host basis:
+<IfModule mod_ssl.c>
+    Logformat "%{HANDLER_TYPE}e %t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \
+    \"%r\" %b"                                              ssl_common
+    Logformat "%{HANDLER_TYPE}e %t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \
+    \"%r\" %b \"%{Referer}i\" \"%{User-Agent}i\""           ssl_combined
+</IfModule>
+
+SetEnv HANDLER_TYPE "default server"
+
+# default to the common log/errorlog formats
+LogFormat "%{HANDLER_TYPE}e %h %l %u %t \"%r\" %>s %b"
+ErrorLogFormat "[%{HANDLER_TYPE}e] [%t] [%l] [pid %P] %F: %E: [client %a] %M"

--- a/containers/proxy-httpd-image/proxy-httpd-image.changes
+++ b/containers/proxy-httpd-image/proxy-httpd-image.changes
@@ -1,5 +1,4 @@
-- Added a custom version of the mod_log_config.conf 
-  for httpd logging in container
+- Prefix log messages with a package name to ease analysis
 
 -------------------------------------------------------------------
 Wed Jul 27 12:22:52 UTC 2022 - Julio González Gil <jgonzalez@suse.com>

--- a/containers/proxy-httpd-image/proxy-httpd-image.changes
+++ b/containers/proxy-httpd-image/proxy-httpd-image.changes
@@ -1,3 +1,6 @@
+- Added a custom version of the mod_log_config.conf 
+  for httpd logging in container
+
 -------------------------------------------------------------------
 Wed Jul 27 12:22:52 UTC 2022 - Julio González Gil <jgonzalez@suse.com>
 

--- a/containers/proxy-httpd-image/uyuni-configure.py
+++ b/containers/proxy-httpd-image/uyuni-configure.py
@@ -93,6 +93,9 @@ with open(config_path + "httpd.yaml") as httpdSource:
     with open("/etc/rhn/rhn.conf", "w") as file:
         file.write(f'''# Automatically generated Uyuni Proxy Server configuration file.
         # -------------------------------------------------------------------------
+        
+        # Debug log level
+        debug = {config.get("debug_log_level", 4)}
 
         # SSL CA certificate location
         proxy.ca_chain = /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT

--- a/containers/proxy-httpd-image/uyuni-configure.py
+++ b/containers/proxy-httpd-image/uyuni-configure.py
@@ -96,6 +96,10 @@ with open(config_path + "httpd.yaml") as httpdSource:
         
         # Debug log level
         debug = {config.get("debug_log_level", 4)}
+        
+        # Logs redirect
+        proxy.broker.log_file = stdout
+        proxy.redirect.log_file = stdout
 
         # SSL CA certificate location
         proxy.ca_chain = /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT

--- a/containers/proxy-httpd-image/uyuni-configure.py
+++ b/containers/proxy-httpd-image/uyuni-configure.py
@@ -95,7 +95,7 @@ with open(config_path + "httpd.yaml") as httpdSource:
         # -------------------------------------------------------------------------
         
         # Debug log level
-        debug = {config.get("debug_log_level", 4)}
+        debug = {config.get("log_level", 1)}
         
         # Logs redirect
         proxy.broker.log_file = stdout

--- a/containers/proxy-httpd-image/uyuni-configure.py
+++ b/containers/proxy-httpd-image/uyuni-configure.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import shutil
 import subprocess
 import re
 import yaml
@@ -38,6 +39,27 @@ def getIPs(fqdn: str) -> Tuple[str, str]:
 
     logging.debug("Detected ips '%s', '%s' for fqdn %s", ipv4, ipv6, fqdn)
     return (ipv4, ipv6)
+
+
+def insert_under_line(file_path, line_to_match, line_to_insert):
+
+    # add 4 leading spaces and a new line in the end
+    line_to_insert = line_to_insert.rjust(len(line_to_insert)+4) + "\n"
+
+    with open(file_path, "r") as f:
+        contents = f.readlines()
+
+    index = -1
+    for ind, line in enumerate(contents):
+        if line_to_match in line:
+            index = ind + 1
+
+    contents.insert(index, line_to_insert)
+
+    with open(file_path, "w") as f:
+        contents = "".join(contents)
+        f.write(contents)
+
 
 # read from files
 with open(config_path + "config.yaml") as source:
@@ -204,6 +226,26 @@ RewriteRule "^/saltboot/(image|boot)(.+)$" "/os-images/%1$2"  [R,L,QSD]
 </IfDefine>
 </IfDefine>
 ''')
+
+    # Adjust logs format in apache httpd:
+    # 1. Replace mod_log_config.conf so that the logger takes a special var HANDLER_TYPE
+    shutil.copyfile('/usr/bin/conf/mod_log_config.conf', '/etc/apache2/mod_log_config.conf')
+    # 2. Modify the other configurations so that the var HANDLER_TYPE gets set based on a directory of a script executed
+    insert_under_line(
+        "/etc/apache2/conf.d/spacewalk-proxy-wsgi.conf",
+        "<Directory /usr/share/rhn>",
+        'SetEnv HANDLER_TYPE "proxy-broker"'
+    )
+    insert_under_line(
+        "/etc/apache2/conf.d/spacewalk-proxy.conf",
+        '<Directory "/srv/www/htdocs/pub/*">',
+        'SetEnv HANDLER_TYPE "proxy-html"'
+    )
+    insert_under_line(
+        "/etc/apache2/conf.d/spacewalk-proxy.conf",
+        '<Directory "/srv/www/htdocs/docs/*">',
+        'SetEnv HANDLER_TYPE "proxy-docs"'
+    )
 
     os.system('chown root:www /etc/rhn/rhn.conf')
     os.system('chmod 640 /etc/rhn/rhn.conf')

--- a/containers/proxy-salt-broker-image/uyuni-configure.py
+++ b/containers/proxy-salt-broker-image/uyuni-configure.py
@@ -9,18 +9,7 @@ with open("/etc/uyuni/config.yaml") as source:
 
     # write to file
     with open("/etc/rhn/rhn.conf", "w") as dest:
-        dest.write(f'''# Automatically generated Uyuni Proxy Server configuration file.
-        # -------------------------------------------------------------------------
-        
-        # Debug log level
-        debug = {config.get("debug_log_level", 4)}
-        
-        # Logs redirect
-        proxy.broker.log_file = stdout
-        proxy.redirect.log_file = stdout
-        
-        # Hostname of Uyuni, SUSE Manager Server or another proxy
-        rhn_parent={config['server']}''')
+       dest.write(f"rhn_parent={config['server']}")
 
     # read to existing config file
     with open("/etc/salt/broker", "r+") as config_file:

--- a/containers/proxy-salt-broker-image/uyuni-configure.py
+++ b/containers/proxy-salt-broker-image/uyuni-configure.py
@@ -15,6 +15,10 @@ with open("/etc/uyuni/config.yaml") as source:
         # Debug log level
         debug = {config.get("debug_log_level", 4)}
         
+        # Logs redirect
+        proxy.broker.log_file = stdout
+        proxy.redirect.log_file = stdout
+        
         # Hostname of Uyuni, SUSE Manager Server or another proxy
         rhn_parent={config['server']}''')
 

--- a/containers/proxy-salt-broker-image/uyuni-configure.py
+++ b/containers/proxy-salt-broker-image/uyuni-configure.py
@@ -9,7 +9,14 @@ with open("/etc/uyuni/config.yaml") as source:
 
     # write to file
     with open("/etc/rhn/rhn.conf", "w") as dest:
-       dest.write(f"rhn_parent={config['server']}")
+        dest.write(f'''# Automatically generated Uyuni Proxy Server configuration file.
+        # -------------------------------------------------------------------------
+        
+        # Debug log level
+        debug = {config.get("debug_log_level", 4)}
+        
+        # Hostname of Uyuni, SUSE Manager Server or another proxy
+        rhn_parent={config['server']}''')
 
     # read to existing config file
     with open("/etc/salt/broker", "r+") as config_file:

--- a/proxy/proxy/apacheServer.py
+++ b/proxy/proxy/apacheServer.py
@@ -44,7 +44,7 @@ class HandlerWrap:
             # upstream all requests
             componentType = getComponentType(req)
             initCFG(componentType)
-            initLOG(CFG.LOG_FILE, CFG.DEBUG)
+            initLOG(CFG.LOG_FILE, CFG.DEBUG, f"wsgi_{componentType}")
             log_debug(1, 'New request, component %s' % (componentType, ))
 
         # Instantiate the handlers

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,5 @@
+- Added passing a component type property to the LOG object 
+  when initializing the logger 
 - renew the cached token when requested channel is not listed in
   the old token (bsc#1202724)
 

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,5 +1,4 @@
-- Added passing a component type property to the LOG object 
-  when initializing the logger 
+- Prefix log messages with the component name to ease analysis
 - renew the cached token when requested channel is not listed in
   the old token (bsc#1202724)
 

--- a/python/spacewalk/common/rhnLog.py
+++ b/python/spacewalk/common/rhnLog.py
@@ -225,7 +225,7 @@ class rhnLog:
         if args:
             msg = "%s%s" % (msg, repr(args))
         if self.component:
-            msg = "%s%s" % (self.component, msg)
+            msg = "%s %s" % (self.component, msg)
         self.writeMessage(msg)
 
     # send a message to the log file w/some extra data (time stamp, etc).

--- a/python/spacewalk/common/rhnLog.py
+++ b/python/spacewalk/common/rhnLog.py
@@ -95,8 +95,8 @@ def initLOG(log_file="stderr", level=0, component=""):
     log_path = os.path.dirname(log_file)
     if log_file not in ('stderr', 'stdout') \
             and log_path and not os.path.exists(os.path.dirname(log_file)):
-        log_stderr("WARNING: log path not found; attempting to create %s for %s" %
-                   (log_path, component), sys.exc_info()[:2])
+        log_stderr("{} WARNING: log path not found; attempting to create {}".format(component, log_path), 
+                   sys.exc_info()[:2])
 
         # fetch uid, gid so we can do a "chown ..."
         if isSUSE():
@@ -108,7 +108,7 @@ def initLOG(log_file="stderr", level=0, component=""):
             os.makedirs(log_path)
             os.chown(log_path, apache_uid, apache_gid)
         except:
-            log_stderr("ERROR: unable to create log file path %s for %s" % (log_path, component),
+            log_stderr("{} ERROR: unable to create log file path {}".format(component, log_path),
                        sys.exc_info()[:2])
             return
 

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,4 +1,6 @@
 - Upgrade Cobbler requirement to 3.3.3 or later
+- Added an optional component_type property to the LOG object 
+  and included it to a log message
 - Make reposync use the configured http proxy with mirrorlist (bsc#1198168)
 - Prevent tracebacks on running spacewalk-repo-sync
   on loading update notice with no version specified in the meta data

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,6 +1,7 @@
 - Upgrade Cobbler requirement to 3.3.3 or later
 - Added an optional component_type property to the LOG object 
   and included it to a log message
+- Add an optional component property to the log messages
 - Make reposync use the configured http proxy with mirrorlist (bsc#1198168)
 - Prevent tracebacks on running spacewalk-repo-sync
   on loading update notice with no version specified in the meta data


### PR DESCRIPTION
## What does this PR change?

This PR should make it easier to debug the containerized broker by redirecting logs into stdout/stderr inside a container.
Optionally we want also do discuss the possibility of implementing a more robust logs management solution for our container suite. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
No tests: already covered

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18428

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
