### PR TITLE
QE: use new testsuite container

### DIFF
--- a/testsuite/documentation/container-build-image.md
+++ b/testsuite/documentation/container-build-image.md
@@ -1,0 +1,18 @@
+## About the Container Build Image
+
+In `testsuite/features/profiles/Docker/` we have defined 3 Dockerfiles to build
+container images as test.
+
+The Dockerfiles in `authprofile/` and `serverhost/` are based on
+`registry.mgr.suse.de[:5000]/systemsmanagement/uyuni/master/docker/containers/uyuni-master-testsuite`
+which is build in OBS `systemsmanagement:Uyuni:Master:Docker/uyuni-master-testsuite` .
+
+The image is based on openSUSE Leap and install in addition some of our test packages from
+the `systemsmanagement:Uyuni:Test-Packages:Pool` repositories.
+The following packages are installed in this image (Version 1.0):
+* andromeda-dummy
+* milkyway-dummy
+* virgo-dummy
+
+While rebuilding the images we can test if the available update candidates from
+our Update Repository are installed and if the UI show correct status.

--- a/testsuite/features/core/srv_channels_add.feature
+++ b/testsuite/features/core/srv_channels_add.feature
@@ -91,9 +91,8 @@ Feature: Adding channels
     And I enter "Test-Channel-Deb-AMD64 for testing" as "Channel Summary"
     And I enter "No more description for base channel." as "Channel Description"
     # WORKAROUND
-    # GPG verification of Debian-like repos was added and the TestRepoDebUpdates repo
-    # is signed by a GPG key that is not in the keyring. This workaround temporarily
-    # disables GPG check, before this is properly handled at sumaform/terraform level.
+    # GPG verification of Debian-like repos is possible with an own GPG key.
+    # This is not yet part of the testsuite and we run with disabled checkes for Ubuntu/Debian
     And I uncheck "gpg_check"
     # End of WORKAROUND
     And I click on "Create Channel"

--- a/testsuite/features/core/srv_create_repository.feature
+++ b/testsuite/features/core/srv_create_repository.feature
@@ -83,12 +83,6 @@ Feature: Add a repository to a channel
     And I enter "Test-Repository-Deb" as "label"
     And I select "deb" from "contenttype"
     And I enter "http://localhost/pub/TestRepoDebUpdates/" as "url"
-    # WORKAROUND
-    # GPG verification of Debian-like repos was added and the TestRepoDebUpdates repo
-    # is signed by a GPG key that is not in the keyring. This workaround temporarily
-    # disables GPG check, before this is properly handled at sumaform/terraform level.
-    And I uncheck "metadataSigned"
-    # End of WORKAROUND
     And I click on "Create Repository"
     Then I should see a "Repository created successfully" text
 

--- a/testsuite/features/core/srv_create_repository.feature
+++ b/testsuite/features/core/srv_create_repository.feature
@@ -30,7 +30,10 @@ Feature: Add a repository to a channel
   Scenario: Add the repository to the x86_64 channel
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Test-Channel-x86_64"
-    And I follow "Repositories" in the content area
+    And I enter "file:///etc/pki/rpm-gpg/uyuni-tools-gpg-pubkey-0d20833e.key" as "GPG key URL"
+    And I click on "Update Channel"
+    Then I should see a "Channel Test-Channel-x86_64 updated" text
+    When I follow "Repositories" in the content area
     And I select the "Test-Repository-x86_64" repo
     And I click on "Save Repositories"
     Then I should see a "Test-Channel-x86_64 repository information was successfully updated" text
@@ -56,7 +59,10 @@ Feature: Add a repository to a channel
   Scenario: Add the repository to the i586 channel
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Test-Channel-i586"
-    And I follow "Repositories" in the content area
+    And I enter "file:///etc/pki/rpm-gpg/uyuni-tools-gpg-pubkey-0d20833e.key" as "GPG key URL"
+    And I click on "Update Channel"
+    Then I should see a "Channel Test-Channel-i586 updated" text
+    When I follow "Repositories" in the content area
     And I select the "Test-Repository-i586" repo
     And I click on "Save Repositories"
     Then I should see a "Test-Channel-i586 repository information was successfully updated" text

--- a/testsuite/features/profiles/Docker/Dockerfile
+++ b/testsuite/features/profiles/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.mgr.suse.de/suse/sle15:15.4
+FROM registry.mgr.suse.de/opensuse/leap:15.4
 MAINTAINER Admin User "noemail@example.com"
 
 ARG repo

--- a/testsuite/features/profiles/Docker/add_packages.sh
+++ b/testsuite/features/profiles/Docker/add_packages.sh
@@ -16,7 +16,7 @@ zypper rr sles15sp4
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref
-zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar python3 python3-psutil
+zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar gzip python3 python3-psutil
 
 # kill avahi
 /usr/sbin/avahi-daemon -k

--- a/testsuite/features/profiles/Docker/authprofile/Dockerfile
+++ b/testsuite/features/profiles/Docker/authprofile/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION               1.0.0
 
-FROM registry.mgr.suse.de/suse/sle15:15.4
+FROM registry.mgr.suse.de:5000/systemsmanagement/uyuni/master/docker/containers/uyuni-master-testsuite
 MAINTAINER Michael Calmer "mc@suse.com"
 
 ARG repo

--- a/testsuite/features/profiles/Docker/authprofile/add_packages.sh
+++ b/testsuite/features/profiles/Docker/authprofile/add_packages.sh
@@ -11,7 +11,7 @@ cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
 # install python3 and python3-psutil in the container
-zypper --non-interactive in python3 python3-psutil
+zypper --non-interactive in tar gzip python3 python3-psutil
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Test-Channel-x86_64 || :

--- a/testsuite/features/profiles/Docker/serverhost/Dockerfile
+++ b/testsuite/features/profiles/Docker/serverhost/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION               1.0.0
 
-FROM registry.mgr.suse.de/suse/sle15:15.4
+FROM registry.mgr.suse.de/systemsmanagement/uyuni/master/docker/containers/uyuni-master-testsuite
 MAINTAINER Michael Calmer "mc@suse.com"
 
 ARG repo

--- a/testsuite/features/profiles/Docker/serverhost/add_packages.sh
+++ b/testsuite/features/profiles/Docker/serverhost/add_packages.sh
@@ -11,7 +11,7 @@ cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
 # install python3 and python3-psutil in the container
-zypper --non-interactive in python3 python3-psutil
+zypper --non-interactive in tar gzip python3 python3-psutil
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Test-Channel-x86_64 || :

--- a/testsuite/features/profiles/internal_nue/Docker/Dockerfile
+++ b/testsuite/features/profiles/internal_nue/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.mgr.suse.de/suse/sle15:15.4
+FROM registry.mgr.suse.de/opensuse/leap:15.4
 MAINTAINER Admin User "noemail@example.com"
 
 ARG repo

--- a/testsuite/features/profiles/internal_nue/Docker/add_packages.sh
+++ b/testsuite/features/profiles/internal_nue/Docker/add_packages.sh
@@ -16,7 +16,7 @@ zypper rr sles15sp4
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref
-zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar python3 python3-psutil
+zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar gzip python3 python3-psutil
 
 # kill avahi
 /usr/sbin/avahi-daemon -k

--- a/testsuite/features/profiles/internal_nue/Docker/authprofile/Dockerfile
+++ b/testsuite/features/profiles/internal_nue/Docker/authprofile/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION               1.0.0
 
-FROM registry.mgr.suse.de/suse/sle15:15.4
+FROM registry.mgr.suse.de:5000/systemsmanagement/uyuni/master/docker/containers/uyuni-master-testsuite
 MAINTAINER Michael Calmer "mc@suse.com"
 
 ARG repo

--- a/testsuite/features/profiles/internal_nue/Docker/authprofile/add_packages.sh
+++ b/testsuite/features/profiles/internal_nue/Docker/authprofile/add_packages.sh
@@ -11,7 +11,7 @@ cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
 # install python3 and python3-psutil in the container
-zypper --non-interactive in python3 python3-psutil
+zypper --non-interactive in tar gzip python3 python3-psutil
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Test-Channel-x86_64 || :

--- a/testsuite/features/profiles/internal_nue/Docker/serverhost/Dockerfile
+++ b/testsuite/features/profiles/internal_nue/Docker/serverhost/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION               1.0.0
 
-FROM registry.mgr.suse.de/suse/sle15:15.4
+FROM registry.mgr.suse.de/systemsmanagement/uyuni/master/docker/containers/uyuni-master-testsuite
 MAINTAINER Michael Calmer "mc@suse.com"
 
 ARG repo

--- a/testsuite/features/profiles/internal_nue/Docker/serverhost/add_packages.sh
+++ b/testsuite/features/profiles/internal_nue/Docker/serverhost/add_packages.sh
@@ -11,7 +11,7 @@ cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
 # install python3 and python3-psutil in the container
-zypper --non-interactive in python3 python3-psutil
+zypper --non-interactive in tar gzip python3 python3-psutil
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Test-Channel-x86_64 || :

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -4,7 +4,7 @@
     <description type="system">
         <author>Admin User</author>
         <contact>noemail@example.com</contact>
-        <specification>SUSE Linux Enterprise 15 SP3 JeOS</specification>
+        <specification>SUSE Linux Enterprise 15 SP4 JeOS</specification>
     </description>
     <preferences>
         <version>7.0.0</version>
@@ -29,28 +29,28 @@
          in that case, sync those repos in Uyuni, and add them to the activation key;
          finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
     <repository type="rpm-md">  <!-- product -->
-        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP3/x86_64/product/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP4/x86_64/product/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP3/x86_64/update/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP4/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">  <!-- base system -->
-        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP3/x86_64/product/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP4/x86_64/product/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP4/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">  <!-- desktop applications -->
-        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Desktop-Applications/15-SP3/x86_64/product/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Desktop-Applications/15-SP4/x86_64/product/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP3/x86_64/update/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP4/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">  <!-- development tools -->
-        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Development-Tools/15-SP3/x86_64/product/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Development-Tools/15-SP4/x86_64/product/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Development-Tools/15-SP3/x86_64/update/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Development-Tools/15-SP4/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">  <!-- manager tools -->
         <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Manager-Tools/15/x86_64/product/"/>

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -4,7 +4,7 @@
     <description type="system">
         <author>Admin User</author>
         <contact>noemail@example.com</contact>
-        <specification>SUSE Linux Enterprise 15 SP3 JeOS</specification>
+        <specification>SUSE Linux Enterprise 15 SP4 JeOS</specification>
     </description>
     <preferences>
         <version>7.0.0</version>
@@ -29,28 +29,28 @@
          in that case, sync those repos in Uyuni, and add them to the activation key;
          finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
     <repository type="rpm-md">  <!-- product -->
-        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP3/x86_64/product/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP4/x86_64/product/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP3/x86_64/update/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP4/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">  <!-- base system -->
-        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP3/x86_64/product/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP4/x86_64/product/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP4/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">  <!-- desktop applications -->
-        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Desktop-Applications/15-SP3/x86_64/product/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Desktop-Applications/15-SP4/x86_64/product/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP3/x86_64/update/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP4/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">  <!-- development tools -->
-        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Development-Tools/15-SP3/x86_64/product/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Development-Tools/15-SP4/x86_64/product/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Development-Tools/15-SP3/x86_64/update/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Development-Tools/15-SP4/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">  <!-- manager tools -->
         <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Manager-Tools/15/x86_64/product/"/>

--- a/testsuite/features/profiles/internal_prv/Docker/Dockerfile
+++ b/testsuite/features/profiles/internal_prv/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.mgr.suse.de/suse/sle15:15.4
+FROM registry.mgr.prv.suse.net/opensuse/leap:15.4
 MAINTAINER Admin User "noemail@example.com"
 
 ARG repo

--- a/testsuite/features/profiles/internal_prv/Docker/add_packages.sh
+++ b/testsuite/features/profiles/internal_prv/Docker/add_packages.sh
@@ -16,7 +16,7 @@ zypper rr sles15sp4
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref
-zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar python3 python3-psutil
+zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar gzip python3 python3-psutil
 
 # kill avahi
 /usr/sbin/avahi-daemon -k

--- a/testsuite/features/profiles/internal_prv/Docker/authprofile/Dockerfile
+++ b/testsuite/features/profiles/internal_prv/Docker/authprofile/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION               1.0.0
 
-FROM registry.mgr.prv.suse.net/suse/sle15:15.4
+FROM registry.mgr.prv.suse.net:5000/systemsmanagement/uyuni/master/docker/containers/uyuni-master-testsuite
 MAINTAINER Michael Calmer "mc@suse.com"
 
 ARG repo

--- a/testsuite/features/profiles/internal_prv/Docker/authprofile/add_packages.sh
+++ b/testsuite/features/profiles/internal_prv/Docker/authprofile/add_packages.sh
@@ -11,7 +11,7 @@ cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
 # install python3 and python3-psutil in the container
-zypper --non-interactive in python3 python3-psutil
+zypper --non-interactive in tar gzip python3 python3-psutil
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Test-Channel-x86_64 || :

--- a/testsuite/features/profiles/internal_prv/Docker/serverhost/Dockerfile
+++ b/testsuite/features/profiles/internal_prv/Docker/serverhost/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION               1.0.0
 
-FROM registry.mgr.prv.suse.net/suse/sle15:15.4
+FROM registry.mgr.prv.suse.net/systemsmanagement/uyuni/master/docker/containers/uyuni-master-testsuite
 MAINTAINER Michael Calmer "mc@suse.com"
 
 ARG repo

--- a/testsuite/features/profiles/internal_prv/Docker/serverhost/add_packages.sh
+++ b/testsuite/features/profiles/internal_prv/Docker/serverhost/add_packages.sh
@@ -11,7 +11,7 @@ cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
 # install python3 and python3-psutil in the container
-zypper --non-interactive in python3 python3-psutil
+zypper --non-interactive in tar gzip python3 python3-psutil
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Test-Channel-x86_64 || :

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -4,7 +4,7 @@
     <description type="system">
         <author>Admin User</author>
         <contact>noemail@example.com</contact>
-        <specification>SUSE Linux Enterprise 15 SP3 JeOS</specification>
+        <specification>SUSE Linux Enterprise 15 SP4 JeOS</specification>
     </description>
     <preferences>
         <version>7.0.0</version>
@@ -29,28 +29,28 @@
          in that case, sync those repos in Uyuni, and add them to the activation key;
          finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
     <repository type="rpm-md">  <!-- product -->
-        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP3/x86_64/product/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP4/x86_64/product/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP3/x86_64/update/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP4/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">  <!-- base system -->
-        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP3/x86_64/product/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP4/x86_64/product/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP4/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">  <!-- desktop applications -->
-        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Desktop-Applications/15-SP3/x86_64/product/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Desktop-Applications/15-SP4/x86_64/product/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP3/x86_64/update/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP4/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">  <!-- development tools -->
-        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Development-Tools/15-SP3/x86_64/product/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Development-Tools/15-SP4/x86_64/product/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Development-Tools/15-SP3/x86_64/update/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Development-Tools/15-SP4/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">  <!-- manager tools -->
         <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Manager-Tools/15/x86_64/product/"/>

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -4,7 +4,7 @@
     <description type="system">
         <author>Admin User</author>
         <contact>noemail@example.com</contact>
-        <specification>SUSE Linux Enterprise 15 SP3 JeOS</specification>
+        <specification>SUSE Linux Enterprise 15 SP4 JeOS</specification>
     </description>
     <preferences>
         <version>7.0.0</version>
@@ -29,28 +29,28 @@
          in that case, sync those repos in Uyuni, and add them to the activation key;
          finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
     <repository type="rpm-md">  <!-- product -->
-        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP3/x86_64/product/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP4/x86_64/product/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP3/x86_64/update/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP4/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">  <!-- base system -->
-        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP3/x86_64/product/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP4/x86_64/product/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP4/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">  <!-- desktop applications -->
-        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Desktop-Applications/15-SP3/x86_64/product/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Desktop-Applications/15-SP4/x86_64/product/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP3/x86_64/update/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP4/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">  <!-- development tools -->
-        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Development-Tools/15-SP3/x86_64/product/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Development-Tools/15-SP4/x86_64/product/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Development-Tools/15-SP3/x86_64/update/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Development-Tools/15-SP4/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">  <!-- manager tools -->
         <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Manager-Tools/15/x86_64/product/"/>


### PR DESCRIPTION
## What does this PR change?

As suma-head-testsuite was build internally and manual, it was replaced with a uyuni based container build in OBS together with the other containers.
All teststuites should use the new uyuni-master-testsuite container. It is based on opensuse/leap:15.4 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18450

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
