### PR TITLE
Fix reposync on loading update notice with no version

### DIFF
--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -288,6 +288,8 @@ class UpdateNotice(object):
         if elem.tag == 'update':
             for attrib in ('from', 'type', 'status', 'version'):
                 self._md[attrib] = elem.attrib.get(attrib)
+            if self._md["version"] is None:
+                self._md["version"] = "0"
             for child in elem:
                 if child.tag == 'id':
                     if not child.text:

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,3 +1,6 @@
+- Prevent tracebacks on running spacewalk-repo-sync
+  on loading update notice with no version specified in the meta data
+
 -------------------------------------------------------------------
 Wed Jul 27 14:16:43 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fixes tracebacks on calling `spacewalk-repo-sync` on the repos with the update notice in the repos with missing `version`.
It sets the version to `"0"` to prevent DB schema issues.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- Unit tests were added

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/5617

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
