### PR TITLE
fix taskomatic task remain in progress

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/threaded/TaskQueue.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/threaded/TaskQueue.java
@@ -167,6 +167,9 @@ public class TaskQueue {
      */
     public void waitForEmptyQueue() throws InterruptedException {
         synchronized (emptyQueueWait) {
+            if (queueSize == 0) {
+                return;
+            }
             emptyQueueWait.wait();
         }
     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- fix taskomatic task remain in progress
+
 -------------------------------------------------------------------
 Wed Jul 27 14:18:34 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Taskomatic job `mgr-update-reporting-hub` won't finish. The issue seems to be caused on an error on checking when the task queue is empty.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/5665
Fixes https://github.com/SUSE/spacewalk/issues/18384

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
