### PR TITLE
Add mgrnet salt module

### DIFF
--- a/susemanager-utils/susemanager-sls/src/modules/mgrnet.py
+++ b/susemanager-utils/susemanager-sls/src/modules/mgrnet.py
@@ -1,0 +1,90 @@
+"""
+Module for gathering DNS FQDNs
+"""
+
+import logging
+import re
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import salt.utils.network
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    """
+    Only works on POSIX-like systems having 'host' or 'nslookup' available
+    """
+    if not (__utils__["path.which"]("host") or __utils__["path.which"]("nslookup")):
+        log.debug("Neither 'host' nor 'nslookup' is available on the system")
+    return True
+
+
+def dns_fqdns():
+    """
+    Return all known DNS FQDNs for the system by enumerating all interfaces and
+    then trying to reverse resolve them with native DNS tools
+    """
+    # Provides:
+    # dns_fqdns
+
+    grains = {}
+    fqdns = set()
+    cmd_run_all_func = __salt__["cmd.run_all"]
+    if __utils__["path.which"]("host"):
+        cmd = "host"
+        cmd_ret_regex = re.compile(r".* domain name pointer (.*)\.$")
+    elif __utils__["path.which"]("nslookup"):
+        cmd = "nslookup"
+        cmd_ret_regex = re.compile(r".*\tname = (.*)\.$")
+    else:
+        log.error("Neither 'host' nor 'nslookup' is available on the system")
+        return {"dns_fqdns": []}
+
+    def _lookup_dns_fqdn(ip):
+        try:
+            ret = cmd_run_all_func([cmd, ip], ignore_retcode=True)
+        except Exception as e:
+            log.error("Error while trying to use '%s' to resolve '%s': %s", cmd, ip, e)
+        if ret["retcode"] != 0:
+            log.debug("Unable to resolve '%s' using '%s': %s", ip, cmd, ret)
+            return []
+        fqdns = []
+        for line in ret["stdout"].split("\n"):
+            match = cmd_ret_regex.match(line)
+            if match:
+                fqdns.append(match.group(1))
+        return fqdns
+
+    start = time.time()
+
+    addresses = salt.utils.network.ip_addrs(
+        include_loopback=False, interface_data=salt.utils.network._get_interfaces()
+    )
+    addresses.extend(
+        salt.utils.network.ip_addrs6(
+            include_loopback=False, interface_data=salt.utils.network._get_interfaces()
+        )
+    )
+
+    results = []
+    try:
+        # Create a ThreadPoolExecutor to process the underlying calls
+        # to resolve DNS FQDNs in parallel.
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            results = {executor.submit(_lookup_dns_fqdn, ip): ip for ip in addresses}
+            for item in as_completed(results):
+                item = item.result()
+                if item:
+                    fqdns.update(item)
+    except Exception as exc:  # pylint: disable=broad-except
+        log.error(
+            "Exception while running ThreadPoolExecutor for FQDNs resolution: %s",
+            exc,
+        )
+
+    elapsed = time.time() - start
+    log.debug("Elapsed time getting DNS FQDNs: %s seconds", elapsed)
+
+    return {"dns_fqdns": sorted(list(fqdns))}

--- a/susemanager-utils/susemanager-sls/src/modules/mgrnet.py
+++ b/susemanager-utils/susemanager-sls/src/modules/mgrnet.py
@@ -17,7 +17,7 @@ def __virtual__():
     Only works on POSIX-like systems having 'host' or 'nslookup' available
     """
     if not (__utils__["path.which"]("host") or __utils__["path.which"]("nslookup")):
-        log.debug("Neither 'host' nor 'nslookup' is available on the system")
+        return (False, "Neither 'host' nor 'nslookup' is available on the system")
     return True
 
 

--- a/susemanager-utils/susemanager-sls/src/tests/mockery.py
+++ b/susemanager-utils/susemanager-sls/src/tests/mockery.py
@@ -20,6 +20,7 @@ def setup_environment():
         sys.modules['salt.utils.versions'] = MagicMock()
         sys.modules['salt.utils.odict'] = MagicMock()
         sys.modules['salt.utils.minions'] = MagicMock()
+        sys.modules['salt.utils.network'] = MagicMock()
         sys.modules['salt.modules'] = MagicMock()
         sys.modules['salt.modules.cmdmod'] = MagicMock()
         sys.modules['salt.modules.virt'] = MagicMock()

--- a/susemanager-utils/susemanager-sls/src/tests/test_module_mgrnet.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_mgrnet.py
@@ -1,0 +1,94 @@
+import sys
+
+from unittest.mock import MagicMock, patch
+from . import mockery
+
+mockery.setup_environment()
+
+from ..modules import mgrnet
+
+
+mgrnet.__salt__ = {}
+mgrnet.__utils__ = {}
+
+
+def test_mgrnet_dns_fqdns():
+    """
+    Test getting possible FQDNs with DNS tools
+    """
+
+    check_calls = {"host": [], "nslookup": []}
+
+    ipv4_addresses = ["10.0.0.1", "172.16.0.1", "192.168.0.1", "10.10.1.1"]
+    ipv6_addresses = ["fd12:3456:789a:1::1", "fd12:abcd:1234:1::1"]
+
+    names = {
+        "10.0.0.1": "host10.example.org",
+        "172.16.0.1": "host172.example.org",
+        "192.168.0.1": "host10.example.org",
+        "fd12:3456:789a:1::1": "ipv6host3456.example.org",
+        "fd12:abcd:1234:1::1": "ipv6hostabcd.example.org",
+    }
+
+    def _cmd_run_host_nslookup(cmd, ignore_retcode=False):
+        """
+        This function is emulating the output of 'host' or 'nslookup'
+        """
+        ip = cmd[1]
+        cmd = cmd[0]
+        check_calls[cmd].append(ip)
+        rc = 0
+        if ":" in ip:
+            # the conversation is not very accurate here, but it's enough for testing
+            ptr = "{}.ip6.arpa".format(".".join(reversed([*ip.replace(":", "")])))
+        else:
+            ptr = "{}.in-addr.arpa".format(".".join(reversed(ip.split())))
+        if cmd == "host":
+            if ip in names:
+                out = "{} domain name pointer {}.\n".format(ptr, names[ip])
+            else:
+                out = "Host {}. not found: 3(NXDOMAIN)\n".format(ptr)
+                rc = 1
+        else:
+            if ip in names:
+                out = "{}\tname = {}.\n".format(ptr, names[ip])
+            else:
+                out = "** server can't find {}: NXDOMAIN\n".format(ptr)
+                rc = 1
+        return {"retcode": rc, "stdout": out}
+
+    with patch.dict(
+        mgrnet.__salt__, {"cmd.run_all": _cmd_run_host_nslookup}
+    ), patch.dict(
+        mgrnet.__utils__,
+        {"path.which": MagicMock(side_effect=[True, False, True, False, False])},
+    ), patch.object(
+        mgrnet.salt.utils.network,
+        "ip_addrs",
+        MagicMock(side_effect=[ipv4_addresses.copy(), ipv4_addresses.copy()]),
+    ), patch.object(
+        mgrnet.salt.utils.network,
+        "ip_addrs6",
+        MagicMock(side_effect=[ipv6_addresses.copy(), ipv6_addresses.copy()]),
+    ):
+        # Test 'host' util output
+        ret = mgrnet.dns_fqdns()
+        assert sorted(ret["dns_fqdns"]) == sorted(set(names.values()))
+
+        # Test 'nslookup' util output
+        ret = mgrnet.dns_fqdns()
+        assert sorted(ret["dns_fqdns"]) == sorted(set(names.values()))
+
+        # Check if 'host' and 'nslookup' were called for all of IPv4 and IPv6 addresses
+        for ip in ipv4_addresses:
+            assert ip in check_calls["host"]
+            assert ip in check_calls["nslookup"]
+        for ip in ipv6_addresses:
+            assert ip in check_calls["host"]
+            assert ip in check_calls["nslookup"]
+
+        assert len(check_calls["host"]) == len(ipv4_addresses) + len(ipv6_addresses)
+
+        # Test the case when neither 'host' nor 'nslookup' is present on the system
+        ret = mgrnet.dns_fqdns()
+        assert ret == {"dns_fqdns": []}

--- a/susemanager-utils/susemanager-sls/src/tests/test_module_mgrnet.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_mgrnet.py
@@ -59,7 +59,7 @@ def test_mgrnet_dns_fqdns():
         check_calls[cmd].append(ip)
         rc = 0
         if ":" in ip:
-            # the conversation is not very accurate here, but it's enough for testing
+            # the conversion is not very accurate here, but it's enough for testing
             ptr = "{}.ip6.arpa".format(".".join(reversed([*ip.replace(":", "")])))
         else:
             ptr = "{}.in-addr.arpa".format(".".join(reversed(ip.split())))

--- a/susemanager-utils/susemanager-sls/src/tests/test_module_mgrnet.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_mgrnet.py
@@ -12,6 +12,26 @@ mgrnet.__salt__ = {}
 mgrnet.__utils__ = {}
 
 
+def test_mgrnet_virtual():
+    """
+    Test __virtual__ function for the possible cases
+    when either 'host' or 'nslookup' is available or none of them
+    """
+
+    with patch.dict(
+        mgrnet.__utils__,
+        {"path.which": MagicMock(side_effect=[True, False, True, False, False])},
+    ):
+        ret = mgrnet.__virtual__()
+        assert ret is True
+
+        ret = mgrnet.__virtual__()
+        assert ret is True
+
+        ret = mgrnet.__virtual__()
+        assert ret[0] is False
+
+
 def test_mgrnet_dns_fqdns():
     """
     Test getting possible FQDNs with DNS tools

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Add mgrnet salt module with mgrnet.dns_fqnd function implementation
+  allowing to get all possible FQDNs from DNS (bsc#1199726)
 - Copy grains file with util.mgr_switch_to_venv_minion state apply
 - Remove the message 'rpm: command not found' on using Salt SSH
   with Debian based systems which has no Salt Bundle


### PR DESCRIPTION
## What does this PR change?

Implements `mgrnet` salt module with the only function `mgrnet.dns_fqdns`.

`mgrnet.dns_fqdns` returns the list `dns_fqdns` with all found FQDNs with native DNS tools: `host` or `nslookup`.
If none of these tools available on the system, the function returns the list `fqdns` identical to the result of `network.fqdns` salt function.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
TBD
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/17929

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
