### PR TITLE
Disable gpgckeck for container build

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -1574,10 +1574,8 @@ public class SaltServerActionService {
                                     "autorefresh=1\n\n" +
                                     "baseurl=" + getChannelUrl(minion, s.getLabel()) + "\n\n" +
                                     "type=rpm-md\n\n" +
-                                    "gpgcheck=1\n\n" +
-                                    "repo_gpgcheck=0\n\n" +
-                                    "pkg_gpgcheck=1\n\n").collect(Collectors.joining("\n\n"));
-
+                                    "gpgcheck=0\n\n" // we use trusted content and SSL.
+                                ).collect(Collectors.joining("\n\n"));
                         }
                         pillar.put("repo", repocontent);
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- disable gpgckeck when building docker containers as we
+  work with trusted content and the repos are served via SSL
 - Fix deleting custom info pillar (bsc#1209253)
 - Update report outdated system query to de-duplicate errata id's
 - change jar versions in ivy configuration file


### PR DESCRIPTION
## What does this PR change?

When building Docker containers we would need to deploy the GPG signing keys into the container to be able to install packages. As this requires additional work for customers to prepare the Dockerfile correctly to use another buildarg we decided that it is better to disable the GPG ckeck on the repositories we use during the building of the image.
The repository is available only during the buildtime and provide trusted content. We use SSL to access the repository to secure the connection.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- TBD

- [ ] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
