### PR TITLE
force new report_db_sslrootcert if previous default is set

### DIFF
--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,6 @@
+- reportdb access: force new report_db_sslrootcert if
+  previous default is set
+
 -------------------------------------------------------------------
 Fri May 20 00:16:12 CEST 2022 - jgonzalez@suse.com
 

--- a/spacewalk/admin/spacewalk-admin.spec
+++ b/spacewalk/admin/spacewalk-admin.spec
@@ -94,6 +94,10 @@ if [ -x /usr/bin/systemctl ]; then
     /usr/bin/systemctl daemon-reload || :
 fi
 
+# Fix Uyuni issue 5718: this should happen upgrading from version between 2022.02 and 2022.05
+if grep -E "^report_db_sslrootcert[[:space:]]*=[[:space:]]*/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT" /etc/rhn/rhn.conf; then
+    sed -i "s|^report_db_sslrootcert[[:space:]]*=.*|report_db_sslrootcert = /etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT|" /etc/rhn/rhn.conf
+
 %files
 %license LICENSE
 %{_sbindir}/spacewalk-startup-helper

--- a/spacewalk/admin/spacewalk-admin.spec
+++ b/spacewalk/admin/spacewalk-admin.spec
@@ -97,6 +97,7 @@ fi
 # Fix Uyuni issue 5718: this should happen upgrading from version between 2022.02 and 2022.05
 if grep -E "^report_db_sslrootcert[[:space:]]*=[[:space:]]*/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT" /etc/rhn/rhn.conf; then
     sed -i "s|^report_db_sslrootcert[[:space:]]*=.*|report_db_sslrootcert = /etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT|" /etc/rhn/rhn.conf
+fi
 
 %files
 %license LICENSE


### PR DESCRIPTION
## What does this PR change?

in `rhn.conf`, the default value for  `report_db_sslrootcert` is `/etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT` . This value is added in new reportdb installation, but it's not updated when an old reportdb version is already installed. This PR updates  `report_db_sslrootcert` to the new default value is the previous default value is set.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/5718
Fixes https://github.com/SUSE/spacewalk/issues/18506

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
