### PR TITLE
Using a new user per feature, to facilitate parallelization of secondary_parallelizable.yml in CI

### DIFF
--- a/testsuite/features/secondary/allcli_config_channel.feature
+++ b/testsuite/features/secondary/allcli_config_channel.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022 SUSE LLC
+# Copyright (c) 2018-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_configuration_channels

--- a/testsuite/features/secondary/allcli_config_channel.feature
+++ b/testsuite/features/secondary/allcli_config_channel.feature
@@ -4,8 +4,8 @@
 @scope_configuration_channels
 Feature: Management of configuration of all types of clients in a single channel
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Create a configuration channel for mixed client types
     When I follow the left menu "Configuration > Channels"
@@ -164,7 +164,7 @@ Feature: Management of configuration of all types of clients in a single channel
     And I click on "Compare Files"
     And I click on "Schedule Compare"
     Then I should see a "1 files scheduled for comparison." text
-    When I wait until event "Show differences between profiled config files and deployed config files scheduled by admin" is completed
+    When I wait until event "Show differences between profiled config files and deployed config files scheduled" is completed
     Then I should see a "Differences exist" link
     When I follow "Differences exist"
     Then I should see a "+COLOR=white" text

--- a/testsuite/features/secondary/allcli_overview_systems_details.feature
+++ b/testsuite/features/secondary/allcli_overview_systems_details.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2022 SUSE LLC.
+# Copyright (c) 2017-2024 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 @scope_visualization
@@ -6,7 +6,7 @@ Feature: The system details of each minion and client provides an overview of th
 
   Scenario: Log in as org admin user
     Given I am authorized
-    
+
 @sle_minion
   Scenario: SLE minion hardware refresh
     Given I navigate to the Systems overview page of this "sle_minion"

--- a/testsuite/features/secondary/allcli_overview_systems_details.feature
+++ b/testsuite/features/secondary/allcli_overview_systems_details.feature
@@ -4,15 +4,16 @@
 @scope_visualization
 Feature: The system details of each minion and client provides an overview of the system
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
+    
 @sle_minion
   Scenario: SLE minion hardware refresh
     Given I navigate to the Systems overview page of this "sle_minion"
     When I follow "Hardware"
     And I click on "Schedule Hardware Refresh"
     Then I should see a "You have successfully scheduled a hardware profile refresh" text
-    When I wait until event "Hardware List Refresh scheduled by admin" is completed
+    When I wait until event "Hardware List Refresh scheduled" is completed
     And I wait until there is no Salt job calling the module "hardware.profileupdate" on "sle_minion"
 
 @sle_minion
@@ -34,7 +35,7 @@ Feature: The system details of each minion and client provides an overview of th
     When I follow "Hardware"
     And I click on "Schedule Hardware Refresh"
     Then I should see a "You have successfully scheduled a hardware profile refresh" text
-    When I wait until event "Hardware List Refresh scheduled by admin" is completed
+    When I wait until event "Hardware List Refresh scheduled" is completed
     And I wait until there is no Salt job calling the module "hardware.profileupdate" on "rhlike_minion"
 
 @rhlike_minion
@@ -56,7 +57,7 @@ Feature: The system details of each minion and client provides an overview of th
     When I follow "Hardware"
     And I click on "Schedule Hardware Refresh"
     Then I should see a "You have successfully scheduled a hardware profile refresh" text
-    When I wait until event "Hardware List Refresh scheduled by admin" is completed
+    When I wait until event "Hardware List Refresh scheduled" is completed
     And I wait until there is no Salt job calling the module "hardware.profileupdate" on "deblike_minion"
 
 @deblike_minion
@@ -78,7 +79,7 @@ Feature: The system details of each minion and client provides an overview of th
     When I follow "Hardware"
     And I click on "Schedule Hardware Refresh"
     Then I should see a "You have successfully scheduled a hardware profile refresh" text
-    And I wait until event "Hardware List Refresh scheduled by admin" is completed
+    And I wait until event "Hardware List Refresh scheduled" is completed
 
   @ssh_minion
   Scenario: SSH-managed minion grains are displayed correctly on the details page

--- a/testsuite/features/secondary/allcli_reboot.feature
+++ b/testsuite/features/secondary/allcli_reboot.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2022 SUSE LLC.
+# Copyright (c) 2017-2024 SUSE LLC.
 # Licensed under the terms of the MIT license.
 #
 # Idempotency note:
@@ -14,7 +14,7 @@
 # - features/secondary/min_deblike_openscap_audit.feature
 # - features/secondary/min_deblike_remote_command.feature
 # - features/secondary/min_deblike_ssh.feature
-# If the minions take over the alloted 10 minutes to reboot, 
+# If the minions take over the alloted 10 minutes to reboot,
 # the following features could fail due to the minions not being reachable.
 # Depending on how long they take to reboot, even more features could fail.
 

--- a/testsuite/features/secondary/allcli_reboot.feature
+++ b/testsuite/features/secondary/allcli_reboot.feature
@@ -22,8 +22,8 @@
 @scope_onboarding
 Feature: Reboot systems managed by Uyuni
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
 @ssh_minion
   Scenario: Reboot the SSH-managed SLES minion
@@ -41,7 +41,7 @@ Feature: Reboot systems managed by Uyuni
     And I should see a "Reboot system" button
     And I click on "Reboot system"
     Then I should see a "Reboot scheduled for system" text
-    When I wait at most 600 seconds until event "System reboot scheduled by admin" is completed
+    When I wait at most 600 seconds until event "System reboot scheduled" is completed
     And I should see a "Reboot completed." text
 
 @rhlike_minion
@@ -52,7 +52,7 @@ Feature: Reboot systems managed by Uyuni
     And I should see a "Reboot system" button
     When I click on "Reboot system"
     Then I should see a "Reboot scheduled for system" text
-    When I wait at most 600 seconds until event "System reboot scheduled by admin" is completed
+    When I wait at most 600 seconds until event "System reboot scheduled" is completed
     Then I should see a "Reboot completed." text
 
 @deblike_minion
@@ -63,5 +63,5 @@ Feature: Reboot systems managed by Uyuni
     And I should see a "Reboot system" button
     When I click on "Reboot system"
     Then I should see a "Reboot scheduled for system" text
-    When I wait at most 600 seconds until event "System reboot scheduled by admin" is completed
+    When I wait at most 600 seconds until event "System reboot scheduled" is completed
     Then I should see a "Reboot completed." text

--- a/testsuite/features/secondary/allcli_software_channels.feature
+++ b/testsuite/features/secondary/allcli_software_channels.feature
@@ -5,8 +5,8 @@
 @scc_credentials
 Feature: Channel subscription via SSM
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
 @sle_minion
 @susemanager
@@ -102,7 +102,7 @@ Feature: Channel subscription via SSM
 @sle_minion
   Scenario: Check channel change has completed for the SLES minion
     Given I am on the Systems overview page of this "sle_minion"
-    When I wait until event "Subscribe channels scheduled by admin" is completed
+    When I wait until event "Subscribe channels scheduled" is completed
     Then I should see "The client completed this action on" at least 3 minutes after I scheduled an action
 
 @sle_minion

--- a/testsuite/features/secondary/allcli_software_channels_dependencies.feature
+++ b/testsuite/features/secondary/allcli_software_channels_dependencies.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 SUSE LLC
+# Copyright (c) 2018-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_changing_software_channels

--- a/testsuite/features/secondary/allcli_software_channels_dependencies.feature
+++ b/testsuite/features/secondary/allcli_software_channels_dependencies.feature
@@ -5,8 +5,8 @@
 @scc_credentials
 Feature: Channel subscription with recommended or required dependencies
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Pre-requisite: remove remaining systems from SSM after software channel tests
     When I click on the clear SSM button

--- a/testsuite/features/secondary/allcli_system_group.feature
+++ b/testsuite/features/secondary/allcli_system_group.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2022 SUSE LLC
+# Copyright (c) 2017-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @skip_if_github_validation
@@ -62,7 +62,7 @@ Feature: Manage a group of systems
     And I should see "sle_minion" as link
 
    #container already has locale formula installed
-   @skip_if_containerized_server 
+   @skip_if_containerized_server
    Scenario: Install the locale formula package on the server
      When I manually install the "locale" formula on the server
 
@@ -106,7 +106,7 @@ Feature: Manage a group of systems
 
   # Red Hat-like minion is intentionally not removed from group
 
-  @skip_if_containerized_server 
+  @skip_if_containerized_server
   Scenario: Cleanup: uninstall formula from the server
     When I manually uninstall the "locale" formula from the server
 

--- a/testsuite/features/secondary/allcli_system_group.feature
+++ b/testsuite/features/secondary/allcli_system_group.feature
@@ -5,8 +5,8 @@
 @scope_visualization
 Feature: Manage a group of systems
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Fail to create a group with only its name
     When I follow the left menu "Systems > System Groups"

--- a/testsuite/features/secondary/buildhost_docker_build_image.feature
+++ b/testsuite/features/secondary/buildhost_docker_build_image.feature
@@ -1,11 +1,11 @@
-# Copyright (c) 2017-2023 SUSE LLC
+# Copyright (c) 2017-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # Basic images do not contain zypper nor the name of the server,
 # so the inspect functionality is not tested here.
 #
 # This feature is a dependency for:
-# - features/secondary/srv_docker_cve_audit.feature 
+# - features/secondary/srv_docker_cve_audit.feature
 #
 # This feature depends on:
 # - features/secondary/min_docker_api.feature
@@ -76,7 +76,7 @@ Feature: Build container images
     Then the list of packages of image "suse_simple" with version "latest" is not empty
 
   Scenario: Build the suse_real_key image with and without activation key
-    Given I am on the Systems overview page of this "build_host"  
+    Given I am on the Systems overview page of this "build_host"
     When I schedule the build of image "suse_real_key" via API calls
     And I wait at most 660 seconds until event "Image Build suse_real_key scheduled" is completed
     And I wait at most 60 seconds until all "3" container images are built correctly on the Image List page

--- a/testsuite/features/secondary/buildhost_docker_build_image.feature
+++ b/testsuite/features/secondary/buildhost_docker_build_image.feature
@@ -19,8 +19,8 @@
 @no_auth_registry
 Feature: Build container images
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Create a simple image profile without activation key
     When I follow the left menu "Images > Profiles"
@@ -59,7 +59,7 @@ Feature: Build container images
   Scenario: Build the suse_key image with and without activation key
     Given I am on the Systems overview page of this "build_host"
     When I schedule the build of image "suse_key" via API calls
-    And I wait at most 660 seconds until event "Image Build suse_key scheduled by admin" is completed
+    And I wait at most 660 seconds until event "Image Build suse_key scheduled" is completed
     # We should see the same result via API.
     # Also, check that all inspect actions are finished:
     And I wait at most 600 seconds until image "suse_key" with version "latest" is built successfully via API
@@ -70,7 +70,7 @@ Feature: Build container images
   Scenario: Build the suse_simple image with and without activation key
     Given I am on the Systems overview page of this "build_host"
     When I schedule the build of image "suse_simple" via API calls
-    And I wait at most 660 seconds until event "Image Build suse_simple scheduled by admin" is completed
+    And I wait at most 660 seconds until event "Image Build suse_simple scheduled" is completed
     And I wait at most 600 seconds until image "suse_simple" with version "latest" is built successfully via API
     And I wait at most 300 seconds until image "suse_simple" with version "latest" is inspected successfully via API
     Then the list of packages of image "suse_simple" with version "latest" is not empty
@@ -78,7 +78,7 @@ Feature: Build container images
   Scenario: Build the suse_real_key image with and without activation key
     Given I am on the Systems overview page of this "build_host"  
     When I schedule the build of image "suse_real_key" via API calls
-    And I wait at most 660 seconds until event "Image Build suse_real_key scheduled by admin" is completed
+    And I wait at most 660 seconds until event "Image Build suse_real_key scheduled" is completed
     And I wait at most 60 seconds until all "3" container images are built correctly on the Image List page
     And I wait at most 600 seconds until image "suse_real_key" with version "latest" is built successfully via API
     And I wait at most 300 seconds until image "suse_real_key" with version "latest" is inspected successfully via API

--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 SUSE LLC
+# Copyright (c) 2018-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature relies on having properly configured

--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -22,8 +22,10 @@
 @scope_building_container_images
 Feature: Build OS images
 
+  Scenario: Log in as org admin user
+    Given I am authorized
+
   Scenario: Create an OS image profile with activation key
-    Given I am authorized for the "Admin" section
     When I follow the left menu "Images > Profiles"
     And I follow "Create"
     And I enter "suse_os_image" as "label"

--- a/testsuite/features/secondary/min_activationkey.feature
+++ b/testsuite/features/secondary/min_activationkey.feature
@@ -9,8 +9,8 @@
 @scope_onboarding
 Feature: Bootstrap a Salt minion via the GUI with an activation key
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Delete SLES minion system profile
     Given I am on the Systems overview page of this "sle_minion"

--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 SUSE LLC
+# Copyright (c) 2021-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @skip_if_github_validation

--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -5,8 +5,8 @@
 @scope_ansible
 Feature: Operate an Ansible control node in a normal minion
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Pre-requisite: Deploy test playbooks and inventory file
     When I deploy testing playbooks and inventory files to "sle_minion"
@@ -33,7 +33,7 @@ Feature: Operate an Ansible control node in a normal minion
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "States" in the content area
     And I click on "Apply Highstate"
-    And I wait until event "Apply highstate scheduled by admin" is completed
+    And I wait until event "Apply highstate scheduled" is completed
     Then "ansible" should be installed on "sle_minion"
 
   Scenario: The Ansible tab appears in the system overview page
@@ -78,7 +78,7 @@ Feature: Operate an Ansible control node in a normal minion
     And I select "/srv/playbooks/orion_dummy/hosts" from "inventory-path-select"
     And I click on "Schedule"
     Then I should see a "Playbook execution has been scheduled" text
-    And I wait until event "Execute playbook 'playbook_orion_dummy.yml' scheduled by admin" is completed
+    And I wait until event "Execute playbook 'playbook_orion_dummy.yml' scheduled" is completed
     And file "/tmp/file.txt" should exist on "sle_minion"
 
   Scenario: Cleanup: Disable Ansible and remove test playbooks and inventory file

--- a/testsuite/features/secondary/min_bootstrap_api.feature
+++ b/testsuite/features/secondary/min_bootstrap_api.feature
@@ -9,8 +9,8 @@
 @scope_onboarding
 Feature: Register a Salt minion via API
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Delete SLES minion system profile before API bootstrap test
     Given I am on the Systems overview page of this "sle_minion"
@@ -62,7 +62,7 @@ Feature: Register a Salt minion via API
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
-    And I wait until event "Subscribe channels scheduled by admin" is completed
+    And I wait until event "Subscribe channels scheduled" is completed
 
 @uyuni
   Scenario: API bootstrap: subscribe to base channel
@@ -83,7 +83,7 @@ Feature: Register a Salt minion via API
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
-    And I wait until event "Subscribe channels scheduled by admin" is completed
+    And I wait until event "Subscribe channels scheduled" is completed
 
   Scenario: Check events history for failures on SLES minion after API bootstrap
     Given I am on the Systems overview page of this "sle_minion"

--- a/testsuite/features/secondary/min_bootstrap_negative.feature
+++ b/testsuite/features/secondary/min_bootstrap_negative.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 SUSE LLC
+# Copyright (c) 2021-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @skip_if_github_validation

--- a/testsuite/features/secondary/min_bootstrap_negative.feature
+++ b/testsuite/features/secondary/min_bootstrap_negative.feature
@@ -9,8 +9,8 @@ Feature: Negative tests for bootstrapping normal minions
   As an authorized user
   I want to avoid registration with invalid input parameters
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Bootstrap should fail when minion already exists
     When I follow the left menu "Systems > Bootstrapping"

--- a/testsuite/features/secondary/min_bootstrap_reactivation.feature
+++ b/testsuite/features/secondary/min_bootstrap_reactivation.feature
@@ -9,8 +9,8 @@ Feature: Bootstrapping with reactivation key
   As an authorized user
   I want to avoid re-registration with invalid input parameters
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Generate a re-activation key
     Given I am on the Systems overview page of this "sle_minion"
@@ -63,7 +63,7 @@ Feature: Bootstrapping with reactivation key
     When I follow "Events" in the content area
     And I follow "History" in the content area
     And I wait until I see "Server reactivated as Salt minion" text, refreshing the page
-    And I wait until event "Apply states [certs, channels, packages, services.salt-minion] scheduled by admin" is completed
+    And I wait until event "Apply states [certs, channels, packages, services.salt-minion] scheduled" is completed
 
   Scenario: Cleanup: delete SLES minion after reactivation tests
     Given I am on the Systems overview page of this "sle_minion"

--- a/testsuite/features/secondary/min_bootstrap_reactivation.feature
+++ b/testsuite/features/secondary/min_bootstrap_reactivation.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 SUSE LLC
+# Copyright (c) 2021-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @skip_if_github_validation

--- a/testsuite/features/secondary/min_bootstrap_script.feature
+++ b/testsuite/features/secondary/min_bootstrap_script.feature
@@ -18,8 +18,8 @@ Feature: Register a Salt minion with a bootstrap script
   2) subscribe minion to a base channels
   3) install and remove a package
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Delete SLES minion system profile before script bootstrap test
     Given I am on the Systems overview page of this "sle_minion"
@@ -59,7 +59,7 @@ Feature: Register a Salt minion with a bootstrap script
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
-    And I wait until event "Subscribe channels scheduled by admin" is completed
+    And I wait until event "Subscribe channels scheduled" is completed
 
 @uyuni
   Scenario: Subscribe the script-bootstrapped SLES minion to a base channel
@@ -75,7 +75,7 @@ Feature: Register a Salt minion with a bootstrap script
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
-    And I wait until event "Subscribe channels scheduled by admin" is completed
+    And I wait until event "Subscribe channels scheduled" is completed
 
   Scenario: Install a package to the script-bootstrapped SLES minion
    Given I am on the Systems overview page of this "sle_minion"
@@ -87,7 +87,7 @@ Feature: Register a Salt minion with a bootstrap script
    And I click on "Install Selected Packages"
    And I click on "Confirm"
    Then I should see a "1 package install has been scheduled for" text
-   When I wait until event "Package Install/Upgrade scheduled by admin" is completed
+   When I wait until event "Package Install/Upgrade scheduled" is completed
    Then "orion-dummy-1.1-1.1" should be installed on "sle_minion"
 
   Scenario: Run a remote command on normal SLES minion

--- a/testsuite/features/secondary/min_bootstrap_ssh_key.feature
+++ b/testsuite/features/secondary/min_bootstrap_ssh_key.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 SUSE LLC
+# Copyright (c) 2021-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 #

--- a/testsuite/features/secondary/min_bootstrap_ssh_key.feature
+++ b/testsuite/features/secondary/min_bootstrap_ssh_key.feature
@@ -10,8 +10,8 @@
 @scope_onboarding
 Feature: Bootstrap a Salt minion via the GUI using SSH key
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Delete SLES minion system profile before bootstrap with SSH key test
     Given I am on the Systems overview page of this "sle_minion"

--- a/testsuite/features/secondary/min_change_software_channel.feature
+++ b/testsuite/features/secondary/min_change_software_channel.feature
@@ -11,8 +11,8 @@
 @sle_minion
 Feature: Assign child channel to a system
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
 @susemanager
   Scenario: Check the system is still subscribed to old channels before channel change completes
@@ -80,7 +80,7 @@ Feature: Assign child channel to a system
 
   Scenario: Check channel change has completed for the system
     Given I am on the Systems overview page of this "sle_minion"
-    When I wait until event "Subscribe channels scheduled by admin" is completed
+    When I wait until event "Subscribe channels scheduled" is completed
     Then I should see a "The client completed this action on" text
 
 @susemanager

--- a/testsuite/features/secondary/min_check_patches_install.feature
+++ b/testsuite/features/secondary/min_check_patches_install.feature
@@ -4,7 +4,7 @@
 @scope_onboarding
 Feature: Display patches
 
-  Scenario: Log in as admin user
+  Scenario: Log in as org admin user
     Given I am authorized for the "Admin" section
 
   Scenario: Pre-require: enable old packages to fake a possible installation

--- a/testsuite/features/secondary/min_config_state_channel.feature
+++ b/testsuite/features/secondary/min_config_state_channel.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 SUSE LLC.
+# Copyright (c) 2018-2024 SUSE LLC.
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features when running in sequential:

--- a/testsuite/features/secondary/min_config_state_channel.feature
+++ b/testsuite/features/secondary/min_config_state_channel.feature
@@ -11,8 +11,8 @@ Feature: Configuration state channels
   In order to configure systems through Salt
   I want to be able to use the state channels
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Create a state channel
     When I follow the left menu "Configuration > Channels"
@@ -54,7 +54,7 @@ Feature: Configuration state channels
     Then I should see a "Execute States" button
     When I click on "Execute States"
     Then I should see a "Applying the config channels has been scheduled" text
-    When I wait until event "Apply states [custom] scheduled by admin" is completed
+    When I wait until event "Apply states [custom] scheduled" is completed
     And I wait until file "/root/foobar" exists on "sle_minion"
 
   Scenario: Try to remove init.sls file

--- a/testsuite/features/secondary/min_config_state_channel_subscriptions.feature
+++ b/testsuite/features/secondary/min_config_state_channel_subscriptions.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2021 SUSE LLC.
+# Copyright (c) 2018-2024 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 @skip_if_github_validation

--- a/testsuite/features/secondary/min_config_state_channel_subscriptions.feature
+++ b/testsuite/features/secondary/min_config_state_channel_subscriptions.feature
@@ -8,8 +8,8 @@ Feature: State Configuration channels
   In order to configure systems through Salt
   I want to be able to use channels from the state tab
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Create the 1st state channel
     When I follow the left menu "Configuration > Channels"
@@ -74,7 +74,7 @@ Feature: State Configuration channels
     And I wait until I see "Execute States" text
     When I click on "Execute States"
     Then I should see a "Applying the config channels has been scheduled" text
-    When I wait until event "Apply states [custom] scheduled by admin" is completed
+    When I wait until event "Apply states [custom] scheduled" is completed
     And I wait until file "/root/statechannel" exists on "sle_minion"
     And I wait until file "/root/statechannel2" exists on "sle_minion"
 

--- a/testsuite/features/secondary/min_custom_pkg_download_endpoint.feature
+++ b/testsuite/features/secondary/min_custom_pkg_download_endpoint.feature
@@ -8,8 +8,8 @@
 @custom_download_endpoint
 Feature: Repos file generation based on custom pillar data
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
 @susemanager
   Scenario: Select the channels of the SLES minion

--- a/testsuite/features/secondary/min_cve_id_new_syntax.feature
+++ b/testsuite/features/secondary/min_cve_id_new_syntax.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2022 SUSE LLC
+# Copyright (c) 2015-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_cve_audit

--- a/testsuite/features/secondary/min_cve_id_new_syntax.feature
+++ b/testsuite/features/secondary/min_cve_id_new_syntax.feature
@@ -4,8 +4,8 @@
 @scope_cve_audit
 Feature: Support for new CVE-ID syntax
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Check perseus-dummy-7891 patches
     When I follow the left menu "Patches > Patch List > All"

--- a/testsuite/features/secondary/min_deblike_monitoring.feature
+++ b/testsuite/features/secondary/min_deblike_monitoring.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 SUSE LLC
+# Copyright (c) 2022-2004 SUSE LLC
 # Licensed under the terms of the MIT license.
 # This feature depends on:
 # - features/secondary/srv_monitoring.feature: as this feature disables/re-enables monitoring capabilities

--- a/testsuite/features/secondary/min_deblike_monitoring.feature
+++ b/testsuite/features/secondary/min_deblike_monitoring.feature
@@ -16,8 +16,8 @@ Feature: Monitor SUMA environment with Prometheus on a Debian-like Salt minion
   Scenario: Pre-requisite: enable Prometheus exporters repository on the Debian-like minion
     When I enable the necessary repositories before installing Prometheus exporters on this "deblike_minion"
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Apply Prometheus exporter formulas on the Debian-like minion
     Given I am on the Systems overview page of this "deblike_minion"
@@ -43,7 +43,7 @@ Feature: Monitor SUMA environment with Prometheus on a Debian-like Salt minion
     When I follow "States" in the content area
     And I click on "Apply Highstate"
     Then I should see a "Applying the highstate has been scheduled." text
-    And I wait until event "Apply highstate scheduled by admin" is completed
+    And I wait until event "Apply highstate scheduled" is completed
 
   Scenario: Visit monitoring endpoints on the Debian-like minion
     When I wait until "node" exporter service is active on "deblike_minion"
@@ -63,7 +63,7 @@ Feature: Monitor SUMA environment with Prometheus on a Debian-like Salt minion
     When I follow "States" in the content area
     And I click on "Apply Highstate"
     Then I should see a "Applying the highstate has been scheduled." text
-    And I wait until event "Apply highstate scheduled by admin" is completed
+    And I wait until event "Apply highstate scheduled" is completed
 
   Scenario: Cleanup: disable Prometheus exporters repository on the Debian-like minion
     When I disable the necessary repositories before installing Prometheus exporters on this "deblike_minion" without error control

--- a/testsuite/features/secondary/min_deblike_remote_command.feature
+++ b/testsuite/features/secondary/min_deblike_remote_command.feature
@@ -12,8 +12,10 @@ Feature: Remote command on Debian-like Salt minion
   As an authorized user
   I want to run a remote command on it
 
+  Scenario: Log in as org admin user
+    Given I am authorized
+
   Scenario: Run a remote command on the Debian-like minion
-    Given I am authorized for the "Admin" section
     When I follow the left menu "Salt > Remote Commands"
     Then I should see a "Remote Commands" text in the content area
     When I enter command "cat /etc/os-release"

--- a/testsuite/features/secondary/min_deblike_remote_command.feature
+++ b/testsuite/features/secondary/min_deblike_remote_command.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 SUSE LLC
+# Copyright (c) 2021-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 # Skip if container. This test is broken

--- a/testsuite/features/secondary/min_deblike_salt_install_package.feature
+++ b/testsuite/features/secondary/min_deblike_salt_install_package.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022 SUSE LLC
+# Copyright (c) 2019-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @skip_if_github_validation

--- a/testsuite/features/secondary/min_deblike_salt_install_package.feature
+++ b/testsuite/features/secondary/min_deblike_salt_install_package.feature
@@ -6,8 +6,8 @@
 @deblike_minion
 Feature: Install and upgrade package on the Debian-like minion via Salt through the UI
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Pre-requisite: install virgo-dummy-1.0 package on Debian-like minion
     When I enable repository "test_repo_deb_pool" on this "deblike_minion"
@@ -18,7 +18,7 @@ Feature: Install and upgrade package on the Debian-like minion via Salt through 
     And I follow "Software" in the content area
     And I click on "Update Package List"
     And I follow "Events" in the content area
-    And I wait until I do not see "Package List Refresh scheduled by admin" text, refreshing the page
+    And I wait until I do not see "Package List Refresh scheduled" text, refreshing the page
     And I wait until package "virgo-dummy" is installed on "deblike_minion" via spacecmd
     And I wait until package "andromeda-dummy" is removed from "deblike_minion" via spacecmd
 
@@ -29,7 +29,7 @@ Feature: Install and upgrade package on the Debian-like minion via Salt through 
     And I click on "Install Selected Packages"
     And I click on "Confirm"
     And I should see a "1 package install has been scheduled for" text
-    When I wait until event "Package Install/Upgrade scheduled by admin" is completed
+    When I wait until event "Package Install/Upgrade scheduled" is completed
     Then Deb package "andromeda-dummy" with version "2.0" should be installed on "deblike_minion"
 
   Scenario: Update a package on the Debian-like minion
@@ -40,7 +40,7 @@ Feature: Install and upgrade package on the Debian-like minion via Salt through 
     And I click on "Upgrade Packages"
     And I click on "Confirm"
     And I should see a "1 package upgrade has been scheduled for" text
-    When I wait until event "Package Install/Upgrade scheduled by admin" is completed
+    When I wait until event "Package Install/Upgrade scheduled" is completed
     Then Deb package "virgo-dummy" with version "2.0" should be installed on "deblike_minion"
 
   Scenario: Cleanup: remove virgo-dummy and andromeda-dummy packages from Debian-like minion

--- a/testsuite/features/secondary/min_deblike_ssh.feature
+++ b/testsuite/features/secondary/min_deblike_ssh.feature
@@ -18,8 +18,8 @@
 @deblike_minion
 Feature: Bootstrap a SSH-managed Debian-like minion and do some basic operations on it
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Delete the Debian-like minion
     When I am on the Systems overview page of this "deblike_minion"
@@ -69,7 +69,7 @@ Feature: Bootstrap a SSH-managed Debian-like minion and do some basic operations
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
-    And I wait until event "Subscribe channels scheduled by admin" is completed
+    And I wait until event "Subscribe channels scheduled" is completed
 
   Scenario: Check events history for failures on SSH-managed Debian-like minion
     Given I am on the Systems overview page of this "deblike_minion"
@@ -125,4 +125,4 @@ Feature: Bootstrap a SSH-managed Debian-like minion and do some basic operations
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
-    And I wait until event "Subscribe channels scheduled by admin" is completed
+    And I wait until event "Subscribe channels scheduled" is completed

--- a/testsuite/features/secondary/min_deblike_ssh.feature
+++ b/testsuite/features/secondary/min_deblike_ssh.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 SUSE LLC
+# Copyright (c) 2017-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # 1) delete Debian-like minion and register as SSH minion

--- a/testsuite/features/secondary/min_docker_api.feature
+++ b/testsuite/features/secondary/min_docker_api.feature
@@ -30,7 +30,7 @@ Feature: API "image" namespace for containers and sub-namespaces
     And I set and get profile details via API
 
   Scenario: Cleanup: remove custom system info
-    Given I am authorized for the "Admin" section
+    Given I am authorized
     When I follow the left menu "Systems > Custom System Info"
     And I follow "arancio"
     And I follow "Delete Key"

--- a/testsuite/features/secondary/min_docker_api.feature
+++ b/testsuite/features/secondary/min_docker_api.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 SUSE LLC
+# Copyright (c) 2017-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # Note: image building via API is not tested here

--- a/testsuite/features/secondary/min_empty_system_profiles.feature
+++ b/testsuite/features/secondary/min_empty_system_profiles.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022 SUSE LLC
+# Copyright (c) 2018-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_onboarding

--- a/testsuite/features/secondary/min_empty_system_profiles.feature
+++ b/testsuite/features/secondary/min_empty_system_profiles.feature
@@ -4,8 +4,8 @@
 @scope_onboarding
 Feature: Empty minion profile operations
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Create an empty minion profile with HW address via API
     When I call system.create_system_profile() with name "empty-profile" and HW address "00:11:22:33:44:55"

--- a/testsuite/features/secondary/min_monitoring.feature
+++ b/testsuite/features/secondary/min_monitoring.feature
@@ -16,9 +16,8 @@ Feature: Monitor SUMA environment with Prometheus on a SLE Salt minion
     When I enable the necessary repositories before installing Prometheus exporters on this "sle_minion"
     And I refresh the metadata for "sle_minion"
 
-
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Apply Prometheus and Prometheus exporter formulas
     Given I am on the Systems overview page of this "sle_minion"
@@ -54,7 +53,7 @@ Feature: Monitor SUMA environment with Prometheus on a SLE Salt minion
     When I follow "States" in the content area
     And I click on "Apply Highstate"
     Then I should see a "Applying the highstate has been scheduled." text
-    And I wait until event "Apply highstate scheduled by admin" is completed
+    And I wait until event "Apply highstate scheduled" is completed
 
   Scenario: Visit monitoring endpoints on the minion
     When I wait until "prometheus" service is active on "sle_minion"
@@ -77,7 +76,7 @@ Feature: Monitor SUMA environment with Prometheus on a SLE Salt minion
     And I follow "States" in the content area
     And I click on "Apply Highstate"
     Then I should see a "Applying the highstate has been scheduled." text
-    And I wait until event "Apply highstate scheduled by admin" is completed
+    And I wait until event "Apply highstate scheduled" is completed
 
   Scenario: Cleanup: disable Prometheus exporters repository
     When I disable the necessary repositories before installing Prometheus exporters on this "sle_minion" without error control

--- a/testsuite/features/secondary/min_monitoring.feature
+++ b/testsuite/features/secondary/min_monitoring.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 SUSE LLC
+# Copyright (c) 2022-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 # This feature depends on:
 # - features/secondary/srv_monitoring.feature : As this feature disable/re-enable monitoring capabilities

--- a/testsuite/features/secondary/min_move_from_and_to_proxy.feature
+++ b/testsuite/features/secondary/min_move_from_and_to_proxy.feature
@@ -5,8 +5,8 @@
 @proxy
 Feature: Move a minion from a proxy to direct connection
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Delete minion system profile before bootstrap
     Given I am on the Systems overview page of this "sle_minion"
@@ -57,8 +57,8 @@ Feature: Move a minion from a proxy to direct connection
     And I wait until I see "scheduled" text
     And I follow "Events"
     And I follow "History"
-    And I wait until I see the event "Apply states [bootstrap.set_proxy] scheduled by admin" completed during last minute, refreshing the page
-    And I wait until I see the event "Apply states [channels] scheduled by admin" completed during last minute, refreshing the page
+    And I wait until I see the event "Apply states [bootstrap.set_proxy] scheduled" completed during last minute, refreshing the page
+    And I wait until I see the event "Apply states [channels] scheduled" completed during last minute, refreshing the page
 
   Scenario: Check direct connection
     Given I am on the Systems overview page of this "sle_minion"
@@ -83,8 +83,8 @@ Feature: Move a minion from a proxy to direct connection
     Given I am on the Systems overview page of this "sle_minion"
     And I follow "Events"
     And I follow "History"
-    And I wait until I see the event "Apply states [bootstrap.set_proxy] scheduled by admin" completed during last minute, refreshing the page
-    And I wait until I see the event "Apply states [channels] scheduled by admin" completed during last minute, refreshing the page
+    And I wait until I see the event "Apply states [bootstrap.set_proxy] scheduled" completed during last minute, refreshing the page
+    And I wait until I see the event "Apply states [channels] scheduled" completed during last minute, refreshing the page
 
   Scenario: Check registration on proxy of minion
     Given I am on the Systems overview page of this "proxy"

--- a/testsuite/features/secondary/min_move_from_and_to_proxy.feature
+++ b/testsuite/features/secondary/min_move_from_and_to_proxy.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 SUSE LLC
+# Copyright (c) 2021-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle_minion

--- a/testsuite/features/secondary/min_project_lotus.feature
+++ b/testsuite/features/secondary/min_project_lotus.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 SUSE LLC
+# Copyright (c) 2023-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle_minion

--- a/testsuite/features/secondary/min_project_lotus.feature
+++ b/testsuite/features/secondary/min_project_lotus.feature
@@ -9,8 +9,8 @@ Feature: Project Lotus
   As an authorized user
   I want to be able to install and remove them through the WebUI
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Pre-requisite: Create custom channel for PTFs
     When I follow the left menu "Software > Manage > Channels"
@@ -74,7 +74,7 @@ Feature: Project Lotus
     And I click on "Install PTFs"
     And I click on "Confirm"
     Then I should see a "The action has been scheduled" text
-    And I wait until event "Package Install/Upgrade scheduled by admin" is completed
+    And I wait until event "Package Install/Upgrade scheduled" is completed
 
   Scenario: Remove PTF through PTFs tab
     Given I am on the Systems overview page of this "sle_minion"
@@ -85,7 +85,7 @@ Feature: Project Lotus
     And I click on "Remove PTFs"
     And I click on "Confirm"
     Then I should see a "The action has been scheduled" text
-    And I wait until event "Package Removal scheduled by admin" is completed
+    And I wait until event "Package Removal scheduled" is completed
 
   Scenario: Install PTF through Packages tab
     Given I am on the Systems overview page of this "sle_minion"
@@ -98,7 +98,7 @@ Feature: Project Lotus
     And I click on "Install Selected Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text
-    And I wait until event "Package Install/Upgrade scheduled by admin" is completed
+    And I wait until event "Package Install/Upgrade scheduled" is completed
 
   Scenario: Remove PTF through Packages tab
     Given I am on the Systems overview page of this "sle_minion"
@@ -111,7 +111,7 @@ Feature: Project Lotus
     And I click on "Remove Packages"
     And I click on "Confirm"
     Then I should see a "1 package removal has been scheduled for" text
-    And I wait until event "Package Removal scheduled by admin" is completed
+    And I wait until event "Package Removal scheduled" is completed
 
   Scenario: Cleanup: Delete custom channel for PTFs
     When I follow the left menu "Software > Manage > Channels"

--- a/testsuite/features/secondary/min_recurring_action.feature
+++ b/testsuite/features/secondary/min_recurring_action.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 SUSE LLC
+# Copyright (c) 2020-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @skip_if_github_validation

--- a/testsuite/features/secondary/min_recurring_action.feature
+++ b/testsuite/features/secondary/min_recurring_action.feature
@@ -41,7 +41,7 @@ Feature: Recurring Actions
     And I should see a "Minion" text
     When I follow "Events"
     And I follow "History"
-    Then I wait until I see the event "Apply recurring states [manager_org_1.statechannel-recurring] scheduled by admin" completed during last minute, refreshing the page
+    Then I wait until I see the event "Apply recurring states [manager_org_1.statechannel-recurring] scheduled" completed during last minute, refreshing the page
     And file "/proc/sys/net/ipv4/conf/all/forwarding" should contain "1" on "sle_minion"
 
   Scenario: Edit the IP forwarding custom state recurring action
@@ -63,8 +63,8 @@ Feature: Recurring Actions
     And I should see a "Minion" text
     When I follow "Events"
     And I follow "History"
-    Then I wait until I see the event "Apply recurring states [util.syncstates] scheduled by admin" completed during last minute, refreshing the page
-    And I follow the event "Apply recurring states [util.syncstates] scheduled by admin" completed during last minute
+    Then I wait until I see the event "Apply recurring states [util.syncstates] scheduled" completed during last minute, refreshing the page
+    And I follow the event "Apply recurring states [util.syncstates] scheduled" completed during last minute
     And I should see a "SLS: util.syncstates" text
 
   Scenario: Cleanup: Disable IP forwarding
@@ -102,7 +102,7 @@ Feature: Recurring Actions
     And I should see a "Minion" text
     When I follow "Events"
     And I follow "History"
-    And I wait until I see the event "Apply highstate in test-mode scheduled by admin" completed during last minute, refreshing the page
+    And I wait until I see the event "Apply highstate in test-mode scheduled" completed during last minute, refreshing the page
 
   Scenario: Edit the minion Highstate Recurring Action
     When I am on the "Recurring Actions" page of this "sle_minion"
@@ -152,7 +152,7 @@ Feature: Recurring Actions
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
-    And I wait until event "Subscribe channels scheduled by admin" is completed
+    And I wait until event "Subscribe channels scheduled" is completed
 
   Scenario: Pre-requisite: downgrade milkyway-dummy to lower version
     When I enable repository "test_repo_rpm_pool" on this "sle_minion"
@@ -191,7 +191,7 @@ Feature: Recurring Actions
     And I should see a "Group" text
     When I am on the "Events" page of this "sle_minion"
     And I follow "History"
-    Then I wait until I see the event "Apply recurring states [uptodate] scheduled by admin" completed during last minute, refreshing the page
+    Then I wait until I see the event "Apply recurring states [uptodate] scheduled" completed during last minute, refreshing the page
     When I am on the Systems overview page of this "sle_minion"
     Then I wait until I see "System is up to date" text, refreshing the page
 
@@ -220,7 +220,7 @@ Feature: Recurring Actions
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
-    And I wait until event "Subscribe channels scheduled by admin" is completed
+    And I wait until event "Subscribe channels scheduled" is completed
 
 @uyuni
   Scenario: Cleanup: subscribe system back to default base channel
@@ -242,7 +242,7 @@ Feature: Recurring Actions
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
-    And I wait until event "Subscribe channels scheduled by admin" is completed
+    And I wait until event "Subscribe channels scheduled" is completed
 
   Scenario: Edit the group Recurring Action
     When I follow the left menu "Systems > System Groups"
@@ -293,7 +293,7 @@ Feature: Recurring Actions
     And I should see a "Organization" text
     When I am on the "Events" page of this "sle_minion"
     And I follow "History"
-    Then I wait until I see the event "Apply recurring states [packages.profileupdate] scheduled by admin" completed during last minute, refreshing the page
+    Then I wait until I see the event "Apply recurring states [packages.profileupdate] scheduled" completed during last minute, refreshing the page
 
   Scenario: Edit the yourorg Recurring Action
     When I follow the left menu "Home > My Organization > Recurring Actions"
@@ -351,7 +351,7 @@ Feature: Recurring Actions
     And I should see a "Organization" text
     When I am on the "Events" page of this "sle_minion"
     And I follow "History"
-    Then I wait until I see the event "Apply recurring states [hardware.profileupdate] scheduled by admin" completed during last minute, refreshing the page
+    Then I wait until I see the event "Apply recurring states [hardware.profileupdate] scheduled" completed during last minute, refreshing the page
 
   Scenario: Edit the admin org Recurring Action
     When I follow the left menu "Admin > Organizations"

--- a/testsuite/features/secondary/min_retracted_patches.feature
+++ b/testsuite/features/secondary/min_retracted_patches.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2021-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_retracted_patches
@@ -53,7 +53,7 @@ Feature: Retracted patches
     Then I should see a "No systems." text
     When I remove package "rute-dummy" from this "sle_minion"
     And I wait until package "rute-dummy" is removed from "sle_minion" via spacecmd
-   
+
   Scenario: Target systems for stable packages should not be empty
     When I follow the left menu "Software > Channel List > All"
     And I follow "Show All Child Channels"
@@ -62,7 +62,7 @@ Feature: Retracted patches
     And I follow "rute-dummy-2.0-1.2.x86_64"
     And I follow "Target Systems"
     And I refresh page until I see "sle_minion" hostname as text
-   
+
   Scenario: Target systems for retracted packages should be empty
     When I follow the left menu "Software > Channel List > All"
     And I follow "Show All Child Channels"
@@ -105,7 +105,7 @@ Feature: Retracted patches
     Then the table row for "rute-dummy-0815" should contain "retracted" icon
     And the table row for "rute-dummy-0816" should not contain "retracted" icon
     And the table row for "rute-dummy-0817" should contain "retracted" icon
- 
+
   Scenario: Retracted packages in the channel packages list
     When I follow the left menu "Software > Channel List > All"
     And I follow "Show All Child Channels"
@@ -118,7 +118,7 @@ Feature: Retracted patches
   Scenario: SSM: Retracted package should not be available for installation
     When I follow the left menu "Systems > System List > All"
     And I click on the clear SSM button
-    And I check the "sle_minion" client 
+    And I check the "sle_minion" client
     And I follow the left menu "Systems > System Set Manager > Overview"
     And I follow "Packages" in the content area
     And I follow "Install"

--- a/testsuite/features/secondary/min_retracted_patches.feature
+++ b/testsuite/features/secondary/min_retracted_patches.feature
@@ -4,8 +4,8 @@
 @scope_retracted_patches
 Feature: Retracted patches
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Installed retracted package should show icon in the system packages list
     When I install package "rute-dummy=2.1-1.1" on this "sle_minion"

--- a/testsuite/features/secondary/min_rhlike_monitoring.feature
+++ b/testsuite/features/secondary/min_rhlike_monitoring.feature
@@ -16,8 +16,8 @@ Feature: Monitor SUMA environment with Prometheus on a Red Hat-like Salt minion
   Scenario: Pre-requisite: enable Prometheus exporters repository on the Red Hat-like minion
     When I enable the necessary repositories before installing Prometheus exporters on this "rhlike_minion"
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Apply Prometheus exporter formulas on the Red Hat-like minion
     Given I am on the Systems overview page of this "rhlike_minion"
@@ -43,7 +43,7 @@ Feature: Monitor SUMA environment with Prometheus on a Red Hat-like Salt minion
     When I follow "States" in the content area
     And I click on "Apply Highstate"
     Then I should see a "Applying the highstate has been scheduled." text
-    And I wait until event "Apply highstate scheduled by admin" is completed
+    And I wait until event "Apply highstate scheduled" is completed
 
   Scenario: Visit monitoring endpoints on the Red Hat-like minion
     When I wait until "node" exporter service is active on "rhlike_minion"
@@ -63,7 +63,7 @@ Feature: Monitor SUMA environment with Prometheus on a Red Hat-like Salt minion
     When I follow "States" in the content area
     And I click on "Apply Highstate"
     Then I should see a "Applying the highstate has been scheduled." text
-    And I wait until event "Apply highstate scheduled by admin" is completed
+    And I wait until event "Apply highstate scheduled" is completed
 
   Scenario: Cleanup: disable Prometheus exporters repository on the Red Hat-like minion
     When I disable the necessary repositories before installing Prometheus exporters on this "rhlike_minion" without error control

--- a/testsuite/features/secondary/min_rhlike_monitoring.feature
+++ b/testsuite/features/secondary/min_rhlike_monitoring.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 SUSE LLC
+# Copyright (c) 2022-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 # This feature depends on:
 # - features/secondary/srv_monitoring.feature: as this feature disables/re-enables monitoring capabilities

--- a/testsuite/features/secondary/min_rhlike_openscap_audit.feature
+++ b/testsuite/features/secondary/min_rhlike_openscap_audit.feature
@@ -93,4 +93,4 @@ Feature: OpenSCAP audit of Red Hat-like Salt minion
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
-    And I wait until event "Subscribe channels scheduled by admin" is completed
+    And I wait until event "Subscribe channels scheduled" is completed

--- a/testsuite/features/secondary/min_rhlike_remote_command.feature
+++ b/testsuite/features/secondary/min_rhlike_remote_command.feature
@@ -12,8 +12,10 @@ Feature: Remote command on the Red Hat-like Salt minion
   As an authorized user
   I want to run a remote command on it
 
+  Scenario: Log in as org admin user
+    Given I am authorized
+
   Scenario: Run a remote command on the Red Hat-like minion
-    Given I am authorized as "testing" with password "testing"
     When I follow the left menu "Salt > Remote Commands"
     Then I should see a "Remote Commands" text in the content area
     When I enter command "cat /etc/os-release"

--- a/testsuite/features/secondary/min_rhlike_remote_command.feature
+++ b/testsuite/features/secondary/min_rhlike_remote_command.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 SUSE LLC
+# Copyright (c) 2021-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 # Skip if container. This test is broken

--- a/testsuite/features/secondary/min_rhlike_salt_install_package_and_patch.feature
+++ b/testsuite/features/secondary/min_rhlike_salt_install_package_and_patch.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2022 SUSE LLC
+# Copyright (c) 2015-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @skip_if_github_validation

--- a/testsuite/features/secondary/min_rhlike_salt_install_package_and_patch.feature
+++ b/testsuite/features/secondary/min_rhlike_salt_install_package_and_patch.feature
@@ -17,7 +17,7 @@ Feature: Install a patch on the Red Hat-like minion via Salt through the UI
     And I wait until refresh package list on "rhlike_minion" is finished
     Then spacecmd should show packages "virgo-dummy-1.0" installed on "rhlike_minion"
 
-  Scenario: Log in as admin user
+  Scenario: Log in as org admin user
     Given I am authorized for the "Admin" section
 
   Scenario: Pre-requisite: re-subscribe the Red Hat-like minion to a base channel
@@ -31,7 +31,7 @@ Feature: Install a patch on the Red Hat-like minion via Salt through the UI
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
-    And I wait until event "Subscribe channels scheduled by admin" is completed
+    And I wait until event "Subscribe channels scheduled" is completed
 
   Scenario: Schedule errata refresh to reflect channel assignment on Red Hat-like minion
     When I follow "Software" in the content area
@@ -62,7 +62,7 @@ Feature: Install a patch on the Red Hat-like minion via Salt through the UI
     And I click on "Install Selected Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text
-    And I wait until event "Package Install/Upgrade scheduled by admin" is completed
+    And I wait until event "Package Install/Upgrade scheduled" is completed
 
   Scenario: Cleanup: remove virgo-dummy and andromeda-dummy packages from Red Hat-like minion
     When I follow "Software" in the content area
@@ -76,5 +76,5 @@ Feature: Install a patch on the Red Hat-like minion via Salt through the UI
     And I click on "Remove Packages"
     And I click on "Confirm"
     Then I should see a "2 package removals have been scheduled" text
-    And I wait until event "Package Removal scheduled by admin" is completed
+    And I wait until event "Package Removal scheduled" is completed
     And I disable repository "test_repo_rpm_pool" on this "rhlike_minion"

--- a/testsuite/features/secondary/min_rhlike_ssh.feature
+++ b/testsuite/features/secondary/min_rhlike_ssh.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 SUSE LLC
+# Copyright (c) 2017-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # 1) delete Red Hat-like minion and register as SSH minion

--- a/testsuite/features/secondary/min_rhlike_ssh.feature
+++ b/testsuite/features/secondary/min_rhlike_ssh.feature
@@ -17,8 +17,8 @@
 @rhlike_minion
 Feature: Bootstrap a SSH-managed Red Hat-like minion and do some basic operations on it
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Delete the Red Hat-like minion before SSH minion tests
     When I am on the Systems overview page of this "rhlike_minion"
@@ -68,7 +68,7 @@ Feature: Bootstrap a SSH-managed Red Hat-like minion and do some basic operation
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
-    And I wait until event "Subscribe channels scheduled by admin" is completed
+    And I wait until event "Subscribe channels scheduled" is completed
 
   Scenario: Check events history for failures on SSH-managed Red Hat-like minion
     Given I am on the Systems overview page of this "rhlike_minion"
@@ -125,4 +125,4 @@ Feature: Bootstrap a SSH-managed Red Hat-like minion and do some basic operation
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
-    And I wait until event "Subscribe channels scheduled by admin" is completed
+    And I wait until event "Subscribe channels scheduled" is completed

--- a/testsuite/features/secondary/min_salt_formulas.feature
+++ b/testsuite/features/secondary/min_salt_formulas.feature
@@ -8,8 +8,8 @@ Feature: Use salt formulas
   As an authorized user
   I want to be able to install and use salt formulas
 
-   Scenario: Log in as admin user
-      Given I am authorized for the "Admin" section
+   Scenario: Log in as org admin user
+      Given I am authorized
 
    #container already has locale formula installed
    @skip_if_containerized_server 
@@ -71,7 +71,7 @@ Feature: Use salt formulas
      And I follow "States" in the content area
      And I click on "Apply Highstate"
      Then I should see a "Applying the highstate has been scheduled." text
-     When I wait until event "Apply highstate scheduled by admin" is completed
+     When I wait until event "Apply highstate scheduled" is completed
      Then the timezone on "sle_minion" should be "+05"
      And the keymap on "sle_minion" should be "ca"
      And the language on "sle_minion" should be "fr_FR.UTF-8"
@@ -95,7 +95,7 @@ Feature: Use salt formulas
      And I follow "States" in the content area
      And I click on "Apply Highstate"
      Then I should see a "Applying the highstate has been scheduled." text
-     When I wait until event "Apply highstate scheduled by admin" is completed
+     When I wait until event "Apply highstate scheduled" is completed
      Then the timezone on "sle_minion" should be "CET"
      And the keymap on "sle_minion" should be "us"
      And the language on "sle_minion" should be "en_US.UTF-8"
@@ -162,7 +162,7 @@ Feature: Use salt formulas
      And I follow "States" in the content area
      And I click on "Apply Highstate"
      Then I should see a "Applying the highstate has been scheduled." text
-     When I wait until event "Apply highstate scheduled by admin" is completed
+     When I wait until event "Apply highstate scheduled" is completed
      Then the timezone on "sle_minion" should be "CET"
      And the keymap on "sle_minion" should be "us"
      And the language on "sle_minion" should be "en_US.UTF-8"

--- a/testsuite/features/secondary/min_salt_formulas.feature
+++ b/testsuite/features/secondary/min_salt_formulas.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2022 SUSE LLC
+# Copyright (c) 2017-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @skip_if_github_validation
@@ -12,7 +12,7 @@ Feature: Use salt formulas
       Given I am authorized
 
    #container already has locale formula installed
-   @skip_if_containerized_server 
+   @skip_if_containerized_server
    Scenario: Install the locale formula package on the server
      When I manually install the "locale" formula on the server
 

--- a/testsuite/features/secondary/min_salt_formulas_advanced.feature
+++ b/testsuite/features/secondary/min_salt_formulas_advanced.feature
@@ -7,8 +7,8 @@ Feature: Use advanced features of Salt formulas
   As an authorized user
   I want to be able to install and use Salt formulas
 
-   Scenario: Log in as admin user
-      Given I am authorized for the "Admin" section
+   Scenario: Log in as org admin user
+      Given I am authorized
 
   Scenario: Install a test formula package on the server
      When I install "form.yml" to custom formula metadata directory "testform"

--- a/testsuite/features/secondary/min_salt_formulas_advanced.feature
+++ b/testsuite/features/secondary/min_salt_formulas_advanced.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018 SUSE LLC
+# Copyright (c) 2017-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_formulas

--- a/testsuite/features/secondary/min_salt_install_package.feature
+++ b/testsuite/features/secondary/min_salt_install_package.feature
@@ -14,7 +14,7 @@ Feature: Install a patch on the client via Salt through the UI
     And I wait until refresh package list on "sle_minion" is finished
     Then spacecmd should show packages "virgo-dummy-1.0" installed on "sle_minion"
 
-  Scenario: Log in as admin user
+  Scenario: Log in as org admin user
     Given I am authorized for the "Admin" section
 
   Scenario: Pre-requisite: ensure the errata cache is computed before patching Salt minion

--- a/testsuite/features/secondary/min_salt_install_package.feature
+++ b/testsuite/features/secondary/min_salt_install_package.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2022 SUSE LLC
+# Copyright (c) 2015-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_salt

--- a/testsuite/features/secondary/min_salt_lock_packages.feature
+++ b/testsuite/features/secondary/min_salt_lock_packages.feature
@@ -9,8 +9,8 @@
 @scope_salt
 Feature: Lock packages on SLES salt minion
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Pre-requisite: install packages needed for locking test
     When I install package "orion-dummy" on this "sle_minion"
@@ -26,7 +26,7 @@ Feature: Lock packages on SLES salt minion
     And I check row with "hoag-dummy-1.1-1.1" and arch of "sle_minion"
     And I click on "Lock"
     Then I should see a "Packages has been requested for being locked." text
-    When I wait until event "Lock packages scheduled by admin" is completed
+    When I wait until event "Lock packages scheduled" is completed
     Then "hoag-dummy-1.1-1.1" is locked on "sle_minion"
     When I follow "Software" in the content area
     And I follow "Lock / Unlock"
@@ -46,8 +46,8 @@ Feature: Lock packages on SLES salt minion
     Then I should see a "1 package install has been scheduled for" text
     When I follow "Events"
     And I follow "History"
-    And I wait until I see the event "Package Install/Upgrade scheduled by admin" completed during last minute, refreshing the page
-    And I follow the event "Package Install/Upgrade scheduled by admin" completed during last minute
+    And I wait until I see the event "Package Install/Upgrade scheduled" completed during last minute, refreshing the page
+    And I follow the event "Package Install/Upgrade scheduled" completed during last minute
     Then the package scheduled is "hoag-dummy-1.1-1.1"
     And the action status is "Failed"
 
@@ -61,7 +61,7 @@ Feature: Lock packages on SLES salt minion
     And I check row with "hoag-dummy-1.1-1.1" and arch of "sle_minion"
     And I click on "Unlock"
     Then I should see a "Packages has been requested for being unlocked." text
-    When I wait until event "Lock packages scheduled by admin" is completed
+    When I wait until event "Lock packages scheduled" is completed
     Then "hoag-dummy-1.1-1.1" is unlocked on "sle_minion"
     When I follow "Software" in the content area
     And I follow "Lock / Unlock"
@@ -90,7 +90,7 @@ Feature: Lock packages on SLES salt minion
     And I click on "Lock"
     Then I should see a "Packages has been requested for being locked." text
     And package "milkyway-dummy-2.0-1.1" is reported as pending to be locked
-    When I wait until event "Lock packages scheduled by admin" is completed
+    When I wait until event "Lock packages scheduled" is completed
     Then "hoag-dummy-1.1-1.1" is locked on "sle_minion"
     And "milkyway-dummy-2.0-1.1" is locked on "sle_minion"
     When I follow "Software" in the content area
@@ -120,7 +120,7 @@ Feature: Lock packages on SLES salt minion
     And I click on "Unlock"
     Then I should see a "Packages has been requested for being unlocked." text
     And package "milkyway-dummy-2.0-1.1" is reported as pending to be unlocked
-    When I wait until event "Lock packages scheduled by admin" is completed
+    When I wait until event "Lock packages scheduled" is completed
     Then "hoag-dummy-1.1-1.1" is locked on "sle_minion"
     And "milkyway-dummy-2.0-1.1" is unlocked on "sle_minion"
     And "orion-dummy-1.1-1.1" is locked on "sle_minion"
@@ -140,7 +140,7 @@ Feature: Lock packages on SLES salt minion
     And I click on "Unlock"
     Then I should see a "Packages has been requested for being unlocked." text
     And only packages "hoag-dummy-1.1-1.1, orion-dummy-1.1-1.1" are reported as pending to be unlocked
-    When I wait until event "Lock packages scheduled by admin" is completed
+    When I wait until event "Lock packages scheduled" is completed
     Then "hoag-dummy-1.1-1.1" is unlocked on "sle_minion"
     And "orion-dummy-1.1-1.1" is unlocked on "sle_minion"
     When I follow "Software" in the content area

--- a/testsuite/features/secondary/min_salt_mgrcompat_state.feature
+++ b/testsuite/features/secondary/min_salt_mgrcompat_state.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2023 SUSE LLC.
+# Copyright (c) 2015-2024 SUSE LLC.
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features:

--- a/testsuite/features/secondary/min_salt_mgrcompat_state.feature
+++ b/testsuite/features/secondary/min_salt_mgrcompat_state.feature
@@ -17,8 +17,8 @@
 @scope_salt
 Feature: Verify that Salt mgrcompat state works when the new module.run syntax is enabled
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Remove mgrcompat module from minion synced modules and schedule Hardware Refresh
     Given I remove "minion/extmods/states/mgrcompat.py" from salt cache on "sle_minion"
@@ -27,7 +27,7 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     When I follow "Hardware"
     And I click on "Schedule Hardware Refresh"
     Then I should see a "You have successfully scheduled a hardware profile refresh" text
-    When I wait until event "Hardware List Refresh scheduled by admin" is completed
+    When I wait until event "Hardware List Refresh scheduled" is completed
     And I wait until there is no Salt job calling the module "hardware.profileupdate" on "sle_minion"
 
   Scenario: Remove saltutil grain and mgrcompat module from minion and schedule Hardware Refresh
@@ -39,7 +39,7 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     When I follow "Hardware"
     And I click on "Schedule Hardware Refresh"
     Then I should see a "You have successfully scheduled a hardware profile refresh" text
-    When I wait until event "Hardware List Refresh scheduled by admin" is completed
+    When I wait until event "Hardware List Refresh scheduled" is completed
     And I wait until there is no Salt job calling the module "hardware.profileupdate" on "sle_minion"
 
   Scenario: Delete SLES minion system profile before mgrcompat test
@@ -80,7 +80,7 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     And I follow "Hardware"
     And I click on "Schedule Hardware Refresh"
     Then I should see a "You have successfully scheduled a hardware profile refresh" text
-    When I wait until event "Hardware List Refresh scheduled by admin" is completed
+    When I wait until event "Hardware List Refresh scheduled" is completed
     And I wait until there is no Salt job calling the module "hardware.profileupdate" on "sle_minion"
 
   Scenario: Cleanup: Delete profile of the minion and disable new module.run syntax

--- a/testsuite/features/secondary/min_salt_minion_details.feature
+++ b/testsuite/features/secondary/min_salt_minion_details.feature
@@ -6,8 +6,8 @@ Feature: Verify the minion registration
   In order to validate the completeness of minion registration
   I want to see minion details and installed packages
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Check the Salt entitlement
     Given I am on the Systems overview page of this "sle_minion"
@@ -23,7 +23,7 @@ Feature: Verify the minion registration
     And I follow "Hardware" in the content area
     And I click on "Schedule Hardware Refresh"
     Then I should see a "You have successfully scheduled a hardware profile refresh" text
-    When I wait until event "Hardware List Refresh scheduled by admin" is completed
+    When I wait until event "Hardware List Refresh scheduled" is completed
     And I wait until there is no Salt job calling the module "hardware.profileupdate" on "sle_minion"
 
   Scenario: Check that Update Properties button works

--- a/testsuite/features/secondary/min_salt_minion_details.feature
+++ b/testsuite/features/secondary/min_salt_minion_details.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2018 SUSE LLC.
+# Copyright (c) 2015-2024 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 @scope_salt

--- a/testsuite/features/secondary/min_salt_minions_page.feature
+++ b/testsuite/features/secondary/min_salt_minions_page.feature
@@ -13,8 +13,8 @@ Feature: Management of minion keys
   As an authorized user
   I want to verify all the minion key management features in the UI
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Delete SLES minion system profile before exploring the onboarding page
     Given I am on the Systems overview page of this "sle_minion"

--- a/testsuite/features/secondary/min_salt_minions_page.feature
+++ b/testsuite/features/secondary/min_salt_minions_page.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2023 SUSE LLC
+# Copyright (c) 2015-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features:

--- a/testsuite/features/secondary/min_salt_pkgset_beacon.feature
+++ b/testsuite/features/secondary/min_salt_pkgset_beacon.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2022 SUSE LLC
+# Copyright (c) 2016-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @skip_if_github_validation

--- a/testsuite/features/secondary/min_salt_pkgset_beacon.feature
+++ b/testsuite/features/secondary/min_salt_pkgset_beacon.feature
@@ -15,7 +15,7 @@ Feature: System package list is updated if packages are manually installed or re
     And I wait until refresh package list on "sle_minion" is finished
     Then spacecmd should show packages "milkyway-dummy-1.0" installed on "sle_minion"
 
-  Scenario: Log in as admin user
+  Scenario: Log in as org admin user
     Given I am authorized for the "Admin" section
 
   Scenario: Pre-requisite: ensure the errata cache is computed before package list tests

--- a/testsuite/features/secondary/min_salt_user_states.feature
+++ b/testsuite/features/secondary/min_salt_user_states.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022 SUSE LLC
+# Copyright (c) 2018-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @skip_if_github_validation

--- a/testsuite/features/secondary/min_salt_user_states.feature
+++ b/testsuite/features/secondary/min_salt_user_states.feature
@@ -5,8 +5,8 @@
 @scope_salt
 Feature: Coexistence with user-defined states
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Create a user-defined state
     Given I am on the Systems overview page of this "sle_minion"
@@ -19,7 +19,7 @@ Feature: Coexistence with user-defined states
 
   Scenario: Trigger highstate from API
     When I schedule a highstate for "sle_minion" via API
-    And I wait until event "Apply highstate scheduled by admin" is completed
+    And I wait until event "Apply highstate scheduled" is completed
     Then file "/tmp/test_user_defined_state" should exist on "sle_minion"
 
   Scenario: Cleanup: remove user-defined state and the file it created

--- a/testsuite/features/secondary/min_ssh_tunnel.feature
+++ b/testsuite/features/secondary/min_ssh_tunnel.feature
@@ -10,8 +10,8 @@
 @ssh_minion
 Feature: Register a Salt system to be managed via SSH tunnel
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Pre-requisite: remove package before ssh tunnel test
     When I remove package "milkyway-dummy" from this "ssh_minion" without error control
@@ -53,7 +53,7 @@ Feature: Register a Salt system to be managed via SSH tunnel
     And I click on "Install Selected Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text
-    Then I wait until event "Package Install/Upgrade scheduled by admin" is completed
+    Then I wait until event "Package Install/Upgrade scheduled" is completed
 
   Scenario: Remove a package from this SSH tunnel minion
     Given I am on the Systems overview page of this "ssh_minion"
@@ -66,7 +66,7 @@ Feature: Register a Salt system to be managed via SSH tunnel
     And I click on "Remove Packages"
     And I click on "Confirm"
     Then I should see a "1 package removal has been scheduled" text
-    Then I wait until event "Package Removal scheduled by admin" is completed
+    Then I wait until event "Package Removal scheduled" is completed
 
   Scenario: Run a remote command on this SSH tunnel minion
     When I follow the left menu "Salt > Remote Commands"

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -12,8 +12,8 @@
 @scope_cobbler
 Feature: Manage KVM virtual machines via the GUI
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Start Cobbler monitoring
     When I start local monitoring of Cobbler

--- a/testsuite/features/secondary/minssh_action_chain.feature
+++ b/testsuite/features/secondary/minssh_action_chain.feature
@@ -12,7 +12,7 @@
 @scope_salt_ssh
 Feature: Salt SSH action chain
 
-  Scenario: Log in as admin user
+  Scenario: Log in as org admin user
     Given I am authorized for the "Admin" section
 
   Scenario: Pre-requisite: downgrade repositories to lower version on SSH minion
@@ -163,6 +163,7 @@ Feature: Salt SSH action chain
   Scenario: Execute the action chain from the web UI on SSH minion
     Given I am authorized for the "Admin" section
     When I follow the left menu "Schedule > Action Chains"
+    And I wait until I see "new action chain" text
     And I follow "new action chain"
     Then I click on "Save and Schedule"
     And I should see a "Action Chain new action chain has been scheduled for execution." text
@@ -200,7 +201,7 @@ Feature: Salt SSH action chain
     And I follow "Software" in the content area
     And I click on "Update Package List"
     And I follow "Events" in the content area
-    And I wait until I do not see "Package List Refresh scheduled by admin" text, refreshing the page
+    And I wait until I do not see "Package List Refresh scheduled" text, refreshing the page
     And I follow "Software" in the content area
     And I follow "List / Remove" in the content area
     And I enter "andromeda-dummy" as the filtered package name

--- a/testsuite/features/secondary/minssh_action_chain.feature
+++ b/testsuite/features/secondary/minssh_action_chain.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022 SUSE LLC
+# Copyright (c) 2018-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features:

--- a/testsuite/features/secondary/minssh_ansible_control_node.feature
+++ b/testsuite/features/secondary/minssh_ansible_control_node.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 SUSE LLC
+# Copyright (c) 2021-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @skip_if_github_validation

--- a/testsuite/features/secondary/minssh_ansible_control_node.feature
+++ b/testsuite/features/secondary/minssh_ansible_control_node.feature
@@ -7,8 +7,8 @@
 @ssh_minion
 Feature: Operate an Ansible control node in SSH minion
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Pre-requisite: Deploy test playbooks and inventory file
     When I deploy testing playbooks and inventory files to "ssh_minion"
@@ -35,7 +35,7 @@ Feature: Operate an Ansible control node in SSH minion
     Given I am on the Systems overview page of this "ssh_minion"
     When I follow "States" in the content area
     And I click on "Apply Highstate"
-    And I wait until event "Apply highstate scheduled by admin" is completed
+    And I wait until event "Apply highstate scheduled" is completed
     Then "ansible" should be installed on "ssh_minion"
 
   Scenario: The Ansible tab appears in the system overview page
@@ -80,7 +80,7 @@ Feature: Operate an Ansible control node in SSH minion
     And I select "/srv/playbooks/orion_dummy/hosts" from "inventory-path-select"
     And I click on "Schedule"
     Then I should see a "Playbook execution has been scheduled" text
-    And I wait until event "Execute playbook 'playbook_orion_dummy.yml' scheduled by admin" is completed
+    And I wait until event "Execute playbook 'playbook_orion_dummy.yml' scheduled" is completed
     And file "/tmp/file.txt" should exist on "ssh_minion"
 
   Scenario: Cleanup: Disable Ansible and remove test playbooks and inventory file

--- a/testsuite/features/secondary/minssh_bootstrap_api.feature
+++ b/testsuite/features/secondary/minssh_bootstrap_api.feature
@@ -15,8 +15,8 @@
 @skip_if_github_validation
 Feature: Register a salt-ssh system via API
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Delete SSH minion system profile before API bootstrap test
     Given I am on the Systems overview page of this "ssh_minion"
@@ -72,7 +72,7 @@ Feature: Register a salt-ssh system via API
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
-    And I wait until event "Subscribe channels scheduled by admin" is completed
+    And I wait until event "Subscribe channels scheduled" is completed
 
 @uyuni
   Scenario: API bootstrap: subscribe SSH minion to base channel
@@ -88,7 +88,7 @@ Feature: Register a salt-ssh system via API
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
-    And I wait until event "Subscribe channels scheduled by admin" is completed
+    And I wait until event "Subscribe channels scheduled" is completed
 
 @proxy
   Scenario: cleanup and flush the firewall rules

--- a/testsuite/features/secondary/minssh_move_from_and_to_proxy.feature
+++ b/testsuite/features/secondary/minssh_move_from_and_to_proxy.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 SUSE LLC
+# Copyright (c) 2021-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features:

--- a/testsuite/features/secondary/minssh_move_from_and_to_proxy.feature
+++ b/testsuite/features/secondary/minssh_move_from_and_to_proxy.feature
@@ -15,8 +15,8 @@
 @proxy
 Feature: Move a SSH minion from a proxy to direct connection
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Delete minion system profile before bootstrap
     Given I am on the Systems overview page of this "ssh_minion"
@@ -62,7 +62,7 @@ Feature: Move a SSH minion from a proxy to direct connection
     And I wait until I see "scheduled" text
     And I follow "Events"
     And I follow "History"
-    And I wait until I see the event "Apply states [channels] scheduled by admin" completed during last minute, refreshing the page
+    And I wait until I see the event "Apply states [channels] scheduled" completed during last minute, refreshing the page
 
   Scenario: Check direct connection
     Given I am on the Systems overview page of this "ssh_minion"
@@ -82,7 +82,7 @@ Feature: Move a SSH minion from a proxy to direct connection
     And I wait until I see "scheduled" text
     And I follow "Events"
     And I follow "History"
-    And I wait until I see the event "Apply states [channels] scheduled by admin" completed during last minute, refreshing the page
+    And I wait until I see the event "Apply states [channels] scheduled" completed during last minute, refreshing the page
 
   Scenario: Check registration on proxy of minion
     Given I am on the Systems overview page of this "proxy"

--- a/testsuite/features/secondary/minssh_salt_install_package.feature
+++ b/testsuite/features/secondary/minssh_salt_install_package.feature
@@ -28,7 +28,7 @@ Feature: Install a package on the SSH minion via Salt through the UI
     And I click on "Install Selected Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled" text
-    When I wait until event "Package Install/Upgrade scheduled by admin" is completed
+    When I wait until event "Package Install/Upgrade scheduled" is completed
     Then "hoag-dummy-1.1-1.1" should be installed on "ssh_minion"
 
   Scenario: Cleanup: remove the package from the SSH minion

--- a/testsuite/features/secondary/minssh_salt_install_package.feature
+++ b/testsuite/features/secondary/minssh_salt_install_package.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021 SUSE LLC
+# Copyright (c) 2019-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @skip_if_github_validation

--- a/testsuite/features/secondary/proxy_traditional_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_traditional_cobbler_pxeboot.feature
@@ -15,14 +15,14 @@ Feature: PXE boot a terminal with Cobbler and traditional proxy
   As the system administrator
   I want to PXE boot one host with Cobbler
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
-    And I am on the Systems overview page of this "proxy"
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Start Cobbler monitoring
     When I start local monitoring of Cobbler
 
   Scenario: Configure PXE part of DHCP on the proxy
+    Given I am on the Systems overview page of this "proxy"
     When I follow "Formulas" in the content area
     And I follow first "Dhcpd" in the content area
     And I click on "Expand All Sections"
@@ -35,7 +35,7 @@ Feature: PXE boot a terminal with Cobbler and traditional proxy
   Scenario: Apply the highstate after the formula setup
     When I follow "States" in the content area
     And I click on "Apply Highstate"
-    And I wait until event "Apply highstate scheduled by admin" is completed
+    And I wait until event "Apply highstate scheduled" is completed
 
   # We currently test Cobbler with SLES 15 SP4, even on Uyuni
   Scenario: Install the TFTP boot package on the server for Cobbler tests
@@ -125,7 +125,7 @@ Feature: PXE boot a terminal with Cobbler and traditional proxy
     And I click on "Install Selected Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled" text
-    When I wait until event "Package Install/Upgrade scheduled by admin" is completed
+    When I wait until event "Package Install/Upgrade scheduled" is completed
 
   Scenario: Download the profile from the UI
     When I follow the left menu "Systems > Autoinstallation > Profiles"

--- a/testsuite/features/secondary/proxy_traditional_retail_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_traditional_retail_pxeboot.feature
@@ -24,8 +24,8 @@ Feature: PXE boot a Retail terminal behind a traditional proxy
   As the system administrator
   I PXE boot one of the terminals
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Enable the PXE formulas on the branch server
     Given I am on the Systems overview page of this "proxy"
@@ -102,7 +102,7 @@ Feature: PXE boot a Retail terminal behind a traditional proxy
     When I follow "States" in the content area
     And I enable repositories before installing branch server
     And I click on "Apply Highstate"
-    And I wait until event "Apply highstate scheduled by admin" is completed
+    And I wait until event "Apply highstate scheduled" is completed
     And I disable repositories after installing branch server
     Then socket "tftp" is enabled on "proxy"
     And socket "tftp" is active on "proxy"
@@ -223,7 +223,7 @@ Feature: PXE boot a Retail terminal behind a traditional proxy
     And I click on "Install Selected Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled" text
-    When I wait until event "Package Install/Upgrade scheduled by admin" is completed
+    When I wait until event "Package Install/Upgrade scheduled" is completed
 
   Scenario: Remove the package from the new Retail terminal
     When I navigate to the Systems overview page of this "pxeboot_minion"
@@ -235,7 +235,7 @@ Feature: PXE boot a Retail terminal behind a traditional proxy
     And I click on "Remove Packages"
     And I click on "Confirm"
     Then I should see a "1 package removal has been scheduled" text
-    When I wait until event "Package Removal scheduled by admin" is completed
+    When I wait until event "Package Removal scheduled" is completed
 
   Scenario: Cleanup: let the terminal be reinstalled again
     When I navigate to the Systems overview page of this "pxeboot_minion"
@@ -299,4 +299,4 @@ Feature: PXE boot a Retail terminal behind a traditional proxy
     When I follow "States" in the content area
     And I enable repositories before installing branch server
     And I click on "Apply Highstate"
-    And I wait until event "Apply highstate scheduled by admin" is completed
+    And I wait until event "Apply highstate scheduled" is completed

--- a/testsuite/features/secondary/srv_advanced_search.feature
+++ b/testsuite/features/secondary/srv_advanced_search.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023 SUSE LLC.
+# Copyright (c) 2022-2024 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 @scope_spacewalk_utils

--- a/testsuite/features/secondary/srv_advanced_search.feature
+++ b/testsuite/features/secondary/srv_advanced_search.feature
@@ -8,8 +8,8 @@ Feature: Advanced Search
   As an authorized user
   I want to be able to search for specific systems according to location or other characteristics
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: No search results - inverse results
     Given I clean the search index on the server

--- a/testsuite/features/secondary/srv_change_password.feature
+++ b/testsuite/features/secondary/srv_change_password.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 SUSE LLC
+# Copyright (c) 2017-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features when running in sequential:

--- a/testsuite/features/secondary/srv_change_password.feature
+++ b/testsuite/features/secondary/srv_change_password.feature
@@ -11,7 +11,7 @@ Feature: Change the user's password
   As an authorized user
   I want enter a new password
 
-  Scenario: Log in as admin user
+  Scenario: Log in as org admin user
     Given I am authorized for the "Admin" section
 
   Scenario: Change the password to a new password

--- a/testsuite/features/secondary/srv_check_channels_page.feature
+++ b/testsuite/features/secondary/srv_check_channels_page.feature
@@ -7,8 +7,8 @@ Feature: The channels page
   As an authorized user
   I want to see all the texts and links
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Completeness of the channels page
     When I follow the left menu "Software > Channel List > All"

--- a/testsuite/features/secondary/srv_check_channels_page.feature
+++ b/testsuite/features/secondary/srv_check_channels_page.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2021 SUSE LLC
+# Copyright (c) 2015-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_configuration_channels

--- a/testsuite/features/secondary/srv_check_sync_source_packages.feature
+++ b/testsuite/features/secondary/srv_check_sync_source_packages.feature
@@ -9,8 +9,8 @@
 @scope_configuration_channels
 Feature: Check if source packages were successfully synced
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Check sources for noarch package
     When I follow the left menu "Software > Channel List > All"

--- a/testsuite/features/secondary/srv_check_sync_source_packages.feature
+++ b/testsuite/features/secondary/srv_check_sync_source_packages.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE LLC
+# Copyright (c) 2018-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # requires

--- a/testsuite/features/secondary/srv_clone_channel_npn.feature
+++ b/testsuite/features/secondary/srv_clone_channel_npn.feature
@@ -4,8 +4,8 @@
 @scope_configuration_channels
 Feature: Clone a channel
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Clone a channel without patches
     When I follow the left menu "Software > Manage > Channels"

--- a/testsuite/features/secondary/srv_clone_channel_npn.feature
+++ b/testsuite/features/secondary/srv_clone_channel_npn.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 SUSE LLC
+# Copyright (c) 2017-2024 SUSE LLC
 # License under the terms of the MIT License.
 
 @scope_configuration_channels

--- a/testsuite/features/secondary/srv_content_lifecycle.feature
+++ b/testsuite/features/secondary/srv_content_lifecycle.feature
@@ -5,8 +5,8 @@
 @scope_content_lifecycle_management
 Feature: Content lifecycle
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Create CLM filter to remove all fonts packages
     When I follow the left menu "Content Lifecycle > Filters"

--- a/testsuite/features/secondary/srv_custom_system_info.feature
+++ b/testsuite/features/secondary/srv_custom_system_info.feature
@@ -5,8 +5,8 @@
 @scope_onboarding
 Feature: Custom system info key-value pairs
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Create a new key
     When I follow the left menu "Systems > Custom System Info"

--- a/testsuite/features/secondary/srv_custom_system_info.feature
+++ b/testsuite/features/secondary/srv_custom_system_info.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2022 SUSE LLC
+# Copyright (c) 2017-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_visualization

--- a/testsuite/features/secondary/srv_datepicker.feature
+++ b/testsuite/features/secondary/srv_datepicker.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2022 SUSE LLC
+# Copyright (c) 2017-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_visualization

--- a/testsuite/features/secondary/srv_datepicker.feature
+++ b/testsuite/features/secondary/srv_datepicker.feature
@@ -8,7 +8,7 @@ Feature: Pick dates
   I want to be able to easily pick dates
 
   Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+    Given I am authorized
     And I am on the Systems overview page of this "sle_minion"
 
   Scenario: Date picker is by default set to today

--- a/testsuite/features/secondary/srv_delete_channel_from_ui.feature
+++ b/testsuite/features/secondary/srv_delete_channel_from_ui.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2021-2024 SUSE LLC
 # Licensed under the terms of the MIT License.
 #
 # This feature can cause failures in the following features:

--- a/testsuite/features/secondary/srv_delete_channel_from_ui.feature
+++ b/testsuite/features/secondary/srv_delete_channel_from_ui.feature
@@ -15,8 +15,8 @@ Feature: Delete channels with child or clone is not allowed
   Using the UI, we cannot delete a channel if it has a child
   or a clone created from it
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Clone the first channel before deletion from UI test
     When I follow the left menu "Software > Manage > Channels"

--- a/testsuite/features/secondary/srv_delete_channel_with_tool.feature
+++ b/testsuite/features/secondary/srv_delete_channel_with_tool.feature
@@ -12,8 +12,8 @@ Feature: Deleting channels with children or clones is not allowed
   Using the tool spacewalk-remove-channel, we cannot delete a channel if it has a child
   or a clone created from it
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Clone the first channel before deletion from tool test
     When I follow the left menu "Software > Manage > Channels"

--- a/testsuite/features/secondary/srv_delete_channel_with_tool.feature
+++ b/testsuite/features/secondary/srv_delete_channel_with_tool.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2021-2024 SUSE LLC
 # Licensed under the terms of the MIT License.
 #
 # This feature can cause failures in the following features:

--- a/testsuite/features/secondary/srv_dist_channel_mapping.feature
+++ b/testsuite/features/secondary/srv_dist_channel_mapping.feature
@@ -4,8 +4,8 @@
 @skip_if_github_validation
 Feature: Distribution Channel Mapping
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Check if Distribution Channel Mapping page exists
     When I follow the left menu "Software > Distribution Channel Mapping"

--- a/testsuite/features/secondary/srv_dist_channel_mapping.feature
+++ b/testsuite/features/secondary/srv_dist_channel_mapping.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023 SUSE LLC
+# Copyright (c) 2022-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @skip_if_github_validation

--- a/testsuite/features/secondary/srv_group_union_intersection.feature
+++ b/testsuite/features/secondary/srv_group_union_intersection.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022 SUSE LLC
+# Copyright (c) 2018-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature will be fully tested only if we have a Red Hat-like client

--- a/testsuite/features/secondary/srv_group_union_intersection.feature
+++ b/testsuite/features/secondary/srv_group_union_intersection.feature
@@ -7,8 +7,8 @@
 @scope_visualization
 Feature: Work with Union and Intersection buttons in the group list
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Create a sles group
     When I follow the left menu "Systems > System Groups"

--- a/testsuite/features/secondary/srv_handle_config_channels_with_ISS_v2.feature
+++ b/testsuite/features/secondary/srv_handle_config_channels_with_ISS_v2.feature
@@ -10,8 +10,8 @@ Feature: Export and import configuration channels with new ISS implementation
     When I install packages "inter-server-sync" on this "server"
     Then "inter-server-sync" should be installed on "server"
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Create a configuration channel
     When I follow the left menu "Configuration > Channels"

--- a/testsuite/features/secondary/srv_handle_software_channels_with_ISS_v2.feature
+++ b/testsuite/features/secondary/srv_handle_software_channels_with_ISS_v2.feature
@@ -10,8 +10,8 @@ Feature: Export and import software channels with new ISS implementation
     When I install packages "inter-server-sync" on this "server"
     Then "inter-server-sync" should be installed on "server"
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Clone a channel with patches
     When I follow the left menu "Software > Manage > Channels"

--- a/testsuite/features/secondary/srv_maintenance_windows.feature
+++ b/testsuite/features/secondary/srv_maintenance_windows.feature
@@ -11,8 +11,8 @@
 @rhlike_minion
 Feature: Maintenance windows
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Create single calendar
     When I follow the left menu "Schedule > Maintenance Windows > Calendars"

--- a/testsuite/features/secondary/srv_maintenance_windows.feature
+++ b/testsuite/features/secondary/srv_maintenance_windows.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 SUSE LLC
+# Copyright (c) 2021-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 # skip if container because we do not have a domain name and the

--- a/testsuite/features/secondary/srv_manage_activationkey.feature
+++ b/testsuite/features/secondary/srv_manage_activationkey.feature
@@ -7,8 +7,8 @@ Feature: Manipulate activation keys
   As the testing user
   I want to create and edit activation keys
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Create an activation key for i586
     When I follow the left menu "Systems > Activation Keys"

--- a/testsuite/features/secondary/srv_manage_activationkey.feature
+++ b/testsuite/features/secondary/srv_manage_activationkey.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2023 SUSE LLC
+# Copyright (c) 2010-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @skip_if_github_validation

--- a/testsuite/features/secondary/srv_manage_channels_page.feature
+++ b/testsuite/features/secondary/srv_manage_channels_page.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 SUSE LLC
+# Copyright (c) 2021-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_visualization

--- a/testsuite/features/secondary/srv_manage_channels_page.feature
+++ b/testsuite/features/secondary/srv_manage_channels_page.feature
@@ -7,8 +7,8 @@ Feature: Managing channels
   As an authorized user
   I want to manage channels
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Fail when trying to add a duplicate channel
     When I follow the left menu "Software > Manage > Channels"

--- a/testsuite/features/secondary/srv_notifications.feature
+++ b/testsuite/features/secondary/srv_notifications.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE LLC
+# Copyright (c) 2018-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_visualization

--- a/testsuite/features/secondary/srv_notifications.feature
+++ b/testsuite/features/secondary/srv_notifications.feature
@@ -5,8 +5,8 @@
 @skip_if_github_validation
 Feature: Test the notification/notification-messages feature
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Check the unread notification counter is correct
     When I follow the left menu "Home > Notification Messages"

--- a/testsuite/features/secondary/srv_patches_page.feature
+++ b/testsuite/features/secondary/srv_patches_page.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 SUSE LLC
+# Copyright (c) 2017-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_visualization

--- a/testsuite/features/secondary/srv_patches_page.feature
+++ b/testsuite/features/secondary/srv_patches_page.feature
@@ -7,8 +7,8 @@ Feature: Patches page
   As a authorized user
   I want to see all the texts and links
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Patches left menu
     When I follow the left menu "Patches > Patch List > Relevant"

--- a/testsuite/features/secondary/srv_push_package.feature
+++ b/testsuite/features/secondary/srv_push_package.feature
@@ -8,8 +8,8 @@ Feature: Push a package with unset vendor
   As an authorized user
   I want to push a package with unset vendor
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Pre-requisite: mgr-push package must be installed on the SLES minion
     Given I am on the Systems overview page of this "sle_minion"
@@ -23,7 +23,7 @@ Feature: Push a package with unset vendor
     And I click on "Install Selected Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text
-    And I wait until event "Package Install/Upgrade scheduled by admin" is completed
+    And I wait until event "Package Install/Upgrade scheduled" is completed
 
   Scenario: Push a package with unset vendor through the SLES minion
     When I copy unset package file on "sle_minion"

--- a/testsuite/features/secondary/srv_task_status_engine.feature
+++ b/testsuite/features/secondary/srv_task_status_engine.feature
@@ -14,7 +14,7 @@ Feature: Task Engine Status
     And I should see a "Runtime Status" text
     And I should see a "Last Execution Times" link in the left menu
     And I should see a "Runtime Status" link in the left menu
-  
+
   @uyuni
   Scenario: Check if the Task Engine Status page exists
     When I follow the left menu "Admin > Task Engine Status > Last Execution Times"
@@ -31,7 +31,7 @@ Feature: Task Engine Status
     And I should see a "The server is running or has finished executing the following tasks during the latest 5 minutes." text
     And I should see a "Last Execution Times" link in the left menu
     And I should see a "Runtime Status" link in the left menu
-  
+
   Scenario: Run a remote command on the server to check if it shows up on Last Execution Times page
     When I follow the left menu "Admin > Task Engine Status > Last Execution Times"
     And I run "cobbler sync" on "server"

--- a/testsuite/features/secondary/srv_task_status_engine.feature
+++ b/testsuite/features/secondary/srv_task_status_engine.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023 SUSE LLC
+# Copyright (c) 2022-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Task Engine Status

--- a/testsuite/features/secondary/srv_user_configuration_salt_states.feature
+++ b/testsuite/features/secondary/srv_user_configuration_salt_states.feature
@@ -1,10 +1,13 @@
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @skip_if_github_validation
 @scope_visualization
 @scope_salt
 Feature: Create organizations, users, groups, and activation keys using Salt states
+
+  Scenario: Log in as org admin user
+    Given I am authorized
 
 @skip_if_containerized_server
   Scenario: Apply configuration salt state to server

--- a/testsuite/features/secondary/srv_virtual_host_manager.feature
+++ b/testsuite/features/secondary/srv_virtual_host_manager.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2021 SUSE LLC
+# Copyright (c) 2017-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @skip_if_github_validation

--- a/testsuite/features/secondary/srv_virtual_host_manager.feature
+++ b/testsuite/features/secondary/srv_virtual_host_manager.feature
@@ -6,8 +6,8 @@
 @scope_virtual_host_manager
 Feature: Virtual host manager web UI
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Log in as org admin user
+    Given I am authorized
 
   Scenario: Check the VHM page
     When I follow the left menu "Systems > Virtual Host Managers"

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -378,6 +378,8 @@ end
 
 Given(/^I am not authorized$/) do
   begin
+    xpath_logout = '//a[@href=\'/rhn/Logout.do\']'
+    find(:xpath, xpath_logout).click if has_xpath?(xpath_logout)
     page.reset!
   rescue NoMethodError
     log 'The browser session could not be cleaned.'
@@ -404,6 +406,8 @@ Given(/^I am authorized for the "([^"]*)" section$/) do |section|
     step 'I am authorized as "admin" with password "admin"'
   when 'Images'
     step 'I am authorized as "kiwikiwi" with password "kiwikiwi"'
+  when 'Docker'
+    step 'I am authorized as "docker" with password "docker"'
   else
     log "Section #{section} not supported"
   end
@@ -541,7 +545,7 @@ Given(/^I am authorized as "([^"]*)" with password "([^"]*)"$/) do |user, passwd
 end
 
 Given(/^I am authorized$/) do
-  step 'I am authorized as "testing" with password "testing"'
+  step %(I am authorized as "#{$current_user}" with password "#{$current_password}")
 end
 
 When(/^I sign out$/) do

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -724,3 +724,17 @@ def filter_channels(channels, filters = [])
   end
   channels
 end
+
+# Mutex for processes accessing the API of the server via admin user
+def api_lock?
+  File.open('server_api_call.lock', File::CREAT) do |file|
+    return !file.flock(File::LOCK_EX)
+  end
+end
+
+# Unlock the Mutex for processes accessing the API of the server via admin user
+def api_unlock
+  File.open('server_api_call.lock') do |file|
+    file.flock(File::LOCK_UN)
+  end
+end

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -97,27 +97,21 @@ def capybara_register_driver
       unhandledPromptBehavior: 'accept'
     )
 
-    Capybara::Selenium::Driver.new(
-      app,
-      browser: :chrome,
-      desired_capabilities: capabilities,
-      http_client: client
-    )
+    Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: capabilities, http_client: client)
   end
-
-  Selenium::WebDriver.logger.level = :error unless $debug_mode
-  Capybara.default_driver = :headless_chrome
-  Capybara.javascript_driver = :headless_chrome
-  Capybara.default_normalize_ws = true
-  Capybara.enable_aria_label = true
-  Capybara.automatic_label_click = true
-  Capybara.app_host = "https://#{ENV.fetch('SERVER', nil)}"
-  Capybara.server_port = 8888 + ENV['TEST_ENV_NUMBER'].to_i
-  $stdout.puts "Capybara APP Host: #{Capybara.app_host}:#{Capybara.server_port}"
 end
 
 # register chromedriver headless mode
 $capybara_driver = capybara_register_driver
+Selenium::WebDriver.logger.level = :error unless $debug_mode
+Capybara.default_driver = :headless_chrome
+Capybara.javascript_driver = :headless_chrome
+Capybara.default_normalize_ws = true
+Capybara.enable_aria_label = true
+Capybara.automatic_label_click = true
+Capybara.app_host = "https://#{ENV.fetch('SERVER', nil)}"
+Capybara.server_port = 8888 + ENV['TEST_ENV_NUMBER'].to_i
+$stdout.puts "Capybara APP Host: #{Capybara.app_host}:#{Capybara.server_port}"
 
 # enable minitest assertions in steps
 World(MiniTest::Assertions)
@@ -150,12 +144,9 @@ After do |scenario|
       attach "#{Time.at(@scenario_start_time).strftime('%H:%M:%S:%L')} - #{Time.at(current_epoch).strftime('%H:%M:%S:%L')} | Current URL: #{current_url}", 'text/plain'
     rescue StandardError => e
       warn e.message
-      register_driver
-      visit Capybara.app_host
     ensure
       print_server_logs
       previous_url = current_url
-      visit Capybara.app_host
       step %(I am authorized as "#{$current_user}" with password "#{$current_password}")
       visit previous_url
     end
@@ -201,13 +192,7 @@ After('@scope_cobbler') do |scenario|
 end
 
 AfterStep do
-  next unless Capybara::Session.instance_created?
-
-  begin
-    log 'Timeout: Waiting AJAX transition' if has_css?('.senna-loading', wait: 0) && !has_no_css?('.senna-loading', wait: 30)
-  rescue StandardError
-    next
-  end
+  log 'Timeout: Waiting AJAX transition' if has_css?('.senna-loading', wait: 0) && !has_no_css?('.senna-loading', wait: 30)
 end
 
 Before do


### PR DESCRIPTION
## What does this PR change?

Related to https://github.com/SUSE/spacewalk/issues/9748

Creating a new user per feature, using a scenario hook that will only pass for the first scenario per feature, acting as a feature hook.

It will by-pass the authentication of testing or admin users, using the regular step, when the feature variable @username is not null.

It creates a user name based on the feature filename because the feature name is too long and we have secondary features that acts on several clients during the same feature, so client name can't be use for that purpose on regular CI Tests. 

How to debug parallel tests is another topic, that we can discuss and improve separetely.
The aime of that PR is only to fix the current issue with multiple systems selected as described in the issue linked.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed, need to check on CI

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
