### PR TITLE
Reduce hibernate deprecation

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/ActionChain.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionChain.hbm.xml
@@ -4,8 +4,9 @@
 
     <class name="com.redhat.rhn.domain.action.ActionChain" table="rhnActionChain">
         <id name="id" type="long" column="id">
-            <generator class="sequence">
-                <param name="sequence">rhn_actionchain_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_actionchain_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -652,7 +652,7 @@ select {ra.*}
     SELECT sa.server.id
         FROM ServerAction sa
         JOIN sa.server s
-        WHERE sa.server.class = com.redhat.rhn.domain.server.MinionServer AND action_id = :id
+        WHERE type(s) = com.redhat.rhn.domain.server.MinionServer AND action_id = :id
     ]]>
     </query>
     
@@ -661,7 +661,7 @@ select {ra.*}
         SELECT sa
             FROM ServerAction AS sa
                 JOIN sa.server AS s
-            WHERE s.class != com.redhat.rhn.domain.server.MinionServer
+            WHERE type(s) != com.redhat.rhn.domain.server.MinionServer
                 AND action_id = :id
     ]]>
     </query>
@@ -672,7 +672,7 @@ select {ra.*}
             FROM ServerAction AS sa
                 JOIN sa.server AS s
                 JOIN s.contactMethod AS c
-            WHERE sa.server.class = com.redhat.rhn.domain.server.MinionServer
+            WHERE type(s) = com.redhat.rhn.domain.server.MinionServer
                 AND action_id = :id
     ]]>
     </query>

--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         discriminator-value="-1" >
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_event_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_event_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <discriminator column="action_type" type="java.lang.Integer"

--- a/java/code/src/com/redhat/rhn/domain/action/channel/SubscribeChannelsActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/channel/SubscribeChannelsActionDetails.hbm.xml
@@ -7,8 +7,9 @@
            table="rhnActionSubChannels">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_ACT_SUBSCR_CHNLS_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_ACT_SUBSCR_CHNLS_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="created" type="timestamp" insert="false" update="false" />

--- a/java/code/src/com/redhat/rhn/domain/action/config/ConfigRevisionAction.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/config/ConfigRevisionAction.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                 table="rhnActionConfigRevision" >
                 <id name="id" type="long" column="id">
                         <meta attribute="scope-set">protected</meta>
-                        <generator class="sequence">
-                                <param name="sequence">rhn_actioncr_id_seq</param>
+                        <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                                <param name="sequence_name">rhn_actioncr_id_seq</param>
+                                <param name="increment_size">1</param>
                         </generator>
                 </id>
 

--- a/java/code/src/com/redhat/rhn/domain/action/dup/DistUpgradeActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/dup/DistUpgradeActionDetails.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
          table="rhnActionDup">
     <id name="id" type="long" column="id">
       <meta attribute="scope-set">protected</meta>
-      <generator class="sequence">
-        <param name="sequence">RHN_ACTIONDUP_ID_SEQ</param>
+      <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+        <param name="sequence_name">RHN_ACTIONDUP_ID_SEQ</param>
+        <param name="increment_size">1</param>
       </generator>
     </id>
     <!-- Reference to the parent action -->

--- a/java/code/src/com/redhat/rhn/domain/action/errata/ActionPackageDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/errata/ActionPackageDetails.hbm.xml
@@ -6,8 +6,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
   <class name="com.redhat.rhn.domain.action.errata.ActionPackageDetails" table="rhnActionPackageDetails">
     <id name="id" type="long" column="id">
       <meta attribute="scope-set">protected</meta>
-      <generator class="sequence">
-        <param name="sequence">rhn_actiondpd_id_seq</param>
+      <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+        <param name="sequence_name">rhn_actiondpd_id_seq</param>
+        <param name="increment_size">1</param>
       </generator>
     </id>
     <!-- Reference to the parent action -->

--- a/java/code/src/com/redhat/rhn/domain/action/image/DeployImageActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/image/DeployImageActionDetails.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
          table="rhnActionImageDeploy">
     <id name="id" type="long" column="id">
       <meta attribute="scope-set">protected</meta>
-      <generator class="sequence">
-        <param name="sequence">RHN_ACTION_IMAGE_DEPLOY_ID_SEQ</param>
+      <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+        <param name="sequence_name">RHN_ACTION_IMAGE_DEPLOY_ID_SEQ</param>
+        <param name="increment_size">1</param>
       </generator>
     </id>
     <many-to-one name="parentAction" column="action_id"

--- a/java/code/src/com/redhat/rhn/domain/action/kickstart/KickstartActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/kickstart/KickstartActionDetails.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
                 <id name="id" type="long" column="id">
                         <meta attribute="scope-set">protected</meta>
-                        <generator class="sequence">
-                <param name="sequence">RHN_ACTIONKS_ID_SEQ</param>
+                        <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_ACTIONKS_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
                 </id>
         <property name="appendString" type="string" column="append_string"/>

--- a/java/code/src/com/redhat/rhn/domain/action/kickstart/KickstartGuestActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/kickstart/KickstartGuestActionDetails.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
                 <id name="id" type="long" column="id">
                         <meta attribute="scope-set">protected</meta>
-                        <generator class="sequence">
-                <param name="sequence">RHN_ACTIONKS_ID_SEQ</param>
+                        <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_ACTIONKS_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
                 </id>
 

--- a/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageActionDetails.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnActionPackage" >
                 <id name="packageId" type="long" column="id">
                         <meta attribute="scope-set">protected</meta>
-                        <generator class="sequence">
-                <param name="sequence">RHN_ACT_P_ID_SEQ</param>
+                        <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_ACT_P_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
                 </id>
 

--- a/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesActionDetails.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
             table="rhnActionApplyStates">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_ACT_APPLY_STATES_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_ACT_APPLY_STATES_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="states" column="states" type="string" />

--- a/java/code/src/com/redhat/rhn/domain/action/salt/PlaybookActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/PlaybookActionDetails.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
             table="rhnActionPlaybook">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_act_playbook_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_act_playbook_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="playbookPath" column="playbook_path" type="string" />

--- a/java/code/src/com/redhat/rhn/domain/action/salt/build/ImageBuildActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/build/ImageBuildActionDetails.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
             table="rhnActionImageBuild">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_ACT_IMAGE_BUILD_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_ACT_IMAGE_BUILD_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="version" column="version" type="string" />

--- a/java/code/src/com/redhat/rhn/domain/action/salt/inspect/ImageInspectActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/inspect/ImageInspectActionDetails.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
             table="rhnActionImageInspect">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_ACT_IMAGE_INSPECT_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_ACT_IMAGE_INSPECT_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="name" column="name" type="string" />

--- a/java/code/src/com/redhat/rhn/domain/action/scap/ScapActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/scap/ScapActionDetails.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                 table="rhnActionScap" >
                 <id name="id" type="long" column="id">
                         <meta attribute="scope-set">protected</meta>
-                        <generator class="sequence">
-                                <param name="sequence">RHN_ACT_SCAP_ID_SEQ</param>
+                        <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                                <param name="sequence_name">RHN_ACT_SCAP_ID_SEQ</param>
+                                <param name="increment_size">1</param>
                         </generator>
                 </id>
 

--- a/java/code/src/com/redhat/rhn/domain/action/script/ScriptActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/script/ScriptActionDetails.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                 table="rhnActionScript" >
                 <id name="id" type="long" column="id">
                         <meta attribute="scope-set">protected</meta>
-                        <generator class="sequence">
-                                <param name="sequence">RHN_ACTSCRIPT_ID_SEQ</param>
+                        <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                                <param name="sequence_name">RHN_ACTSCRIPT_ID_SEQ</param>
+                                <param name="increment_size">1</param>
                         </generator>
                 </id>
 

--- a/java/code/src/com/redhat/rhn/domain/audit/XccdfIdent.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/audit/XccdfIdent.hbm.xml
@@ -8,8 +8,9 @@
            mutable="false">
         <cache usage="read-only"/>
         <id name="id" type="long" column="id">
-            <generator class="sequence">
-                <param name="sequence">rhn_xccdf_ident_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_xccdf_ident_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/audit/XccdfIdentSystem.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/audit/XccdfIdentSystem.hbm.xml
@@ -8,8 +8,9 @@
            mutable="false">
         <cache usage="read-only"/>
         <id name="id" type="long" column="id">
-            <generator class="sequence">
-                <param name="sequence">rhn_xccdf_identsytem_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_xccdf_identsytem_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/audit/XccdfRuleResult.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/audit/XccdfRuleResult.hbm.xml
@@ -8,8 +8,9 @@
            mutable="false">
         <cache usage="read-write"/>
         <id name="id" type="long" column="id">
-            <generator class="sequence">
-                <param name="sequence">rhn_xccdf_rresult_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_xccdf_rresult_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/audit/XccdfTestResult.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/audit/XccdfTestResult.hbm.xml
@@ -9,8 +9,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                 <cache usage="read-write"/>
                 <id name="id" type="long" column="id">
                         <meta attribute="scope-set">protected</meta>
-                        <generator class="sequence">
-                                <param name="sequence">rhn_xccdf_tresult_id_seq</param>
+                        <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                                <param name="sequence_name">rhn_xccdf_tresult_id_seq</param>
+                                <param name="increment_size">1</param>
                         </generator>
                 </id>
 

--- a/java/code/src/com/redhat/rhn/domain/channel/AccessToken.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/AccessToken.hbm.xml
@@ -6,8 +6,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     <class name="com.redhat.rhn.domain.channel.AccessToken" table="suseChannelAccessToken">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">suse_chan_access_token_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">suse_chan_access_token_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <many-to-one name="minion" not-null="false"

--- a/java/code/src/com/redhat/rhn/domain/channel/Channel.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/Channel.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_CHANNEL_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_CHANNEL_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFamily.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFamily.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
                 <id name="id" type="long" column="id">
                         <meta attribute="scope-set">protected</meta>
-                        <generator class="sequence">
-                                <param name="sequence">RHN_CHANNEL_FAMILY_ID_SEQ</param>
+                        <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                                <param name="sequence_name">RHN_CHANNEL_FAMILY_ID_SEQ</param>
+                                <param name="increment_size">1</param>
                         </generator>
                 </id>
 

--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelProduct.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelProduct.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnChannelProduct" >
         <id name="id" type="long" column="ID">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_channelprod_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_channelprod_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/channel/ContentSource.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/ContentSource.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_chan_content_src_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_chan_content_src_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/channel/ContentSourceFilter.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/ContentSourceFilter.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_csf_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_csf_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/channel/ContentSourceType.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/ContentSourceType.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <cache usage="read-only"/>
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_content_source_type_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_content_source_type_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/channel/DistChannelMap.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/DistChannelMap.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_dcm_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_dcm_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/channel/ProductName.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/ProductName.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_productname_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_productname_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/channel/PublicChannelFamily.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/PublicChannelFamily.hbm.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.channel.PublicChannelFamily" table="rhnPublicChannelFamily">
-        <id column="channel_family_id" type="long">
+        <id name="id" column="channel_family_id" type="long">
             <generator class="foreign">
                 <param name="property">channelFamily</param>
             </generator>

--- a/java/code/src/com/redhat/rhn/domain/channel/PublicChannelFamily.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/PublicChannelFamily.java
@@ -24,8 +24,27 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
  */
 public class PublicChannelFamily extends BaseDomainHelper {
 
+    /** The id, which is also the associated channel family id */
+    private long id;
+
     /** The channel family. */
     private ChannelFamily channelFamily;
+
+    /**
+     * Gets the channel family id.
+     * @return the channel family id.
+     */
+    public long getId() {
+        return id;
+    }
+
+    /**
+     * Sets the channel family id.
+     * @param idIn The channel family id to set.
+     */
+    public void setId(long idIn) {
+        this.id = idIn;
+    }
 
     /**
      * Gets the channel family.

--- a/java/code/src/com/redhat/rhn/domain/channel/RepoMetadata.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/RepoMetadata.hbm.xml
@@ -10,8 +10,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
         <id name="id" type="long" column="id">
           <meta attribute="scope-set">protected</meta>
-          <generator class="sequence">
-            <param name="sequence">rhn_channelcomps_id_seq</param>
+          <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+            <param name="sequence_name">rhn_channelcomps_id_seq</param>
+            <param name="increment_size">1</param>
           </generator>
         </id>
         <discriminator column="comps_type_id" type="java.lang.Integer"/>

--- a/java/code/src/com/redhat/rhn/domain/common/Checksum.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/common/Checksum.hbm.xml
@@ -7,9 +7,10 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnChecksum" >
         <id name="id" type="long" column="id" >
 
-             <generator class="sequence">
-                <param name="sequence">rhnChecksum_seq</param>
-            </generator>
+             <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhnChecksum_seq</param>
+                <param name="increment_size">1</param>
+             </generator>
         </id>
         <property name="checksum" type="string" column="checksum" />
         <many-to-one

--- a/java/code/src/com/redhat/rhn/domain/common/FileList.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/common/FileList.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_FILELIST_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_FILELIST_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/common/ProvisionState.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/common/ProvisionState.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnProvisionState">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_PROVSTATE_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_PROVSTATE_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/config/ConfigContent.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/config/ConfigContent.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                 table="rhnConfigContent" >
                 <id name="id" type="long" column="id">
                         <meta attribute="scope-set">protected</meta>
-                        <generator class="sequence">
-                                <param name="sequence">rhn_confcontent_id_seq</param>
+                        <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                                <param name="sequence_name">rhn_confcontent_id_seq</param>
+                                <param name="increment_size">1</param>
                         </generator>
                 </id>
                 <property name="contents" column="contents" type="binary" />

--- a/java/code/src/com/redhat/rhn/domain/config/ConfigFileState.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/config/ConfigFileState.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                 <cache usage="read-only"/>
                 <id name="id" type="long" column="id">
                         <meta attribute="scope-set">protected</meta>
-                        <generator class="sequence">
-                                <param name="sequence">rhn_cfstate_id_seq</param>
+                        <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                                <param name="sequence_name">rhn_cfstate_id_seq</param>
+                                <param name="increment_size">1</param>
                         </generator>
                 </id>
                 <property name="label" column="label" type="string" length="32" />

--- a/java/code/src/com/redhat/rhn/domain/credentials/Credentials.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/credentials/Credentials.hbm.xml
@@ -6,8 +6,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
   <class name="com.redhat.rhn.domain.credentials.Credentials"
          table="SUSECREDENTIALS">
     <id name="id" column="id" type="long">
-      <generator class="sequence">
-        <param name="sequence">suse_credentials_id_seq</param>
+      <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+        <param name="sequence_name">suse_credentials_id_seq</param>
+        <param name="increment_size">1</param>
       </generator>
     </id>
     <many-to-one name="user" column="user_id" class="com.redhat.rhn.domain.user.legacy.UserImpl" />

--- a/java/code/src/com/redhat/rhn/domain/errata/Cve.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/errata/Cve.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnCve" >
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_cve_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_cve_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="name" column="name" type="string" length="20" />

--- a/java/code/src/com/redhat/rhn/domain/errata/Errata.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/errata/Errata.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnErrata" >
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_errata_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_errata_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="advisory" column="advisory" type="string" length="32" />

--- a/java/code/src/com/redhat/rhn/domain/errata/ErrataFile.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/errata/ErrataFile.hbm.xml
@@ -6,8 +6,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     <class name="com.redhat.rhn.domain.errata.ErrataFile" table="rhnErrataFile">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_ERRATAFILE_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_ERRATAFILE_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <many-to-one name="checksum" class="com.redhat.rhn.domain.common.Checksum"

--- a/java/code/src/com/redhat/rhn/domain/iss/IssMaster.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/iss/IssMaster.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnissmaster" >
         <id name="id" type="long" column="ID">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_issmaster_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_issmaster_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/iss/IssMasterOrg.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/iss/IssMasterOrg.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnissmasterorgs" >
         <id name="id" type="long" column="ID">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                    <param name="sequence">rhn_issmasterorgs_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                    <param name="sequence_name">rhn_issmasterorgs_seq</param>
+                    <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="masterOrgId" column="MASTER_ORG_ID"  type="long" />

--- a/java/code/src/com/redhat/rhn/domain/iss/IssSlave.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/iss/IssSlave.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnissslave" >
         <id name="id" type="long" column="ID">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_issslave_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_issslave_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="slave" column="SLAVE"  type="string" length="256" />

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartCommand.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartCommand.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_KSCOMMAND_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_KSCOMMAND_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartCommandName.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartCommandName.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnKickstartCommandName">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_KSCOMMANDNAME_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_KSCOMMANDNAME_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartData.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartData.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_KS_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_KS_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <discriminator column = "ks_type"

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartScript.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartScript.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnKickstartScript" >
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_KSSCRIPT_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_KSSCRIPT_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="position" column="position" not-null="true" type="long" />

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartSessionHistory.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartSessionHistory.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnkickstartsessionhistory" >
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_KS_SESSIONHIST_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_KS_SESSIONHIST_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartSessionState.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartSessionState.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnkickstartsessionstate" >
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_KS_SESSION_STATE_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_KS_SESSION_STATE_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="label" column="label" not-null="true" type="string" length="64" />

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartSession_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartSession_legacyUser.hbm.xml
@@ -6,8 +6,9 @@
         table="rhnkickstartsession" >
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_KS_SESSION_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_KS_SESSION_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartVirtualizationType.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartVirtualizationType.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnKickstartVirtualizationType" >
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_kvt_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_kvt_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="label" column="label" not-null="true" type="string" length="128" />

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartableTree.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartableTree.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_KSTREE_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_KSTREE_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/kickstart/crypto/CryptoKey.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/crypto/CryptoKey.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnCryptoKey" >
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_CRYPTOKEY_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_CRYPTOKEY_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <discriminator formula="(SELECT type.label FROM rhnCryptoKeyType type WHERE type.id = crypto_key_type_id)" type="java.lang.String" />

--- a/java/code/src/com/redhat/rhn/domain/kickstart/crypto/CryptoKeyType.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/crypto/CryptoKeyType.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnCryptoKeyType" >
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_CRYPTOKEY_TYPE_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_CRYPTOKEY_TYPE_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="label" column="label" not-null="true" type="string" length="32" />

--- a/java/code/src/com/redhat/rhn/domain/matcher/MatcherRunData.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/matcher/MatcherRunData.hbm.xml
@@ -6,8 +6,9 @@
     <class name="com.redhat.rhn.domain.matcher.MatcherRunData"
            table="suseMatcherRunData">
         <id name="id" type="long" column="id">
-            <generator class="sequence">
-                <param name="sequence">suse_matcher_run_data_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">suse_matcher_run_data_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/org/CustomDataKey_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/org/CustomDataKey_legacyUser.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
            table="rhnCustomDataKey">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_CDATAKEY_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_CDATAKEY_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/org/Org.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/org/Org.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
            table="WEB_CUSTOMER">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">web_customer_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">web_customer_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="name" type="string" />

--- a/java/code/src/com/redhat/rhn/domain/org/TemplateCategory.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/org/TemplateCategory.hbm.xml
@@ -9,8 +9,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <cache usage="read-only"/>
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_TEMPLATE_CAT_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_TEMPLATE_CAT_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
                 <property name="label" column="label" type="string" length="64" />

--- a/java/code/src/com/redhat/rhn/domain/org/TemplateString.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/org/TemplateString.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
            table="RHNTEMPLATESTRING">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_TEMPLATE_STR_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_TEMPLATE_STR_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
                 <property name="label" column="label" type="string" length="64" />

--- a/java/code/src/com/redhat/rhn/domain/org/usergroup/ExtGroup.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/org/usergroup/ExtGroup.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnUserExtGroup">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_userextgroup_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_userextgroup_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <discriminator column="org_id" insert="false"/>

--- a/java/code/src/com/redhat/rhn/domain/org/usergroup/UserGroupImpl.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/org/usergroup/UserGroupImpl.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="RHNUSERGROUP">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_user_group_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_user_group_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="name" column="name" type="string" length="64" />

--- a/java/code/src/com/redhat/rhn/domain/product/SUSEProduct.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/product/SUSEProduct.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
          table="suseProducts">
     <id name="id" type="long" column="id">
       <meta attribute="scope-set">protected</meta>
-      <generator class="sequence">
-        <param name="sequence">SUSE_PRODUCTS_ID_SEQ</param>
+      <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+        <param name="sequence_name">SUSE_PRODUCTS_ID_SEQ</param>
+        <param name="increment_size">1</param>
       </generator>
     </id>
     <many-to-one name="arch"

--- a/java/code/src/com/redhat/rhn/domain/product/SUSEProductChannel.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/product/SUSEProductChannel.hbm.xml
@@ -6,8 +6,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
   <class name="com.redhat.rhn.domain.product.SUSEProductChannel" table="suseProductChannel">
 
     <id name="id" type="long" column="id">
-        <generator class="sequence">
-            <param name="sequence">suse_product_channel_id_seq</param>
+        <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+            <param name="sequence_name">suse_product_channel_id_seq</param>
+            <param name="increment_size">1</param>
         </generator>
     </id>
 

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageCapability.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageCapability.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnPackageCapability">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_PKG_CAPABILITY_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_PKG_CAPABILITY_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageDelta.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageDelta.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnPackageDelta">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_PACKAGEDELTA_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_PACKAGEDELTA_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageEvr.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageEvr.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_PKG_EVR_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_PKG_EVR_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageGroup.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageGroup.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
            table="rhnPackageGroup">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_PACKAGE_GROUP_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_PACKAGE_GROUP_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageKey.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageKey.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnPackageKey">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_pkey_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_pkey_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageKeyType.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageKeyType.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <cache usage="read-only"/>
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_package_key_type_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_package_key_type_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageName.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageName.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnPackageName">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_PKG_NAME_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_PKG_NAME_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageNevra.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageNevra.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnPackageNevra">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_pkgnevra_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_pkgnevra_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageProvider.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageProvider.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_package_provider_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_package_provider_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageSource.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageSource.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_PACKAGE_SOURCE_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_PACKAGE_SOURCE_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/Package_satellite.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/Package_satellite.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_PACKAGE_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_PACKAGE_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/profile/Profile.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/profile/Profile.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                 table="rhnServerProfile">
                 <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_SERVER_PROFILE_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_SERVER_PROFILE_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
                 </id>
                 <property name="name" column="name" type="string" length="128" />

--- a/java/code/src/com/redhat/rhn/domain/role/Role.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/role/Role.hbm.xml
@@ -9,8 +9,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <cache usage="read-only"/>
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_usergroup_type_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_usergroup_type_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="name" column="name" type="string" length="64" />

--- a/java/code/src/com/redhat/rhn/domain/rpm/SourceRpm.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rpm/SourceRpm.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
            table="rhnSourceRpm">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_SOURCERPM_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_SOURCERPM_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/server/CPU.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/CPU.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                 table="rhnCPU">
                 <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_CPU_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_CPU_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
                 </id>
 

--- a/java/code/src/com/redhat/rhn/domain/server/CPUArch.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/CPUArch.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <cache usage="read-only"/>
                 <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_CPU_ARCH_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_CPU_ARCH_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
                 </id>
                 <property name="label" column="label" type="string" length="64" />

--- a/java/code/src/com/redhat/rhn/domain/server/Device.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Device.hbm.xml
@@ -6,8 +6,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     <class name="com.redhat.rhn.domain.server.Device" table="rhnDevice">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_hw_dev_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_hw_dev_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/server/Dmi.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Dmi.hbm.xml
@@ -6,8 +6,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     <class name="com.redhat.rhn.domain.server.Dmi" table="rhnServerDmi">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_ram_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_ram_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/server/InstalledProduct.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/InstalledProduct.hbm.xml
@@ -6,8 +6,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     <class name="com.redhat.rhn.domain.server.InstalledProduct"
                 table="suseInstalledProduct" >
         <id name="id" type="long" column="id">
-            <generator class="sequence">
-                <param name="sequence">suse_inst_pr_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">suse_inst_pr_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="name" type="string" column="name"/>

--- a/java/code/src/com/redhat/rhn/domain/server/InvalidSnapshotReason.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/InvalidSnapshotReason.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     <class name="com.redhat.rhn.domain.server.InvalidSnapshotReason" table="rhnSnapshotInvalidReason">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_ssinvalid_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_ssinvalid_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/server/Location.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Location.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnServerLocation" >
         <id name="id" type="long" column="ID">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_server_loc_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_server_loc_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <many-to-one name="server" class="com.redhat.rhn.domain.server.Server"

--- a/java/code/src/com/redhat/rhn/domain/server/Note_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Note_legacyUser.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                 table="rhnServerNotes">
                 <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_SERVER_NOTE_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_SERVER_NOTE_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
                 </id>
                 <property name="subject" column="subject" type="string" length="80" />

--- a/java/code/src/com/redhat/rhn/domain/server/PinnedSubscription.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/PinnedSubscription.hbm.xml
@@ -6,8 +6,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     <class name="com.redhat.rhn.domain.server.PinnedSubscription"
         table="susePinnedSubscription">
         <id name="id" type="long" column="id">
-            <generator class="sequence">
-                <param name="sequence">suse_pinsub_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">suse_pinsub_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="systemId" type="long" column="system_id"/>

--- a/java/code/src/com/redhat/rhn/domain/server/PushClient.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/PushClient.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnpushclient" >
         <id name="id" type="long" column="ID">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_pclient_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_pclient_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="name" column="NAME" not-null="true" type="string" length="256" />

--- a/java/code/src/com/redhat/rhn/domain/server/PushClientState.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/PushClientState.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnPushClientState" >
         <id name="id" type="long" column="ID">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_pclient_state_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_pclient_state_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="label" column="LABEL" not-null="true" type="string" length="64" />

--- a/java/code/src/com/redhat/rhn/domain/server/Ram.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Ram.hbm.xml
@@ -6,8 +6,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     <class name="com.redhat.rhn.domain.server.Ram" table="rhnRam">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_ram_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_ram_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFQDN.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFQDN.hbm.xml
@@ -4,8 +4,9 @@
     <class name="com.redhat.rhn.domain.server.ServerFQDN" table="rhnServerFQDN">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_SERVERFQDN_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_SERVERFQDN_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="name" column="name" type="string" length="253" />

--- a/java/code/src/com/redhat/rhn/domain/server/ServerGroup.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerGroup.hbm.xml
@@ -6,8 +6,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     <class name="com.redhat.rhn.domain.server.ServerGroup" table="rhnServerGroup">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-                <generator class="sequence">
-                    <param name="sequence">rhn_server_group_id_seq</param>
+                <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                    <param name="sequence_name">rhn_server_group_id_seq</param>
+                    <param name="increment_size">1</param>
                 </generator>
         </id>
         <discriminator column = "group_type" type="string"/>

--- a/java/code/src/com/redhat/rhn/domain/server/ServerHistoryEvent.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerHistoryEvent.hbm.xml
@@ -6,8 +6,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     <class name="com.redhat.rhn.domain.server.ServerHistoryEvent" table="rhnserverhistory">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_event_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_event_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <many-to-one name="server"

--- a/java/code/src/com/redhat/rhn/domain/server/ServerSnapshot.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerSnapshot.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     <class name="com.redhat.rhn.domain.server.ServerSnapshot" table="rhnSnapshot">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_snapshot_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_snapshot_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
@@ -6,8 +6,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     <class name="com.redhat.rhn.domain.server.Server" table="rhnServer">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_server_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_server_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
@@ -344,7 +344,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     <query name="Server.findNonZypperTradClientsIds">
         <![CDATA[SELECT s.id
                  FROM Server s
-                 WHERE s.class != com.redhat.rhn.domain.server.MinionServer
+                 WHERE type(s) != com.redhat.rhn.domain.server.MinionServer
                      AND s.id in (:serverIds)
                      AND NOT EXISTS (SELECT 1
                                      FROM com.redhat.rhn.domain.server.InstalledPackage as p
@@ -411,7 +411,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     <![CDATA[
         SELECT s.minionId, s.id
             FROM Server AS s
-            WHERE s.class = com.redhat.rhn.domain.server.MinionServer
+            WHERE type(s) = com.redhat.rhn.domain.server.MinionServer
                 AND s.minionId IN (:minionIds)
     ]]>
     </query>

--- a/java/code/src/com/redhat/rhn/domain/server/SnapshotTag.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/SnapshotTag.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     <class name="com.redhat.rhn.domain.server.SnapshotTag" table="rhnTag">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_tag_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_tag_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/server/SnapshotTagName.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/SnapshotTagName.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                 table="rhnTagName">
                 <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_tagname_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_tagname_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
                 </id>
                 <property name="name" column="name" type="string" length="128" />

--- a/java/code/src/com/redhat/rhn/domain/server/VirtualInstance.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/VirtualInstance.hbm.xml
@@ -9,8 +9,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     <class name="com.redhat.rhn.domain.server.VirtualInstance" table="RhnVirtualInstance">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_vi_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_vi_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/server/virtualhostmanager/VirtualHostManager.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/virtualhostmanager/VirtualHostManager.hbm.xml
@@ -4,8 +4,9 @@
 
     <class name="com.redhat.rhn.domain.server.virtualhostmanager.VirtualHostManager" table="suseVirtualHostManager">
         <id name="id" type="long" column="id">
-            <generator class="sequence">
-                <param name="sequence">suse_vhms_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">suse_vhms_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/server/virtualhostmanager/VirtualHostManagerConfig.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/virtualhostmanager/VirtualHostManagerConfig.hbm.xml
@@ -4,8 +4,9 @@
 
     <class name="com.redhat.rhn.domain.server.virtualhostmanager.VirtualHostManagerConfig" table="suseVHMConfig">
         <id name="id" type="long" column="id">
-            <generator class="sequence">
-                <param name="sequence">suse_vhm_config_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">suse_vhm_config_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <many-to-one name="virtualHostManager"

--- a/java/code/src/com/redhat/rhn/domain/session/WebSessionImpl.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/session/WebSessionImpl.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="PXTSessions">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">pxt_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">pxt_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="value"

--- a/java/code/src/com/redhat/rhn/domain/state/PackageState.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/state/PackageState.hbm.xml
@@ -3,8 +3,9 @@
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.state.PackageState" table="susePackageState">
         <id name="id" type="long" column="id">
-            <generator class="sequence">
-                <param name="sequence">suse_pkg_state_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">suse_pkg_state_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <many-to-one name="name" column="name_id" class="com.redhat.rhn.domain.rhnpackage.PackageName"/>

--- a/java/code/src/com/redhat/rhn/domain/state/StateRevision.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/state/StateRevision.hbm.xml
@@ -3,8 +3,9 @@
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.state.StateRevision" table="suseStateRevision">
         <id name="id" type="long" column="id">
-            <generator class="sequence">
-                <param name="sequence">suse_state_revision_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">suse_state_revision_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <set name="packageStates" lazy="true" inverse="true" cascade="all">

--- a/java/code/src/com/redhat/rhn/domain/test/TestImpl.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/test/TestImpl.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="PERSIST_TEST">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">PERSIST_SEQUENCE</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">PERSIST_SEQUENCE</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="foobar" column="foobar" type="string" length="32" />

--- a/java/code/src/com/redhat/rhn/domain/token/TokenPackage.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/token/TokenPackage.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">rhn_reg_tok_pkg_id_seq</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">rhn_reg_tok_pkg_id_seq</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/domain/token/Token_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/token/Token_legacyUser.hbm.xml
@@ -6,8 +6,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     <class name="com.redhat.rhn.domain.token.Token" table="rhnRegToken">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_REG_TOKEN_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_REG_TOKEN_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="note" column="note" type="string" length="2048"/>

--- a/java/code/src/com/redhat/rhn/domain/user/Pane.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/user/Pane.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
       <meta attribute="scope-set">private</meta>
       <id name="id" type="long" column="id">
         <meta attribute="scope-set">protected</meta>
-        <generator class="sequence">
-          <param name="sequence">RHN_INFO_PANE_ID_SEQ</param>
+        <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+          <param name="sequence_name">RHN_INFO_PANE_ID_SEQ</param>
+          <param name="increment_size">1</param>
         </generator>
       </id>
       <property name="label"

--- a/java/code/src/com/redhat/rhn/domain/user/legacy/AddressImpl.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/user/legacy/AddressImpl.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
            table="WEB_USER_SITE_INFO">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">WEB_USER_SITE_INFO_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">WEB_USER_SITE_INFO_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="address1" column="address1" type="string" length="128" />

--- a/java/code/src/com/redhat/rhn/domain/user/legacy/StateChange.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/user/legacy/StateChange.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         table="rhnWebContactChangeLog">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_WCON_DISABLED_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_WCON_DISABLED_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <!-- Let the db take care of setting this column -->

--- a/java/code/src/com/redhat/rhn/domain/user/legacy/UserImpl.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/user/legacy/UserImpl.hbm.xml
@@ -7,8 +7,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
            table="WEB_CONTACT">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">WEB_CONTACT_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">WEB_CONTACT_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
         <property name="login" column="login" type="string" length="64" />

--- a/java/code/src/com/redhat/rhn/taskomatic/domain/TaskoBunch.hbm.xml
+++ b/java/code/src/com/redhat/rhn/taskomatic/domain/TaskoBunch.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_TASKO_BUNCH_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_TASKO_BUNCH_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/taskomatic/domain/TaskoRun.hbm.xml
+++ b/java/code/src/com/redhat/rhn/taskomatic/domain/TaskoRun.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_TASKO_RUN_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_TASKO_RUN_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/taskomatic/domain/TaskoSchedule.hbm.xml
+++ b/java/code/src/com/redhat/rhn/taskomatic/domain/TaskoSchedule.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_TASKO_SCHEDULE_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_TASKO_SCHEDULE_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/taskomatic/domain/TaskoTask.hbm.xml
+++ b/java/code/src/com/redhat/rhn/taskomatic/domain/TaskoTask.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_TASKO_TASK_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_TASKO_TASK_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/com/redhat/rhn/taskomatic/domain/TaskoTemplate.hbm.xml
+++ b/java/code/src/com/redhat/rhn/taskomatic/domain/TaskoTemplate.hbm.xml
@@ -8,8 +8,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
-            <generator class="sequence">
-                <param name="sequence">RHN_TASKO_TEMPLATE_ID_SEQ</param>
+            <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
+                <param name="sequence_name">RHN_TASKO_TEMPLATE_ID_SEQ</param>
+                <param name="increment_size">1</param>
             </generator>
         </id>
 

--- a/java/code/src/log4j2.xml
+++ b/java/code/src/log4j2.xml
@@ -102,8 +102,24 @@
         </Logger>
         -->
 
-        <!-- this should shut up hibernate until this gets fixed upstream -->
-        <Logger name="org.hibernate.orm.deprecation" level="error" />
+        <!-- Ignore deprecation not yet addressed to reduce log noise -->
+        <Logger name="org.hibernate.orm.deprecation" level="warn">
+            <Filters>
+                <!-- Disable outer-join attribute on <many-to-many> has been deprecated -->
+                <RegexFilter regex="HHH90000009: .*" onMatch="DENY" onMismatch="NEUTRAL"/>
+                <!-- Disable org.hibernate.Criteria API deprecation message -->
+                <RegexFilter regex="HHH90000022: .*" onMatch="DENY" onMismatch="NEUTRAL"/>
+                <!-- Disable ehcache 2 deprecation message -->
+                <RegexFilter regex="HHH020100: .*" onMatch="DENY" onMismatch="NEUTRAL"/>
+            </Filters>
+        </Logger>
+
+        <Logger name="org.hibernate.cfg.AnnotationBinder" level="warn">
+            <Filters>
+                <!-- Current hibernate behaviour of to apply the @DiscriminatorColumn is what we want -->
+                <RegexFilter regex="HHH000457: .*" onMatch="DENY" onMismatch="NEUTRAL"/>
+            </Filters>
+        </Logger>
 
         <!-- this silences ehcache on Fedoras complaining about using default values -->
         <Logger name="org.hibernate.cache.ehcache.AbstractEhcacheRegionFactory" level="error" />

--- a/java/conf/default/rhn_hibernate.conf
+++ b/java/conf/default/rhn_hibernate.conf
@@ -34,5 +34,5 @@ hibernate.bytecode.use_reflection_optimizer=false
 hibernate.jdbc.batch_size=0
 hibernate.cache.provider_class=org.hibernate.cache.EhCacheProvider
 hibernate.cache.region.factory_class=org.hibernate.cache.ehcache.EhCacheRegionFactory
-hibernate.id.new_generator_mappings = false
+hibernate.id.new_generator_mappings = true
 hibernate.cache.ehcache.missing_cache_strategy=create

--- a/java/conf/log4j2.xml.taskomatic
+++ b/java/conf/log4j2.xml.taskomatic
@@ -57,6 +57,25 @@
         </Logger>
         -->
 
+        <!-- Ignore deprecation not yet addressed to reduce log noise -->
+        <Logger name="org.hibernate.orm.deprecation" level="warn">
+            <Filters>
+                <!-- Disable outer-join attribute on <many-to-many> has been deprecated -->
+                <RegexFilter regex="HHH90000009: .*" onMatch="DENY" onMismatch="NEUTRAL"/>
+                <!-- Disable org.hibernate.Criteria API deprecation message -->
+                <RegexFilter regex="HHH90000022: .*" onMatch="DENY" onMismatch="NEUTRAL"/>
+                <!-- Disable ehcache 2 deprecation message -->
+                <RegexFilter regex="HHH020100: .*" onMatch="DENY" onMismatch="NEUTRAL"/>
+            </Filters>
+        </Logger>
+
+        <Logger name="org.hibernate.cfg.AnnotationBinder" level="warn">
+            <Filters>
+                <!-- Current hibernate behaviour of to apply the @DiscriminatorColumn is what we want -->
+                <RegexFilter regex="HHH000457: .*" onMatch="DENY" onMismatch="NEUTRAL"/>
+            </Filters>
+        </Logger>
+
         <!-- this silences ehcache on Fedoras complaining about using default values -->
         <Logger name="org.hibernate.cache.ehcache.AbstractEhcacheRegionFactory" level="error" />
         <Root level="warn"><AppenderRef ref="rootAppender" /></Root>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Reduced the usage of deprecated Hibernate API
 - Fixed formula deselection in systemgroup (bsc#1202271)
 - Fix out of memory error when building a CLM project (bsc#1202217)
 - Use mgrnet.dns_fqdns module to improve FQDN detection (bsc#1199726)


### PR DESCRIPTION
## What does this PR change?

This PR removes the deprecation warning generated by Hibernate by updating the code and the configuration up the the 5.3 best practices when possible. It also filter out the entries from the logs only for the warnings that could not be fixed.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18088

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
