### PR TITLE
authenticated registry uses path prefix cucutest/

### DIFF
--- a/testsuite/features/profiles/Docker/authprofile/Dockerfile
+++ b/testsuite/features/profiles/Docker/authprofile/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION               1.0.0
 
-FROM registry.mgr.suse.de:5000/systemsmanagement/uyuni/master/docker/containers/uyuni-master-testsuite
+FROM registry.mgr.suse.de:5000/cucutest/systemsmanagement/uyuni/master/docker/containers/uyuni-master-testsuite
 MAINTAINER Michael Calmer "mc@suse.com"
 
 ARG repo

--- a/testsuite/features/profiles/internal_nue/Docker/authprofile/Dockerfile
+++ b/testsuite/features/profiles/internal_nue/Docker/authprofile/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION               1.0.0
 
-FROM registry.mgr.suse.de:5000/systemsmanagement/uyuni/master/docker/containers/uyuni-master-testsuite
+FROM registry.mgr.suse.de:5000/cucutest/systemsmanagement/uyuni/master/docker/containers/uyuni-master-testsuite
 MAINTAINER Michael Calmer "mc@suse.com"
 
 ARG repo

--- a/testsuite/features/profiles/internal_prv/Docker/authprofile/Dockerfile
+++ b/testsuite/features/profiles/internal_prv/Docker/authprofile/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION               1.0.0
 
-FROM registry.mgr.prv.suse.net:5000/systemsmanagement/uyuni/master/docker/containers/uyuni-master-testsuite
+FROM registry.mgr.prv.suse.net:5000/cucutest/systemsmanagement/uyuni/master/docker/containers/uyuni-master-testsuite
 MAINTAINER Michael Calmer "mc@suse.com"
 
 ARG repo


### PR DESCRIPTION
## What does this PR change?

The template for authenticated registry uses the wrong prefix.
When we copy the images, we store them below /cucutest

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
