### PR TITLE
use FTP server in minima-mirror for download endpoint test

### DIFF
--- a/testsuite/features/secondary/min_custom_pkg_download_endpoint.feature
+++ b/testsuite/features/secondary/min_custom_pkg_download_endpoint.feature
@@ -54,7 +54,7 @@ Feature: Repos file generation based on custom pillar data
   Scenario: Check the channel.repo file to see the custom RPM download point
     Given I am on the Systems overview page of this "sle_minion"
     Then the susemanager repo file should exist on the "sle_minion"
-    And I should see "ftp", "scc.com" and "445" in the repo file on the "sle_minion"
+    And I should see "ftp", "minima-mirror.mgr.prv.suse.net" and "445" in the repo file on the "sle_minion"
 
   Scenario: Cleanup: remove the custom RPM download point
     When I delete a salt "pillar" file with name "pkg_endpoint.sls" on the server

--- a/testsuite/features/upload_files/pkg_endpoint.sls
+++ b/testsuite/features/upload_files/pkg_endpoint.sls
@@ -1,3 +1,3 @@
 pkg_download_point_protocol: ftp
-pkg_download_point_host: scc.com
+pkg_download_point_host: minima-mirror.mgr.prv.suse.net
 pkg_download_point_port: 445


### PR DESCRIPTION
## What does this PR change?

For the download endpoint test we need now a really existing server.
To fix the test a ftp server with a dummy repo was setup on the minima mirror.
Use that for the test.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18530

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
