### PR TITLE
fix problems with parallel running processes

### DIFF
--- a/tftpsync/susemanager-tftpsync-recv/add.wsgi
+++ b/tftpsync/susemanager-tftpsync-recv/add.wsgi
@@ -89,9 +89,10 @@ def application(environ, start_response):
         content = "No file content"
     else:
         path = os.path.join(CFG.TFTPBOOT, directory)
+        tfname = None
         try:
             if not os.path.exists(path):
-                os.makedirs(path)
+                os.makedirs(path, exist_ok=True)
 
             rfname = os.path.join(path, file_name)
             tfname = "%s.tmp" % (rfname)

--- a/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
+++ b/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
@@ -1,3 +1,5 @@
+- fix problems with parallel running processes
+
 -------------------------------------------------------------------
 Tue Apr 19 12:14:26 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Seems that it can happen that 2 "cobbler sync" run in parallel and the receiver on the proxy execute the same file in parallel.
This change is a step into better handling of this case.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/18618 https://github.com/SUSE/spacewalk/pull/18619

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
