### PR TITLE
make zypper use proxy with mirrorlist

### DIFF
--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -662,6 +662,7 @@ type=rpm-md
 
         :returns: str
         """
+        ret_url = None
         query_params = {}
         if self.proxy_hostname:
             query_params['proxy'] = quote(self.proxy_hostname)
@@ -689,7 +690,7 @@ type=rpm-md
             return "{0}&{1}".format(url, new_query)
         parsed_url = urlparse(url)
         existing_query = parsed_url.query
-        combined_query = "&".join(filter(None, [existing_query, new_query]))
+        combined_query = "&".join([q for q in [existing_query, new_query] if q])
         return urlunparse((
             parsed_url.scheme,
             parsed_url.netloc,

--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -582,6 +582,8 @@ class ContentSource:
 
         returnlist = _replace_and_check_url(returnlist)
 
+        returnlist = [self._prep_zypp_repo_url(url, False) for url in returnlist]
+
         try:
            # Write the final mirrorlist that is going to be pass to Zypper
            with open(mirrorlist_path, 'w') as mirrorlist_file:
@@ -660,7 +662,6 @@ type=rpm-md
 
         :returns: str
         """
-        ret_url = None
         query_params = {}
         if self.proxy_hostname:
             query_params['proxy'] = quote(self.proxy_hostname)
@@ -683,11 +684,20 @@ type=rpm-md
         if self.sslclientkey:
             query_params['ssl_clientkey'] = self.sslclientkey
         new_query = unquote(urlencode(query_params, doseq=True))
-        if self.authtoken or uln_repo:
-            ret_url = "{0}&{1}".format(url, new_query)
-        else:
-            ret_url = "{0}?{1}".format(url, new_query) if new_query else url
-        return ret_url
+        # urlparse cannot handle uln urls, so we need to keep this check
+        if uln_repo:
+            return "{0}&{1}".format(url, new_query)
+        parsed_url = urlparse(url)
+        existing_query = parsed_url.query
+        combined_query = "&".join(filter(None, [existing_query, new_query]))
+        return urlunparse((
+            parsed_url.scheme,
+            parsed_url.netloc,
+            parsed_url.path,
+            parsed_url.params,
+            combined_query,
+            parsed_url.fragment
+        ))
 
     def _md_exists(self, tag):
         """

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Make reposync use the configured http proxy with mirrorlist (bsc#1198168)
 - Prevent tracebacks on running spacewalk-repo-sync
   on loading update notice with no version specified in the meta data
 

--- a/python/test/unit/spacewalk/satellite_tools/test_yum_src.py
+++ b/python/test/unit/spacewalk/satellite_tools/test_yum_src.py
@@ -19,6 +19,7 @@ import shutil
 import os
 import solv
 import unittest
+import pytest
 from urllib.parse import quote
 import xml.etree.ElementTree as etree
 try:
@@ -66,6 +67,10 @@ class YumSrcTest(unittest.TestCase):
         yum_src.ContentSource.setup_repo = real_setup_repo
 
         return cs
+
+    @pytest.fixture(autouse=True)
+    def set_temp_path(self, tmpdir):
+        self.tmpdir = tmpdir.strpath
 
     def setUp(self):
         patch('spacewalk.satellite_tools.repo_plugins.yum_src.fileutils.makedirs').start()
@@ -197,11 +202,13 @@ class YumSrcTest(unittest.TestCase):
     @patch("spacewalk.satellite_tools.repo_plugins.yum_src.etree.parse", MagicMock(side_effect=Exception))
     def test_mirror_list_arch(self):
         cs = self._make_dummy_cs()
+        fake_mirrorlist_file = self.tmpdir + "/mirrorlist.txt"
+        self.repo.root = self.tmpdir
         cs.channel_arch = "arch1"
         grabber_mock = Mock()
 
         with patch("spacewalk.satellite_tools.repo_plugins.yum_src.urlgrabber.urlgrab", grabber_mock):
-            with open(os.path.join(self.repo.root, "mirrorlist.txt"), "w") as fake_list:
+            with open(fake_mirrorlist_file, "w") as fake_list:
                 fake_list.writelines([
                     "http://host1/base/$basearch/os/\n",
                     "http://host2/base/$BASEARCH/os/\n",
@@ -222,6 +229,8 @@ class YumSrcTest(unittest.TestCase):
     @patch("spacewalk.satellite_tools.repo_plugins.yum_src.etree.parse", MagicMock(side_effect=Exception))
     def test_proxy_usage_with_mirrorlist(self):
         cs = self._make_dummy_cs()
+        fake_mirrorlist_file = self.tmpdir + "/mirrorlist.txt"
+        self.repo.root = self.tmpdir
         proxy_url = "http://proxy.example.com:8080"
         proxy_user = "user"
         proxy_pass = "pass"
@@ -237,11 +246,11 @@ class YumSrcTest(unittest.TestCase):
             ]
         for url in url_list:
             if "?" in url:
-                query = "&"
+                separator = "&"
             else:
-                query = "?"
+                separator = "?"
             expected_url_list.append("{}{}proxy={}&proxyuser={}&proxypass={}".format(url,
-                                                                                     query,
+                                                                                     separator,
                                                                                      quote(proxy_url),
                                                                                      proxy_user,
                                                                                      proxy_pass
@@ -249,7 +258,7 @@ class YumSrcTest(unittest.TestCase):
         grabber_mock = Mock()
 
         with patch("spacewalk.satellite_tools.repo_plugins.yum_src.urlgrabber.urlgrab", grabber_mock):
-            with open(os.path.join(self.repo.root, "mirrorlist.txt"), "w") as fake_list:
+            with open(fake_mirrorlist_file, "w") as fake_list:
                 fake_list.writelines([
                     "http://example/base/arch1/os/\n",
                     "http://example/\n",
@@ -262,13 +271,12 @@ class YumSrcTest(unittest.TestCase):
 
     def test_prep_zypp_repo_url_with_proxy(self):
         cs = self._make_dummy_cs()
-        url_list = ["http://example.com/",
-                    "https://example.com/",
-                    "https://example.org/repo/path/?token",
-                    "uln://example.com/",
-                    "uln:///channel"
-                    ]
-        uln_list = [False, False, False, True, True]
+        urls = [("http://example.com/", False),
+                ("https://example.com/", False),
+                ("https://example.org/repo/path/?token", False),
+                ("uln://example.com/", True),
+                ("uln:///channel", True)
+                ]
         proxy_url = "http://proxy.example.com:8080"
         proxy_user = "user"
         proxy_pass = "pass"
@@ -276,20 +284,20 @@ class YumSrcTest(unittest.TestCase):
         cs.proxy_user = proxy_user
         cs.proxy_pass = proxy_pass
 
-        for i in range(0, len(url_list)):
-            if uln_list[i] or "?" in url_list[i]:
-                query = "&"
+        for url, is_uln in urls:
+            if is_uln or "?" in url:
+                separator = "&"
             else:
-                query = "?"
+                separator = "?"
 
-            expected_url = "{}{}proxy={}&proxyuser={}&proxypass={}".format(url_list[i],
-                                                                           query,
+            expected_url = "{}{}proxy={}&proxyuser={}&proxypass={}".format(url,
+                                                                           separator,
                                                                            quote(proxy_url),
                                                                            proxy_user,
                                                                            proxy_pass
                                                                            )
 
-            comp_url = cs._prep_zypp_repo_url(url_list[i], uln_list[i])
+            comp_url = cs._prep_zypp_repo_url(url, is_uln)
 
             assert expected_url == comp_url
 


### PR DESCRIPTION
## What does this PR change?

Adds the configured proxy to the url when using mirrorlist in reposync

## GUI diff

No difference.

## Documentation

- No documentation needed: only internal and user invisible changes

## Test coverage

- [x] Added test for adding proxy to url
- [x] Added test for building the url correctly

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17493
Part of https://github.com/SUSE/spacewalk/issues/18523

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
