### PR TITLE
Fix for httpd container failing to build

### DIFF
--- a/containers/proxy-httpd-image/remove_unused.sh
+++ b/containers/proxy-httpd-image/remove_unused.sh
@@ -3,9 +3,6 @@
 
 set -xe
 
-# remove rpm-build and its dependencies
-rpm -e diffutils
-
 # remove perl and its dependencies
 rpm -e --nodeps perl
 
@@ -13,3 +10,4 @@ rpm -e --nodeps perl
 rm -rf /usr/share/locale
 
 zypper clean --all
+


### PR DESCRIPTION
## What does this PR change?

the httpd container failed to build at `remove_unused.sh` step. In a previous version we used to remove the `rpm-build` and its dependencies. Then we've decided to keep the `rpm-build` but the call to removing one of its dependencies stayed. I think we can safely remove it as well, since the zypper cache accounts for most of the used space in the image anyway. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests needed

- [x] **DONE**

## Links

Fixes #
Tracks # 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
