### PR TITLE
The PXE boot minion is now SLE 15 SP4

### DIFF
--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -82,10 +82,10 @@ Feature: PXE boot a terminal with Cobbler
     When I restart squid service on the proxy
 
   Scenario: PXE boot the PXE boot minion
-    Given I set the default PXE menu entry to the "target profile" on the "proxy"
+    Given I set the default PXE menu entry to the target profile on the "proxy"
     When I reboot the terminal "pxeboot_minion"
     And I wait for "60" seconds
-    And I set the default PXE menu entry to the "local boot" on the "proxy"
+    And I set the default PXE menu entry to the local boot on the "proxy"
     And I wait at most 1200 seconds until Salt master sees "pxeboot_minion" as "unaccepted"
     And I accept "pxeboot_minion" key in the Salt master
     And I am on the Systems page

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -616,7 +616,7 @@ When(/^I synchronize the tftp configuration on the proxy with the server$/) do
   raise 'cobbler sync failed' if out.include? 'Push failed'
 end
 
-When(/^I set the default PXE menu entry to the "([^"]*)" on the "([^"]*)"$/) do |entry, host|
+When(/^I set the default PXE menu entry to the (target profile|local boot) on the "([^"]*)"$/) do |entry, host|
   raise "This step doesn't support #{host}" unless ['server', 'proxy'].include? host
 
   node = get_target(host)
@@ -625,7 +625,7 @@ When(/^I set the default PXE menu entry to the "([^"]*)" on the "([^"]*)"$/) do 
   when 'local boot'
     script = "-e 's/^TIMEOUT .*/TIMEOUT 1/' -e 's/ONTIMEOUT .*/ONTIMEOUT local/'"
   when 'target profile'
-    script = "-e 's/^TIMEOUT .*/TIMEOUT 1/' -e 's/ONTIMEOUT .*/ONTIMEOUT 15-sp2-cobbler:1:SUSETest/'"
+    script = "-e 's/^TIMEOUT .*/TIMEOUT 1/' -e 's/ONTIMEOUT .*/ONTIMEOUT 15-sp4-cobbler:1:SUSETest/'"
   end
   node.run("sed -i #{script} #{target}")
 end


### PR DESCRIPTION
## What does this PR change?

This PR fixes the Cobbler tests. The PXE boot minion could not choose a SLE 15 SP2 entry in the boot menu that did not exist anymore.

It also removes quotes around something that is not a "string variable" but part of the step's name.


## Links

No ports, Uyuni and 4.3 only.


## Changelogs

- [x] No changelog needed
