### PR TITLE
Remove obsolete XML tags from cobbler profile

### DIFF
--- a/testsuite/features/upload_files/sle-15-sp4-autoyast.xml
+++ b/testsuite/features/upload_files/sle-15-sp4-autoyast.xml
@@ -27,7 +27,9 @@
   <general>
 $SNIPPET('spacewalk/sles_no_signature_checks')
 <mode><confirm config:type="boolean">false</confirm></mode>
-<storage><partition_alignment config:type="symbol">align_optimal</partition_alignment><start_multipath config:type="boolean">false</start_multipath></storage>
+<storage>
+  <start_multipath config:type="boolean">false</start_multipath>
+</storage>
 </general>
   <partitioning config:type="list">
     <drive>
@@ -51,7 +53,6 @@ $SNIPPET('spacewalk/sles_no_signature_checks')
     </dns>
   </networking>
   <software>
-    <image/>
     <install_recommended config:type="boolean">true</install_recommended>
     <instsource/>
     <packages config:type="list">


### PR DESCRIPTION
## What does this PR change?

This PR removes obsolete XML tags from SLE 15 SP4 cobbler profile.

See https://bugzilla.suse.com/show_bug.cgi?id=1201600.


## Links

No ports, Uyuni/4.3 only.


## Changelogs

- [x] No changelog needed
