### PR TITLE
Ci add label to pr if translation is needed

### DIFF
--- a/.github/workflows/check_translations.yml
+++ b/.github/workflows/check_translations.yml
@@ -1,0 +1,22 @@
+name: Check if translation is required
+
+on: [pull_request_target]
+
+jobs:
+  run:
+    name: Check by trying to locally update translation files 
+    if: github.repository == 'uyuni-project/uyuni'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.8.0
+      with:
+        access_token: ${{ github.token }}
+    - name: Add label
+      uses: actions-ecosystem/action-add-labels@v1
+      with:
+        labels: needs-translation
+        github_token: "${{ secrets.GITHUB_TOKEN }}"
+
+
+


### PR DESCRIPTION
## What does this PR change?

Add a label to the Pull Request if a translation is needed.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed

- [ ] **DONE**

## Test coverage
- No tests



- [ ] **DONE**

## Links


- [ ] **DONE**

## Changelogs



- [X] No changelog needed




## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
