### PR TITLE
Fix migration of image actions (bsc#1202272)

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Fix migration of image actions (bsc#1202272)
 - Add Rocky Linux 9 and EPEL 9 key
 - improve schema compatibility with Amazon RDS
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.0-to-susemanager-schema-4.4.1/200-fix-rhnActionImage-null.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.0-to-susemanager-schema-4.4.1/200-fix-rhnActionImage-null.sql
@@ -1,0 +1,2 @@
+ALTER TABLE rhnActionImageBuild ALTER COLUMN image_profile_id DROP NOT NULL;
+ALTER TABLE rhnActionImageInspect ALTER COLUMN image_store_id DROP NOT NULL;


### PR DESCRIPTION
## What does this PR change?

The schema migration in https://github.com/uyuni-project/uyuni/pull/4404 is not correct, 
"NOT NULL" must be explicitly dropped.

## GUI diff

No difference.


## Documentation
- No documentation needed: bugfix

## Test coverage
- No tests: schema migration tests do not catch this, not sure why.

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18574
https://bugzilla.suse.com/show_bug.cgi?id=1202272

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
