### PR TITLE
Update expected state after disabling monitoring

### DIFF
--- a/testsuite/features/secondary/srv_monitoring.feature
+++ b/testsuite/features/secondary/srv_monitoring.feature
@@ -26,8 +26,8 @@ Feature: Disable and re-enable monitoring of the server
     And I should see a list item with text "System" and a failing bullet
     And I should see a list item with text "PostgreSQL database" and a failing bullet
     And I should see a list item with text "Server self monitoring" and a warning bullet
-    And I should see a list item with text "Taskomatic (Java JMX)" and a failing bullet
-    And I should see a list item with text "Tomcat (Java JMX)" and a failing bullet
+    And I should see a list item with text "Taskomatic (Java JMX)" and a warning bullet
+    And I should see a list item with text "Tomcat (Java JMX)" and a warning bullet
     And I should see a "Restarting Tomcat and Taskomatic is needed for the configuration changes to take effect." text
 
   Scenario: Restart spacewalk services to apply config changes after disabling monitoring


### PR DESCRIPTION


## What does this PR change?

After disabling monitoring Tomcat and Taskomatic services have to be
restarted. Accordingly the warning is displayed which should be checked
as the expected state.


## GUI diff

No difference.

## Documentation
- No documentation needed: changed test scenario only.

## Test coverage
- No tests: already covered

## Links

Depends-On: uyuni-project/sumaform#1133

## Changelogs

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
