### PR TITLE
Action Chain: reboot on transactional update minions

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
@@ -35,7 +35,6 @@ import java.util.Set;
 public class MinionServer extends Server implements SaltConfigurable {
 
     private String minionId;
-    private String osFamily;
     private String kernelLiveVersion;
     private Integer sshPushPort;
     private Set<AccessToken> accessTokens = new HashSet<>();
@@ -70,24 +69,6 @@ public class MinionServer extends Server implements SaltConfigurable {
      */
     public void setMinionId(String minionIdIn) {
         this.minionId = minionIdIn;
-    }
-
-    /**
-     * Getter for os family
-     *
-     * @return String to get
-     */
-    public String getOsFamily() {
-        return this.osFamily;
-    }
-
-    /**
-     * Setter for os family
-     *
-     * @param osFamilyIn to set
-     */
-    public void setOsFamily(String osFamilyIn) {
-        this.osFamily = osFamilyIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/MinionSummary.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionSummary.java
@@ -33,6 +33,7 @@ public class MinionSummary {
     private String machineId;
     private String os;
     private Optional<String> contactMethodLabel;
+    private Boolean transactionalUpdate;
 
     /**
      * Convenience constructor from a MinionServer instance.
@@ -41,7 +42,8 @@ public class MinionSummary {
      */
     public MinionSummary(MinionServer minion) {
         this(minion.getId(), minion.getMinionId(), minion.getDigitalServerId(),
-                minion.getMachineId(), minion.getContactMethodLabel(), minion.getOs());
+                minion.getMachineId(), minion.getContactMethodLabel(), minion.getOs(),
+                minion.doesOsSupportsTransactionalUpdate());
     }
 
     /**
@@ -56,13 +58,40 @@ public class MinionSummary {
      */
     public MinionSummary(Long serverIdIn, String minionIdIn, String digitalServerIdIn, String machineIdIn,
             Optional<String> contactMethodLabelIn, String osIn) {
+        this(serverIdIn, minionIdIn, digitalServerIdIn, machineIdIn, contactMethodLabelIn, osIn,
+                ServerConstants.SLEMICRO.equals(osIn) ? true : false);
+    }
+
+    /**
+     * Standard constructor.
+     *
+     * @param serverIdIn the server id
+     * @param minionIdIn the minion id
+     * @param digitalServerIdIn the digital server id
+     * @param machineIdIn the machine id
+     * @param contactMethodLabelIn the contact method label
+     * @param osIn the minion os
+     * @param transactionalUpdateIn if minion supports transactional update
+
+     */
+    public MinionSummary(Long serverIdIn, String minionIdIn, String digitalServerIdIn, String machineIdIn,
+            Optional<String> contactMethodLabelIn, String osIn, Boolean transactionalUpdateIn) {
         this.serverId = serverIdIn;
         this.minionId = minionIdIn;
         this.digitalServerId = digitalServerIdIn;
         this.machineId = machineIdIn;
         this.contactMethodLabel = contactMethodLabelIn;
         this.os = osIn;
+        this.transactionalUpdate = transactionalUpdateIn;
     }
+
+    /**
+     * @return true is minion is transactiona update
+     */
+    public Boolean isTransactionalUpdate() {
+        return transactionalUpdate;
+    }
+
 
     /**
      * @return the minion os

--- a/java/code/src/com/redhat/rhn/domain/server/Server.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Server.java
@@ -88,6 +88,7 @@ public class Server extends BaseDomainHelper implements Identifiable {
     private Org org;
     private String digitalServerId;
     private String os;
+    private String osFamily;
     private String release;
     private String name;
     private String description;
@@ -624,22 +625,6 @@ public class Server extends BaseDomainHelper implements Identifiable {
      */
     public String getOs() {
         return this.os;
-    }
-
-    /**
-     * Disabled for non-minions servers. @see com.redhat.rhn.domain.server.MinionServer
-     * @return <code>false</code>.
-     */
-    public boolean doesOsSupportsContainerization() {
-        return false;
-    }
-
-    /**
-     * Disabled for non-minions servers. @see com.redhat.rhn.domain.server.MinionServer
-     * @return <code>false</code>.
-     */
-    public boolean doesOsSupportsOSImageBuilding() {
-        return false;
     }
 
     /**
@@ -2191,14 +2176,6 @@ public class Server extends BaseDomainHelper implements Identifiable {
     }
 
     /**
-     * Whether server supports monitoring or not.
-     * @return false per default
-     */
-    public boolean doesOsSupportsMonitoring() {
-        return false;
-    }
-
-    /**
      *
      * @return payg
      */
@@ -2290,4 +2267,159 @@ public class Server extends BaseDomainHelper implements Identifiable {
     public PackageType getPackageType() {
         return getServerArch().getArchType().getPackageType();
     }
+
+    /**
+     * Return <code>true</code> if OS on this system supports OS Image building,
+     * <code>false</code> otherwise.
+     *
+     * @return <code>true</code> if OS supports OS Image building
+     */
+    public boolean doesOsSupportsOSImageBuilding() {
+        return isSLES11() || isSLES12() || isSLES15() || isLeap15();
+    }
+
+    /**
+     * Return <code>true</code> if OS on this system supports Containerization,
+     * <code>false</code> otherwise.
+     * <p>
+     * Note: For SLES, we are only checking if it's not 10 nor 11.
+     * Older than SLES 10 are not being checked.
+     * </p>
+     *
+     * @return <code>true</code> if OS supports Containerization
+     */
+    public boolean doesOsSupportsContainerization() {
+        return !isSLES10() && !isSLES11();
+    }
+
+    /**
+     * Return <code>true</code> if OS on this system supports Transactional Update,
+     * <code>false</code> otherwise.
+     *
+     * @return <code>true</code> if OS supports Transactional Update
+     */
+    public boolean doesOsSupportsTransactionalUpdate() {
+        return isSLEMicro();
+    }
+
+    /**
+     * Return <code>true</code> if OS on supports monitoring
+     * <code>false</code> otherwise.
+     *
+     * @return <code>true</code> if OS supports monitoring
+     */
+    public boolean doesOsSupportsMonitoring() {
+        return isSLES12() || isSLES15() || isLeap15() || isUbuntu1804() || isUbuntu2004() || isUbuntu2204() ||
+                isRedHat6() || isRedHat7() || isRedHat8() || isAlibaba2() || isAmazon2() || isRocky8() ||
+                isRocky9() || isDebian11() || isDebian10();
+    }
+
+    /**
+     * @return true if the installer type is of SLES 10
+     */
+    private boolean isSLES10() {
+        return ServerConstants.SLES.equals(getOs()) && getRelease().startsWith("10");
+    }
+
+    /**
+     * @return true if the installer type is of SLES 11
+     */
+    private boolean isSLES12() {
+        return ServerConstants.SLES.equals(getOs()) && getRelease().startsWith("12");
+    }
+
+    /**
+     * @return true if the installer type is of SLES 11
+     */
+    private boolean isSLES11() {
+        return ServerConstants.SLES.equals(getOs()) && getRelease().startsWith("11");
+    }
+
+    /**
+     * @return true if the installer type is of SLE Micro
+     */
+    private boolean isSLEMicro() {
+        return ServerConstants.SLEMICRO.equals(getOs());
+    }
+
+    /**
+     * @return true if the installer type is of SLES 15
+     */
+    private boolean isSLES15() {
+        return ServerConstants.SLES.equals(getOs()) && getRelease().startsWith("15");
+    }
+
+    private boolean isLeap15() {
+        return ServerConstants.LEAP.equalsIgnoreCase(getOs()) && getRelease().startsWith("15");
+    }
+
+    private boolean isUbuntu1804() {
+        return ServerConstants.UBUNTU.equals(getOs()) && getRelease().equals("18.04");
+    }
+
+    private boolean isUbuntu2004() {
+        return ServerConstants.UBUNTU.equals(getOs()) && getRelease().equals("20.04");
+    }
+
+    private boolean isUbuntu2204() {
+        return ServerConstants.UBUNTU.equals(getOs()) && getRelease().equals("22.04");
+    }
+
+    private boolean isDebian11() {
+        return ServerConstants.DEBIAN.equals(getOs()) && getRelease().equals("11");
+    }
+
+    private boolean isDebian10() {
+        return ServerConstants.DEBIAN.equals(getOs()) && getRelease().equals("10");
+    }
+
+    /**
+     * This is supposed to cover all RedHat flavors (incl. RHEL, RES and CentOS Linux)
+     */
+    private boolean isRedHat6() {
+        return ServerConstants.REDHAT.equals(getOsFamily()) && getRelease().equals("6");
+    }
+
+    private boolean isRedHat7() {
+        return ServerConstants.REDHAT.equals(getOsFamily()) && getRelease().equals("7");
+    }
+
+    private boolean isRedHat8() {
+        return ServerConstants.REDHAT.equals(getOsFamily()) && getRelease().equals("8");
+    }
+
+    private boolean isAlibaba2() {
+        return ServerConstants.ALIBABA.equals(getOs());
+    }
+
+    private boolean isAmazon2() {
+        return ServerConstants.AMAZON.equals(getOsFamily()) && getRelease().equals("2");
+    }
+
+    private boolean isRocky8() {
+        return ServerConstants.ROCKY.equals(getOs()) && getRelease().startsWith("8.");
+    }
+
+    private boolean isRocky9() {
+        return ServerConstants.ROCKY.equals(getOs()) && getRelease().startsWith("9.");
+    }
+
+    /**
+     * Getter for os family
+     *
+     * @return String to get
+     */
+    public String getOsFamily() {
+        return this.osFamily;
+    }
+
+    /**
+     * Setter for os family
+     *
+     * @param osFamilyIn to set
+     */
+    public void setOsFamily(String osFamilyIn) {
+        this.osFamily = osFamilyIn;
+    }
+
 }

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -161,6 +161,7 @@ import com.suse.utils.Opt;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 
@@ -757,8 +758,7 @@ public class SaltServerActionService {
                                 rebootServerAction.ifPresentOrElse(
                                         ract -> {
                                             if (ract.getStatus().equals(ActionFactory.STATUS_QUEUED)) {
-                                                rebootServerAction.get().setStatus(ActionFactory.STATUS_PICKED_UP);
-                                                rebootServerAction.get().setPickupTime(new Date());
+                                                setActionAsPickedUp(ract);
                                             }
                                         },
                                         () -> LOG.error("Action of type {} found in action chain result but not " +
@@ -2537,9 +2537,9 @@ public class SaltServerActionService {
                             saltUtils.updateServerAction(sa, 0L, true, "n/a", jsonResult,
                                     Optional.of(Xor.right(function)));
                         }
+
                         else if (sa.getStatus().equals(ActionFactory.STATUS_QUEUED)) {
-                            sa.setStatus(ActionFactory.STATUS_PICKED_UP);
-                            sa.setPickupTime(new Date());
+                            setActionAsPickedUp(sa);
                         }
 
                         // Perform a "check-in" after every executed action
@@ -2635,6 +2635,18 @@ public class SaltServerActionService {
     }
 
     /**
+     * In action chains at this point the action is still queued so we have
+     * to set it to picked up.
+     * This could still lead to the race condition on when event processing is slow.
+     *
+     */
+    private void setActionAsPickedUp(ServerAction sa) {
+        sa.setStatus(ActionFactory.STATUS_PICKED_UP);
+        sa.setPickupTime(new Date());
+        return;
+    }
+
+    /**
      * Update the action properly based on the Job results from Salt.
      *
      * @param actionId the ID of the Action to handle
@@ -2669,16 +2681,12 @@ public class SaltServerActionService {
                         LOG.debug("Updating action for server: {}", minionServer.getId());
                     }
                     try {
-                        // Reboot has been scheduled so set reboot action to PICKED_UP.
-                        // Wait until next "minion/start/event" to set it to COMPLETED.
-                        if (action.get().getActionType().equals(ActionFactory.TYPE_REBOOT) &&
-                                success && retcode == 0) {
-                            // In action chains at this point the action is still queued so we have
-                            // to set it to picked up.
-                            // This could still lead to the race condition on when event processing is slow.
+                        if (action.get().getActionType().equals(
+                                ActionFactory.TYPE_REBOOT) && success && retcode == 0) {
+                            // Reboot has been scheduled so set reboot action to PICKED_UP.
+                            // Wait until next "minion/start/event" to set it to COMPLETED.
                             if (sa.getStatus().equals(ActionFactory.STATUS_QUEUED)) {
-                                sa.setStatus(ActionFactory.STATUS_PICKED_UP);
-                                sa.setPickupTime(new Date());
+                                setActionAsPickedUp(sa);
                             }
                             return;
                         }
@@ -2724,6 +2732,34 @@ public class SaltServerActionService {
         }
     }
 
+    private boolean checkIfRebootRequired(StateApplyResult<Ret<JsonElement>> actionStateApply) {
+        JsonElement ret = actionStateApply.getChanges().getRet();
+        if (!ret.isJsonObject()) {
+            return false;
+        }
+
+        JsonPrimitive prim = ret.getAsJsonObject().getAsJsonPrimitive("reboot_required");
+        if (!prim.isBoolean()) {
+            return false;
+
+        }
+        return prim.getAsBoolean();
+    }
+
+    private long checkActionID(StateApplyResult<Ret<JsonElement>> actionStateApply) {
+        JsonElement ret = actionStateApply.getChanges().getRet();
+        if (!ret.isJsonObject()) {
+            return 0;
+        }
+
+        JsonPrimitive prim = ret.getAsJsonObject().getAsJsonPrimitive("current_action_id");
+        if (!prim.isNumber()) {
+            return 0;
+
+        }
+        return prim.getAsLong();
+    }
+
     /**
      * Handle action chain Salt result.
      *
@@ -2737,7 +2773,7 @@ public class SaltServerActionService {
             Map<String, StateApplyResult<Ret<JsonElement>>> actionChainResult,
             Function<StateApplyResult<Ret<JsonElement>>, Boolean> skipFunction) {
         int chunk = 1;
-        Long retActionChainId = null;
+        Long retActionChainId = Long.valueOf(0);
         boolean actionChainFailed = false;
         List<Long> failedActionIds = new ArrayList<>();
         for (Map.Entry<String, StateApplyResult<Ret<JsonElement>>> entry : actionChainResult.entrySet()) {
@@ -2767,6 +2803,36 @@ public class SaltServerActionService {
                         jobId,
                         actionStateApply.getChanges().getRet(),
                         actionStateApply.getName());
+            }
+            else if (key.contains("schedule_next_chunk") && checkIfRebootRequired(actionStateApply) &&
+                    checkActionID(actionStateApply) != 0) {
+                /*
+                 * Transactional update does not contains reboot in sls files, but apply a reboot using
+                 * activate_transaction=True in transactional_update.sls . So it's required to parse the return
+                 * to check if schedule_next_chunk contains reboot_required param, then we can suppose that
+                 * the next action is a reboot. Then we need to pick up the action.
+                 */
+
+                long actionId = checkActionID(actionStateApply);
+                Optional<MinionServer> minionServerOpt = MinionServerFactory.findByMinionId(minionId);
+
+                minionServerOpt.ifPresent(minionServer -> {
+
+                        final Optional<Action> action  = Optional.ofNullable(ActionFactory.lookupById(actionId));
+                        if (action.isPresent()) {
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("Matched salt job with action (id={})", actionId);
+                            }
+                        Optional<ServerAction> serverAction = action.get()
+                                .getServerActions()
+                                .stream()
+                                .filter(sa -> sa.getServer().equals(minionServer)).findFirst();
+
+                        serverAction.ifPresent(sa -> {
+                            setActionAsPickedUp(sa);
+                        });
+                    }
+                });
             }
             else if (!key.contains("schedule_next_chunk")) {
                 LOG.warn("Could not find action id in action chain state key: {}", key);

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -2767,7 +2767,7 @@ public class SaltServerActionService {
         }
 
         JsonPrimitive prim = obj.getAsJsonPrimitive("current_action_id");
-        if (!prim.isNumber()) {
+        if (prim == null || !prim.isNumber()) {
             return 0;
 
         }

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -970,29 +970,36 @@ public class SaltServerActionService {
             switch(fun) {
                 case "state.apply":
                     List<String> mods = (List<String>)kwargs.get("mods");
+                    if (CollectionUtils.isEmpty(mods)) {
+                        if (minion.isSshPush()) {
+                            // Apply highstate using a custom top.
+                            // The custom top is needed because salt-ssh invokes
+                            // "salt-call --local" and this needs a top file in order to apply the highstate
+                            // and salt-ssh doesn't pack one automatically in the state tarball
+                            return new SaltModuleRun(stateId,
+                                    "state.top",
+                                    serverAction.getParentAction().getId(),
+                                    singletonMap("topfn",
+                                            saltActionChainGeneratorService
+                                                    .getActionChainTopPath(actionChainId,
+                                                            serverAction.getParentAction().getId())),
+                                    emptyMap());
+                        }
+                        else {
+                            return new SaltModuleRun(stateId,
+                                    "state.apply",
+                                    serverAction.getParentAction().getId(),
+                                    emptyMap(),
+                                    createStateApplyKwargs(kwargs));
+                        }
 
-                    if (minion.isSshPush() && CollectionUtils.isEmpty(mods)) {
-                        // Apply highstate using a custom top.
-                        // The custom top is needed because salt-ssh invokes
-                        // "salt-call --local" and this needs a top file in order to apply the highstate
-                        // and salt-ssh doesn't pack one automatically in the state tarball
-                        return new SaltModuleRun(stateId,
-                                "state.top",
-                                serverAction.getParentAction().getId(),
-                                singletonMap("topfn",
-                                        saltActionChainGeneratorService
-                                        .getActionChainTopPath(actionChainId,
-                                                serverAction.getParentAction().getId())),
-                                emptyMap());
                     }
-                    else {
-                        return new SaltModuleRun(stateId,
-                                "state.apply",
-                                        serverAction.getParentAction().getId(),
-                                        !mods.isEmpty() ?
-                                                singletonMap("mods", mods) : emptyMap(),
-                                                createStateApplyKwargs(kwargs));
-                    }
+                    return new SaltModuleRun(stateId,
+                            "state.apply",
+                            serverAction.getParentAction().getId(),
+                            !mods.isEmpty() ?
+                                    singletonMap("mods", mods) : emptyMap(),
+                            createStateApplyKwargs(kwargs));
                 case "system.reboot":
                     Integer time = (Integer)kwargs.get("at_time");
                     return new SaltSystemReboot(stateId,

--- a/java/code/src/com/suse/manager/webui/services/test/SaltActionChainGeneratorServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltActionChainGeneratorServiceTest.java
@@ -264,6 +264,8 @@ public class SaltActionChainGeneratorServiceTest extends BaseTestCaseWithUser {
                         "schedule_next_chunk:\n" +
                         "    mgrcompat.module_run:\n" +
                         "    -   name: mgractionchains.clean\n" +
+                        "    -   actionchain_id: 131\n" +
+                        "    -   current_action_id: 2\n" +
                         "    -   reboot_required: true\n")
                         .replaceAll("131", actionChain.getId() + ""),
                 fileContent);
@@ -335,6 +337,7 @@ public class SaltActionChainGeneratorServiceTest extends BaseTestCaseWithUser {
                         "    -   actionchain_id: 131\n" +
                         "    -   chunk: 2\n" +
                         "    -   next_action_id: 3\n" +
+                        "    -   current_action_id: 2\n" +
                         "    -   reboot_required: true\n" +
                         "    -   require:\n" +
                         "        -   mgrcompat: mgr_actionchain_131_action_1_chunk_1\n")

--- a/java/code/src/com/suse/manager/webui/services/test/SaltActionChainGeneratorServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltActionChainGeneratorServiceTest.java
@@ -27,6 +27,7 @@ import com.redhat.rhn.domain.action.ActionChain;
 import com.redhat.rhn.domain.action.ActionChainFactory;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionSummary;
+import com.redhat.rhn.domain.server.ServerConstants;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
@@ -206,6 +207,150 @@ public class SaltActionChainGeneratorServiceTest extends BaseTestCaseWithUser {
                 "    mgrcompat.module_run:\n" +
                 "    -   name: state.apply\n").replaceAll("131", actionChain.getId() + ""), fileContent);
     }
+
+    @Test
+    public void testCreateActionChainSLSFilesOneChunksTransactionalUpdate() throws Exception {
+        String label = TestUtils.randomString();
+
+        ActionChain actionChain = ActionChainFactory.createActionChain(label, user);
+
+        MinionServer minion1 = MinionServerFactoryTest.createTestMinionServer(user);
+        minion1.setOs(ServerConstants.SLEMICRO);
+        MinionSummary minionSummary1 = new MinionSummary(minion1);
+
+        SystemManager.giveCapability(minion1.getId(), SystemManager.CAP_SCRIPT_RUN, 1L);
+
+        List<SaltState> states = new ArrayList<>();
+        states.add(new SaltModuleRun(
+                ACTION_STATE_ID_PREFIX + actionChain.getId() + "_action_" + 1,
+                "state.apply",
+                1,
+                singletonMap("mods", "remotecommands"),
+                singletonMap("pillar",
+                        // Use a TreeMap to keep the keys order or they may break the assert
+                        new TreeMap<String, String>() {{
+                                put("mgr_remote_cmd_script", "salt://scripts/script_1.sh");
+                                put("mgr_remote_cmd_runas", "foobar");
+                        }}
+                )
+        ));
+        states.add(new SaltSystemReboot(
+                ACTION_STATE_ID_PREFIX + actionChain.getId() + "_action_" + 2,
+                2,
+                1
+        ));
+
+        Path stateFilesRoot = Files.createTempDirectory("actionchaingentest");
+
+        SaltActionChainGeneratorService service = new SaltActionChainGeneratorService();
+        service.setSuseManagerStatesFilesRoot(stateFilesRoot);
+        service.setSkipSetOwner(true);
+        service.createActionChainSLSFiles(actionChain, minionSummary1, states, Optional.empty());
+
+        String fileContent = FileUtils
+                .readFileToString(stateFilesRoot
+                        .resolve(ACTIONCHAIN_SLS_FOLDER)
+                        .resolve(service
+                                .getActionChainSLSFileName(actionChain.getId(), minionSummary1, 1))
+                        .toFile());
+        assertEquals(("mgr_actionchain_131_action_1_chunk_1:\n" +
+                        "    mgrcompat.module_run:\n" +
+                        "    -   name: state.apply\n" +
+                        "    -   mods: remotecommands\n" +
+                        "    -   kwargs:\n" +
+                        "            pillar:\n" +
+                        "                mgr_remote_cmd_runas: foobar\n" +
+                        "                mgr_remote_cmd_script: salt://scripts/script_1.sh\n" +
+                        "schedule_next_chunk:\n" +
+                        "    mgrcompat.module_run:\n" +
+                        "    -   name: mgractionchains.clean\n" +
+                        "    -   reboot_required: true\n")
+                        .replaceAll("131", actionChain.getId() + ""),
+                fileContent);
+    }
+
+    @Test
+    public void testCreateActionChainSLSFilesTwoChunksTransactionalUpdate() throws Exception {
+        String label = TestUtils.randomString();
+
+        ActionChain actionChain = ActionChainFactory.createActionChain(label, user);
+
+        MinionServer minion1 = MinionServerFactoryTest.createTestMinionServer(user);
+        minion1.setOs(ServerConstants.SLEMICRO);
+        MinionSummary minionSummary1 = new MinionSummary(minion1);
+
+        SystemManager.giveCapability(minion1.getId(), SystemManager.CAP_SCRIPT_RUN, 1L);
+
+        List<SaltState> states = new ArrayList<>();
+        states.add(new SaltModuleRun(
+                ACTION_STATE_ID_PREFIX + actionChain.getId() + "_action_" + 1,
+                "state.apply",
+                1,
+                singletonMap("mods", "remotecommands"),
+                singletonMap("pillar",
+                        // Use a TreeMap to keep the keys order or they may break the assert
+                        new TreeMap<String, String>() {{
+                                put("mgr_remote_cmd_script", "salt://scripts/script_1.sh");
+                                put("mgr_remote_cmd_runas", "foobar");
+                        }}
+                )
+        ));
+        states.add(new SaltSystemReboot(
+                ACTION_STATE_ID_PREFIX + actionChain.getId() + "_action_" + 2,
+                2,
+                1
+        ));
+        states.add(new SaltModuleRun(
+                ACTION_STATE_ID_PREFIX + actionChain.getId() + "_action_" + 3,
+                "state.apply",
+                3,
+                null,
+                null
+        ));
+
+        Path stateFilesRoot = Files.createTempDirectory("actionchaingentest");
+
+        SaltActionChainGeneratorService service = new SaltActionChainGeneratorService();
+        service.setSuseManagerStatesFilesRoot(stateFilesRoot);
+        service.setSkipSetOwner(true);
+        service.createActionChainSLSFiles(actionChain, minionSummary1, states, Optional.empty());
+
+        String fileContent = FileUtils
+                .readFileToString(stateFilesRoot
+                        .resolve(ACTIONCHAIN_SLS_FOLDER)
+                        .resolve(service
+                                .getActionChainSLSFileName(actionChain.getId(), minionSummary1, 1))
+                        .toFile());
+        assertEquals(("mgr_actionchain_131_action_1_chunk_1:\n" +
+                        "    mgrcompat.module_run:\n" +
+                        "    -   name: state.apply\n" +
+                        "    -   mods: remotecommands\n" +
+                        "    -   kwargs:\n" +
+                        "            pillar:\n" +
+                        "                mgr_remote_cmd_runas: foobar\n" +
+                        "                mgr_remote_cmd_script: salt://scripts/script_1.sh\n" +
+                        "schedule_next_chunk:\n" +
+                        "    mgrcompat.module_run:\n" +
+                        "    -   name: mgractionchains.next\n" +
+                        "    -   actionchain_id: 131\n" +
+                        "    -   chunk: 2\n" +
+                        "    -   next_action_id: 3\n" +
+                        "    -   reboot_required: true\n" +
+                        "    -   require:\n" +
+                        "        -   mgrcompat: mgr_actionchain_131_action_1_chunk_1\n")
+                        .replaceAll("131", actionChain.getId() + ""),
+                fileContent);
+        fileContent = FileUtils
+                .readFileToString(stateFilesRoot
+                        .resolve(ACTIONCHAIN_SLS_FOLDER)
+                        .resolve(service
+                                .getActionChainSLSFileName(actionChain.getId(), minionSummary1, 2))
+                        .toFile());
+        assertEquals(("mgr_actionchain_131_action_3_chunk_2:\n" +
+                "    mgrcompat.module_run:\n" +
+                "    -   name: state.apply\n").replaceAll("131", actionChain.getId() + ""), fileContent);
+    }
+
 
     @Test
     public void testCreateActionChainSLSFilesSaltUpgrade() throws Exception {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Manage reboot in transactional update action chain (bsc#1201476)
 - In an action chain, use transactional.apply instead of state.apply
   in transactional update minions (bsc#1201476)
 - Enable monitoring for RHEL 9 Salt clients

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- In an action chain, use transactional.apply instead of state.apply
+  in transactional update minions (bsc#1201476)
 - Enable monitoring for RHEL 9 Salt clients
 - Optimize performance of config channels operations for UI and API (bsc#1204029)
 - Don't add the same channel twice in the System config addChannel API (bsc#1204029)

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,6 +1,4 @@
 - Manage reboot in transactional update action chain (bsc#1201476)
-- In an action chain, use transactional.apply instead of state.apply
-  in transactional update minions (bsc#1201476)
 - Enable monitoring for RHEL 9 Salt clients
 - Optimize performance of config channels operations for UI and API (bsc#1204029)
 - Don't add the same channel twice in the System config addChannel API (bsc#1204029)

--- a/susemanager-utils/susemanager-sls/src/modules/mgractionchains.py
+++ b/susemanager-utils/susemanager-sls/src/modules/mgractionchains.py
@@ -145,15 +145,16 @@ def start(actionchain_id):
     except Exception as exc:
         log.error("There was an error while syncing custom states and execution modules")
 
+    transactional_update = __grains__.get("transactional")
     reboot_required = False
     inside_transaction = False
-    if __grains__.get("transactional"):
+    if transactional_update:
         reboot_required = check_reboot_required(target_sls)
         inside_transaction = os.environ.get("TRANSACTIONAL_UPDATE")
 
-    if __grains__.get("transactional") and reboot_required:
+    if transactional_update and reboot_required:
         ret = __salt__['transactional_update.sls'](target_sls, queue=True, activate_transaction=True)
-    elif __grains__.get("transactional") and not inside_transaction:
+    elif transactional_update and not inside_transaction:
         ret = __salt__['transactional_update.sls'](target_sls, queue=True)
     else:
         ret = __salt__['state.sls'](target_sls, queue=True)
@@ -220,15 +221,16 @@ def resume():
     log.debug("Resuming execution of SUSE Manager Action Chain -> Target SLS: "
               "{0}".format(next_chunk))
     
+    transactional_update = __grains__.get("transactional")
     reboot_required = False
     inside_transaction = False
-    if __grains__.get("transactional"):
+    if transactional_update:
         reboot_required = yaml_file.get('reboot_required')
         inside_transaction = os.environ.get("TRANSACTIONAL_UPDATE")
 
-    if __grains__.get("transactional") and reboot_required:
+    if transactional_update and reboot_required:
         ret =  __salt__['transactional_update.sls'](next_chunk, queue=True, activate_transaction=True)
-    elif __grains__.get("transactional") and not inside_transaction:
+    elif transactional_update and not inside_transaction:
         ret =  __salt__['transactional_update.sls'](next_chunk, queue=True)
     else:
         ret = __salt__['state.sls'](next_chunk, queue=True)

--- a/susemanager-utils/susemanager-sls/src/modules/mgractionchains.py
+++ b/susemanager-utils/susemanager-sls/src/modules/mgractionchains.py
@@ -162,7 +162,7 @@ def start(actionchain_id):
         raise CommandExecutionError(ret)
     return ret
 
-def next(actionchain_id, chunk, next_action_id=None, ssh_extra_filerefs=None, reboot_required=False):
+def next(actionchain_id, chunk, next_action_id=None, current_action_id=None,  ssh_extra_filerefs=None, reboot_required=False):
     '''
     Persist the next Action Chain chunk to be executed by the 'resume' method.
 
@@ -178,13 +178,17 @@ def next(actionchain_id, chunk, next_action_id=None, ssh_extra_filerefs=None, re
     yaml_dict = {
         'next_chunk': _calculate_sls(actionchain_id, __grains__['machine_id'], chunk)
     }
+    yaml_dict['actionchain_id'] = actionchain_id
     if next_action_id:
         yaml_dict['next_action_id'] = next_action_id
+    if current_action_id:
+        yaml_dict['current_action_id'] = current_action_id
     if ssh_extra_filerefs:
         yaml_dict['ssh_extra_filerefs'] = ssh_extra_filerefs
     if reboot_required:
         yaml_dict['reboot_required'] = reboot_required
     _persist_next_ac_chunk(yaml_dict)
+    return yaml_dict
 
 def get_pending_resume():
     '''
@@ -233,9 +237,17 @@ def resume():
         raise CommandExecutionError(ret)
     return ret
 
-def clean():
+def clean(actionchain_id=None, current_action_id=None, reboot_required=None):
     '''
     Clean execution of an Action Chain by removing '_mgractionchains.conf'.
     '''
     _read_next_ac_chunk()
-    return {"success": True}
+    yaml_dict = {}
+    yaml_dict['success'] = True
+    if actionchain_id:
+        yaml_dict['actionchain_id'] = actionchain_id
+    if current_action_id:
+        yaml_dict['current_action_id'] = current_action_id
+    if reboot_required:
+        yaml_dict['reboot_required'] = reboot_required
+    return yaml_dict

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Manager reboot in transactional update action chain (bsc#1201476)
 - Fix kiwi inspect regexp to allow image names with "-" (bsc#1204541)
 - Use the actual sudo user home directory for salt ssh
   clients on bootstrap and clean up (bsc#1202093)

--- a/testsuite/features/reposync/srv_add_rocky8_repositories.feature
+++ b/testsuite/features/reposync/srv_add_rocky8_repositories.feature
@@ -7,109 +7,107 @@ Feature: Add the Rocky 8 distribution custom repositories
   As a SUSE Manager administrator
   I want to filter them out to remove the modules information
 
-  Scenario: Download the iso of Rocky 8 DVD and mount it on the server
-    When I mount as "rocky-8-iso" the ISO from "http://minima-mirror.mgr.suse.de/pub/rocky/8/isos/x86_64/Rocky-x86_64-dvd.iso" in the server
-
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
-
-  Scenario: Add a child channel for Rocky 8 DVD repositories
-    When I follow the left menu "Software > Manage > Channels"
-    And I follow "Create Channel"
-    And I enter "Custom Channel for Rocky 8 DVD" as "Channel Name"
-    And I enter "rocky-8-iso" as "Channel Label"
-    And I select "RHEL8-Pool for x86_64" from "Parent Channel"
-    And I enter "Custom channel" as "Channel Summary"
-    And I click on "Create Channel"
-    Then I should see a "Channel Custom Channel for Rocky 8 DVD created" text
-
-  Scenario: Add the Rocky 8 Appstream DVD repository
-    When I follow the left menu "Software > Manage > Repositories"
-    And I follow "Create Repository"
-    And I enter "rocky-8-iso-appstream" as "label"
-    And I enter "http://127.0.0.1/rocky-8-iso/AppStream" as "url"
-    And I uncheck "metadataSigned"
-    And I click on "Create Repository"
-    Then I should see a "Repository created successfully" text
-
-  Scenario: Add the Rocky 8 BaseOS DVD repository
-    When I follow the left menu "Software > Manage > Repositories"
-    And I follow "Create Repository"
-    And I enter "rocky-8-iso-baseos" as "label"
-    And I enter "http://127.0.0.1/rocky-8-iso/BaseOS" as "url"
-    And I uncheck "metadataSigned"
-    And I click on "Create Repository"
-    Then I should see a "Repository created successfully" text
-
-  Scenario: Add both repositories to the custom channel for Rocky 8 DVD
-    When I follow the left menu "Software > Manage > Channels"
-    And I follow "Custom Channel for Rocky 8 DVD"
-    And I follow "Repositories" in the content area
-    And I select the "rocky-8-iso-appstream" repo
-    And I select the "rocky-8-iso-baseos" repo
-    And I click on "Save Repositories"
-    Then I should see a "repository information was successfully updated" text
-
-  Scenario: Synchronize the repositories in the custom channel for Rocky 8 DVD
-    When I call spacewalk-repo-sync to sync the channel "rocky-8-iso"
-    And I wait until all spacewalk-repo-sync finished
-    Then the reposync logs should not report errors
-
-  Scenario: The custom channel for Rocky 8 has been synced
-    When I wait until the channel "rocky-8-iso" has been synced
-
-  Scenario: Create CLM filters to remove AppStream metadata
-    Given I am authorized for the "Admin" section
-    When I follow the left menu "Content Lifecycle > Filters"
-    And I click on "Create Filter"
-    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
-    Then I should see a "Create a new filter" text
-    When I enter "ruby-2.7" as "filter_name"
-    And I select "Module (Stream)" from "type"
-    And I enter "ruby" as "moduleName"
-    And I enter "2.7" as "moduleStream"
-    And I click on "Save" in "Create a new filter" modal
-    Then I should see a "ruby-2.7" text
-    When I click on "Create Filter"
-    Then I wait at most 10 seconds until I see modal containing "Create a new filter" text
-    Then I should see a "Create a new filter" text
-    When I enter "python-3.6" as "filter_name"
-    And I select "Module (Stream)" from "type"
-    And I enter "python36" as "moduleName"
-    And I enter "3.6" as "moduleStream"
-    And I click on "Save" in "Create a new filter" modal
-    Then I should see a "python-3.6" text
-
-  Scenario: Create a CLM project to remove AppStream metadata
-    When I follow the left menu "Content Lifecycle > Projects"
-    Then I should see a "Content Lifecycle Projects" text
-    And I should see a "There are no entries to show." text
-    When I follow "Create Project"
-    And I enter "Remove AppStream metadata" as "name"
-    And I enter "no-appstream" as "label"
-    And I click on "Create"
-    Then I should see a "Content Lifecycle Project - Remove AppStream metadata" text
-    When I click on "Attach/Detach Sources"
-    And I wait until I do not see "Loading" text
-    And I select "RHEL8-Pool for x86_64" from "selectedBaseChannel"
-    And I check "Custom Channel for Rocky 8 DVD"
-    And I click on "Save"
-    Then I should see a "Custom Channel for Rocky 8 DVD" text
-    When I click on "Attach/Detach Filters"
-    And I check "python-3.6: enable module python36:3.6"
-    And I check "ruby-2.7: enable module ruby:2.7"
-    And I click on "Save"
-    Then I should see a "python-3.6: enable module python36:3.6" text
-    When I click on "Add Environment"
-    And I enter "result" as "name"
-    And I enter "result" as "label"
-    And I enter "Filtered channels without AppStream channels" as "description"
-    And I click on "Save"
-    Then I should see a "not built" text
-    When I click on "Build"
-    And I enter "Initial build" as "message"
-    And I click the environment build button
-    Then I should see a "Version 1: Initial build" text
-
-  Scenario: Create the bootstrap repository for the Rocky 8 minion
-    When I create the bootstrap repository for "rhlike_minion" on the server
+  #  Scenario: Download the iso of Rocky 8 DVD and mount it on the server
+  #    When I mount as "rocky-8-iso" the ISO from "http://minima-mirror.mgr.suse.de/pub/rocky/8/isos/x86_64/Rocky-x86_64-dvd.iso" in the server
+  #
+  #  Scenario: Log in as admin user
+  #    Given I am authorized for the "Admin" section
+  #
+  #  Scenario: Add a child channel for Rocky 8 DVD repositories
+  #    When I follow the left menu "Software > Manage > Channels"
+  #    And I follow "Create Channel"
+  #    And I enter "Custom Channel for Rocky 8 DVD" as "Channel Name"
+  #    And I enter "rocky-8-iso" as "Channel Label"
+  #    And I select "RHEL8-Pool for x86_64" from "Parent Channel"
+  #    And I enter "Custom channel" as "Channel Summary"
+  #    And I click on "Create Channel"
+  #    Then I should see a "Channel Custom Channel for Rocky 8 DVD created" text
+  #
+  #  Scenario: Add the Rocky 8 Appstream DVD repository
+  #    When I follow the left menu "Software > Manage > Repositories"
+  #    And I follow "Create Repository"
+  #    And I enter "rocky-8-iso-appstream" as "label"
+  #    And I enter "http://127.0.0.1/rocky-8-iso/AppStream" as "url"
+  #    And I uncheck "metadataSigned"
+  #    And I click on "Create Repository"
+  #    Then I should see a "Repository created successfully" text
+  #
+  #  Scenario: Add the Rocky 8 BaseOS DVD repository
+  #    When I follow the left menu "Software > Manage > Repositories"
+  #    And I follow "Create Repository"
+  #    And I enter "rocky-8-iso-baseos" as "label"
+  #    And I enter "http://127.0.0.1/rocky-8-iso/BaseOS" as "url"
+  #    And I uncheck "metadataSigned"
+  #    And I click on "Create Repository"
+  #    Then I should see a "Repository created successfully" text
+  #
+  #  Scenario: Add both repositories to the custom channel for Rocky 8 DVD
+  #    When I follow the left menu "Software > Manage > Channels"
+  #    And I follow "Custom Channel for Rocky 8 DVD"
+  #    And I follow "Repositories" in the content area
+  #    And I select the "rocky-8-iso-appstream" repo
+  #    And I select the "rocky-8-iso-baseos" repo
+  #    And I click on "Save Repositories"
+  #    Then I should see a "repository information was successfully updated" text
+  #
+  #  Scenario: Synchronize the repositories in the custom channel for Rocky 8 DVD
+  #    When I call spacewalk-repo-sync to sync the channel "rocky-8-iso"
+  #    And I wait until all spacewalk-repo-sync finished
+  #    Then the reposync logs should not report errors
+  #
+  #  Scenario: The custom channel for Rocky 8 has been synced
+  #    When I wait until the channel "rocky-8-iso" has been synced
+  #
+  #  Scenario: Create CLM filters to remove AppStream metadata
+  #    Given I am authorized for the "Admin" section
+  #    When I follow the left menu "Content Lifecycle > Filters"
+  #    And I click on "Create Filter"
+  #    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+  #    Then I should see a "Create a new filter" text
+  #    When I enter "ruby-2.7" as "filter_name"
+  #    And I select "Module (Stream)" from "type"
+  #    And I enter "ruby" as "moduleName"
+  #    And I enter "2.7" as "moduleStream"
+  #    And I click on "Save" in "Create a new filter" modal
+  #    Then I should see a "ruby-2.7" text
+  #    When I click on "Create Filter"
+  #    Then I wait at most 10 seconds until I see modal containing "Create a new filter" text
+  #    Then I should see a "Create a new filter" text
+  #    When I enter "python-3.6" as "filter_name"
+  #    And I select "Module (Stream)" from "type"
+  #    And I enter "python36" as "moduleName"
+  #    And I enter "3.6" as "moduleStream"
+  #    And I click on "Save" in "Create a new filter" modal
+  #    Then I should see a "python-3.6" text
+  #
+  #  Scenario: Create a CLM project to remove AppStream metadata
+  #    When I follow the left menu "Content Lifecycle > Projects"
+  #    And I follow "Create Project"
+  #    And I enter "Remove AppStream metadata" as "name"
+  #    And I enter "no-appstream" as "label"
+  #    And I click on "Create"
+  #    Then I should see a "Content Lifecycle Project - Remove AppStream metadata" text
+  #    When I click on "Attach/Detach Sources"
+  #    And I wait until I do not see "Loading" text
+  #    And I select "RHEL8-Pool for x86_64" from "selectedBaseChannel"
+  #    And I check "Custom Channel for Rocky 8 DVD"
+  #    And I click on "Save"
+  #    Then I should see a "Custom Channel for Rocky 8 DVD" text
+  #    When I click on "Attach/Detach Filters"
+  #    And I check "python-3.6: enable module python36:3.6"
+  #    And I check "ruby-2.7: enable module ruby:2.7"
+  #    And I click on "Save"
+  #    Then I should see a "python-3.6: enable module python36:3.6" text
+  #    When I click on "Add Environment"
+  #    And I enter "result" as "name"
+  #    And I enter "result" as "label"
+  #    And I enter "Filtered channels without AppStream channels" as "description"
+  #    And I click on "Save"
+  #    Then I should see a "not built" text
+  #    When I click on "Build"
+  #    And I enter "Initial build" as "message"
+  #    And I click the environment build button
+  #    Then I should see a "Version 1: Initial build" text
+  #
+  #  Scenario: Create the bootstrap repository for the Rocky 8 minion
+  #    When I create the bootstrap repository for "rhlike_minion" on the server

--- a/testsuite/features/reposync/srv_add_rocky8_repositories.feature
+++ b/testsuite/features/reposync/srv_add_rocky8_repositories.feature
@@ -7,107 +7,109 @@ Feature: Add the Rocky 8 distribution custom repositories
   As a SUSE Manager administrator
   I want to filter them out to remove the modules information
 
-  #  Scenario: Download the iso of Rocky 8 DVD and mount it on the server
-  #    When I mount as "rocky-8-iso" the ISO from "http://minima-mirror.mgr.suse.de/pub/rocky/8/isos/x86_64/Rocky-x86_64-dvd.iso" in the server
-  #
-  #  Scenario: Log in as admin user
-  #    Given I am authorized for the "Admin" section
-  #
-  #  Scenario: Add a child channel for Rocky 8 DVD repositories
-  #    When I follow the left menu "Software > Manage > Channels"
-  #    And I follow "Create Channel"
-  #    And I enter "Custom Channel for Rocky 8 DVD" as "Channel Name"
-  #    And I enter "rocky-8-iso" as "Channel Label"
-  #    And I select "RHEL8-Pool for x86_64" from "Parent Channel"
-  #    And I enter "Custom channel" as "Channel Summary"
-  #    And I click on "Create Channel"
-  #    Then I should see a "Channel Custom Channel for Rocky 8 DVD created" text
-  #
-  #  Scenario: Add the Rocky 8 Appstream DVD repository
-  #    When I follow the left menu "Software > Manage > Repositories"
-  #    And I follow "Create Repository"
-  #    And I enter "rocky-8-iso-appstream" as "label"
-  #    And I enter "http://127.0.0.1/rocky-8-iso/AppStream" as "url"
-  #    And I uncheck "metadataSigned"
-  #    And I click on "Create Repository"
-  #    Then I should see a "Repository created successfully" text
-  #
-  #  Scenario: Add the Rocky 8 BaseOS DVD repository
-  #    When I follow the left menu "Software > Manage > Repositories"
-  #    And I follow "Create Repository"
-  #    And I enter "rocky-8-iso-baseos" as "label"
-  #    And I enter "http://127.0.0.1/rocky-8-iso/BaseOS" as "url"
-  #    And I uncheck "metadataSigned"
-  #    And I click on "Create Repository"
-  #    Then I should see a "Repository created successfully" text
-  #
-  #  Scenario: Add both repositories to the custom channel for Rocky 8 DVD
-  #    When I follow the left menu "Software > Manage > Channels"
-  #    And I follow "Custom Channel for Rocky 8 DVD"
-  #    And I follow "Repositories" in the content area
-  #    And I select the "rocky-8-iso-appstream" repo
-  #    And I select the "rocky-8-iso-baseos" repo
-  #    And I click on "Save Repositories"
-  #    Then I should see a "repository information was successfully updated" text
-  #
-  #  Scenario: Synchronize the repositories in the custom channel for Rocky 8 DVD
-  #    When I call spacewalk-repo-sync to sync the channel "rocky-8-iso"
-  #    And I wait until all spacewalk-repo-sync finished
-  #    Then the reposync logs should not report errors
-  #
-  #  Scenario: The custom channel for Rocky 8 has been synced
-  #    When I wait until the channel "rocky-8-iso" has been synced
-  #
-  #  Scenario: Create CLM filters to remove AppStream metadata
-  #    Given I am authorized for the "Admin" section
-  #    When I follow the left menu "Content Lifecycle > Filters"
-  #    And I click on "Create Filter"
-  #    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
-  #    Then I should see a "Create a new filter" text
-  #    When I enter "ruby-2.7" as "filter_name"
-  #    And I select "Module (Stream)" from "type"
-  #    And I enter "ruby" as "moduleName"
-  #    And I enter "2.7" as "moduleStream"
-  #    And I click on "Save" in "Create a new filter" modal
-  #    Then I should see a "ruby-2.7" text
-  #    When I click on "Create Filter"
-  #    Then I wait at most 10 seconds until I see modal containing "Create a new filter" text
-  #    Then I should see a "Create a new filter" text
-  #    When I enter "python-3.6" as "filter_name"
-  #    And I select "Module (Stream)" from "type"
-  #    And I enter "python36" as "moduleName"
-  #    And I enter "3.6" as "moduleStream"
-  #    And I click on "Save" in "Create a new filter" modal
-  #    Then I should see a "python-3.6" text
-  #
-  #  Scenario: Create a CLM project to remove AppStream metadata
-  #    When I follow the left menu "Content Lifecycle > Projects"
-  #    And I follow "Create Project"
-  #    And I enter "Remove AppStream metadata" as "name"
-  #    And I enter "no-appstream" as "label"
-  #    And I click on "Create"
-  #    Then I should see a "Content Lifecycle Project - Remove AppStream metadata" text
-  #    When I click on "Attach/Detach Sources"
-  #    And I wait until I do not see "Loading" text
-  #    And I select "RHEL8-Pool for x86_64" from "selectedBaseChannel"
-  #    And I check "Custom Channel for Rocky 8 DVD"
-  #    And I click on "Save"
-  #    Then I should see a "Custom Channel for Rocky 8 DVD" text
-  #    When I click on "Attach/Detach Filters"
-  #    And I check "python-3.6: enable module python36:3.6"
-  #    And I check "ruby-2.7: enable module ruby:2.7"
-  #    And I click on "Save"
-  #    Then I should see a "python-3.6: enable module python36:3.6" text
-  #    When I click on "Add Environment"
-  #    And I enter "result" as "name"
-  #    And I enter "result" as "label"
-  #    And I enter "Filtered channels without AppStream channels" as "description"
-  #    And I click on "Save"
-  #    Then I should see a "not built" text
-  #    When I click on "Build"
-  #    And I enter "Initial build" as "message"
-  #    And I click the environment build button
-  #    Then I should see a "Version 1: Initial build" text
-  #
-  #  Scenario: Create the bootstrap repository for the Rocky 8 minion
-  #    When I create the bootstrap repository for "rhlike_minion" on the server
+  Scenario: Download the iso of Rocky 8 DVD and mount it on the server
+    When I mount as "rocky-8-iso" the ISO from "http://minima-mirror.mgr.suse.de/pub/rocky/8/isos/x86_64/Rocky-x86_64-dvd.iso" in the server
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Add a child channel for Rocky 8 DVD repositories
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Create Channel"
+    And I enter "Custom Channel for Rocky 8 DVD" as "Channel Name"
+    And I enter "rocky-8-iso" as "Channel Label"
+    And I select "RHEL8-Pool for x86_64" from "Parent Channel"
+    And I enter "Custom channel" as "Channel Summary"
+    And I click on "Create Channel"
+    Then I should see a "Channel Custom Channel for Rocky 8 DVD created" text
+
+  Scenario: Add the Rocky 8 Appstream DVD repository
+    When I follow the left menu "Software > Manage > Repositories"
+    And I follow "Create Repository"
+    And I enter "rocky-8-iso-appstream" as "label"
+    And I enter "http://127.0.0.1/rocky-8-iso/AppStream" as "url"
+    And I uncheck "metadataSigned"
+    And I click on "Create Repository"
+    Then I should see a "Repository created successfully" text
+
+  Scenario: Add the Rocky 8 BaseOS DVD repository
+    When I follow the left menu "Software > Manage > Repositories"
+    And I follow "Create Repository"
+    And I enter "rocky-8-iso-baseos" as "label"
+    And I enter "http://127.0.0.1/rocky-8-iso/BaseOS" as "url"
+    And I uncheck "metadataSigned"
+    And I click on "Create Repository"
+    Then I should see a "Repository created successfully" text
+
+  Scenario: Add both repositories to the custom channel for Rocky 8 DVD
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Custom Channel for Rocky 8 DVD"
+    And I follow "Repositories" in the content area
+    And I select the "rocky-8-iso-appstream" repo
+    And I select the "rocky-8-iso-baseos" repo
+    And I click on "Save Repositories"
+    Then I should see a "repository information was successfully updated" text
+
+  Scenario: Synchronize the repositories in the custom channel for Rocky 8 DVD
+    When I call spacewalk-repo-sync to sync the channel "rocky-8-iso"
+    And I wait until all spacewalk-repo-sync finished
+    Then the reposync logs should not report errors
+
+  Scenario: The custom channel for Rocky 8 has been synced
+    When I wait until the channel "rocky-8-iso" has been synced
+
+  Scenario: Create CLM filters to remove AppStream metadata
+    Given I am authorized for the "Admin" section
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "ruby-2.7" as "filter_name"
+    And I select "Module (Stream)" from "type"
+    And I enter "ruby" as "moduleName"
+    And I enter "2.7" as "moduleStream"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "ruby-2.7" text
+    When I click on "Create Filter"
+    Then I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "python-3.6" as "filter_name"
+    And I select "Module (Stream)" from "type"
+    And I enter "python36" as "moduleName"
+    And I enter "3.6" as "moduleStream"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "python-3.6" text
+
+  Scenario: Create a CLM project to remove AppStream metadata
+    When I follow the left menu "Content Lifecycle > Projects"
+    Then I should see a "Content Lifecycle Projects" text
+    And I should see a "There are no entries to show." text
+    When I follow "Create Project"
+    And I enter "Remove AppStream metadata" as "name"
+    And I enter "no-appstream" as "label"
+    And I click on "Create"
+    Then I should see a "Content Lifecycle Project - Remove AppStream metadata" text
+    When I click on "Attach/Detach Sources"
+    And I wait until I do not see "Loading" text
+    And I select "RHEL8-Pool for x86_64" from "selectedBaseChannel"
+    And I check "Custom Channel for Rocky 8 DVD"
+    And I click on "Save"
+    Then I should see a "Custom Channel for Rocky 8 DVD" text
+    When I click on "Attach/Detach Filters"
+    And I check "python-3.6: enable module python36:3.6"
+    And I check "ruby-2.7: enable module ruby:2.7"
+    And I click on "Save"
+    Then I should see a "python-3.6: enable module python36:3.6" text
+    When I click on "Add Environment"
+    And I enter "result" as "name"
+    And I enter "result" as "label"
+    And I enter "Filtered channels without AppStream channels" as "description"
+    And I click on "Save"
+    Then I should see a "not built" text
+    When I click on "Build"
+    And I enter "Initial build" as "message"
+    And I click the environment build button
+    Then I should see a "Version 1: Initial build" text
+
+  Scenario: Create the bootstrap repository for the Rocky 8 minion
+    When I create the bootstrap repository for "rhlike_minion" on the server


### PR DESCRIPTION
## What does this PR change?
Currently the reboot of a transactional update minions does not work inside in a action chains. This is because all the actions are converted in a sls file, and this file is executed as a single transaction: since reboot is not allowed inside a transaction, the action chains stop to work.

In order to have the reboot action working:
-  more than one sls file are created, each one of them contains all the action until a reboot (if present in the action chain)
- the reboot action is not converted in an sls file, but it managed directly by `mgractionchains.py` (using the argument `activate_transaction=true`)

**KNOWN ISSUE:**

- If action does not generate any new snapshot, the reboot action would not work (since there's no reboot action but an `activate_transaction=true` ) . A possible solution is to perform a dummy action to force the creation of a new snapshot, but not sure about the dummy action to execute. 

- the approach seems it's not working if with `REBOOT_METHOD=auto` (in `/etc/transactional-update.conf` ) , but the reason is on transaction-update module itself. It work as expected with `REBOOT_METHOD=systemd`.  **(UPDATE: after some debug, I opened this issue: https://github.com/openSUSE/transactional-update/issues/92)** **(UPDATE: the issue was caused by a misleading log, it works as expected)**

- although reboot is performed, WebUI `events -> pending` still show that the reboot action was not executed. No ideaabout the reason. **(UPDATE: FIXED)**

## GUI diff

No difference.


- [x] **DONE**

## Documentation

- Doc changes are required. DOC Issue here: https://github.com/uyuni-project/uyuni-docs/issues/1843

- [x] **DONE**

## Test coverage
- Added unit test

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18381

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
