### PR TITLE
Fix state apply test mode result parsing

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
@@ -50,6 +50,8 @@ import org.apache.logging.log4j.Logger;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -101,6 +103,16 @@ public class JobReturnEventMessageAction implements MessageAction {
 
         // React according to the function the minion ran
         String function = jobReturnEvent.getData().getFun();
+
+        List<Map<String, Object>> functionArgs = new LinkedList<>();
+        if (jobReturnEvent.getData().getFunArgs() instanceof List) {
+            List<Object> funArgs = (List<Object>) jobReturnEvent.getData().getFunArgs();
+            if (!funArgs.isEmpty() && funArgs.get(0) instanceof Map) {
+                functionArgs = (List<Map<String, Object>>) jobReturnEvent.getData().getFunArgs();
+            }
+        }
+        boolean isFunctionTestMode = functionArgs.stream()
+                .anyMatch(e -> e.containsKey("test") && ((Boolean) e.get("test")).booleanValue());
 
         if (Objects.isNull(function) && LOG.isDebugEnabled()) {
             LOG.debug("Function is null in JobReturnEvent -> \n{}", Json.GSON.toJson(jobReturnEvent));
@@ -181,7 +193,7 @@ public class JobReturnEventMessageAction implements MessageAction {
                     actionChainResult,
                     stateResult -> false);
 
-            boolean packageRefreshNeeded = actionChainResult.entrySet().stream()
+            boolean packageRefreshNeeded = !isFunctionTestMode && actionChainResult.entrySet().stream()
                     .map(entry -> SaltActionChainGeneratorService.parseActionChainStateId(entry.getKey())
                             .map(stateId -> handlePackageChanges(jobReturnEvent, entry.getValue().getName(),
                                     Optional.ofNullable(entry.getValue().getChanges().getRet())))
@@ -194,8 +206,8 @@ public class JobReturnEventMessageAction implements MessageAction {
             }
         });
 
-        //For all jobs except when action chains are involved
-        if (!isActionChainInvolved && handlePackageChanges(jobReturnEvent,
+        //For all jobs except when action chains are involved or the action was in test mode
+        if (!isActionChainInvolved && !isFunctionTestMode && handlePackageChanges(jobReturnEvent,
                 Optional.ofNullable(function).map(Xor::right), jobResult)) {
             Date earliest = new Date();
             if (actionId.isPresent()) {

--- a/java/code/src/com/suse/manager/reactor/messaging/test/state.apply.with.test.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/state.apply.with.test.json
@@ -1,0 +1,231 @@
+{
+    "tag": "salt/job/20220813132425331229/ret/abcdefg.vagrant.local",
+    "data": {
+        "cmd": "_return",
+        "id": "abcdefg.vagrant.local",
+        "success": true,
+        "jid": "20220813132425331229",
+        "fun": "state.apply",
+        "fun_args": [
+            {
+                "mods": [],
+                "queue": true,
+                "test": true
+            }
+        ],
+        "metadata": {
+            "suma-action-id": 50,
+            "suma-force-pkg-list-refresh": false,
+            "suma-action-chain": false,
+            "batch-mode": true,
+            "suma-minion-startup": false
+        },
+        "out": "highstate",
+        "return": {
+            "saltutil_|-sync_states_|-sync_states_|-sync_states": {
+                "name": "sync_states",
+                "changes": {},
+                "result": null,
+                "comment": "saltutil.sync_states would have been run",
+                "__sls__": "util.syncstates",
+                "__run_num__": 0,
+                "start_time": "15:24:30.761469",
+                "duration": 4.046,
+                "__id__": "sync_states"
+            },
+            "file_|-mgrchannels_repo_|-/etc/zypp/repos.d/susemanager:channels.repo_|-managed": {
+                "changes": {},
+                "comment": "The file /etc/zypp/repos.d/susemanager:channels.repo is in the correct state",
+                "name": "/etc/zypp/repos.d/susemanager:channels.repo",
+                "result": true,
+                "__sls__": "channels",
+                "__run_num__": 1,
+                "start_time": "15:24:30.831103",
+                "duration": 185.937,
+                "__id__": "mgrchannels_repo"
+            },
+            "product_|-mgrchannels_install_products_|-mgrchannels_install_products_|-all_installed": {
+                "name": "mgrchannels_install_products",
+                "changes": {},
+                "result": true,
+                "comment": "All subscribed products are already installed",
+                "__sls__": "channels",
+                "__run_num__": 2,
+                "start_time": "15:24:31.080723",
+                "duration": 1248.668,
+                "__id__": "mgrchannels_install_products"
+            },
+            "file_|-/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT_|-/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT_|-managed": {
+                "changes": {},
+                "comment": "The file /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT is in the correct state",
+                "name": "/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT",
+                "result": true,
+                "__sls__": "certs",
+                "__run_num__": 3,
+                "start_time": "15:24:32.330009",
+                "duration": 31.623,
+                "__id__": "/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT"
+            },
+            "cmd_|-update-ca-certificates_|-/usr/sbin/update-ca-certificates_|-run": {
+                "changes": {},
+                "result": true,
+                "duration": 0.006,
+                "start_time": "15:24:32.364928",
+                "comment": "State was not run because none of the onchanges reqs changed",
+                "__state_ran__": false,
+                "__run_num__": 4,
+                "__sls__": "certs"
+            },
+            "pkg_|-pkg_installed_|-pkg_installed_|-installed": {
+                "name": "pkg_installed",
+                "changes": {
+                    "acct": {
+                        "new": "installed",
+                        "old": ""
+                    }
+                },
+                "result": null,
+                "comment": "The following packages would be installed/updated: acct",
+                "__sls__": "packages.packages_5a7005b0512016666dfa9f2e62f6fa79",
+                "__run_num__": 5,
+                "start_time": "15:24:34.600651",
+                "duration": 8041.756,
+                "__id__": "pkg_installed"
+            },
+            "pkg_|-pkg_removed_|-pkg_removed_|-removed": {
+                "name": "pkg_removed",
+                "changes": {},
+                "result": true,
+                "comment": "All specified packages are already absent",
+                "__sls__": "packages.packages_5a7005b0512016666dfa9f2e62f6fa79",
+                "__run_num__": 6,
+                "start_time": "15:24:42.757541",
+                "duration": 27.268,
+                "__id__": "pkg_removed"
+            },
+            "pkg_|-pkg_latest_|-pkg_latest_|-latest": {
+                "name": "pkg_latest",
+                "changes": {},
+                "result": true,
+                "comment": "No packages to install provided",
+                "__sls__": "packages.packages_5a7005b0512016666dfa9f2e62f6fa79",
+                "__run_num__": 7,
+                "start_time": "15:24:42.785366",
+                "duration": 6.628,
+                "__id__": "pkg_latest"
+            },
+            "product_|-mgr_install_products_|-mgr_install_products_|-all_installed": {
+                "name": "mgr_install_products",
+                "changes": {},
+                "result": true,
+                "comment": "All subscribed products are already installed",
+                "__sls__": "packages",
+                "__run_num__": 8,
+                "start_time": "15:24:42.878475",
+                "duration": 9123.877,
+                "__id__": "mgr_install_products"
+            },
+            "service_|-disable_spacewalksd_|-rhnsd_|-dead": {
+                "name": "rhnsd",
+                "changes": {},
+                "result": null,
+                "comment": "Service rhnsd not present; if created in this state run, it would have been stopped",
+                "__sls__": "services.salt-minion",
+                "__run_num__": 9,
+                "start_time": "15:24:53.378958",
+                "duration": 38.622,
+                "__id__": "disable_spacewalksd"
+            },
+            "service_|-disable_spacewalk-update-status_|-spacewalk-update-status_|-dead": {
+                "name": "spacewalk-update-status",
+                "changes": {},
+                "result": null,
+                "comment": "Service spacewalk-update-status not present; if created in this state run, it would have been stopped",
+                "__sls__": "services.salt-minion",
+                "__run_num__": 10,
+                "start_time": "15:24:53.418301",
+                "duration": 18.599,
+                "__id__": "disable_spacewalk-update-status"
+            },
+            "service_|-disable_osad_|-osad_|-dead": {
+                "name": "osad",
+                "changes": {},
+                "result": null,
+                "comment": "Service osad not present; if created in this state run, it would have been stopped",
+                "__sls__": "services.salt-minion",
+                "__run_num__": 11,
+                "start_time": "15:24:53.437436",
+                "duration": 18.561,
+                "__id__": "disable_osad"
+            },
+            "pkg_|-remove_traditional_stack_all_|-remove_traditional_stack_all_|-removed": {
+                "name": "remove_traditional_stack_all",
+                "changes": {},
+                "result": true,
+                "comment": "All specified packages are already absent",
+                "__sls__": "services.salt-minion",
+                "__run_num__": 12,
+                "start_time": "15:24:53.456567",
+                "duration": 15.332,
+                "__id__": "remove_traditional_stack_all"
+            },
+            "pkg_|-remove_traditional_stack_|-remove_traditional_stack_|-removed": {
+                "name": "remove_traditional_stack",
+                "changes": {},
+                "result": true,
+                "comment": "All specified packages are already absent",
+                "__sls__": "services.salt-minion",
+                "__run_num__": 13,
+                "start_time": "15:24:53.472215",
+                "duration": 653.278,
+                "__id__": "remove_traditional_stack"
+            },
+            "file_|-/etc/sysconfig/rhn/systemid_|-/etc/sysconfig/rhn/systemid_|-managed": {
+                "changes": {},
+                "comment": "File /etc/sysconfig/rhn/systemid not updated",
+                "name": "/etc/sysconfig/rhn/systemid",
+                "result": true,
+                "__sls__": "services.salt-minion",
+                "__run_num__": 14,
+                "start_time": "15:24:54.126155",
+                "duration": 5.652,
+                "__id__": "/etc/sysconfig/rhn/systemid"
+            },
+            "pkg_|-mgr_salt_minion_inst_|-salt-minion_|-installed": {
+                "name": "salt-minion",
+                "changes": {},
+                "result": true,
+                "comment": "All specified packages are already installed",
+                "__sls__": "services.salt-minion",
+                "__run_num__": 15,
+                "start_time": "15:24:54.133374",
+                "duration": 14.472,
+                "__id__": "mgr_salt_minion_inst"
+            },
+            "file_|-/etc/salt/minion.d/susemanager.conf_|-/etc/salt/minion.d/susemanager.conf_|-managed": {
+                "changes": {},
+                "comment": "The file /etc/salt/minion.d/susemanager.conf is in the correct state",
+                "name": "/etc/salt/minion.d/susemanager.conf",
+                "result": true,
+                "__sls__": "services.salt-minion",
+                "__run_num__": 16,
+                "start_time": "15:24:54.148344",
+                "duration": 322.629,
+                "__id__": "/etc/salt/minion.d/susemanager.conf"
+            },
+            "service_|-mgr_salt_minion_run_|-salt-minion_|-running": {
+                "name": "salt-minion",
+                "changes": {},
+                "result": true,
+                "comment": "The service salt-minion is already running",
+                "__sls__": "services.salt-minion",
+                "__run_num__": 17,
+                "start_time": "15:24:54.471576",
+                "duration": 99.153,
+                "__id__": "mgr_salt_minion_run"
+            }
+        },
+        "retcode": 0,
+        "_stamp": "2022-08-13T13:24:54.602818"
+    }
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix state.apply result parsing in test mode (bsc#1201913)
 - require tomcat native interface to prevent misleading warning
   in tomcat startup log (bsc#1202455)
 - Calculate dependencies between cloned channels of vendor channels (bsc#1201626)


### PR DESCRIPTION
## What does this PR change?

With salt 3004 the result of a "pkg.installed" with test=true has changed. 

In older versions and empty `changes: {}` was returned while with 3004 we have a structure similar to
an execution result

```
changes: {
  'installed' : {
    'adobe-sourcecodepro-fonts' : {
      'new' : '2.030-1.30'
      'old' : ''
    }
  }
}
```
Saltstack want to change this and return the same structure as when doing a real installation.
So we need to parse the function arguments and check for `test=True` and skip the evaluation of the result in the Java code.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/18547

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
