### PR TITLE
flush directory also when called for a specific label (bsc#1200573)

### DIFF
--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -756,7 +756,7 @@ def main():
                 if opts.dryrun:
                     log("Move directory: {0}".format(destdir))
                 else:
-                    log("FLUSH: move destdir to old", 2)
+                    log("FLUSH: move destdir '{0}' to old".format(destdir))
                     os.rename(destdir, destdirold)
         r = create_repo(elabel, opts, mgr_bootstrap_data, additional=args)
     elif opts.list:
@@ -765,6 +765,16 @@ def main():
         if opts.create not in mgr_bootstrap_data.DATA:
             log_error("'%s' not found" % opts.create)
             sys.exit(1)
+        if opts.flush:
+            destdir = os.path.normpath(mgr_bootstrap_data.DATA[opts.create]['DEST'])
+            if os.path.exists(destdir):
+                dirprefix, lastdir = os.path.split(destdir)
+                destdirold = os.path.join(dirprefix, "{0}.{1}".format(lastdir, "old"))
+                if opts.dryrun:
+                    log("Move directory: {0}".format(destdir))
+                else:
+                    log("FLUSH: move destdir '{0}' to old".format(destdir))
+                    os.rename(destdir, destdirold)
         r = create_repo(opts.create, opts, mgr_bootstrap_data, additional=args)
     releaseLOCK()
     return r

--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -689,10 +689,8 @@ def generate_all(options, mgr_bootstrap_data, additional=[]):
            if os.path.exists(destdir):
                dirprefix, lastdir = os.path.split(destdir)
                destdirold = os.path.join(dirprefix, "{0}.{1}".format(lastdir, "old"))
-               if options.dryrun:
-                   log("Move directory: {0}".format(destdir))
-               else:
-                   log("FLUSH: move destdir to old", 2)
+               log("FLUSH: move destdir '{0}' to old".format(destdir))
+               if not options.dryrun:
                    os.rename(destdir, destdirold)
            doall = True
        for label in labels:
@@ -753,10 +751,8 @@ def main():
             if os.path.exists(destdir):
                 dirprefix, lastdir = os.path.split(destdir)
                 destdirold = os.path.join(dirprefix, "{0}.{1}".format(lastdir, "old"))
-                if opts.dryrun:
-                    log("Move directory: {0}".format(destdir))
-                else:
-                    log("FLUSH: move destdir '{0}' to old".format(destdir))
+                log("FLUSH: move destdir '{0}' to old".format(destdir))
+                if not opts.dryrun:
                     os.rename(destdir, destdirold)
         r = create_repo(elabel, opts, mgr_bootstrap_data, additional=args)
     elif opts.list:
@@ -770,10 +766,8 @@ def main():
             if os.path.exists(destdir):
                 dirprefix, lastdir = os.path.split(destdir)
                 destdirold = os.path.join(dirprefix, "{0}.{1}".format(lastdir, "old"))
-                if opts.dryrun:
-                    log("Move directory: {0}".format(destdir))
-                else:
-                    log("FLUSH: move destdir '{0}' to old".format(destdir))
+                log("FLUSH: move destdir '{0}' to old".format(destdir))
+                if not opts.dryrun:
                     os.rename(destdir, destdirold)
         r = create_repo(opts.create, opts, mgr_bootstrap_data, additional=args)
     releaseLOCK()

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- mgr-create-bootstrap-repo: flush directory also when called
+  for a specific label (bsc#1200573)
 - pg-migrate-x-to-y.sh: improve output (bsc#1201260)
 - remove python-tornado from bootstrap repo, since no longer
   required for salt version >= 3000


### PR DESCRIPTION
## What does this PR change?

When mgr-create-bootstrap-repo was called with -c <label> the option "--flush" had no effect.
This PR removed the old bootstrap repo also when the repo label is directly provided.

WARNING: bootsrap repos are multiarch. When flushing it for a specific label, all archs are removed, but only the specified is re-generated. The other archs should be generated as well **without using flush**

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: already well explained

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18174
Tracks 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
