### PR TITLE
fix race condition when syncing channels

### DIFF
--- a/testsuite/features/core/srv_channels_add.feature
+++ b/testsuite/features/core/srv_channels_add.feature
@@ -97,3 +97,7 @@ Feature: Adding channels
     # End of WORKAROUND
     And I click on "Create Channel"
     Then I should see a "Channel Test-Channel-Deb-AMD64 created." text
+
+  Scenario: Wait for Channels generated initial metadata
+    When I wait until the channel "test-channel-x86_64" has been synced
+    And I wait until the channel "test-channel-i586" has been synced


### PR DESCRIPTION
## What does this PR change?

When we create a channel, a sync is triggered to create at least "empty" metadata.
In the testsuite we create and assign repositories shortly after it. When we now want to "sync" them
it could happen that the button is disabled as a sync is currently running.

Wait at the end of the channel_add test, for the metadata been generated.
This is also a test if that really happens.
After this we should not have problems to trigger another sync with the repo assigned and syncing the packges.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/18623 https://github.com/SUSE/spacewalk/pull/18624
Not ported to 4.1

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
