### PR TITLE
QE: Fix maintenance crawler script header

### DIFF
--- a/testsuite/ext-tools/maintenance_crawler.rb
+++ b/testsuite/ext-tools/maintenance_crawler.rb
@@ -1,8 +1,7 @@
+#!/usr/bin/env ruby
 # source 'https://rubygems.org'
 #
 # gem 'nokogiri'
-
-#!/usr/bin/env ruby
 
 require 'open-uri'
 require 'optparse'
@@ -135,7 +134,7 @@ class MaintenanceCrawler
         return URI.join(@root_url, url).to_s
     end
   end
-  
+
   # Output the current completions/total_queued to the console
   # Defaults to single-line-update but verbose (-v) mode triggers full output
   def print_status(url)


### PR DESCRIPTION
## What does this PR change?

This will fix the shebang of the maintenance crawler script and some
whitespace left inside.
Without the proper position of the shebang the script can only be
called with `ruby maintenance_crawler.rb` instead of just
`maintenance_crawler.rb`.

```bash
$ crawler.rb 25405                                                                                                                                                            
/home/dgedon/bin/crawler.rb: line 7: require: command not found                                                                                                               
/home/dgedon/bin/crawler.rb: line 8: require: command not found                                                                                                               
/home/dgedon/bin/crawler.rb: line 9: require: command not found                                                                                                               
/home/dgedon/bin/crawler.rb: line 10: require: command not found                                                                                                              
/home/dgedon/bin/crawler.rb: line 12: class: command not found                                                                                                                
/home/dgedon/bin/crawler.rb: line 14: syntax error near unexpected token `('                                                                                                  
/home/dgedon/bin/crawler.rb: line 14: `  def initialize(root_url, options = {})'

$ ruby crawler.rb 25405                                                                                                                                                       
http://download.suse.de/download/ibs/SUSE:/Maintenance:/25405/SUSE_Updates_SLE-Manager-Tools_15_x86_64/                                                                       
(...)
```


## GUI diff

No difference.


- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- No tests: already covered


- [x] **DONE**

## Links

Manager 4.3
Manager 4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
