### PR TITLE
Fix preflight for salt ssh with no rpm message on debian systems

### DIFF
--- a/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
+++ b/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
@@ -203,7 +203,7 @@ if [ -f "${VENV_FILE}" ]; then
 else
     if [ "${INSTALLER}" = "apt" ] && dpkg-query -s venv-salt-minion > /dev/null 2>&1 && [ -d "${VENV_INST_DIR}" ]; then
         VENV_SOURCE="dpkg"
-    elif rpm -q --quiet venv-salt-minion && [ -d "${VENV_INST_DIR}" ]; then
+    elif rpm -q --quiet venv-salt-minion 2> /dev/null && [ -d "${VENV_INST_DIR}" ]; then
         VENV_SOURCE="rpm"
     fi
 fi

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,6 @@
+- Remove the message 'rpm: command not found' on using Salt SSH
+  with Debian based systems which has no Salt Bundle
+
 -------------------------------------------------------------------
 Wed Jul 27 14:17:08 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

In case if there is no Salt Bundle for the debian based system preflight script could emit `rpm: command not found` error on the output, which makes no any sense in this case.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: it's possible on unsupported debian based systems, which are out of scope of the testsuite

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
