### PR TITLE
Fix filtering of modular packages on CentOS flavors (bsc#1201893)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
@@ -369,10 +369,8 @@ public class AccessTest extends BaseTestCaseWithUser {
 
         assertFalse(acl.evalAcl(context, "is_modular_channel()"));
 
-        Modules mod = new Modules();
-        mod.setRelativeFilename("filename");
-        chan.setModules(mod);
-        mod.setChannel(chan);
+        Modules mod = new Modules("filename", new Date());
+        chan.addModules(mod);
 
         assertTrue(acl.evalAcl(context, "is_modular_channel()"));
 

--- a/java/code/src/com/redhat/rhn/domain/channel/Channel.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/Channel.hbm.xml
@@ -75,8 +75,10 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <one-to-one name="comps" property-ref="channel"
             class="com.redhat.rhn.domain.channel.Comps" cascade="all" lazy="proxy"/>
 
-        <one-to-one name="modules" property-ref="channel"
-            class="com.redhat.rhn.domain.channel.Modules" cascade="all" lazy="proxy"/>
+        <set name="modules" cascade="all-delete-orphan" lazy="true" inverse="true" where="comps_type_id = 2">
+            <key column="channel_id" not-null="true"/>
+            <one-to-many class="com.redhat.rhn.domain.channel.Modules"/>
+        </set>
 
         <one-to-one name="mediaProducts" property-ref="channel"
             class="com.redhat.rhn.domain.channel.MediaProducts" cascade="all" lazy="proxy"/>

--- a/java/code/src/com/redhat/rhn/domain/channel/Channel.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/Channel.java
@@ -26,6 +26,7 @@ import com.redhat.rhn.manager.channel.ChannelManager;
 import com.redhat.rhn.manager.system.IncompatibleArchException;
 import com.redhat.rhn.manager.system.SystemManager;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -34,6 +35,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -78,7 +80,7 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
     private ChannelProduct product;
     private ProductName productName;
     private Comps comps;
-    private Modules modules;
+    private Set<Modules> modules;
     private MediaProducts mediaProducts;
     private String summary;
     private Set<Errata> erratas = new HashSet<>();
@@ -221,8 +223,29 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
     /**
      * @param modulesIn The Modules to set.
      */
-    public void setModules(Modules modulesIn) {
+    public void setModules(Set<Modules> modulesIn) {
         this.modules = modulesIn;
+    }
+
+    /**
+     * Add a module metadata file to the channel
+     * @param modulesIn the module metadata entity to add
+     */
+    public void addModules(Modules modulesIn) {
+        if (this.modules == null) {
+            this.modules = new HashSet<>();
+        }
+        modulesIn.setChannel(this);
+        this.modules.add(modulesIn);
+    }
+
+    /**
+     * Remove an existing module metadata file from the channel
+     * @param modulesIn the module metadata entity to remove
+     */
+    public void removeModules(Modules modulesIn) {
+        this.modules.remove(modulesIn);
+        modulesIn.setChannel(null);
     }
 
     /**
@@ -235,14 +258,27 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
     }
 
     /**
+     * Gets the synced module metadata files belonging to the channel
+     * <p>
+     * See {@link Channel#getLatestModules()} to get the latest metadata file currently in use.
+     *
      * @return Returns the Modules.
      */
-    public Modules getModules() {
+    public Set<Modules> getModules() {
         return modules;
     }
 
+    /**
+     * Gets the latest module metadata file in use
+     *
+     * @return the module metadata (modules.yaml) file
+     */
+    public Modules getLatestModules() {
+        return modules.stream().max(Comparator.comparing(Modules::getLastModified)).orElse(null);
+    }
+
     public boolean isModular() {
-        return modules != null;
+        return CollectionUtils.isNotEmpty(modules);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
@@ -1450,19 +1450,13 @@ public class ChannelFactory extends HibernateFactory {
      * @param to  the target Channel
      */
     public static void cloneModulesMetadata(Channel from, Channel to) {
-        if (!from.isModular()) {
-            if (to.isModular()) {
-                HibernateFactory.getSession().delete(to.getModules());
-                to.setModules(null);
-            }
+        if (to.isModular()) {
+            to.getModules().clear();
+            getSession().flush();
         }
-        else {
-            if (!to.isModular()) {
-                Modules modules = new Modules();
-                modules.setChannel(to);
-                to.setModules(modules);
-            }
-            to.getModules().setRelativeFilename(from.getModules().getRelativeFilename());
+        if (from.isModular()) {
+            from.getModules().forEach(fromModule ->
+                    to.addModules(new Modules(fromModule.getRelativeFilename(), fromModule.getLastModified())));
         }
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/channel/Modules.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/Modules.java
@@ -14,10 +14,25 @@
  */
 package com.redhat.rhn.domain.channel;
 
+import java.util.Date;
+
 /**
  *
  *
  */
 public class Modules extends RepoMetadata {
+    /**
+     * Create a new empty {@link Modules} instance
+     */
+    public Modules() { }
 
+    /**
+     * Create a new {@link Modules} instance
+     * @param relativeFilename the relative filename of the module metadata file
+     * @param lastModified the 'last modified date' of the module metadata file
+     */
+    public Modules(String relativeFilename, Date lastModified) {
+        this.setRelativeFilename(relativeFilename);
+        this.setLastModified(lastModified);
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/channel/RepoMetadata.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/RepoMetadata.hbm.xml
@@ -17,6 +17,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         </id>
         <discriminator column="comps_type_id" type="java.lang.Integer"/>
         <property name="relativeFilename" type="string" column="relative_filename" not-null="true"/>
+        <property name="lastModified" type="timestamp" column="last_modified" not-null="true" />
 
         <many-to-one name="channel"
                      class="com.redhat.rhn.domain.channel.Channel"

--- a/java/code/src/com/redhat/rhn/domain/channel/RepoMetadata.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/RepoMetadata.java
@@ -15,6 +15,9 @@
 package com.redhat.rhn.domain.channel;
 
 import com.redhat.rhn.domain.BaseDomainHelper;
+
+import java.util.Date;
+
 /**
  *
  *
@@ -24,6 +27,7 @@ public class RepoMetadata extends BaseDomainHelper {
     private Long id;
     private String relativeFilename;
     private Channel channel;
+    private Date lastModified;
 
     /**
      *
@@ -71,5 +75,21 @@ public class RepoMetadata extends BaseDomainHelper {
      */
     public Channel getChannel() {
         return channel;
+    }
+
+    /**
+     * Gets the last modified date of the underlying comps file
+     * @return the last modified date of the comps file
+     */
+    public Date getLastModified() {
+        return lastModified;
+    }
+
+    /**
+     * Sets the last modified date of the underlying comps file
+     * @param lastModifiedIn the last modified date
+     */
+    public void setLastModified(Date lastModifiedIn) {
+        lastModified = lastModifiedIn;
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/channel/test/ChannelFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/test/ChannelFactoryTest.java
@@ -27,6 +27,7 @@ import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.channel.ChannelFamily;
 import com.redhat.rhn.domain.channel.ChannelFamilyFactory;
 import com.redhat.rhn.domain.channel.ClonedChannel;
+import com.redhat.rhn.domain.channel.Modules;
 import com.redhat.rhn.domain.channel.ProductName;
 import com.redhat.rhn.domain.common.ChecksumType;
 import com.redhat.rhn.domain.kickstart.KickstartInstallType;
@@ -46,6 +47,8 @@ import com.redhat.rhn.testing.UserTestUtils;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -555,5 +558,29 @@ public class ChannelFactoryTest extends RhnBaseTestCase {
         assertEquals("b_parent1", channels.get(1).getLabel());
         assertEquals("a_child1", channels.get(2).getLabel());
         assertEquals("b_parent3", channels.get(3).getLabel());
+    }
+
+    @Test
+    public void testCloneModulesMetadata() throws Exception {
+        User user = UserTestUtils.findNewUser("testUser", "testOrg" + this.getClass().getSimpleName());
+        Instant nowDate = Instant.now();
+        Channel orig = ChannelTestUtils.createTestChannel(user);
+        Modules modules = new Modules("modules1.yaml", Date.from(nowDate.minus(Duration.ofHours(1))));
+        modules.setChannel(orig);
+        orig.addModules(modules);
+        assertTrue(orig.isModular());
+
+        Channel clone = ChannelTestUtils.createTestChannel(user);
+        modules = new Modules("modules2.yaml", Date.from(nowDate));
+        modules.setChannel(clone);
+        clone.addModules(modules);
+        assertTrue(clone.isModular());
+
+        ChannelFactory.cloneModulesMetadata(orig, clone);
+
+        assertTrue(clone.isModular());
+        assertEquals(1, clone.getModules().size());
+        assertEquals("modules1.yaml", clone.getLatestModules().getRelativeFilename());
+        assertEquals(orig.getLatestModules().getLastModified(), clone.getLatestModules().getLastModified());
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/channel/test/ChannelTest.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/test/ChannelTest.java
@@ -45,6 +45,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
 
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -254,7 +255,7 @@ public class ChannelTest extends BaseTestCaseWithUser {
         assertNull(c.getModules());
         assertFalse(c.isModular());
 
-        c.setModules(new Modules());
+        c.addModules(new Modules("filename", new Date()));
         assertNotNull(c.getModules());
         assertTrue(c.isModular());
     }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ModulemdApi.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ModulemdApi.java
@@ -57,14 +57,13 @@ public class ModulemdApi {
     }
 
     /**
-     * Get all modular packages in the specified source channels
+     * Get all modular packages from a single metadata file
      *
-     * @param sources the modular source channels
+     * @param modules the module metadata (modules.yaml) instance
      * @return a list of modular packages in NEVRA format
      */
-    public List<String> getAllPackages(List<Channel> sources) throws ModulemdApiException {
-        List<String> metadataPaths = getMetadataPaths(sources);
-        ModulemdApiResponse res = callSync(ModulemdApiRequest.listPackagesRequest(metadataPaths));
+    public List<String> getAllPackages(Modules modules) throws ModulemdApiException {
+        ModulemdApiResponse res = callSync(ModulemdApiRequest.listPackagesRequest(List.of(getMetadataPath(modules))));
         return res.getListPackages().getPackages();
     }
 
@@ -114,8 +113,17 @@ public class ModulemdApi {
         if (!channel.isModular()) {
             throw new RepositoryNotModularException();
         }
-        Modules metadata = channel.getModules();
-        return new File(MOUNT_POINT_PATH, metadata.getRelativeFilename()).getAbsolutePath();
+        return getMetadataPath(channel.getLatestModules());
+    }
+
+    /**
+     * Get 'modules.yaml' file path for the specified source on the server
+     *
+     * @param modules the module metadata instance
+     * @return the 'modules.yaml' path
+     */
+    private static String getMetadataPath(Modules modules) {
+        return new File(MOUNT_POINT_PATH, modules.getRelativeFilename()).getAbsolutePath();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
@@ -615,7 +615,7 @@ public class DownloadFile extends DownloadAction {
                     }
                     else if (path.endsWith("/modules.yaml")) {
                         diskPath = Config.get().getString(ConfigDefaults.MOUNT_POINT) +
-                            "/" + tree.getChannel().getModules().getRelativeFilename();
+                            "/" + tree.getChannel().getLatestModules().getRelativeFilename();
                     }
                     else {
                         String[] split = StringUtils.split(path, '/');
@@ -649,7 +649,7 @@ public class DownloadFile extends DownloadAction {
             }
             else if (path.endsWith("/modules.yaml")) {
                 diskPath = Config.get().getString(ConfigDefaults.MOUNT_POINT) +
-                    "/" + child.getModules().getRelativeFilename();
+                    "/" + child.getLatestModules().getRelativeFilename();
             }
             else {
                 String[] split = StringUtils.split(path, '/');

--- a/java/code/src/com/redhat/rhn/manager/channel/CloneChannelCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/CloneChannelCommand.java
@@ -15,7 +15,6 @@
 
 package com.redhat.rhn.manager.channel;
 
-import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelArch;
 import com.redhat.rhn.domain.channel.ChannelFactory;
@@ -117,14 +116,9 @@ public class CloneChannelCommand extends CreateChannelCommand {
         ChannelFactory.save(c);
         c = ChannelFactory.reload(c);
 
-        if (stripModularMetadata) {
-            if (c.getModules() != null) {
-                HibernateFactory.getSession().delete(c.getModules());
-            }
-            c.setModules(null);
-        }
-        else {
-            c.cloneModulesFrom(original);
+        // Comps files are cloned by the DB trigger 'rhn_channel_cloned_comps_trig'
+        if (stripModularMetadata && c.isModular()) {
+            c.getModules().clear();
         }
 
         // This ends up being a mode query call so need to save first to get channel id

--- a/java/code/src/com/redhat/rhn/manager/channel/test/CloneChannelCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/CloneChannelCommandTest.java
@@ -17,6 +17,7 @@ package com.redhat.rhn.manager.channel.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -28,6 +29,9 @@ import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ChannelTestUtils;
 
 import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+import java.util.Set;
 
 public class CloneChannelCommandTest extends BaseTestCaseWithUser {
 
@@ -74,20 +78,28 @@ public class CloneChannelCommandTest extends BaseTestCaseWithUser {
     @Test
     public void testCloneModularSource() throws Exception {
         Channel original = createBaseChannel();
-        Modules modules = new Modules();
-        modules.setChannel(original);
-        modules.setRelativeFilename("blablafilename");
-        original.setModules(modules);
+        Modules modules = new Modules("blablafilename1", new Date());
+        original.addModules(modules);
+
+        modules = new Modules("blablafilename2", new Date());
+        original.addModules(modules);
+
         assertTrue(original.isModular());
 
         CloneChannelCommand ccc = new CloneChannelCommand(CloneChannelCommand.CloneBehavior.ORIGINAL_STATE, original);
         ccc.setUser(user);
         Channel clone = ccc.create();
-        Modules originalModules = original.getModules();
-        Modules cloneModules = clone.getModules();
-        assertEquals(originalModules.getRelativeFilename(), cloneModules.getRelativeFilename());
-        assertEquals(clone, cloneModules.getChannel());
-        assertFalse(originalModules.getId().equals(cloneModules.getId()));
+        Set<Modules> originalModules = original.getModules();
+        Set<Modules> cloneModules = clone.getModules();
+
+        assertEquals(2, cloneModules.size());
+        cloneModules.forEach(m -> {
+            Modules orig = originalModules.stream()
+                    .filter(o -> m.getRelativeFilename().equals(o.getRelativeFilename())).findFirst().get();
+            assertEquals(orig.getLastModified(), m.getLastModified());
+            assertEquals(clone, m.getChannel());
+            assertNotEquals(orig.getId(), m.getId());
+        });
     }
 
     /**
@@ -96,10 +108,8 @@ public class CloneChannelCommandTest extends BaseTestCaseWithUser {
     @Test
     public void testStripModularMetadata() throws Exception {
         Channel original = createBaseChannel();
-        Modules modules = new Modules();
-        modules.setChannel(original);
-        modules.setRelativeFilename("blablafilename");
-        original.setModules(modules);
+        Modules modules = new Modules("blablafilename", new Date());
+        original.addModules(modules);
         assertTrue(original.isModular());
 
         CloneChannelCommand ccc = new CloneChannelCommand(CloneChannelCommand.CloneBehavior.ORIGINAL_STATE, original);

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -769,9 +769,8 @@ public class ContentManager {
     }
 
     private static void stripModuleMetadata(Channel channel) {
-        if (channel != null && channel.getModules() != null) {
-            HibernateFactory.getSession().delete(channel.getModules());
-            channel.setModules(null);
+        if (channel != null && channel.isModular()) {
+            channel.getModules().clear();
         }
     }
 

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/DependencyResolver.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/DependencyResolver.java
@@ -43,28 +43,29 @@ import java.util.stream.Stream;
 
 /**
  * Resolves dependencies in a content management project
- *
+ * <p>
  * At the moment, dependency resolution only works with module filters and modular dependencies. This class can be
  * enhanced to resolve package dependencies as well.
- *
+ * <p>
  * The resolution process takes the complete list of filters as input and queries the libmodulemd API with all the
  * module streams in filters. A module filter represents a selected module in one of the modular sources (filter rules
  * have no effect for module filters). The API returns all the related packages that must be allowed/denied as per
  * current module selection. In return, all module filters are translated into a collection of package filters by the
  * following rules:
- *
- * 1. All modular packages are denied (deny by nevra)
- * 2. For each package publicly provided by a module, all the packages from other sources with the same package name
- *    are denied. As a result, a specific package is only provided exclusively by the module to prevent any conflicts
- *    (deny by name).
- * 3. Modular packages from selected modules are overridden to be allowed (allow by nevra)
- *
- * This algorithm only runs if there are any module filters in the input list. Otherwise the process is bypassed and no
+ * <p>
+ * <ol>
+ * <li>All modular packages are denied (deny by nevra)
+ * <li>For each package publicly provided by a module, all the packages from other sources with the same package name
+ *    are denied. As a result, a specific package is provided exclusively by the module to prevent any conflicts (deny
+ *    by name).
+ * <li>Modular packages from selected modules are overridden to be allowed (allow by nevra)
+ * </ol>
+ * <p>
+ * This algorithm only runs if there are any module filters in the input list. Otherwise, the process is bypassed and no
  * filter transformation is done.
  *
- * The resolve deny-allow override problem:
- *
- * One problem with this approach is that the allow filters will override any further deny filters defined by the user
+ * <h3>The resolve deny-allow override problem</h3>
+ * One problem with this approach is that the ALLOW filters will override any further deny filters defined by the user
  * on those packages. We need to figure out if this is an important case and if so, come up with a different solution.
  *
  * @see com.redhat.rhn.manager.contentmgmt.test.DependencyResolverTest#testModuleFiltersForeignPackagesSelected

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
@@ -76,6 +76,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -990,7 +991,8 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         // Assert that the target channel is also modular
         Channel targetChannel = env.getTargets().get(0).asSoftwareTarget().get().getChannel();
         assertTrue(targetChannel.isModular());
-        assertEquals(channel.getModules().getRelativeFilename(), targetChannel.getModules().getRelativeFilename());
+        assertEquals(channel.getLatestModules().getRelativeFilename(),
+                targetChannel.getLatestModules().getRelativeFilename());
         assertEquals(channel.getPackageCount(), targetChannel.getPackageCount());
     }
 
@@ -1732,10 +1734,8 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
 
         // we already have a modular target cloned from the past
         var alreadyExistingTgt = createChannelInEnvironment(env, of(channel.getLabel()));
-        Modules modules = new Modules();
-        modules.setRelativeFilename("srcfilename");
-        modules.setChannel(alreadyExistingTgt);
-        alreadyExistingTgt.setModules(modules);
+        Modules modules = new Modules("srcfilename", new Date());
+        alreadyExistingTgt.addModules(modules);
         env.addTarget(new SoftwareEnvironmentTarget(env, alreadyExistingTgt));
 
         contentManager.buildProject("cplabel", empty(), false, user);
@@ -1764,10 +1764,8 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         contentManager.attachSource("cplabel", SW_CHANNEL, channel.getLabel(), empty(), user);
 
         var alreadyExistingTgt = createChannelInEnvironment(env, of(channel.getLabel()));
-        Modules modules = new Modules();
-        modules.setRelativeFilename("srcfilename");
-        modules.setChannel(alreadyExistingTgt);
-        alreadyExistingTgt.setModules(modules);
+        Modules modules = new Modules("srcfilename", new Date());
+        alreadyExistingTgt.addModules(modules);
         env.addTarget(new SoftwareEnvironmentTarget(env, alreadyExistingTgt));
 
         // both source and current target have modular metadata...
@@ -1794,18 +1792,15 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         assertFalse(env.getTargets().get(0).asSoftwareTarget().get().getChannel().isModular());
 
         // verify that a modular source results in a modular target
-        Modules modules = new Modules();
-        modules.setRelativeFilename("srcfilename");
-        modules.setChannel(channel);
-        channel.setModules(modules);
+        Modules modules = new Modules("srcfilename", new Date());
+        channel.addModules(modules);
         contentManager.buildProject("cplabel", empty(), false, user);
         var tgtChannel = env.getTargets().get(0).asSoftwareTarget().get().getChannel();
         assertTrue(tgtChannel.isModular());
-        assertEquals("srcfilename",  tgtChannel.getModules().getRelativeFilename());
+        assertEquals("srcfilename",  tgtChannel.getLatestModules().getRelativeFilename());
 
         // verify that a non-modular source strips the modular data
-        HibernateFactory.getSession().delete(channel.getModules());
-        channel.setModules(null);
+        channel.getModules().clear();
         contentManager.buildProject("cplabel", empty(), false, user);
         assertFalse(env.getTargets().get(0).asSoftwareTarget().get().getChannel().isModular());
     }
@@ -1830,11 +1825,11 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         contentManager.buildProject("cplabel", empty(), false, user);
         contentManager.promoteProject("cplabel", "fst", false, user);
 
-        String relativeFilename = channel.getModules().getRelativeFilename();
+        String relativeFilename = channel.getLatestModules().getRelativeFilename();
         Channel fstTgt = fst.getTargets().get(0).asSoftwareTarget().get().getChannel();
         Channel sndTgt = snd.getTargets().get(0).asSoftwareTarget().get().getChannel();
-        assertEquals(relativeFilename, fstTgt.getModules().getRelativeFilename());
-        assertEquals(relativeFilename, sndTgt.getModules().getRelativeFilename());
+        assertEquals(relativeFilename, fstTgt.getLatestModules().getRelativeFilename());
+        assertEquals(relativeFilename, sndTgt.getLatestModules().getRelativeFilename());
     }
 
     private void assertBuildFails(String projectLabel) {

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/DependencyResolverTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/DependencyResolverTest.java
@@ -191,7 +191,7 @@ public class DependencyResolverTest extends BaseTestCaseWithUser {
 
         // DENY filters for all modular packages
         // Deny-all rule for all modular packages (are overridden by ALLOW filters for the selected modules)
-        api.getAllPackages(singletonList(modularChannel))
+        api.getAllPackages(modularChannel.getLatestModules())
                 .forEach(p -> assertTrue(filters.stream().anyMatch(f -> isDenyNevraEquals(f, p))));
     }
 

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/MockModulemdApi.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/MockModulemdApi.java
@@ -44,6 +44,7 @@ import com.redhat.rhn.testing.TestUtils;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -128,10 +129,8 @@ public class MockModulemdApi extends ModulemdApi {
     public static Channel createModularTestChannel(User user) throws Exception {
         Channel channel = TestUtils.reload(ChannelFactoryTest.createTestChannel(user, "channel-x86_64"));
         channel.setChecksumType(ChannelFactory.findChecksumTypeByLabel("sha1"));
-        Modules modulemd = new Modules();
-        modulemd.setChannel(channel);
-        modulemd.setRelativeFilename("/path/to/modulemd.yaml");
-        channel.setModules(modulemd);
+        Modules modulemd = new Modules("/path/to/modulemd.yaml", new Date());
+        channel.addModules(modulemd);
 
         List<String> nevras = doGetAllPackages();
         // perl 5.26 is a special package which is included in the module definition even though it's not served as a
@@ -240,7 +239,7 @@ public class MockModulemdApi extends ModulemdApi {
         if (!channel.isModular()) {
             throw new RepositoryNotModularException();
         }
-        Modules metadata = channel.getModules();
+        Modules metadata = channel.getLatestModules();
         return new File(MOUNT_POINT_PATH, metadata.getRelativeFilename()).getAbsolutePath();
     }
 

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/MockModulemdApi.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/MockModulemdApi.java
@@ -73,10 +73,7 @@ public class MockModulemdApi extends ModulemdApi {
     }
 
     @Override
-    public List<String> getAllPackages(List<Channel> sources) {
-        // Dummy call to trigger RepositoryNotModular exception:
-        getMetadataPaths(sources);
-
+    public List<String> getAllPackages(Modules modules) {
         // Mock list
         try {
             return doGetAllPackages();

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriter.java
@@ -490,7 +490,7 @@ public class RpmRepositoryWriter extends RepositoryWriter {
                 method = channel.getClass().getMethod("getComps");
             }
             else if (metadataType.equals(MODULES)) {
-                method = channel.getClass().getMethod("getModules");
+                method = channel.getClass().getMethod("getLatestModules");
             }
         }
         catch (NoSuchMethodException e) {

--- a/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
@@ -327,10 +327,10 @@ public class DownloadController {
      * @return modules file to be used for this channel
      */
     private static File getModulesFile(Channel channel) {
-        Modules modules = channel.getModules();
+        Modules modules = channel.getLatestModules();
 
         if (modules == null && channel.isCloned()) {
-            modules = channel.getOriginal().getModules();
+            modules = channel.getOriginal().getLatestModules();
         }
         if (modules != null) {
             return new File(MOUNT_POINT_PATH, modules.getRelativeFilename()).getAbsoluteFile();

--- a/java/code/src/com/suse/manager/webui/controllers/test/DownloadControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/DownloadControllerTest.java
@@ -67,10 +67,14 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -332,6 +336,7 @@ public class DownloadControllerTest extends BaseTestCaseWithUser {
             Comps comps = new Comps();
             comps.setChannel(channel);
             comps.setRelativeFilename(compsRelativeDirPath + "/" + compsFile.getName());
+            comps.setLastModified(new Date());
             channel.setComps(comps);
 
             try {
@@ -661,6 +666,7 @@ public class DownloadControllerTest extends BaseTestCaseWithUser {
             Comps comps = new Comps();
             comps.setChannel(channel);
             comps.setRelativeFilename(compsRelativeDirPath + "/" + compsFile.getName());
+            comps.setLastModified(new Date());
             channel.setComps(comps);
 
             try {
@@ -699,28 +705,35 @@ public class DownloadControllerTest extends BaseTestCaseWithUser {
                 Collections.emptyMap(),
                 channel.getLabel(), "modules.yaml");
 
-        String modulesRelativeDirPath = "rhn/modules/" + channel.getName();
-        String modulesDirPath = Config.get().getString(ConfigDefaults.MOUNT_POINT) + "/" + modulesRelativeDirPath;
-        String modulesName = modulesRelativeDirPath + "123hash123-modules";
-        File modulesDir = new File(modulesDirPath);
+        Path modulesRelativeDir = Path.of("rhn", "modules", channel.getName());
+        Path modulesDir = Path.of(Config.get().getString(ConfigDefaults.MOUNT_POINT)).resolve(modulesRelativeDir);
         try {
-            assertTrue(modulesDir.mkdirs());
-            File modulesFile = File.createTempFile(modulesDirPath + "/" + modulesName, ".yaml", modulesDir);
-            Files.write(modulesFile.getAbsoluteFile().toPath(),
-                    TestUtils.randomString().getBytes());
+            Files.createDirectories(modulesDir);
+            Path modulesFile = Files.createTempFile(modulesDir, "n3wha5h", "-modules.yaml");
+            Files.write(modulesFile, TestUtils.randomString().getBytes());
 
             // create modules object
-            Modules modules = new Modules();
-            modules.setChannel(channel);
-            modules.setRelativeFilename(modulesRelativeDirPath + "/" + modulesFile.getName());
-            channel.setModules(modules);
+            Modules modulesLatest = new Modules(modulesRelativeDir.resolve(modulesFile.getFileName()).toString(),
+                    Date.from(Files.getLastModifiedTime(modulesFile).toInstant()));
+            channel.addModules(modulesLatest);
+
+            // Create a second, older modules.yaml file
+            Path modulesFileOlder = Files.createTempFile(modulesDir, "01dha5h", "-modules.yaml");
+            Files.write(modulesFileOlder, TestUtils.randomString().getBytes());
+            // Set file time to 1 second earlier than the other one
+            Files.setLastModifiedTime(modulesFileOlder,
+                    FileTime.from(Files.getLastModifiedTime(modulesFile).toInstant().minus(Duration.ofSeconds(1))));
+
+            Modules modulesOlder = new Modules(modulesRelativeDir.resolve(modulesFileOlder.getFileName()).toString(),
+                    Date.from(Files.getLastModifiedTime(modulesFileOlder).toInstant()));
+            channel.addModules(modulesOlder);
 
             try {
                 assertNotNull(DownloadController.downloadMetadata(request, response));
 
-                assertEquals(modulesFile.getAbsolutePath(), response.raw().getHeader("X-Sendfile"));
+                assertEquals(modulesFile.toAbsolutePath().toString(), response.raw().getHeader("X-Sendfile"));
                 assertEquals("application/octet-stream", response.raw().getHeader("Content-Type"));
-                assertEquals("attachment; filename=" + modulesFile.getName(),
+                assertEquals("attachment; filename=" + modulesFile.getFileName().toString(),
                         response.raw().getHeader("Content-Disposition"));
             }
             catch (spark.HaltException e) {
@@ -728,7 +741,7 @@ public class DownloadControllerTest extends BaseTestCaseWithUser {
             }
         }
         finally {
-            FileUtils.deleteDirectory(modulesDir);
+            FileUtils.deleteDirectory(modulesDir.toFile());
         }
     }
 
@@ -765,6 +778,7 @@ public class DownloadControllerTest extends BaseTestCaseWithUser {
             MediaProducts prd = new MediaProducts();
             prd.setChannel(channel);
             prd.setRelativeFilename(productsRelativeDirPath + "/" + productsFile.getName());
+            prd.setLastModified(new Date());
             channel.setMediaProducts(prd);
 
             try {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Deny packages from older module metadata when building CLM projects (bsc#1201893)
 - Refresh pillar data for the assigned systems when a CLM channel is built (bsc#1200169)
 - Upgrade Bootstrap to 3.4.1
 - Improve Amazon EC2/Nitro detection (bsc#1203685)

--- a/python/spacewalk/satellite_tools/reposync.py
+++ b/python/spacewalk/satellite_tools/reposync.py
@@ -823,7 +823,11 @@ class RepoSync(object):
         src.close()
         if old_checksum and old_checksum != getFileChecksum('sha256', abspath):
             self.regen = True
-        log(0, "*** NOTE: Importing {1} file for the channel '{0}'. Previous {1} will be discarded.".format(self.channel['label'], comps_type))
+
+        if comps_type == 'modules':
+            log(0, "*** NOTE: Importing {1} file for the channel '{0}'.".format(self.channel['label'], comps_type))
+        else:
+            log(0, "*** NOTE: Importing {1} file for the channel '{0}'. Previous {1} will be discarded.".format(self.channel['label'], comps_type))
 
         repoDataKey = 'group' if comps_type == 'comps' else comps_type
         file_timestamp = os.path.getmtime(filename)
@@ -835,26 +839,30 @@ class RepoSync(object):
             return abspath
 
         # update or insert
-        hu = rhnSQL.prepare("""update rhnChannelComps
-                                  set relative_filename = :relpath,
-                                      modified = current_timestamp,
-                                      last_modified = :last_modified
-                                where channel_id = :cid
-                                  and comps_type_id = (select id from rhnCompsType where label = :ctype)""")
+        hu = rhnSQL.prepare("""
+            update rhnChannelComps
+            set relative_filename = :relpath,
+                modified = current_timestamp,
+                last_modified = :last_modified
+            where channel_id = :cid
+                and comps_type_id = (select id from rhnCompsType where label = :ctype)
+                and relative_filename = :relpath""")
         hu.execute(cid=self.channel['id'], relpath=relativepath, ctype=comps_type,
                    last_modified=last_modified)
 
-        hi = rhnSQL.prepare("""insert into rhnChannelComps
-                              (id, channel_id, relative_filename, last_modified, comps_type_id)
-                              (select sequence_nextval('rhn_channelcomps_id_seq'),
-                                      :cid,
-                                      :relpath,
-                                      :last_modified,
-                              (select id from rhnCompsType where label = :ctype)
-                                 from dual
-                                where not exists (select 1 from rhnChannelComps
-                                    where channel_id = :cid
-                                    and comps_type_id = (select id from rhnCompsType where label = :ctype)))""")
+        hi = rhnSQL.prepare("""
+            insert into rhnChannelComps(id, channel_id, relative_filename, last_modified, comps_type_id)
+            (select sequence_nextval('rhn_channelcomps_id_seq'),
+                    :cid,
+                    :relpath,
+                    :last_modified,
+                    (select id from rhnCompsType where label = :ctype)
+                from dual
+                where not exists
+                    (select 1 from rhnChannelComps
+                        where channel_id = :cid
+                            and comps_type_id = (select id from rhnCompsType where label = :ctype)
+                            and relative_filename = :relpath))""")
         hi.execute(cid=self.channel['id'], relpath=relativepath, ctype=comps_type,
                    last_modified=last_modified)
         return abspath

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Keep older module metadata files in database (bsc#1201893)
 - Used the legacy reporting system in spacewalk-debug to obtain
   up-to-date information
 

--- a/schema/spacewalk/common/tables/rhnChannelComps.sql
+++ b/schema/spacewalk/common/tables/rhnChannelComps.sql
@@ -31,12 +31,14 @@ CREATE TABLE rhnChannelComps
                            DEFAULT (current_timestamp) NOT NULL,
     comps_type_id      NUMERIC NOT NULL
                           CONSTRAINT rhn_channelcomps_comps_type_fk
-                               REFERENCES rhnCompsType(id)
+                               REFERENCES rhnCompsType(id),
+    CONSTRAINT rhn_channelcomps_cid_ctype_filename_uq
+        UNIQUE(channel_id, comps_type_id, relative_filename)
 )
 
 ;
 
-CREATE UNIQUE INDEX rhn_channelcomps_cid_ctype_uq
+CREATE INDEX rhn_channelcomps_cid_ctype_idx
     ON rhnChannelComps (channel_id, comps_type_id)
     ;
 

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Keep older module metadata files in database (bsc#1201893)
 - Fix setting of last modified date in channel clone procedure
 - Change 'Amazon EC2/KVM' to 'Amazon EC2/Nitro' (bsc#1203685)
 

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Fix setting of last modified date in channel clone procedure
 - Change 'Amazon EC2/KVM' to 'Amazon EC2/Nitro' (bsc#1203685)
 
 -------------------------------------------------------------------

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.1-to-susemanager-schema-4.4.2/200-rhnChannelComps-drop_unique_index.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.1-to-susemanager-schema-4.4.2/200-rhnChannelComps-drop_unique_index.sql
@@ -1,0 +1,11 @@
+-- Replace the index with a non-unique one
+DROP INDEX IF EXISTS rhn_channelcomps_cid_ctype_uq;
+DROP INDEX IF EXISTS rhn_channelcomps_cid_ctype_idx;
+
+CREATE INDEX rhn_channelcomps_cid_ctype_idx ON rhnChannelComps(channel_id, comps_type_id);
+
+-- Add a unique constraint as (cid, comps_type, filename)
+ALTER TABLE rhnChannelComps DROP CONSTRAINT IF EXISTS rhn_channelcomps_cid_ctype_filename_uq;
+
+ALTER TABLE rhnChannelComps ADD CONSTRAINT rhn_channelcomps_cid_ctype_filename_uq
+    UNIQUE (channel_id, comps_type_id, relative_filename);

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.1-to-susemanager-schema-4.4.2/201-rhn_channel_cloned_comps_trig_fun.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.1-to-susemanager-schema-4.4.2/201-rhn_channel_cloned_comps_trig_fun.sql
@@ -1,18 +1,3 @@
---
--- Copyright (c) 2008--2012 Red Hat, Inc.
---
--- This software is licensed to you under the GNU General Public License,
--- version 2 (GPLv2). There is NO WARRANTY for this software, express or
--- implied, including the implied warranties of MERCHANTABILITY or FITNESS
--- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
--- along with this software; if not, see
--- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
---
--- Red Hat trademarks are not licensed under GPLv2. No permission is
--- granted to use or replicate Red Hat trademarks that are incorporated
--- in this software or its documentation.
---
-
 create or replace function rhn_channel_cloned_comps_trig_fun() returns trigger
 as
 $$
@@ -40,9 +25,9 @@ end;
 $$
 language plpgsql;
 
+drop trigger if exists rhn_channel_cloned_comps_trig on rhnChannelCloned;
 
-create trigger
-rhn_channel_cloned_comps_trig
+create trigger rhn_channel_cloned_comps_trig
 before insert or update on rhnChannelCloned
 for each row
 execute procedure rhn_channel_cloned_comps_trig_fun();


### PR DESCRIPTION
Most CentOS flavors serve only the latest packages in their repositories. When a new release comes out, old packages are wiped out, new packages are served, and the modules.yaml file is replaced with a new one.

SUSE Manager on the other hand never removes synced packages. When a new release is synced, both the old and new packages are still available in channels. We read modules.yaml to look up the AppStream packages to filter out. Since the modules.yaml file is replaced with a new one and it does not contain any information about the older packages, those older packages leak into target repositories.

In SUSE Manager, we already keep the older modules.yaml files in the file system. This PR changes the behavior to also keep them in the database, and use them when retrieving the list of packages to filter during a CLM build.

Followup: migration script to fix the existing channels without the need for a re-sync: https://gist.github.com/cbbayburt/0f83039a21d021e8e1415618cff414ec

See also:
 - https://bugzilla.suse.com/show_bug.cgi?id=1201893
 - https://github.com/uyuni-project/uyuni/issues/4769


## Documentation
- No documentation needed: Bugfix

## Test coverage
- Unit tests were added

## Links
Fixes https://github.com/SUSE/spacewalk/issues/18483
Fixes https://github.com/SUSE/spacewalk/issues/17961
Fixes https://github.com/uyuni-project/uyuni/issues/4769

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
