### PR TITLE
Remove legacy cluster_admin user group

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Remove legacy cluster_admin user group
 - Add subtypes for Amazon EC2 virtual instances (bsc#1195624)
 - Fix migration of image actions (bsc#1202272)
 - Add Rocky Linux 9 and EPEL 9 key

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.0-tosusemanager-schema-4.4.1/001-remove-cluster_admin.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.0-tosusemanager-schema-4.4.1/001-remove-cluster_admin.sql
@@ -1,0 +1,5 @@
+
+DELETE FROM rhnUserExtGroupMapping WHERE int_group_type_id IN (SELECT id FROM rhnusergrouptype WHERE label = 'cluster_admin');
+DELETE FROM rhnUserGroupMembers WHERE user_group_id IN (SELECT G.id FROM rhnusergroup G, rhnusergrouptype GT WHERE G.group_type = GT.id AND GT.label = 'cluster_admin');
+DELETE FROM rhnUserGroup WHERE group_type IN (SELECT id FROM rhnusergrouptype WHERE label = 'cluster_admin');
+DELETE FROM rhnUserGroupType WHERE label = 'cluster_admin';


### PR DESCRIPTION
## What does this PR change?

Remove the `cluster_admin` group from the database now that the cluster feature has been removed from the code base.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [X] **DONE**

## Test coverage
- No tests: removed code is not tested 😉 
- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18617

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
