### PR TITLE
Display a warning message in UI for traditional stack deprecation

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -2097,6 +2097,15 @@ SELECT channel_arch_id
   </query>
 </mode>
 
+<mode name="count_systems_with_entitlement">
+  <query params="user_id, entitlement_label">
+    SELECT  count(S.id)
+    FROM  rhnServer S
+    WHERE EXISTS (SELECT 1 FROM rhnUserServerPerms USP WHERE USP.user_id = :user_id AND USP.server_id = S.id)
+    AND EXISTS (SELECT 1 FROM rhnServerEntitlementView E where E.label = :entitlement_label AND E.server_id = S.id)
+  </query>
+</mode>
+
 <mode name="count_systems_in_set_without_feature">
   <query params="user_id, set_label, feature_label">
     SELECT COUNT(*) as count

--- a/java/code/src/com/redhat/rhn/frontend/servlets/SystemDetailsMessageFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/SystemDetailsMessageFilter.java
@@ -37,13 +37,13 @@ import javax.servlet.annotation.WebFilter;
 import javax.servlet.http.HttpServletRequest;
 
 /**
- * This class implements a WebFilter that applies to all system details pages and adds the transactional update reboot
- * alert if necessary, considering whether the system supports Transactional Update.
+ * This class implements a WebFilter that applies to all system details pages and adds alerts if necessary.
  */
 @WebFilter("/systems/details/*")
-public class TransactionalUpdateRebootMessageFilter implements Filter {
+public class SystemDetailsMessageFilter implements Filter {
 
-    private static final String MESSAGE_KEY = "overview.jsp.transactionalupdate.reboot";
+    private static final String REBOOT_MESSAGE_KEY = "overview.jsp.transactionalupdate.reboot";
+    private static final String TRADITIONAL_STACK_MESSAGE_KEY = "overview.jsp.traditionalstack.deprecated";
 
     @Override
     public void doFilter(
@@ -53,33 +53,37 @@ public class TransactionalUpdateRebootMessageFilter implements Filter {
     ) throws ServletException, IOException {
         chain.doFilter(request, response);
         HttpServletRequest req = (HttpServletRequest) request;
-        if (!isMessageAlreadyPresent(req)) {
-            RequestContext rctx = new RequestContext(req);
-            Long sid = rctx.getRequiredParam("sid");
-            User user = rctx.getCurrentUser();
-            Server s  = SystemManager.lookupByIdAndUser(sid, user);
-            s.asMinionServer().ifPresent(minion -> {
-                if (minion.doesOsSupportsTransactionalUpdate()) {
-                    ActionErrors errs = new ActionErrors();
-                    errs.add(
-                        ActionMessages.GLOBAL_MESSAGE,
-                        new ActionMessage(MESSAGE_KEY)
-                    );
-                    StrutsDelegate.getInstance().saveMessages(req, errs);
-                }
-            });
+        RequestContext rctx = new RequestContext(req);
+        Long sid = rctx.getRequiredParam("sid");
+        User user = rctx.getCurrentUser();
+        Server s  = SystemManager.lookupByIdAndUser(sid, user);
+        s.asMinionServer().ifPresentOrElse(
+            minion -> addMessageIfNecessary(req, minion.doesOsSupportsTransactionalUpdate(), REBOOT_MESSAGE_KEY),
+            () -> addMessageIfNecessary(req, true, TRADITIONAL_STACK_MESSAGE_KEY)
+        );
+    }
+
+    private void addMessageIfNecessary(HttpServletRequest req, boolean condition, String messageKey) {
+        if (!condition || isMessageAlreadyPresent(req, messageKey)) {
+            return;
         }
+        ActionErrors errs = new ActionErrors();
+        errs.add(
+            ActionMessages.GLOBAL_MESSAGE,
+            new ActionMessage(messageKey)
+        );
+        StrutsDelegate.getInstance().saveMessages(req, errs);
     }
 
     /**
      * Checks if the message is already present in the session, to avoid duplicate alerts
      */
-    private boolean isMessageAlreadyPresent(HttpServletRequest request) {
+    private boolean isMessageAlreadyPresent(HttpServletRequest request, String messageKey) {
         Object sessionErrs = request.getSession().getAttribute(Globals.ERROR_KEY);
         if (sessionErrs != null) {
             Iterator<ActionMessage> i = ((ActionMessages) sessionErrs).get(ActionMessages.GLOBAL_MESSAGE);
             while (i.hasNext()) {
-                if (i.next().getKey().equals(MESSAGE_KEY)) {
+                if (i.next().getKey().equals(messageKey)) {
                     return true;
                 }
             }

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -24847,6 +24847,9 @@ given channel.</source>
       <trans-unit id="overview.jsp.transactionalupdate.reboot" xml:space="preserve">
         <source>OS with transactional updates: please reboot after any packages and/or channels changes.</source>
       </trans-unit>
+      <trans-unit id="overview.jsp.traditionalstack.deprecated" xml:space="preserve">
+        <source>The traditional stack is unsupported and scheduled for removal. Consider migrating to salt minions.</source>
+      </trans-unit>
       <trans-unit id="channelOverview.jsp.tasks.modifyCreate.state" xml:space="preserve">
         <source>Create configuration file</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -6137,6 +6137,20 @@ public class SystemHandler extends BaseHandler {
     }
 
     /**
+     * Returns whether there are traditional systems registered
+     *
+     * @param loggedInUser The current user
+     * @return true if there is at least one traditional system registered or else false
+     *
+     * @apidoc.ignore this endpoint is used only internally to determine if a warning
+     * about traditional stack deprecation should be displayed
+     */
+    @ReadOnly
+    public boolean hasTraditionalSystems(User loggedInUser) {
+        return SystemManager.hasTraditionalSystems(loggedInUser);
+    }
+
+    /**
      * Gets a list of all Physical systems visible to user
      * @param loggedInUser The current user
      * @return Returns an array of maps representing all systems visible to user

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -2740,6 +2740,21 @@ public class SystemManager extends BaseManager {
     }
 
     /**
+     * Returns whether there are traditional systems registered
+     *
+     * @param user The current user
+     * @return true if there is at least one system registered with Enterprise entitlement
+     */
+    public static boolean hasTraditionalSystems(User user) {
+        SelectMode m = ModeFactory.getMode("System_queries", "count_systems_with_entitlement");
+        Map<String, Object> params = new HashMap<>();
+        params.put("user_id", user.getId());
+        params.put("entitlement_label", EntitlementManager.ENTERPRISE_ENTITLED);
+        DataResult<Map<String, Object>> dr = makeDataResult(params, null, null, m);
+        return ((Long) dr.get(0).get("count")).intValue() > 0;
+    }
+
+    /**
      * Returns the number of systems subscribed to the channel that are
      * <strong>not</strong> in the given org.
      *

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Added a warning message for traditional stack deprecation
 - Fix rendering of ssm/MigrateSystems page (bsc#1204651)
 - Remove 'SSM' column text where not applicable (bsc#1203588)
 - Improve systems lists queries performance by using an overview table

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Added a warning message for traditional stack deprecation
 - Remove "Undefined return code" from debug messages (bsc#1203283)
 - Update translation strings
 

--- a/spacecmd/src/spacecmd/misc.py
+++ b/spacecmd/src/spacecmd/misc.py
@@ -405,6 +405,7 @@ def do_login(self, args):
     self.server = server
 
     logging.info(_N('Connected to %s as %s'), server_url, username)
+    _show_traditional_stack_message(self)
 
     return True
 
@@ -460,6 +461,17 @@ def do_whoamitalkingto(self, args):
 
 ####################
 
+def _show_traditional_stack_message(self):
+    n_systems = len(self.client.system.listSystems(self.session))
+    n_salt_systems = len(
+        self.client.system.listSystemsWithEntitlement(self.session, 'salt_entitled')
+    )
+
+    if n_systems > n_salt_systems:
+        logging.warning((
+            'The traditional stack is unsupported and scheduled for removal. '
+            'Consider migrating to salt minions.'
+        ))
 
 def tab_complete_errata(self, text):
     options = self.do_errata_list('', True)

--- a/spacecmd/src/spacecmd/misc.py
+++ b/spacecmd/src/spacecmd/misc.py
@@ -462,12 +462,9 @@ def do_whoamitalkingto(self, args):
 ####################
 
 def _show_traditional_stack_message(self):
-    n_systems = len(self.client.system.listSystems(self.session))
-    n_salt_systems = len(
-        self.client.system.listSystemsWithEntitlement(self.session, 'salt_entitled')
-    )
+    has_traditional_systems = self.client.system.hasTraditionalSystems(self.session)
 
-    if n_systems > n_salt_systems:
+    if has_traditional_systems:
         logging.warning((
             'The traditional stack is unsupported and scheduled for removal. '
             'Consider migrating to salt minions.'

--- a/spacecmd/tests/test_misc.py
+++ b/spacecmd/tests/test_misc.py
@@ -319,6 +319,7 @@ class TestSCMisc:
         shell.conf_dir = "/tmp"
         shell.MINIMUM_API_VERSION = 10.8
         client.api.getVersion = MagicMock(return_value=11.5)
+        client.system.hasTraditionalSystems = MagicMock(return_value=False)
 
         with patch("spacecmd.misc.print", mprint) as prt, \
             patch("spacecmd.misc.prompt_user", prompter) as pmt, \
@@ -382,6 +383,7 @@ class TestSCMisc:
         shell.MINIMUM_API_VERSION = 10.8
         client.api.getVersion = MagicMock(return_value=11.5)
         client.auth.login = MagicMock(return_value="5adf5cc50929f71a899b81c2c2eb0979")
+        client.system.hasTraditionalSystems = MagicMock(return_value=False)
 
         with patch("spacecmd.misc.print", mprint) as prt, \
             patch("spacecmd.misc.prompt_user", prompter) as pmt, \
@@ -449,6 +451,7 @@ class TestSCMisc:
         shell.MINIMUM_API_VERSION = 10.8
         client.api.getVersion = MagicMock(return_value=11.5)
         client.auth.login = MagicMock(return_value="5adf5cc50929f71a899b81c2c2eb0979")
+        client.system.hasTraditionalSystems = MagicMock(return_value=False)
 
         with patch("spacecmd.misc.print", mprint) as prt, \
             patch("spacecmd.misc.prompt_user", prompter) as pmt, \
@@ -516,6 +519,7 @@ class TestSCMisc:
         shell.MINIMUM_API_VERSION = 10.8
         client.api.getVersion = MagicMock(return_value=11.5)
         client.auth.login = MagicMock(return_value="5adf5cc50929f71a899b81c2c2eb0979")
+        client.system.hasTraditionalSystems = MagicMock(return_value=False)
 
         with patch("spacecmd.misc.print", mprint) as prt, \
             patch("spacecmd.misc.prompt_user", prompter) as pmt, \
@@ -645,6 +649,7 @@ class TestSCMisc:
         shell.MINIMUM_API_VERSION = 10.8
         client.api.getVersion = MagicMock(return_value=11.5)
         client.auth.login = MagicMock(return_value="5adf5cc50929f71a899b81c2c2eb0979")
+        client.system.hasTraditionalSystems = MagicMock(return_value=False)
 
         with patch("spacecmd.misc.print", mprint) as prt, \
             patch("spacecmd.misc.prompt_user", prompter) as pmt, \


### PR DESCRIPTION
## What does this PR change?

It adds a warning message in UI for traditional stack deprecation. To do so, the webfilter previously used to show a reboot needed message was refactored to be a generic message filter for system details.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: just a warning message.

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/18724

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests" 
