### PR TITLE
Rerun frontend workflows when workflow definitions change

### DIFF
--- a/.github/workflows/automatic-frontend-lint-fix-pr.yml
+++ b/.github/workflows/automatic-frontend-lint-fix-pr.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - 'web/html/src/**'
+      - '.github/workflows/automatic-frontend-lint-fix-pr.yml'
 
 jobs:
   frontend_lint_fix_pr:

--- a/.github/workflows/frontend-dependency-audit.yml
+++ b/.github/workflows/frontend-dependency-audit.yml
@@ -7,6 +7,7 @@ on:
       - master
     paths:
       - 'web/html/src/package.json'
+      - '.github/workflows/frontend-dependency-audit.yml'
 
 jobs:
   frontend_dependency_audit:

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -6,9 +6,11 @@ on:
       - master
     paths:
       - 'web/html/src/**'
+      - '.github/workflows/frontend-lint.yml'
   pull_request:
     paths:
       - 'web/html/src/**'
+      - '.github/workflows/frontend-lint.yml'
 
 jobs:
   frontend_lint:

--- a/.github/workflows/javascript-build.yml
+++ b/.github/workflows/javascript-build.yml
@@ -6,9 +6,11 @@ on:
       - master
     paths:
       - 'web/html/src/**'
+      - '.github/workflows/javascript-build.yml'
   pull_request:
     paths:
       - 'web/html/src/**'
+      - '.github/workflows/javascript-build.yml'
 
 jobs:
   javascript_build:

--- a/.github/workflows/javascript-unit-tests.yml
+++ b/.github/workflows/javascript-unit-tests.yml
@@ -6,9 +6,11 @@ on:
       - master
     paths:
       - 'web/html/src/**'
+      - '.github/workflows/javascript-unit-tests.yml'
   pull_request:
     paths:
       - 'web/html/src/**'
+      - '.github/workflows/javascript-unit-tests.yml'
 
 jobs:
   javascript_unit_tests:

--- a/.github/workflows/typescript-compilation.yml
+++ b/.github/workflows/typescript-compilation.yml
@@ -6,9 +6,11 @@ on:
       - master
     paths:
       - 'web/html/src/**'
+      - '.github/workflows/typescript-compilation.yml'
   pull_request:
     paths:
       - 'web/html/src/**'
+      - '.github/workflows/typescript-compilation.yml'
 
 jobs:
   typescript_compilation:


### PR DESCRIPTION
## What does this PR change?

In response to https://github.com/uyuni-project/uyuni/pull/5808, it would be very handy if the workflows reran themselves when there's a PR to change them so we can see if they're valid or not. I couldn't find a better way to try and implement this, perhaps @renner has any good ideas?

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
