### PR TITLE
QE: BV: Fix service name mismatch on Deblike

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -182,6 +182,7 @@ Feature: Smoke tests for <client>
     When I wait until "prometheus" service is active on "<client>"
     And I visit "Prometheus" endpoint of this "<client>"
 
+@skip_for_traditional
   Scenario: Test Prometheus exporter formula on the <client>
     Given I am on the Systems overview page of this "<client>"
     When I follow "Formulas" in the content area
@@ -203,9 +204,9 @@ Feature: Smoke tests for <client>
     Then I should see a "Applying the highstate has been scheduled." text
     And I wait until event "Apply highstate scheduled by admin" is completed
     # Visit monitoring endpoints on the minion
-    When I wait until "prometheus-node_exporter" service is active on "<client>"
+    When I wait until "node" exporter service is active on "<client>"
     And I visit "Prometheus node exporter" endpoint of this "<client>"
-    And I wait until "prometheus-apache_exporter" service is active on "<client>"
+    And I wait until "apache" exporter service is active on "<client>"
     And I visit "Prometheus apache exporter" endpoint of this "<client>"
-    And I wait until "prometheus-postgres_exporter" service is active on "<client>"
+    And I wait until "postgres" exporter service is active on "<client>"
     And I visit "Prometheus postgres exporter" endpoint of this "<client>"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -260,10 +260,9 @@ end
 
 Then(/^I wait until "([^"]*)" exporter service is active on "([^"]*)"$/) do |service, host|
   node = get_target(host)
-  # necessary since Debian like OSes use different names for the services
-  separator = deb_host?(name) ? "-" : "_"
-  full_service = "prometheus-#{service}#{separator}exporter"
-  cmd = "systemctl is-active #{full_service}"
+  # necessary since Debian-like OSes use different names for the services
+  separator = deb_host?(host) ? "-" : "_"
+  cmd = "systemctl is-active prometheus-#{service}#{separator}exporter"
   node.run_until_ok(cmd)
 end
 

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -258,6 +258,15 @@ Then(/^I wait until "([^"]*)" service is active on "([^"]*)"$/) do |service, hos
   node.run_until_ok(cmd)
 end
 
+Then(/^I wait until "([^"]*)" exporter service is active on "([^"]*)"$/) do |service, host|
+  node = get_target(host)
+  # necessary since Debian like OSes use different names for the services
+  separator = deb_host?(name) ? "-" : "_"
+  full_service = "prometheus-#{service}#{separator}exporter"
+  cmd = "systemctl is-active #{full_service}"
+  node.run_until_ok(cmd)
+end
+
 When(/^I enable product "([^"]*)"$/) do |prd|
   list_output, _code = $server.run("mgr-sync list products", check_errors: false, buffer_size: 1_000_000)
   executed = false

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -252,13 +252,13 @@ When(/^I apply highstate on "([^"]*)"$/) do |host|
   $server.run_until_ok("#{cmd} #{system_name} state.highstate")
 end
 
-Then(/^I wait until "([^"]*)" service is active on "([^"]*)"$/) do |service, host|
+When(/^I wait until "([^"]*)" service is active on "([^"]*)"$/) do |service, host|
   node = get_target(host)
   cmd = "systemctl is-active #{service}"
   node.run_until_ok(cmd)
 end
 
-Then(/^I wait until "([^"]*)" exporter service is active on "([^"]*)"$/) do |service, host|
+When(/^I wait until "([^"]*)" exporter service is active on "([^"]*)"$/) do |service, host|
   node = get_target(host)
   # necessary since Debian-like OSes use different names for the services
   separator = deb_host?(host) ? "-" : "_"


### PR DESCRIPTION
## What does this PR change?

This will fix an issue found during 4.3.1 BV regarding different service
names for SLE/Red Hat and Debian/Ubuntu. This will introduce a new step
to differentiate between them.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were adjusted

- [x] **DONE**

## Links
Manager 4.3
Manager 4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
