### PR TITLE
QE: add Debian-like monitoring feature

### DIFF
--- a/testsuite/features/secondary/min_deblike_monitoring.feature
+++ b/testsuite/features/secondary/min_deblike_monitoring.feature
@@ -1,0 +1,68 @@
+# Copyright (c) 2022 SUSE LLC
+# Licensed under the terms of the MIT license.
+# This feature depends on:
+# - features/secondary/srv_monitoring.feature: as this feature disables/re-enables monitoring capabilities
+# - sumaform: as it is configuring monitoring to be enabled after deployment
+
+@scope_monitoring
+@scope_res
+@deblike_minion
+Feature: Monitor SUMA environment with Prometheus on a Debian-like Salt minion
+  In order to monitor Uyuni server
+  As an authorized user
+  I want to enable Prometheus exporters
+
+  Scenario: Pre-requisite: enable Prometheus exporters repository on the Debian-like minion
+    When I enable the necessary repositories before installing Prometheus exporters on this "deblike_minion"
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Apply Prometheus exporter formulas on the Debian-like minion
+    Given I am on the Systems overview page of this "deblike_minion"
+    When I follow "Formulas" in the content area
+    Then I should see a "Choose formulas:" text
+    And I should see a "Monitoring" text
+    When I check the "prometheus-exporters" formula
+    And I click on "Save"
+    And I wait until I see "Formula saved" text
+
+  Scenario: Configure Prometheus exporter formula on the Debian-like minion
+    When I follow "Formulas" in the content area
+    And I follow "Prometheus Exporters" in the content area
+    And I click on "Expand All Sections"
+    Then I should see a "Enable and configure Prometheus exporters for managed systems." text
+    When I check "node" exporter
+    And I check "apache" exporter
+    And I check "postgres" exporter
+    And I click on "Save"
+    Then I should see a "Formula saved" text
+
+  Scenario: Apply highstate for Prometheus exporters on the Debian-like minion
+    When I follow "States" in the content area
+    And I click on "Apply Highstate"
+    Then I should see a "Applying the highstate has been scheduled." text
+    And I wait until event "Apply highstate scheduled by admin" is completed
+
+  Scenario: Visit monitoring endpoints on the Debian-like minion
+    When I wait until "node" exporter service is active on "deblike_minion"
+    And I visit "Prometheus node exporter" endpoint of this "deblike_minion"
+    And I wait until "apache" exporter service is active on "deblike_minion"
+    And I visit "Prometheus apache exporter" endpoint of this "deblike_minion"
+    And I wait until "postgres" exporter service is active on "deblike_minion"
+    And I visit "Prometheus postgres exporter" endpoint of this "deblike_minion"
+
+  Scenario: Cleanup: undo Prometheus exporter formulas on the Debian-like minion
+    When I follow "Formulas" in the content area
+    And I uncheck the "prometheus-exporters" formula
+    And I click on "Save"
+    Then I wait until I see "Formula saved" text
+
+  Scenario: Cleanup: apply highstate after test monitoring on the Debian-like minion
+    When I follow "States" in the content area
+    And I click on "Apply Highstate"
+    Then I should see a "Applying the highstate has been scheduled." text
+    And I wait until event "Apply highstate scheduled by admin" is completed
+
+  Scenario: Cleanup: disable Prometheus exporters repository on the Debian-like minion
+    When I disable the necessary repositories before installing Prometheus exporters on this "deblike_minion" without error control

--- a/testsuite/features/secondary/min_monitoring.feature
+++ b/testsuite/features/secondary/min_monitoring.feature
@@ -57,11 +57,11 @@ Feature: Monitor SUMA environment with Prometheus on a SLE Salt minion
   Scenario: Visit monitoring endpoints on the minion
     When I wait until "prometheus" service is active on "sle_minion"
     And I visit "Prometheus" endpoint of this "sle_minion"
-    And I wait until "prometheus-node_exporter" service is active on "sle_minion"
+    And I wait until "node" exporter service is active on "sle_minion"
     And I visit "Prometheus node exporter" endpoint of this "sle_minion"
-    And I wait until "prometheus-apache_exporter" service is active on "sle_minion"
+    And I wait until "apache" exporter service is active on "sle_minion"
     And I visit "Prometheus apache exporter" endpoint of this "sle_minion"
-    And I wait until "prometheus-postgres_exporter" service is active on "sle_minion"
+    And I wait until "postgres" exporter service is active on "sle_minion"
     And I visit "Prometheus postgres exporter" endpoint of this "sle_minion"
 
   Scenario: Cleanup: undo Prometheus and Prometheus exporter formulas

--- a/testsuite/features/secondary/min_rhlike_monitoring.feature
+++ b/testsuite/features/secondary/min_rhlike_monitoring.feature
@@ -45,11 +45,11 @@ Feature: Monitor SUMA environment with Prometheus on a Red Hat-like Salt minion
     And I wait until event "Apply highstate scheduled by admin" is completed
 
   Scenario: Visit monitoring endpoints on the Red Hat-like minion
-    When I wait until "prometheus-node_exporter" service is active on "rhlike_minion"
+    When I wait until "node" exporter service is active on "rhlike_minion"
     And I visit "Prometheus node exporter" endpoint of this "rhlike_minion"
-    And I wait until "prometheus-apache_exporter" service is active on "rhlike_minion"
+    And I wait until "apache" exporter service is active on "rhlike_minion"
     And I visit "Prometheus apache exporter" endpoint of this "rhlike_minion"
-    And I wait until "prometheus-postgres_exporter" service is active on "rhlike_minion"
+    And I wait until "postgres" exporter service is active on "rhlike_minion"
     And I visit "Prometheus postgres exporter" endpoint of this "rhlike_minion"
 
   Scenario: Cleanup: undo Prometheus exporter formulas on the Red Hat-like minion

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -50,6 +50,7 @@
 - features/secondary/min_rhlike_monitoring.feature
 - features/secondary/minssh_salt_install_package.feature
 - features/secondary/minssh_ansible_control_node.feature
+- features/secondary/min_deblike_monitoring.feature
 - features/secondary/min_deblike_salt_install_with_staging.feature
 - features/secondary/min_deblike_salt_install_package.feature
 - features/secondary/min_bootstrap_api.feature


### PR DESCRIPTION
## What does this PR change?

This will add the same monitoring feature for the Debian-like minion like we already have for the SLE and the Red Hat-like minion.
Furthermore the old monitoring features now use the same logic as the new file introduced with https://github.com/uyuni-project/uyuni/pull/5819

## GUI diff

No difference.


- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were added

- [x] **DONE**

## Links

- Fixes https://github.com/SUSE/spacewalk/issues/18702
- https://github.com/uyuni-project/uyuni/pull/5819
- Manager 4.3
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
