### PR TITLE
create bootstrap repository data for Ubuntu 22.04 Vendor Channels

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1581,6 +1581,11 @@ DATA = {
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/ubuntu/20/4/bootstrap/',
         'TYPE' : 'deb'
     },
+    'ubuntu-22.04-amd64' : {
+        'PDID' : [-33, 2531], 'BETAPDID' : [2532], 'PKGLIST' : PKGLISTUBUNTU2204,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/ubuntu/22/4/bootstrap/',
+        'TYPE' : 'deb'
+    },
     'ubuntu-16.04-amd64-uyuni' : {
         'BASECHANNEL' : 'ubuntu-16.04-pool-amd64-uyuni', 'PKGLIST' : PKGLISTUBUNTU1604,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/ubuntu/16/4/bootstrap/',

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- create bootstrap repository data for Ubuntu 22.04 Vendor Channels
 - remove obsoleted sysv init script (bsc#1191857)
 - Add Rocky Linux 9 bootstrap repositories for Uyuni
 - mgr-create-bootstrap-repo: flush directory also when called

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -118,7 +118,7 @@ Requires(pre):  uyuni-base-server
 Requires:       firewalld
 %endif
 Requires:       postfix
-Requires:       reprepro
+Requires:       reprepro >= 5.4
 # mgr-setup want to call mksubvolume for btrfs filesystems
 Recommends:     snapper
 # mgr-setup calls dig


### PR DESCRIPTION
## What does this PR change?

Add bootstrap repo data for Ubuntu 22.04 when synced with vendor channels.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- https://github.com/SUSE/spacewalk/issues/18278

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/18685

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
