### PR TITLE
Check reformatting in Cobbler

### DIFF
--- a/testsuite/features/build_validation/retail/sle12sp5_terminal_deploy.feature
+++ b/testsuite/features/build_validation/retail/sle12sp5_terminal_deploy.feature
@@ -13,7 +13,7 @@ Feature: PXE boot a SLES 12 SP5 retail terminal
     Given I am authorized for the "Admin" section
 
   Scenario: PXE boot the SLES 12 SP5 retail terminal
-    When I reboot the terminal "sle12sp5_terminal"
+    When I reboot the Retail terminal "sle12sp5_terminal"
     And I wait at most 180 seconds until Salt master sees "sle12sp5_terminal" as "unaccepted"
     And I accept "sle12sp5_terminal" key in the Salt master
     And I follow the left menu "Systems > Overview"

--- a/testsuite/features/build_validation/retail/sle15sp4_terminal_deploy.feature
+++ b/testsuite/features/build_validation/retail/sle15sp4_terminal_deploy.feature
@@ -13,7 +13,7 @@ Feature: PXE boot a SLES 15 SP4 retail terminal
     Given I am authorized for the "Admin" section
 
   Scenario: PXE boot the SLES 15 SP4 retail terminal
-    When I reboot the terminal "sle15sp4_terminal"
+    When I reboot the Retail terminal "sle15sp4_terminal"
     And I wait at most 180 seconds until Salt master sees "sle15sp4_terminal" as "unaccepted"
     And I accept "sle15sp4_terminal" key in the Salt master
     And I follow the left menu "Systems > Overview"

--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -29,7 +29,7 @@ Feature: PXE boot a terminal with Cobbler
     And I click on "Apply Highstate"
     And I wait until event "Apply highstate scheduled by admin" is completed
 
-   Scenario: Install TFTP boot package on the server
+  Scenario: Install TFTP boot package on the server
     When I install package tftpboot-installation on the server
     And I wait for "tftpboot-installation-SLE-15-SP4-x86_64" to be installed on "server"
 
@@ -83,7 +83,7 @@ Feature: PXE boot a terminal with Cobbler
 
   Scenario: PXE boot the PXE boot minion
     Given I set the default PXE menu entry to the target profile on the "proxy"
-    When I reboot the terminal "pxeboot_minion"
+    When I reboot the Cobbler terminal "pxeboot_minion"
     And I wait for "60" seconds
     And I set the default PXE menu entry to the local boot on the "proxy"
     And I wait at most 1200 seconds until Salt master sees "pxeboot_minion" as "unaccepted"
@@ -91,6 +91,7 @@ Feature: PXE boot a terminal with Cobbler
     And I am on the Systems page
     And I wait until I see the name of "pxeboot_minion", refreshing the page
     And I wait until onboarding is completed for "pxeboot_minion"
+    Then "pxeboot_minion" should have been reformatted
 
   Scenario: Check connection from PXE boot minion to the proxy
     When I follow "Details" in the content area

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -184,7 +184,7 @@ Feature: PXE boot a Retail terminal
     Then I should see a "Formula saved" text
 
   Scenario: PXE boot the PXE boot minion
-    When I reboot the terminal "pxeboot_minion"
+    When I reboot the Retail terminal "pxeboot_minion"
     And I wait at most 180 seconds until Salt master sees "pxeboot_minion" as "unaccepted"
     And I accept "pxeboot_minion" key in the Salt master
     And I follow the left menu "Systems > Overview"

--- a/testsuite/features/step_definitions/retail_steps.rb
+++ b/testsuite/features/step_definitions/retail_steps.rb
@@ -226,7 +226,7 @@ When(/^I restart the network on the PXE boot minion$/) do
   $proxy.run("expect -f /tmp/#{file} #{ipv6}")
 end
 
-When(/^I reboot the terminal "([^"]*)"$/) do |host|
+When(/^I reboot the (Retail|Cobbler) terminal "([^"]*)"$/) do |context, host|
   # we might have no or any IPv4 address on that machine
   # convert MAC address to IPv6 link-local address
   if host == 'pxeboot_minion'
@@ -245,7 +245,7 @@ When(/^I reboot the terminal "([^"]*)"$/) do |host|
   dest = '/tmp/' + file
   return_code = file_inject($proxy, source, dest)
   raise 'File injection failed' unless return_code.zero?
-  $proxy.run("expect -f /tmp/#{file} #{ipv6}")
+  $proxy.run("expect -f /tmp/#{file} #{ipv6} #{context}")
 end
 
 When(/^I create bootstrap script for "([^"]+)" hostname and set the activation key "([^"]*)" in the bootstrap script on the proxy$/) do |host, key|

--- a/testsuite/features/upload_files/reboot-pxeboot.exp
+++ b/testsuite/features/upload_files/reboot-pxeboot.exp
@@ -1,11 +1,12 @@
 set address [lindex $argv 0]
+set context [lindex $argv 1]
 
 spawn /usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $address
 match_max 100000
 expect "*?assword:*"
 send -- "linux\r"
 expect "#"
-send -- "touch /intact\r"
+send -- "echo $context > /intact\r"
 expect "#"
 send -- "reboot\r"
 expect "#"


### PR DESCRIPTION
## What does this PR change?

Like in Retail, we would like to know in test suite's Cobbler feature tests if reformatting really happened. For that we drop an `/intact` file in the PXE boot minion before trying to PXE boot it. After the PXE boot, the disk should have been reformatted and that file should be gone.

Also, when debugging a failed PXE boot, we would like to know which one of Cobbler or Retail was last to happen, by inspecting whether `/intact` contains `Cobbler` or `Retail`.


## Links

Ports:
* 4.2: SUSE/spacewalk#18713
* 4.3: SUSE/spacewalk#18712


## Changelogs

- [x] No changelog needed
