### PR TITLE
Enabling and disabling repositories before and after locale formula test

### DIFF
--- a/testsuite/features/secondary/min_salt_formulas.feature
+++ b/testsuite/features/secondary/min_salt_formulas.feature
@@ -10,7 +10,7 @@ Feature: Use salt formulas
    Scenario: Log in as admin user
       Given I am authorized for the "Admin" section
 
-   Scenario: Install the locale formula package on the server and enable repositories on minion
+   Scenario: Install the locale formula package on the server and enable repositories on the minion
      When I manually install the "locale" formula on the server
      And I synchronize all Salt dynamic modules on "sle_minion"
      And I enable repository "os_pool_repo os_update_repo" on this "sle_minion"

--- a/testsuite/features/secondary/min_salt_formulas.feature
+++ b/testsuite/features/secondary/min_salt_formulas.feature
@@ -10,7 +10,7 @@ Feature: Use salt formulas
    Scenario: Log in as admin user
       Given I am authorized for the "Admin" section
 
-   Scenario: Install the locale formula package on the server and enable repositories on the minion
+   Scenario: Install the locale formula package on the server
      When I manually install the "locale" formula on the server
      And I synchronize all Salt dynamic modules on "sle_minion"
      And I enable repository "os_pool_repo os_update_repo" on this "sle_minion"
@@ -162,7 +162,7 @@ Feature: Use salt formulas
      And the keymap on "sle_minion" should be "us.map.gz"
      And the language on "sle_minion" should be "en_US.UTF-8"
 
-  Scenario: Cleanup: uninstall formula package from the server and disable repositories on the minion
+  Scenario: Cleanup: uninstall formula package from the server
      And I manually uninstall the "locale" formula from the server
      And I disable repository "os_pool_repo os_update_repo" on this "sle_minion"
      And I refresh the metadata for "sle_minion

--- a/testsuite/features/secondary/min_salt_formulas.feature
+++ b/testsuite/features/secondary/min_salt_formulas.feature
@@ -163,7 +163,7 @@ Feature: Use salt formulas
      And the language on "sle_minion" should be "en_US.UTF-8"
 
   Scenario: Cleanup: uninstall formula package from the server
-     And I manually uninstall the "locale" formula from the server
+     When I manually uninstall the "locale" formula from the server
      And I disable repository "os_pool_repo os_update_repo" on this "sle_minion"
      And I refresh the metadata for "sle_minion
 

--- a/testsuite/features/secondary/min_salt_formulas.feature
+++ b/testsuite/features/secondary/min_salt_formulas.feature
@@ -162,7 +162,7 @@ Feature: Use salt formulas
      And the keymap on "sle_minion" should be "us.map.gz"
      And the language on "sle_minion" should be "en_US.UTF-8"
 
-  Scenario: Cleanup: uninstall formula package from the server adn disable repositories on the minion
+  Scenario: Cleanup: uninstall formula package from the server and disable repositories on the minion
      And I manually uninstall the "locale" formula from the server
      And I disable repository "os_pool_repo os_update_repo" on this "sle_minion"
      And I refresh the metadata for "sle_minion

--- a/testsuite/features/secondary/min_salt_formulas.feature
+++ b/testsuite/features/secondary/min_salt_formulas.feature
@@ -10,9 +10,11 @@ Feature: Use salt formulas
    Scenario: Log in as admin user
       Given I am authorized for the "Admin" section
 
-   Scenario: Install the locale formula package on the server
+   Scenario: Install the locale formula package on the server and enable repositories on minion
      When I manually install the "locale" formula on the server
      And I synchronize all Salt dynamic modules on "sle_minion"
+     And I enable repository "os_pool_repo os_update_repo" on this "sle_minion"
+     And I refresh the metadata for "sle_minion"
 
   Scenario: The new formula appears on the server
      When I follow the left menu "Salt > Formula Catalog"
@@ -160,8 +162,10 @@ Feature: Use salt formulas
      And the keymap on "sle_minion" should be "us.map.gz"
      And the language on "sle_minion" should be "en_US.UTF-8"
 
-  Scenario: Cleanup: uninstall formula package from the server
+  Scenario: Cleanup: uninstall formula package from the server adn disable repositories on the minion
      And I manually uninstall the "locale" formula from the server
+     And I disable repository "os_pool_repo os_update_repo" on this "sle_minion"
+     And I refresh the metadata for "sle_minion
 
   Scenario: Cleanup: remove remaining systems from SSM after formula tests
      When I follow "Clear"


### PR DESCRIPTION
## What does this PR change?

Enables and disables `os-update-repo` and `os-pool-repo` repositories before and after testing the locale formula as to include a missing package.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18537
Tracks # **add downstream PR, if any**
4.2
4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
