### PR TITLE
fix root CAs which do not have authorityKeyIdentifier set to themself

### DIFF
--- a/spacewalk/certs-tools/mgr_ssl_cert_setup.py
+++ b/spacewalk/certs-tools/mgr_ssl_cert_setup.py
@@ -278,6 +278,9 @@ def getCertData(cert):
     data["content"] = cert
     if data["subject"] == data["issuer"]:
         data["root"] = True
+        # Some Root CAs might not have their authorityKeyIdentifier set to themself
+        if data["isca"] and "authorityKeyIdentifier" not in data:
+            data["authorityKeyIdentifier"] = data["subjectKeyIdentifier"]
     else:
         data["root"] = False
 

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,6 @@
+- fix mgr-ssl-cert-setup for root CAs which do not set
+  authorityKeyIdentifier
+
 -------------------------------------------------------------------
 Wed Jul 27 14:13:56 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Letsencrypt Root CA does not have an authorityKeyIdentifier set. This might be correct as it would point
anyway only to itself. But the script is using it to identify the self signed root ca.
This change detect "subject" == "issuer" and "isCA" and set the value for the internal evaluation.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/5830
Tracks https://github.com/SUSE/spacewalk/pull/18734

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
