### PR TITLE
Add missing IPv6 default configuration

### DIFF
--- a/tftpsync/susemanager-tftpsync-recv/rhn_tftpsync.conf
+++ b/tftpsync/susemanager-tftpsync-recv/rhn_tftpsync.conf
@@ -1,7 +1,9 @@
 server_fqdn =
 server_ip =
+server_ip6 =
 
 proxy_ip =
+proxy_ip6 =
 proxy_fqdn =
 
 tftpboot = /srv/tftpboot

--- a/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
+++ b/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
@@ -1,3 +1,4 @@
+- Add missing IPv6 default configuration (bsc#1201589)
 - fix problems with parallel running processes
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Without these keys, existing proxies need to re-run the configuration script to add these keys to their config files. The config files are expected to exist, if they are missing, cobbler sync fails.

## GUI diff

No difference.

 - [x] **DONE**

## Documentation
 
- No documentation needed: only internal and user invisible changes
 
- [x] **DONE**

## Test coverage
- No tests: @uyuni-project/qe deems it too resource intensive to properly test proxy upgrades + cobbler.

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
