### PR TITLE
Added orphan removal to pillars mapping

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/ServerGroup.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerGroup.hbm.xml
@@ -23,7 +23,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
         <many-to-one name="org" class="com.redhat.rhn.domain.org.Org" column="org_id"/>
 
-        <set name="pillars" lazy="true" inverse="true" cascade="all" access="field">
+        <set name="pillars" lazy="true" inverse="true" cascade="all-delete-orphan" access="field">
             <key column="group_id"/>
             <one-to-many class="com.redhat.rhn.domain.server.Pillar"/>
         </set>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fixed formula deselection in systemgroup (bsc#1202271)
 - Fix out of memory error when building a CLM project (bsc#1202217)
 - Use mgrnet.dns_fqdns module to improve FQDN detection (bsc#1199726)
 - Support Pay-as-you-go new CA location for SLES15SP4


### PR DESCRIPTION
## What does this PR change?

It fixes deleting a formula from a system group by adding orphan removal in the hibernate mapping.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
No documentation needed: bug fix.

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/18711

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
