### PR TITLE
Include "openssh-server" to be installed by SLE15SP4 autoyast profile

### DIFF
--- a/testsuite/features/upload_files/sle-15-sp4-autoyast.xml
+++ b/testsuite/features/upload_files/sle-15-sp4-autoyast.xml
@@ -57,6 +57,7 @@ $SNIPPET('spacewalk/sles_no_signature_checks')
     <instsource/>
     <packages config:type="list">
       <package>salt-minion</package>
+      <package>openssh-server</package>
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>
@@ -86,6 +87,14 @@ $SNIPPET('spacewalk/sles_no_signature_checks')
       <username>root</username>
     </user>
   </users>
+  <services-manager>
+    <default_target>multi-user</default_target>
+    <services>
+      <enable config:type="list">
+        <service>sshd</service>
+      </enable>
+    </services>
+  </services-manager>
   <scripts>
     <init-scripts config:type="list">
           $SNIPPET('spacewalk/minion_script')


### PR DESCRIPTION
## What does this PR change?

This PR fixes and issue happening on the testsuite around PXE booting, where we get errors like:

```
 FAIL: expect -f /tmp/cleanup-pxeboot.exp 192.168.99.4 returned status code = 1.
Output:
spawn /usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null 192.168.99.4
ssh: connect to host 192.168.99.4 port 22: Connection refused

send: spawn id exp3 not open
    while executing
"send -- "linux\r""
    (file "/tmp/cleanup-pxeboot.exp" line 6)
 (RuntimeError)
./features/support/lavanda.rb:75:in `run'
./features/step_definitions/retail_steps.rb:284:in `/^I stop salt-minion on the PXE boot minion$/'
features/secondary/proxy_cobbler_pxeboot.feature:134:in `I stop salt-minion on the PXE boot minion'
```

The issue was caused because, the SLE15SP4 autoyast profile was **not** mentioning to "openssh", and therefore, after PXE booting and perfoming autoinstallation on the "pxeboot" minion, the deployed instance has no "sshd" service running and these steps failed.

This issue was causing several other failures on the testsuite, as we cannot execute commands via SSH on the autoinstalled "pxeboot" minion.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
