### PR TITLE
renew the cached token when requested channel is not authorized

### DIFF
--- a/proxy/proxy/broker/rhnBroker.py
+++ b/proxy/proxy/broker/rhnBroker.py
@@ -661,9 +661,12 @@ class BrokerHandler(SharedHandler):
         self.cachedClientInfo['X-RHN-Server-ID'] = self.clientServerId
         log_debug(4, 'Retrieved token from cache: %s' % self.cachedClientInfo)
 
+        authChannels = [x[0] for x in self.authChannels]
+        log_debug(4, "Auth channels: '%s'" % authChannels)
+
         # Compare the two things
-        if not _dictEquals(token, self.cachedClientInfo,
-                           ['X-RHN-Auth-Channels']):
+        if not _dictEquals(token, self.cachedClientInfo, ['X-RHN-Auth-Channels']) or \
+                channel not in authChannels:
             # Maybe the client logged in through a different load-balanced
             # proxy? Check validity of the token the client passed us.
             updatedToken = self.proxyAuth.update_client_token_if_valid(

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,6 @@
+- renew the cached token when requested channel is not listed in
+  the old token (bsc#1202724)
+
 -------------------------------------------------------------------
 Wed Jul 27 14:09:14 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

When changing the channels on the server side, the proxy token with a list of authenticated channels is still cached.
This prevent access to the new channels.
In case the requested channel is not in the channel list of the cached token, just try to renew it and check the channels
on the freshly updated token.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/18758

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
