### PR TITLE
QE: Adjusting small API errors

### DIFF
--- a/testsuite/features/support/http_client.rb
+++ b/testsuite/features/support/http_client.rb
@@ -33,7 +33,8 @@ class HttpClient
     [call_type, url]
   end
 
-  def call(name, params: {})
+  def call(name, *parameters)
+    params = parameters.first
     # Get session cookie from previous calls
     if params.nil? || params.empty?
       session_cookie = nil

--- a/testsuite/features/support/http_client.rb
+++ b/testsuite/features/support/http_client.rb
@@ -33,9 +33,9 @@ class HttpClient
     [call_type, url]
   end
 
-  def call(name, params = {})
+  def call(name, params: {})
     # Get session cookie from previous calls
-    if params.nil?
+    if params.nil? || params.empty?
       session_cookie = nil
     else
       session_cookie = params[:sessionKey]

--- a/testsuite/features/support/http_client.rb
+++ b/testsuite/features/support/http_client.rb
@@ -33,7 +33,7 @@ class HttpClient
     [call_type, url]
   end
 
-  def call(name, params)
+  def call(name, params = {})
     # Get session cookie from previous calls
     if params.nil?
       session_cookie = nil

--- a/testsuite/features/support/http_client.rb
+++ b/testsuite/features/support/http_client.rb
@@ -13,7 +13,7 @@ class HttpClient
   def prepare_call(name, params)
     short_name = name.split('.')[-1]
     call_type =
-      if short_name.start_with?('list', 'get', 'is', 'find', 'system') ||
+      if short_name.start_with?('list', 'get', 'is', 'find') ||
          name.start_with?('system.search.', 'packages.search.') ||
          ['errata.applicableToChannels'].include?(name)
         'GET'
@@ -33,10 +33,9 @@ class HttpClient
     [call_type, url]
   end
 
-  def call(name, *parameters)
-    params = parameters.first
+  def call(name, params)
     # Get session cookie from previous calls
-    if params.nil? || params.empty?
+    if params.nil?
       session_cookie = nil
     else
       session_cookie = params[:sessionKey]

--- a/testsuite/features/support/http_client.rb
+++ b/testsuite/features/support/http_client.rb
@@ -13,7 +13,7 @@ class HttpClient
   def prepare_call(name, params)
     short_name = name.split('.')[-1]
     call_type =
-      if short_name.start_with?('list', 'get', 'is', 'find') ||
+      if short_name.start_with?('list', 'get', 'is', 'find', 'system') ||
          name.start_with?('system.search.', 'packages.search.') ||
          ['errata.applicableToChannels'].include?(name)
         'GET'

--- a/testsuite/features/support/namespaces/activationkey.rb
+++ b/testsuite/features/support/namespaces/activationkey.rb
@@ -39,11 +39,11 @@ class NamespaceActivationkey
   end
 
   def add_config_channels(id, config_channels)
-    @test.call('activationkey.addConfigChannels', sessionKey: @test.token, keys: id, configChannels: config_channels, addToTop: false)
+    @test.call('activationkey.addConfigChannels', sessionKey: @test.token, keys: id, configChannelLabels: config_channels, addToTop: false)
   end
 
   def add_child_channels(id, child_channels)
-    @test.call('activationkey.addChildChannels', sessionKey: @test.token, key: id, childChannels: child_channels)
+    @test.call('activationkey.addChildChannels', sessionKey: @test.token, key: id, childChannelLabels: child_channels)
   end
 
   def get_details(id)

--- a/testsuite/features/support/namespaces/api.rb
+++ b/testsuite/features/support/namespaces/api.rb
@@ -8,11 +8,11 @@ class NamespaceApi
   end
 
   def get_version
-    @test.call('api.getVersion', {})
+    @test.call('api.getVersion')
   end
 
   def system_version
-    @test.call('api.systemVersion', {})
+    @test.call('api.systemVersion')
   end
 
   def get_count_of_api_namespaces

--- a/testsuite/features/support/namespaces/api.rb
+++ b/testsuite/features/support/namespaces/api.rb
@@ -8,11 +8,11 @@ class NamespaceApi
   end
 
   def get_version
-    @test.call('api.getVersion')
+    @test.call('api.getVersion', {})
   end
 
   def system_version
-    @test.call('api.systemVersion')
+    @test.call('api.systemVersion', {})
   end
 
   def get_count_of_api_namespaces

--- a/testsuite/features/support/namespaces/api.rb
+++ b/testsuite/features/support/namespaces/api.rb
@@ -7,14 +7,6 @@ class NamespaceApi
     @test = api_test
   end
 
-  def get_version
-    @test.call('api.getVersion')
-  end
-
-  def system_version
-    @test.call('api.systemVersion')
-  end
-
   def get_count_of_api_namespaces
     namespaces = @test.call('api.getApiNamespaces', sessionKey: @test.token)
     namespaces.nil? ? 0 : namespaces.length

--- a/testsuite/features/support/xmlrpc_client.rb
+++ b/testsuite/features/support/xmlrpc_client.rb
@@ -10,7 +10,7 @@ class XmlrpcClient
     @xmlrpc_client = XMLRPC::Client.new2('https://' + host + '/rpc/api', nil, DEFAULT_TIMEOUT)
   end
 
-  def call(name, params = {})
+  def call(name, params: {})
     @xmlrpc_client.call(name, *params.values)
   end
 end

--- a/testsuite/features/support/xmlrpc_client.rb
+++ b/testsuite/features/support/xmlrpc_client.rb
@@ -10,7 +10,8 @@ class XmlrpcClient
     @xmlrpc_client = XMLRPC::Client.new2('https://' + host + '/rpc/api', nil, DEFAULT_TIMEOUT)
   end
 
-  def call(name, params: {})
+  def call(name, *parameters)
+    params = parameters.first || {}
     @xmlrpc_client.call(name, *params.values)
   end
 end

--- a/testsuite/features/support/xmlrpc_client.rb
+++ b/testsuite/features/support/xmlrpc_client.rb
@@ -10,8 +10,8 @@ class XmlrpcClient
     @xmlrpc_client = XMLRPC::Client.new2('https://' + host + '/rpc/api', nil, DEFAULT_TIMEOUT)
   end
 
-  def call(name, *parameters)
-    params = parameters.first || {}
+  def call(name, params)
+    # TODO: What happens if params.nil?
     @xmlrpc_client.call(name, *params.values)
   end
 end

--- a/testsuite/features/support/xmlrpc_client.rb
+++ b/testsuite/features/support/xmlrpc_client.rb
@@ -10,7 +10,7 @@ class XmlrpcClient
     @xmlrpc_client = XMLRPC::Client.new2('https://' + host + '/rpc/api', nil, DEFAULT_TIMEOUT)
   end
 
-  def call(name, params)
+  def call(name, params = {})
     @xmlrpc_client.call(name, *params.values)
   end
 end


### PR DESCRIPTION
## What does this PR change?

Makes small adjustments to API calls while following the API doc.

- `activationkey.rb` correcting parameters values
- ~~`api.rb` adjusting `get_version` and `system_version` calls so they include a second parameter that is required (empty Hash)~~
- ~~`http_client.rb` to include `system_version` as a GET request and accept a default empty argument on api call~~
- ~~`xmlrpc_client.rb` to accept a default empty argument on api call~~
- Remove paraemeter-less api calls in `api.rb`
## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links
Ports :
4.2
4.3


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
