### PR TITLE
QE: Add lock to package to prevent prometheus conflict

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1535,11 +1535,18 @@ end
 
 When(/^I (enable|disable) the necessary repositories before installing Prometheus exporters on this "([^"]*)"((?: without error control)?)$/) do |action, host, error_control|
   node = get_target(host)
-  _os_version, os_family = get_os_version(node)
+  os_version, os_family = get_os_version(node)
   repositories = 'tools_pool_repo tools_update_repo'
   if os_family =~ /^opensuse/ || os_family =~ /^sles/
     repositories.concat(' os_pool_repo os_update_repo')
-    repositories.concat(' tools_additional_repo') unless $product == 'Uyuni'
+    if $product != 'Uyuni'
+      repositories.concat(' tools_additional_repo')
+      # Needed because in SLES15SP3 and openSUSE 15.3 and higher, firewalld will replace this package.
+      # But the tools_update_repo's priority doesn't allow to cope with the obsoletes option from firewalld.
+      if os_version.to_f >= 15.3
+        node.run('zypper addlock -r tools_additional_repo firewalld-prometheus-config')
+      end
+    end
   end
   step %(I #{action} the repositories "#{repositories}" on this "#{host}"#{error_control})
 end


### PR DESCRIPTION
## What does this PR change?
Due to
```
Detected 1 file conflict:

File /usr/lib/firewalld/services/prometheus.xml
  from install of
     firewalld-0.9.3-150300.3.3.1.noarch (os_update_repo)
  conflicts with file from install of
     firewalld-prometheus-config-0.1-150430.2.5.devel43.x86_64 (tools_additional_repo)
```
that happens because we need the development repos for testing, which have a different priority, for the prometheus formulas to work. 
We need to make sure to avoid installing ` firewalld-prometheus-config-0.1-150430.2.5.devel43.x86_64 (tools_additional_repo)` and just use ` firewalld-0.9.3-150300.3.3.1.noarch (os_update_repo)` instead. This is only applicable for SLES and openSUSE >= SP3. For more details, check the [sumaform PR](https://github.com/uyuni-project/sumaform/pull/1090), the original [issue](https://github.com/SUSE/spacewalk/issues/17512), or the [current issue ](https://github.com/SUSE/spacewalk/issues/18746)where it's being followed

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were modified

- [x] **DONE**

## Links

Fixes #18746 
- [4.2](https://github.com/SUSE/spacewalk/pull/18756)
- [4.3](https://github.com/SUSE/spacewalk/pull/18766)

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
