### PR TITLE
QE: Fix test typo

### DIFF
--- a/testsuite/features/secondary/min_salt_formulas.feature
+++ b/testsuite/features/secondary/min_salt_formulas.feature
@@ -165,7 +165,7 @@ Feature: Use salt formulas
   Scenario: Cleanup: uninstall formula package from the server
      When I manually uninstall the "locale" formula from the server
      And I disable repository "os_pool_repo os_update_repo" on this "sle_minion"
-     And I refresh the metadata for "sle_minion
+     And I refresh the metadata for "sle_minion"
 
   Scenario: Cleanup: remove remaining systems from SSM after formula tests
      When I follow "Clear"


### PR DESCRIPTION
## What does this PR change?

Adds the missing " for a test.

## GUI diff

No difference.


- [ ] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

[4.2](https://github.com/SUSE/spacewalk/pull/18773)
[4.3](https://github.com/SUSE/spacewalk/pull/18774)

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
