### PR TITLE
Synchronize code between branches

### DIFF
--- a/testsuite/features/core/proxy_register_as_minion_with_gui.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_gui.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2021 SUSE LLC
+# Copyright (c) 2017-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # The scenarios in this feature are skipped if there is no proxy
@@ -15,8 +15,8 @@ Feature: Setup Uyuni proxy
 
   Scenario: Install proxy software
     When I refresh the metadata for "proxy"
-    # uncomment when product is out:
-    # When I install "SUSE-Manager-Proxy" product on the proxy
+    # TODO: uncomment when SCC product becomes available
+    # And I install "SUSE-Manager-Proxy" product on the proxy
     And I install proxy pattern on the proxy
     And I let squid use avahi on the proxy
 

--- a/testsuite/features/core/proxy_register_as_minion_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_script.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2021 SUSE LLC
+# Copyright (c) 2017-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # The scenarios in this feature are skipped if there is no proxy
@@ -15,10 +15,8 @@ Feature: Setup Uyuni proxy
 
   Scenario: Install proxy software
     When I refresh the metadata for "proxy"
-    # workaround for bug 1192195, remove when fixed
-    And I adapt zyppconfig
-    # uncomment when product is out:
-    # When I install "SUSE-Manager-Proxy" product on the proxy
+    # TODO: uncomment when SCC product becomes available
+    # And I install "SUSE-Manager-Proxy" product on the proxy
     And I install proxy pattern on the proxy
     And I let squid use avahi on the proxy
 
@@ -31,7 +29,7 @@ Feature: Setup Uyuni proxy
     And I run "sh ./bootstrap-proxy.sh" on "proxy"
 
   @salt_bundle
-  Scenario: Create the bootstrap script for the proxy and use it
+  Scenario: Create the bundle-aware bootstrap script for the proxy and use it
     When I execute mgr-bootstrap "--script=bootstrap-proxy.sh --no-up2date --force-bundle"
     Then I should get "* bootstrap script (written):"
     And I should get "    '/srv/www/htdocs/pub/bootstrap/bootstrap-proxy.sh'"

--- a/testsuite/features/core/proxy_register_as_trad_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_trad_with_script.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2021 SUSE LLC
+# Copyright (c) 2017-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # The scenarios in this feature are skipped if there is no proxy
@@ -15,8 +15,8 @@ Feature: Setup Uyuni proxy
 
   Scenario: Install proxy software
     When I refresh the metadata for "proxy"
-    # uncomment when product is out:
-    # When I install "SUSE-Manager-Proxy" product on the proxy
+    # TODO: uncomment when SCC product becomes available
+    # And I install "SUSE-Manager-Proxy" product on the proxy
     And I install proxy pattern on the proxy
     And I let squid use avahi on the proxy
 

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1014,11 +1014,6 @@ When(/^I install "([^"]*)" product on the proxy$/) do |product|
   log "Installed #{product} product: #{out}"
 end
 
-When(/^I adapt zyppconfig$/) do
-   cmd = "sed -i 's/^rpm.install.excludedocs =.*$/rpm.install.excludedocs = no/' /etc/zypp/zypp.conf"
-   $proxy.run(cmd)
-end
-
 When(/^I install proxy pattern on the proxy$/) do
   pattern = $product == 'Uyuni' ? 'uyuni_proxy' : 'suma_proxy'
   cmd = "zypper --non-interactive install -t pattern #{pattern}"


### PR DESCRIPTION
## What does this PR change?

Synchronize code between branches - bootstrapping proxies

In 4.3 and Uyuni, we don't need anymore the work around for bsc#1192195.


## Links

Sibling PRs:
 * 4.2: https://github.com/SUSE/spacewalk/pull/18776
 * 4.3: https://github.com/SUSE/spacewalk/pull/18775


## Changelogs

- [x] No changelog needed
