### PR TITLE
jakarta-activation not required in SUSE

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -49,7 +49,6 @@
         <dependency org="suse" name="jackson-core" rev="2.10.2" />
         <dependency org="suse" name="jackson-databind" rev="2.10.5.1" />
         <dependency org="suse" name="jade4j" rev="1.2.7" />
-        <dependency org="suse" name="jakarta-activation-api" rev="2.1.0" />
         <dependency org="suse" name="jakarta-persistence-api" rev="2.2.2" />
         <dependency org="suse" name="java-saml" rev="2.4.0" />
         <dependency org="suse" name="java-saml-core" rev="2.4.0" />

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -131,9 +131,6 @@ artifacts:
     repository: Leap
   - artifact: jade4j
     repository: Uyuni_Other
-  - artifact: jakarta-activation-api
-    package: jakarta-activation
-    repository: Uyuni_Other
   - artifact: jakarta-persistence-api
     package: jpa-api
     repository: Uyuni_Other


### PR DESCRIPTION
## What does this PR change?

In SUSE jakarta-activation does not provide what we need. We use glassfish-activation-api

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
