### PR TITLE
Calculate dependencies between cloned channels of vendor channels (bsc#1201626)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/channel/Channel.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/Channel.java
@@ -39,6 +39,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * Channel
@@ -918,6 +919,15 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
     /**
      * @return the clonedChannels
      */
+
+    /**
+     * Returns all cloned channels of this channel which includes all clones of clones.
+     * @return all cloned channels
+     */
+    public Stream<ClonedChannel> allClonedChannels() {
+        return getClonedChannels().stream().flatMap(c -> Stream.concat(Stream.of(c), c.allClonedChannels()));
+    }
+
     public Set<ClonedChannel> getClonedChannels() {
         return clonedChannels;
     }
@@ -948,6 +958,16 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
      */
     public Channel getOriginal() {
         throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Creates a Stream starting with this channel and waking up the getOriginal chain
+     * until getting to the original non cloned channel.
+     *
+     * @return stream of channels
+     */
+    public Stream<Channel> originChain() {
+        return Stream.iterate(this, c -> c != null, c -> c.isCloned() ? c.getOriginal() : null);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/product/SUSEProductFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/product/SUSEProductFactory.java
@@ -276,24 +276,37 @@ public class SUSEProductFactory extends HibernateFactory {
      * @return a stream of synced {@link Channel}
      */
     public static Stream<Channel> findSyncedMandatoryChannels(String channelLabel) {
-        return findSyncProductChannelByLabel(channelLabel).map(suseProductChannel -> {
+        Channel channel = ChannelFactory.lookupByLabel(channelLabel);
+        Channel baseChannel = Optional.ofNullable(channel.getParentChannel()).orElse(channel);
+        if (channel.isCloned()) {
+            return channel.originChain().filter(c -> !c.isCloned()).findFirst().map(original -> {
+                return findSyncedMandatoryChannels(original.getLabel())
+                        .flatMap(c -> c.allClonedChannels())
+                        .filter(c ->
+                                (c.getParentChannel() != null && c.getParentChannel()
+                                        .equals(channel.getParentChannel())) || c.equals(channel.getParentChannel())
+                        )
+                        .map(c -> (Channel) c);
+            }).orElse(Stream.empty());
+        }
+        else {
+            return findSyncProductChannelByLabel(channelLabel).map(suseProductChannel -> {
 
-            Channel channel = ChannelFactory.lookupByLabel(channelLabel);
-            Channel baseChannel = Optional.ofNullable(channel.getParentChannel()).orElse(channel);
+                        SUSEProductChannel baseProductChannel = findSyncProductChannelByLabel(baseChannel.getLabel())
+                                .orElseThrow(() -> new NoSuchElementException("No product channel found for " +
+                                        baseChannel + " of " + channel));
+                        Stream<SUSEProductChannel> suseProductChannelStream = findSyncedMandatoryChannels(
+                                suseProductChannel.getProduct(),
+                                baseProductChannel.getProduct(),
+                                baseChannel.getLabel()
+                        );
+                        return Stream.concat(Stream.of(suseProductChannel), suseProductChannelStream)
+                                .filter(pc -> pc.getChannel().getChannelArch().equals(channel.getChannelArch()));
+                    }).orElse(Stream.empty())
+                    .filter(SUSEProductChannel::isMandatory)
+                    .map(SUSEProductChannel::getChannel);
 
-            SUSEProductChannel baseProductChannel = findSyncProductChannelByLabel(baseChannel.getLabel())
-                    .orElseThrow(() -> new NoSuchElementException("No product channel found for " + baseChannel +
-                            " of " + channel));
-            Stream<SUSEProductChannel> suseProductChannelStream = findSyncedMandatoryChannels(
-                        suseProductChannel.getProduct(),
-                        baseProductChannel.getProduct(),
-                        baseChannel.getLabel()
-            );
-            return Stream.concat(Stream.of(suseProductChannel), suseProductChannelStream)
-                    .filter(pc -> pc.getChannel().getChannelArch().equals(channel.getChannelArch()));
-        }).orElse(Stream.empty())
-          .filter(SUSEProductChannel::isMandatory)
-          .map(SUSEProductChannel::getChannel);
+        }
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Calculate dependencies between cloned channels of vendor channels (bsc#1201626)
 - Reduce the length of image channel URL (bsc#1201220)
 - Fixed system search
 - update java dependencies


### PR DESCRIPTION
## What does this PR change?

Add support for calculating the dependencies of cloned vendor channels. By

- Get the original vendor channel and calculate dependencies for that
- Get all the clones of those dependencies
- Keep the clones that have the same base channel as the input channel we want the dependencies for.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes #
Tracks https://github.com/SUSE/spacewalk/pull/18510

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
