### PR TITLE
remove server-migrator.sh from SUSE Manager installations

### DIFF
--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- remove server-migrator.sh from SUSE Manager installations (bsc#1202728)
 - create bootstrap repository data for Ubuntu 22.04 Vendor Channels
 - remove obsoleted sysv init script (bsc#1191857)
 - Add Rocky Linux 9 bootstrap repositories for Uyuni

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -218,6 +218,11 @@ mkdir -p %{buildroot}/%{_sysconfdir}/firewalld/services
 install -m 0644 etc/firewalld/services/suse-manager-server.xml %{buildroot}/%{_sysconfdir}/firewalld/services
 %endif
 
+%if 0%{?sle_version} && !0%{?is_opensuse}
+# this script migrate the server to Uyuni. It should not be available on SUSE Manager
+rm -f %{buildroot}/%{_prefix}/lib/susemanager/bin/server-migrator.sh
+%endif
+
 make -C po install PREFIX=$RPM_BUILD_ROOT
 
 %find_lang susemanager


### PR DESCRIPTION
## What does this PR change?

server-migrator.sh is really only for Uyuni. Do not install it on SUSE Manager.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/18794 https://github.com/SUSE/spacewalk/pull/18795

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
