### PR TITLE
QE: Add activation key to sle_minion

### DIFF
--- a/testsuite/features/init_clients/sle_minion.feature
+++ b/testsuite/features/init_clients/sle_minion.feature
@@ -14,6 +14,7 @@ Feature: Bootstrap a Salt minion via the GUI
     And I enter "22" as "port"
     And I enter "root" as "user"
     And I enter "linux" as "password"
+    And I select "1-SUSE-KEY-x86_64" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text


### PR DESCRIPTION
## What does this PR change?

There's been an ongoing failing test across all branches, where we expected the `Test-Channel-x86_64` to be the Base Channel used for the SLE minion, but it's always the actual product channel being used as the Base Channel. After some investigation, it was found that, when removing the product migration from the normal CI testsuite, the part where we added the activation key was removed as well (https://github.com/uyuni-project/uyuni/commit/950514e00b43b2aff880303d5cd683ef4cc059d1#diff-81a40bfd7b5fe026484339618df80c8a557710f2bf8e4e80627c9c24345d17cbL78). So I added it to when we bootstrap the minion from the start.

## Uyuni PR
Run [#1571](https://ci.suse.de/view/Manager/view/Uyuni-PRs/job/uyuni-prs-ci-tests/1571/)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were modified

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18731
- [4.2](https://github.com/SUSE/spacewalk/pull/18796)
- [4.3](https://github.com/SUSE/spacewalk/pull/18797)

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
