### PR TITLE
Form clear after delete

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/formula/test/FormulaManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/formula/test/FormulaManagerTest.java
@@ -214,6 +214,45 @@ public class FormulaManagerTest extends JMockBaseTestCaseWithUser {
     }
 
     /**
+     * Test the saving of server formula data when group formula is already assigned
+     * When saving server data to group assigned formula, make sure server formula is assigned
+     * @throws Exception
+     */
+    @Test
+    public void testSaveServerFormulaDataForGroupFormula() throws Exception {
+        String contentsData = TestUtils.readAll(TestUtils.findTestData(FORMULA_DATA));
+        Map<String, Object> contents = Json.GSON.fromJson(contentsData, Map.class);
+        ManagedServerGroup group = ServerGroupTestUtils.createManaged(user);
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        minion.addGroup(group);
+        FormulaFactory.setDataDir(tmpSaltRoot.resolve(TEMP_PATH).toString());
+        context().checking(new Expectations() {{
+            allowing(saltServiceMock).refreshPillar(with(any(MinionList.class)));
+        }});
+        manager.saveGroupFormulaData(user, group.getId(), FORMULA_NAME, contents);
+        Map<String, Object> savedFormulaData =
+                FormulaFactory.getGroupFormulaValuesByNameAndGroup(FORMULA_NAME, group)
+                        .orElseGet(Collections::emptyMap);
+        assertNotNull(savedFormulaData);
+        assertEquals(contents, savedFormulaData);
+
+        List<String> formulasServer = FormulaFactory.getFormulasByMinion(minion);
+        assertTrue(formulasServer.isEmpty());
+
+        Map<String, Object> contentsServer = Json.GSON.fromJson(contentsData, Map.class);
+        ((Map<String, Object>)contentsServer.get(FORMULA_NAME)).replace("domain_name", "server_domain_test");
+        manager.saveServerFormulaData(user, minion.getId(), FORMULA_NAME, contentsServer);
+        Map<String, Object> savedFormulaSystemData =
+                FormulaFactory.getFormulaValuesByNameAndMinion(FORMULA_NAME, minion)
+                        .orElseGet(Collections::emptyMap);
+        assertNotNull(savedFormulaData);
+        assertEquals(contentsServer, savedFormulaSystemData);
+
+        List<String> formulasServerNew = FormulaFactory.getFormulasByMinion(minion);
+        assertTrue(formulasServerNew.contains(FORMULA_NAME));
+    }
+
+    /**
      * Test if unauthorized user can save formula data
      * @throws Exception
      */

--- a/java/code/src/com/redhat/rhn/testing/ServerGroupTestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/ServerGroupTestUtils.java
@@ -21,8 +21,10 @@ import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.server.ServerGroupType;
 import com.redhat.rhn.domain.server.test.ServerGroupTest;
 import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 
 import com.suse.manager.webui.services.SaltStateGeneratorService;
+import com.suse.manager.webui.services.iface.SaltApi;
 
 
 /**
@@ -58,5 +60,17 @@ public class ServerGroupTestUtils {
         return GlobalInstanceHolder.SERVER_GROUP_MANAGER.
                                         create(user, NAME + TestUtils.randomString(),
                                                     DESCRIPTION);
+    }
+
+    /**
+     * Remove ManagedServerGroup
+     * @param user owning user
+     * @param group group to be removed
+     * @param saltApi the mocked Salt Api
+     */
+    public static void removeManaged(User user, ManagedServerGroup group, SaltApi saltApi) {
+        ServerGroupTest.checkSysGroupAdminRole(user);
+        ServerGroupManager groupManager = new ServerGroupManager(saltApi);
+        groupManager.remove(user, group);
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,7 @@
+- Check if system has all formulas correctly assigned
+  (bsc#1201607)
+- Remove group formula assignements and data on group delete
+  (bsc#1201606)
 - Process salt events in FIFO order (bsc#1203532)
 - Added a warning message for traditional stack deprecation
 - Fix rendering of ssm/MigrateSystems page (bsc#1204651)


### PR DESCRIPTION
Forward port of https://github.com/SUSE/spacewalk/pull/18448

## What does this PR change?

Check if system has all formulas correctly assigned

    When system has group formula assigned and user then edits this formula, we
    need to assign edited formula as system formula as well for proper cleanup and
    tracking.

Remove group formula assignments and data on group delete

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Unit tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18421 and https://github.com/SUSE/spacewalk/issues/18422
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
