### PR TITLE
MinionPillarManager - refresh pillar on update (bsc#1197724)

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarManager.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarManager.java
@@ -18,6 +18,9 @@ package com.suse.manager.webui.services.pillar;
 import com.redhat.rhn.domain.channel.AccessToken;
 import com.redhat.rhn.domain.channel.AccessTokenFactory;
 import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.GlobalInstanceHolder;
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.salt.netapi.datatypes.target.MinionList;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -40,6 +43,8 @@ public class MinionPillarManager {
 
     /** Logger */
     private static final Logger LOG = LogManager.getLogger(MinionPillarManager.class);
+
+    private static SaltApi saltApi = GlobalInstanceHolder.SALT_API;
 
     public static final MinionPillarManager INSTANCE = new MinionPillarManager(
                     new MinionPillarFileManager(MinionGeneralPillarGenerator.INSTANCE),
@@ -106,6 +111,8 @@ public class MinionPillarManager {
                     throw new RuntimeException("unreachable");
             }
         }
+        // push the changed pillar data to the minion
+        saltApi.refreshPillar(new MinionList(minion.getMinionId()));
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- MinionPillarManager - refresh pillar on update (bsc#1197724)
 - Adjust cobbler requirement to version 3.3.3
 - Support inherited values for kernel options from Cobbler API
 - Fix virtFileSize type after cobbler upgrade


### PR DESCRIPTION
Triggers pillar data refresh. Targeting a salt-minion via CLI by a group newly joined using GUI fails without refreshing pillar data first.

Port of: https://github.com/SUSE/spacewalk/pull/18810

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
