### PR TITLE
Detect Amazon EC2 instances

### DIFF
--- a/java/code/src/com/suse/manager/reactor/hardware/HardwareMapper.java
+++ b/java/code/src/com/suse/manager/reactor/hardware/HardwareMapper.java
@@ -608,6 +608,19 @@ public class HardwareMapper {
                         LOG.info(String.format("Detected virtual instance type '%s' for minion '%s'",
                                 virtTypeLabel, server.getMinionId()));
                 }
+                if (virtSubtype.startsWith("Amazon EC2")) {
+                    switch (virtTypeLowerCase) {
+                        case "xen":
+                            virtTypeLabel = "aws_xen";
+                            break;
+                        case "qemu":
+                        case "kvm":
+                            virtTypeLabel = "aws_kvm";
+                            break;
+                        default:
+                            virtTypeLabel = "aws";
+                    }
+                }
                 type = VirtualInstanceFactory.getInstance()
                         .getVirtualInstanceType(virtTypeLabel);
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Detect the clients running on Amazon EC2 (bsc#1195624)
 - Adjust cobbler requirement to version 3.3.3
 - Support inherited values for kernel options from Cobbler API
 - Fix virtFileSize type after cobbler upgrade

--- a/schema/spacewalk/common/data/rhnVirtualInstanceType.sql
+++ b/schema/spacewalk/common/data/rhnVirtualInstanceType.sql
@@ -43,6 +43,12 @@ insert into rhnVirtualInstanceType (id, name, label)
     values (sequence_nextval('rhn_vit_id_seq'), 'Amazon EC2', 'aws');
 
 insert into rhnVirtualInstanceType (id, name, label)
+    values (sequence_nextval('rhn_vit_id_seq'), 'Amazon EC2/KVM', 'aws_kvm');
+
+insert into rhnVirtualInstanceType (id, name, label)
+    values (sequence_nextval('rhn_vit_id_seq'), 'Amazon EC2/Xen', 'aws_xen');
+
+insert into rhnVirtualInstanceType (id, name, label)
     values (sequence_nextval('rhn_vit_id_seq'), 'Google CE', 'gce');
 
 insert into rhnVirtualInstanceType (id, name, label)

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Add subtypes for Amazon EC2 virtual instances (bsc#1195624)
 - Fix migration of image actions (bsc#1202272)
 - Add Rocky Linux 9 and EPEL 9 key
 - improve schema compatibility with Amazon RDS

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.0-to-susemanager-schema-4.4.1/300-rhnVirtualInstanceType.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.0-to-susemanager-schema-4.4.1/300-rhnVirtualInstanceType.sql
@@ -1,0 +1,7 @@
+INSERT INTO rhnVirtualInstanceType (id, name, label)
+SELECT sequence_nextval('rhn_vit_id_seq'), 'Amazon EC2/KVM', 'aws_kvm'
+WHERE NOT EXISTS ( SELECT 1 FROM rhnVirtualInstanceType WHERE label = 'aws_kvm' AND name = 'Amazon EC2/KVM');
+
+INSERT INTO rhnVirtualInstanceType (id, name, label)
+SELECT sequence_nextval('rhn_vit_id_seq'), 'Amazon EC2/Xen', 'aws_xen'
+WHERE NOT EXISTS ( SELECT 1 FROM rhnVirtualInstanceType WHERE label = 'aws_xen' AND name = 'Amazon EC2/Xen');


### PR DESCRIPTION
## What does this PR change?

Show `Amazon EC2` in `Virtualization` field in the system profile for Amazon EC2 instances.

Requires https://github.com/openSUSE/salt/pull/555 to be present on the salt minion side.

## GUI diff

Before:
Virtualization field in system profile was shown as `KVM/QEMU` or `Para-Virtualized` if running as `xen` instance.

After:
Virtualization field in system profile is labeled as `Amazon EC2`

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: there is no tests for this part of functionality

## Links

Fixes https://github.com/SUSE/spacewalk/issues/16940

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
