### PR TITLE
Fix out of memory error when building a CLM project

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -1094,10 +1094,10 @@ public class ContentManager {
 
         // First add the denied packages by testing all DENY filters against a package, and then filter out any package
         // that is explicitly allowed by testing all ALLOW filters against the same package and negating the result.
-        Set<T> denied = entities.stream()
-                .filter(e -> denyFilters.stream().map(f -> f.test(e)).reduce(false, Boolean::logicalOr))
-                .filter(e -> !allowFilters.stream().map(f -> f.test(e)).reduce(false, Boolean::logicalOr))
-                .collect(Collectors.toUnmodifiableSet());
+        Set<T> denied = entities.stream().filter(
+                e -> denyFilters.stream().anyMatch(f -> f.test(e)) &&
+                allowFilters.stream().noneMatch(f -> f.test(e))
+        ).collect(Collectors.toUnmodifiableSet());
 
         Set<T> allowed = new HashSet<>(entities);
         allowed.removeAll(denied);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix out of memory error when building a CLM project (bsc#1202217)
 - Use mgrnet.dns_fqdns module to improve FQDN detection (bsc#1199726)
 - Support Pay-as-you-go new CA location for SLES15SP4
   and higher (bsc#1202729)


### PR DESCRIPTION
## What does this PR change?

It fixes an out of memory error by changing the strategy to apply allow/deny filters. The problem currently happens when applying live patch template filters on the `SLES12-SP5-Updates for x86_64` channel which has a large number of errata to be filtered out. But, the root cause is related to a high number of `java.util.HashMap$Node` in the heap space, flooding it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bug fix.

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18630

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
