### PR TITLE
QE: Fix source package syncing

### DIFF
--- a/testsuite/features/core/srv_create_repository.feature
+++ b/testsuite/features/core/srv_create_repository.feature
@@ -47,6 +47,8 @@ Feature: Add a repository to a channel
     And I wait at most 60 seconds until I do not see "Repository sync is running." text, refreshing the page
     And I click on "Sync Now"
     Then I should see a "Repository sync scheduled for Test-Channel-x86_64." text
+    When I wait until the channel "Test-Channel-x86_64" has been synced
+    And I disable source package syncing
 
   Scenario: Add a test repository for i586
     When I follow the left menu "Software > Manage > Repositories"
@@ -69,8 +71,7 @@ Feature: Add a repository to a channel
     Then I should see a "Test-Channel-i586 repository information was successfully updated" text
 
   Scenario: Synchronize the repository in the i586 channel
-    When I disable source package syncing
-    And I follow the left menu "Software > Manage > Channels"
+    When I follow the left menu "Software > Manage > Channels"
     And I follow "Test-Channel-i586"
     And I follow "Repositories" in the content area
     And I follow "Sync"


### PR DESCRIPTION
## What does this PR change?
Makes sure to check that the reposync has finished before disabling source package syncing. Outcome of discussion with @mcalmer on the root cause for the test failure on [this slack thread](https://suse.slack.com/archives/C02DDMY6R0R/p1661861712795339)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were modified

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18801
Will be ported only after running successfully in either Uyuni PR testsuite or Head and Master
- 4.2
- 4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
