### PR TITLE
expect local default installation if no host paramater is set

### DIFF
--- a/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb
+++ b/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb
@@ -605,7 +605,7 @@ while true ; do
 done
 
 case $HOST in
-    "localhost"|$(hostname -s)|$(hostname -f))
+    "localhost"|$(hostname -s)|$(hostname -f)|"")
         EXTERNALDB=0 ;;
     *)
         EXTERNALDB=1 ;;


### PR DESCRIPTION
## What does this PR change?

uyuni-setup-reportdb might be called without --host. We should assume the default behavior of a local installation in this case.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Follow up on https://github.com/uyuni-project/uyuni/pull/5643

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
