### PR TITLE
export armored GPG key to salt filesystem

### DIFF
--- a/python/spacewalk/satellite_tools/mgr-sign-metadata-ctl
+++ b/python/spacewalk/satellite_tools/mgr-sign-metadata-ctl
@@ -93,7 +93,9 @@ if [ -n "$1" ]; then
 fi
 
 RHN_CONF="/etc/rhn/rhn.conf"
-GPG_SALT_EXPORT_FILE="/srv/susemanager/salt/gpg/mgr-keyring.gpg"
+GPG_SALT_EXPORT_DIR="/srv/susemanager/salt/gpg"
+GPG_SALT_EXPORT_FILE="$GPG_SALT_EXPORT_DIR/mgr-keyring.gpg"
+GPG_ARMOR_SALT_EXPORT_FILE="$GPG_SALT_EXPORT_DIR/mgr-gpg-pub.key"
 GPG_PUB_EXPORT_FILE="$(spacewalk-cfg-get documentroot)/pub/mgr-gpg-pub.key"
 SIGNING_CONF="/etc/rhn/signing.conf"
 
@@ -135,21 +137,26 @@ if [[  $ACTION = "enable" ]]; then
 
     # check if key was exported to the salt dir
     EXPORT_SALT_KEY=true
-    if [ -f $GPG_SALT_EXPORT_FILE ]; then
+    if [ -f $GPG_SALT_EXPORT_FILE -a -f $GPG_ARMOR_SALT_EXPORT_FILE ]; then
         if gpg --no-default-keyring --keyring $GPG_SALT_EXPORT_FILE --list-keys | grep --quiet "$ENABLE_KEYID"; then
             echo "OK. Key ${ENABLE_KEYID} was exported to ${GPG_SALT_EXPORT_FILE}."
-            EXPORT_SALT_KEY=false
+            if cat $GPG_ARMOR_SALT_EXPORT_FILE | gpg -q --with-colons --import-options show-only --import | grep --quiet $KEYID; then
+                echo "OK. Key ${ENABLE_KEYID} was exported to ${GPG_ARMOR_SALT_EXPORT_FILE}."
+                EXPORT_SALT_KEY=false
+            fi
         fi
     fi
     if [ "$EXPORT_SALT_KEY" = true ]; then
         rm -f $GPG_SALT_EXPORT_FILE
-        GPG_SALT_EXPORT_DIR=$(dirname $GPG_SALT_EXPORT_FILE)
+        rm -f $GPG_ARMOR_SALT_EXPORT_FILE
         mkdir -p $GPG_SALT_EXPORT_DIR
         chown salt:salt $GPG_SALT_EXPORT_DIR
         chmod 775 $GPG_SALT_EXPORT_DIR
         gpg --export $ENABLE_KEYID > $GPG_SALT_EXPORT_FILE
-        chmod 644 $GPG_SALT_EXPORT_FILE
         echo "DONE. Exported key ${ENABLE_KEYID} to ${GPG_SALT_EXPORT_FILE}."
+        chmod 644 $GPG_SALT_EXPORT_FILE
+        gpg --batch --export --armor --output $GPG_ARMOR_SALT_EXPORT_FILE $ENABLE_KEYID
+        echo "DONE. Exported key ${ENABLE_KEYID} to ${GPG_ARMOR_SALT_EXPORT_FILE}."
     fi
 
     # check if key was exported to the http pub dir
@@ -194,6 +201,16 @@ elif [[  $ACTION = "check-config" ]]; then
             fi
         else
             echo "ERROR. Public key file $GPG_SALT_EXPORT_FILE is missing."
+        fi
+
+        if [ -f $GPG_ARMOR_SALT_EXPORT_FILE ]; then
+            if cat $GPG_ARMOR_SALT_EXPORT_FILE | gpg -q --with-colons --import-options show-only --import | grep --quiet $KEYID; then
+                echo "OK. Key ${KEYID} was exported to ${GPG_ARMOR_SALT_EXPORT_FILE}."
+            else
+                echo "ERROR. Public key file ${GPG_ARMOR_SALT_EXPORT_FILE} exists but it doesn't contain key ${KEYID}."
+            fi
+        else
+            echo "ERROR. Public key file $GPG_ARMOR_SALT_EXPORT_FILE is missing."
         fi
 
         if [ -f $GPG_PUB_EXPORT_FILE ]; then
@@ -249,6 +266,13 @@ elif [[  $ACTION = "disable" ]]; then
         echo "DONE. Removed key export file ${GPG_SALT_EXPORT_FILE}."
     else
         echo "OK. Key file ${GPG_SALT_EXPORT_FILE} is not present."
+    fi
+
+    if [ -f $GPG_ARMOR_SALT_EXPORT_FILE ]; then
+        rm -f $GPG_ARMOR_SALT_EXPORT_FILE
+        echo "DONE. Removed key export file ${GPG_ARMOR_SALT_EXPORT_FILE}."
+    else
+        echo "OK. Key file ${GPG_ARMOR_SALT_EXPORT_FILE} is not present."
     fi
 
     if [ -f $GPG_PUB_EXPORT_FILE ]; then

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- export armored GPG key to salt filesystem as well
 - Upgrade Cobbler requirement to 3.3.3 or later
 - Added an optional component_type property to the LOG object 
   and included it to a log message


### PR DESCRIPTION
## What does this PR change?

When signing metadata we deploy now also the armored key to the managed systems.
To do this, we need to make the key present in the salt filesystem.

This PR adapt `mgr-sign-metadata-ctl` command to permform the export

## GUI diff

No difference.

- [x] **DONE**

## Documentation

* Release Notes (note added to https://github.com/SUSE/spacewalk/issues/18198)
* https://github.com/uyuni-project/uyuni-docs/pull/1744

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/5805
Tracks https://github.com/SUSE/spacewalk/pull/18840

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
