### PR TITLE
QE: Fix core reposync with channel label

### DIFF
--- a/testsuite/features/core/srv_create_repository.feature
+++ b/testsuite/features/core/srv_create_repository.feature
@@ -47,7 +47,7 @@ Feature: Add a repository to a channel
     And I wait at most 60 seconds until I do not see "Repository sync is running." text, refreshing the page
     And I click on "Sync Now"
     Then I should see a "Repository sync scheduled for Test-Channel-x86_64." text
-    When I ensure the channel "Test-Channel-x86_64" has started syncing
+    When I ensure the channel "test-channel-x86_64" has started syncing
     And I disable source package syncing
 
   Scenario: Add a test repository for i586

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -382,7 +382,7 @@ When(/^I kill all running spacewalk\-repo\-sync, excepted the ones needed to boo
 end
 # rubocop:enable Metrics/BlockLength
 
-When(/^I ensure the channel "([^"]*)" has started syncing$/) do |given_channel|
+When(/^I ensure the channel "([^"]*)" has started syncing$/) do |channel_label|
   reposync_not_running_streak = 0
   # wait a maximum of 120s for reposync to start
   while reposync_not_running_streak <= 120
@@ -394,11 +394,11 @@ When(/^I ensure the channel "([^"]*)" has started syncing$/) do |given_channel|
     end
     process = command_output.split("\n")[0]
     channel = process.split[5]
-    return if channel == given_channel
+    return if channel == channel_label
     log "Channel #{channel} is syncing"
     reposync_not_running_streak += 1
   end
-  raise "Channel #{given_channel} didn't start syncing in 2 minutes"
+  raise "Channel #{channel_label} didn't start syncing in 2 minutes"
 end
 
 Then(/^the reposync logs should not report errors$/) do


### PR DESCRIPTION
## What does this PR change?

:weary: 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18801
Fixes https://github.com/uyuni-project/uyuni/pull/5869
Fixes https://github.com/uyuni-project/uyuni/pull/5876
Ports
4.2
4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
