### PR TITLE
spacewalk-debug: enhance passwords cleanup and include extra files (bsc#1201059)

### DIFF
--- a/python/spacewalk/satellite_tools/spacewalk-debug
+++ b/python/spacewalk/satellite_tools/spacewalk-debug
@@ -141,13 +141,17 @@ cp -fapRd /etc/sysconfig/rhn $DIR/conf/rhn/sysconfig
 rm -r $DIR/conf/rhn/sysconfig/rhn/schema-upgrade
 
 # there might be backups of rhn.conf so clean them up as well (bsc#1146419)
-find $DIR/conf/rhn -name 'rhn.conf*' -o -name 'uln.conf*' -exec sed -i 's/^server.susemanager.mirrcred_pass.*/server.susemanager.mirrcred_pass = <replaced_by_debug_tool>/' {} \;
-find $DIR/conf/rhn -name 'rhn.conf*' -o -name 'uln.conf*' -exec sed -i 's/^server.secret_key.*/server.secret_key = <replaced_by_debug_tool>/' {} \;
-find $DIR/conf/rhn -name 'rhn.conf*' -o -name 'uln.conf*' -exec sed -i 's/^session_secret_.*/session_secret_N = <replaced_by_debug_tool>/' {} \;
-find $DIR/conf/rhn -name 'rhn.conf*' -o -name 'uln.conf*' -exec sed -i 's/^web.session_swap_secret_.*/web.session_swap_secret_N = <replaced_by_debug_tool>/' {} \;
-find $DIR/conf/rhn -name 'rhn.conf*' -o -name 'uln.conf*' -exec sed -i 's/^db_password.*/db_password = <replaced_by_debug_tool>/' {} \;
-find $DIR/conf/rhn -name 'rhn.conf*' -o -name 'uln.conf*' -exec sed -i 's/^report_db_password.*/report_db_password = <replaced_by_debug_tool>/' {} \;
-find $DIR/conf/rhn -name 'rhn.conf*' -o -name 'uln.conf*' -exec sed -i 's/^server.satellite.http_proxy_password.*/server.satellite.http_proxy_password = <replaced_by_debug_tool>/' {} \;
+find $DIR/conf/rhn -name 'rhn.conf*' -exec sed -i 's/^server.susemanager.mirrcred_pass.*/server.susemanager.mirrcred_pass = <replaced_by_debug_tool>/' {} \;
+find $DIR/conf/rhn -name 'rhn.conf*' -exec sed -i 's/^server.secret_key.*/server.secret_key = <replaced_by_debug_tool>/' {} \;
+find $DIR/conf/rhn -name 'rhn.conf*' -exec sed -i 's/^session_secret_.*/session_secret_N = <replaced_by_debug_tool>/' {} \;
+find $DIR/conf/rhn -name 'rhn.conf*' -exec sed -i 's/^web.session_swap_secret_.*/web.session_swap_secret_N = <replaced_by_debug_tool>/' {} \;
+find $DIR/conf/rhn -name 'rhn.conf*' -exec sed -i 's/^db_password.*/db_password = <replaced_by_debug_tool>/' {} \;
+find $DIR/conf/rhn -name 'rhn.conf*' -exec sed -i 's/^report_db_password.*/report_db_password = <replaced_by_debug_tool>/' {} \;
+find $DIR/conf/rhn -name 'rhn.conf*' -exec sed -i 's/^server.satellite.http_proxy_password.*/server.satellite.http_proxy_password = <replaced_by_debug_tool>/' {} \;
+
+# cleanup also some other files
+find $DIR/conf/rhn -name 'uln.conf*' -exec sed -i 's/^password.*/password = <replaced_by_debug_tool>/' {} \;
+find $DIR/conf/rhn -name 'signing.conf*' -exec sed -i 's/^GPGPASS=.*/GPGPASS=<replaced_by_debug_tool>/' {} \;
 
 if [ -f /etc/tnsnames.ora ] ; then
     cp -fad /etc/tnsnames.ora $DIR/conf

--- a/python/spacewalk/satellite_tools/spacewalk-debug
+++ b/python/spacewalk/satellite_tools/spacewalk-debug
@@ -141,13 +141,13 @@ cp -fapRd /etc/sysconfig/rhn $DIR/conf/rhn/sysconfig
 rm -r $DIR/conf/rhn/sysconfig/rhn/schema-upgrade
 
 # there might be backups of rhn.conf so clean them up as well (bsc#1146419)
-find $DIR/conf/rhn -name rhn.conf -exec sed -i 's/^server.susemanager.mirrcred_pass.*/server.susemanager.mirrcred_pass = <replaced_by_debug_tool>/' {} \;
-find $DIR/conf/rhn -name rhn.conf -exec sed -i 's/^server.secret_key.*/server.secret_key = <replaced_by_debug_tool>/' {} \;
-find $DIR/conf/rhn -name rhn.conf -exec sed -i 's/^session_secret_.*/session_secret_N = <replaced_by_debug_tool>/' {} \;
-find $DIR/conf/rhn -name rhn.conf -exec sed -i 's/^web.session_swap_secret_.*/web.session_swap_secret_N = <replaced_by_debug_tool>/' {} \;
-find $DIR/conf/rhn -name rhn.conf -exec sed -i 's/^db_password.*/db_password = <replaced_by_debug_tool>/' {} \;
-find $DIR/conf/rhn -name rhn.conf -exec sed -i 's/^report_db_password.*/report_db_password = <replaced_by_debug_tool>/' {} \;
-find $DIR/conf/rhn -name rhn.conf -exec sed -i 's/^server.satellite.http_proxy_password.*/server.satellite.http_proxy_password = <replaced_by_debug_tool>/' {} \;
+find $DIR/conf/rhn -name 'rhn.conf*' -o -name 'uln.conf*' -exec sed -i 's/^server.susemanager.mirrcred_pass.*/server.susemanager.mirrcred_pass = <replaced_by_debug_tool>/' {} \;
+find $DIR/conf/rhn -name 'rhn.conf*' -o -name 'uln.conf*' -exec sed -i 's/^server.secret_key.*/server.secret_key = <replaced_by_debug_tool>/' {} \;
+find $DIR/conf/rhn -name 'rhn.conf*' -o -name 'uln.conf*' -exec sed -i 's/^session_secret_.*/session_secret_N = <replaced_by_debug_tool>/' {} \;
+find $DIR/conf/rhn -name 'rhn.conf*' -o -name 'uln.conf*' -exec sed -i 's/^web.session_swap_secret_.*/web.session_swap_secret_N = <replaced_by_debug_tool>/' {} \;
+find $DIR/conf/rhn -name 'rhn.conf*' -o -name 'uln.conf*' -exec sed -i 's/^db_password.*/db_password = <replaced_by_debug_tool>/' {} \;
+find $DIR/conf/rhn -name 'rhn.conf*' -o -name 'uln.conf*' -exec sed -i 's/^report_db_password.*/report_db_password = <replaced_by_debug_tool>/' {} \;
+find $DIR/conf/rhn -name 'rhn.conf*' -o -name 'uln.conf*' -exec sed -i 's/^server.satellite.http_proxy_password.*/server.satellite.http_proxy_password = <replaced_by_debug_tool>/' {} \;
 
 if [ -f /etc/tnsnames.ora ] ; then
     cp -fad /etc/tnsnames.ora $DIR/conf
@@ -267,6 +267,9 @@ fi
 if [ -d /var/lib/rhn/kickstarts ]; then
    cp -fa /var/lib/rhn/kickstarts/* $DIR/kickstarts/
 fi
+
+# Remove passwords from cobbler settings
+find $DIR/conf/cobbler -type f -name 'settings*' -exec sed -i 's/^default_password_crypted.*/default_password_crypted <replaced_by_debug_tool>/' {} \;
 
 # ssl-build
 if [ -d /root/ssl-build ] ; then

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Enhance passwords cleanup and add extra files in spacewalk-debug (bsc#1201059)
 - Prevent mixing credentials for proxy and repository server
   while using basic authentication and avoid hiding errors
   i.e. timeouts while having proxy settings issues


### PR DESCRIPTION
## What does this PR change?

This PR enhance the cleanup of passwords done by `spacewalk-debug` when executed on the context of `supportconfig`.

There were some missing files that were not taken into account for the cleanup, like `rhn.conf.orig`, `uln.conf` and also cobbler settings.

This PR takes cares of including those missing files into the cleanup.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/18286

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
