### PR TITLE
QE: Fix reposync fix

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -394,11 +394,12 @@ When(/^I ensure the channel "([^"]*)" has started syncing$/) do |channel_label|
     end
     process = command_output.split("\n")[0]
     channel = process.split[5]
-    return if channel == channel_label
+    break if channel == channel_label
+
     log "Channel #{channel} is syncing"
     reposync_not_running_streak += 1
   end
-  raise "Channel #{channel_label} didn't start syncing in 2 minutes"
+  raise StandardError "Channel #{channel_label} didn't start syncing in 2 minutes" if reposync_not_running_streak > 120
 end
 
 Then(/^the reposync logs should not report errors$/) do


### PR DESCRIPTION
## What does this PR change?

:weary: :tired_face: 

## Uyuni PR tests
https://ci.suse.de/view/Manager/view/Uyuni-PRs/job/uyuni-prs-ci-tests/1588/
https://ci.suse.de/view/Manager/view/Uyuni-PRs/job/uyuni-prs-ci-tests/1590/
https://ci.suse.de/view/Manager/view/Uyuni-PRs/job/uyuni-prs-ci-tests/1591/
https://ci.suse.de/view/Manager/view/Uyuni-PRs/job/uyuni-prs-ci-tests/1593/

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18801
Fixes https://github.com/uyuni-project/uyuni/pull/5869
Fixes https://github.com/uyuni-project/uyuni/pull/5876
Ports
4.2
4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
