### PR TITLE
Make RollingFile filePattern an absolute path

### DIFF
--- a/java/code/src/log4j2.xml
+++ b/java/code/src/log4j2.xml
@@ -1,24 +1,26 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <Configuration status="warn" name="UyuniConfig">
     <Appenders>
-        <RollingFile name="rootAppender" fileName="/var/log/rhn/rhn_web_ui.log" filePattern="rhn_web_ui-%i.log">
+        <RollingFile name="rootAppender" fileName="/var/log/rhn/rhn_web_ui.log"
+                     filePattern="/var/log/rhn/rhn_web_ui-%i.log">
             <PatternLayout pattern="%d [%t] %-5p %c - %m%n" />
             <SizeBasedTriggeringPolicy size="10MB" />
             <DefaultRolloverStrategy max="5" />
         </RollingFile>
-        <RollingFile name="apiLogFileAppender" fileName="/var/log/rhn/rhn_web_api.log" filePattern="rhn_web_api-%i.log">
+        <RollingFile name="apiLogFileAppender" fileName="/var/log/rhn/rhn_web_api.log"
+                     filePattern="/var/log/rhn/rhn_web_api-%i.log">
             <PatternLayout pattern="[%d] %-5p - %m%n" />
             <SizeBasedTriggeringPolicy size="10MB" />
             <DefaultRolloverStrategy max="5" />
         </RollingFile>
         <RollingFile name="frontendLogControllerAppender" fileName="/var/log/rhn/rhn_web_frontend.log"
-                     filePattern="rhn_web_frontend-%i.log">
+                     filePattern="/var/log/rhn/rhn_web_frontend-%i.log">
             <PatternLayout pattern="%d [%t] %-5p %c - %m%n" />
             <SizeBasedTriggeringPolicy size="10MB" />
             <DefaultRolloverStrategy max="30" />
         </RollingFile>
         <RollingFile name="remoteCommandsAppender" fileName="/var/log/rhn/rhn_salt_remote_commands.log"
-                     filePattern="rhn_salt_remote_commands-%i.log">
+                     filePattern="/var/log/rhn/rhn_salt_remote_commands-%i.log">
             <PatternLayout pattern="%d [%t] %-5p %c - %m%n" />
             <SizeBasedTriggeringPolicy size="10MB" />
             <DefaultRolloverStrategy max="30" />

--- a/java/conf/log4j2.xml.taskomatic
+++ b/java/conf/log4j2.xml.taskomatic
@@ -2,7 +2,7 @@
 <Configuration status="warn" name="TaskomaticConfig">
     <Appenders>
         <RollingFile name="rootAppender" fileName="/var/log/rhn/rhn_taskomatic_daemon.log"
-                     filePattern="rhn_taskomatic_daemon-%i.log">
+                     filePattern="/var/log/rhn/rhn_taskomatic_daemon-%i.log">
             <PatternLayout pattern="%d [%t] %-5p %c - %m%n" />
             <SizeBasedTriggeringPolicy size="10MB" />
             <DefaultRolloverStrategy max="5" />


### PR DESCRIPTION
## What does this PR change?

Should fix #5883. Log4J2 should no more try to write the rotated logfile into CATALINA_HOME

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: no functional change

## Links

Fixes #5883

- [x] **DONE**

## Changelogs

- [x] No changelog needed (what is the criteria to make a fix worth a changelog entry?)

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
