### PR TITLE
fix syntax error - remove trailing colon (bsc#1203049)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/certs/suse.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/suse.sls
@@ -10,7 +10,7 @@ mgr_ca_cert:
 {%- if grains['osrelease']|int == 11 %}
 mgr_split_ca:
   cmd.wait_script:
-    - name: salt://certs/update-multi-cert.sh:
+    - name: salt://certs/update-multi-cert.sh
     - runas: root
     - watch:
         - file: mgr_ca_cert

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- fix syntax error - remove trailing colon (bsc#1203049)
 - Add mgrnet salt module with mgrnet.dns_fqnd function implementation
   allowing to get all possible FQDNs from DNS (bsc#1199726)
 - Copy grains file with util.mgr_switch_to_venv_minion state apply


### PR DESCRIPTION
## What does this PR change?

Syntax error in state file

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **unsupported os**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/18865

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
