### PR TITLE
Use sumaform as single source of truth for beta tools

### DIFF
--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -45,8 +45,6 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I should see a "Legacy Module 12 x86_64" text
     When I select the addon "Legacy Module 12 x86_64"
     Then I should see the "Legacy Module 12 x86_64" selected
-    # Comment following 1 line if you wish to re-enable testing with beta client tools for SLE12
-    # When I deselect "SUSE Manager Client Tools Beta for SLE 12 x86_64 (BETA)" as a SUSE Manager product
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 12 SP5 x86_64" product has been added
     Then the SLE12 SP5 product should be added
@@ -63,10 +61,6 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I select "SUSE Linux Enterprise Server 15 SP4 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server 15 SP4 x86_64" selected
     And I should see the "Basesystem Module 15 SP4 x86_64" selected
-    # Comment following 3 lines if you wish to re-enable testing with beta client tools for SLE15
-    # And I open the sub-list of the product "Basesystem Module 15 SP4 x86_64"
-    # And I open the sub-list of the product "SUSE Manager Client Tools for SLE 15 x86_64" on SUSE Manager
-    # And I deselect "SUSE Manager Client Tools Beta for SLE 15 x86_64 (BETA)" as a SUSE Manager product
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 15 SP4 x86_64" product has been added
     Then the SLE15 SP4 product should be added

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -534,12 +534,6 @@ When(/^I (deselect|select) "([^\"]*)" as a product$/) do |select, product|
   raise "xpath: #{xpath} not found" unless find(:xpath, xpath).set(select == "select")
 end
 
-When(/^I (deselect|select) "([^\"]*)" as a (SUSE Manager|Uyuni) product$/) do |select, product, product_version|
-  if $product == product_version
-    step %(I #{select} "#{product}" as a product)
-  end
-end
-
 When(/^I wait at most (\d+) seconds until the tree item "([^"]+)" has no sub-list$/) do |timeout, item|
   repeat_until_timeout(timeout: timeout.to_i, message: "could still find a sub list for tree item #{item}") do
     xpath = "//span[contains(text(), '#{item}')]/ancestor::div[contains(@class, 'product-details-wrapper')]/div/i[contains(@class, 'fa-angle-')]"


### PR DESCRIPTION
## What does this PR change?

This PR lets sumaform decide alone about the beta tools (we won't deselect them anymore from the test suite).


## Links

Sibling PRs:

* sumaform: uyuni-project/sumaform#1159
* 4.2: SUSE/spacewalk#18866
* 4.3: SUSE/spacewalk#18870


## Changelogs

- [x] No changelog needed
