### PR TITLE
Fixed pagination for completed/failed systems in action details

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/schedule/CompletedSystemsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/schedule/CompletedSystemsAction.java
@@ -16,7 +16,6 @@ package com.redhat.rhn.frontend.action.schedule;
 
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFormatter;
-import com.redhat.rhn.frontend.listview.PageControl;
 import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.frontend.struts.RhnHelper;
@@ -94,7 +93,6 @@ public class CompletedSystemsAction extends RhnAction implements Listable {
     @Override
     public List getResult(RequestContext context) {
         Action action = context.lookupAndBindAction();
-        PageControl pc = new PageControl();
-        return ActionManager.completedSystems(context.getCurrentUser(), action, pc);
+        return ActionManager.completedSystems(context.getCurrentUser(), action, null);
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/action/schedule/FailedSystemsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/schedule/FailedSystemsAction.java
@@ -16,7 +16,6 @@ package com.redhat.rhn.frontend.action.schedule;
 
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFormatter;
-import com.redhat.rhn.frontend.listview.PageControl;
 import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.frontend.struts.RhnHelper;
@@ -119,9 +118,7 @@ public class FailedSystemsAction extends RhnAction implements Listable {
     @Override
     public List getResult(RequestContext context) {
         Action action = context.lookupAndBindAction();
-        PageControl pc = new PageControl();
-        pc.setFilterColumn("earliest");
-        return ActionManager.failedSystems(context.getCurrentUser(), action, pc);
+        return ActionManager.failedSystems(context.getCurrentUser(), action, null);
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fixed pagination for completed/failed systems in action details
 - Add support in rhn.conf for smtp port, auth, ssl/tls config
 - Fix sync for external repositories (bsc#1201753)
 - Detect the clients running on Amazon EC2 (bsc#1195624)


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue in the pagination of the completed and failed system of the event details page. Currently only the first 25 system are extracted from the database because the `PageControl` is recreated on each request. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bug fix on a documented functionality

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18871
Tracks https://github.com/uyuni-project/uyuni/issues/5854

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
