### PR TITLE
Do not use same SP for SLES and SLED

### DIFF
--- a/testsuite/features/reposync/srv_enable_sync_products.feature
+++ b/testsuite/features/reposync/srv_enable_sync_products.feature
@@ -17,17 +17,19 @@ Feature: Be able to list available products and enable them
     And I should get "  [ ] (R) Basesystem Module 15 SP3 x86_64"
     And I should get "  [ ] Desktop Applications Module 15 SP3 x86_64"
 
-  Scenario: Enable "SUSE Linux Enterprise Desktop 15 SP4 x86_64" with recommended modules
-    When I enable product "SUSE Linux Enterprise Desktop 15 SP4 x86_64"
-    Then I should get "Adding channels required by 'SUSE Linux Enterprise Desktop 15 SP4 x86_64' product"
-    And I should get "- sle-product-sled15-sp4-updates-x86_64"
-    And I should get "- sle-product-sled15-sp4-pool-x86_64"
-    And I should get "- sle-module-basesystem15-sp4-updates-x86_64-sled"
-    And I should get "- sle-module-basesystem15-sp4-pool-x86_64-sled"
-    And I should get "- sle-module-desktop-applications15-sp4-updates-x86_64-sled"
-    And I should get "- sle-module-desktop-applications15-sp4-pool-x86_64-sled"
-    And I should get "- sle-product-we15-sp4-updates-x86_64-sled"
-    And I should get "- sle-product-we15-sp4-pool-x86_64-sled"
+  Scenario: Enable "SUSE Linux Enterprise Desktop 15 SP3 x86_64" with recommended modules
+    # do NOT use same SP as for SLES minions
+    # ask mcalmer for technical details why this is a problem
+    When I enable product "SUSE Linux Enterprise Desktop 15 SP3 x86_64"
+    Then I should get "Adding channels required by 'SUSE Linux Enterprise Desktop 15 SP3 x86_64' product"
+    And I should get "- sle-product-sled15-sp3-updates-x86_64"
+    And I should get "- sle-product-sled15-sp3-pool-x86_64"
+    And I should get "- sle-module-basesystem15-sp3-updates-x86_64-sled"
+    And I should get "- sle-module-basesystem15-sp3-pool-x86_64-sled"
+    And I should get "- sle-module-desktop-applications15-sp3-updates-x86_64-sled"
+    And I should get "- sle-module-desktop-applications15-sp3-pool-x86_64-sled"
+    And I should get "- sle-product-we15-sp3-updates-x86_64-sled"
+    And I should get "- sle-product-we15-sp3-pool-x86_64-sled"
     And I should get "Product successfully added"
 
   Scenario: Enable "SUSE Linux Enterprise Server for SAP Applications 15 x86_64" without recommended modules


### PR DESCRIPTION
## What does this PR change?

When we test the product wizard, we enable SLED 15 SP4, while we intend to bootstrap SLES 15 SP4.

The problem is that both products share same packages. This creates a problem when we kill the reposyncs, the bootstrap repo for SLES 15 SP4 does not get created because SUSE Manager waits for the killed repos to be fully synced.

Strictly speaking, this is a product issue, but it needs a serious refactoring, for a use case that not many customers will meet. So let's work around it by reposyncing different SPs.


## Links

Ports:
* 4.2: https://github.com/SUSE/spacewalk/pull/18893
* 4.3: https://github.com/SUSE/spacewalk/pull/18892

Fixes #18707


## Changelogs

- [x] No changelog needed
