### PR TITLE
Tools for SLED are shared with SLES, we must not kill their reposync

### DIFF
--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -275,12 +275,14 @@ CHANNEL_TO_SYNCH_BY_OS_VERSION = {
   %w[
     sle-product-sles15-sp4-pool-x86_64
     sle-manager-tools15-pool-x86_64-sp4
+    sle-manager-tools15-pool-x86_64-sled-sp4
     sle-manager-tools15-beta-pool-x86_64-sp4
     sle-module-containers15-sp4-pool-x86_64
     sle-module-basesystem15-sp4-pool-x86_64
     sle-module-server-applications15-sp4-pool-x86_64
     sle-product-sles15-sp4-updates-x86_64
     sle-manager-tools15-updates-x86_64-sp4
+    sle-manager-tools15-updates-x86_64-sled-sp4
     sle-manager-tools15-beta-updates-x86_64-sp4
     sle-module-containers15-sp4-updates-x86_64
     sle-module-basesystem15-sp4-updates-x86_64
@@ -290,29 +292,35 @@ CHANNEL_TO_SYNCH_BY_OS_VERSION = {
   %w[
     sles12-sp4-pool-x86_64
     sle-manager-tools12-pool-x86_64-sp4
+    sle-manager-tools12-pool-x86_64-sled-sp4
     sle-module-containers12-pool-x86_64-sp4
     sles12-sp4-updates-x86_64
     sle-manager-tools12-updates-x86_64-sp4
+    sle-manager-tools12-updates-x86_64-sled-sp4
     sle-module-containers12-updates-x86_64-sp4
   ],
   '12-SP5' =>
   %w[
     sles12-sp5-pool-x86_64
     sle-manager-tools12-pool-x86_64-sp5
+    sle-manager-tools12-pool-x86_64-sled-sp5
     sle-module-containers12-pool-x86_64-sp5
     sles12-sp5-updates-x86_64
     sle-manager-tools12-updates-x86_64-sp5
+    sle-manager-tools12-updates-x86_64-sled-sp5
     sle-module-containers12-updates-x86_64-sp5
   ],
   '15-SP1' =>
   %w[
     sle-product-sles15-sp1-pool-x86_64
     sle-manager-tools15-pool-x86_64-sp1
+    sle-manager-tools15-pool-x86_64-sled-sp1
     sle-module-containers15-sp1-pool-x86_64
     sle-module-basesystem15-sp1-pool-x86_64
     sle-module-server-applications15-sp1-pool-x86_64
     sle-product-sles15-sp1-updates-x86_64
     sle-manager-tools15-updates-x86_64-sp1
+    sle-manager-tools15-updates-x86_64-sled-sp1
     sle-module-containers15-sp1-updates-x86_64
     sle-module-basesystem15-sp1-updates-x86_64
     sle-module-server-applications15-sp1-updates-x86_64
@@ -321,12 +329,14 @@ CHANNEL_TO_SYNCH_BY_OS_VERSION = {
   %w[
     sle-product-sles15-sp2-pool-x86_64
     sle-manager-tools15-pool-x86_64-sp2
+    sle-manager-tools15-pool-x86_64-sled-sp2
     sle-manager-tools15-beta-pool-x86_64-sp2
     sle-module-containers15-sp2-pool-x86_64
     sle-module-basesystem15-sp2-pool-x86_64
     sle-module-server-applications15-sp2-pool-x86_64
     sle-product-sles15-sp2-updates-x86_64
     sle-manager-tools15-updates-x86_64-sp2
+    sle-manager-tools15-updates-x86_64-sled-sp2
     sle-manager-tools15-beta-updates-x86_64-sp2
     sle-module-containers15-sp2-updates-x86_64
     sle-module-basesystem15-sp2-updates-x86_64
@@ -336,12 +346,14 @@ CHANNEL_TO_SYNCH_BY_OS_VERSION = {
   %w[
     sle-product-sles15-sp3-pool-x86_64
     sle-manager-tools15-pool-x86_64-sp3
+    sle-manager-tools15-pool-x86_64-sled-sp3
     sle-manager-tools15-beta-pool-x86_64-sp3
     sle-module-containers15-sp3-pool-x86_64
     sle-module-basesystem15-sp3-pool-x86_64
     sle-module-server-applications15-sp3-pool-x86_64
     sle-product-sles15-sp3-updates-x86_64
     sle-manager-tools15-updates-x86_64-sp3
+    sle-manager-tools15-updates-x86_64-sled-sp3
     sle-manager-tools15-beta-updates-x86_64-sp3
     sle-module-containers15-sp3-updates-x86_64
     sle-module-basesystem15-sp3-updates-x86_64
@@ -351,12 +363,14 @@ CHANNEL_TO_SYNCH_BY_OS_VERSION = {
   %w[
     sle-product-sles15-sp4-pool-x86_64
     sle-manager-tools15-pool-x86_64-sp4
+    sle-manager-tools15-pool-x86_64-sled-sp4
     sle-manager-tools15-beta-pool-x86_64-sp4
     sle-module-containers15-sp4-pool-x86_64
     sle-module-basesystem15-sp4-pool-x86_64
     sle-module-server-applications15-sp4-pool-x86_64
     sle-product-sles15-sp4-updates-x86_64
     sle-manager-tools15-updates-x86_64-sp4
+    sle-manager-tools15-updates-x86_64-sled-sp4
     sle-manager-tools15-beta-updates-x86_64-sp4
     sle-module-containers15-sp4-updates-x86_64
     sle-module-basesystem15-sp4-updates-x86_64


### PR DESCRIPTION
## What does this PR change?

Tools for SLED are shared with SLES, we must not kill their reposync.

Note: version for 4.2 has a piggyback commit, meant to use sle 15 sp3 as the default for auto-installation, instead of sp2.


## Links

Ports:
* 4.2: https://github.com/SUSE/spacewalk/pull/18915
* 4.3: https://github.com/SUSE/spacewalk/pull/18914


## Changelogs

- [x] No changelog needed
