### PR TITLE
QE: Wait for "Hosted Virtual Systems" text in KVM feature

### DIFF
--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -417,7 +417,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I select "15-sp4-kvm" from "cobbler_profile"
     And I select "test-net0" from "network0_source"
     And I click on "Create"
-    Then I should see a "Hosted Virtual Systems" text
+    Then I wait until I see a "Hosted Virtual Systems" text
     When I wait until I see "test-vm2" text
     And I wait until table row for "test-vm2" contains button "Stop"
     # Test the VM boot params

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -417,7 +417,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I select "15-sp4-kvm" from "cobbler_profile"
     And I select "test-net0" from "network0_source"
     And I click on "Create"
-    Then I wait until I see a "Hosted Virtual Systems" text
+    Then I wait until I see "Hosted Virtual Systems" text
     When I wait until I see "test-vm2" text
     And I wait until table row for "test-vm2" contains button "Stop"
     # Test the VM boot params

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -417,7 +417,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I select "15-sp4-kvm" from "cobbler_profile"
     And I select "test-net0" from "network0_source"
     And I click on "Create"
-    Then I wait until I see "Hosted Virtual Systems" text
+    And I wait until I see "Hosted Virtual Systems" text
     When I wait until I see "test-vm2" text
     And I wait until table row for "test-vm2" contains button "Stop"
     # Test the VM boot params


### PR DESCRIPTION
## What does this PR change?

Wait for "Hosted Virtual Systems" text in Create an auto installing KVM virtual machine scenario as the page is not ready when the step is run, causing it to fail.


## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks # 
4.2
4.3

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
