### PR TITLE
add bugnumbers to changelog

### DIFF
--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,7 +1,7 @@
 - Upgrade moment-timezone
 - Fix packaging issues to address CVE-2021-43138 (bsc#1200480)
-- Upgrade shell-quote to fix CVE-2021-42740, upgrade moment to fix 
-  CVE-2022-31129
+- Upgrade shell-quote to fix CVE-2021-42740 (bsc#1203287)
+- Upgrade moment to fix CVE-2022-31129 (bsc#1203288)
 - Fix table header layout for unselectable tables
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

The CVE numbers mentioned in the changelog got now bugnumbers. Add them to the changelog.

Port of https://github.com/SUSE/spacewalk/pull/18928

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
