### PR TITLE
For Head and Uyuni, use an endpoint in NUE

### DIFF
--- a/testsuite/features/upload_files/pkg_endpoint.sls
+++ b/testsuite/features/upload_files/pkg_endpoint.sls
@@ -1,3 +1,5 @@
+# Move the endpoint to Provo after the release
+
 pkg_download_point_protocol: ftp
-pkg_download_point_host: minima-mirror.mgr.prv.suse.net
+pkg_download_point_host: minima-mirror.mgr.suse.de
 pkg_download_point_port: 445


### PR DESCRIPTION
## What does this PR change?

With the new firewalled network, it will get harder to use a test resource in PRV with test suites in NUE.

The best strategy is to duplicate every resource between NUE and PRV. It's also a good idea for resiliency / disaster recovery.

This PR uses the custom endpoint for FTP test in minima-mirror.mgr.suse.de in substitution for minima-mirror.mgr.prv.net in case of the HEAD and Uyuni test suites.

It will be followed by another PR that will add a sanity check to check the availability of the resource.


## Links

Fixes SUSE/spacewalk#18568

No ports, uyuni branch only


## Changelogs

- [x] No changelog needed
