### PR TITLE
QE: An additional bootstrap channel is enabled by default now in our minions

### DIFF
--- a/testsuite/features/secondary/allcli_software_channels.feature
+++ b/testsuite/features/secondary/allcli_software_channels.feature
@@ -82,7 +82,7 @@ Feature: Channel subscription via SSM
 @sle_minion
   Scenario: Check old channels are still enabled on SLES minion before channel change completes
     When I refresh the metadata for "sle_minion"
-    Then "1" channels should be enabled on "sle_minion"
+    Then "2" channels should be enabled on "sle_minion"
     And channel "Test-Channel-x86_64" should be enabled on "sle_minion"
 
 @sle_client
@@ -129,7 +129,7 @@ Feature: Channel subscription via SSM
 @sle_minion
   Scenario: Check the new channels are enabled on the SLES minion
     When I refresh the metadata for "sle_minion"
-    Then "2" channels should be enabled on "sle_minion"
+    Then "3" channels should be enabled on "sle_minion"
     And channel "Test Base Channel" should be enabled on "sle_minion"
     And channel "Test Child Channel" should be enabled on "sle_minion"
 

--- a/testsuite/features/secondary/min_change_software_channel.feature
+++ b/testsuite/features/secondary/min_change_software_channel.feature
@@ -19,7 +19,7 @@ Feature: Assign child channel to a system
 
   Scenario: Check old channels are still enabled on the system before channel change completes
     When I refresh the metadata for "sle_minion"
-    Then "1" channels should be enabled on "sle_minion"
+    Then "2" channels should be enabled on "sle_minion"
     And channel "Test-Channel-x86_64" should be enabled on "sle_minion"
 
   Scenario: Assign a child channel to the system
@@ -52,7 +52,7 @@ Feature: Assign child channel to a system
 
   Scenario: Check the new channels are enabled on the system
     When I refresh the metadata for "sle_minion"
-    Then "2" channels should be enabled on "sle_minion"
+    Then "3" channels should be enabled on "sle_minion"
     And channel "Test-Channel-x86_64" should be enabled on "sle_minion"
     And channel "Test-Channel-x86_64 Child Channel" should be enabled on "sle_minion"
 


### PR DESCRIPTION
## What does this PR change?

This PR aims to fix these issues:

https://github.com/SUSE/spacewalk/issues/18934
https://github.com/SUSE/spacewalk/issues/18947

We now have an additional bootstrap channel enabled by default in our minions. So we need to change some expected values.

Log output evidence:
```
[2022-09-13T01:40:24.881Z] zypper lr -E | tail -n +5 returned status code = 0.
[2022-09-13T01:40:24.881Z] Output:
[2022-09-13T01:40:24.881Z] 1 | SUSE-Manager-Bootstrap          | SUSE-Manager-Bootstrap | Yes     | (  ) No   | Yes
[2022-09-13T01:40:24.881Z] 5 | susemanager:test-channel-x86_64 | Test-Channel-x86_64    | Yes     | ( p) Yes  | Yes
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Port:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
