### PR TITLE
disable always the bootstrap repository

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/init.sls
@@ -3,14 +3,11 @@ include:
   - certs
   - channels.gpg-keys
 
-{%- if salt['pillar.get']('mgr_disable_local_repos', True) %}
-{# disable all local repos which are not from susemanager unless the pillar say it different #}
-{%- include 'channels/disablelocalrepos.sls' %}
-{%- else %}
+{%- if not salt['pillar.get']('mgr_disable_local_repos', True) %}
 {# disable at least the SUSE-Manager-Bootstrap repo #}
 {% set repos_disabled = {'match_str': 'SUSE-Manager-Bootstrap', 'matching': true} %}
-{%- include 'channels/disablelocalrepos.sls' %}
 {%- endif %}
+{%- include 'channels/disablelocalrepos.sls' %}
 
 {%- if grains['os_family'] == 'RedHat' %}
 

--- a/susemanager-utils/susemanager-sls/salt/channels/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/init.sls
@@ -6,6 +6,10 @@ include:
 {%- if salt['pillar.get']('mgr_disable_local_repos', True) %}
 {# disable all local repos which are not from susemanager unless the pillar say it different #}
 {%- include 'channels/disablelocalrepos.sls' %}
+{%- else %}
+{# disable at least the SUSE-Manager-Bootstrap repo #}
+{% set repos_disabled = {'match_str': 'SUSE-Manager-Bootstrap', 'matching': true} %}
+{%- include 'channels/disablelocalrepos.sls' %}
 {%- endif %}
 
 {%- if grains['os_family'] == 'RedHat' %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- disable always the bootstrap repository also when
+  "mgr_disable_local_repos" is set to False
 - Use mgrnet.dns_fqdns module to improve FQDN detection (bsc#1199726)
 - fix syntax error - remove trailing colon (bsc#1203049)
 - Add mgrnet salt module with mgrnet.dns_fqnd function implementation


### PR DESCRIPTION
## What does this PR change?

When "mgr_disable_local_repos" is set to `False`, the bootstrap repository stays enabled as all local repos are disabled only before the bootstrapping.
In this case disable at least the bootstrap  repo.

Port of https://github.com/SUSE/spacewalk/pull/18973

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
