### PR TITLE
k3s doc fixes

### DIFF
--- a/containers/README.md
+++ b/containers/README.md
@@ -31,13 +31,13 @@ MetalLB is the LoadBalancer that will expose the proxy pod services to the outsi
 To install it, run:
 
     helm repo add metallb https://metallb.github.io/metallb
-    helm install --create-namespace -n metallb metallb metallb/metallb -f metallb-values.yaml 
+    helm install --create-namespace -n metallb metallb metallb/metallb 
 
 MetalLB still requires a configuration to know the virtual IP address range to be used.
 In this example, the virtual IP addresses will be from `192.168.122.240` to `192.168.122.250`, but we could lower that range since only one address will be used in the end.
 This addresses obviously need to be a subset of the server network.
 
-Create a `metallb-config.yaml` with content like the following with adjusted IP addresses:
+Create a `metallb-config.yaml` with content like the following with an IP address range that aligns with the deployed network:
 
 ```yaml
 apiVersion: metallb.io/v1beta1
@@ -47,7 +47,7 @@ metadata:
   namespace: metallb
 spec:
   addresses:
-  - 192.168.1.240-192.168.1.250
+  - 192.168.122.240-192.168.122.250
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement


### PR DESCRIPTION
## What does this PR change?

More k3s documentation fix

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: It is a doc that is updated
- [X] **DONE**

## Test coverage
- No tests: doc
- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
