### PR TITLE
Helm chart: remove namespace value

### DIFF
--- a/containers/proxy-helm/proxy-helm.changes
+++ b/containers/proxy-helm/proxy-helm.changes
@@ -1,3 +1,4 @@
+- Remove the namespace configuration value to honor helm's -n
 - Add the log level value to the config.yaml
 
 -------------------------------------------------------------------

--- a/containers/proxy-helm/templates/config.yaml
+++ b/containers/proxy-helm/templates/config.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: proxy-configmap
-  namespace: "{{ .Values.namespace }}"
+  namespace: "{{ .Release.namespace }}"
 data:
   config.yaml: |
     server: {{ .Values.server }}
@@ -18,7 +18,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: proxy-secret
-  namespace: "{{ .Values.namespace }}"
+  namespace: "{{ .Release.namespace }}"
 stringData:
   httpd.yaml: |
     httpd:

--- a/containers/proxy-helm/templates/deployment.yaml
+++ b/containers/proxy-helm/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: uyuni-proxy
-  namespace: "{{ .Values.namespace }}"
+  namespace: "{{ .Release.namespace }}"
 spec:
   replicas: 1
   selector:

--- a/containers/proxy-helm/templates/service.yaml
+++ b/containers/proxy-helm/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: uyuni-proxy-tcp
-  namespace: "{{ .Values.namespace }}"
+  namespace: "{{ .Release.namespace }}"
 {{- if .Values.services.annotations }}
   annotations:
 {{ toYaml .Values.services.annotations | indent 4 }}
@@ -43,7 +43,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: uyuni-proxy-udp
-  namespace: "{{ .Values.namespace }}"
+  namespace: "{{ .Release.namespace }}"
 {{- if .Values.services.annotations }}
   annotations:
 {{ toYaml .Values.services.annotations | indent 4 }}

--- a/containers/proxy-helm/templates/volumes.yaml
+++ b/containers/proxy-helm/templates/volumes.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: package-cache-pv-claim
-  namespace: "{{ .Values.namespace }}"
+  namespace: "{{ .Release.namespace }}"
 spec:
 {{- if .Values.persistentVolume.storageClass }}
 {{- if (eq "-" .Values.persistentVolume.storageClass) }}
@@ -21,7 +21,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: squid-cache-pv-claim
-  namespace: "{{ .Values.namespace }}"
+  namespace: "{{ .Release.namespace }}"
 spec:
 {{- if .Values.persistentVolume.storageClass }}
 {{- if (eq "-" .Values.persistentVolume.storageClass) }}
@@ -40,7 +40,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: tftp-boot-pv-claim
-  namespace: "{{ .Values.namespace }}"
+  namespace: "{{ .Release.namespace }}"
 spec:
 {{- if .Values.persistentVolume.storageClass }}
 {{- if (eq "-" .Values.persistentVolume.storageClass) }}

--- a/containers/proxy-helm/values.yaml
+++ b/containers/proxy-helm/values.yaml
@@ -6,8 +6,6 @@ version: latest
 ##
 pullPolicy: "Always"
 
-namespace: "default"
-
 persistentVolume:
     ## uyuni proxy overall Persistent Volume access modes
     ## Must match those of existing PV or dynamic provisioner


### PR DESCRIPTION
## What does this PR change?

Setting the namespace as a value overrides the helm `-n myns` option. Removing those would just use the default option unless the user provides the `-n` parameter.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: would just work as expected by user

- [X] **DONE**

## Test coverage
- No tests: helm chart is not tested

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
