### PR TITLE
Add serializer for the Action class

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ActionSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ActionSerializer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.frontend.xmlrpc.serializer;
+
+import com.redhat.rhn.domain.action.Action;
+
+import com.suse.manager.api.ApiResponseSerializer;
+import com.suse.manager.api.SerializationBuilder;
+import com.suse.manager.api.SerializedApiResponse;
+
+/**
+ * Serializer for Action class
+ */
+public class ActionSerializer extends ApiResponseSerializer<Action> {
+
+    @Override
+    public SerializedApiResponse serialize(Action action) {
+        return getSerializationBuilder(action).build();
+    }
+
+    /**
+     * @return a serialization builder using the Action provided as parameter
+     * @param act - Action instance being serialized
+     */
+    public static SerializationBuilder getSerializationBuilder(Action act) {
+        SerializationBuilder builder = new SerializationBuilder()
+                .add("failed_count", act.getFailedCount())
+                .add("modified", act.getModified().toString())
+                .add("created", act.getCreated().toString())
+                .add("action_type", act.getActionType().getName())
+                .add("successful_count", act.getSuccessfulCount())
+                .add("earliest_action", act.getEarliestAction().toString())
+                .add("archived", act.getArchived())
+                .add("prerequisite", act.getPrerequisite())
+                .add("name", act.getName())
+                .add("id", act.getId())
+                .add("version", act.getVersion().toString())
+                .add("modified_date", act.getModified())
+                .add("created_date", act.getCreated());
+        if (act.getSchedulerUser() != null) {
+            builder.add("scheduler_user", act.getSchedulerUser().getLogin());
+        }
+        return builder;
+    }
+
+    @Override
+    public Class<Action> getSupportedClass() {
+        return Action.class;
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SerializerRegistry.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SerializerRegistry.java
@@ -109,6 +109,7 @@ public class SerializerRegistry {
         SERIALIZER_CLASSES.add(FilePreservationDtoSerializer.class);
         SERIALIZER_CLASSES.add(FileListSerializer.class);
         SERIALIZER_CLASSES.add(ServerActionSerializer.class);
+        SERIALIZER_CLASSES.add(ActionSerializer.class);
         SERIALIZER_CLASSES.add(ChannelTreeNodeSerializer.class);
         SERIALIZER_CLASSES.add(TrustedOrgDtoSerializer.class);
         SERIALIZER_CLASSES.add(PackageKeySerializer.class);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ServerActionSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ServerActionSerializer.java
@@ -70,19 +70,7 @@ public class ServerActionSerializer extends ApiResponseSerializer<ServerAction> 
     public SerializedApiResponse serialize(ServerAction src) {
         Action act = src.getParentAction();
 
-        SerializationBuilder builder = new SerializationBuilder()
-                .add("failed_count", act.getFailedCount())
-                .add("modified", act.getModified().toString())
-                .add("created", act.getCreated().toString())
-                .add("action_type", act.getActionType().getName())
-                .add("successful_count", act.getSuccessfulCount())
-                .add("earliest_action", act.getEarliestAction().toString())
-                .add("archived", act.getArchived())
-                .add("scheduler_user", act.getSchedulerUser().getLogin())
-                .add("prerequisite", act.getPrerequisite())
-                .add("name", act.getName())
-                .add("id", act.getId())
-                .add("version", act.getVersion().toString());
+        SerializationBuilder builder = ActionSerializer.getSerializationBuilder(act);
 
         if (src.getCompletionTime() != null) {
             builder.add("completion_time", src.getCompletionTime().toString());
@@ -91,9 +79,7 @@ public class ServerActionSerializer extends ApiResponseSerializer<ServerAction> 
             builder.add("pickup_time", src.getPickupTime().toString());
         }
 
-        builder.add("modified_date", act.getModified())
-                .add("created_date", act.getCreated())
-                .add("completed_date", src.getCompletionTime())
+        builder.add("completed_date", src.getCompletionTime())
                 .add("pickup_date", src.getPickupTime())
                 .add("result_msg", src.getResultMsg());
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fixed serialization problems (bsc#1202899)
 - Filter out successors that have no repositories on SP migration (bsc#1202367)
 - Reduced the usage of deprecated Hibernate API
 - Fixed formula deselection in systemgroup (bsc#1202271)


### PR DESCRIPTION
## What does this PR change?

It fixes errors when serializing instances of the com.redhat.rhn.domain.action.Action class by adding a specific serializer to it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/5860
Port of https://github.com/SUSE/spacewalk/pull/18922


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
