### PR TITLE
Revert "Sanity check for resource for custom endpoint test"

### DIFF
--- a/testsuite/features/core/allcli_sanity.feature
+++ b/testsuite/features/core/allcli_sanity.feature
@@ -109,6 +109,3 @@ Feature: Sanity checks
 @no_auth_registry
   Scenario: The registry without authentication is healthy
     Then it should be possible to reach the not authenticated registry
-
-  Scenario: The FTP server is working
-    Then it should be possible to use the FTP server

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -71,12 +71,6 @@ Then(/^it should be possible to use the HTTP proxy$/) do
   $server.run("curl --insecure --proxy '#{proxy}' --proxy-anyauth --location '#{url}' --output /dev/null")
 end
 
-Then(/^it should be possible to use the FTP server$/) do
-  # TODO: use a URL in Provo after the release
-  url = 'ftp://minima-mirror.mgr.suse.de:445/rhn/manager/download/test-channel-x86_64/repodata/repomd.xml'
-  $server.run("curl --ipv4 --location #{url} --output /dev/null")
-end
-
 Then(/^it should be possible to reach the build sources$/) do
   if $product == 'Uyuni'
     # TODO: move that internal resource to some other external location

--- a/testsuite/features/upload_files/pkg_endpoint.sls
+++ b/testsuite/features/upload_files/pkg_endpoint.sls
@@ -1,4 +1,4 @@
-# TODO: move the endpoint to Provo after the release
+# Move the endpoint to Provo after the release
 
 pkg_download_point_protocol: ftp
 pkg_download_point_host: minima-mirror.mgr.suse.de


### PR DESCRIPTION
Reverts uyuni-project/uyuni#5906

PR testing is done in PRV and we can't access minima-mirror in NUE. Let's not do this test until https://github.com/SUSE/spacewalk/issues/18953 is fixed.