### PR TITLE
Disable sanity check for ftp custom download point

### DIFF
--- a/testsuite/features/core/allcli_sanity.feature
+++ b/testsuite/features/core/allcli_sanity.feature
@@ -110,5 +110,8 @@ Feature: Sanity checks
   Scenario: The registry without authentication is healthy
     Then it should be possible to reach the not authenticated registry
 
-  Scenario: The FTP server is working
-    Then it should be possible to use the FTP server
+# Disable the FTP server check because we can't run this at the PR
+# given the test run in PRV but the ftp server is in NUE and firewall
+# rules prevent this connection.
+#  Scenario: The FTP server is working
+#    Then it should be possible to use the FTP server


### PR DESCRIPTION
## What does this PR change?

When running the tests at PR, we are running this test in PRV while the download point is in NUE. This can't work because firewall rules prevent this connection.

This can be reverted once
https://github.com/SUSE/spacewalk/issues/18953 is fixed.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed. This a change in the testsuite.

- [X] **DONE**

## Test coverage
- This is a change in the testsuite.

- [X] **DONE**

## Links

Temporary fix until https://github.com/SUSE/spacewalk/issues/18953 is fixed.

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
