### PR TITLE
QE: Printing node OS in twopence_init.rb

### DIFF
--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -132,7 +132,7 @@ $nodes.each do |node|
 
   STDOUT.puts "Host '#{$named_nodes[node.hash]}' is alive with determined hostname #{hostname.strip} and FQDN #{fqdn.strip}" unless $build_validation
   result, _code = node.run('grep PRETTY /etc/os-release')
-  puts "'#{$named_nodes[node.hash]}' is running OS #{result}"
+  STDOUT.puts "'#{$named_nodes[node.hash]}' is running OS #{result}"
 end
 
 # This function is used to get one of the nodes based on its type

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -131,6 +131,8 @@ $nodes.each do |node|
   node.init_full_hostname(fqdn)
 
   STDOUT.puts "Host '#{$named_nodes[node.hash]}' is alive with determined hostname #{hostname.strip} and FQDN #{fqdn.strip}" unless $build_validation
+  result, _code = node.run('grep PRETTY /etc/os-release')
+  puts "'#{$named_nodes[node.hash]}' is running OS #{result}"
 end
 
 # This function is used to get one of the nodes based on its type


### PR DESCRIPTION
## What does this PR change?

Prints the OS version of each node in the testsuite at runtime.

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/18722
Tracks # 
4.2
4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
