### PR TITLE
mark some bootstrap repo packages as optional

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -469,8 +469,8 @@ PKGLIST15_SALT_NO_BUNDLE = [
     "salt",
     "python3-salt",
     "salt-minion",
-    "python3-apipkg",
-    "python3-iniconfig",
+    "python3-apipkg*",
+    "python3-iniconfig*",
 ]
 
 PKGLIST15_SALT = PKGLIST15_SALT_NO_BUNDLE + [

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- mark new dependencies for python-py optional in bootstrap repo
+  to fix generation for older service packs (bsc#1203449)
 - add bootstrap repository definition for OES2023 (bsc#1202602)
 - add missing packages on SLES 15
 - remove server-migrator.sh from SUSE Manager installations (bsc#1202728)


### PR DESCRIPTION
## What does this PR change?

python3-py is required by salt.
This package was updated in SLE15 SP3/SP4 and with this update it got new dependencies to 'python3-apipkg' and 'python3-iniconfig'. But they do not exist in older SPs as the old version did not require them.

This PR mark these packages as optional.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/19002

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
