### PR TITLE
QE: Fix for https://github.com/SUSE/salt-formulas/pull/179

### DIFF
--- a/testsuite/features/secondary/min_salt_formulas.feature
+++ b/testsuite/features/secondary/min_salt_formulas.feature
@@ -69,7 +69,7 @@ Feature: Use salt formulas
      Then I should see a "Applying the highstate has been scheduled." text
      When I wait until event "Apply highstate scheduled by admin" is completed
      Then the timezone on "sle_minion" should be "+05"
-     And the keymap on "sle_minion" should be "ca.map.gz"
+     And the keymap on "sle_minion" should be "ca"
      And the language on "sle_minion" should be "fr_FR.UTF-8"
 
   Scenario: Reset the formula on the minion
@@ -92,7 +92,7 @@ Feature: Use salt formulas
      Then I should see a "Applying the highstate has been scheduled." text
      When I wait until event "Apply highstate scheduled by admin" is completed
      Then the timezone on "sle_minion" should be "CET"
-     And the keymap on "sle_minion" should be "us.map.gz"
+     And the keymap on "sle_minion" should be "us"
      And the language on "sle_minion" should be "en_US.UTF-8"
 
   Scenario: Disable the formula on the minion
@@ -159,7 +159,7 @@ Feature: Use salt formulas
      Then I should see a "Applying the highstate has been scheduled." text
      When I wait until event "Apply highstate scheduled by admin" is completed
      Then the timezone on "sle_minion" should be "CET"
-     And the keymap on "sle_minion" should be "us.map.gz"
+     And the keymap on "sle_minion" should be "us"
      And the language on "sle_minion" should be "en_US.UTF-8"
 
   Scenario: Cleanup: uninstall formula package from the server

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -124,7 +124,7 @@ end
 
 When(/^I apply state "([^"]*)" to "([^"]*)"$/) do |state, host|
   system_name = get_system_name(host)
-  $server.run("salt #{system_name} state.apply #{state}")
+  $server.run("salt #{system_name} state.apply #{state}", verbose: true)
 end
 
 Then(/^salt\-api should be listening on local port (\d+)$/) do |port|


### PR DESCRIPTION
## What does this PR change?

Part of https://github.com/SUSE/spacewalk/issues/18537
Fix for https://github.com/SUSE/salt-formulas/pull/179

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.3 https://github.com/SUSE/spacewalk/pull/19007
- Manager-4.2 https://github.com/SUSE/spacewalk/pull/19008

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
