### PR TITLE
fix jinja newline removal causing state text joins

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/init.sls
@@ -7,7 +7,7 @@ include:
 {# disable at least the SUSE-Manager-Bootstrap repo #}
 {% set repos_disabled = {'match_str': 'SUSE-Manager-Bootstrap', 'matching': true} %}
 {%- endif %}
-{%- include 'channels/disablelocalrepos.sls' %}
+{% include 'channels/disablelocalrepos.sls' %}
 
 {%- if grains['os_family'] == 'RedHat' %}
 


### PR DESCRIPTION
## What does this PR change?

Multiple `{%-` cause removing multiple empty lines until 2 states appear in the same line which cause the json parse error.
Including disablelocalrepos.sls without removing the line.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/19012

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
