### PR TITLE
properly handle salt function name array check

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -726,7 +726,9 @@ public class SaltServerActionService {
                 handleActionChainResult(minionId, "",
                         actionChainResult,
                         // skip reboot, needs special handling
-                        stateResult -> SYSTEM_REBOOT.equals(stateResult.getName()));
+                        stateResult ->
+                                stateResult.getName().map(x -> x.fold(Arrays::asList, List::of)
+                                        .contains(SYSTEM_REBOOT)).orElse(false));
 
                 boolean refreshPkg = false;
                 for (Map.Entry<String, StateApplyResult<Ret<JsonElement>>> entry : actionChainResult.entrySet()) {
@@ -739,7 +741,9 @@ public class SaltServerActionService {
                         SaltActionChainGeneratorService.ActionChainStateId stateId = actionChainStateId.get();
                         // only reboot needs special handling,
                         // for salt pkg update there's no need to split the sls in case of salt-ssh minions
-                        if (SYSTEM_REBOOT.equals(stateResult.getName()) && stateResult.isResult()) {
+
+                        if (stateResult.getName().map(x -> x.fold(Arrays::asList, List::of)
+                                .contains(SYSTEM_REBOOT)).orElse(false) && stateResult.isResult()) {
                             Action rebootAction = ActionFactory.lookupById(stateId.getActionId());
 
                             if (rebootAction.getActionType().equals(ActionFactory.TYPE_REBOOT)) {


### PR DESCRIPTION
## What does this PR change?

Fixes two more places that didn't properly handle the new salt function name format.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
