### PR TITLE
Fix mgrnet availability check

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/hardware/profileupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/hardware/profileupdate.sls
@@ -141,6 +141,8 @@ dns_fqdns:
 {%- else %}
       - mgrcompat: sync_states
 {%- endif %}
+    - onlyif:
+        which host || which nslookup
 {% endif%}
 {% if 'network.fqdns' in salt %}
 fqdns:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix mgrnet availability check
 - Remove dependence on Kiwi libraries
 - disable always the bootstrap repository also when
   "mgr_disable_local_repos" is set to False


### PR DESCRIPTION
## What does this PR change?

The check `if 'mgrnet.dns_fqdns' in salt` does not work with ssh minion.
Checking the required tools is more reliable.

## GUI diff

No difference.


## Documentation
- No documentation needed: bugfix

## Test coverage
- covered by Cucumber tests

## Links

Fixes 


## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
