### PR TITLE
QE: Replacing get_os_version occurences

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -855,7 +855,7 @@ end
 # rubocop:disable Metrics/BlockLength
 When(/^I (enable|disable) (the repositories|repository) "([^"]*)" on this "([^"]*)"((?: without error control)?)$/) do |action, _optional, repos, host, error_control|
   node = get_target(host)
-  _os_version, os_family = get_os_version(node)
+  os_family = node.os_family
   cmd = ''
   if os_family =~ /^opensuse/ || os_family =~ /^sles/
     mand_repos = ''
@@ -928,7 +928,7 @@ end
 
 When(/^I (install|remove) OpenSCAP dependencies (on|from) "([^"]*)"$/) do |action, where, host|
   node = get_target(host)
-  _os_version, os_family = get_os_version(node)
+  os_family = node.os_family
   if os_family =~ /^opensuse/ || os_family =~ /^sles/
     pkgs = 'openscap-utils openscap-content scap-security-guide'
   elsif os_family =~ /^centos/
@@ -1556,7 +1556,8 @@ end
 
 When(/^I (enable|disable) the necessary repositories before installing Prometheus exporters on this "([^"]*)"((?: without error control)?)$/) do |action, host, error_control|
   node = get_target(host)
-  os_version, os_family = get_os_version(node)
+  os_version = node.os_version
+  os_family = node.os_family
   repositories = 'tools_pool_repo tools_update_repo'
   if os_family =~ /^opensuse/ || os_family =~ /^sles/
     repositories.concat(' os_pool_repo os_update_repo')

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -37,7 +37,8 @@ end
 
 Then(/^the OS version for "([^"]*)" should be correct$/) do |host|
   node = get_target(host)
-  os_version, os_family = get_os_version(node)
+  os_version = node.os_version
+  os_family = node.os_family
   # skip this test for Red Hat-like and Debian-like systems
   step %(I should see a "#{os_version.gsub!('-SP', ' SP')}" text) if os_family.include? 'sles'
 end
@@ -351,7 +352,7 @@ end
 
 When(/^I refresh the metadata for "([^"]*)"$/) do |host|
   node = get_target(host)
-  _os_version, os_family = get_os_version(node)
+  os_family = node-os_family
   if os_family =~ /^opensuse/ || os_family =~ /^sles/
     node.run_until_ok('zypper --non-interactive refresh -s')
   elsif os_family =~ /^centos/
@@ -756,7 +757,7 @@ end
 # Enable tools repositories (both stable and development)
 When(/^I enable client tools repositories on "([^"]*)"$/) do |host|
   node = get_target(host)
-  _os_version, os_family = get_os_version(node)
+  os_family = node.os_family
   case os_family
   when /^(opensuse|sles)/
     repos, _code = node.run('zypper lr | grep "tools" | cut -d"|" -f2')
@@ -778,7 +779,7 @@ end
 
 When(/^I disable client tools repositories on "([^"]*)"$/) do |host|
   node = get_target(host)
-  _os_version, os_family = get_os_version(node)
+  os_family = node.os_family
   case os_family
   when /^(opensuse|sles)/
     repos, _code = node.run('zypper lr | grep "tools" | cut -d"|" -f2')
@@ -799,7 +800,8 @@ When(/^I disable client tools repositories on "([^"]*)"$/) do |host|
 end
 
 When(/^I enable repositories before installing Docker$/) do
-  os_version, os_family = get_os_version($build_host)
+  os_version = $build_host.os_version
+  os_family = $build_host.os_family
 
   # Distribution
   repos = "os_pool_repo os_update_repo"
@@ -827,7 +829,8 @@ When(/^I enable repositories before installing Docker$/) do
 end
 
 When(/^I disable repositories after installing Docker$/) do
-  os_version, os_family = get_os_version($build_host)
+  os_version = $build_host.os_version
+  os_family = $build_host.os_family
 
   # Distribution
   repos = "os_pool_repo os_update_repo"
@@ -923,7 +926,7 @@ Then(/^I should see "([^"]*)" as link$/) do |host|
 end
 
 Then(/^I should see a text describing the OS release$/) do
-  _os_version, os_family = get_os_version($client)
+  os_family = $client.os_family
   release = os_family =~ /^opensuse/ ? 'openSUSE-release' : 'sles-release'
   step %(I should see a "OS: #{release}" text)
 end

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -352,7 +352,7 @@ end
 
 When(/^I refresh the metadata for "([^"]*)"$/) do |host|
   node = get_target(host)
-  os_family = node-os_family
+  os_family = node.os_family
   if os_family =~ /^opensuse/ || os_family =~ /^sles/
     node.run_until_ok('zypper --non-interactive refresh -s')
   elsif os_family =~ /^centos/

--- a/testsuite/features/step_definitions/retail_steps.rb
+++ b/testsuite/features/step_definitions/retail_steps.rb
@@ -112,7 +112,7 @@ When(/^I enable repositories before installing branch server$/) do
 end
 
 When(/^I disable repositories after installing branch server$/) do
-  os_version = $proxy.os_version 
+  os_version = $proxy.os_version
   os_family = $proxy.os_family
 
   # Distribution

--- a/testsuite/features/step_definitions/retail_steps.rb
+++ b/testsuite/features/step_definitions/retail_steps.rb
@@ -97,7 +97,8 @@ def compute_kiwi_profile_version(host)
 end
 
 When(/^I enable repositories before installing branch server$/) do
-  os_version, os_family = get_os_version($proxy)
+  os_version = $proxy.os_version
+  os_family = $proxy.os_family
 
   # Distribution
   repos = 'os_pool_repo os_update_repo'
@@ -111,7 +112,8 @@ When(/^I enable repositories before installing branch server$/) do
 end
 
 When(/^I disable repositories after installing branch server$/) do
-  os_version, os_family = get_os_version($proxy)
+  os_version = $proxy.os_version 
+  os_family = $proxy.os_family
 
   # Distribution
   repos = 'os_pool_repo os_update_repo'

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -29,7 +29,8 @@ end
 When(/^I stop salt-minion on "(.*?)"$/) do |minion|
   node = get_target(minion)
   pkgname = $use_salt_bundle ? "venv-salt-minion" : "salt-minion"
-  os_version, os_family = get_os_version(node)
+  os_version = node.os_version
+  os_family = node.os_family
   if os_family =~ /^sles/ && os_version =~ /^11/
     node.run("rc#{pkgname} stop", check_errors: false)
   else
@@ -40,7 +41,8 @@ end
 When(/^I start salt-minion on "(.*?)"$/) do |minion|
   node = get_target(minion)
   pkgname = $use_salt_bundle ? "venv-salt-minion" : "salt-minion"
-  os_version, os_family = get_os_version(node)
+  os_version = node.os_version
+  os_family = node.os_family
   if os_family =~ /^sles/ && os_version =~ /^11/
     node.run("rc#{pkgname} start", check_errors: false)
   else
@@ -51,7 +53,8 @@ end
 When(/^I restart salt-minion on "(.*?)"$/) do |minion|
   node = get_target(minion)
   pkgname = $use_salt_bundle ? "venv-salt-minion" : "salt-minion"
-  os_version, os_family = get_os_version(node)
+  os_version = node.os_version
+  os_family = node.os_family
   if os_family =~ /^sles/ && os_version =~ /^11/
     node.run("rc#{pkgname} restart", check_errors: false)
   else
@@ -117,7 +120,7 @@ end
 
 Then(/^it should contain the OS of "([^"]*)"$/) do |host|
   node = get_target(host)
-  _os_version, os_family = get_os_version(node)
+  os_family = node.os_family
   family = os_family =~ /^opensuse/ ? 'Leap' : 'SLES'
   assert_match(/#{family}/, $output)
 end

--- a/testsuite/features/support/client_stack.rb
+++ b/testsuite/features/support/client_stack.rb
@@ -67,7 +67,8 @@ def get_os_version(node)
 end
 
 def get_gpg_keys(node, target = $server)
-  os_version, os_family = get_os_version(node)
+  os_version = node.os_version
+  os_family = node.os_family
   if os_family =~ /^sles/
     # HACK: SLE 15 uses SLE 12 GPG key
     os_version = 12 if os_version =~ /^15/

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -31,7 +31,8 @@ def compute_channels_to_leave_running
   do_not_kill = CHANNEL_TO_SYNCH_BY_OS_VERSION['default']
   [$minion, $build_host, $sshminion].each do |node|
     next unless node
-    os_version, os_family = get_os_version(node)
+    os_version = node.os_version
+    os_family = node.os_family
     next unless os_family == 'sles'
     raise "Can't build list of reposyncs to leave running" unless ['12-SP4', '12-SP5', '15-SP3', '15-SP4'].include? os_version
     do_not_kill += CHANNEL_TO_SYNCH_BY_OS_VERSION[os_version]
@@ -206,7 +207,7 @@ def generate_repository_name(repo_url)
 end
 
 def extract_logs_from_node(node)
-  _os_version, os_family = get_os_version(node)
+  os_family = node.os_family
   if os_family =~ /^opensuse/
     node.run('zypper mr --enable os_pool_repo os_update_repo') unless $build_validation
     node.run('zypper --non-interactive install tar')

--- a/testsuite/features/support/lavanda.rb
+++ b/testsuite/features/support/lavanda.rb
@@ -33,6 +33,14 @@ module LavandaBasic
     @in_public_interface = public_interface
   end
 
+  def init_os_family(os_family)
+    @in_os_family = os_family
+  end
+
+  def init_os_version(os_version)
+    @in_os_version = os_version
+  end
+
   # getter functions, executed on testsuite
   def hostname
     raise 'empty hostname, something wrong' if @in_hostname.empty?
@@ -64,6 +72,16 @@ module LavandaBasic
     @in_public_interface
   end
 
+  def os_family
+    raise 'empty os_family, something wrong' if @in_os_family.empty?
+    @in_os_family
+  end
+
+  def os_version
+    raise 'empty os_version, something wrong' if @in_os_version.empty?
+    @in_os_version
+  end
+   
   # run functions
   def run(cmd, separated_results: false, check_errors: true, timeout: DEFAULT_TIMEOUT, user: 'root', successcodes: [0], buffer_size: 65536, verbose: false)
     if separated_results

--- a/testsuite/features/support/lavanda.rb
+++ b/testsuite/features/support/lavanda.rb
@@ -81,7 +81,7 @@ module LavandaBasic
     raise 'empty os_version, something wrong' if @in_os_version.empty?
     @in_os_version
   end
-  
+
   # run functions
   def run(cmd, separated_results: false, check_errors: true, timeout: DEFAULT_TIMEOUT, user: 'root', successcodes: [0], buffer_size: 65536, verbose: false)
     if separated_results

--- a/testsuite/features/support/lavanda.rb
+++ b/testsuite/features/support/lavanda.rb
@@ -81,7 +81,7 @@ module LavandaBasic
     raise 'empty os_version, something wrong' if @in_os_version.empty?
     @in_os_version
   end
-   
+  
   # run functions
   def run(cmd, separated_results: false, check_errors: true, timeout: DEFAULT_TIMEOUT, user: 'root', successcodes: [0], buffer_size: 65536, verbose: false)
     if separated_results

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -131,7 +131,6 @@ $nodes.each do |node|
   node.init_full_hostname(fqdn)
 
   STDOUT.puts "Host '#{$named_nodes[node.hash]}' is alive with determined hostname #{hostname.strip} and FQDN #{fqdn.strip}" unless $build_validation
-  result, _code = node.run('grep PRETTY /etc/os-release')
   os_version, os_family = get_os_version(node)
   node.init_os_family(os_family)
   node.init_os_version(os_version)

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -132,7 +132,10 @@ $nodes.each do |node|
 
   STDOUT.puts "Host '#{$named_nodes[node.hash]}' is alive with determined hostname #{hostname.strip} and FQDN #{fqdn.strip}" unless $build_validation
   result, _code = node.run('grep PRETTY /etc/os-release')
-  STDOUT.puts "'#{$named_nodes[node.hash]}' is running OS #{result}"
+  os_version, os_family = get_os_version(node)
+  node.init_os_family(os_family)
+  node.init_os_version(os_version)
+  STDOUT.puts "'#{$named_nodes[node.hash]}' is running OS #{node.os_family} #{node.os_version}"
 end
 
 # This function is used to get one of the nodes based on its type


### PR DESCRIPTION
## What does this PR change?

Implement OS attributes in `lavanda.rb` and using these attributes to replace calls to `get_os_version` and reduce the number of SSH calls.

Original comment: https://github.com/uyuni-project/uyuni/pull/5931#discussion_r971704252

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/19000
Tracks # 
4.2
4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
