### PR TITLE
Checking /var/log/messages for OOM errors

### DIFF
--- a/testsuite/features/finishing/srv_debug.feature
+++ b/testsuite/features/finishing/srv_debug.feature
@@ -16,4 +16,4 @@ Feature: Debug the server after the testsuite has run
     Then the taskomatic logs should not contain errors
 
   Scenario: Check for out of memory errors
-   Then the messages log should not contain out of memory errors
+   Then the log messages should not contain out of memory errors

--- a/testsuite/features/finishing/srv_debug.feature
+++ b/testsuite/features/finishing/srv_debug.feature
@@ -14,3 +14,6 @@ Feature: Debug the server after the testsuite has run
 
   Scenario: Check the taskomatic logs on server
     Then the taskomatic logs should not contain errors
+
+  Scenario: Check for out of memory errors
+   Then the messages log should not contain out of memory errors

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -496,7 +496,7 @@ end
 
 Then(/^the messages log should not contain out of memory errors$/) do
   output, code = $server.run('grep -i "Out of memory: Killed process" /var/log/messages', check_errors: false)
-  raise "Out of memory errors in /var/log/messages:\n#{output}" if code.zero?
+  raise "Out of memory errors in /var/log/messages:\n#{output}" unless code.zero?
 end
 
 When(/^I restart cobbler on the server$/) do

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -494,6 +494,11 @@ Then(/^the taskomatic logs should not contain errors$/) do
   end
 end
 
+Then(/^the messages log should not contain out of memory errors$/) do
+  output, code = $server.run('grep -i "Out of memory: Killed process" /var/log/messages', check_errors: false)
+  raise "Out of memory errors in /var/log/messages:\n#{output}" if code.zero?
+end
+
 When(/^I restart cobbler on the server$/) do
   $server.run('systemctl restart cobblerd.service')
 end


### PR DESCRIPTION
## What does this PR change?

`grep` OOM error messages in `/var/log/messages` 


## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Cucumber tests were added

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/16986
Tracks # 
4.2
4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
