### PR TITLE
Fix reading postgres options with suma_minion ext pillar module

### DIFF
--- a/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
+++ b/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
@@ -79,17 +79,14 @@ def __virtual__():
 
 @contextmanager
 def _get_cursor():
-    defaults = {
-        'host': 'localhost',
-        'user': 'spacewalk',
-        'pass': 'spacewalk',
-        'db': 'susemanager',
-        'port': 5432,
+    options = {
+        "host": "localhost",
+        "user": "",
+        "pass": "",
+        "db": "susemanager",
+        "port": 5432,
     }
-    opts = __opts__.get("postgres", {})
-    options = {}
-    for attr, default in defaults.items():
-        options[attr] = opts.get(attr, default)
+    options.update(__opts__.get("__master_opts__", __opts__).get("postgres", {}))
 
     cnx = psycopg2.connect(
             host=options['host'],

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Prevent possible tracebacks on reading postgres opts
+  with suma_minion salt pillar extension module
 - Fix mgrnet availability check
 - Remove dependence on Kiwi libraries
 - disable always the bootstrap repository also when


### PR DESCRIPTION
## What does this PR change?

Read `postgres` options from `__master_opts__` if present to avoid possible tracebacks described in https://github.com/uyuni-project/uyuni/issues/5710

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- Unit tests were added

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/5710
Tracks https://github.com/SUSE/spacewalk/issues/18980 https://github.com/SUSE/spacewalk/issues/19030

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
