### PR TITLE
QE: Customizing the time we wait until a event is picked up

### DIFF
--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -195,7 +195,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I select "disk1.qcow2" from "disk1_source_file"
     And I click on "Create"
     And I wait until I see "Hosted Virtual Systems" text
-    And I wait until event "Creates a virtual domain: test-vm2" is completed
+    And I wait 180 seconds until the event is picked up and 300 seconds until the event "Creates a virtual domain: test-vm2" is completed
     And I follow "Virtualization" in the content area
     And I wait until table row for "test-vm2" contains button "Stop"
     And "test-vm2" virtual machine on "kvm_server" should have 1024MB memory and 1 vcpus
@@ -234,7 +234,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I enter "/usr/share/qemu/ovmf-x86_64-ms-vars.bin" as "nvramTemplate"
     And I click on "Create"
     And I wait until I see "Hosted Virtual Systems" text
-    And I wait until event "Creates a virtual domain: test-vm2" is completed
+    And I wait 180 seconds until the event is picked up and 300 seconds until the event "Creates a virtual domain: test-vm2" is completed
     And I follow "Virtualization" in the content area
     And I wait until table row for "test-vm2" contains button "Stop"
     And "test-vm2" virtual machine on "kvm_server" should have 1024MB memory and 1 vcpus
@@ -354,7 +354,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I enter "192.168.128.20" as "ipv4def_dhcpranges0_end"
     And I click on "Create"
     And I wait until I see "Virtual Networks" text
-    And I wait until event "Creates a virtual network: test-net2" is completed
+    And I wait 180 seconds until the event is picked up and 300 seconds until the event "Creates a virtual domain: test-net2" is completed
     And I follow "Virtualization" in the content area
     And I follow "Networks"
     And I wait until table row for "test-net2" contains button "Stop"
@@ -428,7 +428,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I select "test-net0" from "network0_source"
     And I click on "Create"
     And I wait until I see "Hosted Virtual Systems" text
-    And I wait until event "Creates a virtual domain: test-vm2" is completed
+    And I wait 180 seconds until the event is picked up and 300 seconds until the event "Creates a virtual domain: test-vm2" is completed
     And I follow "Virtualization" in the content area
     And I wait until table row for "test-vm2" contains button "Stop"
     # Test the VM boot params

--- a/testsuite/features/secondary/minxen_guests.feature
+++ b/testsuite/features/secondary/minxen_guests.feature
@@ -183,7 +183,7 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And I select "VNC" from "graphicsType"
     And I click on "Create"
     And I wait until I see "Hosted Virtual Systems" text
-    And I wait until event "Creates a virtual domain: test-vm2" is completed
+    And I wait 180 seconds until the event is picked up and 300 seconds until the event "Creates a virtual domain: test-vm2" is completed
     And I follow "Virtualization" in the content area
     And I wait at most 500 seconds until table row for "test-vm2" contains button "Stop"
     And "test-vm2" virtual machine on "xen_server" should have 1 NIC using "test-net0" network
@@ -208,7 +208,7 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And I select "Spice" from "graphicsType"
     And I click on "Create"
     And I wait until I see "Hosted Virtual Systems" text
-    And I wait until event "Creates a virtual domain: test-vm3" is completed
+    And I wait 180 seconds until the event is picked up and 300 seconds until the event "Creates a virtual domain: test-vm3" is completed
     And I follow "Virtualization" in the content area
     And I wait at most 500 seconds until table row for "test-vm3" contains button "Stop"
     And "test-vm3" virtual machine on "xen_server" should have 1 NIC using "test-net0" network

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -129,19 +129,23 @@ When(/^I wait until event "([^"]*)" is completed$/) do |event|
   step %(I wait at most #{DEFAULT_TIMEOUT} seconds until event "#{event}" is completed)
 end
 
-When(/^I wait at most (\d+) seconds until event "([^"]*)" is completed$/) do |final_timeout, event|
+When(/^I wait (\d+) seconds until the event is picked up and (\d+) seconds until the event "([^"]*)" is completed$/) do |pickup_timeout, complete_timeout, event|
   # The code below is not perfect because there might be other events with the
   # same name in the events history - however, that's the best we have so far.
   steps %(
     When I follow "Events"
     And I follow "Pending"
-    And I wait at most 90 seconds until I do not see "#{event}" text, refreshing the page
+    And I wait at most #{pickup_timeout} seconds until I do not see "#{event}" text, refreshing the page
     And I follow "History"
     And I wait until I see "System History" text
     And I wait until I see "#{event}" text, refreshing the page
     And I follow first "#{event}"
-    And I wait at most #{final_timeout} seconds until the event is completed, refreshing the page
+    And I wait at most #{complete_timeout} seconds until the event is completed, refreshing the page
   )
+end
+
+When(/^I wait at most (\d+) seconds until event "([^"]*)" is completed$/) do |final_timeout, event|
+  step %(I wait 90 seconds until the event is picked up and #{final_timeout} seconds until the event "#{event}" is completed)
 end
 
 When(/^I wait until I see the event "([^"]*)" completed during last minute, refreshing the page$/) do |event|


### PR DESCRIPTION
## What does this PR change?

In order to fix : https://github.com/SUSE/spacewalk/issues/18659

Customizing the time we wait until a event is picked up

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were refactored

- [x] **DONE**

## Links

Ports:
- Manager-4.2
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
