### PR TITLE
QE: Add a timeout bootstrapping pxeboot

### DIFF
--- a/testsuite/features/upload_files/bootstrap-pxeboot.exp
+++ b/testsuite/features/upload_files/bootstrap-pxeboot.exp
@@ -14,5 +14,6 @@ expect "#"
 send -- "chmod 750 /root/bootstrap.sh\r"
 expect "#"
 send -- "bash -x /root/bootstrap.sh\r"
+set timeout 180
 expect "?bootstrap complete?"
 puts "\r"


### PR DESCRIPTION
## What does this PR change?

Fix this issue https://github.com/SUSE/spacewalk/issues/18970

**Scenario: Bootstrap the PXE boot minion**

![Image](https://user-images.githubusercontent.com/2827771/189913634-6356a020-3ddd-4e84-81b5-d7dc3fde358c.png)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.2
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
