### PR TITLE
Fix spacewalk-hostname-rename failing on reading /etc/cobbler/settings

### DIFF
--- a/utils/spacewalk-hostname-rename
+++ b/utils/spacewalk-hostname-rename
@@ -448,7 +448,11 @@ else
 fi
 
 # This awk command can read a single line yaml value which may optionally be double or single quoted.
-OLD_HOSTNAME=$(awk -F ':' '/redhat_management_server/{sub(/^[[:blank:]]+/,"", $2); gsub(/["'\'']/, "", $2); print $2}' /etc/cobbler/settings)
+COBBLER_CONF="/etc/cobbler/settings.yaml"
+if [ ! -f "$COBBLER_CONF" ]; then
+    COBBLER_CONF="/etc/cobbler/settings"
+fi
+OLD_HOSTNAME=$(awk -F ':' '/redhat_management_server/{sub(/^[[:blank:]]+/,"", $2); gsub(/["'\'']/, "", $2); print $2}' "$COBBLER_CONF")
 
 echo "=============================================" | tee -a $LOG
 echo "hostname: $HOSTNAME" | tee -a $LOG

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- Make spacewalk-hostname-rename working with settings.yaml
+  cobbler config file (bsc#1203564)
 - Add Rocky Linux 9 to spacewalk-common-channels
 - spacewalk-common-channels now syncs the channels automatically
   on creation, if the new configuration property named


### PR DESCRIPTION
## What does this PR change?

Settings file for cobbler was moved from `/etc/cobbler/settings` to `/etc/cobbler/settings.yaml`, so the `spacewalk-hostname-rename` is failing if cobbler is migrated to `/etc/cobbler/settings.yaml` already.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: already covered

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19053

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
