### PR TITLE
Prevent race conditions on cobbler sync

### DIFF
--- a/tftpsync/susemanager-tftpsync-recv/add.wsgi
+++ b/tftpsync/susemanager-tftpsync-recv/add.wsgi
@@ -22,6 +22,7 @@ try:
     from cStringIO import OutputType
 except:
     from io import StringIO as OutputType
+from fcntl import flock, LOCK_EX
 from io import BytesIO
 from spacewalk.common.rhnConfig import CFG, initCFG
 
@@ -50,7 +51,7 @@ class TftpFieldStorage(cgi.FieldStorage):
     def make_file(self, binary=None):
         tmpdir = os.path.join(CFG.TFTPBOOT, "tmp")
         if not os.path.exists(tmpdir):
-                os.makedirs(tmpdir)
+            os.makedirs(tmpdir, exist_ok=True)
 
         return tempfile.NamedTemporaryFile(mode="w+b", suffix='', prefix='tmp',
                                            dir=tmpdir, delete=False)
@@ -96,21 +97,24 @@ def application(environ, start_response):
 
             rfname = os.path.join(path, file_name)
             tfname = "%s.tmp" % (rfname)
+            lfname = os.path.join(path, ".lock")
             if file_type == 'pxe' or file_type == 'grub':
-                tf = open(tfname, 'wb')
                 file_content = form.getvalue('file')
                 file_content = file_content.replace(CFG.SERVER_IP.encode(), CFG.PROXY_IP.encode())
                 file_content = file_content.replace(CFG.SERVER_FQDN.encode(), CFG.PROXY_FQDN.encode())
                 if CFG.SERVER_IP6 and CFG.PROXY_IP6:
                     file_content = file_content.replace(CFG.SERVER_IP6.encode(), CFG.PROXY_IP6.encode())
-                tf.write(file_content)
-                tf.close()
-                os.rename(tfname, rfname)
+                with open(lfname, 'w') as lf:
+                    flock(lf, LOCK_EX)
+                    with open(tfname, 'wb') as tf:
+                        tf.write(file_content)
+                    os.rename(tfname, rfname)
             elif isinstance(tfpointer, OutputType) or isinstance(tfpointer, BytesIO):
-                tf = open(tfname, 'wb')
-                tf.write(form.getvalue('file'))
-                tf.close()
-                os.rename(tfname, rfname)
+                with open(lfname, 'w') as lf:
+                    flock(lf, LOCK_EX)
+                    with open(tfname, 'wb') as tf:
+                        tf.write(form.getvalue('file'))
+                    os.rename(tfname, rfname)
             else:
                 if (tfpointer and os.path.exists(tfpointer.name)):
                     os.chmod(tfpointer.name, 0o644)

--- a/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
+++ b/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
@@ -1,3 +1,5 @@
+- Prevent possible race conditions causing traceback
+  while processing cobbler sync (bsc#1192817)
 - Add missing IPv6 default configuration (bsc#1201589)
 - fix problems with parallel running processes
 


### PR DESCRIPTION
## What does this PR change?

There are some possible casses on getting the following tracebacks due to the race condition:
```
2021-12-05 18:36:02,531 - tftpsync_add - ERROR - Writing file failed: [Errno 2] No such file or directory: '/srv/tftpboot/grub/i386-pc/echo.mod.tmp' -> '/srv/tftpboot/grub/i386-pc/echo.mod'
Traceback (most recent call last):
  File "/srv/www/tftpsync/add", line 105, in application
    os.rename(tfname, rfname)
FileNotFoundError: [Errno 2] No such file or directory: '/srv/tftpboot/grub/i386-pc/echo.mod.tmp' -> '/srv/tftpboot/grub/i386-pc/echo.mod'
2021-12-05 18:36:02,568 - tftpsync_add - INFO - setting file '/srv/tftpboot/grub/i386-pc/blocklist.mod' (grub), status: 200 OK
2021-12-05 18:36:02,569 - tftpsync_add - ERROR - Writing file failed: [Errno 2] No such file or directory: '/srv/tftpboot/grub/i386-pc/blocklist.mod.tmp' -> '/srv/tftpboot/grub/i386-pc/blocklist.mod'
Traceback (most recent call last):
  File "/srv/www/tftpsync/add", line 105, in application
    os.rename(tfname, rfname)
FileNotFoundError: [Errno 2] No such file or directory: '/srv/tftpboot/grub/i386-pc/blocklist.mod.tmp' -> '/srv/tftpboot/grub/i386-pc/blocklist.mod'
```
This PR is fixing this issue.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: seems there is no direct unit tests for this part

## Links

Tracks https://github.com/SUSE/spacewalk/issues/16495

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
