### PR TITLE
import gpg keys on SUSE systems directly

### DIFF
--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- import gpg keys on SUSE systems directly to prevent using
+  gpg-auto-import-keys on all package operations (bsc#1203580)
 - Prevent possible tracebacks on reading postgres opts
   with suma_minion salt pillar extension module
 - Fix mgrnet availability check


### PR DESCRIPTION
## What does this PR change?

When using `gpgkeys` parameter in the repository configuration, the installer import the key only when needed.
As the repositories are not signed, a refresh operation does not import the key.
Only a package install/update operation would import this key, but we do not want to use "gpg-auto-import-gpg-keys" option in every state and teach also the users to set this option always.

So we better directly import the GPG keys which are set in **assigned** channels.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **nothing relevant changed**

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/19074

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
