### PR TITLE
QE: Enable SUSE Manager Proxy product

### DIFF
--- a/testsuite/features/core/proxy_register_as_minion_with_gui.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_gui.feature
@@ -15,8 +15,8 @@ Feature: Setup Uyuni proxy
 
   Scenario: Install proxy software
     When I refresh the metadata for "proxy"
-    # TODO: uncomment when SCC product becomes available
-    # And I install "SUSE-Manager-Proxy" product on the proxy
+    # TODO: comment when SCC product becomes unavailable
+    And I install "SUSE-Manager-Proxy" product on the proxy
     And I install proxy pattern on the proxy
     And I let squid use avahi on the proxy
 
@@ -49,8 +49,8 @@ Feature: Setup Uyuni proxy
   Scenario: Check proxy system details
     When I am on the Systems overview page of this "proxy"
     Then I should see "proxy" hostname
-    # TODO: uncomment when SCC product becomes available
-    # When I wait until I see "SUSE Manager Proxy" text, refreshing the page
+    # TODO: comment when SCC product becomes unavailable
+    When I wait until I see "SUSE Manager Proxy" text, refreshing the page
     Then I should see a "Proxy" link in the content area
 
 @uyuni

--- a/testsuite/features/core/proxy_register_as_minion_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_script.feature
@@ -15,8 +15,8 @@ Feature: Setup Uyuni proxy
 
   Scenario: Install proxy software
     When I refresh the metadata for "proxy"
-    # TODO: uncomment when SCC product becomes available
-    # And I install "SUSE-Manager-Proxy" product on the proxy
+    # TODO: comment when SCC product becomes unavailable
+    And I install "SUSE-Manager-Proxy" product on the proxy
     And I install proxy pattern on the proxy
     And I let squid use avahi on the proxy
 
@@ -60,8 +60,8 @@ Feature: Setup Uyuni proxy
   Scenario: Check proxy system details
     When I am on the Systems overview page of this "proxy"
     Then I should see "proxy" hostname
-    # TODO: uncomment when SCC product becomes available
-    # When I wait until I see "SUSE Manager Proxy" text, refreshing the page
+    # TODO: comment when SCC product becomes unavailable
+    When I wait until I see "SUSE Manager Proxy" text, refreshing the page
     Then I should see a "Proxy" link in the content area
 
 @uyuni

--- a/testsuite/features/core/proxy_register_as_trad_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_trad_with_script.feature
@@ -15,8 +15,8 @@ Feature: Setup Uyuni proxy
 
   Scenario: Install proxy software
     When I refresh the metadata for "proxy"
-    # TODO: uncomment when SCC product becomes available
-    # And I install "SUSE-Manager-Proxy" product on the proxy
+    # TODO: comment when SCC product becomes unavailable
+    And I install "SUSE-Manager-Proxy" product on the proxy
     And I install proxy pattern on the proxy
     And I let squid use avahi on the proxy
 
@@ -40,8 +40,8 @@ Feature: Setup Uyuni proxy
   Scenario: Check proxy system details
     When I am on the Systems overview page of this "proxy"
     Then I should see "proxy" hostname
-    # TODO: uncomment when SCC product becomes available
-    # When I wait until I see "SUSE Manager Proxy" text, refreshing the page
+    # TODO: comment when SCC product becomes unavailable
+    When I wait until I see "SUSE Manager Proxy" text, refreshing the page
     Then I should see a "Proxy" link in the content area
 
 @uyuni


### PR DESCRIPTION
## What does this PR change?

Card: https://github.com/SUSE/spacewalk/issues/19070

We can enable SUSE Manager Proxy in Head, as now it seems available in SCC.

We can't enable Uyuni Proxy in master yet, as for now, we need to understand why it's not available, most probably a mirror issue.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.3
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
