### PR TITLE
QE: Remove a check for Uyuni proxy product in our system details

### DIFF
--- a/testsuite/features/core/proxy_register_as_minion_with_gui.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_gui.feature
@@ -57,8 +57,6 @@ Feature: Setup Uyuni proxy
   Scenario: Check proxy system details
     When I am on the Systems overview page of this "proxy"
     Then I should see "proxy" hostname
-    # TODO: uncomment when SCC product becomes available
-    # When I wait until I see "Uyuni Proxy" text, refreshing the page
     Then I should see a "Proxy" link in the content area
 
   Scenario: Install expect package on proxy for bootstrapping minion with GUI

--- a/testsuite/features/core/proxy_register_as_minion_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_script.feature
@@ -68,8 +68,6 @@ Feature: Setup Uyuni proxy
   Scenario: Check proxy system details
     When I am on the Systems overview page of this "proxy"
     Then I should see "proxy" hostname
-    # TODO: uncomment when SCC product becomes available
-    # When I wait until I see "Uyuni Proxy" text, refreshing the page
     Then I should see a "Proxy" link in the content area
 
   Scenario: Install expect package on proxy for bootstrapping minion via script

--- a/testsuite/features/core/proxy_register_as_trad_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_trad_with_script.feature
@@ -48,8 +48,6 @@ Feature: Setup Uyuni proxy
   Scenario: Check proxy system details
     When I am on the Systems overview page of this "proxy"
     Then I should see "proxy" hostname
-    # TODO: uncomment when SCC product becomes available
-    # When I wait until I see "Uyuni Proxy" text, refreshing the page
     Then I should see a "Proxy" link in the content area
 
   Scenario: Install expect package on proxy for bootstrapping client via script


### PR DESCRIPTION
## What does this PR change?

Remove a check for Uyuni proxy product in our system details.
We will never use this commented step, as the system details in Uyuni will never show a product not available in SCC. And Uyuni Proxy is not in SCC.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were removed

- [x] **DONE**

## Links

Ports (only for the sake of homogenized code):
- Manager-4.2
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
