### PR TITLE
Decouple mgr push

### DIFF
--- a/client/tools/mgr-push/mgr-push.changes
+++ b/client/tools/mgr-push/mgr-push.changes
@@ -1,3 +1,4 @@
+- Decouple mgr-push from spacewalk-client-tools
 - Allow rhnpush to handle Debian packages
 
 -------------------------------------------------------------------

--- a/client/tools/mgr-push/src/rhnpush/rhnpush_main.py
+++ b/client/tools/mgr-push/src/rhnpush/rhnpush_main.py
@@ -549,25 +549,14 @@ class UploadClass(uploadLib.UploadClass):
             # computing checksum and other info is expensive process and session
             # could have expired.Make sure its re-authenticated.
             self.authenticate()
-            if uploadLib.exists_getPackageChecksumBySession(self.server):
-                checksum_data = uploadLib.getPackageChecksumBySession(self.server,
-                                                                      self.session.getSessionString(), info)
-            else:
-                # old server only md5 capable
-                checksum_data = uploadLib.getPackageMD5sumBySession(self.server,
-                                                                    self.session.getSessionString(), info)
+            checksum_data = uploadLib.getPackageChecksumBySession(self.server,
+                                                                  self.session.getSessionString(), info)
         else:
             # computing checksum and other info is expensive process and session
             # could have expired.Make sure its re-authenticated.
             self.authenticate()
-            if uploadLib.exists_getPackageChecksumBySession(self.server):
-                checksum_data = uploadLib.getSourcePackageChecksumBySession(self.server,
-                                                                            self.session.getSessionString(), info)
-            else:
-                # old server only md5 capable
-                checksum_data = uploadLib.getSourcePackageMD5sumBySession(self.server,
-                                                                          self.session.getSessionString(), info)
-
+            checksum_data = uploadLib.getSourcePackageChecksumBySession(self.server,
+                                                                        self.session.getSessionString(), info)
         return (checksum_data, pkg_hash, digest_hash)
 
     def package(self, package, fileChecksumType, fileChecksum):


### PR DESCRIPTION
## What does this PR change?

`mgr-push` has a dependency on `spacewalk-client-tools`. This causes `mgr-push` to be removed when the traditional stack is removed.

This PR causes `mgr-push` to no longer depend on the traditional stack.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- ~~No tests: A PR with new unit tests for mgr-push is currently under review and will hopefully be merged soon. 
https://github.com/uyuni-project/uyuni/pull/5654~~. That PR was already merged.
- No tests: already covered. 


- [X] **DONE**

## Links

Fixes #4725 
Tracks https://github.com/SUSE/spacewalk/issues/17775

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
