### PR TITLE
wait until remote command was really executed

### DIFF
--- a/testsuite/features/secondary/min_timezone.feature
+++ b/testsuite/features/secondary/min_timezone.feature
@@ -64,6 +64,8 @@ Feature: Correct timezone display
       """
     And I click on "Schedule"
     And I follow "Events" in the content area
+    And I follow "Pending" in the content area
+    And I wait at most 180 seconds until I do not see "Remote Command on" text, refreshing the page
     And I follow "History" in the content area
     And I follow first "scheduled by MalaysianUser"
     Then I should see a "MYT" text

--- a/testsuite/features/secondary/min_timezone.feature
+++ b/testsuite/features/secondary/min_timezone.feature
@@ -38,22 +38,6 @@ Feature: Correct timezone display
     Given I am authorized as "MalaysianUser" with password "MalaysianUser"
     Then I should see a "MalaysianUser" link
 
-  Scenario: Schedule a remote script in the future and see the correct timezone as a pop up
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Remote Command" in the content area
-    And I enter as remote command this script in
-      """
-      #!/bin/bash
-      ls
-      """
-    And I enter "00:00" as "date_timepicker_widget_input"
-    And I click on "Schedule"
-    Then I should see a "00:00:00 MYT" text
-    
-  Scenario: Login as the new Malaysian user if the previous scenario failed
-    Given I am authorized as "MalaysianUser" with password "MalaysianUser"
-    Then I should see a "MalaysianUser" link
-
   Scenario: Schedule a remote script to run now  and see the correct timezone details in history
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Remote Command" in the content area
@@ -69,8 +53,24 @@ Feature: Correct timezone display
     And I follow "History" in the content area
     And I follow first "scheduled by MalaysianUser"
     Then I should see a "MYT" text
-    # WORKAROUND for bsc #1195191, the below line is commented out but if the bug is fixed we should enable it. 
+    # WORKAROUND for bsc #1195191, the below line is commented out but if the bug is fixed we should enable it.
     # And I should not see a "PM" text
+    
+  Scenario: Login as the new Malaysian user if the previous scenario failed
+    Given I am authorized as "MalaysianUser" with password "MalaysianUser"
+    Then I should see a "MalaysianUser" link
+
+  Scenario: Schedule a remote script in the future and see the correct timezone as a pop up
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Remote Command" in the content area
+    And I enter as remote command this script in
+      """
+      #!/bin/bash
+      ls
+      """
+    And I enter "00:00" as "date_timepicker_widget_input"
+    And I click on "Schedule"
+    Then I should see a "00:00:00 MYT" text
     
   Scenario: Login as the new Malaysian user if the previous scenario failed
     Given I am authorized as "MalaysianUser" with password "MalaysianUser"


### PR DESCRIPTION
## What does this PR change?

We see errors on this test, not finding "scheduled by MalaysianUser" but there are pending actions.
So wait until the action was at least picked up before checking for this text

Switched 2 tests to execute "run now" first as we need to wait until this action is completed.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/19126 https://github.com/SUSE/spacewalk/pull/19125

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
