### PR TITLE
Cobbler's get_item_resolved_value has not token

### DIFF
--- a/java/code/src/org/cobbler/CobblerObject.java
+++ b/java/code/src/org/cobbler/CobblerObject.java
@@ -260,7 +260,7 @@ public abstract class CobblerObject {
      * @return The resolved value or in case an attribute doesn't resolve its raw value
      */
     protected final Object getResolvedValue(String key) {
-        return client.invokeTokenMethod("get_item_resolved_value", getUid(), key);
+        return client.invokeMethod("get_item_resolved_value", getUid(), key);
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix get_item_resolved_value call
 - Fix hardware update where there is no DNS FQDN changes (bsc#1203611)
 - Fix prerequisite action serialization (bsc#1202899)(bsc#1203484)
 - Fix UI crash when filtering on systems list (bsc#1203169)


### PR DESCRIPTION
## What does this PR change?

Fixes cobbler API use showing this exception:

```
redstone.xmlrpc.XmlRpcFault: <class 'TypeError'>:get_item_resolved_value() takes 3 positional arguments but 4 were given
        at redstone.xmlrpc.XmlRpcClient.handleResponse(XmlRpcClient.java:444) ~[redstone-xmlrpc-client-1.1_20071120.jar:?]
        at redstone.xmlrpc.XmlRpcClient.endCall(XmlRpcClient.java:376) ~[redstone-xmlrpc-client-1.1_20071120.jar:?]
        at redstone.xmlrpc.XmlRpcClient.invoke(XmlRpcClient.java:165) ~[redstone-xmlrpc-client-1.1_20071120.jar:?]
        at org.cobbler.CobblerConnection.invokeMethod(CobblerConnection.java:146) ~[rhn.jar:?]
        at org.cobbler.CobblerConnection.invokeTokenMethod(CobblerConnection.java:179) ~[rhn.jar:?]
        at org.cobbler.CobblerObject.getResolvedValue(CobblerObject.java:263) ~[rhn.jar:?]
        at org.cobbler.CobblerObject.getResolvedKernelOptions(CobblerObject.java:648) ~[rhn.jar:?]
        at com.suse.manager.webui.services.SaltServerActionService.buildKernelOptions(SaltServerActionService.java:1989) ~[rhn.jar:?]
        at com.suse.manager.webui.services.SaltServerActionService.prepareCobblerBoot(SaltServerActionService.java:1938) ~[rhn.jar:?]
        at com.suse.manager.webui.services.SaltServerActionService.virtCreateAction(SaltServerActionService.java:1825) ~[rhn.jar:?]
        at com.suse.manager.webui.services.SaltServerActionService.callsForAction(SaltServerActionService.java:408) ~[rhn.jar:?]
        at com.suse.manager.webui.services.SaltServerActionService.executeForRegularMinions(SaltServerActionService.java:517) ~[rhn.jar:?]
        at com.suse.manager.webui.services.SaltServerActionService.execute(SaltServerActionService.java:495) ~[rhn.jar:?]
        at com.redhat.rhn.taskomatic.task.MinionActionExecutor.execute(MinionActionExecutor.java:133) ~[rhn.jar:?]
        at com.redhat.rhn.taskomatic.task.RhnJavaJob.execute(RhnJavaJob.java:91) [rhn.jar:?]
        at com.redhat.rhn.taskomatic.TaskoJob.execute(TaskoJob.java:155) [rhn.jar:?]
        at org.quartz.core.JobRunShell.run(JobRunShell.java:202) [quartz-2.3.0.jar:?]
        at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:573) [quartz-2.3.0.jar:?]
```

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
