### PR TITLE
snakeyaml version update to 1.31

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -86,7 +86,7 @@
         <dependency org="suse" name="sitemesh" rev="2.1" />
         <dependency org="suse" name="slf4j-api" rev="1.7.30" />
         <dependency org="suse" name="log4j-slf4j-impl" rev="2.17.1" />
-        <dependency org="suse" name="snakeyaml" rev="1.28" />
+        <dependency org="suse" name="snakeyaml" rev="1.31" />
         <dependency org="suse" name="spark-core" rev="2.9.3" />
         <dependency org="suse" name="spark-template-jade" rev="2.7.1" />
         <dependency org="suse" name="spy" rev="0.8.7" />

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -255,7 +255,7 @@ artifacts:
     jar: api
     repository: Leap
   - artifact: snakeyaml
-    repository: Leap
+    repository: Leap_sle
   - artifact: spark-core
     repository: Uyuni_Other
   - artifact: spark-template-jade


### PR DESCRIPTION
## What does this PR change?

snakeyaml was updated to version 1.31. Use the new version in ivy as well.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/19119

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
