### PR TITLE
QE: Disabling XEN test coverage, in preparation to completely remove them

### DIFF
--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -75,7 +75,6 @@
 - features/secondary/srv_scc_user_credentials.feature
 
 - features/secondary/minkvm_guests.feature
-- features/secondary/minxen_guests.feature
 
 - features/secondary/trad_metadata_check.feature
 - features/secondary/trad_cve_audit.feature


### PR DESCRIPTION
## What does this PR change?

First PR for this card https://github.com/SUSE/spacewalk/issues/19103

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were disabled

- [x] **DONE**

## Links

Ports:
- Manager-4.2 https://github.com/SUSE/spacewalk/pull/19121
- Manager-4.3 https://github.com/SUSE/spacewalk/pull/19122

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
