### PR TITLE
QE: Refactor of negative tests to don't collide with other tests

### DIFF
--- a/testsuite/features/secondary/min_bootstrap_negative.feature
+++ b/testsuite/features/secondary/min_bootstrap_negative.feature
@@ -23,14 +23,6 @@ Feature: Negative tests for bootstrapping normal minions
     Then I should not see a "GenericSaltError" text
     And I should see a "seems to already exist, please check!" text
 
-  Scenario: Delete SLES minion system profile before bootstrap negative tests
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Delete System"
-    Then I should see a "Confirm System Profile Deletion" text
-    When I click on "Delete Profile"
-    And I wait until I see "has been deleted" text
-    Then "sle_minion" should not be registered
-
   Scenario: Bootstrap a SLES minion with wrong hostname
     When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
@@ -50,7 +42,7 @@ Feature: Negative tests for bootstrapping normal minions
   Scenario: Bootstrap a SLES minion with wrong SSH credentials
     When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
-    When I enter the hostname of "sle_minion" as "hostname"
+    When I enter the hostname of "localhost" as "hostname"
     And I enter "22" as "port"
     And I enter "FRANZ" as "user"
     And I enter "KAFKA" as "password"
@@ -66,7 +58,7 @@ Feature: Negative tests for bootstrapping normal minions
   Scenario: Bootstrap a SLES minion with wrong SSH port number
     When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
-    When I enter the hostname of "sle_minion" as "hostname"
+    When I enter the hostname of "localhost" as "hostname"
     And I enter "11" as "port"
     And I enter "root" as "user"
     And I enter "linux" as "password"
@@ -78,29 +70,3 @@ Feature: Negative tests for bootstrapping normal minions
     Then I should see a "Standard Error" text
     And I should see "port 11: Connection refused" or "port 11: Invalid argument" in the textarea
     When I close the modal dialog
-
-  Scenario: Cleanup: bootstrap a SLES minion after negative tests
-    When I follow the left menu "Systems > Bootstrapping"
-    Then I should see a "Bootstrap Minions" text
-    When I enter the hostname of "sle_minion" as "hostname"
-    And I enter "22" as "port"
-    And I enter "root" as "user"
-    And I enter "linux" as "password"
-    And I select the hostname of "proxy" from "proxies" if present
-    And I click on "Bootstrap"
-    And I wait until I see "Successfully bootstrapped host!" text
-    And I follow the left menu "Systems > Overview"
-    And I wait until I see the name of "sle_minion", refreshing the page
-
-  Scenario: Cleanup: subscribe again to base channel after negative tests
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Software" in the content area
-    And I follow "Software Channels" in the content area
-    And I wait until I do not see "Loading..." text
-    And I check radio button "Test-Channel-x86_64"
-    And I wait until I do not see "Loading..." text
-    And I click on "Next"
-    Then I should see a "Confirm Software Channel Change" text
-    When I click on "Confirm"
-    Then I should see a "Changing the channels has been scheduled." text
-    And I wait until event "Subscribe channels scheduled by admin" is completed


### PR DESCRIPTION
## What does this PR change?

Refactor of negative tests to don't collide with other tests.
We now use localhost (controller host) to run the negative tests. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were refactored

- [x] **DONE**

## Links

Ports:
- Manager-4.2 https://github.com/SUSE/spacewalk/pull/19130
- Manager-4.3 https://github.com/SUSE/spacewalk/pull/19129

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
