### PR TITLE
QE: Changing the only moving piece in our CT to update Ubuntu version

### DIFF
--- a/testsuite/features/secondary/min_deblike_openscap_audit.feature
+++ b/testsuite/features/secondary/min_deblike_openscap_audit.feature
@@ -30,7 +30,7 @@ Feature: OpenSCAP audit of Debian-like Salt minion
     And I follow "Schedule" in the content area
     And I wait at most 30 seconds until I do not see "This system does not yet have OpenSCAP scan capability." text, refreshing the page
     And I enter "--profile standard" as "params"
-    And I enter "/usr/share/xml/scap/ssg/content/ssg-ubuntu2004-xccdf.xml" as "path"
+    And I enter "/usr/share/xml/scap/ssg/content/ssg-ubuntu2204-xccdf.xml" as "path"
     And I click on "Schedule"
     Then I should see a "XCCDF scan has been scheduled" text
     And I wait at most 500 seconds until event "OpenSCAP xccdf scanning" is completed


### PR DESCRIPTION
## What does this PR change?

Switch to Ubuntu 22.04 only in 4.3/Head/Uyuni CT

Card: https://github.com/SUSE/spacewalk/issues/18857
Epic: https://github.com/SUSE/spacewalk/issues/17721
Dependency: https://github.com/SUSE/spacewalk/issues/18408

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were updated

- [x] **DONE**

## Links

Ports:
- Manager-4.3 https://github.com/SUSE/spacewalk/pull/19132

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
