### PR TITLE
Refactor command result printing (bsc#1203283)

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Remove "Undefined return code" from debug messages (bsc#1203283)
 - Update translation strings
 
 -------------------------------------------------------------------

--- a/spacecmd/src/bin/spacecmd
+++ b/spacecmd/src/bin/spacecmd
@@ -208,7 +208,8 @@ if __name__ == '__main__':
                 precmd = shell.precmd(command)
                 if precmd == '':
                     sys.exit(1)
-                result = shell.print_result(shell.onecmd(precmd), precmd)
+                result = shell.onecmd(precmd)
+                logging.debug("command=%s, return_value=%s", precmd, repr(result))
                 if result == 1:
                     sys.exit(result)
             except KeyboardInterrupt:

--- a/spacecmd/src/spacecmd/activationkey.py
+++ b/spacecmd/src/spacecmd/activationkey.py
@@ -1686,7 +1686,8 @@ def do_activationkey_diff(self, args):
     source_data = self.dump_activationkey(source_channel, source_replacedict)
     target_data = self.dump_activationkey(target_channel, target_replacedict)
 
-    return diff(source_data, target_data, source_channel, target_channel)
+    for line in diff(source_data, target_data, source_channel, target_channel):
+        print(line)
 
 ####################
 

--- a/spacecmd/src/spacecmd/configchannel.py
+++ b/spacecmd/src/spacecmd/configchannel.py
@@ -304,7 +304,8 @@ def do_configchannel_filedetails(self, args):
             result.append('--------')
             result.append(details.get('contents'))
 
-    return result
+    for line in result:
+        print(line)
 
 ####################
 
@@ -1579,7 +1580,8 @@ def do_configchannel_diff(self, args):
     source_data = self.dump_configchannel(source_channel, source_replacedict)
     target_data = self.dump_configchannel(target_channel, target_replacedict)
 
-    return diff(source_data, target_data, source_channel, target_channel)
+    for line in diff(source_data, target_data, source_channel, target_channel):
+        print(line)
 
 ####################
 

--- a/spacecmd/src/spacecmd/kickstart.py
+++ b/spacecmd/src/spacecmd/kickstart.py
@@ -513,7 +513,8 @@ def do_kickstart_details(self, args):
             result.append('')
             result.append(s.get('contents'))
 
-    return result
+    for line in result:
+        print(line)
 
 ####################
 
@@ -2647,7 +2648,8 @@ def do_kickstart_diff(self, args):
     source_data = self.dump_kickstart(source_channel, source_replacedict)
     target_data = self.dump_kickstart(target_channel, target_replacedict)
 
-    return diff(source_data, target_data, source_channel, target_channel)
+    for line in diff(source_data, target_data, source_channel, target_channel):
+        print(line)
 
 ####################
 

--- a/spacecmd/src/spacecmd/proxy.py
+++ b/spacecmd/src/spacecmd/proxy.py
@@ -82,7 +82,7 @@ def do_proxy_container_config(self, args):
 
     with open(options.output, 'wb') as fd:
         fd.write(config.data)
-    return options.output
+    print(options.output)
 
 
 def help_proxy_container_config_generate_cert(self):
@@ -154,7 +154,7 @@ def do_proxy_container_config_generate_cert(self, args):
 
     with open(options.output, 'wb') as fd:
         fd.write(config.data)
-    return options.output
+    print(options.output)
 
 
 def read_file(path):

--- a/spacecmd/src/spacecmd/shell.py
+++ b/spacecmd/src/spacecmd/shell.py
@@ -233,26 +233,10 @@ class SpacewalkShell(Cmd):
             logging.warning(_N('%s: event not found'), command)
             return ''
 
-    @staticmethod
-    def print_result(cmdresult, cmd):
-        logging.debug(cmd + ": " + repr(cmdresult))
-        if cmd:
-            try:
-                if type(cmdresult).__name__ == 'str':
-                    print(cmdresult)
-                else:
-                    for i in cmdresult:
-                        print(i)
-            except TypeError:
-                # catch methods returning undefined results at least in debug mode
-                logging.debug('Undefined return code from \"%s\"', cmd)
-
-        return cmdresult
-
     # update the prompt with the SSM size
     # pylint: disable=arguments-differ
     def postcmd(self, cmdresult, cmd):
-        SpacewalkShell.print_result(cmdresult, cmd)
+        logging.debug("command=%s, return_value=%s", cmd, repr(cmdresult))
         self.prompt = re.sub('##', str(len(self.ssm)), self.prompt_template)
 
     def default(self, line):

--- a/spacecmd/tests/test_activationkey.py
+++ b/spacecmd/tests/test_activationkey.py
@@ -8,7 +8,7 @@ import time
 import hashlib
 import spacecmd.activationkey
 from xmlrpc import client as xmlrpclib
-from helpers import shell, exc2str
+from helpers import shell, exc2str, assert_list_args_expect
 
 
 class TestSCActivationKey:
@@ -1777,10 +1777,15 @@ class TestSCActivationKeyMethods:
         shell.do_activationkey_getcorresponding = MagicMock(return_value="some_channel")
 
         gsdd = MagicMock(return_value=({"one": "two", "three": "three"}, {"one": "two", "three": "four"}))
-        with patch("spacecmd.activationkey.get_string_diff_dicts", gsdd):
-            out = spacecmd.activationkey.do_activationkey_diff(shell, "some_key")
-        assert out == ['--- some_key\n', '+++ some_channel\n', '@@ -1 +1 @@\n', '-some data', '+some data again']
-    
+        with patch("spacecmd.activationkey.get_string_diff_dicts", gsdd), \
+             patch("spacecmd.activationkey.print") as mprint:
+            spacecmd.activationkey.do_activationkey_diff(shell, "some_key")
+
+        assert_list_args_expect(
+            mprint.call_args_list,
+            ['--- some_key\n', '+++ some_channel\n', '@@ -1 +1 @@\n', '-some data', '+some data again']
+        )
+
     def test_do_activationkey_diable_noargs(self, shell):
         """
         Test do_activationkey_disable command triggers help on no args.

--- a/spacecmd/tests/test_configchannel.py
+++ b/spacecmd/tests/test_configchannel.py
@@ -465,7 +465,6 @@ class TestSCConfigChannel:
         :param shell:
         :return:
         """
-        mprint = MagicMock()
         logger = MagicMock()
         shell.user_confirm = MagicMock()
         shell.client.configchannel.lookupFileInfo = MagicMock(return_value={
@@ -474,7 +473,7 @@ class TestSCConfigChannel:
         shell.do_configchannel_listfiles = MagicMock(return_value=[
             "/tmp/valid.file", "/tmp/another-valid.file", "/tmp/file.txt"
         ])
-        with patch("spacecmd.configchannel.print", mprint) as prt, \
+        with patch("spacecmd.configchannel.print") as mprint, \
                 patch("spacecmd.configchannel.logging", logger) as lgr:
             result = spacecmd.configchannel.do_configchannel_filedetails(
                 shell, "base_channel /tmp/file.txt 3")
@@ -483,14 +482,24 @@ class TestSCConfigChannel:
         assert not shell.help_configchannel_filedetails.called
         assert not logger.warning.called
         assert not logger.error.called
-        assert not mprint.called
         assert shell.client.configchannel.lookupFileInfo.called
         assert shell.do_configchannel_listfiles.called
 
-        assert result is not None
-        assert result == ['Path:     /tmp.file.txt', 'Type:     N/A', 'Revision: N/A', 'Created:  N/A',
-                          'Modified: N/A', '', 'Owner:           N/A', 'Group:           N/A',
-                          'Mode:            N/A', 'SELinux Context: N/A']
+        assert_list_args_expect(
+            mprint.call_args_list,
+            [
+                'Path:     /tmp.file.txt',
+                'Type:     N/A',
+                'Revision: N/A',
+                'Created:  N/A',
+                'Modified: N/A',
+                '',
+                'Owner:           N/A',
+                'Group:           N/A',
+                'Mode:            N/A',
+                'SELinux Context: N/A'
+            ]
+        )
 
     def test_configchannel_filedetails_with_correct_revision_data(self, shell):
         """
@@ -499,7 +508,6 @@ class TestSCConfigChannel:
         :param shell:
         :return:
         """
-        mprint = MagicMock()
         logger = MagicMock()
         shell.user_confirm = MagicMock()
         shell.client.configchannel.lookupFileInfo = MagicMock(return_value={
@@ -512,7 +520,7 @@ class TestSCConfigChannel:
         shell.do_configchannel_listfiles = MagicMock(return_value=[
             "/tmp/valid.file", "/tmp/another-valid.file", "/tmp/file.txt"
         ])
-        with patch("spacecmd.configchannel.print", mprint) as prt, \
+        with patch("spacecmd.configchannel.print") as mprint, \
                 patch("spacecmd.configchannel.logging", logger) as lgr:
             result = spacecmd.configchannel.do_configchannel_filedetails(
                 shell, "base_channel /tmp/file.txt 3")
@@ -521,15 +529,29 @@ class TestSCConfigChannel:
         assert not shell.help_configchannel_filedetails.called
         assert not logger.warning.called
         assert not logger.error.called
-        assert not mprint.called
         assert shell.client.configchannel.lookupFileInfo.called
         assert shell.do_configchannel_listfiles.called
 
-        assert result is not None
-        assert result == ['Path:     /tmp.file.txt', 'Type:     file', 'Revision: 3', 'Created:  2019.01.01',
-                          'Modified: 2019.01.02', '', 'Owner:           Fred', 'Group:           lusers',
-                          'Mode:            0700', 'SELinux Context: system_u', 'SHA256:          1234567',
-                          'Binary:          False', '', 'Contents', '--------', 'Improper keyboard linear orientation']
+        assert_list_args_expect(
+            mprint.call_args_list,
+            ['Path:     /tmp.file.txt',
+             'Type:     file',
+             'Revision: 3',
+             'Created:  2019.01.01',
+             'Modified: 2019.01.02',
+             '',
+             'Owner:           Fred',
+             'Group:           lusers',
+             'Mode:            0700',
+             'SELinux Context: system_u',
+             'SHA256:          1234567',
+             'Binary:          False',
+             '',
+             'Contents',
+             '--------',
+             'Improper keyboard linear orientation'
+            ]
+        )
 
     def test_configchannel_backup_noargs(self, shell):
         """

--- a/spacecmd/tests/test_shell.py
+++ b/spacecmd/tests/test_shell.py
@@ -180,7 +180,6 @@ class TestSCShell:
 
     @patch("spacecmd.shell.atexit", MagicMock())
     @patch("spacecmd.shell.readline.set_completer_delims", MagicMock())
-    @patch("spacecmd.shell.SpacewalkShell.print_result", MagicMock())
     @patch("spacecmd.shell.readline.get_completer_delims", MagicMock(return_value=readline.get_completer_delims()))
     def test_shell_postcmd(self):
         """


### PR DESCRIPTION
## What does this PR change?

Previously there were two ways to print the "results" of commands: by leveraging a function called by postcmd or inside the command definitions. Most commands already printed "internally", but a few returned string or other sequences that were printed "externally".

For consistency, all output must be generated inside command definitions going forward. Existing code is adapted in this PR to meet that requirement.

## CLI diff

Before:
On many commands, debug output contained the following:
```
DEBUG: system_list: 0
DEBUG: Undefined return code from "system_list"
```

After:
The only debug output is the following, independent of the type of the return value.
```
DEBUG: command=system_list, return_value=0
```
- [x] **DONE**

## Documentation
- No documentation needed: Only debug output changes.

- [x] **DONE**

## Test coverage
- Unit tests were updated

- [x] **DONE**

## Links

Related issue https://github.com/SUSE/spacewalk/issues/18926
Tracks https://github.com/SUSE/spacewalk/pull/19204

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Other 
This PR is based on https://github.com/uyuni-project/uyuni/pull/5991