### PR TITLE
QE: Cobbler system record trigger step updating

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -299,7 +299,7 @@ When(/^I trigger cobbler system record on the "([^"]*)"$/) do |host|
   unless out.include? 'ssh-push-tunnel'
     steps %(
       Given I am authorized as "testing" with password "testing"
-      And I follow this "#{host}" link
+      And I am on the Systems overview page of this "#{host}"
       And I follow "Provisioning"
       And I click on "Create PXE installation configuration"
       And I click on "Continue"


### PR DESCRIPTION
## What does this PR change?

Using a step going to the client's profile instead of clicking on its link in a Cobbler feature.

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/19184
Tracks # 
4.2 https://github.com/SUSE/spacewalk/pull/19192
4.3 https://github.com/SUSE/spacewalk/pull/19193

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
