### PR TITLE
ServerConfigHandler: don't add the same channel twice

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/config/ConfigChannel.java
+++ b/java/code/src/com/redhat/rhn/domain/config/ConfigChannel.java
@@ -29,7 +29,6 @@ import java.util.SortedSet;
  * ConfigChannel - Class representation of the table rhnConfigChannel.
  */
 public class ConfigChannel extends BaseDomainHelper implements Identifiable {
-
     private Long id;
     private Org org;
     private String name;

--- a/java/code/src/com/redhat/rhn/domain/config/ConfigChannelListProcessor.java
+++ b/java/code/src/com/redhat/rhn/domain/config/ConfigChannelListProcessor.java
@@ -56,7 +56,7 @@ public class ConfigChannelListProcessor {
      *                          the new channel will be appended
      * @param cc The config channel to subscribe to
      */
-    public void add(List cfgChannels, ConfigChannel cc) {
+    public void add(List<ConfigChannel> cfgChannels, ConfigChannel cc) {
         add(cfgChannels, cc, cfgChannels.size());
     }
 
@@ -68,8 +68,7 @@ public class ConfigChannelListProcessor {
      * @param rank the positon/ranking of the channel in the system list,
      *                  must be {@literal > 0}
      */
-
-    public void add(List cfgChannels, ConfigChannel cc, int rank) {
+    public void add(List<ConfigChannel> cfgChannels, ConfigChannel cc, int rank) {
         check(cc);
         checkRank(rank);
         cfgChannels.remove(cc);
@@ -92,7 +91,7 @@ public class ConfigChannelListProcessor {
      * @param cc the ConfigChannel to remove
      * @return returns true if the remove operation succeded
      */
-    public boolean remove(List cfgChannels, ConfigChannel cc) {
+    public boolean remove(List<ConfigChannel> cfgChannels, ConfigChannel cc) {
         return cfgChannels.remove(cc);
     }
 
@@ -123,7 +122,7 @@ public class ConfigChannelListProcessor {
      *  these channels before embarking on it..
      * @param cfgChannels the config channels list that'll be cleared.
      */
-    public void clear(List cfgChannels) {
+    public void clear(List<ConfigChannel> cfgChannels) {
             cfgChannels.clear();
     }
 

--- a/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
@@ -49,6 +49,16 @@ public class MinionServer extends Server implements SaltConfigurable {
     }
 
     /**
+     * Minimal constructor used to avoid loading all properties in SSM config channel subscription
+     *
+     * @param idIn the server id
+     * @param machineIdIn the machine id
+     */
+    public MinionServer(long idIn, String machineIdIn) {
+        super(idIn, machineIdIn);
+    }
+
+    /**
      * @return the minion id
      */
     public String getMinionId() {

--- a/java/code/src/com/redhat/rhn/domain/server/Server.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Server.java
@@ -471,16 +471,18 @@ public class Server extends BaseDomainHelper implements Identifiable {
                 .setParameter("sid", getId())
                 .executeUpdate();
 
-        String values = IntStream.range(0, configChannels.size())
-                .boxed()
-                .map(i -> String.format("(%s, %s, %s)", getId(), configChannels.get(i).getId(), i + 1))
-                .collect(Collectors.joining(","));
+        if (!configChannels.isEmpty()) {
+            String values = IntStream.range(0, configChannels.size())
+                    .boxed()
+                    .map(i -> String.format("(%s, %s, %s)", getId(), configChannels.get(i).getId(), i + 1))
+                    .collect(Collectors.joining(","));
 
 
-        HibernateFactory.getSession().createNativeQuery(
-                "INSERT INTO rhnServerConfigChannel (server_id, config_channel_id, position) " +
-                    "VALUES " + values + ";")
-                .executeUpdate();
+            HibernateFactory.getSession().createNativeQuery(
+                            "INSERT INTO rhnServerConfigChannel (server_id, config_channel_id, position) " +
+                                    "VALUES " + values + ";")
+                    .executeUpdate();
+        }
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -676,6 +676,38 @@ public class ServerFactory extends HibernateFactory {
     }
 
     /**
+     * Get Systems for fast channel subscriptions
+     *
+     * @param sids the system ids to look for
+     * @param user the user to get systems for
+     * @return the servers with only limited number of loaded fields
+     */
+    public static List<Server> getSystemsForSubscribe(List<Long> sids, User user) {
+        List<Tuple> res = getSession().createNativeQuery(
+                        "SELECT S.id, S.machine_id, SMI.minion_id, {CC.*} " +
+                                "FROM rhnServer S " +
+                                "   LEFT OUTER JOIN suseMinionInfo SMI ON S.id = SMI.server_id " +
+                                "   LEFT OUTER JOIN rhnServerConfigChannel SCC ON S.id = SCC.server_id " +
+                                "   LEFT OUTER JOIN rhnConfigChannel CC on CC.id = SCC.config_channel_id " +
+                                "   JOIN rhnUserServerPerms USP ON (S.id = USP.server_id) " +
+                                "WHERE " +
+                                "   S.id IN (:sids) " +
+                                "   AND USP.user_id = :user_id " +
+                                "   AND EXISTS(SELECT 1 FROM rhnServerFeaturesView SFV WHERE SFV.server_id = S.id " +
+                                "   AND SFV.label = 'ftr_config') " +
+                                "ORDER BY S.name, SCC.position", Tuple.class)
+                .addScalar("id", StandardBasicTypes.BIG_INTEGER)
+                .addScalar("machine_id", StandardBasicTypes.STRING)
+                .addScalar("minion_id", StandardBasicTypes.STRING)
+                .addEntity("CC", ConfigChannel.class)
+                .setParameter("user_id", user.getId())
+                .setParameterList("sids", sids)
+                .list();
+
+        return getServersFromTuplesForSubscribe(res);
+    }
+
+    /**
      * Lookup a Server by their id
      * @param id the id to search for
      * @return the Server found

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -26,6 +26,7 @@ import com.redhat.rhn.common.db.datasource.WriteMode;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.validator.ValidatorError;
 import com.redhat.rhn.domain.channel.ChannelArch;
+import com.redhat.rhn.domain.config.ConfigChannel;
 import com.redhat.rhn.domain.credentials.Credentials;
 import com.redhat.rhn.domain.credentials.CredentialsFactory;
 import com.redhat.rhn.domain.dto.SystemIDInfo;
@@ -56,6 +57,7 @@ import org.hibernate.criterion.MatchMode;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.criterion.Subqueries;
+import org.hibernate.type.StandardBasicTypes;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -71,6 +73,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.persistence.Tuple;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.JoinType;
@@ -604,6 +607,72 @@ public class ServerFactory extends HibernateFactory {
 
         return dr.stream().map(m -> new SystemIDInfo((Long) m.get("id"), (String) m.get("name")))
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Get Systems from SSM for fast channel subscriptions
+     *
+     * @param user the user to get systems for
+     * @return the servers with only limited number of loaded fields
+     */
+    public static List<Server> getSsmSystemsForSubscribe(User user) {
+        List<Tuple> res = getSession().createNativeQuery(
+                "SELECT S.id, S.machine_id, SMI.minion_id, {CC.*} " +
+                    "FROM rhnServer S " +
+                    "   LEFT OUTER JOIN suseMinionInfo SMI ON S.id = SMI.server_id " +
+                    "   INNER JOIN rhnSet ST ON S.id = ST.element " +
+                    "   LEFT OUTER JOIN rhnServerConfigChannel SCC ON S.id = SCC.server_id " +
+                    "   LEFT OUTER JOIN rhnConfigChannel CC on CC.id = SCC.config_channel_id " +
+                    "WHERE " +
+                    "   S.id = ST.element " +
+                    "   AND ST.user_id = :user_id " +
+                    "   AND ST.label = :system_set_label " +
+                    "   AND EXISTS(SELECT 1 FROM rhnServerFeaturesView SFV WHERE SFV.server_id = ST.element " +
+                    "   AND SFV.label = 'ftr_config') " +
+                    "ORDER BY S.name, SCC.position", Tuple.class)
+                .addScalar("id", StandardBasicTypes.BIG_INTEGER)
+                .addScalar("machine_id", StandardBasicTypes.STRING)
+                .addScalar("minion_id", StandardBasicTypes.STRING)
+                .addEntity("CC", ConfigChannel.class)
+                .setParameter("user_id", user.getId())
+                .setParameter("system_set_label", RhnSetDecl.SYSTEMS.getLabel())
+                .list();
+        return getServersFromTuplesForSubscribe(res);
+    }
+
+    private static List<Server> getServersFromTuplesForSubscribe(List<Tuple> tuples) {
+        // I know this is not conforming to the new functional programming style,
+        // but at least I am sure we won't loop unnecessarily on thousands of rows
+        List<Server> data = new ArrayList<>();
+        Server current = null;
+        List<ConfigChannel> channels = new ArrayList<>();
+
+        for (Tuple tuple : tuples) {
+            long sid = tuple.get(0, Number.class).longValue();
+            if (current == null || current.getId() != sid) {
+                if (current != null) {
+                    current.setConfigChannelsHibernate(channels);
+                    data.add(current);
+                    channels = new ArrayList<>();
+                }
+                String machineId = tuple.get(1, String.class);
+                String minionId = tuple.get(2, String.class);
+                if (minionId != null) {
+                    current = new MinionServer(sid, machineId);
+                }
+                else {
+                    current = new Server(sid, machineId);
+                }
+            }
+            channels.add(tuple.get(3, ConfigChannel.class));
+        }
+
+        if (current != null) {
+            current.setConfigChannelsHibernate(channels);
+            data.add(current);
+        }
+
+        return data;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/ssm/SubscribeConfirm.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/ssm/SubscribeConfirm.java
@@ -14,29 +14,31 @@
  */
 package com.redhat.rhn.frontend.action.configuration.ssm;
 
-import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.config.ConfigChannel;
 import com.redhat.rhn.domain.rhnset.RhnSet;
 import com.redhat.rhn.domain.rhnset.RhnSetElement;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.action.common.BadParameterException;
 import com.redhat.rhn.frontend.action.configuration.ConfigActionHelper;
 import com.redhat.rhn.frontend.action.configuration.ConfigChannelSetComparator;
-import com.redhat.rhn.frontend.dto.ConfigSystemDto;
 import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.frontend.taglibs.list.ListTagHelper;
 import com.redhat.rhn.manager.configuration.ConfigurationManager;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
-import com.redhat.rhn.manager.system.SystemManager;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -50,6 +52,9 @@ import javax.servlet.http.HttpServletResponse;
  * SubscribeConfirmSetup, for ssm config subscribe.
  */
 public class SubscribeConfirm extends RhnAction {
+
+    private static final Logger LOG = LogManager.getLogger(SubscribeConfirm.class);
+
     public static final String REPLACE = "replace";
     public static final String LOWEST = "lowest";
     public static final String HIGHEST = "highest";
@@ -116,25 +121,32 @@ public class SubscribeConfirm extends RhnAction {
         String position = request.getParameter(POSITION);
         checkPosition(request);
 
-        List systems = ConfigurationManager.getInstance().ssmSystemsForSubscribe(user);
-        RhnSet channels = RhnSetDecl.CONFIG_CHANNELS.get(user);
+        List<Server> systems = ServerFactory.getSsmSystemsForSubscribe(user);
 
         //visit every server and change their subscriptions
         //keep track of how many servers we have changed
-        int successes = 0;
-        for (Object systemIn : systems) {
-            Long sid = ((ConfigSystemDto) systemIn).getId();
-            try {
-                Server server = SystemManager.lookupByIdAndUser(sid, user);
+        LocalDateTime start = LocalDateTime.now();
 
-                if (subscribeServer(user, server, position)) {
-                    successes++;
-                }
-            }
-            catch (LookupException e) {
-                //skip this server
+        // Order the new channels in the order requested by user
+        ConfigurationManager cm = ConfigurationManager.getInstance();
+        List<RhnSetElement> rankElements = new ArrayList<>(RhnSetDecl.CONFIG_CHANNELS_RANKING.get(user).getElements());
+        rankElements.sort(new ConfigChannelSetComparator());
+
+        RhnSet selectedChannels = RhnSetDecl.CONFIG_CHANNELS.get(user);
+
+        List<ConfigChannel> configChannels = rankElements.stream()
+                .filter(elm -> selectedChannels.contains(elm.getElement()))
+                .map(elm -> cm.lookupConfigChannel(user, elm.getElement()))
+                .collect(Collectors.toList());
+
+        LOG.debug("Start adding config state");
+        int successes = 0;
+        for (Server server : systems) {
+            if (subscribeServer(user, server, configChannels, position)) {
+                successes++;
             }
         }
+        LOG.debug("End adding config state, duration: {}", Duration.between(start, LocalDateTime.now()));
 
         ConfigActionHelper.clearRhnSets(user);
 
@@ -152,33 +164,22 @@ public class SubscribeConfirm extends RhnAction {
         return mapping.findForward("success");
     }
 
-    private boolean subscribeServer(User user, Server server, String position) {
-        ConfigurationManager cm = ConfigurationManager.getInstance();
+    private boolean subscribeServer(User user, Server server, List<ConfigChannel> channels, String position) {
 
         // Position:
         //   LOWEST: Subscribe to new channels at the lowest priority
         //   REPLACE: Replace subscriptions with the new list
         //   HIGHEST: Subscripe to new channels at the highest priority
 
-        // Order the new channels in the order requested by user
-        List rankElements = new ArrayList(
-                RhnSetDecl.CONFIG_CHANNELS_RANKING.get(user).getElements());
-        rankElements.sort(new ConfigChannelSetComparator());
-
-        RhnSet selectedChannels = RhnSetDecl.CONFIG_CHANNELS.get(user);
-
-        List<ConfigChannel> channels = ((List<RhnSetElement>) rankElements).stream()
-                .filter(elm -> selectedChannels.contains(elm.getElement()))
-                .map(elm -> cm.lookupConfigChannel(user, elm.getElement()))
-                .collect(Collectors.toList());
-
         List<ConfigChannel> existingChannels = server.getConfigChannelList();
+        ArrayList<ConfigChannel> newChannels = new ArrayList<>(channels);
 
         if (LOWEST.equals(position)) {
             // Subscribe the new channels in the end. No re-ordering needed.
-            channels.removeAll(existingChannels);
-            if (!channels.isEmpty()) {
-                server.subscribeConfigChannels(channels, user);
+            newChannels.removeAll(existingChannels);
+            if (!newChannels.isEmpty()) {
+                server.subscribeConfigChannels(newChannels, user);
+                server.storeConfigChannels();
                 return true;
             }
         }
@@ -186,12 +187,13 @@ public class SubscribeConfirm extends RhnAction {
             // Previously subscribed channels to append in the end,
             // or nothing in case of REPLACE
             if (HIGHEST.equals(position)) {
-                channels.addAll(existingChannels);
+                newChannels.addAll(existingChannels);
             }
 
-            if (!channels.equals(existingChannels)) {
+            if (!newChannels.equals(existingChannels)) {
                 // Replace config channel subscriptions with the new list
-                server.setConfigChannels(channels, user);
+                server.setConfigChannels(newChannels, user);
+                server.storeConfigChannels();
                 return true;
             }
         }

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/ssm/UnsubscribeConfirmAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/ssm/UnsubscribeConfirmAction.java
@@ -26,7 +26,7 @@ import com.redhat.rhn.manager.configuration.ConfigurationManager;
  */
 public class UnsubscribeConfirmAction extends BaseListAction {
 
-    /**
+    /*
      * {@inheritDoc}
      */
     protected DataResult getDataResult(RequestContext rctxIn, PageControl pcIn) {

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/ssm/UnsubscribeConfirmSubmitAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/ssm/UnsubscribeConfirmSubmitAction.java
@@ -14,21 +14,19 @@
  */
 package com.redhat.rhn.frontend.action.configuration.ssm;
 
-import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.domain.config.ConfigChannel;
 import com.redhat.rhn.domain.rhnset.RhnSet;
 import com.redhat.rhn.domain.rhnset.RhnSetElement;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.action.configuration.ConfigActionHelper;
-import com.redhat.rhn.frontend.dto.ConfigSystemDto;
 import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.frontend.struts.RhnListDispatchAction;
 import com.redhat.rhn.manager.configuration.ConfigurationManager;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 import com.redhat.rhn.manager.rhnset.RhnSetManager;
-import com.redhat.rhn.manager.system.SystemManager;
 
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
@@ -76,37 +74,30 @@ public class UnsubscribeConfirmSubmitAction extends RhnListDispatchAction {
         User user = new RequestContext(request).getCurrentUser();
         RhnSet channelSet = RhnSetDecl.CONFIG_CHANNELS.get(user);
         ConfigurationManager cm = ConfigurationManager.getInstance();
-        DataResult systemSet = cm.ssmSystemListForChannels(user, null);
 
-        //go through each system in the set
-        for (Object oIn : systemSet) {
-            Long sid = ((ConfigSystemDto) oIn).getId();
-            Server server;
+        List<ConfigChannel> configChannelList = new ArrayList<>();
+        for (RhnSetElement ch : channelSet.getElements()) {
             try {
-                server = SystemManager.lookupByIdAndUser(sid, user);
+                configChannelList.add(cm.lookupConfigChannel(user, ch.getElement()));
             }
-            catch (LookupException e) {
-                continue; //skip this element
+            catch (LookupException ignored) {
+                // Ignore non-existing channels to remove: shouldn't happen
             }
-
-            List<ConfigChannel> configChannelList = new ArrayList<>();
-            for (RhnSetElement ch : channelSet.getElements()) {
-                try {
-                    configChannelList.add(cm.lookupConfigChannel(user, ch.getElement()));
-                }
-                catch (LookupException ignored) {
-                }
-            }
-
-            server.unsubscribeConfigChannels(configChannelList, user);
         }
+
+        List<Server> systems = ServerFactory.getSsmSystemsForSubscribe(user);
+
+        systems.forEach(server -> {
+            server.unsubscribeConfigChannels(configChannelList, user);
+            server.storeConfigChannels();
+        });
 
         RhnSetManager.remove(channelSet); //clear the set
         //now that we have unsubscribed from channels, these other sets may
         //no longer be valid, so delete them too.
         ConfigActionHelper.clearRhnSets(user);
 
-        createMessage(request, systemSet.size() == 1);
+        createMessage(request, systems.size() == 1);
         return mapping.findForward("success");
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/ssm/test/SubscribeConfirmTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/ssm/test/SubscribeConfirmTest.java
@@ -28,6 +28,7 @@ import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 import com.redhat.rhn.testing.ConfigTestUtils;
 import com.redhat.rhn.testing.RhnMockStrutsTestCase;
 import com.redhat.rhn.testing.ServerTestUtils;
+import com.redhat.rhn.testing.TestUtils;
 
 import org.junit.jupiter.api.Test;
 
@@ -110,6 +111,10 @@ public class SubscribeConfirmTest extends RhnMockStrutsTestCase {
         channelRanking.addElement(channel1.getId(), 3L);
         RhnSetFactory.save(channelRanking);
 
+        TestUtils.flushAndEvict(server1);
+        TestUtils.flushAndEvict(server2);
+        TestUtils.flushAndEvict(server3);
+
         // Send confirm request
         setRequestPathInfo("/systems/ssm/config/SubscribeConfirm");
         addDispatchCall("ssm.config.subscribeconfirm.jsp.confirm");
@@ -127,10 +132,9 @@ public class SubscribeConfirmTest extends RhnMockStrutsTestCase {
         List<ConfigChannel> srv2Expected = Arrays.asList(channel3, channel2, channel4);
         List<ConfigChannel> srv3Expected = Arrays.asList(channel2, channel4, channel3);
 
-        // Assert channel counts
-        assertEquals(srv1Expected.size(), server1.getConfigChannelCount());
-        assertEquals(srv2Expected.size(), server2.getConfigChannelCount());
-        assertEquals(srv3Expected.size(), server3.getConfigChannelCount());
+        server1 = ServerFactory.lookupById(server1.getId());
+        server2 = ServerFactory.lookupById(server2.getId());
+        server3 = ServerFactory.lookupById(server3.getId());
 
         // Assert channel order
         assertEquals(srv1Expected, server1.getConfigChannelList());
@@ -198,6 +202,10 @@ public class SubscribeConfirmTest extends RhnMockStrutsTestCase {
         channelRanking.addElement(channel1.getId(), 3L);
         RhnSetFactory.save(channelRanking);
 
+        TestUtils.flushAndEvict(server1);
+        TestUtils.flushAndEvict(server2);
+        TestUtils.flushAndEvict(server3);
+
         // Send confirm request
         setRequestPathInfo("/systems/ssm/config/SubscribeConfirm");
         addDispatchCall("ssm.config.subscribeconfirm.jsp.confirm");
@@ -215,10 +223,9 @@ public class SubscribeConfirmTest extends RhnMockStrutsTestCase {
         List<ConfigChannel> srv2Expected = Arrays.asList(channel4, channel3, channel2);
         List<ConfigChannel> srv3Expected = Arrays.asList(channel2, channel4, channel3);
 
-        // Assert channel counts
-        assertEquals(srv1Expected.size(), server1.getConfigChannelCount());
-        assertEquals(srv2Expected.size(), server2.getConfigChannelCount());
-        assertEquals(srv3Expected.size(), server3.getConfigChannelCount());
+        server1 = ServerFactory.lookupById(server1.getId());
+        server2 = ServerFactory.lookupById(server2.getId());
+        server3 = ServerFactory.lookupById(server3.getId());
 
         // Assert channel order
         assertEquals(srv1Expected, server1.getConfigChannelList());
@@ -285,6 +292,10 @@ public class SubscribeConfirmTest extends RhnMockStrutsTestCase {
         channelRanking.addElement(channel3.getId(), 2L);
         RhnSetFactory.save(channelRanking);
 
+        TestUtils.flushAndEvict(server1);
+        TestUtils.flushAndEvict(server2);
+        TestUtils.flushAndEvict(server3);
+
         // Send confirm request
         setRequestPathInfo("/systems/ssm/config/SubscribeConfirm");
         addDispatchCall("ssm.config.subscribeconfirm.jsp.confirm");
@@ -302,10 +313,9 @@ public class SubscribeConfirmTest extends RhnMockStrutsTestCase {
         List<ConfigChannel> srv2Expected = Arrays.asList(channel2, channel4, channel3);
         List<ConfigChannel> srv3Expected = Arrays.asList(channel2, channel4, channel3);
 
-        // Assert channel counts
-        assertEquals(srv1Expected.size(), server1.getConfigChannelCount());
-        assertEquals(srv2Expected.size(), server2.getConfigChannelCount());
-        assertEquals(srv3Expected.size(), server3.getConfigChannelCount());
+        server1 = ServerFactory.lookupById(server1.getId());
+        server2 = ServerFactory.lookupById(server2.getId());
+        server3 = ServerFactory.lookupById(server3.getId());
 
         // Assert channel order
         assertEquals(srv1Expected, server1.getConfigChannelList());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/XmlRpcSystemHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/XmlRpcSystemHelper.java
@@ -16,6 +16,7 @@ package com.redhat.rhn.frontend.xmlrpc.system;
 
 import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.xmlrpc.BootstrapException;
 import com.redhat.rhn.frontend.xmlrpc.NoSuchSystemException;
@@ -94,6 +95,27 @@ public class XmlRpcSystemHelper {
         try {
             return SystemManager.lookupByServerIdsAndUser(
                     serverIds.stream().map(Number::longValue).collect(Collectors.toList()), user.getId());
+        }
+        catch (LookupException e) {
+            throw new NoSuchSystemException("No such systems found for user: " + user.getId());
+        }
+    }
+
+    /**
+     * Fast helper method to lookup a bunch of servers from a list of server ids optimized for channels subscriptions,
+     * and throws a FaultException if the server cannot be found.
+     *
+     * @param user The user looking up the server
+     * @param serverIds The ids of the servers we're looking for
+     * @return Returns a list of server corresponding to provided server id
+     * @throws NoSuchSystemException A NoSuchSystemException is thrown if the server
+     * corresponding to sid cannot be found.
+     */
+    public List<Server> lookupServersForSubscribe(User user, List<? extends Number> serverIds)
+            throws NoSuchSystemException {
+        try {
+            return ServerFactory.getSystemsForSubscribe(
+                    serverIds.stream().map(Number::longValue).collect(Collectors.toList()), user);
         }
         catch (LookupException e) {
             throw new NoSuchSystemException("No such systems found for user: " + user.getId());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/ServerConfigHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/ServerConfigHandler.java
@@ -555,13 +555,18 @@ public class ServerConfigHandler extends BaseHandler {
      */
     public int setChannels(User loggedInUser, List<Number> sids,
             List<String> configChannelLabels) {
-        List<Server> servers = xmlRpcSystemHelper.lookupServers(loggedInUser, sids);
+        List<Server> servers = xmlRpcSystemHelper.lookupServersForSubscribe(loggedInUser, sids);
         XmlRpcConfigChannelHelper configHelper =
                 XmlRpcConfigChannelHelper.getInstance();
         List<ConfigChannel> channels = configHelper.
                 lookupGlobals(loggedInUser, configChannelLabels);
 
-        servers.forEach(s -> s.setConfigChannels(channels, loggedInUser));
+        servers.forEach(s -> {
+            if (!channels.equals(s.getConfigChannelList())) {
+                s.setConfigChannels(channels, loggedInUser);
+                s.storeConfigChannels();
+            }
+        });
         return 1;
     }
 
@@ -583,7 +588,7 @@ public class ServerConfigHandler extends BaseHandler {
      */
     public int removeChannels(User loggedInUser, List<Number> sids,
             List<String> configChannelLabels) {
-        List<Server> servers = xmlRpcSystemHelper.lookupServers(loggedInUser, sids);
+        List<Server> servers = xmlRpcSystemHelper.lookupServersForSubscribe(loggedInUser, sids);
         XmlRpcConfigChannelHelper configHelper =
                 XmlRpcConfigChannelHelper.getInstance();
         List<ConfigChannel> channels = configHelper.
@@ -593,7 +598,12 @@ public class ServerConfigHandler extends BaseHandler {
         int channelCount = configChannelLabels.size();
         int[] countsExpected = servers.stream().mapToInt(s -> s.getConfigChannelCount() - channelCount).toArray();
 
-        servers.forEach(s -> s.unsubscribeConfigChannels(channels, loggedInUser));
+        servers.forEach(s -> {
+            if (channels.stream().anyMatch(ch -> s.getConfigChannelList().contains(ch))) {
+                s.unsubscribeConfigChannels(channels, loggedInUser);
+                s.storeConfigChannels();
+            }
+        });
 
         int[] countsActual = servers.stream().mapToInt(Server::getConfigChannelCount).toArray();
         return Arrays.equals(countsExpected, countsActual) ? 1 : 0;

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/ServerConfigHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/ServerConfigHandler.java
@@ -496,7 +496,7 @@ public class ServerConfigHandler extends BaseHandler {
      */
     public int addChannels(User loggedInUser, List<Number> sids, List<String> configChannelLabels,
                            Boolean addToTop) {
-        List<Server> servers = xmlRpcSystemHelper.lookupServers(loggedInUser, sids);
+        List<Server> servers = xmlRpcSystemHelper.lookupServersForSubscribe(loggedInUser, sids);
         XmlRpcConfigChannelHelper configHelper = XmlRpcConfigChannelHelper.getInstance();
         List<ConfigChannel> channels = configHelper.lookupGlobals(loggedInUser, configChannelLabels);
 
@@ -509,6 +509,10 @@ public class ServerConfigHandler extends BaseHandler {
 
         List<ConfigChannel> channelsToAdd;
         for (Server server : servers) {
+            // No need to do anything if we have to add exactly what is already set on the server
+            if (channels.equals(server.getConfigChannelList())) {
+                continue;
+            }
             if (addToTop) {
                 // Add the existing subscriptions to the end so they will be resubscribed
                 // and their ranks will be overridden
@@ -522,6 +526,7 @@ public class ServerConfigHandler extends BaseHandler {
             }
 
             server.subscribeConfigChannels(channelsToAdd, loggedInUser);
+            server.storeConfigChannels();
         }
 
         return 1;

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/ServerConfigHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/ServerConfigHandler.java
@@ -513,7 +513,7 @@ public class ServerConfigHandler extends BaseHandler {
                 // Add the existing subscriptions to the end so they will be resubscribed
                 // and their ranks will be overridden
                 channelsToAdd = Stream
-                        .concat(channels.stream(), server.getConfigChannelStream())
+                        .concat(channels.stream(), server.getConfigChannelStream().filter(c -> !channels.contains(c)))
                         .collect(Collectors.toList());
             }
             else {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/test/ServerConfigHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/test/ServerConfigHandlerTest.java
@@ -78,6 +78,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * SystemConfigHandlerTest
@@ -182,9 +184,79 @@ public class ServerConfigHandlerTest extends BaseHandlerTestCase {
         }
     }
 
+    @Test
+    public void testConfigAddChannelToTop() {
+        // Create  global config channels
+        ConfigChannel gcc1 = ConfigTestUtils.createConfigChannel(admin.getOrg(), ConfigChannelType.normal());
+        ConfigChannel gcc2 = ConfigTestUtils.createConfigChannel(admin.getOrg(), ConfigChannelType.normal());
+
+        Server srv1 = ServerFactoryTest.createTestServer(regular, true);
+
+        List<Number> serverIds = List.of(srv1.getId());
+
+        List<ConfigChannel> channels = List.of(gcc1, gcc2);
+
+        srv1.setConfigChannels(List.of(gcc2), regular);
+
+        //test add channels
+        handler.addChannels(admin, serverIds,
+                Stream.of(gcc1).map(cc -> cc.getLabel()).collect(Collectors.toList()), true);
+
+        TestUtils.saveAndFlush(srv1);
+        HibernateFactory.getSession().detach(srv1);
+
+        assertEquals(channels, handler.listChannels(regular, srv1.getId().intValue()));
+    }
 
     @Test
-    public void testConfigChannels() throws Exception {
+    public void testConfigSetChannels() {
+        // Create  global config channels
+        ConfigChannel gcc1 = ConfigTestUtils.createConfigChannel(admin.getOrg(), ConfigChannelType.normal());
+        ConfigChannel gcc2 = ConfigTestUtils.createConfigChannel(admin.getOrg(), ConfigChannelType.normal());
+
+        Server srv1 = ServerFactoryTest.createTestServer(regular, true);
+
+        List<Number> serverIds = List.of(srv1.getId());
+
+        List<ConfigChannel> channels = List.of(gcc1, gcc2);
+
+        List<String> channelLabels = channels.stream().map(cc -> cc.getLabel()).collect(Collectors.toList());
+
+        //test set channels
+        handler.setChannels(admin, serverIds, channelLabels);
+
+        TestUtils.saveAndFlush(srv1);
+        HibernateFactory.getSession().detach(srv1);
+
+        assertEquals(channels, handler.listChannels(regular, srv1.getId().intValue()));
+    }
+
+    @Test
+    public void testConfigAddChannelsToBottom() {
+        // Create  global config channels
+        ConfigChannel gcc1 = ConfigTestUtils.createConfigChannel(admin.getOrg(), ConfigChannelType.normal());
+        ConfigChannel gcc2 = ConfigTestUtils.createConfigChannel(admin.getOrg(), ConfigChannelType.normal());
+
+        Server srv1 = ServerFactoryTest.createTestServer(regular, true);
+
+        List<Number> serverIds = List.of(srv1.getId());
+
+        List<ConfigChannel> channels = List.of(gcc1, gcc2);
+
+        srv1.setConfigChannels(List.of(gcc1), regular);
+
+        //test add channels
+        handler.addChannels(admin, serverIds,
+                Stream.of(gcc2).map(cc -> cc.getLabel()).collect(Collectors.toList()), false);
+
+        TestUtils.saveAndFlush(srv1);
+        HibernateFactory.getSession().detach(srv1);
+
+        assertEquals(channels, handler.listChannels(regular, srv1.getId().intValue()));
+    }
+
+    @Test
+    public void testConfigChannelRemove() {
         // Create  global config channels
         ConfigChannel gcc1 = ConfigTestUtils.createConfigChannel(admin.getOrg(),
                 ConfigChannelType.normal());
@@ -193,50 +265,44 @@ public class ServerConfigHandlerTest extends BaseHandlerTestCase {
 
         Server srv1 = ServerFactoryTest.createTestServer(regular, true);
 
-        List<Number> serverIds = new LinkedList<>();
-        serverIds.add(srv1.getId());
+        List<Number> serverIds = List.of(srv1.getId());
 
-        List<ConfigChannel> channels = new LinkedList<>();
-        channels.add(gcc1);
-        channels.add(gcc2);
+        List<ConfigChannel> channels = List.of(gcc1, gcc2);
+        List<String> channelLabels = channels.stream()
+                .map(cc -> cc.getLabel())
+                .collect(Collectors.toList());
 
-        List<String> channelLabels = new LinkedList<>();
-        for (ConfigChannel cc : channels) {
-            channelLabels.add(cc.getLabel());
-        }
-        handler.setChannels(admin, serverIds, channelLabels);
-        List<ConfigChannel> actual = handler.listChannels(regular,
-                                    srv1.getId().intValue());
-        assertEquals(channels, actual);
+        srv1.setConfigChannels(channels, regular);
 
-        handler.removeChannels(admin, serverIds,
-                                                channelLabels.subList(0, 1));
-        actual = handler.listChannels(regular,
-                                            srv1.getId().intValue());
-        assertEquals(channels.subList(1, channels.size()), actual);
+        assertEquals(1, handler.removeChannels(admin, serverIds, channelLabels));
 
-        //test add channels
-        handler.addChannels(admin, serverIds, channelLabels.subList(0, 1), true);
-        actual = handler.listChannels(regular,
-                srv1.getId().intValue());
-        assertEquals(channels, actual);
+        TestUtils.reload(srv1);
 
-        assertEquals(1,  handler.removeChannels(admin, serverIds,
-                                    channelLabels.subList(1, channelLabels.size())));
-        assertEquals(1,
-                handler.addChannels(admin, serverIds, channelLabels.subList(1,
-                                                        channelLabels.size()), false));
-        actual = handler.listChannels(regular, srv1.getId().intValue());
-        assertEquals(channels, actual);
+        assertEquals(0, handler.listChannels(admin, srv1.getId().intValue()).size());
+    }
+
+    @Test
+    public void testConfigChannelsRemoveNonExistingConfigChannels() {
+        // Create  global config channels
+        ConfigChannel gcc1 = ConfigTestUtils.createConfigChannel(admin.getOrg(),
+                ConfigChannelType.normal());
+        ConfigChannel gcc2 = ConfigTestUtils.createConfigChannel(admin.getOrg(),
+                ConfigChannelType.normal());
+
+        Server srv1 = ServerFactoryTest.createTestServer(regular, true);
+
+        List<Number> serverIds = List.of(srv1.getId());
+
+        srv1.setConfigChannels(List.of(gcc2), regular);
 
         // Test removing nonexisting channels
-        handler.removeChannels(admin, serverIds, channelLabels.subList(0, 1));
-        assertEquals(0, handler.removeChannels(admin, serverIds, channelLabels));
+        assertEquals(0, handler.removeChannels(admin, serverIds, List.of(gcc1.getLabel(), gcc2.getLabel())));
+
+        TestUtils.reload(srv1);
 
         // The other channel is removed even though the result is 0
         assertEquals(0, handler.listChannels(admin, srv1.getId().intValue()).size());
     }
-
 
     private ConfigRevision createRevision(String path, String contents,
             String group, String owner,

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Don't add the same channel twice in the System config addChannel API (bsc#1204029)
 - Improved taskomatic error logging
 - Optimize action chain processing on job return event (bsc#1203532)
 - Re-calculate salt event queue numbers on restart

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Optimize performance of config channels operations for UI and API (bsc#1204029)
 - Don't add the same channel twice in the System config addChannel API (bsc#1204029)
 - Improved taskomatic error logging
 - Optimize action chain processing on job return event (bsc#1203532)

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Fix dict_keys not supporting indexing in systems_setconfigchannelorger
 - Added a warning message for traditional stack deprecation
 - Remove "Undefined return code" from debug messages (bsc#1203283)
 - Update translation strings

--- a/spacecmd/src/spacecmd/system.py
+++ b/spacecmd/src/spacecmd/system.py
@@ -1725,7 +1725,8 @@ def do_system_setconfigchannelorder(self, args):
 
     # use the systems listed in the SSM
     if re.match('ssm', args[0], re.I):
-        systems = self.ssm.keys()
+        systems = list(self.ssm.keys())
+        args.pop(0)
     else:
         systems = self.expand_systems(args.pop(0))
 


### PR DESCRIPTION
## What does this PR change?

When calling `spacecmd -d -- system_addconfigchannels` with a channel that is already present on a system we have a failure with this error in the log:

```
Caused by: org.postgresql.util.PSQLException: ERROR: duplicate key value violates unique constraint "suse_state_rev_id_cfgchn_id_uq"
  Detail: Key (state_revision_id, config_channel_id)=(18, 1) already exists.
```

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19187

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
