### PR TITLE
QE: Splitting image build check into two steps

### DIFF
--- a/testsuite/features/secondary/buildhost_docker_auth_registry.feature
+++ b/testsuite/features/secondary/buildhost_docker_auth_registry.feature
@@ -37,7 +37,8 @@ Feature: Build image with authenticated registry
     And I click on "submit-btn"
     Then I wait until I see "auth_registry_profile" text
     # Verify the status of images in the authenticated image store
-    When I wait at most 660 seconds until image "auth_registry_profile" with version "latest" is built and inspected successfully via API
+    When I wait at most 600 seconds until image "auth_registry_profile" with version "latest" is built successfully via API
+    When I wait at most 300 seconds until image "auth_registry_profile" with version "latest" is inspected successfully via API
     And I refresh the page
     Then table row for "auth_registry_profile" should contain "1"
     And the list of packages of image "auth_registry_profile" with version "latest" is not empty

--- a/testsuite/features/secondary/buildhost_docker_auth_registry.feature
+++ b/testsuite/features/secondary/buildhost_docker_auth_registry.feature
@@ -38,7 +38,7 @@ Feature: Build image with authenticated registry
     Then I wait until I see "auth_registry_profile" text
     # Verify the status of images in the authenticated image store
     When I wait at most 600 seconds until image "auth_registry_profile" with version "latest" is built successfully via API
-    When I wait at most 300 seconds until image "auth_registry_profile" with version "latest" is inspected successfully via API
+    And I wait at most 300 seconds until image "auth_registry_profile" with version "latest" is inspected successfully via API
     And I refresh the page
     Then table row for "auth_registry_profile" should contain "1"
     And the list of packages of image "auth_registry_profile" with version "latest" is not empty

--- a/testsuite/features/secondary/buildhost_docker_build_image.feature
+++ b/testsuite/features/secondary/buildhost_docker_build_image.feature
@@ -62,10 +62,10 @@ Feature: Build container images
     # We should see the same result via API.
     # Also, check that all inspect actions are finished:
     And I wait at most 600 seconds until image "suse_key" with version "latest" is built successfully via API
-    And I wait at most 300 seconds until image "suse_key" with version "latest" is inspected successfully via API
     And I wait at most 600 seconds until image "suse_simple" with version "latest" is built successfully via API
-    And I wait at most 300 seconds until image "suse_simple" with version "latest" is inspected successfully via API
     And I wait at most 600 seconds until image "suse_real_key" with version "latest" is built successfully via API
+    And I wait at most 300 seconds until image "suse_key" with version "latest" is inspected successfully via API
+    And I wait at most 300 seconds until image "suse_simple" with version "latest" is inspected successfully via API
     And I wait at most 300 seconds until image "suse_real_key" with version "latest" is inspected successfully via API
     Then the list of packages of image "suse_key" with version "latest" is not empty
     And the list of packages of image "suse_simple" with version "latest" is not empty
@@ -75,8 +75,8 @@ Feature: Build container images
     When I schedule the build of image "suse_key" with version "Latest_key-activation1" via API calls
     And I schedule the build of image "suse_simple" with version "Latest_simple" via API calls
     And I wait at most 600 seconds until image "suse_simple" with version "Latest_simple" is built successfully via API
-    And I wait at most 300 seconds until image "suse_simple" with version "Latest_simple" is inspected successfully via API
     And I wait at most 600 seconds until image "suse_key" with version "Latest_key-activation1" is built successfully via API
+    And I wait at most 300 seconds until image "suse_simple" with version "Latest_simple" is inspected successfully via API
     And I wait at most 300 seconds until image "suse_key" with version "Latest_key-activation1" is inspected successfully via API
     Then the list of packages of image "suse_key" with version "Latest_key-activation1" is not empty
     And the list of packages of image "suse_simple" with version "Latest_simple" is not empty
@@ -91,8 +91,8 @@ Feature: Build container images
     When I schedule the build of image "suse_simple" with version "Latest_simple" via API calls
     And I schedule the build of image "suse_key" with version "Latest_key-activation1" via API calls
     And I wait at most 600 seconds until image "suse_key" with version "Latest_key-activation1" is built successfully via API
-    And I wait at most 300 seconds until image "suse_key" with version "Latest_key-activation1" is inspected successfully via API
     And I wait at most 600 seconds until image "suse_simple" with version "Latest_simple" is built successfully via API
+    And I wait at most 300 seconds until image "suse_key" with version "Latest_key-activation1" is inspected successfully via API
     And I wait at most 300 seconds until image "suse_simple" with version "Latest_simple" is inspected successfully via API
     Then the list of packages of image "suse_key" with version "Latest_key-activation1" is not empty
     And the list of packages of image "suse_simple" with version "Latest_simple" is not empty

--- a/testsuite/features/secondary/buildhost_docker_build_image.feature
+++ b/testsuite/features/secondary/buildhost_docker_build_image.feature
@@ -50,36 +50,45 @@ Feature: Build container images
     And I enter "Docker/serverhost" relative to profiles as "path"
     And I click on "create-btn"
 
-  Scenario: Build the images with and without activation key
+  Scenario: Build the suse_key image with and without activation key
     Given I am on the Systems overview page of this "build_host"
     When I schedule the build of image "suse_key" via API calls
     And I wait at most 660 seconds until event "Image Build suse_key scheduled by admin" is completed
-    And I schedule the build of image "suse_simple" via API calls
-    And I wait at most 660 seconds until event "Image Build suse_simple scheduled by admin" is completed
-    And I schedule the build of image "suse_real_key" via API calls
-    And I wait at most 660 seconds until event "Image Build suse_real_key scheduled by admin" is completed
-    And I wait at most 60 seconds until all "3" container images are built correctly on the Image List page
     # We should see the same result via API.
     # Also, check that all inspect actions are finished:
     And I wait at most 600 seconds until image "suse_key" with version "latest" is built successfully via API
-    And I wait at most 600 seconds until image "suse_simple" with version "latest" is built successfully via API
-    And I wait at most 600 seconds until image "suse_real_key" with version "latest" is built successfully via API
     And I wait at most 300 seconds until image "suse_key" with version "latest" is inspected successfully via API
-    And I wait at most 300 seconds until image "suse_simple" with version "latest" is inspected successfully via API
-    And I wait at most 300 seconds until image "suse_real_key" with version "latest" is inspected successfully via API
     Then the list of packages of image "suse_key" with version "latest" is not empty
-    And the list of packages of image "suse_simple" with version "latest" is not empty
-    And the list of packages of image "suse_real_key" with version "latest" is not empty
 
-  Scenario: Build same images with different versions
+
+  Scenario: Build the suse_simple image with and without activation key
+    Given I am on the Systems overview page of this "build_host"
+    When I schedule the build of image "suse_simple" via API calls
+    And I wait at most 660 seconds until event "Image Build suse_simple scheduled by admin" is completed
+    And I wait at most 600 seconds until image "suse_simple" with version "latest" is built successfully via API
+    And I wait at most 300 seconds until image "suse_simple" with version "latest" is inspected successfully via API
+    Then the list of packages of image "suse_simple" with version "latest" is not empty
+
+  Scenario: Build the suse_real_key image with and without activation key
+    Given I am on the Systems overview page of this "build_host"  
+    When I schedule the build of image "suse_real_key" via API calls
+    And I wait at most 660 seconds until event "Image Build suse_real_key scheduled by admin" is completed
+    And I wait at most 60 seconds until all "3" container images are built correctly on the Image List page
+    And I wait at most 600 seconds until image "suse_real_key" with version "latest" is built successfully via API
+    And I wait at most 300 seconds until image "suse_real_key" with version "latest" is inspected successfully via API
+    Then the list of packages of image "suse_real_key" with version "latest" is not empty
+
+  Scenario: Build suse_key images with different versions
     When I schedule the build of image "suse_key" with version "Latest_key-activation1" via API calls
-    And I schedule the build of image "suse_simple" with version "Latest_simple" via API calls
-    And I wait at most 600 seconds until image "suse_simple" with version "Latest_simple" is built successfully via API
     And I wait at most 600 seconds until image "suse_key" with version "Latest_key-activation1" is built successfully via API
-    And I wait at most 300 seconds until image "suse_simple" with version "Latest_simple" is inspected successfully via API
     And I wait at most 300 seconds until image "suse_key" with version "Latest_key-activation1" is inspected successfully via API
     Then the list of packages of image "suse_key" with version "Latest_key-activation1" is not empty
-    And the list of packages of image "suse_simple" with version "Latest_simple" is not empty
+  
+  Scenario: Build suse_simple image with different versions
+    When I schedule the build of image "suse_simple" with version "Latest_simple" via API calls
+    And I wait at most 600 seconds until image "suse_simple" with version "Latest_simple" is built successfully via API
+    And I wait at most 300 seconds until image "suse_simple" with version "Latest_simple" is inspected successfully via API
+    Then the list of packages of image "suse_simple" with version "Latest_simple" is not empty
 
   Scenario: Delete image via API calls
     When I delete the image "suse_key" with version "Latest_key-activation1" via API calls
@@ -87,15 +96,17 @@ Feature: Build container images
     Then the image "suse_simple" with version "Latest_key-activation1" doesn't exist via API calls
     And the image "suse_simple" with version "Latest_simple" doesn't exist via API calls
 
-  Scenario: Rebuild the images
+  Scenario: Rebuild suse_simple image
     When I schedule the build of image "suse_simple" with version "Latest_simple" via API calls
-    And I schedule the build of image "suse_key" with version "Latest_key-activation1" via API calls
-    And I wait at most 600 seconds until image "suse_key" with version "Latest_key-activation1" is built successfully via API
     And I wait at most 600 seconds until image "suse_simple" with version "Latest_simple" is built successfully via API
-    And I wait at most 300 seconds until image "suse_key" with version "Latest_key-activation1" is inspected successfully via API
     And I wait at most 300 seconds until image "suse_simple" with version "Latest_simple" is inspected successfully via API
+    Then the list of packages of image "suse_simple" with version "Latest_simple" is not empty
+
+  Scenario: Rebuild suse_key image
+    When I schedule the build of image "suse_key" with version "Latest_key-activation1" via API calls
+    And I wait at most 600 seconds until image "suse_key" with version "Latest_key-activation1" is built successfully via API
+    And I wait at most 300 seconds until image "suse_key" with version "Latest_key-activation1" is inspected successfully via API
     Then the list of packages of image "suse_key" with version "Latest_key-activation1" is not empty
-    And the list of packages of image "suse_simple" with version "Latest_simple" is not empty
 
   Scenario: Build an image via the GUI
     When I follow the left menu "Images > Build"

--- a/testsuite/features/secondary/buildhost_docker_build_image.feature
+++ b/testsuite/features/secondary/buildhost_docker_build_image.feature
@@ -61,9 +61,12 @@ Feature: Build container images
     And I wait at most 60 seconds until all "3" container images are built correctly on the Image List page
     # We should see the same result via API.
     # Also, check that all inspect actions are finished:
-    And I wait at most 660 seconds until image "suse_key" with version "latest" is built and inspected successfully via API
-    And I wait at most 660 seconds until image "suse_simple" with version "latest" is built and inspected successfully via API
-    And I wait at most 660 seconds until image "suse_real_key" with version "latest" is built and inspected successfully via API
+    And I wait at most 600 seconds until image "suse_key" with version "latest" is built successfully via API
+    And I wait at most 300 seconds until image "suse_key" with version "latest" is inspected successfully via API
+    And I wait at most 600 seconds until image "suse_simple" with version "latest" is built successfully via API
+    And I wait at most 300 seconds until image "suse_simple" with version "latest" is inspected successfully via API
+    And I wait at most 600 seconds until image "suse_real_key" with version "latest" is built successfully via API
+    And I wait at most 300 seconds until image "suse_real_key" with version "latest" is inspected successfully via API
     Then the list of packages of image "suse_key" with version "latest" is not empty
     And the list of packages of image "suse_simple" with version "latest" is not empty
     And the list of packages of image "suse_real_key" with version "latest" is not empty
@@ -71,8 +74,10 @@ Feature: Build container images
   Scenario: Build same images with different versions
     When I schedule the build of image "suse_key" with version "Latest_key-activation1" via API calls
     And I schedule the build of image "suse_simple" with version "Latest_simple" via API calls
-    And I wait at most 660 seconds until image "suse_simple" with version "Latest_simple" is built and inspected successfully via API
-    And I wait at most 660 seconds until image "suse_key" with version "Latest_key-activation1" is built and inspected successfully via API
+    And I wait at most 600 seconds until image "suse_simple" with version "Latest_simple" is built successfully via API
+    And I wait at most 300 seconds until image "suse_simple" with version "Latest_simple" is inspected successfully via API
+    And I wait at most 600 seconds until image "suse_key" with version "Latest_key-activation1" is built successfully via API
+    And I wait at most 300 seconds until image "suse_key" with version "Latest_key-activation1" is inspected successfully via API
     Then the list of packages of image "suse_key" with version "Latest_key-activation1" is not empty
     And the list of packages of image "suse_simple" with version "Latest_simple" is not empty
 
@@ -85,8 +90,10 @@ Feature: Build container images
   Scenario: Rebuild the images
     When I schedule the build of image "suse_simple" with version "Latest_simple" via API calls
     And I schedule the build of image "suse_key" with version "Latest_key-activation1" via API calls
-    And I wait at most 660 seconds until image "suse_key" with version "Latest_key-activation1" is built and inspected successfully via API
-    And I wait at most 660 seconds until image "suse_simple" with version "Latest_simple" is built and inspected successfully via API
+    And I wait at most 600 seconds until image "suse_key" with version "Latest_key-activation1" is built successfully via API
+    And I wait at most 300 seconds until image "suse_key" with version "Latest_key-activation1" is inspected successfully via API
+    And I wait at most 600 seconds until image "suse_simple" with version "Latest_simple" is built successfully via API
+    And I wait at most 300 seconds until image "suse_simple" with version "Latest_simple" is inspected successfully via API
     Then the list of packages of image "suse_key" with version "Latest_key-activation1" is not empty
     And the list of packages of image "suse_simple" with version "Latest_simple" is not empty
 
@@ -97,7 +104,8 @@ Feature: Build container images
     And I select the hostname of "build_host" from "buildHostId"
     And I click on "submit-btn"
     Then I wait until I see "GUI_BUILT_IMAGE" text
-    And I wait at most 660 seconds until image "suse_real_key" with version "GUI_BUILT_IMAGE" is built and inspected successfully via API
+    And I wait at most 600 seconds until image "suse_real_key" with version "GUI_BUILT_IMAGE" is built successfully via API
+    And I wait at most 300 seconds until image "suse_real_key" with version "GUI_BUILT_IMAGE" is inspected successfully via API
 
   Scenario: Login as Docker image administrator and build an image
     Given I am authorized as "docker" with password "docker"
@@ -107,7 +115,8 @@ Feature: Build container images
     And I select the hostname of "build_host" from "buildHostId"
     And I click on "submit-btn"
     Then I wait until I see "GUI_DOCKERADMIN" text
-    And I wait at most 660 seconds until image "suse_real_key" with version "GUI_DOCKERADMIN" is built and inspected successfully via API
+    And I wait at most 600 seconds until image "suse_real_key" with version "GUI_DOCKERADMIN" is built successfully via API
+    And I wait at most 300 seconds until image "suse_real_key" with version "GUI_DOCKERADMIN" is inspected successfully via API
 
   Scenario: Cleanup: delete all images
     Given I am authorized as "admin" with password "admin"

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -30,7 +30,7 @@ When(/^I enter URI, username and password for registry$/) do
   )
 end
 
-When(/^I wait at most (\d+) seconds until image "([^"]*)" with version "([^"]*)" is built and inspected successfully via API$/) do |timeout, name, version|
+When(/^I wait at most (\d+) seconds until image "([^"]*)" with version "([^"]*)" is built successfully via API$/) do |timeout, name, version|
   images_list = $api_test.image.list_images
   log "List of images: #{images_list}"
   image_id = 0
@@ -45,8 +45,28 @@ When(/^I wait at most (\d+) seconds until image "([^"]*)" with version "([^"]*)"
   repeat_until_timeout(timeout: timeout.to_i, message: 'image build did not complete') do
     image_details = $api_test.image.get_details(image_id)
     log "Image Details: #{image_details}"
-    break if image_details['buildStatus'] == 'completed' && image_details['inspectStatus'] == 'completed'
+    break if image_details['buildStatus'] == 'completed'
     raise 'image build failed.' if image_details['buildStatus'] == 'failed'
+    sleep 5
+  end
+end
+
+When(/^I wait at most (\d+) seconds until image "([^"]*)" with version "([^"]*)" is inspected successfully via API$/) do |timeout, name, version|
+  images_list = $api_test.image.list_images
+  log "List of images: #{images_list}"
+  image_id = 0
+  images_list.each do |element|
+    if element['name'] == name && element['version'] == version
+      image_id = element['id']
+      break
+    end
+  end
+  raise 'unable to find the image id' if image_id.zero?
+
+  repeat_until_timeout(timeout: timeout.to_i, message: 'image inspection did not complete') do
+    image_details = $api_test.image.get_details(image_id)
+    log "Image Details: #{image_details}"
+    break if image_details['inspectStatus'] == 'completed'
     raise 'image inspect failed.' if image_details['inspectStatus'] == 'failed'
     sleep 5
   end


### PR DESCRIPTION
## What does this PR change?

Separate the step waiting for an image to be successfully built and inspected in two different steps to reduce the number of failures and better identify the potential source of failure

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
