### PR TITLE
Don't read env from ant files

### DIFF
--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -1,8 +1,6 @@
 <project name="build-props">
   <property name="rhn-home" location="." />
 
-  <property environment="env" />
-
   <property file="${user.home}/.rhn.properties" />
   <property name="src.dir" location="${rhn-home}/code" />
   <property name="build.dir" location="${rhn-home}/build" />

--- a/java/manager-build.xml
+++ b/java/manager-build.xml
@@ -208,10 +208,9 @@
   </target>
 
   <target name="is-yarn-installed">
-    <property environment="env" />
-    <available file="yarn"
-               filepath="${env.PATH}"
-               property="yarn.installed"/>
+    <exec failifexecutionfails="false" resultproperty="yarn.installed" executable="yarn">
+      <arg line="--version" />
+    </exec>
   </target>
 
   <target name="warn-if-yarn-not-installed" depends="is-yarn-installed" unless="yarn.installed">

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,3 +9,4 @@ sonar.coverage.jacoco.xmlReportPaths=java/test-results/coverage/report.xml
 sonar.tests=.
 sonar.exclusions=*.c,java/buildconf/**/*,**/*.jsp*,java/scripts/**/*,**/*.xml
 sonar.test.inclusions=testsuite/**/*,**/test/**/*,**/tests/**/*,**/*test.ts,**/*test.tsx,**/testing/**/*,java/**/*Test.java
+sonar.coverage.exclusions=branding/**/*, client/**/*, containers/**/*, contrib/**/*, documentation/**/*, out/**/*, projects/**/*, proxy/**/*, python/**/*, rel-eng/**/*, reporting/**/*, reports/**/*, schema/**/*, scripts/**/*, search-server/**/*, selinux/**/*, spacecmd/**/*, spacewalk/**/*, susemanager/**/*, susemanager-branding-oss/**/*, susemanager-frontend/**/*, susemanager-sync-data/**/*, susemanager-utils/**/*, suseRegisterInfo/**/*, testsuite/**/*, tftpsync/**/*, utils/**/*, uyuni/**/*, web/**/*


### PR DESCRIPTION
## What does this PR change?

Remove the use of `<property environment="env"/>` in ant scripts since this may break if one environment variable has a value containing `${`... happens seldomly, but still...

Also add sonarcloud config to avoid counting the non-java files in the coverage checks

## GUI diff

No difference.
- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: tooling
- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
