### PR TITLE
QE: Fix another remaining issue from trad stack removal

### DIFF
--- a/testsuite/features/secondary/allcli_action_chain.feature
+++ b/testsuite/features/secondary/allcli_action_chain.feature
@@ -9,13 +9,28 @@ Feature: Action chains on several systems at once
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
+  Scenario: Pre-requisite: Use the Test-Channel-x86_64 in Red Hat-like minion
+    Given I am on the Systems overview page of this "rhlike_minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    And I check radio button "Test-Channel-x86_64"
+    And I wait until I see "Test-Channel-x86_64 Child Channel" text
+    And I uncheck "Test-Channel-x86_64 Child Channel"
+    And I click on "Next"
+    Then I should see a "Confirm Software Channel Change" text
+    When I click on "Confirm"
+    Then I should see a "Changing the channels has been scheduled." text
+    When I follow "scheduled" in the content area
+    And I wait until I see "1 system successfully completed this action." text, refreshing the page
+
   Scenario: Pre-requisite: downgrade packages before action chain test on several systems
     When I enable repository "test_repo_rpm_pool" on this "sle_minion"
     And I enable repository "test_repo_rpm_pool" on this "rhlike_minion"
     And I remove package "andromeda-dummy" from this "rhlike_minion" without error control
     And I remove package "andromeda-dummy" from this "sle_minion" without error control
-    And I install old package "andromeda-dummy-1.0" on this "sle_minion"
-    And I install old package "andromeda-dummy-1.0" on this "rhlike_minion"
+    And I install package "andromeda-dummy-1.0" on this "sle_minion"
+    And I install package "andromeda-dummy-1.0" on this "rhlike_minion"
     And I refresh the metadata for "sle_minion"
     And I refresh the metadata for "rhlike_minion"
 
@@ -108,6 +123,20 @@ Feature: Action chains on several systems at once
   Scenario: Cleanup: remove temporary files for testing action chains on several systems
     When I run "rm /tmp/action_chain_done" on "sle_minion" without error control
     And I run "rm /tmp/action_chain_done" on "rhlike_minion" without error control
+
+  Scenario: Cleanup: Use the Test Base Channel in Red Hat-like minion
+    Given I am on the Systems overview page of this "rhlike_minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    And I check radio button "Test Base Channel"
+    And I wait until I do not see "Loading..." text
+    And I click on "Next"
+    Then I should see a "Confirm Software Channel Change" text
+    When I click on "Confirm"
+    Then I should see a "Changing the channels has been scheduled." text
+    When I follow "scheduled" in the content area
+    And I wait until I see "1 system successfully completed this action." text, refreshing the page
 
   Scenario: Cleanup: remove remaining systems from SSM after action chain tests on several systems
     When I follow "Clear"

--- a/testsuite/features/secondary/allcli_software_channels.feature
+++ b/testsuite/features/secondary/allcli_software_channels.feature
@@ -49,6 +49,9 @@ Feature: Channel subscription via SSM
     Then "1" channels should be enabled on "sle_minion"
     And channel "Test-Channel-x86_64" should be enabled on "sle_minion"
 
+  Scenario: Wait 3 minutes for the scheduled action to be executed
+    When I wait for "180" seconds
+
 @sle_minion
   Scenario: Check channel change has completed for the SLES minion
     Given I am on the Systems overview page of this "sle_minion"


### PR DESCRIPTION
## What does this PR change?

Fix another remaining issue from trad stack removal.

We need to have both sle and rh-like minion subscribed to the same channel in order to select a package to be installed. In this PR we fix this. Plus a scenario removed by mistake.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were fixed

- [x] **DONE**

## Links

NO PORTS

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
