### PR TITLE
QE: Adding ibs subfolder needed in minima mirror paths

### DIFF
--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_41/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_41/config.xml
@@ -44,7 +44,7 @@
         <source path="http://minima-mirror.mgr.prv.suse.net/SUSE/Updates/SLE-Manager-Tools/12/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">  <!-- 4.2 client tools -->
-        <source path="http://minima-mirror.mgr.prv.suse.net/Devel:/Galaxy:/Manager:/4.2:/SLE12-SUSE-Manager-Tools/SLE_12/"/>
+        <source path="http://minima-mirror.mgr.prv.suse.net/ibs/Devel:/Galaxy:/Manager:/4.2:/SLE12-SUSE-Manager-Tools/SLE_12/"/>
     </repository>
 
     <packages type="image">

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_42/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_42/config.xml
@@ -44,7 +44,7 @@
         <source path="http://minima-mirror.mgr.prv.suse.net/SUSE/Updates/SLE-Manager-Tools/12/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">  <!-- 4.2 client tools -->
-        <source path="http://minima-mirror.mgr.prv.suse.net/Devel:/Galaxy:/Manager:/4.2:/SLE12-SUSE-Manager-Tools/SLE_12/"/>
+        <source path="http://minima-mirror.mgr.prv.suse.net/ibs/Devel:/Galaxy:/Manager:/4.2:/SLE12-SUSE-Manager-Tools/SLE_12/"/>
     </repository>
 
     <packages type="image">

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_head/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_head/config.xml
@@ -44,7 +44,7 @@
         <source path="http://minima-mirror.mgr.prv.suse.net/SUSE/Updates/SLE-Manager-Tools/12/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">  <!-- head development client tools -->
-        <source path="http://minima-mirror.mgr.prv.suse.net/Devel:/Galaxy:/Manager:/Head:/SLE12-SUSE-Manager-Tools/SLE_12/"/>
+        <source path="http://minima-mirror.mgr.prv.suse.net/ibs/Devel:/Galaxy:/Manager:/Head:/SLE12-SUSE-Manager-Tools/SLE_12/"/>
     </repository>
 
     <packages type="image">

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_41/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_41/config.xml
@@ -63,7 +63,7 @@
         <source path="http://minima-mirror.mgr.prv.suse.net/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://minima-mirror.mgr.prv.suse.net/Devel:/Galaxy:/Manager:/4.2:/SLE15-SUSE-Manager-Tools/SLE_15/"/>
+        <source path="http://minima-mirror.mgr.prv.suse.net/ibs/Devel:/Galaxy:/Manager:/4.2:/SLE15-SUSE-Manager-Tools/SLE_15/"/>
     </repository>
 
     <packages type="image">

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_42/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_42/config.xml
@@ -63,7 +63,7 @@
         <source path="http://minima-mirror.mgr.prv.suse.net/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://minima-mirror.mgr.prv.suse.net/Devel:/Galaxy:/Manager:/4.2:/SLE15-SUSE-Manager-Tools/SLE_15/"/>
+        <source path="http://minima-mirror.mgr.prv.suse.net/ibs/Devel:/Galaxy:/Manager:/4.2:/SLE15-SUSE-Manager-Tools/SLE_15/"/>
     </repository>
 
     <packages type="image">

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -59,7 +59,7 @@
         <source path="http://minima-mirror.mgr.prv.suse.net/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">  <!-- head development client toools -->
-        <source path="http://minima-mirror.mgr.prv.suse.net/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/SLE_15/"/>
+        <source path="http://minima-mirror.mgr.prv.suse.net/ibs/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/SLE_15/"/>
     </repository>
 
     <packages type="image">


### PR DESCRIPTION
## What does this PR change?

Corrects some paths used in Kiwi image building in the testsuite.

**Keeping open as expecting more input on the subject**

## Links

Fixes #
Tracks # No ports

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
