### PR TITLE
CI: add wait for sync tool

### DIFF
--- a/susemanager-utils/testing/automation/wait-for-syncs.sh
+++ b/susemanager-utils/testing/automation/wait-for-syncs.sh
@@ -1,0 +1,76 @@
+#!/bin/bash +ex
+tries=60
+wait=10
+
+function usage() {
+    echo "Usage: ${0} -h host [-t tries] [-w wait]"
+    echo "host: an IP or hostname (mandatory)"
+    echo "tries: number of attempts before failing (Optional, default value is ${tries})"
+    echo "wait: number of seconds to wait between retries (Optional, default value: ${wait})"
+}
+
+while getopts ":h:t:w" o; do
+    case "${o}" in
+        h)
+            host=${OPTARG}
+            ;;
+        t)
+            tries=${OPTARG}
+            ;;
+        w)
+            wait=${OPTARG}
+            ;;
+        :)
+            echo "ERROR: Option -${OPTARG} requires an argument"
+            usage
+            exit -1
+            ;;
+        \?)
+            echo "ERROR: Invalid option -${OPTARG}"
+            usage
+            exit -2
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+if [ "${host}" == "" ]; then
+    echo "ERROR: Please specify host"
+    exit -3
+fi
+
+echo "Wait for sync to start and finish"
+i=0
+echo "Waiting for the sync to start"
+while [ ${i} -lt ${tries} ]; do
+  wget -S http://${host}/sync-obs/sync-started 2>/dev/null
+  if [ ${?} -eq 0 ]; then
+    echo "Sync started"
+    break
+  fi
+  i=$((${i}+1))
+  sleep ${wait}
+done
+if [ ${i} -eq ${tries} ]; then
+  echo "Reached max number of tries"
+  exit -4
+fi
+
+i=0
+rm -f sync-started
+echo "Waiting for the sync to end"
+while [ ${i} -lt ${tries} ]; do
+  wget -S http://${host}/sync-obs/sync-finished 2>/dev/null
+  if [ ${?} -eq 0 ];then
+    echo "Sync finished"
+    break
+  fi
+  i=$((${i}+1))
+  sleep ${wait}
+done
+if [ ${i} -eq ${tries} ]; then
+  echo "Reached max number of tries"
+  exit -5
+fi
+
+rm -f sync-finished
+


### PR DESCRIPTION
## What does this PR change?

This script is used in the CI to wait for package synchronization in the mirror.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/18522

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
