### PR TITLE
Perform refresh with packages.pkgupdate state (bsc#1203884)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/packages/pkgupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/pkgupdate.sls
@@ -3,6 +3,7 @@ include:
 
 mgr_pkg_update:
   pkg.uptodate:
+    - refresh: True
 {%- if grains['os_family'] == 'Debian' %}
     - skip_verify: {{ not pillar.get('mgr_metadata_signing_enabled', false) }}
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Perform refresh with packages.pkgupdate state (bsc#1203884)
+
 -------------------------------------------------------------------
 Wed Sep 28 11:14:52 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Add `refresh` to `packages.pkgupdate` the same way as set for `packages.pkginstall` as it could fail on updating the packages on the client if the repo was not refreshed before and has no this update in the cached repo metadata yet.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Links

Tracks https://github.com/SUSE/spacewalk/issues/19151

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
