### PR TITLE
Add speed measure plugin for Webpack

### DIFF
--- a/web/html/src/build/webpack.config.js
+++ b/web/html/src/build/webpack.config.js
@@ -4,13 +4,22 @@ const CleanWebpackPlugin = require("clean-webpack-plugin");
 const LicenseCheckerWebpackPlugin = require("license-checker-webpack-plugin");
 const webpackAlias = require("./webpack.alias");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const SpeedMeasurePlugin = require("speed-measure-webpack-plugin");
 
 const DEVSERVER_WEBSOCKET_PATHNAME = "/ws";
 
 module.exports = (env, argv) => {
   const isProductionMode = argv && argv.mode !== "development";
+  const measurePerformance = env.MEASURE_PERFORMANCE === "true";
 
-  let pluginsInUse = [
+  let pluginsInUse = [];
+
+  if (measurePerformance) {
+    pluginsInUse.push(new SpeedMeasurePlugin());
+  }
+
+  pluginsInUse = [
+    ...pluginsInUse,
     new CleanWebpackPlugin(["dist"], { root: path.resolve(__dirname, "../") }),
     new CopyWebpackPlugin([
       // Legacy scripts
@@ -48,151 +57,149 @@ module.exports = (env, argv) => {
     ];
   }
 
-  return [
-    {
-      entry: {
-        "javascript/manager/main": "./manager/index.ts",
-        "css/uyuni": path.resolve(__dirname, "../branding/css/uyuni.less"),
-        "css/susemanager-fullscreen": path.resolve(__dirname, "../branding/css/susemanager-fullscreen.less"),
-        "css/susemanager-light": path.resolve(__dirname, "../branding/css/susemanager-light.less"),
-        "css/susemanager-dark": path.resolve(__dirname, "../branding/css/susemanager-dark.less"),
-      },
-      output: {
-        filename: `[name].bundle.js`,
-        path: path.resolve(__dirname, "../dist/"),
-        chunkFilename: "javascript/manager/[name].bundle.js",
+  return {
+    entry: {
+      "javascript/manager/main": "./manager/index.ts",
+      "css/uyuni": path.resolve(__dirname, "../branding/css/uyuni.less"),
+      "css/susemanager-fullscreen": path.resolve(__dirname, "../branding/css/susemanager-fullscreen.less"),
+      "css/susemanager-light": path.resolve(__dirname, "../branding/css/susemanager-light.less"),
+      "css/susemanager-dark": path.resolve(__dirname, "../branding/css/susemanager-dark.less"),
+    },
+    output: {
+      filename: `[name].bundle.js`,
+      path: path.resolve(__dirname, "../dist/"),
+      chunkFilename: "javascript/manager/[name].bundle.js",
+      publicPath: "/",
+      hashFunction: "md5",
+    },
+    devtool: isProductionMode ? "source-map" : "eval-source-map",
+    module: {
+      rules: [
+        {
+          test: /\.(ts|js)x?$/,
+          exclude: /node_modules/,
+          use: {
+            loader: "babel-loader",
+          },
+        },
+        {
+          // Stylesheets that are imported directly by components
+          test: /(components|core|manager)\/.*\.(css|less)$/,
+          exclude: /node_modules/,
+          use: [
+            MiniCssExtractPlugin.loader,
+            {
+              loader: "css-loader",
+              options: {
+                modules: true,
+              },
+            },
+            { loader: "less-loader" },
+          ],
+        },
+        {
+          // Global stylesheets
+          test: /branding\/.*\.less$/,
+          exclude: /node_modules/,
+          use: [
+            MiniCssExtractPlugin.loader,
+            {
+              loader: "css-loader",
+              options: {
+                // NB! This is crucial, we don't consume Bootstrap etc as a module, but as a regular style
+                modules: false,
+              },
+            },
+            { loader: "less-loader" },
+          ],
+        },
+        {
+          // Stylesheets of third party dependencies
+          test: /\.css$/,
+          include: /node_modules/,
+          use: [{ loader: "style-loader" }, { loader: "css-loader" }],
+        },
+        {
+          test: /\.po$/,
+          type: "json",
+          use: {
+            loader: path.resolve(__dirname, "loaders/po-loader.js"),
+          },
+        },
+        {
+          // Assets that are imported directly by components
+          test: /\.(png|jpe?g|gif|svg)$/i,
+          type: "asset/resource",
+          generator: {
+            filename: "img/[hash][ext][query]",
+          },
+        },
+        {
+          test: /\.(eot|ttf|woff|woff2)$/i,
+          type: "asset/resource",
+          generator: {
+            filename: "fonts/[hash][ext][query]",
+          },
+        },
+      ],
+    },
+    resolve: {
+      alias: webpackAlias,
+      extensions: [".ts", ".tsx", ".js", ".jsx", ".json"],
+      symlinks: false,
+    },
+    plugins: pluginsInUse,
+    devServer: {
+      hot: true,
+      open: true,
+      static: {
+        directory: path.resolve(__dirname, "../dist"),
         publicPath: "/",
-        hashFunction: "md5",
+        // This is currently redundant, but will become relevant when we include static files in Webpack
+        watch: true,
       },
-      devtool: isProductionMode ? "source-map" : "eval-source-map",
-      module: {
-        rules: [
-          {
-            test: /\.(ts|js)x?$/,
-            exclude: /node_modules/,
-            use: {
-              loader: "babel-loader",
-            },
-          },
-          {
-            // Stylesheets that are imported directly by components
-            test: /(components|core|manager)\/.*\.(css|less)$/,
-            exclude: /node_modules/,
-            use: [
-              MiniCssExtractPlugin.loader,
-              {
-                loader: "css-loader",
-                options: {
-                  modules: true,
-                },
-              },
-              { loader: "less-loader" },
-            ],
-          },
-          {
-            // Global stylesheets
-            test: /branding\/.*\.less$/,
-            exclude: /node_modules/,
-            use: [
-              MiniCssExtractPlugin.loader,
-              {
-                loader: "css-loader",
-                options: {
-                  // NB! This is crucial, we don't consume Bootstrap etc as a module, but as a regular style
-                  modules: false,
-                },
-              },
-              { loader: "less-loader" },
-            ],
-          },
-          {
-            // Stylesheets of third party dependencies
-            test: /\.css$/,
-            include: /node_modules/,
-            use: [{ loader: "style-loader" }, { loader: "css-loader" }],
-          },
-          {
-            test: /\.po$/,
-            type: "json",
-            use: {
-              loader: path.resolve(__dirname, "loaders/po-loader.js"),
-            },
-          },
-          {
-            // Assets that are imported directly by components
-            test: /\.(png|jpe?g|gif|svg)$/i,
-            type: "asset/resource",
-            generator: {
-              filename: "img/[hash][ext][query]",
-            },
-          },
-          {
-            test: /\.(eot|ttf|woff|woff2)$/i,
-            type: "asset/resource",
-            generator: {
-              filename: "fonts/[hash][ext][query]",
-            },
-          },
-        ],
+      server: {
+        type: "https",
       },
-      resolve: {
-        alias: webpackAlias,
-        extensions: [".ts", ".tsx", ".js", ".jsx", ".json"],
-        symlinks: false,
+      client: {
+        webSocketURL: {
+          // Hardcode this so it always matches
+          pathname: DEVSERVER_WEBSOCKET_PATHNAME,
+        },
       },
-      plugins: pluginsInUse,
-      devServer: {
-        hot: true,
-        open: true,
-        static: {
-          directory: path.resolve(__dirname, "../dist"),
-          publicPath: "/",
-          // This is currently redundant, but will become relevant when we include static files in Webpack
-          watch: true,
+      // Override CORS headers for `yarn storybook`, these are not required otherwise
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+      },
+      /**
+       * The documentation isn't very good for this, but shortly we're proxying everything besides what comes out of Webpack through to the provided server
+       * See https://webpack.js.org/configuration/dev-server/#devserverproxy and https://github.com/chimurai/http-proxy-middleware#options
+       */
+      proxy: [
+        {
+          target: env && env.server,
+          // Proxy everything, including websockets, besides the Webpack updates websocket
+          context: ["!" + DEVSERVER_WEBSOCKET_PATHNAME],
+          ws: true,
+          /**
+           * Rewrite the host and port on redirects, so we stay on the proxy after logging in, logging out etc
+           * See https://github.com/http-party/node-http-proxy/issues/1227
+           */
+          autoRewrite: true,
+          changeOrigin: true,
+          // Ignore sertificate errors for dev servers
+          secure: false,
         },
-        server: {
-          type: "https",
-        },
-        client: {
-          webSocketURL: {
-            // Hardcode this so it always matches
-            pathname: DEVSERVER_WEBSOCKET_PATHNAME,
-          },
-        },
-        // Override CORS headers for `yarn storybook`, these are not required otherwise
-        headers: {
-          "Access-Control-Allow-Origin": "*",
-        },
-        /**
-         * The documentation isn't very good for this, but shortly we're proxying everything besides what comes out of Webpack through to the provided server
-         * See https://webpack.js.org/configuration/dev-server/#devserverproxy and https://github.com/chimurai/http-proxy-middleware#options
-         */
-        proxy: [
-          {
-            target: env && env.server,
-            // Proxy everything, including websockets, besides the Webpack updates websocket
-            context: ["!" + DEVSERVER_WEBSOCKET_PATHNAME],
-            ws: true,
-            /**
-             * Rewrite the host and port on redirects, so we stay on the proxy after logging in, logging out etc
-             * See https://github.com/http-party/node-http-proxy/issues/1227
-             */
-            autoRewrite: true,
-            changeOrigin: true,
-            // Ignore sertificate errors for dev servers
-            secure: false,
-          },
-        ],
-        devMiddleware: {
-          publicPath: "/",
-          // Don't write changes to disk so we can do hard reloads only on static file changes in the future
-          // TODO: Revert
-          // writeToDisk: false,
-          writeToDisk: true,
-          // Allow proxying requests to root "/" (disabled by default), see https://webpack.js.org/configuration/dev-server/#devserverproxy
-          index: false,
-        },
+      ],
+      devMiddleware: {
+        publicPath: "/",
+        // Don't write changes to disk so we can do hard reloads only on static file changes in the future
+        // TODO: Revert
+        // writeToDisk: false,
+        writeToDisk: true,
+        // Allow proxying requests to root "/" (disabled by default), see https://webpack.js.org/configuration/dev-server/#devserverproxy
+        index: false,
       },
     },
-  ];
+  };
 };

--- a/web/html/src/package.json
+++ b/web/html/src/package.json
@@ -56,7 +56,6 @@
     "path-browserify": "^1.0.1",
     "react-select-event": "^5.3.0",
     "react-styleguidist": "11.2.0",
-    "speed-measure-webpack-plugin": "^1.5.0",
     "ts-jest": "27.1.2",
     "webpack-dev-server": "4.7.3"
   },
@@ -116,6 +115,7 @@
     "regenerator-runtime": "^0.13.7",
     "senna": "^2.7.8",
     "shelljs": "0.8.5",
+    "speed-measure-webpack-plugin": "^1.5.0",
     "style-loader": "^0.23.1",
     "typescript": "4.1.2",
     "use-immer": "^0.3.0",

--- a/web/html/src/package.json
+++ b/web/html/src/package.json
@@ -11,6 +11,7 @@
     "proxy": "NODE_OPTIONS=\"--trace-warnings --trace-deprecation --unhandled-rejections=strict\"; proxy () { webpack-dev-server --mode development --config build/webpack.config.js --env server=$*; }; proxy",
     "build": "NODE_OPTIONS=\"--trace-warnings --trace-deprecation --unhandled-rejections=strict\" node build",
     "build:novalidate": "NODE_OPTIONS=\"--trace-warnings --trace-deprecation --unhandled-rejections=strict\" BUILD_VALIDATION=false node build",
+    "build:measure": "NODE_OPTIONS=\"--trace-warnings --trace-deprecation --unhandled-rejections=strict\" MEASURE_PERFORMANCE=true node build",
     "lint": "eslint . -f codeframe --fix",
     "lint:production": "NODE_ENV=production eslint . -f codeframe",
     "test": "NODE_OPTIONS=\"--trace-warnings --trace-deprecation\" BABEL_ENV=test jest",
@@ -55,6 +56,7 @@
     "path-browserify": "^1.0.1",
     "react-select-event": "^5.3.0",
     "react-styleguidist": "11.2.0",
+    "speed-measure-webpack-plugin": "^1.5.0",
     "ts-jest": "27.1.2",
     "webpack-dev-server": "4.7.3"
   },

--- a/web/html/src/yarn.lock
+++ b/web/html/src/yarn.lock
@@ -11173,6 +11173,13 @@ spdy@^4.0.2:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+speed-measure-webpack-plugin@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.5.0.tgz#caf2c5bee24ab66c1c7c30e8daa7910497f7681a"
+  integrity sha512-Re0wX5CtM6gW7bZA64ONOfEPEhwbiSF/vz6e2GvadjuaPrQcHTQdRGsD8+BE7iUOysXH8tIenkPCQBEcspXsNg==
+  dependencies:
+    chalk "^4.1.0"
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"


### PR DESCRIPTION
## What does this PR change?

Add a plugin to measure Webpack build times when needed.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: Build tooling.

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
