### PR TITLE
Exclude invalid mirror urls for reposync

### DIFF
--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -31,6 +31,7 @@ import bz2
 import lzma
 import os
 import re
+import requests
 import solv
 import subprocess
 import sys
@@ -525,6 +526,21 @@ class ContentSource:
         mirrorlist_path = os.path.join(repo.root, 'mirrorlist.txt')
         returnlist = []
         content = []
+        # If page not plaintext or xml, is not a valid mirrorlist or metalink,
+        # so continue without it.
+        proxies = get_proxies(self.proxy_url, self.proxy_user, self.proxy_pass)
+        cert = (self.sslclientcert, self.sslclientkey)
+        verify = self.sslcacert
+        try:
+            webpage = requests.get(url, proxies=proxies, cert=cert, verify=verify)
+            content_type = webpage.headers["Content-Type"]
+            if "text/plain" not in content_type and "xml" not in content_type:
+                # Not a valid mirrorlist or metalink; continue without it
+                return returnlist
+        except requests.exceptions.RequestException as exc:
+            self.error_msg("ERROR: Failed to reach repo url: {} - {}".format(url, exc))
+            return returnlist
+
         try:
             urlgrabber_opts = {}
             self.set_download_parameters(urlgrabber_opts, url, mirrorlist_path)
@@ -548,7 +564,7 @@ class ContentSource:
                 )
                 msg = msg.replace(url, repl_url)
                 log(0, msg)
-            # no mirror list found continue without
+            # no mirror list or metalink found continue without
             return returnlist
 
         def _replace_and_check_url(url_list):
@@ -562,6 +578,7 @@ class ContentSource:
                 forbidden_characters = "<>^`{|}"
                 url_is_invalid = [x for x in forbidden_characters if(x in url)]
                 if url_is_invalid:
+                    self.error_msg("Discarding invalid url: {}".format(url))
                     continue
                 try:
                     # This started throwing ValueErrors, BZ 666826

--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -555,8 +555,13 @@ class ContentSource:
             goodurls = []
             skipped = None
             for url in url_list:
-                # obvious bogons get ignored b/c, we could get more interesting checks but <shrug>
+                # obvious bogons get ignored
                 if url in ['', None]:
+                    continue
+                # Discard any urls containing some invalid characters
+                forbidden_characters = "<>^`{|}"
+                url_is_invalid = [x for x in forbidden_characters if(x in url)]
+                if url_is_invalid:
                     continue
                 try:
                     # This started throwing ValueErrors, BZ 666826

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,15 +1,10 @@
+- Exclude invalid mirror urls for reposync (bsc#1203826)
 - require python3-debian version which support new compression
   methods to sync ubuntu22-04 repositories (bsc#1205212)
 - Update system overview table in reposync
 - Keep older module metadata files in database (bsc#1201893)
 - Used the legacy reporting system in spacewalk-debug to obtain
   up-to-date information
-
--------------------------------------------------------------------
-Thu Oct 13 09:28:27 UTC 2022 - Zara Zaimeche <zara.zaimeche@suse.com>
-
-- Exclude invalid mirror urls for reposync (bsc#1203826)
-  * Ignore any mirror urls that contain forbidden characters
 
 -------------------------------------------------------------------
 Wed Sep 28 11:14:14 CEST 2022 - jgonzalez@suse.com

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -6,6 +6,12 @@
   up-to-date information
 
 -------------------------------------------------------------------
+Thu Oct 13 09:28:27 UTC 2022 - Zara Zaimeche <zara.zaimeche@suse.com>
+
+- Exclude invalid mirror urls for reposync (bsc#1203826)
+  * Ignore any mirror urls that contain forbidden characters
+
+-------------------------------------------------------------------
 Wed Sep 28 11:14:14 CEST 2022 - jgonzalez@suse.com
 
 - version 4.4.1-1


### PR DESCRIPTION
## What does this PR change?

This commit fixes bsc#1203826. Previously, reposync would treat broken urls in the list of mirrors as valid, causing it to fail. The first commit checks whether urls contain any forbidden characters, and if they do, it discards them. The second commit checks that any page used as a candidate for a mirrorlist is a plaintext or xml page.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

- [x] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
