### PR TITLE
CI: add repo and arch to wait-for-build script

### DIFF
--- a/susemanager-utils/testing/automation/wait-for-builds.sh
+++ b/susemanager-utils/testing/automation/wait-for-builds.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 usage() {
-  echo "Usage: $0 -a api -c config_file -p project -u"
+  echo "Usage: $0 -a api -c config_file -p project -u -r repo -x arch"
   echo "project is mandatory. The rest are optionals."
   echo "u option is for unlocking the package after the build has finished"
 }
@@ -10,6 +10,7 @@ api=https://api.opensuse.org
 config_file=$HOME/.oscrc
 lock="yes"
 osc_timeout="2h"
+extres=""
 
 while getopts ":a:c:p:u" o;do
     case "${o}" in
@@ -25,6 +26,12 @@ while getopts ":a:c:p:u" o;do
         u)
             lock="no"
             ;;    
+        r)
+            extres="${extres} -r ${OPTARG}"
+            ;;
+        x)
+            extres="${extres} -a ${OPTARG}"
+            ;;
         :)
             echo "ERROR: Option -$OPTARG requires an argument"
             ;;
@@ -48,10 +55,10 @@ echo "Waiting for $project to build"
 # Autobuild has been informed but until we have a better solution,
 # we are running it with a timeout command twice. If the second timeout
 # is triggered, we exit with an error
-timeout --foreground ${osc_timeout} osc -A ${api} -c ${config_file} results ${project} -w --xml
+timeout --foreground ${osc_timeout} osc -A ${api} -c ${config_file} results ${project} -w --xml ${extres}
 if [ $? -eq 124 ];then
     echo "Trying again to wait for ${project} to build"
-    timeout --foreground ${osc_timeout} osc -A ${api} -c ${config_file} results ${project} -w --xml
+    timeout --foreground ${osc_timeout} osc -A ${api} -c ${config_file} results ${project} -w --xml ${extres}
     if [ $? -eq 124 ];then
         echo "Waiting for the results of ${project} got stucked twice"
         echo "Please check ${project} build results"


### PR DESCRIPTION
## What does this PR change?

Waiting on other archs and on images makes the thing suuuuper slow. Let's add the possibility to set repo and arch as optional args.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests
- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18522

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
