### PR TITLE
Project lotus - Fix ptf package visibility

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/ErrataCache_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/ErrataCache_queries.xml
@@ -106,7 +106,7 @@ DELETE FROM rhnOrgErrataCacheQueue WHERE org_id = :org_id
              P.id as package_id,
              :channel_id as channel_id
                 FROM
-                     rhnPackage P,
+                     susePackageExcludingPartOfPtf P,
                      rhnServerPackageArchCompat SPAC,
                      rhnPackageEVR P_EVR,
                      rhnPackageEVR SP_EVR,
@@ -150,7 +150,7 @@ DELETE FROM rhnOrgErrataCacheQueue WHERE org_id = :org_id
              P.id as package_id,
              :channel_id as channel_id
                 FROM
-                     rhnPackage P,
+                     susePackageExcludingPartOfPtf P,
                      rhnServerPackageArchCompat SPAC,
                      rhnPackageEVR P_EVR,
                      rhnPackageEVR SP_EVR,
@@ -161,7 +161,7 @@ DELETE FROM rhnOrgErrataCacheQueue WHERE org_id = :org_id
                 WHERE
                          SC.channel_id = :channel_id
                   AND    SC.server_id = S.id
-              AND    p.id in (%s)
+                  AND    p.id in (%s)
                   AND    p.package_arch_id = spac.package_arch_id
                   AND    spac.server_arch_id = s.server_arch_id
                   AND    SP_EVR.id = SP.evr_id

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
@@ -53,7 +53,7 @@ SELECT PKG.id AS id,
        NVL((PEVR.evr).release, ' ') AS release,
        NVL((PEVR.evr).epoch, ' ') AS epoch,
        NVL(PA.label, ' ') AS arch_label
-  FROM rhnPackage PKG
+  FROM susePackageExcludingPartOfPtf PKG
        join rhnPackageName PN on PKG.name_id = PN.id
        join rhnPackageEVR PEVR on PKG.evr_id = PEVR.id
        join rhnPackageArch PA on PKG.package_arch_id = PA.id
@@ -109,7 +109,7 @@ SELECT
                  max(pe.evr) evr,
                  pa.id as arch_id,
                  pa.label as arch_label
-           FROM  rhnPackageArch PA, rhnPackageEVR PE, rhnPackage P,
+           FROM  rhnPackageArch PA, rhnPackageEVR PE, susePackageExcludingPartOfPtf P,
                  rhnChannelNewestPackage CNP, rhnServerChannel SC
           WHERE  sc.server_id = :sid
             AND  sc.channel_id = cnp.channel_id
@@ -995,7 +995,7 @@ DELETE FROM rhnlockedpackages l
 SELECT  pn.id as name_id, lookup_evr((full_list.evr).epoch, (full_list.evr).version, (full_list.evr).release, (full_list.evr).type) AS evr_id
   FROM  (
          SELECT  p.name_id name_id, max(pe.evr) evr
-           FROM  rhnPackageEVR PE, rhnPackage P,
+           FROM  rhnPackageEVR PE, susePackageExcludingPartOfPtf P,
                   suseChannelPackageRetractedStatusView CP,
                   rhnServerChannel SC
           WHERE  sc.server_id = :sid

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
@@ -569,8 +569,7 @@ SELECT PN.name as NAME,
    WHERE sp.server_id = :sid
    ORDER BY nvre
   </query>
-  <elaborator name="package_is_retracted" />
-  <elaborator name="package_is_part_of_ptf" />
+  <elaborator name="package_retracted_and_ptf_details" />
 </mode>
 
 <mode name="system_canonical_package_list" class="com.redhat.rhn.frontend.dto.PackageListItem">
@@ -661,7 +660,7 @@ SELECT PN.id || '|' || SPE.id AS ID_COMBO,
          (scp.package_id is null)
    order by nvre
   </query>
-  <elaborator name="package_is_part_of_ptf" />
+  <elaborator name="package_retracted_and_ptf_details" />
 </mode>
 
 <mode name="packages_from_server_set" class="com.redhat.rhn.frontend.dto.SsmRemovePackageListItem">
@@ -797,20 +796,32 @@ SELECT P.id, P.summary, PP.name as provider
  WHERE P.id IN(%s)
 </query>
 
-<query name="package_is_retracted" column="package_id" params="sid">
-    SELECT
-      pid as package_id,
-      1 as retracted
-    FROM suseServerChannelsRetractedPackagesView
-    WHERE sid = :sid AND pid IN(%s)
-</query>
-
-<query name="package_is_part_of_ptf" column="package_id" parmas="">
-    SELECT pp.package_id AS package_id,
-            1 as part_Of_ptf
-      FROM rhnpackagecapability pc
-                INNER JOIN rhnpackageprovides pp ON pc.id = pp.capability_id
-     WHERE pc.name = 'ptf-package()' AND pp.package_id IN (%s)
+<query name="package_retracted_and_ptf_details" column="package_id" params="sid">
+    WITH retractedPackages AS (
+        SELECT pid as package_id
+          FROM suseServerChannelsRetractedPackagesView
+         WHERE sid = :sid
+    ), ptfPackages AS (
+        SELECT pp.package_id
+          FROM rhnpackagecapability pc
+                  INNER JOIN rhnpackageprovides pp ON pc.id = pp.capability_id
+         WHERE pc.name = 'ptf()'
+    ), partOfPtfPackages AS (
+        SELECT pp.package_id
+          FROM rhnpackagecapability pc
+                  INNER JOIN rhnpackageprovides pp ON pc.id = pp.capability_id
+         WHERE pc.name = 'ptf-package()'
+    )
+    SELECT pk.id AS package_id
+              -- Convert the ids to 0/1 flags
+              , SIGN(COALESCE(rp.package_id, 0)) AS retracted
+              , SIGN(COALESCE(mp.package_id, 0)) AS master_ptf_package
+              , SIGN(COALESCE(pp.package_id, 0)) AS part_of_ptf
+      FROM rhnpackage pk
+              LEFT JOIN retractedPackages rp ON rp.package_id = pk.id
+              LEFT JOIN ptfPackages mp ON mp.package_id = pk.id
+              LEFT JOIN partOfPtfPackages pp ON pp.package_id = pk.id
+     WHERE pk.id IN (%s) AND ( rp.package_id IS NOT NULL OR mp.package_id IS NOT NULL OR pp.package_id IS NOT NULL )
 </query>
 
 <mode name="system_available_packages"  class="com.redhat.rhn.frontend.dto.PackageListItem">

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
@@ -570,6 +570,7 @@ SELECT PN.name as NAME,
    ORDER BY nvre
   </query>
   <elaborator name="package_is_retracted" />
+  <elaborator name="package_is_part_of_ptf" />
 </mode>
 
 <mode name="system_canonical_package_list" class="com.redhat.rhn.frontend.dto.PackageListItem">
@@ -624,8 +625,8 @@ SELECT PN.id || '|' || SPE.id AS ID_COMBO,
 </mode>
 
 <mode name="extra_packages_for_system" class="com.redhat.rhn.frontend.dto.PackageListItem">
-  <query params="serverid">
-  select scp.package_id,
+  <query params="sid">
+  select pk.id AS package_id,
          pn.id || '|' || pe.id || '|' || pa.id as id_combo,
          pn.name || '-' || pe.version || '-' || pe.release as nvre,
          pn.name || '-' || evr_t_as_vre_simple(pe.evr) || '.' || pa.label as nvrea,
@@ -655,10 +656,12 @@ SELECT PN.id || '|' || SPE.id AS ID_COMBO,
          left outer join rhnPackageName pn on (pn.id = sp.name_id)
          left outer join rhnPackageArch pa on (pa.id = sp.package_arch_id)
          left outer join rhnPackageEvr pe on (pe.id = sp.evr_id)
-   where sp.server_id = :serverid and
+         left outer join rhnPackage pk ON pk.name_id = pn.id AND pk.package_arch_id = pa.id AND pk.evr_id = pe.id
+   where sp.server_id = :sid and
          (scp.package_id is null)
    order by nvre
   </query>
+  <elaborator name="package_is_part_of_ptf" />
 </mode>
 
 <mode name="packages_from_server_set" class="com.redhat.rhn.frontend.dto.SsmRemovePackageListItem">
@@ -800,6 +803,14 @@ SELECT P.id, P.summary, PP.name as provider
       1 as retracted
     FROM suseServerChannelsRetractedPackagesView
     WHERE sid = :sid AND pid IN(%s)
+</query>
+
+<query name="package_is_part_of_ptf" column="package_id" parmas="">
+    SELECT pp.package_id AS package_id,
+            1 as part_Of_ptf
+      FROM rhnpackagecapability pc
+                INNER JOIN rhnpackageprovides pp ON pc.id = pp.capability_id
+     WHERE pc.name = 'ptf-package()' AND pp.package_id IN (%s)
 </query>
 
 <mode name="system_available_packages"  class="com.redhat.rhn.frontend.dto.PackageListItem">

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
@@ -815,7 +815,7 @@ SELECT rp.id AS package_id,
                 pa.id AS arch_id
            FROM
                 rhnPackageEVR PE
-           JOIN rhnPackage p ON p.evr_id = pe.id
+           JOIN susePackageExcludingPartOfPtf p ON p.evr_id = pe.id
            JOIN rhnChannelNewestPackage cp ON cp.package_id = p.id
            JOIN rhnServerChannel sc ON sc.channel_id = cp.channel_id
            JOIN rhnPackageArch pa ON pa.id = p.package_arch_id

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -400,7 +400,7 @@ ORDER BY  UPPER(COALESCE(S.NAME, '(none)')), S.ID
 <mode name="potential_systems_for_package" class="com.redhat.rhn.frontend.dto.SystemOverview">
   <query params="org_id, pid, user_id">
 SELECT  S.id, S.name, 1 as selectable
-  FROM  rhnPackage P, suseChannelPackageRetractedStatusView CP, rhnServerChannel SC, rhnServer S, rhnServerArch SA, rhnArchType AT
+  FROM  susePackageExcludingPartOfPtf P, suseChannelPackageRetractedStatusView CP, rhnServerChannel SC, rhnServer S, rhnServerArch SA, rhnArchType AT
  WHERE  S.org_id = :org_id
    AND  SC.server_id = S.id
    AND  SA.id = S.server_arch_id

--- a/java/code/src/com/redhat/rhn/common/hibernate/AnnotationRegistry.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/AnnotationRegistry.java
@@ -26,6 +26,7 @@ import com.redhat.rhn.domain.contentmgmt.ErrataFilter;
 import com.redhat.rhn.domain.contentmgmt.ModuleFilter;
 import com.redhat.rhn.domain.contentmgmt.PackageFilter;
 import com.redhat.rhn.domain.contentmgmt.ProjectSource;
+import com.redhat.rhn.domain.contentmgmt.PtfFilter;
 import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
 import com.redhat.rhn.domain.contentmgmt.SoftwareProjectSource;
 import com.redhat.rhn.domain.image.DeltaImageInfo;
@@ -82,8 +83,6 @@ import java.util.List;
 
 
 /**
- * AnnotationRegistry
- *
  * Stores a list of hibernate annotation classes for registration the first time the
  * ConnectionManager.
  */
@@ -128,6 +127,7 @@ public class AnnotationRegistry {
         PackageFilter.class,
         ErrataFilter.class,
         ModuleFilter.class,
+        PtfFilter.class,
         EnvironmentTarget.class,
         SoftwareEnvironmentTarget.class,
         ContentProjectHistoryEntry.class,

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
@@ -21,7 +21,6 @@ import com.redhat.rhn.domain.org.Org;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
-import java.util.Optional;
 import java.util.function.Predicate;
 
 import javax.persistence.Column;
@@ -63,9 +62,10 @@ public abstract class ContentFilter<T> extends BaseDomainHelper implements Predi
     public enum EntityType {
         PACKAGE("package"),
         ERRATUM("erratum"),
-        MODULE("module");
+        MODULE("module"),
+        PTF("ptf");
 
-        private String label;
+        private final String label;
 
         EntityType(String labelIn) {
             this.label = labelIn;
@@ -142,27 +142,6 @@ public abstract class ContentFilter<T> extends BaseDomainHelper implements Predi
      */
     @Transient
     public abstract EntityType getEntityType();
-
-    /**
-     * Returns the filter as {@link PackageFilter} if it is one
-     *
-     * @return Optional of {@link PackageFilter}
-     */
-    public abstract Optional<PackageFilter> asPackageFilter();
-
-    /**
-     * Returns the filter as {@link ErrataFilter} if it is one
-     *
-     * @return Optional of {@link ErrataFilter}
-     */
-    public abstract Optional<ErrataFilter> asErrataFilter();
-
-    /**
-     * Returns the filter as {@link ModuleFilter} if it is one
-     *
-     * @return Optional of {@link ModuleFilter}
-     */
-    public abstract Optional<ModuleFilter> asModuleFilter();
 
     /**
      * Gets the id.
@@ -273,7 +252,7 @@ public abstract class ContentFilter<T> extends BaseDomainHelper implements Predi
             return false;
         }
 
-        ContentFilter that = (ContentFilter) o;
+        ContentFilter<?> that = (ContentFilter<?>) o;
 
         return new EqualsBuilder()
                 .append(org, that.org)

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -551,6 +551,9 @@ public class ContentProjectFactory extends HibernateFactory {
             case MODULE:
                 filter = new ModuleFilter();
                 break;
+            case PTF:
+                filter = new PtfFilter();
+                break;
             default:
                 throw new IllegalArgumentException("Incompatible type " + entityType);
         }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
@@ -24,7 +24,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
@@ -114,12 +113,11 @@ public class ErrataFilter extends ContentFilter<Errata> {
                         throw new UnsupportedOperationException("Matcher " + matcher + " not supported");
                 }
             case "advisory_type":
-                switch (matcher) {
-                    case EQUALS:
-                        return getField(erratum, field, String.class).equals(value);
-                    default:
-                        throw new UnsupportedOperationException("Matcher " + matcher + " not supported");
+                if (matcher == FilterCriteria.Matcher.EQUALS) {
+                    return getField(erratum, field, String.class).equals(value);
                 }
+
+                throw new UnsupportedOperationException("Matcher " + matcher + " not supported");
             case "synopsis":
                 switch (matcher) {
                     case EQUALS:
@@ -135,22 +133,20 @@ public class ErrataFilter extends ContentFilter<Errata> {
                         throw new UnsupportedOperationException("Matcher " + matcher + " not supported");
                 }
             case "keyword":
-                switch (matcher) {
-                    case CONTAINS:
-                        return erratum.hasKeyword(value);
-                    default:
-                        throw new UnsupportedOperationException("Matcher " + matcher + " not supported");
+                if (matcher == FilterCriteria.Matcher.CONTAINS) {
+                    return erratum.hasKeyword(value);
                 }
+
+                throw new UnsupportedOperationException("Matcher " + matcher + " not supported");
             case "package_provides_name":
-                switch (matcher) {
-                case CONTAINS_PROVIDES_NAME:
+                if (matcher == FilterCriteria.Matcher.CONTAINS_PROVIDES_NAME) {
                     return erratum.getPackages().stream()
-                            .flatMap(pkg -> pkg.getProvides().stream())
-                            .map(p -> p.getCapability().getName())
-                            .anyMatch(n -> n.equals(value));
-                default:
-                    throw new UnsupportedOperationException("Matcher " + matcher + " not supported");
+                                  .flatMap(pkg -> pkg.getProvides().stream())
+                                  .map(p -> p.getCapability().getName())
+                                  .anyMatch(n -> n.equals(value));
                 }
+
+                throw new UnsupportedOperationException("Matcher " + matcher + " not supported");
             default:
                 throw new UnsupportedOperationException("Field " + field + " not supported");
         }
@@ -177,18 +173,4 @@ public class ErrataFilter extends ContentFilter<Errata> {
         return EntityType.ERRATUM;
     }
 
-    @Override
-    public Optional<PackageFilter> asPackageFilter() {
-        return Optional.empty();
-    }
-
-    @Override
-    public Optional<ErrataFilter> asErrataFilter() {
-        return Optional.of(this);
-    }
-
-    @Override
-    public Optional<ModuleFilter> asModuleFilter() {
-        return Optional.empty();
-    }
 }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
@@ -18,6 +18,7 @@ package com.redhat.rhn.domain.contentmgmt;
 import static com.redhat.rhn.domain.contentmgmt.ContentFilter.EntityType.ERRATUM;
 import static com.redhat.rhn.domain.contentmgmt.ContentFilter.EntityType.MODULE;
 import static com.redhat.rhn.domain.contentmgmt.ContentFilter.EntityType.PACKAGE;
+import static com.redhat.rhn.domain.contentmgmt.ContentFilter.EntityType.PTF;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.CONTAINS;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.CONTAINS_PKG_EQ_EVR;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.CONTAINS_PKG_GE_EVR;
@@ -34,6 +35,10 @@ import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.LOWEREQ;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.MATCHES;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.MATCHES_PKG_NAME;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.PROVIDES_NAME;
+import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.PTF_ALL;
+import static com.redhat.rhn.domain.contentmgmt.PtfFilter.FIELD_PTF_ALL;
+import static com.redhat.rhn.domain.contentmgmt.PtfFilter.FIELD_PTF_NUMBER;
+import static com.redhat.rhn.domain.contentmgmt.PtfFilter.FIELD_PTF_PACKAGE;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -41,10 +46,10 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.tuple.Triple;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
@@ -67,41 +72,48 @@ public class FilterCriteria {
     private String field;
     private String value;
 
-    private static HashSet<Triple<ContentFilter.EntityType, Matcher, String>> validCombinations = new HashSet<>();
-
-    static {
-        validCombinations.add(Triple.of(PACKAGE, CONTAINS, "name"));
-        validCombinations.add(Triple.of(PACKAGE, LOWER, "nevr"));
-        validCombinations.add(Triple.of(PACKAGE, LOWEREQ, "nevr"));
-        validCombinations.add(Triple.of(PACKAGE, EQUALS, "nevr"));
-        validCombinations.add(Triple.of(PACKAGE, GREATEREQ, "nevr"));
-        validCombinations.add(Triple.of(PACKAGE, GREATER, "nevr"));
-        validCombinations.add(Triple.of(PACKAGE, LOWER, "nevra"));
-        validCombinations.add(Triple.of(PACKAGE, LOWEREQ, "nevra"));
-        validCombinations.add(Triple.of(PACKAGE, EQUALS, "nevra"));
-        validCombinations.add(Triple.of(PACKAGE, GREATEREQ, "nevra"));
-        validCombinations.add(Triple.of(PACKAGE, GREATER, "nevra"));
-        validCombinations.add(Triple.of(PACKAGE, MATCHES, "name"));
-        validCombinations.add(Triple.of(ERRATUM, EQUALS, "advisory_name"));
-        validCombinations.add(Triple.of(ERRATUM, EQUALS, "advisory_type"));
-        validCombinations.add(Triple.of(ERRATUM, EQUALS, "synopsis"));
-        validCombinations.add(Triple.of(ERRATUM, MATCHES, "advisory_name"));
-        validCombinations.add(Triple.of(ERRATUM, MATCHES, "synopsis"));
-        validCombinations.add(Triple.of(ERRATUM, CONTAINS, "synopsis"));
-        validCombinations.add(Triple.of(ERRATUM, CONTAINS, "keyword"));
-        validCombinations.add(Triple.of(ERRATUM, GREATER, "issue_date"));
-        validCombinations.add(Triple.of(ERRATUM, GREATEREQ, "issue_date"));
-        validCombinations.add(Triple.of(ERRATUM, MATCHES_PKG_NAME, "package_name"));
-        validCombinations.add(Triple.of(ERRATUM, CONTAINS_PKG_NAME, "package_name"));
-        validCombinations.add(Triple.of(ERRATUM, CONTAINS_PKG_LT_EVR, "package_nevr"));
-        validCombinations.add(Triple.of(ERRATUM, CONTAINS_PKG_LE_EVR, "package_nevr"));
-        validCombinations.add(Triple.of(ERRATUM, CONTAINS_PKG_EQ_EVR, "package_nevr"));
-        validCombinations.add(Triple.of(ERRATUM, CONTAINS_PKG_GE_EVR, "package_nevr"));
-        validCombinations.add(Triple.of(ERRATUM, CONTAINS_PKG_GT_EVR, "package_nevr"));
-        validCombinations.add(Triple.of(MODULE, EQUALS, "module_stream"));
-        validCombinations.add(Triple.of(PACKAGE, PROVIDES_NAME, "provides_name"));
-        validCombinations.add(Triple.of(ERRATUM, CONTAINS_PROVIDES_NAME, "package_provides_name"));
-    }
+    private static final Set<Triple<ContentFilter.EntityType, Matcher, String>> VALID_COMBINATIONS = Set.of(
+        Triple.of(PACKAGE, CONTAINS, "name"),
+        Triple.of(PACKAGE, LOWER, "nevr"),
+        Triple.of(PACKAGE, LOWEREQ, "nevr"),
+        Triple.of(PACKAGE, EQUALS, "nevr"),
+        Triple.of(PACKAGE, GREATEREQ, "nevr"),
+        Triple.of(PACKAGE, GREATER, "nevr"),
+        Triple.of(PACKAGE, LOWER, "nevra"),
+        Triple.of(PACKAGE, LOWEREQ, "nevra"),
+        Triple.of(PACKAGE, EQUALS, "nevra"),
+        Triple.of(PACKAGE, GREATEREQ, "nevra"),
+        Triple.of(PACKAGE, GREATER, "nevra"),
+        Triple.of(PACKAGE, MATCHES, "name"),
+        Triple.of(ERRATUM, EQUALS, "advisory_name"),
+        Triple.of(ERRATUM, EQUALS, "advisory_type"),
+        Triple.of(ERRATUM, EQUALS, "synopsis"),
+        Triple.of(ERRATUM, MATCHES, "advisory_name"),
+        Triple.of(ERRATUM, MATCHES, "synopsis"),
+        Triple.of(ERRATUM, CONTAINS, "synopsis"),
+        Triple.of(ERRATUM, CONTAINS, "keyword"),
+        Triple.of(ERRATUM, GREATER, "issue_date"),
+        Triple.of(ERRATUM, GREATEREQ, "issue_date"),
+        Triple.of(ERRATUM, MATCHES_PKG_NAME, "package_name"),
+        Triple.of(ERRATUM, CONTAINS_PKG_NAME, "package_name"),
+        Triple.of(ERRATUM, CONTAINS_PKG_LT_EVR, "package_nevr"),
+        Triple.of(ERRATUM, CONTAINS_PKG_LE_EVR, "package_nevr"),
+        Triple.of(ERRATUM, CONTAINS_PKG_EQ_EVR, "package_nevr"),
+        Triple.of(ERRATUM, CONTAINS_PKG_GE_EVR, "package_nevr"),
+        Triple.of(ERRATUM, CONTAINS_PKG_GT_EVR, "package_nevr"),
+        Triple.of(MODULE, EQUALS, "module_stream"),
+        Triple.of(PACKAGE, PROVIDES_NAME, "provides_name"),
+        Triple.of(ERRATUM, CONTAINS_PROVIDES_NAME, "package_provides_name"),
+        Triple.of(PTF, PTF_ALL, FIELD_PTF_ALL),
+        Triple.of(PTF, LOWER, FIELD_PTF_NUMBER),
+        Triple.of(PTF, LOWEREQ, FIELD_PTF_NUMBER),
+        Triple.of(PTF, EQUALS, FIELD_PTF_NUMBER),
+        Triple.of(PTF, GREATEREQ, FIELD_PTF_NUMBER),
+        Triple.of(PTF, GREATER, FIELD_PTF_NUMBER),
+        Triple.of(PTF, EQUALS, FIELD_PTF_PACKAGE),
+        Triple.of(PTF, MATCHES, FIELD_PTF_PACKAGE),
+        Triple.of(PTF, CONTAINS, FIELD_PTF_PACKAGE)
+    );
 
     /**
      * The matcher type
@@ -122,9 +134,10 @@ public class FilterCriteria {
         GREATEREQ("greatereq"),
         MATCHES("matches"),
         PROVIDES_NAME("provides_name"),
-        CONTAINS_PROVIDES_NAME("contains_provides_name");
+        CONTAINS_PROVIDES_NAME("contains_provides_name"),
+        PTF_ALL("ptf_all");
 
-        private String label;
+        private final String label;
 
         Matcher(String labelIn) {
             this.label = labelIn;
@@ -185,7 +198,7 @@ public class FilterCriteria {
      */
     public static void validate(ContentFilter.EntityType entityType, Matcher matcher, String field)
             throws IllegalArgumentException {
-        if (!validCombinations.contains(Triple.of(entityType, matcher, field))) {
+        if (!VALID_COMBINATIONS.contains(Triple.of(entityType, matcher, field))) {
             throw new IllegalArgumentException(
                     String.format("Invalid criteria combination (entityType: '%s', matcher: '%s', field: '%s')",
                             entityType, matcher, field));
@@ -199,7 +212,7 @@ public class FilterCriteria {
      */
     public static List<Map<String, String>> listFilterCriteria() {
         List<Map<String, String>> result = new LinkedList<>();
-        for (Triple<ContentFilter.EntityType, Matcher, String> c : validCombinations) {
+        for (Triple<ContentFilter.EntityType, Matcher, String> c : VALID_COMBINATIONS) {
             Map<String, String> criteria = new HashMap<>();
             criteria.put("type", c.getLeft().getLabel());
             criteria.put("matcher", c.getMiddle().getLabel());

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ModuleFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ModuleFilter.java
@@ -17,8 +17,6 @@ package com.redhat.rhn.domain.contentmgmt;
 
 import com.redhat.rhn.domain.contentmgmt.modulemd.Module;
 
-import java.util.Optional;
-
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.Transient;
@@ -28,7 +26,7 @@ import javax.persistence.Transient;
  * {@link com.redhat.rhn.domain.rhnpackage.Package} objects instead, these filters must be replaced with
  * {@link PackageFilter} counterparts.
  *
- * @see com.redhat.rhn.manager.contentmgmt.DependencyResolver#resolveModularDependencies
+ * @see com.redhat.rhn.manager.contentmgmt.DependencyResolver
  */
 @Entity
 @DiscriminatorValue("module")
@@ -66,20 +64,5 @@ public class ModuleFilter extends ContentFilter<Module> {
     @Transient
     public EntityType getEntityType() {
         return EntityType.MODULE;
-    }
-
-    @Override
-    public Optional<PackageFilter> asPackageFilter() {
-        return Optional.empty();
-    }
-
-    @Override
-    public Optional<ErrataFilter> asErrataFilter() {
-        return Optional.empty();
-    }
-
-    @Override
-    public Optional<ModuleFilter> asModuleFilter() {
-        return Optional.of(this);
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
@@ -18,7 +18,6 @@ package com.redhat.rhn.domain.contentmgmt;
 import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.rhnpackage.PackageEvr;
 
-import java.util.Optional;
 import java.util.regex.Pattern;
 
 import javax.persistence.DiscriminatorValue;
@@ -115,20 +114,5 @@ public class PackageFilter extends ContentFilter<Package> {
     @Transient
     public EntityType getEntityType() {
         return EntityType.PACKAGE;
-    }
-
-    @Override
-    public Optional<PackageFilter> asPackageFilter() {
-        return Optional.of(this);
-    }
-
-    @Override
-    public Optional<ErrataFilter> asErrataFilter() {
-        return Optional.empty();
-    }
-
-    @Override
-    public Optional<ModuleFilter> asModuleFilter() {
-        return Optional.empty();
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/PtfFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/PtfFilter.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.domain.contentmgmt;
+
+import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.PackageProperty;
+
+import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Set;
+import java.util.function.Predicate;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.Transient;
+
+@Entity
+@DiscriminatorValue("ptf")
+public class PtfFilter extends ContentFilter<Package> {
+
+    public static final String FIELD_PTF_ALL = "ptf_all";
+    public static final String FIELD_PTF_NUMBER = "ptf_number";
+    public static final String FIELD_PTF_PACKAGE = "ptf_package";
+
+    private static final Logger LOGGER = LogManager.getLogger(PtfFilter.class);
+
+    @Override
+    public boolean test(Package pack) {
+        // If the package is neither a ptf nor part of a ptf we cannot have a match
+        if (!pack.isMasterPtfPackage() && !pack.isPartOfPtf()) {
+            return false;
+        }
+
+        FilterCriteria.Matcher matcher = getCriteria().getMatcher();
+        String field = getCriteria().getField();
+        String value = getCriteria().getValue();
+
+        if (FIELD_PTF_ALL.equals(field)) {
+            // If we filter all we have already a match
+            return true;
+        }
+
+        if (FIELD_PTF_NUMBER.equals(field)) {
+            if (!NumberUtils.isParsable(value)) {
+                LOGGER.warn("Filter value {} is invalid for field ptf_number", value);
+                return false;
+            }
+
+            String numberPart = findPtfNumber(pack);
+            if (numberPart == null) {
+                // No ptf number found, something wrong as the package should be already a ptf here
+                LOGGER.warn("Unable to retrieve ptf number from package #{}", pack.getId());
+                return false;
+            }
+
+            long ptfNumber = Long.parseLong(numberPart);
+            long threshold = Long.parseLong(value);
+            switch (matcher) {
+                case LOWER:
+                    return ptfNumber < threshold;
+                case LOWEREQ:
+                    return ptfNumber <= threshold;
+                case EQUALS:
+                    return ptfNumber == threshold;
+                case GREATEREQ:
+                    return ptfNumber >= threshold;
+                case GREATER:
+                    return ptfNumber > threshold;
+                default:
+                    throw new UnsupportedOperationException("Matcher " + matcher + " not supported for ptf_number");
+            }
+        }
+
+        if (FIELD_PTF_PACKAGE.equals(field)) {
+            switch (matcher) {
+                case EQUALS:
+                    return findFixedPackage(pack, name -> name.equals(value));
+                case MATCHES:
+                    return findFixedPackage(pack, name -> name.matches(value));
+                case CONTAINS:
+                    return findFixedPackage(pack, name -> name.contains(value));
+                default:
+                    throw new UnsupportedOperationException("Matcher " + matcher + " not supported for ptf_package");
+            }
+        }
+
+        throw new UnsupportedOperationException("Field " + field + " not supported");
+    }
+
+    @Override
+    @Transient
+    public EntityType getEntityType() {
+        return EntityType.PTF;
+    }
+
+    private static String findPtfNumber(Package pack) {
+        // Decide where to look based on the package type
+        Set<? extends PackageProperty> properties;
+        if (pack.isMasterPtfPackage()) {
+            properties = pack.getProvides();
+        }
+        else if (pack.isPartOfPtf()) {
+            properties = pack.getRequires();
+        }
+        else {
+            return null;
+        }
+
+        // Search for the property in the form ptf-<number>
+        return properties.stream()
+                         .map(property -> property.getCapability().getName())
+                         .filter(name -> name.matches("ptf-[1-9]\\d*"))
+                         .findFirst()
+                         .map(name -> name.split("-")[1])
+                         .orElse(null);
+    }
+
+    private static boolean findFixedPackage(Package pack, Predicate<String> namePredicate) {
+        // Decide where to look based on the package type
+        Set<? extends PackageProperty> properties;
+        if (pack.isMasterPtfPackage()) {
+            properties = pack.getRequires();
+        }
+        else if (pack.isPartOfPtf()) {
+            properties = pack.getProvides();
+        }
+        else {
+            return false;
+        }
+
+        // Search for the property matching the package filter
+        return properties.stream()
+                         .map(property -> property.getCapability().getName())
+                         .anyMatch(namePredicate);
+    }
+
+}

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ModuleFilterTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ModuleFilterTest.java
@@ -47,16 +47,14 @@ public class ModuleFilterTest extends BaseTestCaseWithUser {
     public void testGetModule() {
         FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "module_stream", "mymodule");
         ModuleFilter filter =
-                (ModuleFilter) contentManager.createFilter("mymodule-filter-1", ALLOW, MODULE, criteria, user)
-                        .asModuleFilter().get();
+                (ModuleFilter) contentManager.createFilter("mymodule-filter-1", ALLOW, MODULE, criteria, user);
 
         Module module = filter.getModule();
         assertEquals("mymodule", module.getName());
         assertNull(module.getStream());
 
         criteria = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "module_stream", "mymodule:mystream:foo");
-        filter = (ModuleFilter) contentManager.createFilter("mymodule-filter-2", ALLOW, MODULE, criteria, user)
-                .asModuleFilter().get();
+        filter = (ModuleFilter) contentManager.createFilter("mymodule-filter-2", ALLOW, MODULE, criteria, user);
 
         // The field value is interpreted as module_name : stream_name
         // Additional colons must be included in the stream name

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/PtfFilterTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/PtfFilterTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.domain.contentmgmt.test;
+
+import static com.redhat.rhn.domain.contentmgmt.ContentFilter.EntityType.PTF;
+import static com.redhat.rhn.domain.contentmgmt.ContentFilter.Rule.ALLOW;
+import static com.redhat.rhn.domain.role.RoleFactory.ORG_ADMIN;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.rhn.domain.contentmgmt.FilterCriteria;
+import com.redhat.rhn.domain.contentmgmt.PtfFilter;
+import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.test.PackageTest;
+import com.redhat.rhn.manager.contentmgmt.ContentManager;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
+import com.redhat.rhn.testing.PackageTestUtils;
+import com.redhat.rhn.testing.UserTestUtils;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class PtfFilterTest extends BaseTestCaseWithUser {
+
+    private ContentManager contentManager;
+    private Package testOnePackage;
+    private Package updatedOnePackage;
+    private Package ptfOneMasterPackage;
+    private Package ptfOnePackage;
+    private Package ptfTwoMasterPackage;
+    private Package testTwoPackage;
+    private Package ptfTwoPackage;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+
+        UserTestUtils.addUserRole(user, ORG_ADMIN);
+        contentManager = new ContentManager();
+
+        // Create some packages
+        testOnePackage = PackageTest.createTestPackage(user.getOrg(), "vim-data");
+        updatedOnePackage = PackageTestUtils.newVersionOfPackage(testOnePackage, null, "2.0.0", null, user.getOrg());
+
+        testTwoPackage = PackageTest.createTestPackage(user.getOrg(), "kernel-default");
+
+        ptfOneMasterPackage = PackageTestUtils.createPtfMaster("123456", "1", user.getOrg());
+        ptfOnePackage = PackageTestUtils.createPtfPackage(testOnePackage, "123456", "1", user.getOrg());
+        PackageTestUtils.associatePackageToPtf(ptfOneMasterPackage, ptfOnePackage);
+
+        ptfTwoMasterPackage = PackageTestUtils.createPtfMaster("987654", "1", user.getOrg());
+        ptfTwoPackage = PackageTestUtils.createPtfPackage(testTwoPackage, "987654", "1", user.getOrg());
+        PackageTestUtils.associatePackageToPtf(ptfTwoMasterPackage, ptfTwoPackage);
+    }
+
+    @Test
+    public void testAllPtfFilter() {
+
+        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.PTF_ALL, "ptf_all", "ALL");
+        PtfFilter filter = (PtfFilter) contentManager.createFilter("all-ptfs", ALLOW, PTF, criteria, user);
+
+        assertFalse(filter.test(testOnePackage));
+        assertFalse(filter.test(updatedOnePackage));
+        assertTrue(filter.test(ptfOneMasterPackage));
+        assertTrue(filter.test(ptfOnePackage));
+    }
+
+    @Test
+    public void testPtfNumberLowerFilter() {
+        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.LOWER, "ptf_number", "567890");
+        PtfFilter filter = (PtfFilter) contentManager.createFilter("ptf-number-1", ALLOW, PTF, criteria, user);
+
+        assertFalse(filter.test(testOnePackage));
+        assertTrue(filter.test(ptfOneMasterPackage));
+        assertTrue(filter.test(ptfOnePackage));
+        assertFalse(filter.test(ptfTwoMasterPackage));
+        assertFalse(filter.test(ptfTwoPackage));
+    }
+
+    @Test
+    public void testPtfNumberLowerEqualsFilter() {
+        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.LOWEREQ, "ptf_number", "987654");
+        PtfFilter filter = (PtfFilter) contentManager.createFilter("ptf-number-2", ALLOW, PTF, criteria, user);
+
+        assertFalse(filter.test(testOnePackage));
+        assertTrue(filter.test(ptfOneMasterPackage));
+        assertTrue(filter.test(ptfOnePackage));
+        assertTrue(filter.test(ptfTwoMasterPackage));
+        assertTrue(filter.test(ptfTwoPackage));
+    }
+
+    @Test
+    public void testPtfNumberEqualsFilter() {
+        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "ptf_number", "123456");
+        PtfFilter filter = (PtfFilter) contentManager.createFilter("ptf-number-3", ALLOW, PTF, criteria, user);
+
+        assertFalse(filter.test(testOnePackage));
+        assertTrue(filter.test(ptfOneMasterPackage));
+        assertTrue(filter.test(ptfOnePackage));
+        assertFalse(filter.test(ptfTwoMasterPackage));
+        assertFalse(filter.test(ptfTwoPackage));
+    }
+
+    @Test
+    public void testPtfNumberGreaterFilter() {
+        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.GREATER, "ptf_number", "567890");
+        PtfFilter filter = (PtfFilter) contentManager.createFilter("ptf-number-4", ALLOW, PTF, criteria, user);
+
+        assertFalse(filter.test(testOnePackage));
+        assertFalse(filter.test(ptfOneMasterPackage));
+        assertFalse(filter.test(ptfOnePackage));
+        assertTrue(filter.test(ptfTwoMasterPackage));
+        assertTrue(filter.test(ptfTwoPackage));
+    }
+
+    @Test
+    public void testPtfNumberGreaterEqualsFilter() {
+        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.GREATEREQ, "ptf_number", "987654");
+        PtfFilter filter = (PtfFilter) contentManager.createFilter("ptf-number-5", ALLOW, PTF, criteria, user);
+
+        assertFalse(filter.test(testOnePackage));
+        assertFalse(filter.test(ptfOneMasterPackage));
+        assertFalse(filter.test(ptfOnePackage));
+        assertTrue(filter.test(ptfTwoMasterPackage));
+        assertTrue(filter.test(ptfTwoPackage));
+    }
+
+    @Test
+    public void testFixedPackageEquals() {
+        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "ptf_package", "vim-data");
+        PtfFilter filter = (PtfFilter) contentManager.createFilter("ptf-package-1", ALLOW, PTF, criteria, user);
+
+        assertFalse(filter.test(testOnePackage));
+        assertFalse(filter.test(testTwoPackage));
+        assertTrue(filter.test(ptfOneMasterPackage));
+        assertTrue(filter.test(ptfOnePackage));
+        assertFalse(filter.test(ptfTwoMasterPackage));
+        assertFalse(filter.test(ptfTwoPackage));
+    }
+
+    @Test
+    public void testFixedPackageMatches() {
+        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.MATCHES, "ptf_package", "[a-z]+-[a-z]+");
+        PtfFilter filter = (PtfFilter) contentManager.createFilter("ptf-package-2", ALLOW, PTF, criteria, user);
+
+        assertFalse(filter.test(testOnePackage));
+        assertFalse(filter.test(testTwoPackage));
+        assertTrue(filter.test(ptfOneMasterPackage));
+        assertTrue(filter.test(ptfOnePackage));
+        assertTrue(filter.test(ptfTwoMasterPackage));
+        assertTrue(filter.test(ptfTwoPackage));
+    }
+
+    @Test
+    public void testFixedPackageContains() {
+        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.CONTAINS, "ptf_package", "default");
+        PtfFilter filter = (PtfFilter) contentManager.createFilter("ptf-package-3", ALLOW, PTF, criteria, user);
+
+        assertFalse(filter.test(testOnePackage));
+        assertFalse(filter.test(testTwoPackage));
+        assertFalse(filter.test(ptfOneMasterPackage));
+        assertFalse(filter.test(ptfOnePackage));
+        assertTrue(filter.test(ptfTwoMasterPackage));
+        assertTrue(filter.test(ptfTwoPackage));
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/ModularDependencyValidator.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/ModularDependencyValidator.java
@@ -21,6 +21,7 @@ import static com.redhat.rhn.domain.contentmgmt.validation.ContentValidationMess
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.contentmgmt.ContentProject;
+import com.redhat.rhn.domain.contentmgmt.ModuleFilter;
 import com.redhat.rhn.domain.contentmgmt.SoftwareProjectSource;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ConflictingStreamsException;
 import com.redhat.rhn.domain.contentmgmt.modulemd.Module;
@@ -40,8 +41,8 @@ import java.util.stream.Collectors;
  */
 public class ModularDependencyValidator implements ContentValidator {
 
-    private ModulemdApi modulemdApi;
-    private LocalizationService loc = LocalizationService.getInstance();
+    private final ModulemdApi modulemdApi;
+    private final LocalizationService loc = LocalizationService.getInstance();
 
     /**
      * Initialize a modular dependency validator with {@link ModulemdApi} as the default modulemd API
@@ -66,8 +67,7 @@ public class ModularDependencyValidator implements ContentValidator {
                 .map(SoftwareProjectSource::getChannel)
                 .anyMatch(Channel::isModular);
 
-        boolean hasModuleFilters = project.getActiveFilters().stream()
-                .anyMatch(f -> f.asModuleFilter().isPresent());
+        boolean hasModuleFilters = project.getActiveFilters().stream().anyMatch(f -> f instanceof ModuleFilter);
 
         if (!(hasModularSources && hasModuleFilters)) {
             return Collections.emptyList();

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/ModularSourcesValidator.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/ModularSourcesValidator.java
@@ -18,6 +18,7 @@ package com.redhat.rhn.domain.contentmgmt.validation;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.contentmgmt.ContentProject;
+import com.redhat.rhn.domain.contentmgmt.ModuleFilter;
 import com.redhat.rhn.domain.contentmgmt.SoftwareProjectSource;
 
 import java.util.Collections;
@@ -28,7 +29,7 @@ import java.util.List;
  */
 public class ModularSourcesValidator implements ContentValidator {
 
-    private LocalizationService loc = LocalizationService.getInstance();
+    private final LocalizationService loc = LocalizationService.getInstance();
 
     @Override
     public List<ContentValidationMessage> validate(ContentProject project) {
@@ -37,8 +38,7 @@ public class ModularSourcesValidator implements ContentValidator {
                 .map(SoftwareProjectSource::getChannel)
                 .anyMatch(Channel::isModular);
 
-        boolean hasModuleFilters = project.getActiveFilters().stream()
-                .anyMatch(f -> f.asModuleFilter().isPresent());
+        boolean hasModuleFilters = project.getActiveFilters().stream().anyMatch(f -> f instanceof ModuleFilter);
 
         ContentValidationMessage msg = null;
         if (hasModularSources && !hasModuleFilters) {

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/Package.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/Package.java
@@ -109,6 +109,15 @@ public class Package extends BaseDomainHelper {
     }
 
     /**
+     * Check if this package is the main one of a PTF.
+     *
+     * @return true if the package is PTF master package
+     */
+    public boolean isMasterPtfPackage() {
+        return provides.stream().anyMatch(p -> SpecialCapabilityNames.PTF.equals(p.getCapability().getName()));
+    }
+
+    /**
      * Check if the package is part of a PTF.
      *
      * @return true if the package is part of PTF

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/Package.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/Package.java
@@ -109,6 +109,15 @@ public class Package extends BaseDomainHelper {
     }
 
     /**
+     * Check if the package is part of a PTF.
+     *
+     * @return true if the package is part of PTF
+     */
+    public boolean isPartOfPtf() {
+        return provides.stream().anyMatch(p -> SpecialCapabilityNames.PTF_PACKAGE.equals(p.getCapability().getName()));
+    }
+
+    /**
      * @return Returns the provides.
      */
     public Set<PackageProvides> getProvides() {

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageFactory.java
@@ -358,6 +358,25 @@ public class PackageFactory extends HibernateFactory {
     }
 
     /**
+     * Find a package based off of the NEVRA ids
+     * @param org the org that owns the package
+     * @param nameId the id of the name to search for
+     * @param evrId the id of  the evr to search for
+     * @param archId the id of the arch to search for
+     * @return the requested Package
+     */
+    public static List<Package> lookupByNevraIds(Org org, long nameId, long evrId, long archId) {
+
+        return HibernateFactory.getSession().createNamedQuery("Package.lookupByNevraIds", Package.class)
+                                            .setParameter("org", org)
+                                            .setParameter("nameId", nameId)
+                                            .setParameter("evrId", evrId)
+                                            .setParameter("archId", archId)
+                                            .list();
+
+    }
+
+    /**
      * Find a package based off of the channel, NEVRA and checksum
      * @param channel the channel label
      * @param name the name to search for

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageProperty.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageProperty.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.domain.rhnpackage;
 
 import com.redhat.rhn.domain.BaseDomainHelper;
+import com.redhat.rhn.manager.rhnpackage.PackageManager;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -117,4 +118,12 @@ public class PackageProperty extends BaseDomainHelper {
         return eq.isEquals();
     }
 
+    @Override
+    public String toString() {
+        if (capability.getVersion() != null) {
+            return capability.getName() + "  " + PackageManager.getDependencyModifier(sense, capability.getVersion());
+        }
+
+        return capability.getName();
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/Package_satellite.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/Package_satellite.hbm.xml
@@ -212,6 +212,16 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         ]]>
     </query>
 
+    <query name="Package.lookupByNevraIds">
+        <![CDATA[ select p
+                from com.redhat.rhn.domain.rhnpackage.Package as p
+                where p.packageArch.id = :archId and
+                        p.packageName.id = :nameId and
+                        p.packageEvr.id = :evrId and
+                        (p.org is null or p.org = :org)
+        ]]>
+    </query>
+
     <sql-query name="Package.lookupByChannelLabelNevraCs">
         <![CDATA[ select {p.*}
                 from

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/SpecialCapabilityNames.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/SpecialCapabilityNames.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.domain.rhnpackage;
+
+/**
+ * Constants for tracking special package capabilities used by the application logic
+ */
+public final class SpecialCapabilityNames {
+
+    /** Capability provided by PTF master packages */
+    public static final String PTF = "ptf()";
+
+    /** Capability provided by packages part of a PTF */
+    public static final String PTF_PACKAGE = "ptf-package()";
+
+    private SpecialCapabilityNames() {
+        // Prevent instantiation
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/test/PackageNameTest.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/test/PackageNameTest.java
@@ -30,10 +30,9 @@ public class PackageNameTest extends RhnBaseTestCase {
     /**
      * Simple test to make sure we can create
      * PackageNames and write them to the db.
-     * @throws Exception something bad happened
      */
     @Test
-    public void testPackageName() throws Exception {
+    public void testPackageName() {
         PackageName p = createTestPackageName();
         assertNotNull(p);
         //make sure we got committed to the db.
@@ -44,9 +43,8 @@ public class PackageNameTest extends RhnBaseTestCase {
      * Create a test PackageName
      * @param name the name
      * @return a test PackageName object.
-     * @throws Exception something bad happened
      */
-    public static PackageName createTestPackageName(String name) throws Exception {
+    public static PackageName createTestPackageName(String name) {
         PackageName p = PackageFactory.lookupPackageName(name);
         if (p == null) {
             p = new PackageName();
@@ -59,9 +57,8 @@ public class PackageNameTest extends RhnBaseTestCase {
     /**
      * Create a test PackageName
      * @return a test PackageName object.
-     * @throws Exception something bad happened
      */
-    public static PackageName createTestPackageName() throws Exception {
+    public static PackageName createTestPackageName() {
         return createTestPackageName("00JavaTest" + TestUtils.randomString());
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/test/PackageTest.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/test/PackageTest.java
@@ -59,7 +59,7 @@ import java.util.Map;
 public class PackageTest extends BaseTestCaseWithUser {
 
     @Test
-    public void testIsType() throws Exception {
+    public void testIsType() {
         Package pkgRpm = PackageTest.createTestPackage(user.getOrg(),
                 PackageFactory.lookupPackageArchByLabel("x86_64"));
 
@@ -74,7 +74,7 @@ public class PackageTest extends BaseTestCaseWithUser {
     }
 
     @Test
-    public void testPackage() throws Exception {
+    public void testPackage() {
         Package pkg = createTestPackage(user.getOrg());
         assertNotNull(pkg);
         //make sure we got written to the db
@@ -87,7 +87,7 @@ public class PackageTest extends BaseTestCaseWithUser {
     }
 
     @Test
-    public void testFile() throws Exception {
+    public void testFile() {
         User user = UserTestUtils.findNewUser("testUser",
                 "testOrg" + this.getClass().getSimpleName());
         Package pkg = createTestPackage(user.getOrg());
@@ -112,7 +112,7 @@ public class PackageTest extends BaseTestCaseWithUser {
         assertEquals("foo", pkg.getFile());
     }
 
-    public static Package createTestPackage(Org org, PackageArch arch) throws Exception {
+    public static Package createTestPackage(Org org, PackageArch arch) {
         Package p = new Package();
         populateTestPackage(p, org, arch);
 
@@ -121,7 +121,7 @@ public class PackageTest extends BaseTestCaseWithUser {
         return p;
     }
 
-    public static Package createTestPackage(Org org) throws Exception {
+    public static Package createTestPackage(Org org) {
         Package p = populateTestPackage(new Package(), org);
         TestUtils.saveAndFlush(p);
         return p;
@@ -164,13 +164,13 @@ public class PackageTest extends BaseTestCaseWithUser {
         return p;
     }
 
-    public static Package populateTestPackage(Package p, Org org, PackageArch parch) throws Exception {
+    public static Package populateTestPackage(Package p, Org org, PackageArch parch) {
         PackageName pname = PackageNameTest.createTestPackageName();
         PackageEvr pevr = PackageEvrFactoryTest.createTestPackageEvr(parch.getArchType().getPackageType());
         return populateTestPackage(p, org, pname, pevr, parch);
     }
 
-    public static Package populateTestPackage(Package p, Org org) throws Exception {
+    public static Package populateTestPackage(Package p, Org org) {
         PackageArch parch = (PackageArch) TestUtils.lookupFromCacheById(100L, "PackageArch.findById");
         return populateTestPackage(p, org, parch);
     }
@@ -268,7 +268,7 @@ public class PackageTest extends BaseTestCaseWithUser {
     }
 
     @Test
-    public void testGetNevraWithEpoch() throws Exception {
+    public void testGetNevraWithEpoch() {
         Package pkg = createTestPackage(user.getOrg());
         PackageEvr evr = PackageEvrFactoryTest.createTestPackageEvr("1", "2", "3", PackageType.RPM);
         pkg.setPackageEvr(evr);
@@ -292,7 +292,7 @@ public class PackageTest extends BaseTestCaseWithUser {
     }
 
     @Test
-    public void testGetExtraTag() throws Exception {
+    public void testGetExtraTag() {
         Package pkg = createTestPackage(user.getOrg());
         pkg.getExtraTags().put(PackageManagerTest.createExtraTagKey("mytag"), "myvalue");
 
@@ -301,7 +301,7 @@ public class PackageTest extends BaseTestCaseWithUser {
     }
 
     @Test
-    public void testRetrievePtfInformation() throws Exception {
+    public void testRetrievePtfInformation() {
         Package masterPtfPackage = PackageTestUtils.createPtfMaster("123456", "1", user.getOrg());
 
         assertTrue(masterPtfPackage.isMasterPtfPackage());

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/test/PackageTest.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/test/PackageTest.java
@@ -127,6 +127,12 @@ public class PackageTest extends BaseTestCaseWithUser {
         return p;
     }
 
+    public static Package createTestPackage(Org org, String packageName) {
+        Package p = populateTestPackage(new Package(), packageName, org);
+        TestUtils.saveAndFlush(p);
+        return p;
+    }
+
     public static Package populateTestPackage(Package p, Org org, PackageName name, PackageEvr evr, PackageArch arch) {
         PackageGroup pgroup = PackageGroupTest.createTestPackageGroup();
         SourceRpm srpm = SourceRpmTest.createTestSourceRpm();
@@ -166,6 +172,10 @@ public class PackageTest extends BaseTestCaseWithUser {
 
     public static Package populateTestPackage(Package p, Org org, PackageArch parch) {
         PackageName pname = PackageNameTest.createTestPackageName();
+        return populateTestPackage(p, org, parch, pname);
+    }
+
+    private static Package populateTestPackage(Package p, Org org, PackageArch parch, PackageName pname) {
         PackageEvr pevr = PackageEvrFactoryTest.createTestPackageEvr(parch.getArchType().getPackageType());
         return populateTestPackage(p, org, pname, pevr, parch);
     }
@@ -175,8 +185,10 @@ public class PackageTest extends BaseTestCaseWithUser {
         return populateTestPackage(p, org, parch);
     }
 
-
-
+    public static Package populateTestPackage(Package p, String packageName, Org org) {
+        PackageArch parch = (PackageArch) TestUtils.lookupFromCacheById(100L, "PackageArch.findById");
+        return populateTestPackage(p, org, parch, PackageNameTest.createTestPackageName(packageName));
+    }
     public static PackageSource createTestPackageSource(SourceRpm rpm, Org org) {
 
         PackageSource source = new PackageSource();

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/ExtraPackagesListAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/ExtraPackagesListAction.java
@@ -33,7 +33,7 @@ public class ExtraPackagesListAction extends BaseSystemPackagesAction {
         result.elaborate();
 
         // Force the selection to be restricted to only non ptf packages
-        result.stream().filter(PackageListItem::isPartOfPtf).forEach(p -> p.setSelectable(false));
+        result.stream().filter(p -> p.isPartOfPtf() || p.isMasterPtfPackage()).forEach(p -> p.setSelectable(false));
 
         return result;
     }

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/ExtraPackagesListAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/ExtraPackagesListAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2012--2022 SUSE LLC
  * Copyright (c) 2012--2014 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
@@ -11,10 +12,6 @@
  * Red Hat trademarks are not licensed under GPLv2. No permission is
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
- */
-
-/**
- * Copyright (c) 2012 SUSE LLC
  */
 
 package com.redhat.rhn.frontend.action.rhnpackage;
@@ -32,6 +29,12 @@ public class ExtraPackagesListAction extends BaseSystemPackagesAction {
 
     @Override
     protected DataResult<PackageListItem> getDataResult(Server server) {
-        return SystemManager.listExtraPackages(server.getId());
+        DataResult<PackageListItem> result = SystemManager.listExtraPackages(server.getId());
+        result.elaborate();
+
+        // Force the selection to be restricted to only non ptf packages
+        result.stream().filter(PackageListItem::isPartOfPtf).forEach(p -> p.setSelectable(false));
+
+        return result;
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/ExtraPackagesListAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/ExtraPackagesListAction.java
@@ -25,7 +25,6 @@ import com.redhat.rhn.manager.system.SystemManager;
  * ExtraPackagesListAction
  */
 public class ExtraPackagesListAction extends BaseSystemPackagesAction {
-    public static final String DATA_SET = "extras";
 
     @Override
     protected DataResult<PackageListItem> getDataResult(Server server) {

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/LockPackageAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/LockPackageAction.java
@@ -119,8 +119,8 @@ public class LockPackageAction extends BaseSystemPackagesAction {
         pkgsAlreadyLocked.addAll(pkgsFindAlreadyLocked);
 
         SessionSetHelper helper = new SessionSetHelper(request);
-        if (isSubmitted(form)) {
-            // if its one of the Dispatch actions handle it..
+        if (isSubmitted(form) && request.getParameter("dispatch") != null) {
+            // if its one of the Dispatch actions handle it...
             helper.updateSet(pkgsToSelect, LIST_NAME);
             Date scheduleDate = this.getStrutsDelegate().readScheduleDate(
                     form, "date", DatePicker.YEAR_RANGE_POSITIVE);

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/PackageListSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/PackageListSetupAction.java
@@ -34,7 +34,7 @@ public class PackageListSetupAction extends BaseSystemPackagesAction {
         result.elaborate();
 
         // Force the selection to be restricted to only non ptf packages
-        result.stream().filter(PackageListItem::isPartOfPtf).forEach(p -> p.setSelectable(false));
+        result.stream().filter(p -> p.isPartOfPtf() || p.isMasterPtfPackage()).forEach(p -> p.setSelectable(false));
 
         return result;
     }

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/PackageListSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/PackageListSetupAction.java
@@ -29,9 +29,13 @@ public class PackageListSetupAction extends BaseSystemPackagesAction {
      * @param server The system.
      * @return List of installed packages
      */
-    protected DataResult getDataResult(Server server) {
+    protected DataResult<PackageListItem> getDataResult(Server server) {
         DataResult<PackageListItem> result = PackageManager.systemPackageList(server.getId(), null);
         result.elaborate();
+
+        // Force the selection to be restricted to only non ptf packages
+        result.stream().filter(PackageListItem::isPartOfPtf).forEach(p -> p.setSelectable(false));
+
         return result;
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/TargetSystemsListAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/TargetSystemsListAction.java
@@ -67,6 +67,7 @@ public class TargetSystemsListAction extends RhnAction {
         }
         request.setAttribute("pid", pid);
         request.setAttribute("package_name", pkg.getFilename());
+        request.setAttribute("isPtfPackage", pkg.isPartOfPtf());
         request.setAttribute(ListTagHelper.PARENT_URL, request.getRequestURI() + "?pid=" +
                 pid);
         RhnListSetHelper helper = new RhnListSetHelper(request);

--- a/java/code/src/com/redhat/rhn/frontend/dto/PackageListItem.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/PackageListItem.java
@@ -56,10 +56,24 @@ public class PackageListItem extends IdComboDto {
     private String summary;
     private String nvrea;
     private Date installTime;
-    private String locked = null; // Assuming package is free to operate by default.
+    private String locked;
     private String pending; // Either PackageManager.PKG_PENDING_LOCK for "to be locked"
                             // or PackageManager.PKG_PENDING_UNLOCK for "to be unlocked"
     private boolean retracted;
+
+    private boolean partOfPtf;
+
+    private boolean selectable;
+
+    /**
+     * Default constructor
+     */
+    public PackageListItem() {
+        // Assuming package is free to operate by default.
+        this.locked = null;
+        // Assuming the package can be always selectable
+        this.selectable = true;
+    }
 
     /**
      * Set locked status.
@@ -128,6 +142,22 @@ public class PackageListItem extends IdComboDto {
      */
     public void setRetracted(boolean retractedIn) {
         retracted = retractedIn;
+    }
+
+    /**
+     * Check if the package is part of a ptf
+     * @return true if the package is part of a ptf
+     */
+    public boolean isPartOfPtf() {
+        return partOfPtf;
+    }
+
+    /**
+     * Sets if the package is part of a ptf
+     * @param partOfPtfIn true if the package is part of a ptf
+     */
+    public void setPartOfPtf(boolean partOfPtfIn) {
+        this.partOfPtf = partOfPtfIn;
     }
 
     /**
@@ -474,6 +504,23 @@ public class PackageListItem extends IdComboDto {
     */
     public void setInstalltime(Date installTimeIn) {
         installTime = installTimeIn;
+    }
+
+    /**
+     * Specifies if this package is selectable
+     * @return true if it can be selected
+     */
+    @Override
+    public boolean isSelectable() {
+        return selectable;
+    }
+
+    /**
+     * Sets the selectable status for this package
+     * @param selectableIn true to allow the package to be selected
+     */
+    public void setSelectable(boolean selectableIn) {
+        this.selectable = selectableIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/dto/PackageListItem.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/PackageListItem.java
@@ -61,6 +61,8 @@ public class PackageListItem extends IdComboDto {
                             // or PackageManager.PKG_PENDING_UNLOCK for "to be unlocked"
     private boolean retracted;
 
+    private boolean ptf;
+
     private boolean partOfPtf;
 
     private boolean selectable;
@@ -142,6 +144,22 @@ public class PackageListItem extends IdComboDto {
      */
     public void setRetracted(boolean retractedIn) {
         retracted = retractedIn;
+    }
+
+    /**
+     * Check if the package is the main one of a ptf
+     * @return true if the package is a ptf
+     */
+    public boolean isMasterPtfPackage() {
+        return ptf;
+    }
+
+    /**
+     * Sets if the package is the main one of a ptf
+     * @param ptfIn true if the package is  a ptf
+     */
+    public void setMasterPtfPackage(boolean ptfIn) {
+        this.ptf = ptfIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -7598,6 +7598,9 @@ Follow this url to see the full list of inactive systems:
       <trans-unit id="api.package.invalidpackage" xml:space="preserve">
         <source>Invalid package: {0}</source>
       </trans-unit>
+      <trans-unit id="api.package.ptfpackage" xml:space="preserve">
+        <source>Packages part of a Product Temporary Fixes (PTF): {0}</source>
+      </trans-unit>
       <trans-unit id="api.errata.duplicateerrata" xml:space="preserve">
         <source>Patch already exists with advisory {0}</source>
       </trans-unit>

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -7601,6 +7601,9 @@ Follow this url to see the full list of inactive systems:
       <trans-unit id="api.package.ptfpackage" xml:space="preserve">
         <source>Packages part of a Product Temporary Fixes (PTF): {0}</source>
       </trans-unit>
+      <trans-unit id="api.package.ptfmaster" xml:space="preserve">
+        <source>Product Temporary Fixes packages (PTF): {0}</source>
+      </trans-unit>
       <trans-unit id="api.errata.duplicateerrata" xml:space="preserve">
         <source>Patch already exists with advisory {0}</source>
       </trans-unit>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -23111,6 +23111,12 @@ given channel.</source>
           <context context-type="sourcefile">/rhn/software/packages/TargetSystems.do</context>
         </context-group>
       </trans-unit>
+        <trans-unit id="targetsystems.jsp.description_ptf_package" xml:space="preserve">
+        <source>This package is part of a Product Temporary Fix (PTF) and cannot be installed directly. Please select the main package of the temporary fix to review the target systems.</source>
+            <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/software/packages/TargetSystems.do</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="targetsystems.jsp.installpackage" xml:space="preserve">
         <source>Install</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/PtfMasterFault.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/PtfMasterFault.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.xmlrpc;
+
+import com.redhat.rhn.FaultException;
+import com.redhat.rhn.common.localization.LocalizationService;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Retracted Package Exception
+ */
+public class PtfMasterFault extends FaultException  {
+
+    /**
+     * Constructor
+     * @param pkgIds The retracted package ids.
+     */
+    public PtfMasterFault(List<Long> pkgIds) {
+        super(2305, "ptfPackage" , LocalizationService.getInstance().
+                getMessage("api.package.ptfmaster",
+                        pkgIds.stream().map(Object::toString).collect(Collectors.joining(","))));
+    }
+
+    /**
+     * Constructor
+     * @param pkgIds The retracted package ids.
+     * @param cause the cause
+     */
+    public PtfMasterFault(List<Long> pkgIds, Throwable cause) {
+        super(2305, "ptfPackage" , LocalizationService.getInstance().
+                getMessage("api.package.ptfmaster",
+                        pkgIds.stream().map(Object::toString).collect(Collectors.joining(","))),
+                cause);
+    }
+
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/PtfPackageFault.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/PtfPackageFault.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.xmlrpc;
+
+import com.redhat.rhn.FaultException;
+import com.redhat.rhn.common.localization.LocalizationService;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Retracted Package Exception
+ */
+public class PtfPackageFault extends FaultException  {
+
+    /**
+     * Constructor
+     * @param pkgIds The retracted package ids.
+     */
+    public PtfPackageFault(List<Long> pkgIds) {
+        super(2304, "ptfPackage" , LocalizationService.getInstance().
+                getMessage("api.package.ptfpackage",
+                        pkgIds.stream().map(Object::toString).collect(Collectors.joining(","))));
+    }
+
+    /**
+     * Constructor
+     * @param pkgIds The retracted package ids.
+     * @param cause the cause
+     */
+    public PtfPackageFault(List<Long> pkgIds, Throwable cause) {
+        super(2304, "ptfPackage" , LocalizationService.getInstance().
+                getMessage("api.package.ptfpackage",
+                        pkgIds.stream().map(Object::toString).collect(Collectors.joining(","))),
+                cause);
+    }
+
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -136,6 +136,7 @@ import com.redhat.rhn.frontend.xmlrpc.PermissionCheckFailureException;
 import com.redhat.rhn.frontend.xmlrpc.ProfileNameTooLongException;
 import com.redhat.rhn.frontend.xmlrpc.ProfileNameTooShortException;
 import com.redhat.rhn.frontend.xmlrpc.ProfileNoBaseChannelException;
+import com.redhat.rhn.frontend.xmlrpc.PtfMasterFault;
 import com.redhat.rhn.frontend.xmlrpc.PtfPackageFault;
 import com.redhat.rhn.frontend.xmlrpc.RetractedPackageFault;
 import com.redhat.rhn.frontend.xmlrpc.RhnXmlRpcServer;
@@ -4010,6 +4011,16 @@ public class SystemHandler extends BaseHandler {
             throw new PtfPackageFault(ptfPackages);
         }
 
+        // PTF master packages cannot be removed
+        if (ActionFactory.TYPE_PACKAGES_REMOVE.equals(acT)) {
+            List<Long> ptfMasterPackages = packages.stream()
+                                                   .filter(Package::isMasterPtfPackage)
+                                                   .map(Package::getId)
+                                                   .collect(toList());
+            if (!ptfMasterPackages.isEmpty()) {
+                throw new PtfMasterFault(ptfMasterPackages);
+            }
+        }
 
         for (Integer sid : sids) {
             Server server = SystemManager.lookupByIdAndUser(sid.longValue(), loggedInUser);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -136,6 +136,7 @@ import com.redhat.rhn.frontend.xmlrpc.PermissionCheckFailureException;
 import com.redhat.rhn.frontend.xmlrpc.ProfileNameTooLongException;
 import com.redhat.rhn.frontend.xmlrpc.ProfileNameTooShortException;
 import com.redhat.rhn.frontend.xmlrpc.ProfileNoBaseChannelException;
+import com.redhat.rhn.frontend.xmlrpc.PtfPackageFault;
 import com.redhat.rhn.frontend.xmlrpc.RetractedPackageFault;
 import com.redhat.rhn.frontend.xmlrpc.RhnXmlRpcServer;
 import com.redhat.rhn.frontend.xmlrpc.SnapshotTagAlreadyExistsException;
@@ -1391,12 +1392,12 @@ public class SystemHandler extends BaseHandler {
             Map<String, Object> systemMap = new HashMap<>();
 
             // get the package name ID
-            Map pkgEvr = PackageManager.lookupEvrIdByPackageName(sid.longValue(), packageName);
+            Map<String, Long> pkgEvr = PackageManager.lookupEvrIdByPackageName(sid.longValue(), packageName);
 
             if (pkgEvr != null) {
                 // find the latest package available to each system
                 Package pkg = PackageManager.guestimatePackageBySystem(sid.longValue(),
-                        (Long) pkgEvr.get("name_id"), (Long) pkgEvr.get("evr_id"),
+                        pkgEvr.get("name_id"), pkgEvr.get("evr_id"),
                         null, loggedInUser.getOrg());
 
                 // build the hash to return
@@ -3984,22 +3985,16 @@ public class SystemHandler extends BaseHandler {
             }
         }
 
+        List<Package> packages = packageMaps.stream().flatMap(packageMap -> {
+            Org org = loggedInUser.getOrg();
+            Long nameId = packageMap.get("name_id");
+            Long evrId = packageMap.get("evr_id");
+            Long archId = packageMap.get("arch_id");
+
+            return PackageFactory.lookupByNevraIds(org, nameId, evrId, archId).stream();
+        }).collect(toList());
+
         if (ActionFactory.TYPE_PACKAGES_UPDATE.equals(acT)) {
-            List<Package> packages = packageMaps.stream().flatMap(packageMap -> {
-                PackageName packageName = PackageFactory.lookupPackageName(packageMap.get("name_id"));
-                PackageEvr evr = PackageEvrFactory.lookupPackageEvrById(packageMap.get("evr_id"));
-                PackageArch arch = PackageFactory.lookupPackageArchById(packageMap.get("arch_id"));
-
-                return PackageFactory.lookupByNevra(
-                        loggedInUser.getOrg(),
-                        packageName.getName(),
-                        evr.getVersion(),
-                        evr.getRelease(),
-                        evr.getEpoch(),
-                        arch
-                ).stream();
-            }).collect(toList());
-
             List<Tuple2<Long, Long>> pidsidpairs = ErrataFactory.retractedPackages(
                     packages.stream().map(Package::getId).collect(toList()),
                     sids.stream().map(Integer::longValue).collect(toList())
@@ -4009,10 +4004,15 @@ public class SystemHandler extends BaseHandler {
             }
         }
 
+        // Check if the package is part of a PTF. If true it cannot be manually installed/updated/ removed
+        List<Long> ptfPackages = packages.stream().filter(Package::isPartOfPtf).map(Package::getId).collect(toList());
+        if (!ptfPackages.isEmpty()) {
+            throw new PtfPackageFault(ptfPackages);
+        }
+
 
         for (Integer sid : sids) {
-            Server server = SystemManager.lookupByIdAndUser(sid.longValue(),
-                    loggedInUser);
+            Server server = SystemManager.lookupByIdAndUser(sid.longValue(), loggedInUser);
 
             // Would be nice to do this check at the Manager layer but upset many tests,
             // some of which were not cooperative when being fixed. Placing here for now.
@@ -4040,7 +4040,7 @@ public class SystemHandler extends BaseHandler {
 
             actionIds.add(action.getId());
         }
-        return actionIds.toArray(new Long[actionIds.size()]);
+        return actionIds.toArray(new Long[0]);
     }
 
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerPtfTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerPtfTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.xmlrpc.system.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.rhn.domain.action.Action;
+import com.redhat.rhn.domain.action.ActionFactory;
+import com.redhat.rhn.domain.action.rhnpackage.PackageAction;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.ChannelFactory;
+import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
+import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.test.PackageTest;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.ServerGroupFactory;
+import com.redhat.rhn.domain.server.test.ServerFactoryTest;
+import com.redhat.rhn.frontend.xmlrpc.PtfMasterFault;
+import com.redhat.rhn.frontend.xmlrpc.PtfPackageFault;
+import com.redhat.rhn.frontend.xmlrpc.system.SystemHandler;
+import com.redhat.rhn.frontend.xmlrpc.system.XmlRpcSystemHelper;
+import com.redhat.rhn.frontend.xmlrpc.test.BaseHandlerTestCase;
+import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
+import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
+import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
+import com.redhat.rhn.taskomatic.TaskomaticApi;
+import com.redhat.rhn.testing.PackageTestUtils;
+
+import com.suse.manager.virtualization.VirtManagerSalt;
+import com.suse.manager.webui.controllers.bootstrap.RegularMinionBootstrapper;
+import com.suse.manager.webui.controllers.bootstrap.SSHMinionBootstrapper;
+import com.suse.manager.webui.services.iface.MonitoringManager;
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.iface.VirtManager;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
+
+import org.jmock.imposters.ByteBuddyClassImposteriser;
+import org.jmock.junit5.JUnit5Mockery;
+import org.jmock.lib.concurrent.Synchroniser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Test for the {@link SystemHandler} to verify the handling of PTF packages.
+ */
+public class SystemHandlerPtfTest extends BaseHandlerTestCase {
+
+    private SystemHandler handler;
+
+    @RegisterExtension
+    protected JUnit5Mockery mockContext;
+
+    private Package standard;
+    private Package standardUpdated;
+
+    private Package standardUpdatedPtf;
+    private Package ptfMaster;
+    private Package ptfMasterUpdated;
+    private Package ptfPackage;
+    private Package ptfPackageUpdated;
+    private Server server;
+    private Channel channel;
+
+    public SystemHandlerPtfTest() {
+        mockContext = new JUnit5Mockery();
+        mockContext.setThreadingPolicy(new Synchroniser());
+        mockContext.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+    }
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+
+        TaskomaticApi taskomaticApi = new TaskomaticApi();
+        SystemQuery systemQuery = new TestSystemQuery();
+        SaltApi saltApi = new TestSaltApi();
+
+        RegularMinionBootstrapper regularBootstrapper = new RegularMinionBootstrapper(systemQuery, saltApi);
+        SSHMinionBootstrapper sshBootstrapper = new SSHMinionBootstrapper(systemQuery, saltApi);
+        XmlRpcSystemHelper xmlRpcHelper = new XmlRpcSystemHelper(regularBootstrapper, sshBootstrapper);
+
+        ServerGroupManager groupManager = new ServerGroupManager(saltApi);
+        VirtManager virtManager = new VirtManagerSalt(saltApi);
+        MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
+
+        SystemUnentitler unentitler = new SystemUnentitler(virtManager, monitoringManager, groupManager);
+        SystemEntitler entitler = new SystemEntitler(saltApi, virtManager, monitoringManager, groupManager);
+
+        SystemEntitlementManager entitlementManager = new SystemEntitlementManager(unentitler, entitler);
+        SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON, saltApi);
+
+        handler = new SystemHandler(taskomaticApi, xmlRpcHelper, entitlementManager, systemManager, groupManager);
+
+        standard = PackageTest.createTestPackage(admin.getOrg());
+        standardUpdated = PackageTestUtils.newVersionOfPackage(standard, null, "2.0.0", null, admin.getOrg());
+        standardUpdatedPtf = PackageTestUtils.createPtfPackage(standardUpdated, "123456", "1", admin.getOrg());
+        ptfMaster = PackageTestUtils.createPtfMaster("123456", "1", admin.getOrg());
+        ptfMasterUpdated = PackageTestUtils.newVersionOfPackage(ptfMaster, null, "2", null, admin.getOrg());
+        ptfPackage = PackageTestUtils.createPtfPackage("123456", "1", admin.getOrg());
+        ptfPackageUpdated = PackageTestUtils.createPtfPackage("123456", "2", admin.getOrg());
+
+        server = ServerFactoryTest.createTestServer(admin, true);
+        channel = ChannelFactoryTest.createTestChannel(admin);
+
+        SystemManager.subscribeServerToChannel(admin, server, channel);
+    }
+
+    @Test
+    public void allInstallablePackagesDoesNotListPtfsPackages() {
+        channel.getPackages()
+               .addAll(List.of(standard, standardUpdated, ptfMaster, ptfMasterUpdated, ptfPackage, ptfPackageUpdated));
+
+        List<Map<String, Object>> resultMap = handler.listAllInstallablePackages(admin, server.getId().intValue());
+
+        // Only standard and ptf master packages should be listed
+        assertEquals(4, resultMap.size());
+
+        assertEquals(
+            Set.of(standard.getId(), standardUpdated.getId(), ptfMaster.getId(), ptfMasterUpdated.getId()),
+            resultMap.stream().map(map -> (Long) map.get("id")).collect(Collectors.toSet())
+        );
+    }
+
+    @Test
+    public void latestInstallablePackagesDoesNotListPtfsPackages() {
+        channel.getPackages()
+               .addAll(List.of(standard, standardUpdated, ptfMaster, ptfMasterUpdated, ptfPackage, ptfPackageUpdated));
+        ChannelFactory.refreshNewestPackageCache(channel, "java::test");
+
+        List<Map<String, Object>> resultMap = handler.listLatestInstallablePackages(admin, server.getId().intValue());
+
+        // Only standard and ptf master packages should be listed
+        assertEquals(2, resultMap.size());
+
+        Set<Long> actualIds = resultMap.stream().map(map -> (Long) map.get("id")).collect(Collectors.toSet());
+        Set<Long> expectedIds = Set.of(standardUpdated.getId(), ptfMasterUpdated.getId());
+        assertEquals(expectedIds, actualIds);
+    }
+
+    @Test
+    public void listLatestAvailablePackageDoesNotConsiderPtfPackages() {
+        channel.getPackages().addAll(List.of(standard, standardUpdated, standardUpdatedPtf));
+        PackageTestUtils.installPackageOnServer(standard, server);
+
+        List<Map<String, Object>> results = handler.listLatestAvailablePackage(admin,
+            List.of(server.getId().intValue()), standard.getPackageName().getName());
+
+        assertEquals(1, results.size());
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> packageInfoMap = (Map<String, Object>) results.get(0).get("package");
+        assertNotNull(packageInfoMap);
+        assertEquals(standardUpdated.getId(), packageInfoMap.get("id"));
+    }
+
+    @Test
+    public void installingPtfPackageFailsWithPtfPackageFault() {
+        channel.getPackages().add(ptfPackage);
+
+        assertThrows(PtfPackageFault.class, () -> {
+            handler.schedulePackageInstall(admin, List.of(server.getId().intValue()),
+                List.of(ptfPackage.getId().intValue()), new Date());
+        });
+    }
+
+    @Test
+    public void upgradingToPtfPackageFailsWithPtfPackageFault() {
+        channel.getPackages().addAll(List.of(standard, standardUpdated));
+        PackageTestUtils.installPackageOnServer(standard, server);
+
+        assertThrows(PtfPackageFault.class, () -> {
+            handler.schedulePackageInstall(admin, List.of(server.getId().intValue()),
+                List.of(standardUpdatedPtf.getId().intValue()), new Date());
+        });
+    }
+
+    @Test
+    public void removingPtfPackageFailsWithPtfPackageFault() {
+        channel.getPackages().add(ptfPackage);
+        PackageTestUtils.installPackageOnServer(ptfPackage, server);
+
+        assertThrows(PtfPackageFault.class, () -> {
+            handler.schedulePackageRemove(admin, List.of(server.getId().intValue()),
+                List.of(ptfPackage.getId().intValue()), new Date());
+        });
+    }
+
+    @Test
+    public void masterPtfPackagesCanBeInstalled() {
+        channel.getPackages().add(ptfMaster);
+
+        Long[] scheduledActions = handler.schedulePackageInstall(admin, List.of(server.getId().intValue()),
+            List.of(ptfMaster.getId().intValue()), new Date());
+
+        assertNotNull(scheduledActions);
+        assertEquals(1, scheduledActions.length);
+
+        Action action = ActionFactory.lookupByUserAndId(admin, scheduledActions[0]);
+        assertNotNull(action);
+        assertTrue(action instanceof PackageAction);
+    }
+
+    @Test
+    public void removingMasterPtfFailsWithPtfMasterFault() {
+        channel.getPackages().add(ptfMaster);
+        PackageTestUtils.installPackageOnServer(ptfMaster, server);
+
+        assertThrows(PtfMasterFault.class, () -> {
+            handler.schedulePackageRemove(admin, List.of(server.getId().intValue()),
+                List.of(ptfMaster.getId().intValue()), new Date());
+        });
+
+    }
+
+}

--- a/java/code/src/com/redhat/rhn/manager/configuration/EnableConfigHelper.java
+++ b/java/code/src/com/redhat/rhn/manager/configuration/EnableConfigHelper.java
@@ -146,7 +146,7 @@ public class EnableConfigHelper {
     private boolean installPackagesHelper(Server current,
             List packages, String packageName, int status) {
         if (status == ConfigSystemDto.NEEDED) {
-            Map map = PackageManager.lookupEvrIdByPackageName(current.getId(), packageName);
+            Map<String, Long> map = PackageManager.lookupEvrIdByPackageName(current.getId(), packageName);
             if (map == null) {
                 return true;
             }

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -924,87 +924,114 @@ public class ContentSyncManager {
     private void generatePtfChannels(List<SCCRepositoryJson> repositories) {
         List<SCCRepository> reposToSave = new ArrayList<>();
         List<SUSEProductSCCRepository> productReposToSave = new ArrayList<>();
-        for (SCCRepositoryJson jrepo : repositories) {
-            try {
-                URI uri = new URI(jrepo.getUrl());
-                // Format: /PTF/Release/<ACCOUNT>/<Product Identifier>/<Version>/<Architecture>/[ptf|test]
-                String[] parts = uri.getPath().split("/");
-                if (!(parts[1].equals("PTF") && parts[2].equals("Release"))) {
-                    continue;
-                }
-                String prdArch = parts[6];
-                String archStr = prdArch.equals("amd64") ? prdArch + "-deb" : prdArch;
-
-                SCCRepository repo = new SCCRepository();
-                repo.setSigned(true);
-                repo.update(jrepo);
-                reposToSave.add(repo);
-
-                SUSEProduct product = SUSEProductFactory.findSUSEProduct(parts[4], parts[5], null, archStr, false);
-                if (product == null) {
-                    log.warn("Skipping PTF repo for unknown product: " + uri);
-                    continue;
-                }
-                List<String> channelParts = new ArrayList<>(
-                        Arrays.asList(parts[3], product.getName(), product.getVersion()));
-                switch (parts[7]) {
-                case "ptf":
-                    channelParts.add("PTFs");
-                    break;
-                case "test":
-                    channelParts.add("TEST");
-                    break;
-                default:
-                    log.warn("Unknown repo type: " + parts[7] + ". Skipping");
-                    continue;
-                }
-                channelParts.add(prdArch);
-
-                List<SUSEProduct> rootProducts = SUSEProductFactory.findAllRootProductsOf(product);
-                if (rootProducts.isEmpty()) {
-                    // when no root product was found, we are the root product
-                    rootProducts.add(product);
-                }
-                rootProducts.forEach(root -> {
-                    SUSEProductSCCRepository prodRepoLink = new SUSEProductSCCRepository();
-                    prodRepoLink.setProduct(product);
-                    prodRepoLink.setRepository(repo);
-                    prodRepoLink.setRootProduct(root);
-
-                    prodRepoLink.setUpdateTag(null);
-                    prodRepoLink.setMandatory(false);
-                    // Current PTF key for SLE 12/15 and SLE-Micro
-                    prodRepoLink.setGpgKeyUrl("file:///usr/lib/rpm/gnupg/keys/suse_ptf_key.asc");
-                    product.getRepositories().stream()
-                        .filter(r -> r.getRootProduct().equals(root))
-                        .filter(r -> r.getParentChannelLabel() != null)
-                        .findFirst()
-                        .ifPresent(r -> {
-                            List<String> suffix = new ArrayList<>();
-                            prodRepoLink.setParentChannelLabel(r.getParentChannelLabel());
-                            int archIdx = r.getChannelName().lastIndexOf(prdArch);
-                            if (archIdx > -1) {
-                                suffix = Arrays.asList(
-                                        r.getChannelName().substring(archIdx + prdArch.length())
-                                        .strip().split("[\\s-]"));
-                            }
-                            List<String> cList = Stream.concat(channelParts.stream(), suffix.stream())
-                                .filter(e -> !e.isBlank())
-                                .collect(Collectors.toList());
-                            prodRepoLink.setChannelLabel(String.join("-", cList)
-                                    .toLowerCase().replace(" for ", " ").replace(" ", "-"));
-                            prodRepoLink.setChannelName(String.join(" ", cList));
-
-                        });
-                    productReposToSave.add(prodRepoLink);
-                });
+        for (SCCRepositoryJson jRepo : repositories) {
+            PtfProductRepositoryInfo ptfInfo = parsePtfInfoFromUrl(jRepo);
+            if (ptfInfo == null) {
+                continue;
             }
-            catch (URISyntaxException e) {
-                log.warn("Unable to parse URL '" + jrepo.getUrl() + "'. Skipping", e);
+
+            List<SUSEProduct> rootProducts = SUSEProductFactory.findAllRootProductsOf(ptfInfo.getProduct());
+            if (rootProducts.isEmpty()) {
+                // when no root product was found, we are the root product
+                rootProducts.add(ptfInfo.getProduct());
             }
+
+            rootProducts.stream()
+                        .map(root -> convertToProductSCCRepository(root, ptfInfo))
+                        .forEach(productReposToSave::add);
+
+            reposToSave.add(ptfInfo.getRepository());
         }
-        reposToSave.stream().forEach(SUSEProductFactory::save);
-        productReposToSave.stream().forEach(SUSEProductFactory::save);
+
+        reposToSave.forEach(SUSEProductFactory::save);
+        productReposToSave.forEach(SUSEProductFactory::save);
+    }
+
+    private static PtfProductRepositoryInfo parsePtfInfoFromUrl(SCCRepositoryJson jrepo) {
+        URI uri;
+
+        try {
+            uri = new URI(jrepo.getUrl());
+        }
+        catch (URISyntaxException e) {
+            log.warn("Unable to parse URL '{}'. Skipping", jrepo.getUrl(), e);
+            return null;
+        }
+
+        // Format: /PTF/Release/<ACCOUNT>/<Product Identifier>/<Version>/<Architecture>/[ptf|test]
+        String[] parts = uri.getPath().split("/");
+        if (!(parts[1].equals("PTF") && parts[2].equals("Release"))) {
+            return null;
+        }
+        String prdArch = parts[6];
+        String archStr = prdArch.equals("amd64") ? prdArch + "-deb" : prdArch;
+
+        SCCRepository repo = new SCCRepository();
+        repo.setSigned(true);
+        repo.update(jrepo);
+
+        SUSEProduct product = SUSEProductFactory.findSUSEProduct(parts[4], parts[5], null, archStr, false);
+        if (product == null) {
+            log.warn("Skipping PTF repo for unknown product: {}", uri);
+            return null;
+        }
+
+        List<String> channelParts = new ArrayList<>(Arrays.asList(parts[3], product.getName(), product.getVersion()));
+        switch (parts[7]) {
+            case "ptf":
+                channelParts.add("PTFs");
+                break;
+            case "test":
+                channelParts.add("TEST");
+                break;
+            default:
+                log.warn("Unknown repo type: {}. Skipping", parts[7]);
+                return null;
+        }
+        channelParts.add(prdArch);
+
+        return new PtfProductRepositoryInfo(product, repo, channelParts, prdArch);
+    }
+
+    private static SUSEProductSCCRepository convertToProductSCCRepository(SUSEProduct root,
+                                                                          PtfProductRepositoryInfo ptfInfo) {
+        SUSEProductSCCRepository prodRepoLink = new SUSEProductSCCRepository();
+
+        prodRepoLink.setProduct(ptfInfo.getProduct());
+        prodRepoLink.setRepository(ptfInfo.getRepository());
+        prodRepoLink.setRootProduct(root);
+
+        prodRepoLink.setUpdateTag(null);
+        prodRepoLink.setMandatory(false);
+
+        // Current PTF key for SLE 12/15 and SLE-Micro
+        prodRepoLink.setGpgKeyUrl("file:///usr/lib/rpm/gnupg/keys/suse_ptf_key.asc");
+
+        ptfInfo.getProduct()
+               .getRepositories()
+               .stream()
+               .filter(r -> r.getRootProduct().equals(root) && r.getParentChannelLabel() != null)
+               .findFirst()
+               .ifPresent(r -> {
+                   List<String> suffix = new ArrayList<>();
+
+                   prodRepoLink.setParentChannelLabel(r.getParentChannelLabel());
+                   int archIdx = r.getChannelName().lastIndexOf(ptfInfo.getArchitecture());
+                   if (archIdx > -1) {
+                       suffix = Arrays.asList(
+                           r.getChannelName().substring(archIdx + ptfInfo.getArchitecture().length())
+                            .strip().split("[\\s-]"));
+                   }
+
+                   List<String> cList = Stream.concat(ptfInfo.getChannelParts().stream(), suffix.stream())
+                                              .filter(e -> !e.isBlank())
+                                              .collect(Collectors.toList());
+
+                   prodRepoLink.setChannelLabel(String.join("-", cList).toLowerCase().replaceAll("( for | )", "-"));
+                   prodRepoLink.setChannelName(String.join(" ", cList));
+               });
+
+        return prodRepoLink;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/content/PtfProductRepositoryInfo.java
+++ b/java/code/src/com/redhat/rhn/manager/content/PtfProductRepositoryInfo.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.manager.content;
+
+import com.redhat.rhn.domain.product.SUSEProduct;
+import com.redhat.rhn.domain.scc.SCCRepository;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * Class to hold the information of a product and a repository with PTF packages
+ */
+public class PtfProductRepositoryInfo {
+
+    private final SUSEProduct product;
+
+    private final SCCRepository repository;
+
+    private final List<String> channelParts;
+
+    private final String architecture;
+
+    /**
+     * Default constructor
+     * @param productIn the SUSE product
+     * @param repoIn    the repository
+     * @param partsIn   the parts constructing the repository URL
+     * @param archIn    the architecture
+     */
+    public PtfProductRepositoryInfo(SUSEProduct productIn, SCCRepository repoIn, List<String> partsIn, String archIn) {
+        this.product = productIn;
+        this.repository = repoIn;
+        this.channelParts = Collections.unmodifiableList(partsIn);
+        this.architecture = archIn;
+    }
+
+    public SUSEProduct getProduct() {
+        return product;
+    }
+
+    public SCCRepository getRepository() {
+        return repository;
+    }
+
+    public List<String> getChannelParts() {
+        return channelParts;
+    }
+
+    public String getArchitecture() {
+        return architecture;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PtfProductRepositoryInfo that = (PtfProductRepositoryInfo) o;
+        return Objects.equals(product, that.product) && Objects.equals(repository,
+            that.repository) && Objects.equals(channelParts, that.channelParts) && Objects.equals(
+            architecture, that.architecture);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(product, repository, channelParts, architecture);
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", PtfProductRepositoryInfo.class.getSimpleName() + "[", "]")
+            .add("product=" + product)
+            .add("repository=" + repository)
+            .add("channelParts=" + channelParts)
+            .add("architecture='" + architecture + "'")
+            .toString();
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/DependencyResolver.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/DependencyResolver.java
@@ -15,7 +15,6 @@
 
 package com.redhat.rhn.manager.contentmgmt;
 
-import static com.suse.utils.Opt.stream;
 import static java.util.stream.Collectors.toList;
 
 import com.redhat.rhn.domain.channel.Channel;
@@ -74,8 +73,8 @@ import java.util.stream.Stream;
  */
 public class DependencyResolver {
 
-    private ContentProject project;
-    private ModulemdApi modulemdApi;
+    private final ContentProject project;
+    private final ModulemdApi modulemdApi;
 
     /**
      * Initialize a new instance with a content project and a {@link ModulemdApi} instance
@@ -99,8 +98,9 @@ public class DependencyResolver {
     public DependencyResolutionResult resolveFilters(List<ContentFilter> filters) throws DependencyResolutionException {
 
         List<ModuleFilter> moduleFilters = filters.stream()
-                .flatMap(f -> stream((Optional<ModuleFilter>) f.asModuleFilter()))
-                .collect(toList());
+                                                  .filter(f -> f instanceof ModuleFilter)
+                                                  .map(ModuleFilter.class::cast)
+                                                  .collect(toList());
 
         List<ContentFilter> updatedFilters = new ArrayList<>(filters);
 

--- a/java/code/src/com/redhat/rhn/manager/errata/cache/ErrataCacheManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/cache/ErrataCacheManager.java
@@ -26,6 +26,7 @@ import com.redhat.rhn.domain.errata.AdvisoryStatus;
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.errata.ErrataFactory;
 import com.redhat.rhn.domain.org.Org;
+import com.redhat.rhn.frontend.dto.ErrataCacheDto;
 import com.redhat.rhn.frontend.events.UpdateErrataCacheEvent;
 import com.redhat.rhn.manager.errata.ErrataManager;
 
@@ -110,11 +111,8 @@ public class ErrataCacheManager extends HibernateFactory {
      * @param sid Server Id.
      * @return packages needing updates for the given server id.
      */
-    public static DataResult packagesNeedingUpdates(Long sid) {
-        Map<String, Object> params = new HashMap<>();
-        params.put("server_id", sid);
-        return executeSelectMode("ErrataCache_queries",
-                "packages_needing_updates", params);
+    public static DataResult<ErrataCacheDto> packagesNeedingUpdates(Long sid) {
+        return executeSelectMode("ErrataCache_queries", "packages_needing_updates", Map.of("server_id", sid));
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/errata/cache/test/PtfPackagesCacheManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/cache/test/PtfPackagesCacheManagerTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.manager.errata.cache.test;
+
+import com.redhat.rhn.common.db.datasource.DataResult;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.ChannelFactory;
+import com.redhat.rhn.domain.errata.Errata;
+import com.redhat.rhn.domain.errata.test.ErrataFactoryTest;
+import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.PackageFactory;
+import com.redhat.rhn.domain.rhnpackage.test.PackageTest;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.test.ServerFactoryTest;
+import com.redhat.rhn.frontend.dto.ErrataCacheDto;
+import com.redhat.rhn.manager.errata.cache.ErrataCacheManager;
+import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
+import com.redhat.rhn.testing.ChannelTestUtils;
+import com.redhat.rhn.testing.PackageTestUtils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class PtfPackagesCacheManagerTest extends BaseTestCaseWithUser {
+
+    private Server server;
+    private Channel subscribedChannel;
+
+    // 3 ascending versions of the same package
+    private Package originalPackage;
+
+    private Package ptfPackage;
+
+    private Package newerPackage;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+
+        server = ServerFactoryTest.createTestServer(user);
+
+        originalPackage = PackageTest.createTestPackage(user.getOrg());
+        ptfPackage = PackageTestUtils.createPtfPackage(originalPackage, "123456", "1", user.getOrg());
+        newerPackage = PackageTestUtils.newVersionOfPackage(originalPackage, null, "2.0.0", null, user.getOrg());
+
+        subscribedChannel = ChannelTestUtils.createBaseChannel(user);
+        subscribedChannel.setChecksumType(ChannelFactory.findChecksumTypeByLabel("sha256"));
+        SystemManager.subscribeServerToChannel(user, server, subscribedChannel);
+    }
+
+    /**
+     * Test that inserting a ptf package with higher version to the cache has no effect.
+     *
+     */
+    @Test
+    public void ensurePtfPackagesNotAreInsertedByPackageInNeededCache() {
+        // channel has original and ptf packages
+        subscribedChannel.getPackages().addAll(List.of(originalPackage, ptfPackage, newerPackage));
+
+        // original is installed on the server
+        PackageTestUtils.installPackageOnServer(originalPackage, server);
+
+        // insert newer & newest
+        ErrataCacheManager.insertCacheForChannelPackages(subscribedChannel.getId(), null, List.of(ptfPackage.getId()));
+
+        // Verify that no ptf are in the needed cache
+        DataResult<ErrataCacheDto> needingUpdates = ErrataCacheManager.packagesNeedingUpdates(server.getId());
+        Assertions.assertEquals(0L, needingUpdates.stream()
+                                                  .map(e -> PackageFactory.lookupByIdAndUser(e.getPackageId(), user))
+                                                  .filter(Package::isPartOfPtf)
+                                                  .count());
+
+        // just to be sure, recompute the cache and verify that the results are same
+        ServerFactory.updateServerNeededCache(server.getId());
+        needingUpdates = ErrataCacheManager.packagesNeedingUpdates(server.getId());
+        Assertions.assertEquals(0L, needingUpdates.stream()
+                                                  .map(e -> PackageFactory.lookupByIdAndUser(e.getPackageId(), user))
+                                                  .filter(Package::isPartOfPtf)
+                                                  .count());
+    }
+
+    /**
+     * Test that inserting an errata with ptf package with higher version to the cache has no effect.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    public void ensurePtfPackagesNotAreInsertedByErrataInNeededCache() throws Exception {
+        // channel has original and ptf packages
+        subscribedChannel.getPackages().addAll(List.of(originalPackage, ptfPackage, newerPackage));
+
+        Errata errataPtf = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
+        errataPtf.addPackage(ptfPackage);
+        subscribedChannel.addErrata(errataPtf);
+
+        // original is installed on the server
+        PackageTestUtils.installPackageOnServer(originalPackage, server);
+
+        // insert newer & newest
+        ErrataCacheManager.insertCacheForChannelPackages(subscribedChannel.getId(), errataPtf.getId(),
+            List.of(ptfPackage.getId()));
+
+        // Verify that no ptf are in the needed cache
+        DataResult<ErrataCacheDto> needingUpdates = ErrataCacheManager.packagesNeedingUpdates(server.getId());
+        Assertions.assertEquals(0L, needingUpdates.stream()
+                                                  .map(e -> PackageFactory.lookupByIdAndUser(e.getPackageId(), user))
+                                                  .filter(Package::isPartOfPtf)
+                                                  .count());
+
+        // just to be sure, recompute the cache and verify that the results are same
+        ServerFactory.updateServerNeededCache(server.getId());
+        needingUpdates = ErrataCacheManager.packagesNeedingUpdates(server.getId());
+        Assertions.assertEquals(0L, needingUpdates.stream()
+                                                  .map(e -> PackageFactory.lookupByIdAndUser(e.getPackageId(), user))
+                                                  .filter(Package::isPartOfPtf)
+                                                  .count());
+    }
+
+    /**
+     * Test that inserting higher version are respected even when PTF are involved
+     *
+     */
+    @Test
+    public void ensureHigherVersionCalculationIsCorrectWithPtfPackages() {
+        // channel has original and ptf packages
+        subscribedChannel.getPackages().addAll(List.of(originalPackage, ptfPackage, newerPackage));
+
+        // original is installed on the server
+        PackageTestUtils.installPackageOnServer(originalPackage, server);
+
+        // insert newer & newest
+        ErrataCacheManager.insertCacheForChannelPackages(subscribedChannel.getId(), null,
+            List.of(ptfPackage.getId(), newerPackage.getId()));
+
+        // Verify that no ptf are in the needed cache
+        DataResult<ErrataCacheDto> needingUpdates = ErrataCacheManager.packagesNeedingUpdates(server.getId());
+        Assertions.assertEquals(1L, needingUpdates.size());
+        Assertions.assertEquals(0L, needingUpdates.stream()
+                                                  .map(e -> PackageFactory.lookupByIdAndUser(e.getPackageId(), user))
+                                                  .filter(Package::isPartOfPtf)
+                                                  .count());
+
+        // just to be sure, recompute the cache and verify that the results are same
+        ServerFactory.updateServerNeededCache(server.getId());
+        needingUpdates = ErrataCacheManager.packagesNeedingUpdates(server.getId());
+        Assertions.assertEquals(1L, needingUpdates.size());
+        Assertions.assertEquals(0L, needingUpdates.stream()
+                                                  .map(e -> PackageFactory.lookupByIdAndUser(e.getPackageId(), user))
+                                                  .filter(Package::isPartOfPtf)
+                                                  .count());
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
+++ b/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
@@ -606,15 +606,15 @@ public class PackageManager extends BaseManager {
      * @return A map with keys 'name_id' and 'evr_id' containing Long types.
      *         Null if nothing found.
      */
-    public static Map lookupEvrIdByPackageName(Long sid, String name) {
+    public static Map<String, Long> lookupEvrIdByPackageName(Long sid, String name) {
         Map<String, Object> params = new HashMap<>();
         params.put("sid", sid);
         params.put("name", name);
-        SelectMode m = ModeFactory.getMode("Package_queries",
-                "lookup_id_combo_by_name");
-        DataResult dr = m.execute(params);
+        SelectMode m = ModeFactory.getMode("Package_queries", "lookup_id_combo_by_name");
+        @SuppressWarnings("unchecked")
+        DataResult<Map<String, Long>> dr = m.execute(params);
         if (dr.size() > 0) {
-            return (Map) dr.get(0);
+            return dr.get(0);
         }
         return null;
     }

--- a/java/code/src/com/redhat/rhn/manager/rhnpackage/test/PackageManagerPtfTest.java
+++ b/java/code/src/com/redhat/rhn/manager/rhnpackage/test/PackageManagerPtfTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.manager.rhnpackage.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.redhat.rhn.common.db.datasource.DataResult;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.ChannelFactory;
+import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.PackageFactory;
+import com.redhat.rhn.domain.rhnpackage.test.PackageTest;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.test.ServerFactoryTest;
+import com.redhat.rhn.frontend.dto.PackageListItem;
+import com.redhat.rhn.frontend.dto.UpgradablePackageListItem;
+import com.redhat.rhn.manager.rhnpackage.PackageManager;
+import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
+import com.redhat.rhn.testing.ChannelTestUtils;
+import com.redhat.rhn.testing.PackageTestUtils;
+import com.redhat.rhn.testing.TestUtils;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class PackageManagerPtfTest extends BaseTestCaseWithUser {
+    private Server server;
+
+    private Package pkg;
+
+    private Package ptfPackage;
+
+    private Package updatedPtfPackage;
+
+    private Package ptfMaster;
+
+    private Package updatedPtfMaster;
+
+    private Package standard;
+
+    private Package updatedStandard;
+
+    private Channel channel;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+
+        server = ServerFactoryTest.createTestServer(user);
+
+        // The original package with a bug
+        pkg = PackageTest.createTestPackage(user.getOrg());
+
+        // The first version ptf addressing the issue
+        ptfMaster = PackageTestUtils.createPtfMaster("12987", "1", user.getOrg());
+        ptfPackage = PackageTestUtils.createPtfPackage(pkg, "12987", "1", user.getOrg());
+
+        // The second version of the same ptf
+        updatedPtfMaster = PackageTestUtils.createPtfMaster("12987", "2", user.getOrg());
+        updatedPtfPackage = PackageTestUtils.createPtfPackage(pkg, "12987", "2", user.getOrg());
+
+        // A normal package unrelatad to the ptf
+        standard = PackageTest.createTestPackage(user.getOrg());
+        updatedStandard = PackageTestUtils.newVersionOfPackage(standard, null, "3.0.0", null, user.getOrg());
+
+        channel = ChannelTestUtils.createBaseChannel(user);
+        channel.setChecksumType(ChannelFactory.findChecksumTypeByLabel("sha256"));
+
+        SystemManager.subscribeServerToChannel(user, server, channel);
+        server = TestUtils.saveAndReload(server);
+    }
+
+    @Test
+    public void testSystemPackageList() throws Exception {
+        // Add the packages to the channel
+        channel.getPackages().addAll(List.of(pkg, ptfPackage, ptfMaster));
+        channel = TestUtils.saveAndReload(channel);
+        ChannelFactory.refreshNewestPackageCache(channel, "java::test");
+
+        DataResult<PackageListItem> installablePackages = PackageManager.systemAvailablePackages(server.getId(), null);
+
+
+        assertNotNull(installablePackages);
+        // There should be two installable package. The standard one and the PTF.
+        assertEquals(2, installablePackages.size());
+        // No packages should be part of a PTF
+        assertEquals(0L, installablePackages.stream()
+                                            .map(e -> PackageFactory.lookupByIdAndUser(e.getPackageId(), user))
+                                            .filter(Package::isPartOfPtf)
+                                            .count());
+    }
+
+    @Test
+    public void testUpgradable() {
+        channel.getPackages().addAll(
+            List.of(pkg, standard, ptfPackage, ptfMaster, updatedPtfPackage, updatedPtfMaster, updatedStandard)
+        );
+        channel = TestUtils.saveAndReload(channel);
+
+        PackageTestUtils.installPackagesOnServer(List.of(ptfPackage, ptfMaster, standard), server);
+
+        commitAndCloseSession();
+
+        ChannelFactory.refreshNewestPackageCache(channel, "java::test");
+        ServerFactory.updateServerNeededCache(server.getId());
+
+        DataResult<UpgradablePackageListItem> upgradablePackages = PackageManager.upgradable(server.getId(), null);
+
+        assertNotNull(upgradablePackages);
+        // The ptf and the unrelated package should be both upgradable
+        assertEquals(2, upgradablePackages.size());
+
+        // Convert to database packages
+        List<Package> packages = upgradablePackages.stream()
+                                                   .flatMap(e -> PackageFactory.lookupByNevraIds(user.getOrg(),
+                                                       e.getNameId(), e.getEvrId(), e.getArchId()).stream())
+                                                   .filter(Objects::nonNull)
+                                                   .collect(Collectors.toList());
+
+        // There should be still two packages
+        assertEquals(2, packages.size());
+
+        // Only one should be a PTF
+        assertEquals(1L, packages.stream().filter(Package::isMasterPtfPackage).count());
+        // No packages should be part of a PTF
+        assertEquals(0L, packages.stream().filter(Package::isPartOfPtf).count());
+    }
+}
+

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -388,10 +388,9 @@ public class SystemManager extends BaseManager {
         SelectMode m = ModeFactory.getMode("Package_queries",
                                            "extra_packages_for_system");
         Map<String, Object> params = new HashMap<>();
-        params.put("serverid", serverId);
-        Map<String, Object> elabParams = new HashMap<>();
+        params.put("sid", serverId);
 
-        return makeDataResult(params, elabParams, null, m, PackageListItem.class);
+        return makeDataResult(params, params, null, m, PackageListItem.class);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/testing/PackageTestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/PackageTestUtils.java
@@ -47,9 +47,8 @@ public class PackageTestUtils {
      *
      * @param org the org
      * @return lists of the packages, sorted by version
-     * @throws Exception if anything goes wrong
      */
-    public static List<Package> createSubsequentPackages(Org org) throws Exception {
+    public static List<Package> createSubsequentPackages(Org org) {
         Package pkg1 = PackageTest.createTestPackage(org);
         PackageEvr evr = pkg1.getPackageEvr();
         evr.setVersion("1.0.0");
@@ -109,10 +108,8 @@ public class PackageTestUtils {
      * @param release the new release. If null, the release will remain the same
      * @param org the organization owning the package
      * @return a new version of the given package
-     * @throws Exception when the package cannot be created
      */
-    public static Package newVersionOfPackage(Package original, String epoch, String version, String release, Org org)
-        throws Exception {
+    public static Package newVersionOfPackage(Package original, String epoch, String version, String release, Org org) {
         PackageEvr evr = original.getPackageEvr();
 
         if (epoch == null && version == null && release == null) {
@@ -137,9 +134,8 @@ public class PackageTestUtils {
      * @param ptfVersion the version
      * @param org the organization owning the package
      * @return a ptf master package
-     * @throws Exception when the package cannot be created
      */
-    public static Package createPtfMaster(String ptfNumber, String ptfVersion, Org org) throws Exception {
+    public static Package createPtfMaster(String ptfNumber, String ptfVersion, Org org) {
         Package master = PackageTest.createTestPackage(org);
 
         master.setPackageName(PackageNameTest.createTestPackageName("ptf-" + ptfNumber));
@@ -157,9 +153,8 @@ public class PackageTestUtils {
      * @param ptfVersion the ptf version
      * @param org the organization owning the package
      * @return a package part of a ptf
-     * @throws Exception when the package cannot be created
      */
-    public static Package createPtfPackage(String ptfNumber, String ptfVersion, Org org) throws Exception {
+    public static Package createPtfPackage(String ptfNumber, String ptfVersion, Org org) {
         Package ptfPackage = PackageTest.createTestPackage(org);
 
         ptfPackage.setDescription("Package part of ptf-" + ptfNumber + " for RHN-JAVA unit tests. Please disregard.");
@@ -178,10 +173,8 @@ public class PackageTestUtils {
      * @param ptfVersion the ptf version
      * @param org the organization owning the package
      * @return a package part of a ptf
-     * @throws Exception when the package cannot be created
      */
-    public static Package createPtfPackage(Package original, String ptfNumber, String ptfVersion, Org org)
-        throws Exception {
+    public static Package createPtfPackage(Package original, String ptfNumber, String ptfVersion, Org org) {
         Package ptfPackage = PackageTest.createTestPackage(org);
 
         ptfPackage.setPackageName(original.getPackageName());

--- a/java/code/src/com/redhat/rhn/testing/RhnMockStrutsTestCase.java
+++ b/java/code/src/com/redhat/rhn/testing/RhnMockStrutsTestCase.java
@@ -99,6 +99,7 @@ public class RhnMockStrutsTestCase extends MockStrutsTestCase {
         Path tmpPillarRoot = Files.createTempDirectory("pillar");
         Path tmpSaltRoot = Files.createTempDirectory("salt");
         MinionPillarManager.INSTANCE.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
+        SaltStateGeneratorService.INSTANCE.setSkipSetOwner(true);
         SaltStateGeneratorService.INSTANCE.setSuseManagerStatesFilesRoot(tmpSaltRoot
                 .toAbsolutePath());
     }

--- a/java/code/webapp/WEB-INF/pages/rhnpackage/targetsystems.jsp
+++ b/java/code/webapp/WEB-INF/pages/rhnpackage/targetsystems.jsp
@@ -13,26 +13,32 @@
 <bean:message key="targetsystems.jsp.title"/>
 </h2>
 
-<p><bean:message key="targetsystems.jsp.description"/></p>
+<c:if test="${requestScope.isPtfPackage}">
+  <p><bean:message key="targetsystems.jsp.description_ptf_package"/></p>
+</c:if>
 
-<div>
+<c:if test="${not requestScope.isPtfPackage}">
+  <p><bean:message key="targetsystems.jsp.description"/></p>
 
-<rl:listset name="systemSet" legend="system">
-<rhn:csrf />
-  <c:set var="noAddToSsm" value="1" />
-  <%@ include file="/WEB-INF/pages/common/fragments/systems/system_listdisplay.jspf" %>
-    <rhn:submitted/>
-    <div class="form-horizontal">
-        <div class="form-group">
-            <div class="col-md-12">
-                <input type="submit" class="btn btn-success" name="dispatch" value='<bean:message key="targetsystems.jsp.installpackage"/>'/>
-            </div>
-        </div>
-    </div>
+  <div>
 
-</rl:listset>
+  <rl:listset name="systemSet" legend="system">
+  <rhn:csrf />
+    <c:set var="noAddToSsm" value="1" />
+    <%@ include file="/WEB-INF/pages/common/fragments/systems/system_listdisplay.jspf" %>
+      <rhn:submitted/>
+      <div class="form-horizontal">
+          <div class="form-group">
+              <div class="col-md-12">
+                  <input type="submit" class="btn btn-success" name="dispatch" value='<bean:message key="targetsystems.jsp.installpackage"/>'/>
+              </div>
+          </div>
+      </div>
 
-</div>
+  </rl:listset>
+
+  </div>
+</c:if>
 
 </body>
 </html:html>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Added CLM filters to match product temporary fixes packages
 - Restrict product temporary fixes visibility in the UI and in the
   APIs responses
 - Fixed empty selection warning in the lock/unlock page

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Restrict product temporary fixes visibility in the UI and in the
+  APIs responses
 - Fixed empty selection warning in the lock/unlock page
 - set GPG Key Url for PTF repositories
 - Improve systems lists queries performance by using an overview table

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fixed empty selection warning in the lock/unlock page
 - set GPG Key Url for PTF repositories
 - Improve systems lists queries performance by using an overview table
 - Pass mgr_sudo_user pillar on salt ssh client cleanup (bsc#1202093)

--- a/schema/spacewalk/common/views/rhnChannelNewestPackageView.sql
+++ b/schema/spacewalk/common/views/rhnChannelNewestPackageView.sql
@@ -45,7 +45,7 @@ FROM (
                          p.name_id,
                          p.package_arch_id
                     from rhnPackageEVR                           pe,
-                         rhnPackage                              p,
+                         susePackageExcludingPartOfPtf            p,
                          suseChannelPackageRetractedStatusView   cp
                    where p.evr_id = pe.id
                      and cp.package_id = p.id

--- a/schema/spacewalk/common/views/susePackageExcludingPartOfPtf.sql
+++ b/schema/spacewalk/common/views/susePackageExcludingPartOfPtf.sql
@@ -1,0 +1,16 @@
+--
+-- Returns the packages excluding those that are part of a PTF
+--
+
+CREATE OR REPLACE VIEW susePackageExcludingPartOfPtf AS
+  WITH ptfPackages AS (
+      SELECT pp.package_id
+        FROM rhnpackagecapability pc
+                  INNER JOIN rhnpackageprovides pp ON pc.id = pp.capability_id
+       WHERE pc.name = 'ptf-package()'
+  )
+  SELECT pkg.*
+    FROM rhnpackage pkg
+            LEFT JOIN ptfPackages ptf ON pkg.id = ptf.package_id
+   WHERE ptf.package_id IS NULL
+;

--- a/schema/spacewalk/common/views/views.deps
+++ b/schema/spacewalk/common/views/views.deps
@@ -96,6 +96,8 @@ suseChannelUserRoleView          :: rhnSharedChannelView \
                                     rhnOrgChannelSettingsType \
                                     rhnChannelPermission \
                                     rhnChannelPermissionRole
-rhnChannelNewestPackageView      :: suseChannelPackageRetractedStatusView
+rhnChannelNewestPackageView      :: suseChannelPackageRetractedStatusView \
+                                    susePackageExcludingPartOfPtf
 suseChannelPackageRetractedStatusView :: rhnChannelPackage rhnChannelErrata rhnErrataPackage
 suseServerChannelsRetractedPackagesView :: rhnServerChannel rhnChannelErrata rhnErrataPackage
+susePackageExcludingPartOfPtf :: rhnPackageCapability rhnPackageProvides rhnPackage

--- a/schema/spacewalk/postgres/packages/packages.deps
+++ b/schema/spacewalk/postgres/packages/packages.deps
@@ -61,4 +61,5 @@ rhn_server.pkb          :: rhnServerChannel rhnConfigFileName \
                            set_ks_session_history_message \
                            rhnPackage rhnChannelNewestPackage \
                            rhnPackageEVR rhnChannelPackage rhnErrataPackage \
-                           rhnChannelErrata rhnPackageUpgradeArchCompat
+                           rhnChannelErrata rhnPackageUpgradeArchCompat \
+                           susePackageExcludingPartOfPtf

--- a/schema/spacewalk/postgres/packages/rhn_server.pkb
+++ b/schema/spacewalk/postgres/packages/rhn_server.pkb
@@ -676,7 +676,7 @@ update pg_settings set setting = 'rhn_server,' || setting where name = 'search_p
                    FROM rhnServerPackage sp_sp
                    join rhnPackageEvr sp_pe ON sp_pe.id = sp_sp.evr_id
                   GROUP BY sp_sp.server_id, sp_sp.name_id, sp_sp.package_arch_id) sp
-           join rhnPackage p ON p.name_id = sp.name_id
+           join susePackageExcludingPartOfPtf p ON p.name_id = sp.name_id
            join rhnPackageEvr pe ON pe.id = p.evr_id AND (sp.max_evr).type = (pe.evr).type AND sp.max_evr < pe.evr
            join rhnPackageUpgradeArchCompat puac
 	            ON puac.package_arch_id = sp.package_arch_id

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,5 @@
+- Added view to handle ptf packages and updated the procedures
+  to refresh the updatable/installable packages
 - Add system overview table and a procedure to update it
 - Move web.system_checkin_threshold to rhnConfiguration table
 - Fix previous 'Amazon EC2' schema upgrade script

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.0-to-susemanager-schema-4.4.1/400-ptf-package-visibility.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.0-to-susemanager-schema-4.4.1/400-ptf-package-visibility.sql
@@ -1,0 +1,107 @@
+-- New view with all the packages excluding those that are part of a PTF
+CREATE OR REPLACE VIEW susePackageExcludingPartOfPtf AS
+  WITH ptfPackages AS (
+      SELECT pp.package_id
+        FROM rhnpackagecapability pc
+                  INNER JOIN rhnpackageprovides pp ON pc.id = pp.capability_id
+       WHERE pc.name = 'ptf-package()'
+  )
+  SELECT pkg.*
+    FROM rhnpackage pkg
+            LEFT JOIN ptfPackages ptf ON pkg.id = ptf.package_id
+   WHERE ptf.package_id IS NULL
+;
+
+-- Update the view for the newest package to exclude packages part of a PTF
+create or replace view
+rhnChannelNewestPackageView
+as
+SELECT channel_id,
+       name_id,
+       evr_id,
+       package_arch_id,
+       package_id
+FROM (
+      SELECT channel_id,
+             name_id,
+             evr_id,
+             package_arch_id,
+             build_time,
+             max(package_id) as package_id,
+             ROW_NUMBER() OVER(PARTITION BY name_id, channel_id, package_arch_id ORDER BY build_time DESC) rn
+      FROM (
+            SELECT m.channel_id          as channel_id,
+                   p.name_id             as name_id,
+                   p.evr_id              as evr_id,
+                   m.package_arch_id     as package_arch_id,
+                   p.id                  as package_id,
+                   p.build_time          as build_time
+            FROM (select max(pe.evr) AS max_evr,
+                         cp.channel_id,
+                         p.name_id,
+                         p.package_arch_id
+                    from rhnPackageEVR                           pe,
+                         susePackageExcludingPartOfPtf            p,
+                         suseChannelPackageRetractedStatusView   cp
+                   where p.evr_id = pe.id
+                     and cp.package_id = p.id
+                     and NOT cp.is_retracted
+                   group by cp.channel_id, p.name_id, p.package_arch_id) m,
+                 rhnPackageEVR       pe,
+                 rhnPackage          p,
+                 rhnChannelPackage   chp
+            WHERE m.max_evr = pe.evr
+                AND m.name_id = p.name_id
+                AND m.package_arch_id = p.package_arch_id
+                AND p.evr_id = pe.id
+                AND chp.package_id = p.id
+                AND chp.channel_id = m.channel_id
+      ) latest_packages
+      group by channel_id, name_id, evr_id, package_arch_id, build_time
+) n
+WHERE rn = 1;
+
+-- Update the function to refresh the updatable packages to exclude those that are part of a PTF from the results
+UPDATE pg_settings
+   SET setting = 'rhn_server,' || setting
+ WHERE name = 'search_path';
+
+    create or replace function update_needed_cache(
+        server_id_in in numeric
+  ) returns void as $$
+    begin
+      delete from rhnServerNeededCache
+        where server_id = server_id_in;
+      insert into rhnServerNeededCache
+             (server_id, errata_id, package_id, channel_id)
+        (select distinct sp.server_id, x.errata_id, p.id, x.channel_id
+           FROM (SELECT sp_sp.server_id, sp_sp.name_id,
+            sp_sp.package_arch_id, max(sp_pe.evr) AS max_evr
+                   FROM rhnServerPackage sp_sp
+                   join rhnPackageEvr sp_pe ON sp_pe.id = sp_sp.evr_id
+                  GROUP BY sp_sp.server_id, sp_sp.name_id, sp_sp.package_arch_id) sp
+           join susePackageExcludingPartOfPtf p ON p.name_id = sp.name_id
+           join rhnPackageEvr pe ON pe.id = p.evr_id AND (sp.max_evr).type = (pe.evr).type AND sp.max_evr < pe.evr
+           join rhnPackageUpgradeArchCompat puac
+              ON puac.package_arch_id = sp.package_arch_id
+        AND puac.package_upgrade_arch_id = p.package_arch_id
+           join rhnServerChannel sc ON sc.server_id = sp.server_id
+           join rhnChannelPackage cp ON cp.package_id = p.id
+              AND cp.channel_id = sc.channel_id
+           left join (SELECT ep.errata_id, ce.channel_id, ep.package_id
+                        FROM rhnChannelErrata ce
+                        join rhnErrataPackage ep
+               ON ep.errata_id = ce.errata_id
+      join rhnServerChannel sc_sc
+               ON sc_sc.channel_id = ce.channel_id
+           WHERE sc_sc.server_id = server_id_in) x
+             ON x.channel_id = sc.channel_id AND x.package_id = cp.package_id
+     left join rhnErrata e on x.errata_id = e.id
+          where sp.server_id = server_id_in
+            and (x.errata_id IS NULL or e.advisory_status != 'retracted')); -- packages which are part of a retracted errata should not be installed
+  end$$ language plpgsql;
+
+-- restore the original setting
+UPDATE pg_settings
+   SET setting = overlay( setting placing '' FROM 1 FOR (LENGTH('rhn_server') + 1) )
+ WHERE name = 'search_path';

--- a/web/html/src/manager/content-management/list-filters/filter-form.tsx
+++ b/web/html/src/manager/content-management/list-filters/filter-form.tsx
@@ -262,6 +262,26 @@ const FilterForm = (props: Props) => {
               </>
             )}
 
+            {clmFilterOptions.PTF_NUMBER.key === filterType && (
+              <Text
+                name={clmFilterOptions.PTF_NUMBER.key}
+                label={t("Number")}
+                labelClass="col-md-3"
+                divClass="col-md-8"
+                required
+              />
+            )}
+
+            {clmFilterOptions.PTF_PACKAGE_NAME.key === filterType && (
+              <Text
+                name={clmFilterOptions.PTF_PACKAGE_NAME.key}
+                label={t("Package Name")}
+                labelClass="col-md-3"
+                divClass="col-md-8"
+                required
+              />
+            )}
+
             {clmFilterOptions.STREAM.key !== filterType && (
               <Radio
                 inline

--- a/web/html/src/manager/content-management/list-filters/filter.utils.test.ts
+++ b/web/html/src/manager/content-management/list-filters/filter.utils.test.ts
@@ -229,4 +229,19 @@ describe("Testing filters form <> request mappers", () => {
       })
     );
   });
+
+  test("test filter all ptf", () => {
+    const filterForm: FilterFormType = {
+      filter_name: "all ptf",
+      matcher: "ptf_all",
+      type: "ptf_all",
+      rule: "deny",
+    };
+
+    expect(mapResponseToFilterForm([mapFilterFormToRequest(filterForm)])[0]).toEqual(
+      expect.objectContaining({ ...filterForm, ptf_all: "all" })
+    );
+    expect(mapFilterFormToRequest(filterForm).criteriaKey).toEqual("ptf_all");
+    expect(mapFilterFormToRequest(filterForm).criteriaValue).toEqual("all");
+  });
 });

--- a/web/html/src/manager/content-management/list-filters/filter.utils.ts
+++ b/web/html/src/manager/content-management/list-filters/filter.utils.ts
@@ -58,6 +58,8 @@ export function mapFilterFormToRequest(filterForm: Partial<FilterFormType>, proj
     const streamName = !_isEmpty(filterForm.moduleStream) ? `:${filterForm.moduleStream}` : "";
     requestForm.criteriaValue = `${filterForm.moduleName || ""}${streamName}`;
     requestForm.rule = "allow";
+  } else if (filterForm.type === clmFilterOptions.PTF_ALL.key) {
+    requestForm.criteriaValue = "all";
   }
 
   return requestForm;

--- a/web/html/src/manager/content-management/shared/business/filters.enum.test.ts
+++ b/web/html/src/manager/content-management/shared/business/filters.enum.test.ts
@@ -206,4 +206,71 @@ describe("Testing filters enum and descriptions", () => {
       "filter contains package provides name: deny patch contains package which provides name equal installhint(reboot-needed) (package_provides_name)"
     );
   });
+
+  test("test filter ptf all description", () => {
+    const filter = {
+      name: "filter all ptf",
+      criteriaKey: "ptf_all",
+      criteriaValue: "ALL",
+      entityType: "ptf",
+      rule: "deny",
+      matcher: "ptf_all",
+    };
+
+    expect(getClmFilterDescription(filter)).toEqual(
+      "filter all ptf: deny ptf all product temporary fixes ALL (ptf_all)"
+    );
+  });
+
+  test("test filter ptf number description", () => {
+    const filter = {
+      name: "filter by ptf number",
+      criteriaKey: "ptf_number",
+      criteriaValue: "123456",
+      entityType: "ptf",
+      rule: "deny",
+      matcher: "lower",
+    };
+
+    expect(getClmFilterDescription(filter)).toEqual("filter by ptf number: deny ptf lower than 123456 (ptf_number)");
+
+    filter.matcher = "lowereq";
+    expect(getClmFilterDescription(filter)).toEqual(
+      "filter by ptf number: deny ptf lower or equal than 123456 (ptf_number)"
+    );
+
+    filter.matcher = "equals";
+    expect(getClmFilterDescription(filter)).toEqual("filter by ptf number: deny ptf equal 123456 (ptf_number)");
+
+    filter.matcher = "greater";
+    expect(getClmFilterDescription(filter)).toEqual("filter by ptf number: deny ptf greater than 123456 (ptf_number)");
+
+    filter.matcher = "greatereq";
+    expect(getClmFilterDescription(filter)).toEqual(
+      "filter by ptf number: deny ptf greater or equal than 123456 (ptf_number)"
+    );
+  });
+
+  test("test filter ptf number description", () => {
+    const filter = {
+      name: "filter by fixed package",
+      criteriaKey: "ptf_package",
+      criteriaValue: "vim-data",
+      entityType: "ptf",
+      rule: "deny",
+      matcher: "equals",
+    };
+
+    expect(getClmFilterDescription(filter)).toEqual("filter by fixed package: deny ptf equal vim-data (ptf_package)");
+
+    filter.matcher = "contains";
+    expect(getClmFilterDescription(filter)).toEqual(
+      "filter by fixed package: deny ptf containing vim-data (ptf_package)"
+    );
+
+    filter.matcher = "matches";
+    expect(getClmFilterDescription(filter)).toEqual(
+      "filter by fixed package: deny ptf matches regular expression vim-data (ptf_package)"
+    );
+  });
 });

--- a/web/html/src/manager/content-management/shared/business/filters.enum.ts
+++ b/web/html/src/manager/content-management/shared/business/filters.enum.ts
@@ -33,6 +33,10 @@ export const filterEntity: FilterEntityEnumType = {
     key: "module",
     text: t("Module"),
   },
+  PTF: {
+    key: "ptf",
+    text: t("Product Temporary Fix"),
+  },
 };
 
 const filterMatchers: FilterMatcherEnumType = {
@@ -115,6 +119,11 @@ const filterMatchers: FilterMatcherEnumType = {
     key: "provides_name",
     text: t("provides name"),
     longDescription: t("provides name equal"),
+  },
+  PTF_ALL: {
+    key: "ptf_all",
+    text: t("all"),
+    longDescription: t("all product temporary fixes"),
   },
 };
 
@@ -202,6 +211,30 @@ export const clmFilterOptions: ClmFilterOptionsEnumType = {
     text: t("Stream"),
     entityType: filterEntity.MODULE,
     matchers: [filterMatchers.EQUALS],
+  },
+  PTF_ALL: {
+    key: "ptf_all",
+    text: t("All"),
+    entityType: filterEntity.PTF,
+    matchers: [filterMatchers.PTF_ALL],
+  },
+  PTF_NUMBER: {
+    key: "ptf_number",
+    text: t("Number"),
+    entityType: filterEntity.PTF,
+    matchers: [
+      filterMatchers.LOWER,
+      filterMatchers.LOWEREQ,
+      filterMatchers.EQUALS,
+      filterMatchers.GREATER,
+      filterMatchers.GREATEREQ,
+    ],
+  },
+  PTF_PACKAGE_NAME: {
+    key: "ptf_package_name",
+    text: t("Fixes Package Name"),
+    entityType: filterEntity.PTF,
+    matchers: [filterMatchers.EQUALS, filterMatchers.MATCHES, filterMatchers.CONTAINS],
   },
 };
 

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Added CLM filters to match product temporary fixes packages
 - move web.system_checkin_threshold configuration to database
 - Upgrade Bootstrap to 3.4.1
 - Update translation strings


### PR DESCRIPTION
## What does this PR change?

This PR fixes the PTF package visibility preventing to view them where not relevant

## GUI diff

After:

PTF packages will not be interactable directly in the UI were not relevant

- [X] **DONE**

## Documentation

How to document the new behaviour needs to be discussed

- [ ] **DONE**

## Test coverage

- Unit tests have been added and improved to cover the new features and behaviours.

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18910

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
