### PR TITLE
Optimize DB connections by using context for suma_minion pillar

### DIFF
--- a/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
+++ b/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
@@ -491,16 +491,3 @@ def load_formula_metadata(formula_name):
 
     formulas_metadata_cache[formula_name] = metadata
     return metadata
-
-def _pillar_value_by_path(data, path):
-    result = data
-    first_key = None
-    for token in path.split(":"):
-        if token == "*":
-            first_key = next(iter(result))
-            result = result[first_key] if first_key else None
-        elif token in result:
-            result = result[token]
-        else:
-            break
-    return result, first_key

--- a/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
+++ b/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
@@ -79,29 +79,55 @@ def __virtual__():
 
 @contextmanager
 def _get_cursor():
-    options = {
-        "host": "localhost",
-        "user": "",
-        "pass": "",
-        "db": "susemanager",
-        "port": 5432,
-    }
-    options.update(__opts__.get("__master_opts__", __opts__).get("postgres", {}))
-
-    cnx = psycopg2.connect(
+    def _connect_db():
+        options = {
+            "host": "localhost",
+            "user": "",
+            "pass": "",
+            "db": "susemanager",
+            "port": 5432,
+        }
+        options.update(__opts__.get("__master_opts__", __opts__).get("postgres", {}))
+        return psycopg2.connect(
             host=options['host'],
             user=options['user'],
             password=options['pass'],
             dbname=options['db'],
-            port=options['port'])
-    cursor = cnx.cursor()
+            port=options['port'],
+        )
+
+    if "suma_minion_cnx" in __context__:
+        cnx = __context__["suma_minion_cnx"]
+        log.debug("Reusing DB connection from the context")
+    else:
+        try:
+            cnx = _connect_db()
+            log.debug("Connected to the DB")
+            if "__master_opts__" not in __opts__:
+                __context__["suma_minion_cnx"] = cnx
+        except psycopg2.OperationalError as err:
+            log.error("Error on getting database pillar: %s", err.args)
+            return
     try:
-        log.debug("Connected to DB")
+        cursor = cnx.cursor()
+    except psycopg2.InterfaceError as err:
+        log.debug("Reconnecting to the DB")
+        try:
+            cnx = _connect_db()
+            log.debug("Reconnected to the DB")
+            if "__master_opts__" not in __opts__:
+                __context__["suma_minion_cnx"] = cnx
+            cursor = cnx.cursor()
+        except psycopg2.OperationalError as err:
+            log.error("Error on getting database pillar: %s", err.args)
+            return
+    try:
         yield cursor
     except psycopg2.DatabaseError as err:
-        log.error("Error in database pillar: %s", err.args)
+        log.error("Error on getting database pillar: %s", err.args)
     finally:
-        cnx.close()
+        if "__master_opts__" in __opts__:
+            cnx.close()
 
 
 def ext_pillar(minion_id, pillar, *args):

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Reuse DB connection on compiling pillar with suma_minion
 - Do not use non-compatible unique filter in old jinja2 (bsc#1206979) (bsc#1206981)
 - Fix custom "mgrcompat.module_run" state module to work with Salt 3005.1
 - Add missing transactional_update.conf for SLE Micro

--- a/susemanager-utils/susemanager-sls/test/test_pillar_suma_minion.py
+++ b/susemanager-utils/susemanager-sls/test/test_pillar_suma_minion.py
@@ -14,6 +14,7 @@ import suma_minion
 
 
 suma_minion.__opts__ = {}
+suma_minion.__context__ = {}
 suma_minion.psycopg2 = MagicMock()
 
 TEST_FORMULA_ORDER = [
@@ -76,7 +77,7 @@ def test_formula_pillars_db():
 
 def test_reading_postgres_opts_in__get_cursor():
     """
-    Test reading proper postgres opts in _get_cursor:
+    Test reading proper postgres opts in _get_cursor
     """
     pg_connect_mock = MagicMock(return_value=MagicMock())
     test_opts = {
@@ -90,7 +91,7 @@ def test_reading_postgres_opts_in__get_cursor():
     }
     with patch.object(suma_minion, "__opts__", test_opts), patch(
         "suma_minion.psycopg2.connect", pg_connect_mock
-    ):
+    ), patch.dict(suma_minion.__context__, {}):
         with suma_minion._get_cursor() as cursor:
             assert cursor is not None
         assert pg_connect_mock.call_args_list[0][1] == {
@@ -105,10 +106,79 @@ def test_reading_postgres_opts_in__get_cursor():
 
     with patch.object(suma_minion, "__opts__", {"__master_opts__": test_opts}), patch(
         "suma_minion.psycopg2.connect", pg_connect_mock
-    ):
+    ), patch.dict(suma_minion.__context__, {}):
         assert cursor is not None
         with suma_minion._get_cursor() as cursor:
             assert cursor is not None
+        assert pg_connect_mock.call_args_list[0][1] == {
+            "host": "test_host",
+            "user": "test_user",
+            "password": "test_pass",
+            "dbname": "test_db",
+            "port": 1234,
+        }
+
+
+def test_using_context_in__get_cursor():
+    """
+    Test using context to store postgres postgres connection in  _get_cursor
+    """
+    pg_connect_mock = MagicMock(return_value=MagicMock())
+    test_opts = {
+        "postgres": {
+            "host": "test_host",
+            "user": "test_user",
+            "pass": "test_pass",
+            "db": "test_db",
+            "port": 1234,
+        }
+    }
+    with patch.object(suma_minion, "__opts__", test_opts), patch(
+        "suma_minion.psycopg2.connect", pg_connect_mock
+    ), patch.dict(suma_minion.__context__, {}):
+        # Check if it creates new connection if it's not in the context
+        with suma_minion._get_cursor() as cursor:
+            assert cursor is not None
+        assert pg_connect_mock.call_args_list[0][1] == {
+            "host": "test_host",
+            "user": "test_user",
+            "password": "test_pass",
+            "dbname": "test_db",
+            "port": 1234,
+        }
+
+        pg_connect_mock.reset_mock()
+
+        # Check if it reuses the connection from the context
+        with suma_minion._get_cursor() as cursor:
+            assert cursor is not None
+
+        pg_connect_mock.assert_not_called()
+
+        assert "suma_minion_cnx" in suma_minion.__context__
+
+    pg_connect_mock.reset_mock()
+
+    pg_cnx_mock = MagicMock()
+    pg_cnx_mock.cursor = MagicMock(side_effect=[True, Exception])
+
+    with patch.object(suma_minion, "__opts__", test_opts), patch(
+        "suma_minion.psycopg2.connect", pg_connect_mock
+    ), patch.object(suma_minion.psycopg2, "InterfaceError", Exception), patch.dict(
+        suma_minion.__context__, {"suma_minion_cnx": pg_cnx_mock}
+    ):
+        # Check if it reuses the connection from the context
+        with suma_minion._get_cursor() as cursor:
+            assert cursor is not None
+
+        pg_cnx_mock.cursor.assert_called_once()
+
+        pg_connect_mock.assert_not_called()
+
+        # Check if it tries to recoonect if the connection in the context is not alive
+        with suma_minion._get_cursor() as cursor:
+            assert cursor is not None
+
         assert pg_connect_mock.call_args_list[0][1] == {
             "host": "test_host",
             "user": "test_user",


### PR DESCRIPTION
## What does this PR change?

Prevents reopening DB connection on each pillar compile by storing DB connection in the `__context__`.
In large scale environments in case of massive oppertaions with the clients it could cause drop of the performance in case if it opens distinct connection to the DB for each request.

It requires passing `__context__` on the `salt` side, it will be implemented with distinct PR to `salt`.
Salt upstream PR required for this change to work as expected: https://github.com/saltstack/salt/pull/62898
Will backport it to `openSUSE/salt/release/3004` branch and put the link here also.

## GUI diff

No difference.

## Documentation
Maybe just a note in the scaling section of the documentation as it requires extra distinct DB connection for each of salt-master workers.

## Test coverage
- Unit tests were added

## Links

Tracks https://github.com/SUSE/spacewalk/issues/19030
openSUSE/salt PR (merged): https://github.com/openSUSE/salt/pull/569

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
