### PR TITLE
Added missing dependency for Perl XML Simple

### DIFF
--- a/python/spacewalk/satellite_tools/spacewalk-debug
+++ b/python/spacewalk/satellite_tools/spacewalk-debug
@@ -433,9 +433,8 @@ if [ $IS_SUSE -eq 1 ]; then
     if [ -x /usr/bin/spacewalk-report ] && [ $NO_REPORTS -eq 0 ]; then
         # get some inventory info
         echo "    * running spacewalk-report to create reports."
-        /usr/bin/spacewalk-report inventory > $DIR/inventory-report.csv
-        /usr/bin/spacewalk-report channels > $DIR/channels-report.csv
-        /usr/bin/spacewalk-report activation-keys > $DIR/activation-keys-report.csv
+        /usr/bin/spacewalk-report --legacy-report inventory > $DIR/inventory-report.csv
+        /usr/bin/spacewalk-report --legacy-report channels > $DIR/channels-report.csv
     fi
 
     ls -laR $(spacewalk-cfg-get documentroot)/pub > $DIR/ls-laR-htdocs

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,3 +1,6 @@
+- Used the legacy reporting system in spacewalk-debug to obtain
+  up-to-date information
+
 -------------------------------------------------------------------
 Wed Sep 28 11:14:14 CEST 2022 - jgonzalez@suse.com
 

--- a/susemanager-utils/supportutils-plugin-susemanager/supportutils-plugin-susemanager.changes
+++ b/susemanager-utils/supportutils-plugin-susemanager/supportutils-plugin-susemanager.changes
@@ -1,3 +1,5 @@
+- Added dependency for XML Simple
+
 -------------------------------------------------------------------
 Wed Sep 28 11:13:44 CEST 2022 - jgonzalez@suse.com
 

--- a/susemanager-utils/supportutils-plugin-susemanager/supportutils-plugin-susemanager.spec
+++ b/susemanager-utils/supportutils-plugin-susemanager/supportutils-plugin-susemanager.spec
@@ -28,6 +28,7 @@ BuildArch:      noarch
 Requires:       supportconfig-plugin-resource
 Requires:       supportconfig-plugin-tag
 Requires:       susemanager
+Requires:       perl(XML::Simple)
 Supplements:    packageand(spacewalk-common:supportutils)
 
 %description


### PR DESCRIPTION
## What does this PR change?

This PR adds a missing dependency to the Perl library XML Simple.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: runtime environment issue, no code change

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19178

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
