### PR TITLE
consider all matched methods as fallback for xmlrpc (bsc#1203633)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/BaseHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/BaseHandler.java
@@ -21,12 +21,14 @@ import com.redhat.rhn.common.client.ClientCertificateDigester;
 import com.redhat.rhn.common.client.InvalidCertificateException;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.hibernate.LookupException;
+import com.redhat.rhn.common.translation.TranslationException;
 import com.redhat.rhn.common.translation.Translator;
 import com.redhat.rhn.common.util.MethodUtil;
 import com.redhat.rhn.common.util.StringUtil;
 import com.redhat.rhn.domain.entitlement.Entitlement;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.org.OrgFactory;
+import com.redhat.rhn.domain.product.Tuple2;
 import com.redhat.rhn.domain.role.Role;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.Server;
@@ -38,6 +40,7 @@ import com.redhat.rhn.manager.system.SystemManager;
 import com.suse.manager.api.ApiIgnore;
 import com.suse.manager.api.ApiType;
 import com.suse.manager.api.ReadOnly;
+import com.suse.salt.netapi.utils.Xor;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -56,6 +59,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import redstone.xmlrpc.XmlRpcFault;
 import redstone.xmlrpc.XmlRpcInvocationHandler;
@@ -115,25 +119,12 @@ public class BaseHandler implements XmlRpcInvocationHandler {
 
         //Attempt to find a perfect match
         Method foundMethod = findPerfectMethod(params, matchedMethods);
-
         Object[] converted = params.toArray();
 
-
-        //If we were not able to find the exact method match, let's just use the first one
-        //      This isn't the best method, but if you can figure out a better way
-        //      that is easy feel free to change.
-        //Since it is not an exact match, we have to translate the params.
         if (foundMethod == null) {
-            foundMethod = matchedMethods.get(0);
-            Class[] types = foundMethod.getParameterTypes();
-
-            Iterator iter = params.iterator();
-            for (int i = 0; i < types.length; i++) {
-                Object curr = iter.next();
-                if (!types[i].equals(curr.getClass())) {
-                    converted[i] = Translator.convert(curr, types[i]);
-                }
-            }
+            Tuple2<Method, Object[]> fallbackMethod = findFallbackMethod(params, matchedMethods);
+            foundMethod = fallbackMethod.getA();
+            converted = fallbackMethod.getB();
         }
 
         if (user != null && user.isReadOnly()) {
@@ -184,6 +175,48 @@ public class BaseHandler implements XmlRpcInvocationHandler {
             if (session != null) {
                 SessionManager.extendSessionLifetime(session);
             }
+        }
+    }
+
+    private Tuple2<Method, Object[]> findFallbackMethod(
+            List<Object> params, List<Method> matchedMethods) {
+
+        Map<Boolean, List<Xor<TranslationException, Tuple2<Method, Object[]>>>> collect = matchedMethods
+                .stream()
+                .map(method -> {
+                    Class<?>[] types = method.getParameterTypes();
+                    Object[] converted = params.toArray();
+
+                    Iterator<Object> iter = params.iterator();
+                    for (int i = 0; i < types.length; i++) {
+                        Object curr = iter.next();
+                        if (!types[i].equals(curr.getClass())) {
+                            try {
+                                converted[i] = Translator.convert(curr, types[i]);
+                            }
+                            catch (TranslationException e) {
+                                return Xor.<TranslationException, Tuple2<Method, Object[]>>left(e);
+                            }
+                        }
+                    }
+                    return Xor.<TranslationException, Tuple2<Method, Object[]>>right(new Tuple2<>(method, converted));
+
+                }).collect(Collectors.partitioningBy(x -> x.isRight()));
+
+        List<Tuple2<Method, Object[]>> candidates = collect.get(true).stream()
+                .flatMap(x -> x.right().stream()).collect(Collectors.toList());
+
+        List<TranslationException> exceptions = collect.get(false).stream()
+                .flatMap(x -> x.left().stream()).collect(Collectors.toList());
+
+        if (candidates.isEmpty()) {
+           throw exceptions.get(0);
+        }
+        else if (candidates.size() == 1) {
+            return candidates.get(0);
+        }
+        else  {
+            throw new TranslationException("more then one method candidate found during conversion fallback");
         }
     }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,4 +1,6 @@
+- fix xmlrpc call randomly failing with translation error (bsc#1203633)
 - Do not explicitely remove old pillars on minion rename (bsc#1203451)
+
 -------------------------------------------------------------------
 Wed Sep 28 11:15:58 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fixes an issue where only the first method is considered as fallback which leads to random jvm ordering of methods determining if call succeeds or fails.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes #https://github.com/SUSE/spacewalk/issues/19080


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
