### PR TITLE
Fix salt event queue (bsc#1203532)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/reactor/SaltEvent.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/reactor/SaltEvent.hbm.xml
@@ -20,7 +20,7 @@
               SELECT id
               FROM suseSaltEvent
               WHERE queue = :queue
-              ORDER BY minion_id NULLS FIRST, id
+              ORDER BY id
               FOR UPDATE SKIP LOCKED
               LIMIT :limit
             )

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Process salt events in FIFO order (bsc#1203532)
 - Added a warning message for traditional stack deprecation
 - Fix rendering of ssm/MigrateSystems page (bsc#1204651)
 - Remove 'SSM' column text where not applicable (bsc#1203588)


### PR DESCRIPTION
## What does this PR change?

This PR fixes the following problems with salt event queue:

1. Event ordering 

Events were ordered by minion ID. As a result, certain minions had low prority and their events were processed with extreme delays on loaded server.
This behavior was introduced by commit 6c7981570024 but it is no longer needed because 63c9aff6a9ef implements better fix.
This PR reverts the behavior to standard FIFO.

2. Detecting stalled events in `startConnectionWatchdog`

The methods `executor.getTaskCount()` and `executor.getCompletedTaskCount()` are unreliable - according documentation they return "approximate total number of tasks".  Customer's log shows that this is a real problem, it contains messages mentioning negative number of events: `Found [0, 0, 0, 0, 2, 0, -1, 0, 0] events without a job. Scheduling...`
This PR triggers the watchdog if there are queued events and the corresponding thread is idle.

3. Handling exceptions in `startConnectionWatchdog`

The watchdog thread can exit on unhandled exceptions. This PR attempts to catch all exceptions.

## GUI diff

No difference.

## Documentation
- No documentation needed: 

## Test coverage
- No tests: the issues are reproducible only on loaded SUMA server

- [ ] **DONE**

## Links

Partially fixes https://github.com/SUSE/spacewalk/issues/19063  (bsc#1203532)

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
