### PR TITLE
QE: Remove manual Rocky 8 custom channel sync

### DIFF
--- a/testsuite/features/reposync/srv_add_rocky8_repositories.feature
+++ b/testsuite/features/reposync/srv_add_rocky8_repositories.feature
@@ -49,15 +49,6 @@ Feature: Add the Rocky 8 distribution custom repositories
     And I select the "rocky-8-iso-baseos" repo
     And I click on "Save Repositories"
     Then I should see a "repository information was successfully updated" text
-    And I wait until the channel "rocky-8-iso" has been synced
-
-  Scenario: Synchronize the repositories in the custom channel for Rocky 8 DVD
-    When I follow the left menu "Software > Manage > Channels"
-    And I follow "Custom Channel for Rocky 8 DVD"
-    And I follow "Repositories" in the content area
-    And I follow "Sync"
-    And I click on "Sync Now"
-    Then I should see a "Repository sync scheduled" text
 
   Scenario: The custom channel for Rocky 8 has been synced
     When I wait until the channel "rocky-8-iso" has been synced


### PR DESCRIPTION
## What does this PR change?

The sync will autmatically triggered when creating the custom channel or when adding repositories to a custom channel according to @mackdk , so this step can be skipped. Hopefully skipping this manual sync solves the not visible Sync Now button issue seen in the test suite.


## GUI diff

No difference.


- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage
- Cucumber tests were edited

- [x] **DONE**

## Links

No ports needed.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
