### PR TITLE
Uyuni 2022.10: Fix issues triggering Cobbler migrations

### DIFF
--- a/spacewalk/setup/bin/spacewalk-setup-cobbler
+++ b/spacewalk/setup/bin/spacewalk-setup-cobbler
@@ -67,6 +67,10 @@ def manipulate_cobbler_settings(config_dir: str, settings_yaml: str):
     except OSError:
         filecontent["next_server_v6"] = ""
 
+    if not filecontent["next_server_v4"] and not filecontent["next_server_v6"]:
+        print("ERROR: Neither IPv4 or IPv6 addresses can be resolved for configured FQDN: {}. Please check your DNS and hostname configuration.".format(filecontent["server"]))
+        exit(1)
+
     filecontent["pxe_just_once"] = True
     filecontent["redhat_management_server"] = socket.getfqdn()
     yaml_dump = yaml.safe_dump(filecontent)

--- a/spacewalk/setup/bin/spacewalk-setup-cobbler
+++ b/spacewalk/setup/bin/spacewalk-setup-cobbler
@@ -68,7 +68,7 @@ def manipulate_cobbler_settings(config_dir: str, settings_yaml: str):
         filecontent["next_server_v6"] = ""
 
     if not filecontent["next_server_v4"] and not filecontent["next_server_v6"]:
-        print("ERROR: Neither IPv4 or IPv6 addresses can be resolved for configured FQDN: {}. Please check your DNS and hostname configuration.".format(filecontent["server"]))
+        print("ERROR: Neither IPv4 nor IPv6 addresses can be resolved for configured FQDN: {}. Please check your DNS and hostname configuration.".format(filecontent["server"]))
         exit(1)
 
     filecontent["pxe_just_once"] = True

--- a/spacewalk/setup/bin/spacewalk-setup-cobbler
+++ b/spacewalk/setup/bin/spacewalk-setup-cobbler
@@ -53,10 +53,15 @@ def manipulate_cobbler_settings(config_dir: str, settings_yaml: str):
     backup_file(full_path)
     with open(full_path) as settings_file:
         filecontent = yaml.safe_load(settings_file.read())
-    filecontent["server"] = socket.getfqdn()
-    filecontent["next_server_v4"] = socket.getaddrinfo(filecontent["server"], None, socket.AF_INET)[1][4][0]
 
-    # In case there is no IPv6 address, we get a OSError (socket.gaierror)
+    filecontent["server"] = socket.getfqdn()
+
+    # In case of failing DNS resolution, we get a OSError (socket.gaierror)
+    try:
+        filecontent["next_server_v4"] = socket.getaddrinfo(filecontent["server"], None, socket.AF_INET)[1][4][0]
+    except OSError:
+        filecontent["next_server_v4"] = ""
+
     try:
         filecontent["next_server_v6"] = socket.getaddrinfo(filecontent["server"], None, socket.AF_INET6)[1][4][0]
     except OSError:

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,6 @@
+- Fix detected issues to perform migration of Cobbler settings
+  and collections.
+
 -------------------------------------------------------------------
 Wed Sep 28 10:25:24 CEST 2022 - jgonzalez@suse.com
 

--- a/spacewalk/setup/spacewalk-setup.spec
+++ b/spacewalk/setup/spacewalk-setup.spec
@@ -259,6 +259,8 @@ if [ ! -f /etc/cobbler/settings -a -f /etc/cobbler/settings.rpmsave ]; then
     cobbler-settings automigrate -d
     echo "* Readjust settings needed for spacewalk"
     spacewalk-setup-cobbler
+    echo "* Change group to Apache for /etc/cobbler/settings.yaml file"
+    chgrp %{apache_group} /etc/cobbler/settings.yaml
     echo "* Done"
 fi
 

--- a/spacewalk/setup/spacewalk-setup.spec
+++ b/spacewalk/setup/spacewalk-setup.spec
@@ -89,7 +89,7 @@ BuildRequires:  perl-libwww-perl
 %else
 Requires:       %{sbinpath}/restorecon
 %endif
-Requires:       cobbler >= 3.3.3
+Requires(post): cobbler >= 3.3.3
 Requires:       perl-Satcon
 Requires:       spacewalk-admin
 Requires:       spacewalk-backend-tools
@@ -244,9 +244,13 @@ if grep 'authn_spacewalk' /etc/cobbler/modules.conf > /dev/null 2>&1; then
     sed -i 's/module = authn_spacewalk/module = authentication.spacewalk/' /etc/cobbler/modules.conf
 fi
 
-# if old /etc/cobbler/settings exists, we need to perform migration
-if [ -e /etc/cobbler/settings ]; then
-    echo "* Creating a backup of /etc/cobbler/settings file to /etc/cobbler/settings.before-migration-backup before migrating settings"
+# When upgrading to Cobbler 3.3.3, the old /etc/cobbler/settings config file from previous Cobbler version
+# is removed as it not existing anymore in the new version, but a copy is kept with the local changes done
+# at /etc/cobbler/settings.rpmsave. If this file exists, it means we need to perform the migration of these
+# settings and also trigger the migration of stored Cobbler collections.
+if [ ! -f /etc/cobbler/settings -a -f /etc/cobbler/settings.rpmsave ]; then
+    mv /etc/cobbler/settings.rpmsave /etc/cobbler/settings
+    echo "* Creating a backup from old Cobbler settings to /etc/cobbler/settings.before-migration-backup before migrating settings"
     cp /etc/cobbler/settings /etc/cobbler/settings.before-migration-backup
     echo "* Migrating old Cobbler settings to new /etc/cobbler/settings.yaml file and executing migration of stored Cobbler collections"
     echo "  (a backup of the collections will be created at /var/lib/cobbler/)"


### PR DESCRIPTION
## What does this PR change?

This PR fixes some issues detected in Uyuni 2022.10 around Cobbler, that makes Cobbler service to break causing different symthoms in the Uyuni server:

- https://github.com/uyuni-project/uyuni/issues/6037
- https://github.com/uyuni-project/uyuni/issues/6041
- https://github.com/uyuni-project/uyuni/issues/6045

These different issues were caused because the migrations of Cobbler settings and collections to newer Cobbler 3.3.3, triggered by `spacewalk-setup` package during the upgrade, didn't happen as it was expected. This makes the Cobbler service not able to start properly as it still has non-migrated settings and collections.

With the changes in this PR, the new update of `spacewalk-setup` will trigger the execution of the migration as expected, making the Cobbler service able to start successfully.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **tested manually**

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/6037 https://github.com/uyuni-project/uyuni/issues/6041 https://github.com/uyuni-project/uyuni/issues/6045
Tracks https://github.com/SUSE/spacewalk/issues/19276

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
