### PR TITLE
QE: Add sync of custom channels for Rocky 8

### DIFF
--- a/testsuite/features/reposync/srv_add_rocky8_repositories.feature
+++ b/testsuite/features/reposync/srv_add_rocky8_repositories.feature
@@ -8,6 +8,7 @@ Feature: Add the Rocky 8 distribution custom repositories
   I want to filter them out to remove the modules information
 
   Scenario: Download the iso of Rocky 8 DVD and mount it on the server
+    # TODO: Use different mirror URL when on AWS
     When I mount as "rocky-8-iso" the ISO from "http://minima-mirror.mgr.suse.de/pub/rocky/8/isos/x86_64/Rocky-x86_64-dvd.iso" in the server
 
   Scenario: Log in as admin user

--- a/testsuite/features/reposync/srv_add_rocky8_repositories.feature
+++ b/testsuite/features/reposync/srv_add_rocky8_repositories.feature
@@ -50,6 +50,11 @@ Feature: Add the Rocky 8 distribution custom repositories
     And I click on "Save Repositories"
     Then I should see a "repository information was successfully updated" text
 
+  Scenario: Synchronize the repositories in the custom channel for Rocky 8 DVD
+    When I call spacewalk-repo-sync for channel "rocky-8-iso"
+    And I wait until all spacewalk-repo-sync finished
+    Then the reposync logs should not report errors
+
   Scenario: The custom channel for Rocky 8 has been synced
     When I wait until the channel "rocky-8-iso" has been synced
 

--- a/testsuite/features/reposync/srv_add_rocky8_repositories.feature
+++ b/testsuite/features/reposync/srv_add_rocky8_repositories.feature
@@ -52,7 +52,7 @@ Feature: Add the Rocky 8 distribution custom repositories
     Then I should see a "repository information was successfully updated" text
 
   Scenario: Synchronize the repositories in the custom channel for Rocky 8 DVD
-    When I call spacewalk-repo-sync for channel "rocky-8-iso"
+    When I call spacewalk-repo-sync to sync the channel "rocky-8-iso"
     And I wait until all spacewalk-repo-sync finished
     Then the reposync logs should not report errors
 

--- a/testsuite/features/reposync/srv_add_rocky8_repositories.feature
+++ b/testsuite/features/reposync/srv_add_rocky8_repositories.feature
@@ -8,7 +8,6 @@ Feature: Add the Rocky 8 distribution custom repositories
   I want to filter them out to remove the modules information
 
   Scenario: Download the iso of Rocky 8 DVD and mount it on the server
-    # TODO: Use different mirror URL when on AWS
     When I mount as "rocky-8-iso" the ISO from "http://minima-mirror.mgr.suse.de/pub/rocky/8/isos/x86_64/Rocky-x86_64-dvd.iso" in the server
 
   Scenario: Log in as admin user

--- a/testsuite/features/reposync/srv_add_rocky8_repositories.feature
+++ b/testsuite/features/reposync/srv_add_rocky8_repositories.feature
@@ -88,6 +88,7 @@ Feature: Add the Rocky 8 distribution custom repositories
     And I click on "Create"
     Then I should see a "Content Lifecycle Project - Remove AppStream metadata" text
     When I click on "Attach/Detach Sources"
+    And I wait until I do not see "Loading" text
     And I select "RHEL8-Pool for x86_64" from "selectedBaseChannel"
     And I check "Custom Channel for Rocky 8 DVD"
     And I click on "Save"

--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -60,6 +60,8 @@ Feature: Be able to list available channels and enable them
     And I execute mgr-sync "add channel res-8-updates-x86_64"
     And I execute mgr-sync "add channel res-as-8-updates-x86_64"
     And I execute mgr-sync "add channel res-cb-8-updates-x86_64"
+    And I execute mgr-sync "add channel res8-manager-tools-pool-x86_64"
+    And I execute mgr-sync "add channel res8-manager-tools-updates-x86_64"
     And I execute mgr-sync "list channels"
     Then I should get "[I] RHEL8-Pool for x86_64 RHEL or SLES ES or CentOS 8 Base [rhel8-pool-x86_64]"
     And I should get "[I] RES-8-Updates for x86_64 SUSE Linux Enterprise Server with Expanded Support 8 x86_64 [res-8-updates-x86_64]"

--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -75,7 +75,7 @@ Feature: Be able to list available channels and enable them
     And I execute mgr-sync "add channel res-8-updates-x86_64"
     And I execute mgr-sync "add channel res-as-8-updates-x86_64"
     And I execute mgr-sync "add channel res-cb-8-updates-x86_64"
-    And I use spacewalk-common-channel to add channel "res8-suse-manager-tools-x86_64" with arch "x86_64"
+    And I use spacewalk-common-channel to add channel "el8-uyuni-client" with arch "x86_64"
     And I execute mgr-sync "list channels"
     Then I should get "[I] RHEL8-Pool for x86_64 RHEL or SLES ES or CentOS 8 Base [rhel8-pool-x86_64]"
     And I should get "[I] RES-8-Updates for x86_64 SUSE Linux Enterprise Server with Expanded Support 8 x86_64 [res-8-updates-x86_64]"

--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -55,6 +55,7 @@ Feature: Be able to list available channels and enable them
     And I should get "    [I] SLES12-SP4-Updates for x86_64 SUSE Linux Enterprise Server 12 SP4 x86_64 [sles12-sp4-updates-x86_64]"
     And I should get "    [ ] SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp4]"
 
+@susemanager
   Scenario: Enable RHEL 8 channels for Rocky 8
     When I execute mgr-sync "add channel rhel8-pool-x86_64"
     And I execute mgr-sync "add channel res-8-updates-x86_64"
@@ -62,6 +63,19 @@ Feature: Be able to list available channels and enable them
     And I execute mgr-sync "add channel res-cb-8-updates-x86_64"
     And I execute mgr-sync "add channel res8-manager-tools-pool-x86_64"
     And I execute mgr-sync "add channel res8-manager-tools-updates-x86_64"
+    And I execute mgr-sync "list channels"
+    Then I should get "[I] RHEL8-Pool for x86_64 RHEL or SLES ES or CentOS 8 Base [rhel8-pool-x86_64]"
+    And I should get "[I] RES-8-Updates for x86_64 SUSE Linux Enterprise Server with Expanded Support 8 x86_64 [res-8-updates-x86_64]"
+    And I should get "[I] RES-AS-8-Updates for x86_64 SUSE Linux Enterprise Server with Expanded Support 8 x86_64 [res-as-8-updates-x86_64]"
+    And I should get "[I] RES-CB-8-Updates for x86_64 SUSE Linux Enterprise Server with Expanded Support 8 x86_64 [res-cb-8-updates-x86_64]"
+
+@uyuni
+  Scenario: Enable RHEL 8 channels for Rocky 8
+    When I execute mgr-sync "add channel rhel8-pool-x86_64"
+    And I execute mgr-sync "add channel res-8-updates-x86_64"
+    And I execute mgr-sync "add channel res-as-8-updates-x86_64"
+    And I execute mgr-sync "add channel res-cb-8-updates-x86_64"
+    And I use spacewalk-common-channel to add channel "res8-suse-manager-tools-x86_64" with arch "x86_64"
     And I execute mgr-sync "list channels"
     Then I should get "[I] RHEL8-Pool for x86_64 RHEL or SLES ES or CentOS 8 Base [rhel8-pool-x86_64]"
     And I should get "[I] RES-8-Updates for x86_64 SUSE Linux Enterprise Server with Expanded Support 8 x86_64 [res-8-updates-x86_64]"

--- a/testsuite/features/secondary/min_rhlike_remote_command.feature
+++ b/testsuite/features/secondary/min_rhlike_remote_command.feature
@@ -19,5 +19,5 @@ Feature: Remote command on the Red Hat-like Salt minion
     Then I should see "rhlike_minion" hostname
     When I wait for "15" seconds
     And I expand the results for "rhlike_minion"
-    Then I should see a "rhel fedora" text
-    And I should see a "REDHAT_SUPPORT_PRODUCT" text
+    Then I should see a "rhel centos fedora" text
+    And I should see a "ROCKY_SUPPORT_PRODUCT" text

--- a/testsuite/features/secondary/min_rhlike_ssh.feature
+++ b/testsuite/features/secondary/min_rhlike_ssh.feature
@@ -74,8 +74,8 @@ Feature: Bootstrap a SSH-managed Red Hat-like minion and do some basic operation
     Then I should see "rhlike_minion" hostname
     When I wait for "15" seconds
     And I expand the results for "rhlike_minion"
-    Then I should see a "rhel fedora" text
-    And I should see a "REDHAT_SUPPORT_PRODUCT" text
+    Then I should see a "rhel centos fedora" text
+    And I should see a "ROCKY_SUPPORT_PRODUCT" text
 
   Scenario: Check events history for failures on SSH-managed Red Hat-like minion
     Given I am on the Systems overview page of this "rhlike_minion"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -739,7 +739,7 @@ When(/^I call spacewalk\-repo\-sync for channel "(.*?)" with a custom url "(.*?)
   @command_output, _code = $server.run("spacewalk-repo-sync -c #{arg1} -u #{arg2}", check_errors: false)
 end
 
-When(/^I call spacewalk\-repo\-sync for channel "(.*?)"$/) do |channel|
+When(/^I call spacewalk\-repo\-sync to sync the channel "(.*?)"$/) do |channel|
   @command_output, _code = $server.run("spacewalk-repo-sync -c #{channel}", check_errors: false)
 end
 

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -739,6 +739,10 @@ When(/^I call spacewalk\-repo\-sync for channel "(.*?)" with a custom url "(.*?)
   @command_output, _code = $server.run("spacewalk-repo-sync -c #{arg1} -u #{arg2}", check_errors: false)
 end
 
+When(/^I call spacewalk\-repo\-sync for channel "(.*?)"$/) do |channel|
+  @command_output, _code = $server.run("spacewalk-repo-sync -c #{channel}", check_errors: false)
+end
+
 When(/^I get "(.*?)" file details for channel "(.*?)" via spacecmd$/) do |arg1, arg2|
   @command_output, _code = $server.run("spacecmd -u admin -p admin -q -- configchannel_filedetails #{arg2} '#{arg1}'", check_errors: false)
 end

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -15,7 +15,12 @@ When(/^I wait for "(\d+)" seconds?$/) do |arg1|
 end
 
 When(/^I mount as "([^"]+)" the ISO from "([^"]+)" in the server$/) do |name, url|
-  iso_path = "/tmp/#{name}.iso"
+  # When using a mirror it is automatically mounted at /mirror
+  iso_path = if $mirror
+               url.sub(/^http:.*\/pub/, '/mirror/pub')
+             else
+               "/tmp/#{name}.iso"
+             end
   mount_point = "/srv/www/htdocs/#{name}"
   $server.run("wget --no-check-certificate -O #{iso_path} #{url}", timeout: 500)
   $server.run("mkdir -p #{mount_point}")

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -16,13 +16,13 @@ end
 
 When(/^I mount as "([^"]+)" the ISO from "([^"]+)" in the server$/) do |name, url|
   # When using a mirror it is automatically mounted at /mirror
-  iso_path = if $mirror
-               url.sub(/^http:.*\/pub/, '/mirror/pub')
-             else
-               "/tmp/#{name}.iso"
-             end
+  if $mirror
+    iso_path = url.sub(/^http:.*\/pub/, '/mirror/pub')
+  else
+    iso_path = "/tmp/#{name}.iso"
+    $server.run("wget --no-check-certificate -O #{iso_path} #{url}", timeout: 500)
+  end
   mount_point = "/srv/www/htdocs/#{name}"
-  $server.run("wget --no-check-certificate -O #{iso_path} #{url}", timeout: 500)
   $server.run("mkdir -p #{mount_point}")
   $server.run("grep #{iso_path} /etc/fstab || echo '#{iso_path}  #{mount_point}  iso9660  loop,ro  0 0' >> /etc/fstab")
   $server.run("umount #{iso_path}; mount #{iso_path}")

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -29,12 +29,12 @@ end
 def compute_channels_to_leave_running
   # keep the repos needed for the auto-installation tests
   do_not_kill = CHANNEL_TO_SYNCH_BY_OS_VERSION['default']
-  [$minion, $build_host, $ssh_minion].each do |node|
+  [$minion, $build_host, $ssh_minion, $rhlike_minion].each do |node|
     next unless node
     os_version = node.os_version
     os_family = node.os_family
-    next unless os_family == 'sles'
-    raise "Can't build list of reposyncs to leave running" unless %w[12-SP4 12-SP5 15-SP3 15-SP4].include? os_version
+    next unless os_family == 'sles' || os_family == 'rocky'
+    raise "Can't build list of reposyncs to leave running" unless %w[12-SP4 12-SP5 15-SP3 15-SP4 8.6].include? os_version
     do_not_kill += CHANNEL_TO_SYNCH_BY_OS_VERSION[os_version]
   end
   do_not_kill += CHANNEL_TO_SYNCH_BY_OS_VERSION[MIGRATE_SSH_MINION_FROM]

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -33,7 +33,7 @@ def compute_channels_to_leave_running
     next unless node
     os_version = node.os_version
     os_family = node.os_family
-    next unless os_family == 'sles' || os_family == 'rocky'
+    next unless ['sles', 'rocky'].include?(os_family)
     raise "Can't build list of reposyncs to leave running" unless %w[12-SP4 12-SP5 15-SP3 15-SP4 8.6].include? os_version
     do_not_kill += CHANNEL_TO_SYNCH_BY_OS_VERSION[os_version]
   end

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -344,6 +344,12 @@ CHANNEL_TO_SYNCH_BY_OS_VERSION = {
     sle-module-containers15-sp4-updates-x86_64
     sle-module-basesystem15-sp4-updates-x86_64
     sle-module-server-applications15-sp4-updates-x86_64
+  ],
+  '8.6' =>
+  %w[
+    res8-manager-tools-pool-x86_64
+    res8-manager-tools-updates-x86_64
+    el8-uyuni-client-x86_64
   ]
 }.freeze
 

--- a/testsuite/run_sets/reposync.yml
+++ b/testsuite/run_sets/reposync.yml
@@ -14,6 +14,6 @@
 - features/reposync/srv_enable_sync_products.feature
 - features/reposync/srv_wait_for_reposync.feature
 - features/reposync/srv_check_reposync.feature
-#- features/reposync/srv_add_rocky8_repositories.feature
+- features/reposync/srv_add_rocky8_repositories.feature
 
 ## Channels and Product synchronization features END ###

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -3718,3 +3718,13 @@ gpgkey_url = https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9
 gpgkey_id = 3228467C
 gpgkey_fingerprint = FF8A D134 4597 106E CE81 3B91 8A38 72BF 3228 467C
 repo_url = https://mirrors.fedoraproject.org/mirrorlist?repo=epel-9&arch=%(arch)s
+
+[el8-uyuni-client]
+name     = uyuni client tools for %(base_channel_name)s
+archs    = %(_x86_archs)s, aarch64
+checksum = sha256
+base_channels = rhel8-pool-%(arch)s
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/


### PR DESCRIPTION
## What does this PR change?

This will add a sync of Rocky 8 via the command line and fixes some of the issues currently present in the CI.

PR test run: https://ci.suse.de/view/Manager/view/Uyuni-PRs/job/uyuni-prs-ci-tests/1839


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links

fixes https://github.com/SUSE/spacewalk/issues/19322
no ports needed.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
