### PR TITLE
Fix kiwi inspect regexp to allow image names with "-"

### DIFF
--- a/susemanager-utils/susemanager-sls/src/modules/kiwi_info.py
+++ b/susemanager-utils/susemanager-sls/src/modules/kiwi_info.py
@@ -6,6 +6,14 @@ import json
 
 log = logging.getLogger(__name__)
 
+# Kiwi version is always in format "MAJOR.MINOR.RELEASE" with numeric values
+# Source https://osinside.github.io/kiwi/image_description/elements.html#preferences-version
+KIWI_VERSION_REGEX=r'\d+\.\d+\.\d+'
+# Taken from Kiwi sources https://github.com/OSInside/kiwi/blob/eb2b1a84bf7/kiwi/schema/kiwi.rng#L81
+KIWI_ARCH_REGEX=r'(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x|riscv64)'
+# Taken from Kiwi sources https://github.com/OSInside/kiwi/blob/eb2b1a84bf7/kiwi/schema/kiwi.rng#L26
+KIWI_NAME_REGEX=r'[a-zA-Z0-9_\-\.]+'
+
 def parse_profile(chroot):
     ret = {}
     path = os.path.join(chroot, 'image', '.profile')
@@ -172,7 +180,7 @@ def image_details(dest, bundle_dest = None):
     image_type = kiwiresult.get('type') or buildinfo.get('main', {}).get('image.type', 'unknown')
     fstype = kiwiresult.get('filesystem')
 
-    pattern = re.compile(r"^(?P<name>.*)\.(?P<arch>.*)-(?P<version>.*)$")
+    pattern = re.compile(r"^(?P<name>{})\.(?P<arch>{})-(?P<version>{})$".format(KIWI_NAME_REGEX, KIWI_ARCH_REGEX, KIWI_VERSION_REGEX))
     match = pattern.match(basename)
     if match:
         name = match.group('name')
@@ -243,8 +251,8 @@ def inspect_boot_image(dest):
     res = None
     files = __salt__['file.readdir'](dest)
 
-    pattern = re.compile(r"^(?P<name>.*)\.(?P<arch>.*)-(?P<version>.*)\.kernel\.(?P<kernelversion>.*)\.md5$")
-    pattern_kiwi_ng = re.compile(r"^(?P<name>[^-]*)\.(?P<arch>[^-]*)-(?P<version>[^-]*)-(?P<kernelversion>.*)\.kernel$")
+    pattern = re.compile(r"^(?P<name>{})\.(?P<arch>{})-(?P<version>{})\.kernel\.(?P<kernelversion>.*)\.md5$".format(KIWI_NAME_REGEX, KIWI_ARCH_REGEX, KIWI_VERSION_REGEX))
+    pattern_kiwi_ng = re.compile(r"^(?P<name>{})\.(?P<arch>{})-(?P<version>{})-(?P<kernelversion>.*)\.kernel$".format(KIWI_NAME_REGEX, KIWI_ARCH_REGEX, KIWI_VERSION_REGEX))
     for f in files:
         match = pattern.match(f)
         if match:
@@ -351,7 +359,7 @@ def build_info(dest, build_id, bundle_dest = None):
     basename = buildinfo.get('main', {}).get('image.basename', '')
     image_type = kiwiresult.get('type') or buildinfo.get('main', {}).get('image.type', 'unknown')
 
-    pattern = re.compile(r"^(?P<name>.*)\.(?P<arch>.*)-(?P<version>.*)$")
+    pattern = re.compile(r"^(?P<name>{})\.(?P<arch>{})-(?P<version>{})$".format(KIWI_NAME_REGEX, KIWI_ARCH_REGEX, KIWI_VERSION_REGEX))
     match = pattern.match(basename)
     if not match:
         return None

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix kiwi inspect regexp to allow image names with "-" (bsc#1204541)
 - Use the actual sudo user home directory for salt ssh
   clients on bootstrap and clean up (bsc#1202093)
 - dnf repo definition does not support multiline gpgkeys


### PR DESCRIPTION
## What does this PR change?

Fix kiwi inspect regexp to allow image names with "-"

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed: Bugfix

- [X] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19332
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
