### PR TITLE
Fix salt ssh wrong sudoer home directory on bootsrapping/cleanup

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
@@ -819,6 +819,7 @@ public class SaltSSHService {
                         .ifPresent(key ->
                                 pillarData.put("proxy_pub_key", key));
             }
+            pillarData.put("mgr_sudo_user", getSSHUser());
             Map<String, CompletionStage<Result<Map<String, ApplyResult>>>> res =
                     callAsyncSSH(
                             State.apply(

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Pass mgr_sudo_user pillar on salt ssh client cleanup (bsc#1202093)
 - Deny packages from older module metadata when building CLM projects (bsc#1201893)
 - Refresh pillar data for the assigned systems when a CLM channel is built (bsc#1200169)
 - Upgrade Bootstrap to 3.4.1

--- a/susemanager-utils/susemanager-sls/salt/cleanup_ssh_minion/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/cleanup_ssh_minion/init.sls
@@ -1,6 +1,9 @@
 include:
     - cleanup_minion
 
+{%- set mgr_sudo_user = salt['pillar.get']('mgr_sudo_user') or 'root' %}
+{%- set home = salt['user.info'](mgr_sudo_user)['home'] %}
+
 {% if salt['pillar.get']('contact_method') == 'ssh-push-tunnel' %}
 # remove server to localhost aliasing from /etc/hosts
 mgr_remove_mgr_server_localhost_alias:
@@ -14,27 +17,21 @@ mgr_remove_mgr_server_localhost_alias:
 # remove server ssh authorization
 mgr_remove_mgr_ssh_identity:
   ssh_auth.absent:
-    - user: {{ salt['pillar.get']('mgr_sudo_user') or 'root' }}
+    - user: {{ mgr_sudo_user }}
     - source: salt://salt_ssh/mgr_ssh_id.pub
 
 {%- if salt['pillar.get']('proxy_pub_key') and salt['pillar.get']('contact_method') == 'ssh-push-tunnel' %}
 # remove proxy ssh authorization (if any)
 mgr_remove_proxy_ssh_identity:
   ssh_auth.absent:
-    - user: {{ salt['pillar.get']('mgr_sudo_user') or 'root' }}
+    - user: {{ mgr_sudo_user }}
     - source: salt://salt_ssh/{{ salt['pillar.get']('proxy_pub_key') }}
-{%- endif %}
-
-{%- if salt['pillar.get']('mgr_sudo_user') and salt['pillar.get']('mgr_sudo_user') != 'root' %}
-{%- set home = '/home/' ~ salt['pillar.get']('mgr_sudo_user') %}
-{%- else %}
-{%- set home = '/root' %}
 {%- endif %}
 
 # remove own key authorization
 mgr_no_own_key_authorized:
   ssh_auth.absent:
-    - user: {{ salt['pillar.get']('mgr_sudo_user') or 'root' }}
+    - user: {{ mgr_sudo_user }}
     - source: {{ home }}/.ssh/mgr_own_id.pub
 
 # remove own keys

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Use the actual sudo user home directory for salt ssh
+  clients on bootstrap and clean up (bsc#1202093)
 - dnf repo definition does not support multiline gpgkeys
   (bsc#1204444)
 - remove forced refresh in channel state as gpg key trust is now


### PR DESCRIPTION
## What does this PR change?

There is a wrong assumption used in the bootstrap and cleanup state for salt ssh client:
`/home/USERNAME/` home directory with `USERNAME` matching exact actual user name.

But this assumption is not true as the home directory could have any destination.

It has also additional check for cleanup for salt ssh client. In case of using sudo user it could lead to errors with no text in the web UI due to not passing `mgr_sudo_user` on calling `cleanup_ssh_minion` state apply. Works fine with `root` user only.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Links

Tracks https://github.com/SUSE/spacewalk/issues/18529

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
