### PR TITLE
Change trust gpg keys

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/channels.repo
+++ b/susemanager-utils/susemanager-sls/salt/channels/channels.repo
@@ -23,11 +23,10 @@ deb {{ trust_string }} {{protocol}}://{{ args['token'] }}@{{hostname}}:{{port}}/
 [{{ args['alias'] }}]
 name={{ args['name'] }}
 enabled={{ args['enabled'] }}
-{%- if args['gpgkeyurl'] is defined %}
+{%- if args['gpgkeyurl'] is defined and salt['pillar.get']('mgr_metadata_signing_enabled', false) %}
+gpgkey={{ args['gpgkeyurl'] }} file:///etc/pki/rpm-gpg/mgr-gpg-pub.key
+{%- elif args['gpgkeyurl'] is defined %}
 gpgkey={{ args['gpgkeyurl'] }}
-{%- if salt['pillar.get']('mgr_metadata_signing_enabled', false) %}
-file:///etc/pki/rpm-gpg/mgr-gpg-pub.key
-{%- endif %}
 {%- elif salt['pillar.get']('mgr_metadata_signing_enabled', false) %}
 gpgkey=file:///etc/pki/rpm-gpg/mgr-gpg-pub.key
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/salt/channels/gpg-keys.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/gpg-keys.sls
@@ -17,7 +17,7 @@ mgr_trust_customer_gpg_key:
   mgrcompat.module_run:
     - name: pkg.add_repo_key
     - path: /etc/pki/rpm-gpg/mgr-gpg-pub.key
-    - require:
+    - onchanges:
       - file: mgr_deploy_customer_gpg_key
 
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/salt/channels/gpg-keys.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/gpg-keys.sls
@@ -12,6 +12,14 @@ mgr_deploy_customer_gpg_key:
     - source: salt://gpg/mgr-gpg-pub.key
     - makedirs: True
     - mode: 644
+
+mgr_trust_customer_gpg_key:
+  mgrcompat.module_run:
+    - name: pkg.add_repo_key
+    - path: /etc/pki/rpm-gpg/mgr-gpg-pub.key
+    - require:
+      - file: mgr_deploy_customer_gpg_key
+
 {%- endif %}
 {%- endif %}
 
@@ -59,4 +67,21 @@ mgr_deploy_{{ keyname }}:
 {%- endif %}
     - source: salt://gpg/{{ keyname }}
     - mode: 644
+{%- endfor %}
+
+
+{# trust GPG keys used in assigned channels #}
+
+{%- set gpg_urls = [] %}
+{%- for chan, args in pillar.get(pillar.get('_mgr_channels_items_name', 'channels'), {}).items() %}
+{%- if args['gpgkeyurl'] is defined %}
+{{ gpg_urls.append(args['gpgkeyurl']) | default("", True) }}
+{%- endif %}
+{%- endfor %}
+
+{% for url in gpg_urls | unique %}
+{{ url | replace(':', '_') }}:
+  mgrcompat.module_run:
+    - name: pkg.add_repo_key
+    - path: {{ url }}
 {%- endfor %}

--- a/susemanager-utils/susemanager-sls/salt/channels/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/init.sls
@@ -144,23 +144,6 @@ install_gnupg_debian:
       - gnupg
 {%- endif %}
 
-mgrchannels_refresh_repositories:
-  mgrcompat.module_run:
-    - name: pkg.refresh_db
-{%- if grains['os_family'] == 'Suse' %}
-    {#- same behavior as RedHat where --assumeyes is default #}
-    - gpg_auto_import_keys: True
-    - onlyif: /usr/bin/zypper -x lr | grep 'enabled="1"'
-{%- elif grains['os_family'] == 'RedHat' %}
-{%- if is_dnf %}
-    -  unless: "/usr/bin/dnf repolist | grep \"repolist: 0$\""
-{%- else %}
-    -  unless: "/usr/bin/yum repolist | grep \"repolist: 0$\""
-{%- endif %}
-{%- endif %}
-    - require:
-      - file: mgrchannels_repo
-
 {%- if not salt['pillar.get']('susemanager:distupgrade:dryrun', False) %}
 {%- if grains['os_family'] == 'Suse' and grains['osmajorrelease']|int > 11 and not grains['oscodename'] == 'openSUSE Leap 15.3' %}
 mgrchannels_install_products:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- remove forced refresh in channel state as gpg key trust is now
+  handled in a different way (bsc#1204061)
 - import gpg keys directly to prevent using gpg-auto-import-keys
   on package operations (bsc#1203580)
 - Perform refresh with packages.pkgupdate state (bsc#1203884)

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- dnf repo definition does not support multiline gpgkeys
+  (bsc#1204444)
 - remove forced refresh in channel state as gpg key trust is now
   handled in a different way (bsc#1204061)
 - import gpg keys directly to prevent using gpg-auto-import-keys

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- import gpg keys directly to prevent using gpg-auto-import-keys
+  on package operations (bsc#1203580)
 - Perform refresh with packages.pkgupdate state (bsc#1203884)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

When using `gpgkeys` parameter in the repository configuration, the installer import the key only when needed.
As the repositories are not signed, a refresh operation does not import the key. 
Only a package install/update operation would import this key, but we do not want to use "gpg-auto-import-gpg-keys" option in every state and teach also the users to set this option always.

So we better directly import the GPG keys which are set in **assigned** channels. 

As for yum/dnf you can configure "--assume-yes" to not say "yes" to key imports, it is better to directly import GPG keys also on Red Hat systems.

This makes the forced refresh operation in channels.sls obsolete.

Next issue found was, that `dnf` does not support multiline options. GPG keys must be comma or whitespace separated.
As yum and zypp support whitespace separation as well, we changed it to use this syntax everywhere.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/19074

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
