### PR TITLE
Rename 'Amazon EC2/KVM' to 'Amazon EC2/Nitro' and improve the detection (bsc#1203685)

### DIFF
--- a/java/code/src/com/suse/manager/reactor/hardware/HardwareMapper.java
+++ b/java/code/src/com/suse/manager/reactor/hardware/HardwareMapper.java
@@ -604,6 +604,9 @@ public class HardwareMapper {
                     case "kvm":
                         virtTypeLabel = "qemu";
                         break;
+                    case "nitro":
+                        virtTypeLabel = "aws_nitro";
+                        break;
                     default:
                         LOG.info("Detected virtual instance type '{}' for minion '{}'",
                                 virtTypeLabel, server.getMinionId());
@@ -615,7 +618,8 @@ public class HardwareMapper {
                             break;
                         case "qemu":
                         case "kvm":
-                            virtTypeLabel = "aws_kvm";
+                        case "nitro":
+                            virtTypeLabel = "aws_nitro";
                             break;
                         default:
                             virtTypeLabel = "aws";

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Improve Amazon EC2/Nitro detection (bsc#1203685)
 - Add channel availability check for product migration (bsc#1200296)
 - delay hardware refresh action to avoid missing channels (bsc#1204208)
 - fix xmlrpc call randomly failing with translation error (bsc#1203633)

--- a/schema/spacewalk/common/data/rhnVirtualInstanceType.sql
+++ b/schema/spacewalk/common/data/rhnVirtualInstanceType.sql
@@ -43,7 +43,7 @@ insert into rhnVirtualInstanceType (id, name, label)
     values (sequence_nextval('rhn_vit_id_seq'), 'Amazon EC2', 'aws');
 
 insert into rhnVirtualInstanceType (id, name, label)
-    values (sequence_nextval('rhn_vit_id_seq'), 'Amazon EC2/KVM', 'aws_kvm');
+    values (sequence_nextval('rhn_vit_id_seq'), 'Amazon EC2/Nitro', 'aws_nitro');
 
 insert into rhnVirtualInstanceType (id, name, label)
     values (sequence_nextval('rhn_vit_id_seq'), 'Amazon EC2/Xen', 'aws_xen');

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,5 @@
+- Change 'Amazon EC2/KVM' to 'Amazon EC2/Nitro' (bsc#1203685)
+
 -------------------------------------------------------------------
 Wed Sep 28 10:46:55 CEST 2022 - jgonzalez@suse.com
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.1-to-susemanager-schema-4.4.2/100-rhnVirtualInstanceType-Nitro.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.1-to-susemanager-schema-4.4.2/100-rhnVirtualInstanceType-Nitro.sql
@@ -1,0 +1,1 @@
+UPDATE rhnVirtualInstanceType SET name='Amazon EC2/Nitro', label='aws_nitro' WHERE label='aws_kvm';


### PR DESCRIPTION
## What does this PR change?

Renames 'Amazon EC2/KVM' to 'Amazon EC2/Nitro' and improves the detection of this virtual instances with salt.

There are 2 PRs for salt required for it:
https://github.com/openSUSE/salt/pull/560
https://github.com/openSUSE/salt/pull/555

Upstream Salt have already merged these changes.

## GUI diff

Just a name of the virtual instance type set for `Virtualization:` field.

## Documentation
- No documentation needed: only internal and user invisible changes

## Links

Tracks https://github.com/SUSE/spacewalk/issues/19096

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
