### PR TITLE
Project Lotus: handle GPG keys for PTF repositories

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -973,6 +973,8 @@ public class ContentSyncManager {
 
                     prodRepoLink.setUpdateTag(null);
                     prodRepoLink.setMandatory(false);
+                    // Current PTF key for SLE 12/15 and SLE-Micro
+                    prodRepoLink.setGpgKeyUrl("file:///usr/lib/rpm/gnupg/keys/suse_ptf_key.asc");
                     product.getRepositories().stream()
                         .filter(r -> r.getRootProduct().equals(root))
                         .filter(r -> r.getParentChannelLabel() != null)

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- set GPG Key Url for PTF repositories
 - Upgrade Bootstrap to 3.4.1
 - Improve Amazon EC2/Nitro detection (bsc#1203685)
 - Add channel availability check for product migration (bsc#1200296)

--- a/susemanager-utils/susemanager-sls/salt/channels/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/init.sls
@@ -156,5 +156,13 @@ mgrchannels_install_products:
       - mgrcompat: sync_states
 {%- endif %}
 {%- endif %}
+{%- endif %}
 
+{%- if grains['os_family'] == 'Suse' %}
+{# take care that the suse-build-key package with the PTF key is installed #}
+mgrchannels_inst_suse_build_key:
+  pkg.installed:
+    - name: suse-build-key
+    - require:
+      - file: mgrchannels_repo
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- enforce installation of the PTF GPG key package
 - dnf repo definition does not support multiline gpgkeys
   (bsc#1204444)
 - remove forced refresh in channel state as gpg key trust is now


### PR DESCRIPTION
## What does this PR change?

Set GpgKeyUrl for PTF repositories to the locally installed PTF key.
Enforce suse-build-key package been installed which contains the PTF key.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18912

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
