### PR TITLE
Fix number of file handles for deleted files is growing continuously in SUMA 4.3.1

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/RhnJavaJobTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/RhnJavaJobTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.taskomatic.task.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.redhat.rhn.taskomatic.domain.TaskoBunch;
+import com.redhat.rhn.taskomatic.domain.TaskoRun;
+import com.redhat.rhn.taskomatic.domain.TaskoTask;
+import com.redhat.rhn.taskomatic.domain.TaskoTemplate;
+import com.redhat.rhn.taskomatic.task.RhnJavaJob;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.AppenderRef;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.junit.Before;
+import org.junit.jupiter.api.Test;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+import java.util.stream.Collectors;
+
+
+public class RhnJavaJobTest {
+
+    LoggerConfig getLoggerConfig() {
+        final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        var config = ctx.getConfiguration();
+        return config.getLoggerConfig("com.redhat.rhn.taskomatic.task.test.RhnJavaJobTest$1");
+    }
+
+    @Before
+    public void setUp() {
+
+    }
+
+    @Test
+    public void testEnableLogging() throws JobExecutionException {
+
+        for (int i = 0; i < 10; i++) {
+            var job = new RhnJavaJob() {
+                @Override
+                public void execute(JobExecutionContext jobExecutionContextIn) throws JobExecutionException {
+                }
+
+                @Override
+                public void execute(JobExecutionContext context, TaskoRun run) {
+                    enableLogging(run);
+                }
+
+                public RhnJavaJob setPluginName(String name) {
+                    defaultPluginName = name;
+                    return this;
+                }
+
+                @Override
+                public String getConfigNamespace() {
+                    return null;
+                }
+            };
+
+            var task = new TaskoTask();
+            task.setId(1L);
+            task.setName("task_" + i);
+
+            var bunch = new TaskoBunch();
+            bunch.setName("bunch_" + i);
+
+            var template = new TaskoTemplate();
+            template.setBunch(bunch);
+            template.setTask(task);
+
+            var run = new TaskoRun();
+            run.setTemplate(template);
+
+            job.setPluginName("Console").execute(null, run);
+
+        }
+        var config = getLoggerConfig();
+
+        var appenders = config.getAppenders();
+        var appenderRefs = config.getAppenderRefs();
+
+        assertEquals(1, config.getAppenderRefs().size());
+        assertEquals(1, config.getAppenders().size());
+        assertEquals(
+                appenderRefs.stream().map(AppenderRef::getRef).collect(Collectors.toSet()),
+                appenders.keySet()
+        );
+
+    }
+
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Fix number of handlers for deleted files managed by taskomatic growing continuously (bsc#1204050)
+
 -------------------------------------------------------------------
 Wed Sep 28 11:15:58 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fix number of file handles for deleted files is growing continuously in SUMA 4.3.1

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19196

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
