### PR TITLE
Add legacy datetime id to stories for testing

### DIFF
--- a/web/html/src/components/datetime/DateTimePicker.stories.md
+++ b/web/html/src/components/datetime/DateTimePicker.stories.md
@@ -11,6 +11,8 @@ import { DateTimePicker } from "./DateTimePicker";
 
 const [value, setValue] = useState(localizedMoment());
 
+const legacyId = "legacy";
+
 <div>
   <p>
     user time zone: {localizedMoment.userTimeZone.displayValue} (
@@ -31,6 +33,7 @@ const [value, setValue] = useState(localizedMoment());
   <p>iso time: {value.toISOString()}</p>
   {/* eslint-disable-next-line local-rules/no-raw-date */}
   <p>browser time: {moment().toISOString(true)}</p>
-  <DateTimePicker value={value} onChange={(newValue) => setValue(newValue)} />
+  <p>legacy id: "{legacyId}"</p>
+  <DateTimePicker value={value} onChange={(newValue) => setValue(newValue)} legacyId={legacyId} />
 </div>
 ```


### PR DESCRIPTION
## What does this PR change?

Minor internal debugging change for Storybook.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
