### PR TITLE
Install needed deps on Ubuntu 18.04 (bsc#1204517)

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -595,6 +595,12 @@ elif [ "$INSTALLER" == apt ]; then
         local NEEDED="salt-common salt-minion"
         if [ $VENV_ENABLED -eq 1 ]; then
             NEEDED="venv-salt-minion"
+        elif [[ $A_CLIENT_CODE_BASE == "ubuntu" && $A_CLIENT_CODE_MAJOR_VERSION == 18 ]]; then
+            # Ubuntu 18.04 needs these extra dependencies. They are not specified in
+            # python3-salt because we don't maintain multiple .deb build instructions
+            # and we can't add logic that adds the deps depending on which OS the .deb
+            # is built for.
+            NEEDED="$NEEDED python3-contextvars python3-immutables"
         fi
         A_MISSING=""
         for P in $NEEDED; do

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,5 @@
+- Generated bootstrap scripts installs all needed Salt 3004 dependencies
+  for Ubuntu 18.04 (bsc#1204517)
 - drop traditional from bootstrap script
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?
Ubuntu 18.04 needs python3-contextvars and python3-immutables because it runs Python3.6 and Salt 3004 requires these dependencies. We couldn't add them to the .deb as hard dependencies because we only maintain one build instruction for all .deb packages, no matter which OS the package is built for.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [X] **DONE**

## Test coverage
- No tests: This only makes sense as end-to-end tests, out of scope for the bug fix PR.

- [X] **DONE**

## Links

Spacewalk Issue https://github.com/SUSE/spacewalk/issues/19301
Tracks # 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
