### PR TITLE
Refresh pillar data for the assigned systems when a CLM channel is built (bsc#1200169)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -61,6 +61,7 @@ import com.redhat.rhn.domain.errata.ClonedErrata;
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.errata.ErrataFactory;
 import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.events.AlignSoftwareTargetAction;
 import com.redhat.rhn.frontend.events.AlignSoftwareTargetMsg;
@@ -70,6 +71,8 @@ import com.redhat.rhn.manager.channel.ChannelManager;
 import com.redhat.rhn.manager.channel.CloneChannelCommand;
 import com.redhat.rhn.manager.errata.ErrataManager;
 import com.redhat.rhn.manager.errata.cache.ErrataCacheManager;
+
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
@@ -803,6 +806,10 @@ public class ContentManager {
                 Stream.of(Pair.of(leader, leaderTarget)),
                 nonLeaderTargets)
                 .collect(toList());
+
+        // Refresh pillar data for the assigned clients
+        ServerFactory.listMinionsByChannel(leaderTarget.getChannel().getId()).forEach(ms ->
+                MinionPillarManager.INSTANCE.generatePillar(ms, false, MinionPillarManager.PillarSubset.GENERAL));
 
         return srcTgtPairs;
     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Refresh pillar data for the assigned systems when a CLM channel is built (bsc#1200169)
 - Upgrade Bootstrap to 3.4.1
 - Improve Amazon EC2/Nitro detection (bsc#1203685)
 - Add channel availability check for product migration (bsc#1200296)


### PR DESCRIPTION
In some cases, channel-related pillar data changes depending on a CLM project's configuration. If the target channel is already assigned to some systems before the latest build, these changes never reflect to the actual pillar data unless channels are re-assigned manually.

This patch refreshes the pillar data for all the systems assigned to a CLM project's target channels whenever the project is rebuilt.

See: https://bugzilla.suse.com/show_bug.cgi?id=1200169
Case in hand: https://bugzilla.suse.com/show_bug.cgi?id=1200169#c17

Port of: https://github.com/SUSE/spacewalk/pull/19282

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
