### PR TITLE
Call test-coverage-report in ant test-pr target

### DIFF
--- a/java/manager-build.xml
+++ b/java/manager-build.xml
@@ -345,7 +345,7 @@
     </junitlauncher>
   </target>
 
-  <target name="test-pr" depends="test-report" description="Run unit tests for Pull Requests">
+  <target name="test-pr" depends="test-report, test-coverage-report" description="Run unit tests for Pull Requests">
     <fail if="junit_failed"/>
   </target>
 


### PR DESCRIPTION
## What does this PR change?

The `test-pr` target is what makes the pipeline fail... make it depend on `test-coverage-report` and use it in the jenkins pipeline

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered
- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
