### PR TITLE
Fix issues on upgrading Amazon EC2 related schema

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,5 @@
+- Fix previous 'Amazon EC2' schema upgrade script
+  to prevent possible issues on schema upgrade.
 - Keep older module metadata files in database (bsc#1201893)
 - Fix setting of last modified date in channel clone procedure
 - Change 'Amazon EC2/KVM' to 'Amazon EC2/Nitro' (bsc#1203685)

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.0-to-susemanager-schema-4.4.1/300-rhnVirtualInstanceType.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.0-to-susemanager-schema-4.4.1/300-rhnVirtualInstanceType.sql
@@ -1,7 +1,7 @@
 INSERT INTO rhnVirtualInstanceType (id, name, label)
 SELECT sequence_nextval('rhn_vit_id_seq'), 'Amazon EC2/KVM', 'aws_kvm'
-WHERE NOT EXISTS ( SELECT 1 FROM rhnVirtualInstanceType WHERE label = 'aws_kvm' AND name = 'Amazon EC2/KVM');
+WHERE NOT EXISTS ( SELECT 1 FROM rhnVirtualInstanceType WHERE label = 'aws_kvm' OR label = 'aws_nitro');
 
 INSERT INTO rhnVirtualInstanceType (id, name, label)
 SELECT sequence_nextval('rhn_vit_id_seq'), 'Amazon EC2/Xen', 'aws_xen'
-WHERE NOT EXISTS ( SELECT 1 FROM rhnVirtualInstanceType WHERE label = 'aws_xen' AND name = 'Amazon EC2/Xen');
+WHERE NOT EXISTS ( SELECT 1 FROM rhnVirtualInstanceType WHERE label = 'aws_xen');


### PR DESCRIPTION
## What does this PR change?

The previous schema upgrade introducing `aws_kvm` which was renamed to `aws_nitro` after is causing issues on schema upgrade. This PR is making condition for the previous schema upgrade script covering this case.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Links
Tracks https://github.com/SUSE/spacewalk/issues/19096

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
