### PR TITLE
Avoid concurrency issues during reporting database synchronization

### DIFF
--- a/java/buildconf/test/rhn.conf.postgresql-example
+++ b/java/buildconf/test/rhn.conf.postgresql-example
@@ -7,21 +7,40 @@ db_host = localhost
 db_port = 5432
 server.nls_lang = english.UTF8
 
+# Reporting Database configuration
+report_db_backend = postgresql
+report_db_user = pythia
+report_db_password = oracle
+report_db_name = reportdb
+report_db_host = localhost
+report_db_port = 5432
+report_db_ssl_enabled = 0
+
 # Hibernate configuration
 hibernate.dialect = org.hibernate.dialect.PostgreSQLDialect
 hibernate.connection.driver_class = org.postgresql.Driver
 hibernate.connection.driver_proto = jdbc:postgresql
-
 # Uncomment to log all SQL statements issued by Hibernate
 # hibernate.show_sql = true
-
 hibernate.use_outer_join = true
 hibernate.jdbc.batch_size = 0
 hibernate.cache.region.factory_class = org.hibernate.cache.ehcache.EhCacheRegionFactory
 hibernate.cache.use_query_cache = true
 hibernate.bytecode.use_reflection_optimizer = false
-hibernate.jdbc.batch_size = 0
 hibernate.id.new_generator_mappings = false
+
+# Hibernate configuration
+reporting.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialect
+reporting.hibernate.connection.driver_class = org.postgresql.Driver
+reporting.hibernate.connection.driver_proto = jdbc:postgresql
+# Uncomment to log all SQL statements issued by Hibernate
+# reporting.hibernate.show_sql = true
+reporting.hibernate.use_outer_join = true
+reporting.hibernate.jdbc.batch_size = 0
+reporting.hibernate.cache.region.factory_class = org.hibernate.cache.ehcache.EhCacheRegionFactory
+reporting.hibernate.cache.use_query_cache = true
+reporting.hibernate.bytecode.use_reflection_optimizer = false
+reporting.hibernate.id.new_generator_mappings = false
 
 # User creation settings
 min_user_len = 3

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ChannelRepodata.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ChannelRepodata.java
@@ -23,7 +23,7 @@ import org.apache.logging.log4j.Logger;
  *
  *
  */
-public class ChannelRepodata extends RhnQueueJob {
+public class ChannelRepodata extends RhnQueueJob<ChannelRepodataDriver> {
 
     public static final String DISPLAY_NAME = "channel_repodata";
     private static Logger log = null;
@@ -41,7 +41,7 @@ public class ChannelRepodata extends RhnQueueJob {
     }
 
     @Override
-    protected Class getDriverClass() {
+    protected Class<ChannelRepodataDriver> getDriverClass() {
         return ChannelRepodataDriver.class;
     }
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ErrataCacheTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ErrataCacheTask.java
@@ -23,7 +23,7 @@ import org.apache.logging.log4j.Logger;
 /**
  * ErrataCacheTask
  */
-public class ErrataCacheTask extends RhnQueueJob {
+public class ErrataCacheTask extends RhnQueueJob<ErrataCacheDriver> {
 
     public static final String DISPLAY_NAME = "errata_cache";
     private static Logger log = null;
@@ -42,7 +42,7 @@ public class ErrataCacheTask extends RhnQueueJob {
     }
 
     @Override
-    protected Class getDriverClass() {
+    protected Class<ErrataCacheDriver> getDriverClass() {
         return ErrataCacheDriver.class;
     }
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ErrataQueue.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ErrataQueue.java
@@ -23,7 +23,7 @@ import org.apache.logging.log4j.Logger;
  * Manages the pending errata queue
  *
  */
-public class ErrataQueue extends RhnQueueJob {
+public class ErrataQueue extends RhnQueueJob<ErrataQueueDriver> {
 
     public static final String DISPLAY_NAME = "errata_queue";
     private static Logger log = null;
@@ -47,7 +47,7 @@ public class ErrataQueue extends RhnQueueJob {
     }
 
     @Override
-    protected Class getDriverClass() {
+    protected Class<ErrataQueueDriver> getDriverClass() {
         return ErrataQueueDriver.class;
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/HubReportDbUpdateTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/HubReportDbUpdateTask.java
@@ -18,9 +18,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 
-public class HubReportDbUpdateTask extends RhnQueueJob {
+public class HubReportDbUpdateTask extends RhnQueueJob<HubReportDbUpdateDriver> {
 
-    private Logger log = LogManager.getLogger(getClass());
+    private final Logger log = LogManager.getLogger(getClass());
 
     /**
      * {@inheritDoc}
@@ -34,7 +34,7 @@ public class HubReportDbUpdateTask extends RhnQueueJob {
      * {@inheritDoc}
      */
     @Override
-    protected Class getDriverClass() {
+    protected Class<HubReportDbUpdateDriver> getDriverClass() {
         return HubReportDbUpdateDriver.class;
     }
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/HubReportDbUpdateWorker.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/HubReportDbUpdateWorker.java
@@ -14,11 +14,7 @@
  */
 package com.redhat.rhn.taskomatic.task;
 
-
-import static com.redhat.rhn.taskomatic.task.ReportDBHelper.generateDelete;
-import static com.redhat.rhn.taskomatic.task.ReportDBHelper.generateExistingTables;
-import static com.redhat.rhn.taskomatic.task.ReportDBHelper.generateInsert;
-import static com.redhat.rhn.taskomatic.task.ReportDBHelper.generateQuery;
+import static com.redhat.rhn.common.conf.ConfigDefaults.REPORT_DB_BATCH_SIZE;
 
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
@@ -49,11 +45,11 @@ import java.util.stream.Collectors;
 
 public class HubReportDbUpdateWorker implements QueueWorker {
 
-    private static final int BATCH_SIZE = Config.get()
-            .getInt(ConfigDefaults.REPORT_DB_BATCH_SIZE, 2000);
+    private final int batchSize;
+    private final ReportDBHelper dbHelper;
     private TaskQueue parentQueue;
     private final MgrServerInfo mgrServerInfo;
-    private Logger log;
+    private final Logger log;
 
     private static final List<String> TABLES =
             List.of("SystemGroup", "SystemGroupPermission", "System", "SystemHistory", "SystemAction", "SystemChannel",
@@ -70,8 +66,22 @@ public class HubReportDbUpdateWorker implements QueueWorker {
      * @param mgrServerInfoIn mgr server to query data from
      */
     public HubReportDbUpdateWorker(Logger loggerIn, MgrServerInfo mgrServerInfoIn) {
+        this(loggerIn, mgrServerInfoIn, ReportDBHelper.INSTANCE, Config.get().getInt(REPORT_DB_BATCH_SIZE, 2000));
+    }
+
+    /**
+     * Test constructor for Hub Reporting DB Worker.
+     * @param loggerIn logger
+     * @param mgrServerInfoIn mgr server to query data from
+     * @param dbHelperIn the {@link ReportDBHelper}
+     * @param batchSizeIn the batch size
+     */
+    public HubReportDbUpdateWorker(Logger loggerIn, MgrServerInfo mgrServerInfoIn, ReportDBHelper dbHelperIn,
+                                      int batchSizeIn) {
         this.mgrServerInfo = mgrServerInfoIn;
         this.log = loggerIn;
+        this.dbHelper = dbHelperIn;
+        this.batchSize = batchSizeIn;
     }
 
     @Override
@@ -80,7 +90,8 @@ public class HubReportDbUpdateWorker implements QueueWorker {
     }
 
     private List<String> filterExistingTables(Session remoteSession, Long serverId) {
-        SelectMode query = generateExistingTables(remoteSession, TABLES);
+        SelectMode query = dbHelper.generateExistingTables(remoteSession, TABLES);
+        @SuppressWarnings("unchecked")
         DataResult<Map<String, Object>> result = query.execute();
         Set<Map.Entry<String, Object>> tableEntry = result.get(0).entrySet();
         tableEntry.removeIf(t -> {
@@ -91,34 +102,33 @@ public class HubReportDbUpdateWorker implements QueueWorker {
             }
             return false;
         });
-        List<String> existingTables = tableEntry.stream().map(t ->
-                String.valueOf(t.getValue())).collect(Collectors.toList());
-        return existingTables;
+
+        return tableEntry.stream().map(t -> String.valueOf(t.getValue())).collect(Collectors.toList());
     }
 
     private void updateRemoteData(Session remoteSession, Session localSession, String tableName, long mgmId) {
         TimeUtils.logTime(log, "Refreshing table " + tableName, () -> {
-            SelectMode query = generateQuery(remoteSession, tableName, log);
+            SelectMode query = dbHelper.generateQuery(remoteSession, tableName, log);
 
             // Remove all the existing data
             log.debug("Deleting existing data in table {}", tableName);
-            WriteMode delete = generateDelete(localSession, tableName);
+            WriteMode delete = dbHelper.generateDelete(localSession, tableName);
             delete.executeUpdate(Map.of("mgm_id", mgmId));
 
             // Extract the first batch
             @SuppressWarnings("unchecked")
-            DataResult<Map<String, Object>> firstBatch = query.execute(Map.of("offset", 0, "limit", BATCH_SIZE));
+            DataResult<Map<String, Object>> firstBatch = query.execute(Map.of("offset", 0, "limit", batchSize));
             firstBatch.forEach(e -> e.remove("mgm_id"));
 
             if (!firstBatch.isEmpty()) {
                 // Generate the insert using the column name retrieved from the select
-                WriteMode insert = generateInsert(localSession, tableName, mgmId, firstBatch.get(0).keySet());
+                WriteMode insert = dbHelper.generateInsert(localSession, tableName, mgmId, firstBatch.get(0).keySet());
                 insert.executeBatchUpdates(firstBatch);
                 log.debug("Extracted {} rows for table {}", firstBatch.size(), tableName);
 
                 // Iterate further if we can have additional rows
-                if (firstBatch.size() == BATCH_SIZE) {
-                    ReportDBHelper.<Map<String, Object>>batchStream(query, BATCH_SIZE, BATCH_SIZE)
+                if (firstBatch.size() == batchSize) {
+                    dbHelper.<Map<String, Object>>batchStream(query, batchSize, batchSize)
                             .forEach(batch -> {
                                 batch.forEach(e -> e.remove("mgm_id"));
                                 insert.executeBatchUpdates(batch);
@@ -153,7 +163,7 @@ public class HubReportDbUpdateWorker implements QueueWorker {
                 existingTables.forEach(table -> {
                     updateRemoteData(remoteDB.getSession(), localRh.getSession(), table, mgrServerInfo.getId());
                 });
-                ReportDBHelper.analyzeReportDb(localRh.getSession());
+                dbHelper.analyzeReportDb(localRh.getSession());
                 Server mgrServer = ServerFactory.lookupById(mgrServerInfo.getId());
                 mgrServer.getMgrServerInfo().setReportDbLastSynced(new Date());
                 ServerFactory.save(mgrServer);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ReportDBHelper.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ReportDBHelper.java
@@ -139,7 +139,9 @@ public class ReportDBHelper {
      */
     public WriteMode generateInsert(Session session, String table, long mgmId, Set<String> params) {
         final String sqlStatement = String.format(
-                "INSERT INTO %s (mgm_id, %s) VALUES (%s, %s)",
+                "INSERT INTO %s (mgm_id, %s) " +
+                "     VALUES (%s, %s) " +
+                "ON CONFLICT DO NOTHING",
                 table,
                 String.join(",", params),
                 mgmId,
@@ -159,7 +161,9 @@ public class ReportDBHelper {
      */
     public WriteMode generateInsertWithDate(Session session, String table, long mgmId, Set<String> params) {
         final String sqlStatement = String.format(
-                "INSERT INTO %s (mgm_id, synced_date, %s) VALUES (%s, current_timestamp, %s)",
+                "INSERT INTO %s (mgm_id, synced_date, %s) " +
+                "     VALUES (%s, current_timestamp, %s) " +
+                "ON CONFLICT DO NOTHING",
                 table,
                 String.join(",", params),
                 mgmId,

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ReportDBHelper.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ReportDBHelper.java
@@ -34,7 +34,15 @@ import java.util.stream.Stream;
 
 public class ReportDBHelper {
 
-    private ReportDBHelper() {
+    /** The mgm_id used in the reporting database to indicate the data local which belong to the local server. */
+    public static final long LOCAL_MGM_ID = 1;
+
+    public static final ReportDBHelper INSTANCE = new ReportDBHelper();
+
+    /**
+     * Default constructor to allow unit test sub-classes
+     */
+    protected ReportDBHelper() {
     }
 
     /**
@@ -46,14 +54,14 @@ public class ReportDBHelper {
      * @return stream of batched results
      */
     @SuppressWarnings("unchecked")
-    public static <T> Stream<DataResult<T>> batchStream(SelectMode query, int batchSize, int initialOffset) {
+    public <T> Stream<DataResult<T>> batchStream(SelectMode query, int batchSize, int initialOffset) {
         return Stream.iterate(initialOffset, i -> i + batchSize)
                 .map(offset -> (DataResult<T>) query.execute(Map.of("offset", offset, "limit", batchSize)))
                 .takeWhile(batch -> !batch.isEmpty());
     }
 
-    private static String getOrderColumns(Session session, String table, Logger log) {
-        String orderqstr =
+    private String getOrderColumns(Session session, String table, Logger log) {
+        String orderSQL =
                 "SELECT string_agg(a.attname, ', ') AS order " +
                 "  FROM pg_constraint AS c " +
                 "    CROSS JOIN LATERAL UNNEST(c.conkey) AS cols(colnum) " +
@@ -70,14 +78,14 @@ public class ReportDBHelper {
                 "   AND t.relname = '" + table.toLowerCase() + "' " +
                 "   AND i.relname = '" + table.toLowerCase() + "_order_idx'";
 
-        GeneratedSelectMode orderquery = new GeneratedSelectMode("orderquery." + table, session,
-                orderqstr , List.of());
+        GeneratedSelectMode orderQuery = new GeneratedSelectMode("orderquery." + table, session, orderSQL , List.of());
 
-        DataResult<Map<String, String>> order = orderquery.execute();
-        String ordercolumns = order.stream().findFirst().map(o -> o.getOrDefault("order", "ctid")).orElse("ctid");
+        @SuppressWarnings("unchecked")
+        DataResult<Map<String, String>> order = orderQuery.execute();
+        String orderColumns = order.stream().findFirst().map(o -> o.getOrDefault("order", "ctid")).orElse("ctid");
 
-        log.debug("Order Columns of {} by: {}", table, ordercolumns);
-        return ordercolumns;
+        log.debug("Order Columns of {} by: {}", table, orderColumns);
+        return orderColumns;
     }
 
     /**
@@ -86,7 +94,7 @@ public class ReportDBHelper {
      * @param tables tables list name
      * @return select mode query
      */
-    public static SelectMode generateExistingTables(Session session, List<String> tables) {
+    public SelectMode generateExistingTables(Session session, List<String> tables) {
         List<String> selectContent =
                 tables.stream().map(t -> "to_regclass('" + t + "') AS " + t).collect(Collectors.toList());
         final String sqlStatement = "SELECT " + String.join(",", selectContent);
@@ -100,11 +108,11 @@ public class ReportDBHelper {
      * @param log the logger
      * @return select mode query
      */
-    public static SelectMode generateQuery(Session session, String table, Logger log) {
+    public SelectMode generateQuery(Session session, String table, Logger log) {
         String orderColumns = getOrderColumns(session, table, log);
 
         final String sqlStatement = "SELECT * FROM " + table +
-                " WHERE mgm_id = 1 ORDER BY " + orderColumns + " OFFSET :offset LIMIT :limit";
+                " WHERE mgm_id = " + LOCAL_MGM_ID +  " ORDER BY " + orderColumns + " OFFSET :offset LIMIT :limit";
         return new GeneratedSelectMode("select." + table, session, sqlStatement, List.of("offset", "limit"));
     }
 
@@ -114,7 +122,7 @@ public class ReportDBHelper {
      * @param table table name
      * @return write mode query
      */
-    public static WriteMode generateDelete(Session session, String table) {
+    public WriteMode generateDelete(Session session, String table) {
         final String sqlStatement = "DELETE FROM " + table + " WHERE mgm_id = :mgm_id";
         final List<String> params = List.of("mgm_id");
 
@@ -129,7 +137,7 @@ public class ReportDBHelper {
      * @param params table column names (excluding mgm_id)
      * @return write mode query
      */
-    public static WriteMode generateInsert(Session session, String table, long mgmId, Set<String> params) {
+    public WriteMode generateInsert(Session session, String table, long mgmId, Set<String> params) {
         final String sqlStatement = String.format(
                 "INSERT INTO %s (mgm_id, %s) VALUES (%s, %s)",
                 table,
@@ -149,7 +157,7 @@ public class ReportDBHelper {
      * @param params table column names (excluding mgm_id)
      * @return write mode query
      */
-    public static WriteMode generateInsertWithDate(Session session, String table, long mgmId, Set<String> params) {
+    public WriteMode generateInsertWithDate(Session session, String table, long mgmId, Set<String> params) {
         final String sqlStatement = String.format(
                 "INSERT INTO %s (mgm_id, synced_date, %s) VALUES (%s, current_timestamp, %s)",
                 table,
@@ -165,7 +173,7 @@ public class ReportDBHelper {
      * Analyzes the report database tables after massive inserts
      * @param session session the query should use
      */
-    public static void analyzeReportDb(Session session) {
+    public void analyzeReportDb(Session session) {
         var m = ModeFactory.getCallableMode(session, "GeneralReport_queries", "analyze_reportdb");
         m.execute(new HashMap<>(), new HashMap<>());
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ReportDbUpdateTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ReportDbUpdateTask.java
@@ -38,6 +38,11 @@ import java.util.Map;
 
 public class ReportDbUpdateTask extends RhnJavaJob {
 
+    private static final String GENERAL_REPORT_QUERIES = "GeneralReport_queries";
+    private static final String SYSTEM_REPORT_QUERIES = "SystemReport_queries";
+    private static final String CHANNEL_REPORT_QUERIES = "ChannelReport_queries";
+    private static final String SCAP_REPORT_QUERIES = "ScapReport_queries";
+
     private static final int BATCH_SIZE = Config.get()
             .getInt(ConfigDefaults.REPORT_DB_BATCH_SIZE, 2000);
 
@@ -82,38 +87,38 @@ public class ReportDbUpdateTask extends RhnJavaJob {
         long mgmId = 1;
 
         try {
-            fillReportDbTable(rh.getSession(), "GeneralReport_queries", "SystemGroup", mgmId);
-            fillReportDbTable(rh.getSession(), "GeneralReport_queries", "SystemGroupPermission", mgmId);
-            fillReportDbTable(rh.getSession(), "GeneralReport_queries", "Account", mgmId);
-            fillReportDbTable(rh.getSession(), "GeneralReport_queries", "AccountGroup", mgmId);
+            fillReportDbTable(rh.getSession(), GENERAL_REPORT_QUERIES, "SystemGroup", mgmId);
+            fillReportDbTable(rh.getSession(), GENERAL_REPORT_QUERIES, "SystemGroupPermission", mgmId);
+            fillReportDbTable(rh.getSession(), GENERAL_REPORT_QUERIES, "Account", mgmId);
+            fillReportDbTable(rh.getSession(), GENERAL_REPORT_QUERIES, "AccountGroup", mgmId);
 
-            fillReportDbTable(rh.getSession(), "SystemReport_queries", "System", mgmId);
-            fillReportDbTable(rh.getSession(), "SystemReport_queries", "SystemHistory", mgmId);
-            fillReportDbTable(rh.getSession(), "SystemReport_queries", "SystemAction", mgmId);
-            fillReportDbTable(rh.getSession(), "SystemReport_queries", "SystemChannel", mgmId);
-            fillReportDbTable(rh.getSession(), "SystemReport_queries", "SystemConfigChannel", mgmId);
-            fillReportDbTable(rh.getSession(), "SystemReport_queries", "SystemVirtualData", mgmId);
-            fillReportDbTable(rh.getSession(), "SystemReport_queries", "SystemNetInterface", mgmId);
-            fillReportDbTable(rh.getSession(), "SystemReport_queries", "SystemNetAddressV4", mgmId);
-            fillReportDbTable(rh.getSession(), "SystemReport_queries", "SystemNetAddressV6", mgmId);
-            fillReportDbTable(rh.getSession(), "SystemReport_queries", "SystemOutdated", mgmId);
-            fillReportDbTable(rh.getSession(), "SystemReport_queries", "SystemGroupMember", mgmId);
-            fillReportDbTable(rh.getSession(), "SystemReport_queries", "SystemEntitlement", mgmId);
-            fillReportDbTable(rh.getSession(), "SystemReport_queries", "SystemErrata", mgmId);
-            fillReportDbTable(rh.getSession(), "SystemReport_queries", "SystemPackageInstalled", mgmId);
-            fillReportDbTable(rh.getSession(), "SystemReport_queries", "SystemPackageUpdate", mgmId);
-            fillReportDbTable(rh.getSession(), "SystemReport_queries", "SystemCustomInfo", mgmId);
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "System", mgmId);
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemHistory", mgmId);
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemAction", mgmId);
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemChannel", mgmId);
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemConfigChannel", mgmId);
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemVirtualData", mgmId);
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemNetInterface", mgmId);
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemNetAddressV4", mgmId);
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemNetAddressV6", mgmId);
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemOutdated", mgmId);
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemGroupMember", mgmId);
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemEntitlement", mgmId);
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemErrata", mgmId);
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemPackageInstalled", mgmId);
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemPackageUpdate", mgmId);
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemCustomInfo", mgmId);
 
-            fillReportDbTable(rh.getSession(), "ChannelReport_queries", "Channel", mgmId);
-            fillReportDbTable(rh.getSession(), "ChannelReport_queries", "ChannelErrata", mgmId);
-            fillReportDbTable(rh.getSession(), "ChannelReport_queries", "ChannelPackage", mgmId);
-            fillReportDbTable(rh.getSession(), "ChannelReport_queries", "ChannelRepository", mgmId);
-            fillReportDbTable(rh.getSession(), "ChannelReport_queries", "Errata", mgmId);
-            fillReportDbTable(rh.getSession(), "ChannelReport_queries", "Package", mgmId);
-            fillReportDbTable(rh.getSession(), "ChannelReport_queries", "Repository", mgmId);
+            fillReportDbTable(rh.getSession(), CHANNEL_REPORT_QUERIES, "Channel", mgmId);
+            fillReportDbTable(rh.getSession(), CHANNEL_REPORT_QUERIES, "ChannelErrata", mgmId);
+            fillReportDbTable(rh.getSession(), CHANNEL_REPORT_QUERIES, "ChannelPackage", mgmId);
+            fillReportDbTable(rh.getSession(), CHANNEL_REPORT_QUERIES, "ChannelRepository", mgmId);
+            fillReportDbTable(rh.getSession(), CHANNEL_REPORT_QUERIES, "Errata", mgmId);
+            fillReportDbTable(rh.getSession(), CHANNEL_REPORT_QUERIES, "Package", mgmId);
+            fillReportDbTable(rh.getSession(), CHANNEL_REPORT_QUERIES, "Repository", mgmId);
 
-            fillReportDbTable(rh.getSession(), "ScapReport_queries", "XccdScan", mgmId);
-            fillReportDbTable(rh.getSession(), "ScapReport_queries", "XccdScanResult", mgmId);
+            fillReportDbTable(rh.getSession(), SCAP_REPORT_QUERIES, "XccdScan", mgmId);
+            fillReportDbTable(rh.getSession(), SCAP_REPORT_QUERIES, "XccdScanResult", mgmId);
 
             ReportDBHelper.analyzeReportDb(rh.getSession());
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/SSHPush.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/SSHPush.java
@@ -22,7 +22,7 @@ import org.apache.logging.log4j.Logger;
 /**
  * Call rhn_check on relevant systems via SSH using remote port forwarding.
  */
-public class SSHPush extends RhnQueueJob {
+public class SSHPush extends RhnQueueJob<SSHPushDriver> {
 
     public static final String QUEUE_NAME = "ssh_push";
     private static Logger log = null;
@@ -47,7 +47,7 @@ public class SSHPush extends RhnQueueJob {
      * {@inheritDoc}
      */
     @Override
-    protected Class<?> getDriverClass() {
+    protected Class<SSHPushDriver> getDriverClass() {
         return SSHPushDriver.class;
     }
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataCacheDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataCacheDriver.java
@@ -30,7 +30,7 @@ import java.util.Set;
 /**
  * Driver for the threaded errata cache update queue
  */
-public class ErrataCacheDriver implements QueueDriver {
+public class ErrataCacheDriver implements QueueDriver<Task> {
 
     private Logger logger = null;
 
@@ -77,8 +77,7 @@ public class ErrataCacheDriver implements QueueDriver {
     /**
      * {@inheritDoc}
      */
-    public QueueWorker makeWorker(Object workItem) {
-        Task task = (Task) workItem;
+    public QueueWorker makeWorker(Task task) {
         return new ErrataCacheWorker(task, logger);
     }
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataQueueDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataQueueDriver.java
@@ -24,14 +24,13 @@ import com.redhat.rhn.taskomatic.task.threaded.QueueWorker;
 
 import org.apache.logging.log4j.Logger;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 /**
  * Driver for the threaded errata queue
  */
-public class ErrataQueueDriver implements QueueDriver {
+public class ErrataQueueDriver implements QueueDriver<Map<String, Long>> {
 
     private Logger logger = null;
 
@@ -45,11 +44,14 @@ public class ErrataQueueDriver implements QueueDriver {
     /**
      * {@inheritDoc}
      */
-    public List getCandidates() {
+    public List<Map<String, Long>> getCandidates() {
         SelectMode select = ModeFactory.getMode(TaskConstants.MODE_NAME,
                 TaskConstants.TASK_QUERY_ERRATA_QUEUE_FIND_CANDIDATES);
         try {
-            return select.execute(new HashMap());
+            @SuppressWarnings("unchecked")
+            List<Map<String, Long>> result = select.execute();
+
+            return result;
         }
         finally {
             HibernateFactory.closeSession();
@@ -80,8 +82,8 @@ public class ErrataQueueDriver implements QueueDriver {
     /**
      * {@inheritDoc}
      */
-    public QueueWorker makeWorker(Object workItem) {
-        return new ErrataQueueWorker((Map) workItem, logger);
+    public QueueWorker makeWorker(Map<String, Long> workItem) {
+        return new ErrataQueueWorker(workItem, logger);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataDriver.java
@@ -25,8 +25,8 @@ import com.redhat.rhn.taskomatic.task.threaded.QueueWorker;
 
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -34,7 +34,7 @@ import java.util.Map;
  *
  *
  */
-public class ChannelRepodataDriver implements QueueDriver {
+public class ChannelRepodataDriver implements QueueDriver<Map<String, Object>> {
 
     private Logger logger = null;
 
@@ -45,7 +45,7 @@ public class ChannelRepodataDriver implements QueueDriver {
         WriteMode resetChannelRepodata = ModeFactory.getWriteMode(TaskConstants.MODE_NAME,
                 TaskConstants.TASK_QUERY_REPOMOD_CLEAR_IN_PROGRESS);
         try {
-            int eqReset = resetChannelRepodata.executeUpdate(new HashMap());
+            int eqReset = resetChannelRepodata.executeUpdate(Map.of());
             if (eqReset > 0) {
                 logger.info("Resetting {} unfinished channel repodata tasks", eqReset);
             }
@@ -70,19 +70,17 @@ public class ChannelRepodataDriver implements QueueDriver {
     /**
      * @return Returns candidates
      */
-    public List getCandidates() {
+    public List<Map<String, Object>> getCandidates() {
         SelectMode select = ModeFactory.getMode(TaskConstants.MODE_NAME,
                 TaskConstants.TASK_QUERY_REPOMD_DRIVER_QUERY);
 
         Map<String, Object> params = new HashMap<>();
-        List<Object> retval = new LinkedList<>();
-        List results = select.execute(params);
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> results = select.execute(params);
         if (results != null) {
-            for (Object resultIn : results) {
-                retval.add(resultIn);
-            }
+            return results;
         }
-        return retval;
+        return Collections.emptyList();
     }
 
     /**
@@ -111,8 +109,8 @@ public class ChannelRepodataDriver implements QueueDriver {
      * @param workItem work item
      * @return Returns channel repodata worker object
      */
-    public QueueWorker makeWorker(Object workItem) {
-        return new ChannelRepodataWorker((Map) workItem, getLogger());
+    public QueueWorker makeWorker(Map<String, Object> workItem) {
+        return new ChannelRepodataWorker(workItem, getLogger());
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataWorker.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataWorker.java
@@ -20,6 +20,7 @@ import static com.redhat.rhn.domain.contentmgmt.EnvironmentTarget.Status.GENERAT
 
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.db.datasource.ModeFactory;
 import com.redhat.rhn.common.db.datasource.SelectMode;
 import com.redhat.rhn.common.db.datasource.WriteMode;
@@ -47,31 +48,31 @@ import java.util.Optional;
  */
 public class ChannelRepodataWorker implements QueueWorker {
 
-    private RepositoryWriter repoWriter;
+    private final RepositoryWriter repoWriter;
     private TaskQueue parentQueue;
-    private Logger logger;
-    private String channelLabelToProcess;
+    private final Logger logger;
+    private final String channelLabelToProcess;
 
-    private List queueEntries;
+    private List<Map<String, String>> queueEntries;
 
     /**
      *
      * @param workItem work item map
      * @param parentLogger repomd logger
      */
-    public ChannelRepodataWorker(Map workItem, Logger parentLogger) {
+    public ChannelRepodataWorker(Map<String, Object> workItem, Logger parentLogger) {
         logger = parentLogger;
-        String prefixPath = Config.get().getString(ConfigDefaults.REPOMD_PATH_PREFIX,
-                "rhn/repodata");
-        String mountPoint =
-            Config.get().getString(ConfigDefaults.REPOMD_CACHE_MOUNT_POINT, "/pub");
+
+        String prefixPath = Config.get().getString(ConfigDefaults.REPOMD_PATH_PREFIX, "rhn/repodata");
+        String mountPoint = Config.get().getString(ConfigDefaults.REPOMD_CACHE_MOUNT_POINT, "/pub");
+
         channelLabelToProcess = (String) workItem.get("channel_label");
 
         // We need to find out whether to use Rpm or Debian repository
         Channel channelToProcess = ChannelFactory.lookupByLabel(channelLabelToProcess);
         // if the channelExists in the db still
-        if (channelToProcess != null && channelToProcess.getChannelArch()
-                .getArchType().getLabel().equalsIgnoreCase("deb")) {
+        if (channelToProcess != null &&
+            channelToProcess.getChannelArch().getArchType().getLabel().equalsIgnoreCase("deb")) {
             repoWriter = new DebRepositoryWriter(prefixPath, mountPoint);
         }
         else {
@@ -160,12 +161,11 @@ public class ChannelRepodataWorker implements QueueWorker {
     /**
      * populates the queue details for repomd event
      */
+    @SuppressWarnings("unchecked")
     private void populateQueueEntryDetails() {
         SelectMode selector = ModeFactory.getMode(TaskConstants.MODE_NAME,
                 TaskConstants.TASK_QUERY_REPOMD_DETAILS_QUERY);
-        Map<String, Object> params = new HashMap<>();
-        params.put("channel_label", channelLabelToProcess);
-        queueEntries = selector.execute(params);
+        queueEntries = selector.execute(Map.of("channel_label", channelLabelToProcess));
     }
 
     /**
@@ -175,21 +175,20 @@ public class ChannelRepodataWorker implements QueueWorker {
     private boolean isChannelLabelAlreadyInProcess() {
         SelectMode selector = ModeFactory.getMode(TaskConstants.MODE_NAME,
                 TaskConstants.TASK_QUERY_REPOMD_DETAILS_QUERY);
-        Map<String, Object> params = new HashMap<>();
-        params.put("channel_label", channelLabelToProcess);
-        return (selector.execute(params).size() > 0);
+        DataResult<?> resultSet = selector.execute(Map.of("channel_label", channelLabelToProcess));
+        return !resultSet.isEmpty();
     }
 
     /**
      *
-     * @param entryToCheck
+     * @param entryToCheck the name of the entry to verify
      * @return Returns a boolean to force or not
      */
     private boolean queueContainsBypass(String entryToCheck) {
         boolean shouldForce = false;
 
-        for (Object currentEntry : queueEntries) {
-            String forceFlag = (String) ((Map) currentEntry).get(entryToCheck);
+        for (Map<String, String> currentEntry : queueEntries) {
+            String forceFlag = currentEntry.get(entryToCheck);
             if ("Y".equalsIgnoreCase(forceFlag)) {
                 shouldForce = true;
             }
@@ -238,7 +237,7 @@ public class ChannelRepodataWorker implements QueueWorker {
     /**
      * dequeue the queued channel for repomd generation
      */
-    private void dequeueChannel() throws Exception {
+    private void dequeueChannel() {
         WriteMode deqChannel = ModeFactory.getWriteMode(TaskConstants.MODE_NAME,
                 TaskConstants.TASK_QUERY_REPOMD_DEQUEUE);
         Map<String, String> dqeParams = new HashMap<>();

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/SSHPushDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/SSHPushDriver.java
@@ -47,11 +47,10 @@ import java.util.Set;
 /**
  * Call rhn_check on relevant systems via SSH using remote port forwarding.
  */
-public class SSHPushDriver implements QueueDriver {
+public class SSHPushDriver implements QueueDriver<SystemSummary> {
 
     // Synchronized set of systems we are currently talking to
-    private static Set<SystemSummary> currentSystems =
-            Collections.synchronizedSet(new HashSet<>());
+    private static final Set<SystemSummary> CURRENT_SYSTEMS = Collections.synchronizedSet(new HashSet<>());
 
     // String constants
     private static final String WORKER_THREADS_KEY = "taskomatic.ssh_push_workers";
@@ -66,8 +65,6 @@ public class SSHPushDriver implements QueueDriver {
 
     private CheckinCandidatesResolver checkinCandidatesResolver;
 
-    // Properties used to determine when to look for checkin candidates
-    private int checkInterval = SystemCheckinUtils.CHECK_INTERVAL;
     private int moduloRemainder;
 
     /**
@@ -75,7 +72,7 @@ public class SSHPushDriver implements QueueDriver {
      * @return set of systems
      */
     public static Set<SystemSummary> getCurrentSystems() {
-        return currentSystems;
+        return CURRENT_SYSTEMS;
     }
 
     /**
@@ -93,10 +90,10 @@ public class SSHPushDriver implements QueueDriver {
                 TaskConstants.TASK_QUERY_SSH_PUSH_FIND_CHECKIN_CANDIDATES);
 
         // Randomly select a modulo remainder
-        moduloRemainder = SystemCheckinUtils.nextRandom(0, checkInterval - 1);
+        moduloRemainder = SystemCheckinUtils.nextRandom(0, SystemCheckinUtils.CHECK_INTERVAL - 1);
         if (log.isDebugEnabled()) {
-            log.debug("We will look for checkin candidates every {} minutes (remainder = {})", checkInterval,
-                    moduloRemainder);
+            log.debug("We will look for checkin candidates every {} minutes (remainder = {})",
+                SystemCheckinUtils.CHECK_INTERVAL, moduloRemainder);
         }
 
         // Skip all running or ready jobs if any
@@ -111,10 +108,8 @@ public class SSHPushDriver implements QueueDriver {
      */
     @Override
     public List<SystemSummary> getCandidates() {
-        List<SystemSummary> candidates = new LinkedList<>();
-
         // Find traditional systems with actions scheduled
-        candidates.addAll(getTraditionalCandidates());
+        List<SystemSummary> candidates = new LinkedList<>(getTraditionalCandidates());
 
         // Find Salt systems currently rebooting,
         // i.e with reboot actions in status picked-up with picked-up time older than 4 minutes
@@ -149,7 +144,7 @@ public class SSHPushDriver implements QueueDriver {
             log.debug("Current minutes: {}", currentMinutes);
         }
 
-        if (!isDefaultSchedule() || currentMinutes % checkInterval == moduloRemainder) {
+        if (!isDefaultSchedule() || currentMinutes % SystemCheckinUtils.CHECK_INTERVAL == moduloRemainder) {
             List<SystemSummary> checkinCandidates = this.checkinCandidatesResolver.getCheckinCandidates();
             checkinCandidates.stream().filter(c -> !candidates.contains(c)).forEach(candidates::add);
         }
@@ -159,8 +154,8 @@ public class SSHPushDriver implements QueueDriver {
         }
 
         // Do not return candidates we are talking to already
-        synchronized (currentSystems) {
-            for (SystemSummary s : currentSystems) {
+        synchronized (CURRENT_SYSTEMS) {
+            for (SystemSummary s : CURRENT_SYSTEMS) {
                 if (candidates.contains(s)) {
                     log.debug("Skipping system: {}", s.getName());
                     candidates.remove(s);
@@ -175,9 +170,7 @@ public class SSHPushDriver implements QueueDriver {
      * {@inheritDoc}
      */
     @Override
-    public QueueWorker makeWorker(Object item) {
-        SystemSummary system = (SystemSummary) item;
-
+    public QueueWorker makeWorker(SystemSummary system) {
         // Create a Salt worker if the system has a minion id
         if (system.getMinionId() != null) {
             return new SSHPushWorkerSalt(getLogger(), system,

--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/ReportDbUpdateTaskTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/ReportDbUpdateTaskTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.taskomatic.task.test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.redhat.rhn.common.db.datasource.DataResult;
+import com.redhat.rhn.common.db.datasource.SelectMode;
+import com.redhat.rhn.common.hibernate.ConnectionManager;
+import com.redhat.rhn.common.hibernate.ConnectionManagerFactory;
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
+import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.test.PackageTest;
+import com.redhat.rhn.taskomatic.task.ReportDBHelper;
+import com.redhat.rhn.taskomatic.task.ReportDbUpdateTask;
+import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.hibernate.Session;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.quartz.JobExecutionContext;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.persistence.Tuple;
+
+public class ReportDbUpdateTaskTest extends JMockBaseTestCaseWithUser {
+
+    private static ConnectionManager reportDbConnectionManager = null;
+
+    private JobExecutionContext contextMock;
+
+    @BeforeEach
+    public void before() {
+        contextMock = mock(JobExecutionContext.class);
+    }
+
+    @AfterEach
+    public void after() {
+        if (reportDbConnectionManager != null) {
+            reportDbConnectionManager.closeSession();
+        }
+    }
+
+    @Test
+    public void smokeTest() {
+        ReportDbUpdateTask task = new ReportDbUpdateTask();
+
+        // Just run the task and verify that all the queries run smoothly.
+        // This will at least guarantee that the sql queries are syntactically correct
+        assertDoesNotThrow(() -> task.execute(contextMock));
+    }
+
+    @Test
+    public void doesNotProduceConflictWhenDataChanges() throws Exception {
+
+        // Must clean the existing rhnchannelpackage content to make sure the pagination is the one expected by the test
+        HibernateFactory.getSession().createSQLQuery("DELETE FROM rhnchannelpackage").executeUpdate();
+
+        Channel firstChannel = ChannelFactoryTest.createTestChannel(user);
+        Channel secondChannel = ChannelFactoryTest.createTestChannel(user);
+
+        List<Package> testPackages = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            testPackages.add(PackageTest.createTestPackage(user.getOrg()));
+        }
+
+        firstChannel.getPackages().addAll(testPackages.subList(1, 3));
+        secondChannel.getPackages().addAll(testPackages.subList(3, 5));
+
+        ReportDBHelper testReportDbHelper = new ReportDBHelper() {
+            @Override
+            public <T> Stream<DataResult<T>> batchStream(SelectMode query, int batchSize, int initialOffset) {
+                // If we are processing the second batch for the ChannelPackage table...
+                if ("ChannelPackage".equals(query.getName())) {
+                    // Add a new package to the first channel. This will change the order of the result and lead to the
+                    // same row from rhnchannelpackage to be extracted twice. This should not translate in an exception
+                    firstChannel.getPackages().add(testPackages.get(0));
+                }
+                return super.batchStream(query, batchSize, initialOffset);
+            }
+        };
+
+        ReportDbUpdateTask task = new ReportDbUpdateTask(testReportDbHelper, 2);
+
+
+        assertDoesNotThrow(() -> task.execute(contextMock));
+
+        String channelPackageQuery = "SELECT * FROM ChannelPackage WHERE mgm_id = 1 ORDER BY channel_id, package_id";
+        List<Tuple> resultList = getSession().createNativeQuery(channelPackageQuery, Tuple.class).getResultList();
+
+        assertEquals(4, resultList.size());
+
+        // Extract a set of pairs from the tuples
+        Set<Pair<Long, Long>> pairSet = resultList.stream()
+                                                  .map(t -> Pair.of(
+                                                          t.get("channel_id", BigDecimal.class).longValue(),
+                                                          t.get("package_id", BigDecimal.class).longValue()
+                                                      )
+                                                  )
+                                                  .collect(Collectors.toSet());
+
+        // Build the set of expected pairs
+        Set<Pair<Long, Long>> expectedPairSet = Set.of(
+            Pair.of(firstChannel.getId(), testPackages.get(1).getId()),
+            Pair.of(firstChannel.getId(), testPackages.get(2).getId()),
+            Pair.of(secondChannel.getId(), testPackages.get(3).getId()),
+            Pair.of(secondChannel.getId(), testPackages.get(4).getId())
+        );
+
+        assertEquals(expectedPairSet, pairSet);
+
+    }
+
+    private static synchronized Session getSession() {
+        if (reportDbConnectionManager == null) {
+            reportDbConnectionManager = ConnectionManagerFactory.localReportingConnectionManager();
+        }
+
+        return reportDbConnectionManager.getSession();
+    }
+}

--- a/java/code/src/com/redhat/rhn/taskomatic/task/threaded/TaskQueueFactory.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/threaded/TaskQueueFactory.java
@@ -25,16 +25,16 @@ import java.util.Map;
  */
 public class TaskQueueFactory {
 
-    private static TaskQueueFactory instance = new TaskQueueFactory();
+    private static final TaskQueueFactory INSTANCE = new TaskQueueFactory();
 
-    private Map queues = new HashMap();
+    private final Map<String, TaskQueue> queues = new HashMap<>();
 
     /**
      * Get the singleton instance
      * @return the single instance of TaskQueueFactory
      */
     public static TaskQueueFactory get() {
-        return instance;
+        return INSTANCE;
     }
 
     private TaskQueueFactory() {
@@ -48,7 +48,7 @@ public class TaskQueueFactory {
      */
     public TaskQueue getQueue(String name) {
         synchronized (queues) {
-            return (TaskQueue) queues.get(name);
+            return queues.get(name);
         }
     }
 
@@ -62,14 +62,14 @@ public class TaskQueueFactory {
      * @return queue instance
      * @throws Exception error occurred during queue creation
      */
-    public TaskQueue createQueue(String name, Class driverClass, Logger loggerIn)
+    public TaskQueue createQueue(String name, Class<? extends QueueDriver<?>> driverClass, Logger loggerIn)
         throws Exception {
-        TaskQueue retval = null;
+        TaskQueue retval;
         synchronized (queues) {
-            retval = (TaskQueue) queues.get(name);
+            retval = queues.get(name);
             if (retval == null) {
                 retval = new TaskQueue();
-                QueueDriver driver = (QueueDriver) driverClass.newInstance();
+                QueueDriver<?> driver = driverClass.getDeclaredConstructor().newInstance();
                 driver.setLogger(loggerIn);
                 driver.initialize();
                 retval.setQueueDriver(driver);
@@ -86,19 +86,14 @@ public class TaskQueueFactory {
      * @return queue instance if found, otherwise null
      */
     public TaskQueue removeQueue(String name) {
-        TaskQueue retval = null;
         synchronized (queues) {
-            retval = (TaskQueue) queues.remove(name);
+            return queues.remove(name);
         }
-        return retval;
     }
 
     void closeAllQueues() {
         synchronized (queues) {
-            for (Object oIn : queues.values()) {
-                TaskQueue queue = (TaskQueue) oIn;
-                queue.shutdown();
-            }
+            queues.values().forEach(TaskQueue::shutdown);
         }
         queues.clear();
     }
@@ -106,9 +101,9 @@ public class TaskQueueFactory {
     /**
      * JVM shutdown hook used to clean up any remaining queues
      */
-    class ShutdownHook extends Thread {
+    static class ShutdownHook extends Thread {
 
-        private TaskQueueFactory factory;
+        private final TaskQueueFactory factory;
 
         ShutdownHook(TaskQueueFactory factoryIn) {
             factory = factoryIn;

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Ignore insert conflicts during reporting database update (bsc#1202150)
 - Honor page size preference in new system lists
 - Fix kickstart for RHEL 9 to not add install command
 - Remove RHEL kickstart types below 6

--- a/susemanager-utils/testing/docker/scripts/build-reportdb-schema.sh
+++ b/susemanager-utils/testing/docker/scripts/build-reportdb-schema.sh
@@ -11,12 +11,11 @@ make -f Makefile.schema SCHEMA=uyuni-reportdb-schema VERSION=4.3 RELEASE=testing
 
 # Install directories
 install -m 0755 -d /etc/sysconfig/rhn
-install -m 0755 -d /etc/sysconfig/rhn/postgres
+install -m 0755 -d /etc/sysconfig/rhn/reportdb
 install -m 0755 -d /etc/sysconfig/rhn/reportdb-schema-upgrade
 
 # Install sql files
-install -m 0644 postgres/main.sql /etc/sysconfig/rhn/postgres
-install -m 0644 postgres/end.sql /etc/sysconfig/rhn/postgres/upgrade-end.sql
+install -m 0644 postgres/main.sql /etc/sysconfig/rhn/reportdb
+install -m 0644 postgres/end.sql /etc/sysconfig/rhn/reportdb/upgrade-end.sql
 
 ( cd upgrade && tar cf - --exclude='*.sql' . | ( cd /etc/sysconfig/rhn/reportdb-schema-upgrade && tar xf - ) )
-

--- a/susemanager-utils/testing/docker/scripts/reset_pgsql_database.sh
+++ b/susemanager-utils/testing/docker/scripts/reset_pgsql_database.sh
@@ -11,6 +11,7 @@ echo $PATH
 echo $PERLLIB
 
 ./build-schema.sh
+./build-reportdb-schema.sh
 
 export SYSTEMD_NO_WRAP=1
 sysctl -w kernel.shmmax=18446744073709551615
@@ -24,6 +25,13 @@ spacewalk-setup --clear-db --db-only --answer-file=clear-db-answers-pgsql.txt --
   cat /var/log/rhn/populate_db.log
   exit 1
 }
+
+# Create symlinks because uyuni-setup-reportdb uses absolute paths
+ln -s /manager/schema/spacewalk/spacewalk-sql /usr/bin/spacewalk-sql
+ln -s /manager/schema/spacewalk/spacewalk-schema-upgrade /usr/bin/spacewalk-schema-upgrade
+
+/usr/bin/uyuni-setup-reportdb remove --db reportdb --user pythia ||:
+/usr/bin/uyuni-setup-reportdb create --db reportdb --user pythia --password oracle --local
 
 echo "Creating First Org"
 


### PR DESCRIPTION
## What does this PR change?

This PR ignores conflicts that may happen during the insert of the data into the reporting database. These conflicts can only occur if the data from the source tables changes. This modification may change how the extracted data is sorted and paginated, and thus causing the same row to be inserted twice. By ignoring the insert conflict, we prevent an hard failure during the synchronization process, at the cost of losing the newest data, which will be picked up by the following run of the sync task.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18552

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"   
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
