### PR TITLE
Improves schedule product migration in spacecmd

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Changed schedule product migration to use the correct API method
 - Fix dict_keys not supporting indexing in systems_setconfigchannelorger
 - Added a warning message for traditional stack deprecation
 - Remove "Undefined return code" from debug messages (bsc#1203283)

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,5 @@
+- Added two missing options to schedule product migration: allow-vendor-change
+  and remove-products-without-successor (bsc#1204126)
 - Changed schedule product migration to use the correct API method
 - Fix dict_keys not supporting indexing in systems_setconfigchannelorger
 - Added a warning message for traditional stack deprecation

--- a/spacecmd/src/spacecmd/system.py
+++ b/spacecmd/src/spacecmd/system.py
@@ -4607,6 +4607,8 @@ def help_system_scheduleproductmigration(self):
 \n    Options: \
 \n        -s START_TIME \
 \n        -d pass this flag, if you want to do a dry run \
+\n        --allow-vendor-change pass this flag if you want to allow vendor change \
+\n        -r pass this flag if you want to remove remove products which have no successors \
 \n        -c CHILD_CHANNELS (comma-separated child channels labels (with no spaces))'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
@@ -4617,6 +4619,8 @@ def do_system_scheduleproductmigration(self, args):
     arg_parser.add_argument('-s', '--start-time')
     arg_parser.add_argument('-d', '--dry-run', action='store_true', default=False)
     arg_parser.add_argument('-c', '--child-channels')
+    arg_parser.add_argument('--allow-vendor-change', action='store_true', default=False)
+    arg_parser.add_argument('-r', '--remove-products-without-successor', action='store_true', default=False)
 
     (args, options) = parse_command_arguments(args, arg_parser)
 
@@ -4659,7 +4663,8 @@ def do_system_scheduleproductmigration(self, args):
         try:
             result = self.client.system.scheduleProductMigration(self.session,
                                                             system_id, migration_target, base_channel_label,
-                                                            child_channels, options.dry_run, options.start_time)
+                                                            child_channels, options.dry_run, options.allow_vendor_change,
+                                                            options.remove_products_without_successor, options.start_time)
             print(_('Scheduled action ID: ') + str(result))
         except xmlrpclib.Fault as detail:
             logging.error(_N('Failed to schedule %s') % detail)

--- a/spacecmd/src/spacecmd/system.py
+++ b/spacecmd/src/spacecmd/system.py
@@ -4655,8 +4655,9 @@ def do_system_scheduleproductmigration(self, args):
             continue
 
         print(_('Scheduling Product migration for system ') + str(system))
+        print(_('Migration target ') + str(migration_target))
         try:
-            result = self.client.system.scheduleSPMigration(self.session,
+            result = self.client.system.scheduleProductMigration(self.session,
                                                             system_id, migration_target, base_channel_label,
                                                             child_channels, options.dry_run, options.start_time)
             print(_('Scheduled action ID: ') + str(result))


### PR DESCRIPTION
## What does this PR change?

It changes `spacecmd` to use the correct API method when scheduling product migrations. Instead of using `scheduleProductMigration`, it was using `scheduleSPMigration` that is a deprecated method.

This PR also adds `--allow-vendor-change` and `--remove-products-without-successor` parameters to schedule product migration in `spacecmd`.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Documentation issue was created: [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/1859).

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19208

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
