### PR TITLE
Optimize action chain processing on job return event (bsc#1203532)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/ActionChain.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionChain.hbm.xml
@@ -96,4 +96,20 @@
         ]]>
     </query>
 
+    <query name="ActionChain.getActionChainsByServer">
+        <![CDATA[
+            SELECT DISTINCT ac
+            FROM
+                com.redhat.rhn.domain.action.ActionChainEntry ace,
+                com.redhat.rhn.domain.action.ActionChain ac,
+                com.redhat.rhn.domain.action.Action a,
+                com.redhat.rhn.domain.action.server.ServerAction sa
+            WHERE
+                ac.id = ace.actionChain.id
+                AND a.id = ace.action.id
+                AND a.id = sa.parentAction.id
+                AND sa.server.id = :id
+        ]]>
+    </query>
+
 </hibernate-mapping>

--- a/java/code/src/com/redhat/rhn/domain/action/ActionChainFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionChainFactory.java
@@ -316,6 +316,21 @@ public class ActionChainFactory extends HibernateFactory {
     }
 
     /**
+     * Gets all action chains scheduled for given server
+     * @param server the server
+     * @return action chains
+     */
+    public static List<ActionChain> getActionChainsByServer(Server server) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("id", server.getId());
+        return singleton.listObjectsByNamedQuery(
+                "ActionChain.getActionChainsByServer",
+                params
+        );
+    }
+
+
+    /**
      * Gets the next sort order value.
      * @param actionChain the action chain
      * @return the next sort order value

--- a/java/code/src/com/redhat/rhn/domain/action/test/ActionChainFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/test/ActionChainFactoryTest.java
@@ -106,6 +106,55 @@ public class ActionChainFactoryTest extends BaseTestCaseWithUser {
         assertEquals(previousSize + 3, ActionChainFactory.getActionChains(user).size());
     }
 
+
+    /**
+     * Tests getActionChainsByServer().
+     * @throws Exception if something bad happens
+     */
+    @Test
+    public void testGetActionChainsByServer() throws Exception {
+        ActionChain actionChain1 = ActionChainFactory.createActionChain(TestUtils.randomString(), user);
+        ActionChain actionChain2 = ActionChainFactory.createActionChain(TestUtils.randomString(), user);
+        ActionChain actionChain3 = ActionChainFactory.createActionChain(TestUtils.randomString(), user);
+
+        Action action1 = ActionFactory.createAction(ActionFactory.TYPE_ERRATA);
+        action1.setOrg(user.getOrg());
+        Server server1 = ServerFactoryTest.createTestServer(user);
+
+        ActionChainEntry entry1 = ActionChainFactory.queueActionChainEntry(action1,
+            actionChain1, server1);
+
+        Action action2 = ActionFactory.createAction(ActionFactory.TYPE_ERRATA);
+        action2.setOrg(user.getOrg());
+
+        ActionChainEntry entry2 = ActionChainFactory.queueActionChainEntry(action2,
+            actionChain2, server1);
+
+        Action action3 = ActionFactory.createAction(ActionFactory.TYPE_ERRATA);
+        action3.setOrg(user.getOrg());
+        Server server2 = ServerFactoryTest.createTestServer(user);
+
+        ActionChainEntry entry3 = ActionChainFactory.queueActionChainEntry(action3,
+            actionChain3, server2);
+
+        ActionChainFactory.schedule(actionChain1, new Date());
+        ActionChainFactory.schedule(actionChain2, new Date());
+        ActionChainFactory.schedule(actionChain3, new Date());
+
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+        List<ActionChain> list1 = ActionChainFactory.getActionChainsByServer(server1);
+        assertEquals(2, list1.size());
+        assertContains(list1, actionChain1);
+        assertContains(list1, actionChain2);
+
+
+        List<ActionChain> list2 = ActionChainFactory.getActionChainsByServer(server2);
+        assertEquals(1, list2.size());
+        assertContains(list2, actionChain3);
+    }
+
     /**
      * Tests getOrCreateActionChain().
      * @throws Exception if something bad happens

--- a/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
@@ -247,13 +247,8 @@ public class JobReturnEventMessageAction implements MessageAction {
              */
 
             MinionServerFactory.findByMinionId(jobReturnEvent.getMinionId())
-                    .ifPresent(minion -> ActionChainFactory.getAllActionChains().stream()
+                    .ifPresent(minion -> ActionChainFactory.getActionChainsByServer(minion).stream()
                     .filter(ActionChain::isDone)
-                    .filter(ac ->
-                            ac.getEntries().stream()
-                                    .flatMap(ace -> ace.getAction().getServerActions().stream())
-                                    .anyMatch(sa -> sa.getServer().getId().equals(minion.getId()))
-                    )
                     .forEach(ActionChainFactory::delete));
 
         }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Optimize action chain processing on job return event (bsc#1203532)
 - Re-calculate salt event queue numbers on restart
 - Check if system has all formulas correctly assigned
   (bsc#1201607)


### PR DESCRIPTION
## What does this PR change?

This optimizes action chain processing on JobReturn event.
ActionChain::isDone is quite expensive. Before, it was called on all action chains.
(in the log from bsc#1203532 there is 4000 action chains and 26000 action chain entries)

This PR uses SQL query to find the related action chains for given minion.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Partially fixes
https://github.com/SUSE/spacewalk/issues/19063
https://bugzilla.suse.com/show_bug.cgi?id=1203532

Related to https://github.com/uyuni-project/uyuni/pull/4539

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
