### PR TITLE
Do not try to assign channels in saltboot initrd

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -497,8 +497,10 @@ public class RegisterMinionEventMessageAction implements MessageAction {
             }
             minion.setServerArch(arch);
 
-            RegistrationUtils.subscribeMinionToChannels(systemQuery, minion, grains, activationKey,
+            if (!grains.getOptionalAsBoolean("saltboot_initrd").orElse(false)) {
+                RegistrationUtils.subscribeMinionToChannels(systemQuery, minion, grains, activationKey,
                     activationKeyLabel);
+            }
 
             minion.updateServerInfo();
 


### PR DESCRIPTION
## What does this PR change?

Do not try to assign channels in saltboot initrd.
With saltboot, channels are assigned when the final image boots.
This saves some salt calls during registration.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Covered by Cucumber tests

- [x] **DONE**

## Links

Partially fixes https://github.com/SUSE/spacewalk/issues/19063

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
