### PR TITLE
Re-calculate salt event queue numbers on restart

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/reactor/SaltEvent.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/reactor/SaltEvent.hbm.xml
@@ -40,4 +40,12 @@
         ]]>
         <return-scalar column="id" type="long"/>
     </sql-query>
+
+    <sql-query name="SaltEvent.fixQueueNumbers">
+        <![CDATA[
+            UPDATE suseSaltEvent
+                SET queue = mod(cast(cast('x'||substr(md5(minion_id),1,8) as bit(32)) as bigint), :queues) + 1
+                WHERE minion_id <> '';
+        ]]>
+    </sql-query>
 </hibernate-mapping>

--- a/java/code/src/com/redhat/rhn/domain/reactor/SaltEventFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/reactor/SaltEventFactory.java
@@ -91,4 +91,17 @@ public class SaltEventFactory extends HibernateFactory {
                 new HashMap<String, Object>() { { put("ids", ids); } }
         );
     }
+
+    /**
+     * Update event queue numbers after config change.
+     * @param queues number of queues
+     * @return the number of updated events
+     */
+    public static int fixQueueNumbers(int queues) {
+        return getSession()
+                .getNamedQuery("SaltEvent.fixQueueNumbers")
+                .setParameter("queues", queues)
+                .executeUpdate();
+    }
+
 }

--- a/java/code/src/com/redhat/rhn/domain/reactor/test/SaltEventFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/reactor/test/SaltEventFactoryTest.java
@@ -182,6 +182,44 @@ public class SaltEventFactoryTest extends RhnBaseTestCase {
         assertEquals(Arrays.asList(0L, 0L, 0L, 0L), saltEventsCount);
     }
 
+    @Test
+    public void testFixQueueNumbers() throws NoSuchAlgorithmException {
+        // verify there are no salt events
+        List<Long> saltEventsCount = SaltEventFactory.countSaltEvents(5);
+        assertEquals(Arrays.asList(0L, 0L, 0L, 0L, 0L), saltEventsCount);
+
+        // create events in queue 1
+        SaltEvent saltEvent1 = new SaltEvent(1L, "minion_1", "data_minion_1", 1);
+        insertIntoSuseSaltEvent(saltEvent1);
+        SaltEvent saltEvent2 = new SaltEvent(2L, "minion_2", "data_minion_2", 1);
+        insertIntoSuseSaltEvent(saltEvent2);
+        SaltEvent saltEvent3 = new SaltEvent(3L, "minion_3", "data_minion_3", 1);
+        insertIntoSuseSaltEvent(saltEvent3);
+        SaltEvent saltEvent4 = new SaltEvent(4L, "minion_4", "data_minion_4", 1);
+        insertIntoSuseSaltEvent(saltEvent4);
+
+        SaltEventFactory.fixQueueNumbers(4);
+        // events should be spread across queues 1-4
+        // particular queue number depends on the hashing algorithm
+        saltEventsCount = SaltEventFactory.countSaltEvents(5);
+        assertEquals(Arrays.asList(0L, 2L, 0L, 1L, 1L), saltEventsCount);
+
+        SaltEventFactory.fixQueueNumbers(2);
+        // events should be re-arranged in queues 1-2, queues 3-4 should be emptied
+        saltEventsCount = SaltEventFactory.countSaltEvents(5);
+        assertEquals(Arrays.asList(0L, 3L, 1L, 0L, 0L), saltEventsCount);
+
+        // pop the events
+        List<SaltEvent> popedSaltEvents = SaltEventFactory.popSaltEvents(3, 1).collect(Collectors.toList());
+        assertEquals(popedSaltEvents.size(), 3);
+        popedSaltEvents = SaltEventFactory.popSaltEvents(1, 2).collect(Collectors.toList());
+        assertEquals(popedSaltEvents.size(), 1);
+
+        saltEventsCount = SaltEventFactory.countSaltEvents(5);
+        assertEquals(Arrays.asList(0L, 0L, 0L, 0L, 0L), saltEventsCount);
+    }
+
+
     private void insertIntoSuseSaltEvent(SaltEvent saltEvent) {
         Query query = HibernateFactory.getSession().createNativeQuery(INSERT_INTO_SUSE_SALT_EVENT_QUERY);
         query.setParameter("id", saltEvent.getId());

--- a/java/code/src/com/suse/manager/reactor/PGEventStream.java
+++ b/java/code/src/com/suse/manager/reactor/PGEventStream.java
@@ -92,6 +92,11 @@ public class PGEventStream extends AbstractEventStream implements PGNotification
         dataSource.setProtocolIoMode("nio");
 
         try {
+            int pending = SaltEventFactory.fixQueueNumbers(THREAD_POOL_SIZE);
+            if (pending > 0) {
+                LOG.info("Found {} queued salt events", pending);
+            }
+
             connection = (PGConnection) dataSource.getConnection();
             connection.addNotificationListener(this);
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Re-calculate salt event queue numbers on restart
 - Check if system has all formulas correctly assigned
   (bsc#1201607)
 - Remove group formula assignements and data on group delete


### PR DESCRIPTION
## What does this PR change?

After a change of java.salt_event_thread_pool_size, the queue number for pending events must be re-calculated.
Without this PR, changing of  java.salt_event_thread_pool_size with non-empty event queue can lead to events processed in incorrect order or stalled.

Typically, java.salt_event_thread_pool_size must be changed when there is some problem with processing of the events so the queue is not empty at this point.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit test added

- [x] **DONE**

## Links

Part of fix for https://github.com/SUSE/spacewalk/issues/19063
https://bugzilla.suse.com/show_bug.cgi?id=1203532

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"    
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
