### PR TITLE
Enterprise Linux 9 enabelment

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1253,6 +1253,10 @@ DATA = {
         'BASECHANNEL' : 'rhel8-pool-x86_64', 'PKGLIST' : RES8 + RES8_X86,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/res/8/bootstrap/'
     },
+    'SUSE-LibertyLinux9-x86_64' : {
+        'PDID' : [-35, 2543], 'BETAPDID' : [2548], RES9,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/res/9/bootstrap/'
+    },
     'RHEL9-x86_64-uyuni' : {
         'BASECHANNEL' : 'rhel9-pool-x86_64', 'PKGLIST' : RES9,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/res/9/bootstrap/'

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1201,6 +1201,14 @@ DATA = {
         'BASECHANNEL' : 'oraclelinux8-aarch64', 'PKGLIST' : RES8,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/oracle/8/bootstrap/'
     },
+    'oracle-9-x86_64' : {
+        'PDID' : [-41, 2543], 'BETAPDID' : [2548], 'PKGLIST' : RES9,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/oracle/9/bootstrap/'
+    },
+    'oracle-9-aarch64' : {
+        'PDID' : [-40, 2542], 'BETAPDID' : [2547], 'PKGLIST' : RES9,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/oracle/9/bootstrap/'
+    },
     'oracle-9-x86_64-uyuni' : {
         'BASECHANNEL' : 'oraclelinux9-x86_64', 'PKGLIST' : RES9,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/oracle/9/bootstrap/'
@@ -1285,6 +1293,14 @@ DATA = {
         'BASECHANNEL' : 'almalinux8-aarch64', 'PKGLIST' : RES8,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/almalinux/8/bootstrap/'
     },
+    'almalinux-9-x86_64' : {
+        'PDID' : [-38, 2543], 'BETAPDID' : [2548], 'PKGLIST' : RES9,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/almalinux/9/bootstrap/'
+    },
+    'almalinux-9-aarch64' : {
+        'PDID' : [-39, 2542], 'BETAPDID' : [2547], 'PKGLIST' : RES9,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/almalinux/9/bootstrap/'
+    },
     'almalinux-9-x86_64-uyuni' : {
         'BASECHANNEL' : 'almalinux9-x86_64', 'PKGLIST' : RES9,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/almalinux/9/bootstrap/'
@@ -1316,6 +1332,14 @@ DATA = {
     'rockylinux-8-aarch64-uyuni' : {
         'BASECHANNEL' : 'rockylinux8-aarch64', 'PKGLIST' : RES8,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/rockylinux/8/bootstrap/'
+    },
+    'rockylinux-9-x86_64' : {
+        'PDID' : [-36, 2543], 'BETAPDID' : [2548], 'PKGLIST' : RES9,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/rockylinux/9/bootstrap/'
+    },
+    'rockylinux-9-aarch64' : {
+        'PDID' : [-37, 2542], 'BETAPDID' : [2547], 'PKGLIST' : RES9,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/rockylinux/9/bootstrap/'
     },
     'rockylinux-9-x86_64-uyuni' : {
         'BASECHANNEL' : 'rockylinux9-x86_64', 'PKGLIST' : RES9,

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- add bootstrap repo data for SUSE Liberty Linux 9
 - remove traditional stack packages and dependencies from
   bootstrap repo definition
 

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- add bootstrap repo definitions for oracle, alma and rocky linux 9
 - add bootstrap repo data for SUSE Liberty Linux 9
 - remove traditional stack packages and dependencies from
   bootstrap repo definition

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -3728,3 +3728,13 @@ gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/
+
+[el9-uyuni-client]
+name     = uyuni client tools for %(base_channel_name)s
+archs    = %(_x86_archs)s, aarch64
+checksum = sha256
+base_channels = rhel9-pool-%(arch)s
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL9-Uyuni-Client-Tools/EL_9/

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- Add EL9 Client Tools for SUSE Liberty Linux
+
 -------------------------------------------------------------------
 Wed Sep 28 10:46:25 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

- add bootstrap repo data for SUSE Liberty Linux 9
- add bootstrap repo data for Oracle, Alma and Rock Linux 9
- define Uyuni Client Tools Channel for RHEL9/SLL9 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed here: **extra issue is open**

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19157
Fixes https://github.com/SUSE/spacewalk/issues/18468
Tracks https://github.com/SUSE/spacewalk/pull/19408

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
