### PR TITLE
Remove 'SSM' column text where not applicable (bsc#1203588)

### DIFF
--- a/java/code/webapp/WEB-INF/pages/common/fragments/systems/system_listdisplay.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/systems/system_listdisplay.jspf
@@ -27,7 +27,7 @@
         <rl:decorator name="SelectableDecorator"/>
         <rl:selectablecolumn value="${current.id}"
                 width="75"
-                checkboxText="<span class='span-ssm-marg'>SSM</spank>"
+                checkboxText="<span class='span-ssm-marg'>${empty param.action_key ? 'SSM' : ''}</span>"
                 selected="${current.selected}"
                 disabled="${not current.selectable}"
                 />

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Remove 'SSM' column text where not applicable (bsc#1203588)
 - Improve systems lists queries performance by using an overview table
 - Pass mgr_sudo_user pillar on salt ssh client cleanup (bsc#1202093)
 - Deny packages from older module metadata when building CLM projects (bsc#1201893)


### PR DESCRIPTION
In some system lists (e.g. system group page), the selected systems are not added to SSM, but rather a different action is executed. This PR removes the text "SSM" from the selection column to prevent confusion.

See: https://bugzilla.suse.com/show_bug.cgi?id=1203588

## GUI diff

Before:
![ssm-column-before](https://user-images.githubusercontent.com/1103552/199537536-f9c3398a-a039-4bed-b504-79907b82704a.png)

After:
![ssm-column-after](https://user-images.githubusercontent.com/1103552/199537576-aea5414a-448b-49e5-bfb4-d8d7109ce83c.png)


## Documentation
- No documentation needed: Bugfix

## Test coverage
- No tests: minor UI element

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19081

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
