### PR TITLE
Squid pid fix

### DIFF
--- a/containers/proxy-httpd-image/proxy-httpd-image.changes
+++ b/containers/proxy-httpd-image/proxy-httpd-image.changes
@@ -1,3 +1,5 @@
+- Remove chmod and chown of /srv/www/htdocs/pub as this folder does not exist
+
 -------------------------------------------------------------------
 Wed Sep 28 07:44:12 UTC 2022 - Julio González Gil <jgonzalez@suse.com>
 

--- a/containers/proxy-httpd-image/uyuni-configure.py
+++ b/containers/proxy-httpd-image/uyuni-configure.py
@@ -250,8 +250,6 @@ RewriteRule "^/saltboot/(image|boot)(.+)$" "/os-images/%1$2"  [R,L,QSD]
     os.system('chmod 640 /etc/rhn/rhn.conf')
 
 # Make sure permissions are set as desired
-os.system('chown -R root:root /srv/www/htdocs/pub')
-os.system('chmod -R 755 /srv/www/htdocs/pub')
 os.system('chown -R wwwrun:www /var/spool/rhn-proxy')
 os.system('chmod -R 750 /var/spool/rhn-proxy')
 if not os.path.exists('/var/cache/rhn/proxy-auth'):

--- a/containers/proxy-squid-image/Dockerfile
+++ b/containers/proxy-squid-image/Dockerfile
@@ -28,7 +28,7 @@ COPY squid.conf /etc/squid/squid.conf
 #    FATAL: Cannot open '/proc/self/fd/1' for writing.
 # For this we need to give the squid user access to squid.conf and squid.pid
 RUN chown squid:squid /etc/squid/squid.conf
-RUN touch /run/squid.pid && chown squid:squid /run/squid.pid
+RUN mkdir -p /run/squid && chown squid:squid /run/squid
 
 # Ensure the cache is owned by squid user
 RUN chown squid:squid /var/cache/squid

--- a/containers/proxy-squid-image/proxy-squid-image.changes
+++ b/containers/proxy-squid-image/proxy-squid-image.changes
@@ -1,3 +1,5 @@
+- Update the squid.pid path to /run/squid.squid.pid (bsc#1204948)
+
 -------------------------------------------------------------------
 Wed Sep 28 07:44:33 UTC 2022 - Julio González Gil <jgonzalez@suse.com>
 

--- a/containers/proxy-squid-image/squid.conf
+++ b/containers/proxy-squid-image/squid.conf
@@ -69,3 +69,5 @@ range_offset_limit none
 # we download only from 1 server, default is 1024
 # which is too much for us
 fqdncache_size 4
+
+pid_filename /run/squid/squid.pid


### PR DESCRIPTION
## What does this PR change?

Fix the squid container to work with the latest squid update changing the path to the pid file.
Also fix the error changing permissions on `/srv/www/htdocs/pub` folder in `httpd` container since it doesn't exist there.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: automation still to be worked on

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19379

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
