### PR TITLE
Add no-arg constructor to MigrateSystemsAction (bsc#1204651)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/ssm/MigrateSystemsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/ssm/MigrateSystemsAction.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.frontend.action.ssm;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.rhnset.RhnSet;
@@ -49,12 +50,10 @@ public class MigrateSystemsAction extends RhnAction implements Listable {
     private final MigrationManager migrationManager;
 
     /**
-     * Constructor
-     *
-     * @param migrationManagerIn the migration manager
+     * Default constructor
      */
-    public MigrateSystemsAction(MigrationManager migrationManagerIn) {
-        migrationManager = migrationManagerIn;
+    public MigrateSystemsAction() {
+        migrationManager = GlobalInstanceHolder.MIGRATION_MANAGER;
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix rendering of ssm/MigrateSystems page (bsc#1204651)
 - Remove 'SSM' column text where not applicable (bsc#1203588)
 - Improve systems lists queries performance by using an overview table
 - Pass mgr_sudo_user pillar on salt ssh client cleanup (bsc#1202093)


### PR DESCRIPTION
Add a no-arg constructor to `MigrateSystemsAction` so that struts can instantiate it.

Port of: https://github.com/SUSE/spacewalk/pull/19382

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
