### PR TITLE
Add missing label wrappers

### DIFF
--- a/java/code/webapp/WEB-INF/pages/common/fragments/user/preferences.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/user/preferences.jspf
@@ -8,8 +8,10 @@
   <div class="panel-body">
     <p><bean:message key="preferences.jsp.leadin"/></p>
     <div class="checkbox">
-      <html:checkbox  property="emailNotif" value="1" /><bean:message key="preferences.jsp.receivenote"/>
-      <c:if test="${showTaskoNotify}"><br/><html:checkbox  property="taskoNotify" value="1" /><bean:message key="preferences.jsp.receivetaskonote"/></c:if>
+      <label>
+        <html:checkbox  property="emailNotif" value="1" /><bean:message key="preferences.jsp.receivenote"/>
+      </label>
+      <c:if test="${showTaskoNotify}"><br/><label><html:checkbox  property="taskoNotify" value="1" /><bean:message key="preferences.jsp.receivetaskonote"/></label></c:if>
     </div>
   </div>
 </div>

--- a/web/html/src/branding/css/base/checkbox.less
+++ b/web/html/src/branding/css/base/checkbox.less
@@ -1,0 +1,12 @@
+// Temporarily fix input misalignment on forms until we rehaul them in the Bootstrap upgrade
+.radio label, .checkbox label {
+  padding-left: 0;
+}
+
+.radio input[type="radio"],
+.radio-inline input[type="radio"],
+.checkbox input[type="checkbox"],
+.checkbox-inline input[type="checkbox"] {
+  position: relative;
+  margin: 0 8px 0 0;
+}

--- a/web/html/src/branding/css/susemanager/susemanager-theme.less
+++ b/web/html/src/branding/css/susemanager/susemanager-theme.less
@@ -10,6 +10,7 @@
 @import url(../base/network.less);
 // TODO: This needs to be obsolete
 @import url(../base/inputs.less);
+@import url(../base/checkbox.less);
 
 @import url(./fonts.less);
 @import url(./titles.less);

--- a/web/html/src/branding/css/uyuni.less
+++ b/web/html/src/branding/css/uyuni.less
@@ -16,6 +16,7 @@
 @import url(base/setup-wizard.less);
 @import url(base/visualization.less);
 @import url(base/notifications.less);
+@import url(base/checkbox.less);
 @import url(uyuni/login.less);
 @import url(base/fixes.less);
 @import url(base/network.less);

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix checkbox and radio input misalignment
 - move web.system_checkin_threshold configuration to database
 - Upgrade Bootstrap to 3.4.1
 - Update translation strings


### PR DESCRIPTION
## What does this PR change?

My preferences page was missing a wrapper element on some settings.  

## GUI diff

Before:

<img width="350" alt="Screenshot 2022-11-04 at 00 35 28" src="https://user-images.githubusercontent.com/3171718/199858911-c4fe0c33-d32e-4d96-8792-f9aeeecf5fee.png">

After:

<img width="332" alt="Screenshot 2022-11-04 at 00 35 07" src="https://user-images.githubusercontent.com/3171718/199858925-5f79f7fe-76c4-44b8-a1d2-f0488c1a2b58.png">


- [x] **DONE**

## Documentation
- No documentation needed: UI bugfix.

- [x] **DONE**

## Test coverage
- No tests: UI bugfix.

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
