### PR TITLE
Fix maintenance calendar creation test via url

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1239,7 +1239,7 @@ When(/^I add "([^\"]*)" calendar file as url$/) do |file|
   return_code = file_inject($server, source, dest)
   raise 'File injection failed' unless return_code.zero?
   $server.run("chmod 644 #{dest}")
-  url = "http://#{$server.full_hostname}/pub/" + file
+  url = "https://#{$server.full_hostname}/pub/" + file
   log "URL: #{url}"
   step %(I enter "#{url}" as "calendar-data-text")
 end


### PR DESCRIPTION
## What does this PR change?

Use https instead of http when fetching a maintenance calendar via url

Related: https://github.com/SUSE/spacewalk/issues/19383

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: **fix test**

- [x] **DONE**

## Test coverage

Fix ci test

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19429

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
