### PR TITLE
Use registry in Provo when testing in Provo

### DIFF
--- a/java/Makefile.python
+++ b/java/Makefile.python
@@ -4,7 +4,7 @@ include $(CURRENT_DIR)/../rel-eng/Makefile.python
 
 # Docker tests variables
 DOCKER_CONTAINER_BASE = uyuni-master
-DOCKER_REGISTRY       = registry.mgr.suse.de
+DOCKER_REGISTRY       = $(shell [[ `hostname -f` == *.mgr.prv.suse.net ]] && echo "registry.mgr.prv.suse.net" || echo "registry.mgr.suse.de")
 DOCKER_RUN_EXPORT     = "PYTHONPATH=$PYTHONPATH"
 DOCKER_VOLUMES        = -v "$(CURDIR)/../:/manager"
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Use Docker registry in Provo when testing in Provo
 - Don't persist the YAML parser in FormulaFactory (bsc#1205754)
 - check for NULL in DEB package install size value
 - Add vendor_advisory to errata.getDetails (bsc#1205207)

--- a/proxy/installer/Makefile.python
+++ b/proxy/installer/Makefile.python
@@ -4,7 +4,7 @@ include $(CURRENT_DIR)../../rel-eng/Makefile.python
 
 # Docker tests variables
 DOCKER_CONTAINER_BASE = uyuni-master
-DOCKER_REGISTRY       = registry.mgr.suse.de
+DOCKER_REGISTRY       = $(shell [[ `hostname -f` == *.mgr.prv.suse.net ]] && echo "registry.mgr.prv.suse.net" || echo "registry.mgr.suse.de")
 DOCKER_RUN_EXPORT     = "PYTHONPATH=$PYTHONPATH"
 DOCKER_VOLUMES        = -v "$(CURDIR)/../../:/manager"
 

--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,3 +1,4 @@
+- Use Docker registry in Provo when testing in Provo
 -------------------------------------------------------------------
 Wed Sep 28 11:12:52 CEST 2022 - jgonzalez@suse.com
 

--- a/proxy/proxy/Makefile.python
+++ b/proxy/proxy/Makefile.python
@@ -4,7 +4,7 @@ include $(CURRENT_DIR)../../rel-eng/Makefile.python
 
 # Docker tests variables
 DOCKER_CONTAINER_BASE = uyuni-master
-DOCKER_REGISTRY       = registry.mgr.suse.de
+DOCKER_REGISTRY       = $(shell [[ `hostname -f` == *.mgr.prv.suse.net ]] && echo "registry.mgr.prv.suse.net" || echo "registry.mgr.suse.de")
 DOCKER_RUN_EXPORT     = "PYTHONPATH=$PYTHONPATH"
 DOCKER_VOLUMES        = -v "$(CURDIR)/../../:/manager"
 

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,5 @@
+- Use Docker registry in Provo when testing in Provo
+
 -------------------------------------------------------------------
 Wed Sep 28 10:44:28 CEST 2022 - jgonzalez@suse.com
 

--- a/reporting/Makefile.python
+++ b/reporting/Makefile.python
@@ -4,7 +4,7 @@ include $(CURRENT_DIR)../rel-eng/Makefile.python
 
 # Docker tests variables
 DOCKER_CONTAINER_BASE = uyuni-master
-DOCKER_REGISTRY       = registry.mgr.suse.de
+DOCKER_REGISTRY       = $(shell [[ `hostname -f` == *.mgr.prv.suse.net ]] && echo "registry.mgr.prv.suse.net" || echo "registry.mgr.suse.de")
 DOCKER_RUN_EXPORT     = "PYTHONPATH=$PYTHONPATH"
 DOCKER_VOLUMES        = -v "$(CURDIR)/..:/manager"
 

--- a/reporting/spacewalk-reports.changes
+++ b/reporting/spacewalk-reports.changes
@@ -1,3 +1,4 @@
+* Use Docker registry in Provo when testing in Provo
 -------------------------------------------------------------------
 Fri Nov 18 15:05:43 CET 2022 - jgonzalez@suse.com
 

--- a/search-server/spacewalk-search/Makefile.python
+++ b/search-server/spacewalk-search/Makefile.python
@@ -4,7 +4,7 @@ include $(CURRENT_DIR)../../rel-eng/Makefile.python
 
 # Docker tests variables
 DOCKER_CONTAINER_BASE = uyuni-master
-DOCKER_REGISTRY       = registry.mgr.suse.de
+DOCKER_REGISTRY       = $(shell [[ `hostname -f` == *.mgr.prv.suse.net ]] && echo "registry.mgr.prv.suse.net" || echo "registry.mgr.suse.de")
 DOCKER_RUN_EXPORT     = "PYTHONPATH=$PYTHONPATH"
 DOCKER_VOLUMES        = -v "$(CURDIR)/../../:/manager"
 

--- a/search-server/spacewalk-search/spacewalk-search.changes
+++ b/search-server/spacewalk-search/spacewalk-search.changes
@@ -1,3 +1,4 @@
+- Use Docker registry in Provo when testing in Provo
 -------------------------------------------------------------------
 Fri Nov 18 15:15:09 CET 2022 - jgonzalez@suse.com
 

--- a/spacewalk/admin/Makefile.python
+++ b/spacewalk/admin/Makefile.python
@@ -4,7 +4,7 @@ include $(CURRENT_DIR)../../rel-eng/Makefile.python
 
 # Docker tests variables
 DOCKER_CONTAINER_BASE = uyuni-master
-DOCKER_REGISTRY       = registry.mgr.suse.de
+DOCKER_REGISTRY       = $(shell [[ `hostname -f` == *.mgr.prv.suse.net ]] && echo "registry.mgr.prv.suse.net" || echo "registry.mgr.suse.de")
 DOCKER_RUN_EXPORT     = "PYTHONPATH=$PYTHONPATH"
 DOCKER_VOLUMES        = -v "$(CURDIR)/../../:/manager"
 

--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,4 @@
+- Use Docker registry in Provo when testing in Provo
 -------------------------------------------------------------------
 Fri Nov 18 15:04:15 CET 2022 - jgonzalez@suse.com
 

--- a/spacewalk/certs-tools/Makefile.python
+++ b/spacewalk/certs-tools/Makefile.python
@@ -4,7 +4,7 @@ include $(CURRENT_DIR)../../rel-eng/Makefile.python
 
 # Docker tests variables
 DOCKER_CONTAINER_BASE = uyuni-master
-DOCKER_REGISTRY       = registry.mgr.suse.de
+DOCKER_REGISTRY       = $(shell [[ `hostname -f` == *.mgr.prv.suse.net ]] && echo "registry.mgr.prv.suse.net" || echo "registry.mgr.suse.de")
 DOCKER_RUN_EXPORT     = "PYTHONPATH=$PYTHONPATH"
 DOCKER_VOLUMES        = -v "$(CURDIR)/../../:/manager"
 

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,4 @@
+- Use Docker registry in Provo when testing in Provo
 -------------------------------------------------------------------
 Fri Nov 18 15:04:43 CET 2022 - jgonzalez@suse.com
 

--- a/spacewalk/setup/Makefile.python
+++ b/spacewalk/setup/Makefile.python
@@ -4,7 +4,7 @@ include $(CURRENT_DIR)../../rel-eng/Makefile.python
 
 # Docker tests variables
 DOCKER_CONTAINER_BASE = uyuni-master
-DOCKER_REGISTRY       = registry.mgr.suse.de
+DOCKER_REGISTRY       = $(shell [[ `hostname -f` == *.mgr.prv.suse.net ]] && echo "registry.mgr.prv.suse.net" || echo "registry.mgr.suse.de")
 DOCKER_RUN_EXPORT     = "PYTHONPATH=$PYTHONPATH"
 DOCKER_VOLUMES        = -v "$(CURDIR)/../../:/manager"
 

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,4 @@
+- Use Docker registry in Provo when testing in Provo
 -------------------------------------------------------------------
 Fri Nov 18 15:01:37 CET 2022 - jgonzalez@suse.com
 

--- a/suseRegisterInfo/Makefile.python
+++ b/suseRegisterInfo/Makefile.python
@@ -4,7 +4,7 @@ include $(CURRENT_DIR)../rel-eng/Makefile.python
 
 # Docker tests variables
 DOCKER_CONTAINER_BASE = uyuni-master
-DOCKER_REGISTRY       = registry.mgr.suse.de
+DOCKER_REGISTRY       = $(shell [[ `hostname -f` == *.mgr.prv.suse.net ]] && echo "registry.mgr.prv.suse.net" || echo "registry.mgr.suse.de")
 DOCKER_RUN_EXPORT     = "PYTHONPATH=$PYTHONPATH"
 DOCKER_VOLUMES        = -v "$(CURDIR)/../:/manager"
 

--- a/suseRegisterInfo/suseRegisterInfo.changes
+++ b/suseRegisterInfo/suseRegisterInfo.changes
@@ -1,3 +1,4 @@
+- Use Docker registry in Provo when testing in Provo
 -------------------------------------------------------------------
 Wed Sep 28 10:24:42 CEST 2022 - jgonzalez@suse.com
 

--- a/susemanager/Makefile.python
+++ b/susemanager/Makefile.python
@@ -4,7 +4,7 @@ include $(CURRENT_DIR)../rel-eng/Makefile.python
 
 # Docker tests variables
 DOCKER_CONTAINER_BASE = uyuni-master
-DOCKER_REGISTRY       = registry.mgr.suse.de
+DOCKER_REGISTRY       = $(shell [[ `hostname -f` == *.mgr.prv.suse.net ]] && echo "registry.mgr.prv.suse.net" || echo "registry.mgr.suse.de")
 DOCKER_RUN_EXPORT     = "PYTHONPATH=$PYTHONPATH"
 DOCKER_VOLUMES        = -v "$(CURDIR)/../:/manager"
 

--- a/susemanager/Makefile.susemanager
+++ b/susemanager/Makefile.susemanager
@@ -1,6 +1,6 @@
 # Docker tests variables
 DOCKER_CONTAINER_BASE = uyuni-master
-DOCKER_REGISTRY       = registry.mgr.suse.de
+DOCKER_REGISTRY       = $(shell [[ `hostname -f` == *.mgr.prv.suse.net ]] && echo "registry.mgr.prv.suse.net" || echo "registry.mgr.suse.de")
 DOCKER_RUN_EXPORT     = "PYTHONPATH=/manager/client/rhel/rhnlib/:/manager/client/rhel/rhn-client-tools/src"
 DOCKER_VOLUMES        = -v "$(CURDIR)/../:/manager"
 

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Use Docker registry in Provo when testing in Provo
 -------------------------------------------------------------------
 Fri Nov 18 15:14:21 CET 2022 - jgonzalez@suse.com
 

--- a/tftpsync/susemanager-tftpsync/Makefile.python
+++ b/tftpsync/susemanager-tftpsync/Makefile.python
@@ -4,7 +4,7 @@ include $(CURRENT_DIR)../../rel-eng/Makefile.python
 
 # Docker tests variables
 DOCKER_CONTAINER_BASE = uyuni-master
-DOCKER_REGISTRY       = registry.mgr.suse.de
+DOCKER_REGISTRY       = $(shell [[ `hostname -f` == *.mgr.prv.suse.net ]] && echo "registry.mgr.prv.suse.net" || echo "registry.mgr.suse.de")
 DOCKER_RUN_EXPORT     = "PYTHONPATH=$PYTHONPATH"
 DOCKER_VOLUMES        = -v "$(CURDIR)/../../:/manager"
 

--- a/tftpsync/susemanager-tftpsync/susemanager-tftpsync.changes
+++ b/tftpsync/susemanager-tftpsync/susemanager-tftpsync.changes
@@ -1,3 +1,4 @@
+- Use Docker registry in Provo when testing in Provo
 -------------------------------------------------------------------
 Wed Sep 28 11:03:42 CEST 2022 - jgonzalez@suse.com
 

--- a/utils/Makefile.python
+++ b/utils/Makefile.python
@@ -4,7 +4,7 @@ include $(CURRENT_DIR)../rel-eng/Makefile.python
 
 # Docker tests variables
 DOCKER_CONTAINER_BASE = uyuni-master
-DOCKER_REGISTRY       = registry.mgr.suse.de
+DOCKER_REGISTRY       = $(shell [[ `hostname -f` == *.mgr.prv.suse.net ]] && echo "registry.mgr.prv.suse.net" || echo "registry.mgr.suse.de")
 DOCKER_RUN_EXPORT     = "PYTHONPATH=$PYTHONPATH"
 DOCKER_VOLUMES        = -v "$(CURDIR)/..:/manager"
 

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- Use Docker registry in Provo when testing in Provo
 -------------------------------------------------------------------
 Fri Nov 18 15:02:27 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR makes sure we use Provo's Docker registry when we test in Provo.

Rationale:
 - more efficient
 - disaster-safe
 - more secure (can block corresponding ports on firewall)


## Links

Fixes SUSE/spacewalk#19229

Ports:
* 4.2:
* 4.3:


## Changelogs

- [ ] No changelog needed
