### PR TITLE
Improved reboot needed handling for SLE Micro

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
@@ -39,6 +39,14 @@ public class MinionServer extends Server implements SaltConfigurable {
     private Integer sshPushPort;
     private Set<AccessToken> accessTokens = new HashSet<>();
     private Set<Pillar> pillars = new HashSet<>();
+    /**
+       We typically look at the packages installed on a system to identify whether a reboot is necessary.
+       This property initially only works for transactional systems, but the idea is that gradually the
+       other types of systems also provide this information directly to be stored here so we no longer rely
+       on package related inference to determine whether a reboot is necessary. Even because this
+       information does not always depend only on the packages.
+    */
+    private Boolean rebootNeeded;
 
     /**
      * Constructs a MinionServer instance.
@@ -400,5 +408,13 @@ public class MinionServer extends Server implements SaltConfigurable {
                 }
         }
         return changed;
+    }
+
+    public Boolean isRebootNeeded() {
+        return rebootNeeded;
+    }
+
+    public void setRebootNeeded(Boolean rebootNeededIn) {
+        this.rebootNeeded = rebootNeededIn;
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
@@ -184,6 +184,14 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                          table="suseMinionInfo">
             <key column="server_id"/>
             <property name="minionId" column="minion_id" />
+            <!--
+            We typically look at the packages installed on a system to identify whether a reboot is necessary.
+            This property initially only works for transactional systems, but the idea is that gradually the
+            other types of systems also provide this information directly to be stored here so we no longer rely
+            on package related inference to determine whether a reboot is necessary. Even because this
+            information does not always depend only on the packages.
+            -->
+            <property name="rebootNeeded" column="reboot_needed" type="yes_no" />
             <property name="osFamily" column="os_family"  type="string" length="32" />
             <property name="kernelLiveVersion" column="kernel_live_version"  type="string" length="255" />
             <property name="sshPushPort" column="ssh_push_port" access="field"/>

--- a/java/code/src/com/redhat/rhn/frontend/servlets/SystemDetailsMessageFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/SystemDetailsMessageFilter.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.frontend.servlets;
 
+import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.struts.RequestContext;
@@ -58,8 +59,16 @@ public class SystemDetailsMessageFilter implements Filter {
         User user = rctx.getCurrentUser();
         Server s  = SystemManager.lookupByIdAndUser(sid, user);
         s.asMinionServer().ifPresentOrElse(
-            minion -> addMessageIfNecessary(req, minion.doesOsSupportsTransactionalUpdate(), REBOOT_MESSAGE_KEY),
+            minion -> processMinionMessages(req, minion),
             () -> addMessageIfNecessary(req, true, TRADITIONAL_STACK_MESSAGE_KEY)
+        );
+    }
+
+    private void processMinionMessages(HttpServletRequest req, MinionServer minion) {
+        addMessageIfNecessary(
+            req,
+            minion.doesOsSupportsTransactionalUpdate() && Boolean.TRUE.equals(minion.isRebootNeeded()),
+            REBOOT_MESSAGE_KEY
         );
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -24845,7 +24845,7 @@ given channel.</source>
         <source>Changes to channel assignments on salt managed systems will take effect at next highstate application</source>
       </trans-unit>
       <trans-unit id="overview.jsp.transactionalupdate.reboot" xml:space="preserve">
-        <source>OS with transactional updates: please reboot after any packages and/or channels changes.</source>
+        <source>There is a pending transaction for this system, please reboot it to activate the changes.</source>
       </trans-unit>
       <trans-unit id="overview.jsp.traditionalstack.deprecated" xml:space="preserve">
         <source>The traditional stack is unsupported and scheduled for removal. Consider migrating to salt minions.</source>

--- a/java/code/src/com/suse/manager/reactor/test/RebootInfoBeaconTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RebootInfoBeaconTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.reactor.test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
+import com.redhat.rhn.testing.UserTestUtils;
+
+import com.suse.manager.reactor.SaltReactor;
+import com.suse.manager.utils.SaltKeyUtils;
+import com.suse.manager.utils.SaltUtils;
+import com.suse.manager.webui.services.SaltServerActionService;
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.datatypes.Event;
+import com.suse.salt.netapi.datatypes.target.MinionList;
+import com.suse.salt.netapi.event.BeaconEvent;
+import com.suse.salt.netapi.parser.JsonParser;
+import com.suse.salt.netapi.results.Result;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+public class RebootInfoBeaconTest extends RhnJmockBaseTestCase {
+
+    private SaltReactor reactor;
+    private User user;
+    private JsonParser<Event> eventParser;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        user = UserTestUtils.findNewUser("testUser", "testOrg" +
+                this.getClass().getSimpleName());
+        this.eventParser = new JsonParser<>(new TypeToken<>() {
+        });
+        SaltService saltService = createSaltService();
+        SaltServerActionService saltServerActionService = createSaltServerActionService(saltService, saltService);
+        SaltUtils saltUtils = new SaltUtils(saltService, saltService);
+        reactor = new SaltReactor(
+            saltService,
+            saltService,
+            saltServerActionService,
+            saltUtils
+        );
+    }
+
+    @Test
+    public void testRebootInfoEvent() throws Exception {
+        MinionServer minion1 = MinionServerFactoryTest.createTestMinionServer(user);
+        minion1.setMinionId("slemicro100001");
+        minion1.setRebootNeeded(false);
+
+        MinionServer minion2 = MinionServerFactoryTest.createTestMinionServer(user);
+        minion2.setMinionId("slemicro100002");
+        minion2.setRebootNeeded(false);
+
+        // Event indicating that reboot is needed for minion 1
+        BeaconEvent event = buildRebootInfoEvent(minion1.getMinionId(), true);
+        reactor.eventToMessages(event);
+        assertTrue(minion1.isRebootNeeded());
+        assertFalse(minion2.isRebootNeeded());
+
+        // Events indicating that reboot is needed for minion 2, but is not for minion 1
+        event = buildRebootInfoEvent(minion2.getMinionId(), true);
+        reactor.eventToMessages(event);
+        event = buildRebootInfoEvent(minion1.getMinionId(), false);
+        reactor.eventToMessages(event);
+
+        assertFalse(minion1.isRebootNeeded());
+        assertTrue(minion2.isRebootNeeded());
+    }
+
+    private BeaconEvent buildRebootInfoEvent(String minionId, boolean rebootNeeded) {
+        StringBuilder jsonEvent = new StringBuilder();
+        jsonEvent.append("{");
+        jsonEvent.append("  \"tag\": \"salt/beacon/" + minionId + "/reboot_info/1234\", ");
+        jsonEvent.append("  \"data\": { ");
+        jsonEvent.append("    \"reboot_needed\": " + rebootNeeded);
+        jsonEvent.append("   } ");
+        jsonEvent.append("}");
+        Event e = eventParser.parse(jsonEvent.toString());
+        return BeaconEvent.parse(e).get();
+    }
+
+    private SaltService createSaltService() {
+        return new SaltService() {
+            @Override
+            public Optional<Result<JsonElement>> rawJsonCall(LocalCall<?> call, String minionId) {
+                return Optional.of(Result.success(new JsonObject()));
+            }
+
+            @Override
+            public void refreshPillar(MinionList minionList) {
+            }
+        };
+    }
+
+    private SaltServerActionService createSaltServerActionService(SystemQuery systemQuery, SaltApi saltApi) {
+        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi);
+        SaltServerActionService service = new SaltServerActionService(saltApi, saltUtils, new SaltKeyUtils(saltApi));
+        service.setSkipCommandScriptPerms(true);
+        return service;
+    }
+}
+

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
@@ -46,10 +46,13 @@ public class MinionGeneralPillarGenerator implements MinionPillarGenerator {
     public static final String CATEGORY = "general";
 
     private static final int PKGSET_INTERVAL = 5;
+    private static final int REBOOT_INFO_INTERVAL = 10;
 
     private static final Map<String, Object> PKGSET_BEACON_PROPS = new HashMap<>();
+    private static final Map<String, Object> REBOOT_INFO_BEACON_PROPS = new HashMap<>();
     static {
         PKGSET_BEACON_PROPS.put("interval", PKGSET_INTERVAL);
+        REBOOT_INFO_BEACON_PROPS.put("interval", REBOOT_INFO_INTERVAL);
     }
 
     /**
@@ -93,6 +96,9 @@ public class MinionGeneralPillarGenerator implements MinionPillarGenerator {
                 minion.getOsFamily().toLowerCase().equals("redhat") ||
                 minion.getOsFamily().toLowerCase().equals("debian")) {
             beaconConfig.put("pkgset", PKGSET_BEACON_PROPS);
+        }
+        if (minion.doesOsSupportsTransactionalUpdate()) {
+            beaconConfig.put("reboot_info", REBOOT_INFO_BEACON_PROPS);
         }
         if (!beaconConfig.isEmpty()) {
             pillar.add("beacons", beaconConfig);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Improved reboot needed handling for transactional swystems
 - Manage reboot in transactional update action chain (bsc#1201476)
 - Enable monitoring for RHEL 9 Salt clients
 - Optimize performance of config channels operations for UI and API (bsc#1204029)

--- a/schema/spacewalk/common/tables/suseMinionInfo.sql
+++ b/schema/spacewalk/common/tables/suseMinionInfo.sql
@@ -23,6 +23,7 @@ CREATE TABLE suseMinionInfo
     os_family           VARCHAR(32),
     kernel_live_version VARCHAR(255),
     ssh_push_port       NUMERIC,
+    reboot_needed       CHAR(1),
     created   TIMESTAMPTZ
                   DEFAULT (current_timestamp) NOT NULL,
     modified  TIMESTAMPTZ

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.1-to-susemanager-schema-4.4.2/300-add-reboot-need-column-to-suseMinionInfo.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.1-to-susemanager-schema-4.4.2/300-add-reboot-need-column-to-suseMinionInfo.sql
@@ -1,0 +1,2 @@
+ALTER TABLE suseMinionInfo
+    ADD COLUMN IF NOT EXISTS reboot_needed CHAR(1);

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.1-to-susemanager-schema-4.4.2/301-replace-update-system-overview.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.1-to-susemanager-schema-4.4.2/301-replace-update-system-overview.sql
@@ -1,20 +1,8 @@
---
--- Copyright (c) 2022 SUSE, LLC
---
--- This software is licensed to you under the GNU General Public License,
--- version 2 (GPLv2). There is NO WARRANTY for this software, express or
--- implied, including the implied warranties of MERCHANTABILITY or FITNESS
--- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
--- along with this software; if not, see
--- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
---
--- Red Hat trademarks are not licensed under GPLv2. No permission is
--- granted to use or replicate Red Hat trademarks that are incorporated
--- in this software or its documentation.
---
+-------------------
+-- Update procedure
+-------------------
 
-create or replace
-function update_system_overview (
+create or replace function update_system_overview (
     sid in numeric
 ) returns void as
 $$

--- a/susemanager-utils/susemanager-sls/src/beacons/reboot_info.py
+++ b/susemanager-utils/susemanager-sls/src/beacons/reboot_info.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""
+Watch pending transactions in transactional systems and
+fire an event to SUSE Manager indicating if a reboot is needed.
+"""
+
+__virtualname__ = "reboot_info"
+
+
+def __virtual__():
+    return __grains__.get("transactional", False)
+
+
+def validate(config):
+    """
+    The absence of this function could cause noisy logging,
+    when logging level set to DEBUG or TRACE.
+    So we need to have it with no any validation inside.
+    """
+    return True, "There is nothing to validate"
+
+
+def beacon(config):
+    """
+    Monitor pending transactions of transactional update
+    to verify whether a reboot is required. When the reboot
+    needed status changes, it fires a new event.
+
+    Example Config
+
+    .. code-block:: yaml
+
+        beacons:
+          reboot_info:
+            interval: 5
+
+    """
+    ret = []
+    reboot_needed = __salt__["transactional_update.pending_transaction"]()
+
+    if __context__.get("reboot_needed") != reboot_needed:
+        ret.append({"reboot_needed": reboot_needed})
+        __context__["reboot_needed"] = reboot_needed
+
+    return ret

--- a/susemanager-utils/susemanager-sls/src/tests/test_beacon_reboot_info.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_beacon_reboot_info.py
@@ -1,0 +1,70 @@
+from ..beacons import reboot_info
+
+def _pending_transaction_false():
+  return False
+
+def _pending_transaction_true():
+  return True
+
+def test_should_fire_event_when_context_is_empty():
+  """
+    The __context__ is empty and reboot is not required
+  """
+  reboot_info.__context__ = {}
+  reboot_info.__salt__ = {
+    "transactional_update.pending_transaction": _pending_transaction_false
+  }
+  ret = reboot_info.beacon({})
+  assert ret == [{ "reboot_needed": False }]
+
+  """
+    The __context__ is empty and reboot is required
+  """
+  reboot_info.__context__ = {}
+  reboot_info.__salt__ = {
+    "transactional_update.pending_transaction": _pending_transaction_true
+  }
+  ret = reboot_info.beacon({})
+  assert ret == [{ "reboot_needed": True }]
+
+def test_should_not_fire_event_when_already_fired():
+  """
+    The __context__ already register that reboot is required
+  """
+  reboot_info.__salt__ = {
+    "transactional_update.pending_transaction": _pending_transaction_true
+  }
+  reboot_info.__context__ = { "reboot_needed": True }
+  ret = reboot_info.beacon({})
+  assert ret == []
+
+  """
+    The __context__ already register that reboot is not required
+  """
+  reboot_info.__salt__ = {
+    "transactional_update.pending_transaction": _pending_transaction_false
+  }
+  reboot_info.__context__ = { "reboot_needed": False }
+  ret = reboot_info.beacon({})
+  assert ret == []
+
+def test_should_fire_event_when_reboot_status_changes():
+  """
+    The __context__ register that reboot is required but there is no pending transaction
+  """
+  reboot_info.__salt__ = {
+    "transactional_update.pending_transaction": _pending_transaction_false
+  }
+  reboot_info.__context__ = { "reboot_needed": True }
+  ret = reboot_info.beacon({})
+  assert ret == [{ "reboot_needed": False }]
+
+  """
+    The __context__ register that reboot is not required but there is a pending transaction
+  """
+  reboot_info.__salt__ = {
+    "transactional_update.pending_transaction": _pending_transaction_true
+  }
+  reboot_info.__context__ = { "reboot_needed": False }
+  ret = reboot_info.beacon({})
+  assert ret == [{ "reboot_needed": True }]

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Add beacon to check if a reboot is required in transactional systems
 - Manager reboot in transactional update action chain (bsc#1201476)
 - Fix kiwi inspect regexp to allow image names with "-" (bsc#1204541)
 - Use the actual sudo user home directory for salt ssh


### PR DESCRIPTION
## What does this PR change?

It adds a new execution module for SLE Micro systems which returns a boolean indicating if a reboot is needed, and uses the return of this module to show the warning message about necessary reboot only when it returns true.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/19036

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests" (Test skipped, there are no changes to test)
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
