### PR TITLE
move empty CLM Project test to first feature creating a project

### DIFF
--- a/testsuite/features/reposync/srv_add_rocky8_repositories.feature
+++ b/testsuite/features/reposync/srv_add_rocky8_repositories.feature
@@ -82,7 +82,9 @@ Feature: Add the Rocky 8 distribution custom repositories
 
   Scenario: Create a CLM project to remove AppStream metadata
     When I follow the left menu "Content Lifecycle > Projects"
-    And I follow "Create Project"
+    Then I should see a "Content Lifecycle Projects" text
+    And I should see a "There are no entries to show." text
+    When I follow "Create Project"
     And I enter "Remove AppStream metadata" as "name"
     And I enter "no-appstream" as "label"
     And I click on "Create"

--- a/testsuite/features/secondary/srv_content_lifecycle.feature
+++ b/testsuite/features/secondary/srv_content_lifecycle.feature
@@ -10,9 +10,7 @@ Feature: Content lifecycle
 
   Scenario: Create a content lifecycle project
     When I follow the left menu "Content Lifecycle > Projects"
-    Then I should see a "Content Lifecycle Projects" text
-    And I should see a "There are no entries to show." text
-    When I follow "Create Project"
+    And I follow "Create Project"
     Then I should see a "Create a new Content Lifecycle Project" text
     And I should see a "Project Properties" text
     When I enter "clp_label" as "label"


### PR DESCRIPTION
## What does this PR change?

The CLM tests expect that the project is empty. As the Rocky Linux tests added a first project now in "core", this is not true anymore.
This PR move the "empty project" test into the Rocky tests in core.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
