### PR TITLE
Don't call printStackTrace in production code, use logger instead

### DIFF
--- a/java/code/src/com/redhat/rhn/common/messaging/ActionExecutor.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/ActionExecutor.java
@@ -70,7 +70,6 @@ class ActionExecutor implements Runnable {
             }
             catch (Throwable t) {
                 LOG.error(t);
-                t.printStackTrace();
             }
         }
     }

--- a/java/code/src/com/redhat/rhn/common/messaging/SmtpMail.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/SmtpMail.java
@@ -255,7 +255,7 @@ public class SmtpMail implements Mail {
             buf.append(this.message.getContent());
         }
         catch (IOException | MessagingException e) {
-            e.printStackTrace();
+            log.error(e);
         }
         return buf.toString();
     }

--- a/java/code/src/com/redhat/rhn/common/util/MethodUtil.java
+++ b/java/code/src/com/redhat/rhn/common/util/MethodUtil.java
@@ -203,7 +203,7 @@ public class MethodUtil {
             throw new MethodInvocationException("Could not access " + methodCalled, e);
         }
         catch (InvocationTargetException e) {
-            e.printStackTrace();
+            log.debug("Error calling {}", methodCalled, e);
             throw new MethodInvocationException("Something bad happened when " +
                                                 "calling " + methodCalled, e);
         }

--- a/java/code/src/com/redhat/rhn/domain/channel/AccessTokenFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/AccessTokenFactory.java
@@ -191,7 +191,6 @@ public class AccessTokenFactory extends HibernateFactory {
             }
             catch (JoseException e) {
                 LOG.error("Could not regenerate token with id: {}", token.getId(), e);
-                e.printStackTrace();
                 return token;
             }
         }).collect(Collectors.toList());
@@ -260,7 +259,6 @@ public class AccessTokenFactory extends HibernateFactory {
         }
         catch (JoseException e) {
             LOG.error("Could not generate token for minion: {}", minion.getId(), e);
-            e.printStackTrace();
             return Optional.empty();
         }
     }

--- a/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
@@ -172,8 +172,7 @@ public class DownloadFile extends DownloadAction {
             super.execute(mapping, formIn, request, response);
         }
         catch (Exception e) {
-            e.printStackTrace();
-            log.error("Package retrieval error on file download url: {}", url);
+            log.error("Package retrieval error on file download url: {}", url, e);
             return mapping.findForward("error");
         }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/BaseAddFilesAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/BaseAddFilesAction.java
@@ -26,6 +26,8 @@ import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.frontend.struts.RhnValidationHelper;
 import com.redhat.rhn.manager.configuration.ConfigFileBuilder;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
@@ -40,6 +42,8 @@ import javax.servlet.http.HttpServletResponse;
  * BaseAddFilesAction
  */
 public abstract class BaseAddFilesAction extends RhnAction {
+
+    private static final Logger LOG = LogManager.getLogger(BaseAddFilesAction.class);
 
     public static final String MAX_SIZE = "maxbytes";
     public static final String CSRF_TOKEN = "csrfToken";
@@ -132,7 +136,7 @@ public abstract class BaseAddFilesAction extends RhnAction {
             getStrutsDelegate().saveMessages(req, ve.getResult());
         }
         catch (Exception e) {
-            e.printStackTrace();
+            LOG.error(e);
         }
         // If we got here, something went wrong - try again
         return getStrutsDelegate().forwardParams(

--- a/java/code/src/com/redhat/rhn/frontend/action/user/ResetPasswordSubmitAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/ResetPasswordSubmitAction.java
@@ -160,7 +160,7 @@ public class ResetPasswordSubmitAction extends UserEditActionHelper {
             }
         }
         catch (IOException e) {
-            e.printStackTrace();
+            log.error("Error redirecting to login page", e);
         }
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/dto/SystemSearchResult.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/SystemSearchResult.java
@@ -81,7 +81,6 @@ public class SystemSearchResult extends SystemOverview {
             }
         }
         catch (IllegalAccessException | InvocationTargetException e) {
-            e.printStackTrace();
             // ignore
         }
         catch (NoSuchMethodException e) {

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/ToolbarTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/ToolbarTag.java
@@ -546,7 +546,6 @@ public class ToolbarTag extends TagSupport {
             return (EVAL_PAGE);
         }
         catch (Exception e) {
-            e.printStackTrace();
             throw new JspException("Error writing to JSP file:", e);
         }
     }

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/helpers/ListViewHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/helpers/ListViewHelper.java
@@ -218,8 +218,7 @@ public class ListViewHelper {
                 }
             }
             catch (IllegalAccessException | InvocationTargetException | IllegalArgumentException e) {
-                e.printStackTrace();
-                continue;
+                // ignore
             }
         }
     }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/XmlRpcServlet.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/XmlRpcServlet.java
@@ -178,7 +178,6 @@ public class XmlRpcServlet extends HttpServlet {
             // By the time we get here, it can't be a FaultException, so just
             // wrap it in a ServletException and toss.
             ServletException e = new ServletException("Throwable from XmlRpc", t);
-            t.printStackTrace();
             if (e.getCause() != t) {
                 e.initCause(t);
             }

--- a/java/code/src/com/redhat/rhn/manager/audit/scap/file/ScapResultFile.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/scap/file/ScapResultFile.java
@@ -100,9 +100,9 @@ public class ScapResultFile implements StreamInfo {
             return new FileInputStream(getAbsolutePath());
         }
         catch (IOException e) {
-            e.printStackTrace();
             LocalizationService ls = LocalizationService.getInstance();
-            throw new LookupException("Could not server file '" + filename + "' for XCCDF Scan " + testResult.getId(),
+            throw new LookupException("Could not read server file '" + filename +
+                    "' for XCCDF Scan " + testResult.getId(),
                     ls.getMessage("lookup.scapfile.title"), null, null);
         }
     }
@@ -112,8 +112,6 @@ public class ScapResultFile implements StreamInfo {
      * @return string
      */
     public String toString() {
-        return this.getClass().getName() +
-            "[path=" + getAbsolutePath() +
-            "]";
+        return this.getClass().getName() + "[path=" + getAbsolutePath() + "]";
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -1618,7 +1618,6 @@ public class ErrataManager extends BaseManager {
         catch (XmlRpcFault e) {
             // right now updateIndex doesn't throw any faults.
             log.error("Errata index not updated. Search server unavailable.ErrorCode = {}", e.getErrorCode(), e);
-            e.printStackTrace();
         }
         catch (Exception e) {
             // if the search server is down, folks will know when they

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoXmlRpcInvoker.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoXmlRpcInvoker.java
@@ -81,14 +81,14 @@ public class TaskoXmlRpcInvoker implements ProtocolHandler {
             }
         }
         catch (IOException e) {
-            e.printStackTrace();
+            log.error("Error handling request", e);
         }
         finally {
             try {
                 response.commit();
             }
             catch (IOException e) {
-                e.printStackTrace();
+                log.error("Error sending response", e);
             }
         }
 

--- a/java/code/src/com/redhat/rhn/taskomatic/core/SchedulerKernel.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/core/SchedulerKernel.java
@@ -109,7 +109,6 @@ public class SchedulerKernel {
             PrometheusExporter.INSTANCE.registerScheduler(SchedulerKernel.scheduler, "taskomatic");
         }
         catch (SchedulerException e) {
-            e.printStackTrace();
             throw new InstantiationException("this.scheduler failed");
         }
     }
@@ -170,8 +169,7 @@ public class SchedulerKernel {
             SchedulerKernel.scheduler.shutdown();
         }
         catch (SchedulerException e) {
-            // TODO Figure out what to do with this guy
-            e.printStackTrace();
+            log.warn("Failed to cleanly stop the scheduler", e);
         }
         finally {
             MessageQueue.stopMessaging();
@@ -234,10 +232,10 @@ public class SchedulerKernel {
             if (interrupted > 0) {
                 log.warn("Number of interrupted runs: {}", interrupted);
             }
-            TaskoFactory.closeSession();
+            HibernateFactory.closeSession();
         }
         catch (Exception e) {
-            e.printStackTrace();
+            log.error("Unexpected error while initializing schedules", e);
         }
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataWorker.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataWorker.java
@@ -134,7 +134,6 @@ public class ChannelRepodataWorker implements QueueWorker {
         }
         catch (Exception e) {
             logger.error(e);
-            e.printStackTrace();
             parentQueue.getQueueRun().failed();
             // unmark channel to be worked on
             markInProgress(false);


### PR DESCRIPTION
## What does this PR change?

Remove `printStackTrace()` calls in the `java` folder for non-tests. This never shows up and `Logger` should be used instead. This will also address some SonarCloud low security hotspots.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: Logging

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
