### PR TITLE
Pillar migration fix

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Migrate formulas with default values to database (bsc#1204932)
 - Improved reboot needed handling for transactional swystems
 - Manage reboot in transactional update action chain (bsc#1201476)
 - Enable monitoring for RHEL 9 Salt clients


### PR DESCRIPTION
## What does this PR change?

Formulas selected on a server or group without having any configuration defined had no pillar data file on the file system on 4.2 and those were not converted into the DB pillars.

This PR now handles this case too.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: Migration tests using files is painful to unit test

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19374

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
