### PR TITLE
update uyuni sync data

### DIFF
--- a/susemanager-sync-data/additional_products.json
+++ b/susemanager-sync-data/additional_products.json
@@ -537,11 +537,11 @@
         "release_type" : null,
         "arch" : "x86_64",
         "friendly_name" : "Open Enterprise Server 2023",
-        "product_class" : "OES2-BETA",
+        "product_class" : "OES2",
         "cpe" : null,
         "free" : false,
         "description" : null,
-        "release_stage" : "beta",
+        "release_stage" : "released",
         "eula_url" : "",
         "product_type" : "base",
         "offline_predecessor_ids" : [

--- a/susemanager-sync-data/additional_products.json
+++ b/susemanager-sync-data/additional_products.json
@@ -1,5 +1,534 @@
 [
     {
+        "id" : -41,
+        "name" : "Oracle Linux 9",
+        "identifier" : "oraclelinux",
+        "former_identifier" : "",
+        "version" : "9",
+        "release_type" : null,
+        "arch" : "x86_64",
+        "friendly_name" : "Oracle Linux 9 x86_64",
+        "product_class" : "SLE-M-T",
+        "cpe" : null,
+        "free" : true,
+        "description" : null,
+        "release_stage" : "released",
+        "eula_url" : "",
+        "product_type" : "base",
+        "offline_predecessor_ids" : [
+        ],
+        "online_predecessor_ids" : [
+        ],
+        "shortname" : null,
+        "recommended" : false,
+        "extensions" : [
+        ],
+        "repositories" : [
+            {
+                "id" : -488,
+                "url" : "https://yum.oracle.com/repo/OracleLinux/OL9/RDMA/x86_64/",
+                "name" : "oraclelinux9-rdma",
+                "distro_target" : "x86_64",
+                "description" : "Latest RDMA packages on Oracle Linux 9 for the Oracle Integrated Stack.",
+                "enabled" : false,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -489,
+                "url" : "https://yum.oracle.com/repo/OracleLinux/OL9/UEKR7/x86_64/",
+                "name" : "oraclelinux9-uek-r7",
+                "distro_target" : "x86_64",
+                "description" : "Latest Unbreakable Enterprise Kernel Release 7 for Oracle Linux 9",
+                "enabled" : false,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -490,
+                "url" : "https://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/x86_64/",
+                "name" : "oraclelinux9",
+                "distro_target" : "x86_64",
+                "description" : "Oracle Linux 9",
+                "enabled" : true,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -491,
+                "url" : "https://yum.oracle.com/repo/OracleLinux/OL9/appstream/x86_64/",
+                "name" : "oraclelinux9-appstream",
+                "distro_target" : "x86_64",
+                "description" : "Oracle Linux 9 AppStream",
+                "enabled" : true,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -492,
+                "url" : "https://yum.oracle.com/repo/OracleLinux/OL9/addons/x86_64/",
+                "name" : "oraclelinux9-addons",
+                "distro_target" : "x86_64",
+                "description" : "Addons for Oracle Linux 9",
+                "enabled" : false,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -493,
+                "url" : "https://yum.oracle.com/repo/OracleLinux/OL9/codeready/builder/x86_64/",
+                "name" : "oraclelinux9-codereadybuilder",
+                "distro_target" : "x86_64",
+                "description" : "Latest CodeReady Builder packages for Oracle Linux 9",
+                "enabled" : false,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -494,
+                "url" : "https://yum.oracle.com/repo/OracleLinux/OL9/developer/UEKR7/x86_64/",
+                "name" : "oraclelinux9-developer-uek-r7",
+                "distro_target" : "x86_64",
+                "description" : "Latest Unbreakable Enterprise Kernel Release 7 for Oracle Linux 9",
+                "enabled" : false,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -495,
+                "url" : "https://yum.oracle.com/repo/OracleLinux/OL9/developer/x86_64/",
+                "name" : "oraclelinux9-developer",
+                "distro_target" : "x86_64",
+                "description" : "Packages for test and development - Oracle Linux 9",
+                "enabled" : false,
+                "autorefresh" : false,
+                "installer_updates" : false
+            }
+        ]
+    },
+    {
+        "id" : -40,
+        "name" : "Oracle Linux 9",
+        "identifier" : "oraclelinux",
+        "former_identifier" : "",
+        "version" : "9",
+        "release_type" : null,
+        "arch" : "aarch64",
+        "friendly_name" : "Oracle Linux 9 aarch64",
+        "product_class" : "SLE-M-T",
+        "cpe" : null,
+        "free" : true,
+        "description" : null,
+        "release_stage" : "released",
+        "eula_url" : "",
+        "product_type" : "base",
+        "offline_predecessor_ids" : [
+        ],
+        "online_predecessor_ids" : [
+        ],
+        "shortname" : null,
+        "recommended" : false,
+        "extensions" : [
+        ],
+        "repositories" : [
+            {
+                "id" : -481,
+                "url" : "https://yum.oracle.com/repo/OracleLinux/OL9/UEKR7/aarch64/",
+                "name" : "oraclelinux9-uek-r7",
+                "distro_target" : "aarch64",
+                "description" : "Latest Unbreakable Enterprise Kernel Release 7 for Oracle Linux 9",
+                "enabled" : false,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -482,
+                "url" : "https://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/aarch64/",
+                "name" : "oraclelinux9",
+                "distro_target" : "aarch64",
+                "description" : "Oracle Linux 9",
+                "enabled" : true,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -483,
+                "url" : "https://yum.oracle.com/repo/OracleLinux/OL9/appstream/aarch64/",
+                "name" : "oraclelinux9-appstream",
+                "distro_target" : "aarch64",
+                "description" : "Oracle Linux 9 AppStream",
+                "enabled" : true,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -484,
+                "url" : "https://yum.oracle.com/repo/OracleLinux/OL9/addons/aarch64/",
+                "name" : "oraclelinux9-addons",
+                "distro_target" : "aarch64",
+                "description" : "Addons for Oracle Linux 9",
+                "enabled" : false,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -485,
+                "url" : "https://yum.oracle.com/repo/OracleLinux/OL9/codeready/builder/aarch64/",
+                "name" : "oraclelinux9-codereadybuilder",
+                "distro_target" : "aarch64",
+                "description" : "Latest CodeReady Builder packages for Oracle Linux 9",
+                "enabled" : false,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -486,
+                "url" : "https://yum.oracle.com/repo/OracleLinux/OL9/developer/UEKR7/aarch64/",
+                "name" : "oraclelinux9-developer-uek-r7",
+                "distro_target" : "aarch64",
+                "description" : "Latest Unbreakable Enterprise Kernel Release 7 for Oracle Linux 9",
+                "enabled" : false,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -487,
+                "url" : "https://yum.oracle.com/repo/OracleLinux/OL9/developer/aarch64/",
+                "name" : "oraclelinux9-developer",
+                "distro_target" : "aarch64",
+                "description" : "Packages for test and development - Oracle Linux 9",
+                "enabled" : false,
+                "autorefresh" : false,
+                "installer_updates" : false
+            }
+        ]
+    },
+    {
+        "id" : -39,
+        "name" : "AlmaLinux 9",
+        "identifier" : "almalinux",
+        "former_identifier" : "",
+        "version" : "9",
+        "release_type" : null,
+        "arch" : "aarch64",
+        "friendly_name" : "AlmaLinux 9 aarch64",
+        "product_class" : "SLE-M-T",
+        "cpe" : null,
+        "free" : true,
+        "description" : null,
+        "release_stage" : "released",
+        "eula_url" : "",
+        "product_type" : "base",
+        "offline_predecessor_ids" : [
+        ],
+        "online_predecessor_ids" : [
+        ],
+        "shortname" : null,
+        "recommended" : false,
+        "extensions" : [
+        ],
+        "repositories" : [
+            {
+                "id" : -471,
+                "url" : "https://mirrors.almalinux.org/mirrorlist/9/baseos",
+                "name" : "almalinux9",
+                "distro_target" : null,
+                "description" : "AlmaLinux 9",
+                "enabled" : true,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -472,
+                "url" : "https://mirrors.almalinux.org/mirrorlist/9/appstream",
+                "name" : "almalinux9-appstream",
+                "distro_target" : null,
+                "description" : "AlmaLinux 9 AppStream",
+                "enabled" : true,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -473,
+                "url" : "https://mirrors.almalinux.org/mirrorlist/9/extras",
+                "name" : "almalinux9-extras",
+                "distro_target" : null,
+                "description" : "AlmaLinux 9 Extras",
+                "enabled" : false,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -474,
+                "url" : "https://mirrors.almalinux.org/mirrorlist/9/powertools",
+                "name" : "almalinux9-powertools",
+                "distro_target" : null,
+                "description" : "AlmaLinux 9 PowerTools",
+                "enabled" : false,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -475,
+                "url" : "https://mirrors.almalinux.org/mirrorlist/9/ha",
+                "name" : "almalinux9-ha",
+                "distro_target" : null,
+                "description" : "AlmaLinux 9 HighAvailability",
+                "enabled" : false,
+                "autorefresh" : true,
+                "installer_updates" : false
+            }
+        ]
+    },
+    {
+        "id" : -38,
+        "name" : "AlmaLinux 9",
+        "identifier" : "almalinux",
+        "former_identifier" : "",
+        "version" : "9",
+        "release_type" : null,
+        "arch" : "x86_64",
+        "friendly_name" : "AlmaLinux 9 x86_64",
+        "product_class" : "SLE-M-T",
+        "cpe" : null,
+        "free" : true,
+        "description" : null,
+        "release_stage" : "released",
+        "eula_url" : "",
+        "product_type" : "base",
+        "offline_predecessor_ids" : [
+        ],
+        "online_predecessor_ids" : [
+        ],
+        "shortname" : null,
+        "recommended" : false,
+        "extensions" : [
+        ],
+        "repositories" : [
+            {
+                "id" : -476,
+                "url" : "https://mirrors.almalinux.org/mirrorlist/9/baseos",
+                "name" : "almalinux9",
+                "distro_target" : null,
+                "description" : "AlmaLinux 9",
+                "enabled" : true,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -477,
+                "url" : "https://mirrors.almalinux.org/mirrorlist/9/appstream",
+                "name" : "almalinux9-appstream",
+                "distro_target" : null,
+                "description" : "AlmaLinux 9 AppStream",
+                "enabled" : true,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -478,
+                "url" : "https://mirrors.almalinux.org/mirrorlist/9/extras",
+                "name" : "almalinux9-extras",
+                "distro_target" : null,
+                "description" : "AlmaLinux 9 Extras",
+                "enabled" : false,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -479,
+                "url" : "https://mirrors.almalinux.org/mirrorlist/9/powertools",
+                "name" : "almalinux9-powertools",
+                "distro_target" : null,
+                "description" : "AlmaLinux 9 PowerTools",
+                "enabled" : false,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -480,
+                "url" : "https://mirrors.almalinux.org/mirrorlist/9/ha",
+                "name" : "almalinux9-ha",
+                "distro_target" : null,
+                "description" : "AlmaLinux 9 HighAvailability",
+                "enabled" : false,
+                "autorefresh" : true,
+                "installer_updates" : false
+            }
+        ]
+    },
+    {
+        "id" : -37,
+        "name" : "Rocky Linux 9",
+        "identifier" : "rockylinux",
+        "former_identifier" : "",
+        "version" : "9",
+        "release_type" : null,
+        "arch" : "aarch64",
+        "friendly_name" : "Rocky Linux 9 aarch64",
+        "product_class" : "SLE-M-T",
+        "cpe" : null,
+        "free" : true,
+        "description" : null,
+        "release_stage" : "released",
+        "eula_url" : "",
+        "product_type" : "base",
+        "offline_predecessor_ids" : [
+        ],
+        "online_predecessor_ids" : [
+        ],
+        "shortname" : null,
+        "recommended" : false,
+        "extensions" : [
+        ],
+        "repositories" : [
+            {
+                "id" : -466,
+                "url" : "https://mirrors.rockylinux.org/mirrorlist?repo=BaseOS-9&arch=aarch64",
+                "name" : "rockylinux-9",
+                "distro_target" : "aarch64",
+                "description" : "Rocky Linux 9",
+                "enabled" : true,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -467,
+                "url" : "https://mirrors.rockylinux.org/mirrorlist?repo=AppStream-9&arch=aarch64",
+                "name" : "rockylinux-9-appstream",
+                "distro_target" : "aarch64",
+                "description" : "Rocky Linux 9 AppStream",
+                "enabled" : true,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -468,
+                "url" : "https://mirrors.rockylinux.org/mirrorlist?repo=extras-9&arch=aarch64",
+                "name" : "rockylinux-9-extras",
+                "distro_target" : "aarch64",
+                "description" : "Rocky Linux 9 Extras",
+                "enabled" : false,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -470,
+                "url" : "https://mirrors.rockylinux.org/mirrorlist?repo=HighAvailability-9&arch=aarch64",
+                "name" : "rockylinux-9-ha",
+                "distro_target" : "aarch64",
+                "description" : "Rocky Linux 9 HighAvailability",
+                "enabled" : false,
+                "autorefresh" : true,
+                "installer_updates" : false
+            }
+        ]
+    },
+    {
+        "id" : -36,
+        "name" : "Rocky Linux 9",
+        "identifier" : "rockylinux",
+        "former_identifier" : "",
+        "version" : "9",
+        "release_type" : null,
+        "arch" : "x86_64",
+        "friendly_name" : "Rocky Linux 9 x86_64",
+        "product_class" : "SLE-M-T",
+        "cpe" : null,
+        "free" : true,
+        "description" : null,
+        "release_stage" : "released",
+        "eula_url" : "",
+        "product_type" : "base",
+        "offline_predecessor_ids" : [
+        ],
+        "online_predecessor_ids" : [
+        ],
+        "shortname" : null,
+        "recommended" : false,
+        "extensions" : [
+        ],
+        "repositories" : [
+            {
+                "id" : -461,
+                "url" : "https://mirrors.rockylinux.org/mirrorlist?repo=BaseOS-9&arch=x86_64",
+                "name" : "rockylinux-9",
+                "distro_target" : "x86_64",
+                "description" : "Rocky Linux 9",
+                "enabled" : true,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -462,
+                "url" : "https://mirrors.rockylinux.org/mirrorlist?repo=AppStream-9&arch=x86_64",
+                "name" : "rockylinux-9-appstream",
+                "distro_target" : "x86_64",
+                "description" : "Rocky Linux 9 AppStream",
+                "enabled" : true,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -463,
+                "url" : "https://mirrors.rockylinux.org/mirrorlist?repo=extras-9&arch=x86_64",
+                "name" : "rockylinux-9-extras",
+                "distro_target" : "x86_64",
+                "description" : "Rocky Linux 9 Extras",
+                "enabled" : false,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -465,
+                "url" : "https://mirrors.rockylinux.org/mirrorlist?repo=HighAvailability-9&arch=x86_64",
+                "name" : "rockylinux-9-ha",
+                "distro_target" : "x86_64",
+                "description" : "Rocky Linux 9 HighAvailability",
+                "enabled" : false,
+                "autorefresh" : true,
+                "installer_updates" : false
+            }
+        ]
+    },
+    {
+        "id" : -35,
+        "name" : "EL 9 Base",
+        "identifier" : "el-base",
+        "former_identifier" : "",
+        "version" : "9",
+        "release_type" : null,
+        "arch" : "x86_64",
+        "friendly_name" : "EL 9 Base",
+        "product_class" : "SLE-M-T",
+        "cpe" : null,
+        "free" : false,
+        "description" : null,
+        "release_stage" : "released",
+        "eula_url" : "",
+        "product_type" : "base",
+        "offline_predecessor_ids" : [
+        ],
+        "online_predecessor_ids" : [
+        ],
+        "shortname" : null,
+        "recommended" : false,
+        "extensions" : [
+        ],
+        "repositories" : [
+            {
+                "id" : -460,
+                "url" : "http://localhost/pub/repositories/empty/",
+                "name" : "EL9-Pool",
+                "distro_target" : "x86_64",
+                "description" : "EL9-Pool",
+                "enabled" : true,
+                "autorefresh" : false,
+                "installer_updates" : false
+            }
+        ]
+    },
+    {
         "id" : -34,
         "name" : "Open Enterprise Server 2023",
         "identifier" : "Open_Enterprise_Server",

--- a/susemanager-sync-data/susemanager-sync-data.changes
+++ b/susemanager-sync-data/susemanager-sync-data.changes
@@ -1,3 +1,4 @@
+- release oes2023 products
 - add sll 9, oraclelinux 9, almalinux 9 and rockylinux 9
 
 -------------------------------------------------------------------

--- a/susemanager-sync-data/susemanager-sync-data.changes
+++ b/susemanager-sync-data/susemanager-sync-data.changes
@@ -1,3 +1,5 @@
+- add sll 9, oraclelinux 9, almalinux 9 and rockylinux 9
+
 -------------------------------------------------------------------
 Wed Sep 28 10:25:03 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

updates uyuni sync data with almalinux9, rockylinux9, oraclelinux9 and sll9. Also sets oes2023 products to released.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
