### PR TITLE
fix client tools product name after rename

### DIFF
--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -32,7 +32,7 @@ Feature: Be able to list available channels and enable them
     When I execute mgr-sync "list products --expand"
     Then I should get "[ ] SUSE Linux Enterprise Server 12 SP4 x86_64"
     And I should get "[ ] SUSE Manager Proxy 4.1 x86_64"
-    And I should get "  [ ] (R) SUSE Manager Client Tools for RHEL and ES 7 x86_64"
+    And I should get "  [ ] (R) SUSE Manager Client Tools for RHEL, Liberty and Clones 7 x86_64
     And I should get "  [ ] (R) SUSE Manager Client Tools for SLE 15 x86_64"
 
   Scenario: List products with filter


### PR DESCRIPTION
## What does this PR change?

`SUSE Manager Client Tools for RHEL and ES 7 x86_64` was renamed to
`SUSE Manager Client Tools for RHEL, Liberty and Clones 7 x86_64`

## GUI diff

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
