### PR TITLE
require python3-debian which support compressions used by ubuntu 22.04

### DIFF
--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- require python3-debian version which support new compression
+  methods to sync ubuntu22-04 repositories (bsc#1205212)
 - Update system overview table in reposync
 - Keep older module metadata files in database (bsc#1201893)
 - Used the legacy reporting system in spacewalk-debug to obtain

--- a/python/spacewalk/spacewalk-backend.spec
+++ b/python/spacewalk/spacewalk-backend.spec
@@ -71,7 +71,7 @@ Requires(pre):  %{apache_pkg}
 Requires:       %{apache_pkg}
 Requires:       python3-pycurl
 # for Debian support
-Requires:       python3-debian
+Requires:       python3-debian >= 0.1.44
 %if 0%{?pylint_check}
 BuildRequires:  spacewalk-python3-pylint
 %endif


### PR DESCRIPTION
## What does this PR change?

Only new version of python3-debian support compression algorithms which are required by some Ubuntu 22.04 packages.
We released this already, but as optional update. This PR enforce installing the new version on Uyuni.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **only dependency change**

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/19475

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
