### PR TITLE
Correct RuboCop error from navigation steps

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -530,10 +530,10 @@ end
 
 Then(/^I am logged in$/) do
   raise 'User is not logged in' unless find(:xpath, "//a[@href='/rhn/Logout.do']").visible?
-  text = "You have just created your first #{product} user. To finalize your installation please use the Setup Wizard"
+  # text = "You have just created your first #{product} user. To finalize your installation please use the Setup Wizard"
   # Workaround: Ignore the fact that the message is not shown
   # TODO: restore this as soon as the related issue is fixed: https://github.com/SUSE/spacewalk/issues/19369
-  #raise 'The welcome message is not shown' unless has_content?(text)
+  # raise 'The welcome message is not shown' unless has_content?(text)
 end
 
 Then(/^I should see an update in the list$/) do


### PR DESCRIPTION
## What does this PR change?

Correct Rubocop warning coming from a temporary fix

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks # 
4.3 https://github.com/SUSE/spacewalk/pull/19480


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
