### PR TITLE
Increase cron_expr varchar length in suseRecurringAction table

### DIFF
--- a/schema/spacewalk/common/tables/suseRecurringAction.sql
+++ b/schema/spacewalk/common/tables/suseRecurringAction.sql
@@ -19,7 +19,7 @@ CREATE TABLE suseRecurringAction
                     CONSTRAINT suse_recurring_action_id_pk PRIMARY KEY,
   target_type       VARCHAR(32) NOT NULL,
   name              VARCHAR(256) NOT NULL,
-  cron_expr         VARCHAR(32) NOT NULL,
+  cron_expr         VARCHAR(120) NOT NULL,
   minion_id         NUMERIC
                     CONSTRAINT suse_rec_action_minion_fk
                       REFERENCES suseMinionInfo(server_id)

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,6 @@
+- Increase cron_expr varchar length to 120 in suseRecurringAction
+  table (bsc#1205040)
+
 -------------------------------------------------------------------
 Fri Nov 18 15:03:27 CET 2022 - jgonzalez@suse.com
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.2-to-susemanager-schema-4.4.3/001-varchar-length-suseRecurringAction.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.2-to-susemanager-schema-4.4.3/001-varchar-length-suseRecurringAction.sql
@@ -1,0 +1,1 @@
+alter table suseRecurringAction alter column cron_expr type varchar(120);


### PR DESCRIPTION
## What does this PR change?

Increase `cron_expr` varchar length to 120 to match the length of `cron_expr` in rhnTaskoSchedule table.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: **Bug**

- [x] **DONE**

## Test coverage

- No tests: **Bug**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/19461

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
