### PR TITLE
QE: Add automated test for Task Engine Status

### DIFF
--- a/testsuite/features/secondary/srv_task_status_engine.feature
+++ b/testsuite/features/secondary/srv_task_status_engine.feature
@@ -22,7 +22,7 @@ Feature: Task Engine Status
     And I should see a "Last Execution Times" link in the left menu
     And I should see a "Runtime Status" link in the left menu
   
-  Scenario: Run a remote command on a minion to have and check if it shows up on Last Execution Times page
+  Scenario: Run a remote command on the server to have and check if it shows up on Last Execution Times page
     When I follow the left menu "Admin > Task Engine Status > Last Execution Times"
     And I run "cobbler sync" on "server"
     And I refresh the page
@@ -30,7 +30,7 @@ Feature: Task Engine Status
     And I should see the correct timestamp for task "Cobbler Sync:"
     And I should see a "FINISHED" text
 
-  Scenario: Resync a product to trigger a new tast and check if it is visible on the Runtime Status page
+  Scenario: Resync a product to trigger a new task and check if it is visible on the Runtime Status page
     When I follow the left menu "Admin > Task Engine Status > Runtime Status"
     And I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text

--- a/testsuite/features/secondary/srv_task_status_engine.feature
+++ b/testsuite/features/secondary/srv_task_status_engine.feature
@@ -1,0 +1,46 @@
+# Copyright (c) 2022 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Task Engine Status
+
+  Scenario: Login as admin
+    Given I am authorized for the "Admin" section
+    
+  Scenario: Check if the Task Engine Status page exists
+    When I follow the left menu "Admin > Task Engine Status > Last Execution Times"
+    Then I should see a "Task Engine Status" text
+    And I should see a "The following is a status report for the various tasks run by the Uyuni task engine:" text
+    And I should see a "Runtime Status" text
+    And I should see a "Last Execution Times" link in the left menu
+    And I should see a "Runtime Status" link in the left menu
+
+  Scenario: Check if the Runtime Status Page exists
+    When I follow the left menu "Admin > Task Engine Status > Runtime Status"
+    Then I should see a "Task Engine Status" text
+    And I should see a "Last Execution Times" text
+    And I should see a "The server is running or has finished executing the following tasks during the latest 5 minutes." text
+    And I should see a "Last Execution Times" link in the left menu
+    And I should see a "Runtime Status" link in the left menu
+  
+  Scenario: Run a remote command on a minion to have and check if it shows up on Last Execution Times page
+    When I follow the left menu "Admin > Task Engine Status > Last Execution Times"
+    And I run "cobbler sync" on "server"
+    And I refresh the page
+    Then I should see a "Cobbler Sync:" text
+    And I should see the correct timestamp for task "Cobbler Sync:"
+    And I should see a "FINISHED" text
+
+  Scenario: Resync a product to trigger a new tast and check if it is visible on the Runtime Status page
+    When I follow the left menu "Admin > Task Engine Status > Runtime Status"
+    And I follow the left menu "Admin > Setup Wizard > Products"
+    And I wait until I do not see "Loading" text
+    And I enter "SUSE Linux Enterprise Server 15 SP4 x86_64" as "product-description-filter"
+    And I wait until I see "SUSE Linux Enterprise Server 15 SP4 x86_64" text
+    Then I should see the "SUSE Linux Enterprise Server 15 SP4 x86_64" selected
+    When I click on "Schedule channels product resync"
+    And I follow the left menu "Admin > Task Engine Status > Runtime Status"
+    And I wait until I see "repo-sync" text
+    Then I should see the correct timestamp for task "repo-sync"
+    And I should see a "running" text in the content area
+    And I wait until I see "finished" text
+    And I should see the correct timestamp for task "repo-sync"

--- a/testsuite/features/secondary/srv_task_status_engine.feature
+++ b/testsuite/features/secondary/srv_task_status_engine.feature
@@ -22,7 +22,7 @@ Feature: Task Engine Status
     And I should see a "Last Execution Times" link in the left menu
     And I should see a "Runtime Status" link in the left menu
   
-  Scenario: Run a remote command on the server to have and check if it shows up on Last Execution Times page
+  Scenario: Run a remote command on the server to check if it shows up on Last Execution Times page
     When I follow the left menu "Admin > Task Engine Status > Last Execution Times"
     And I run "cobbler sync" on "server"
     And I refresh the page

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -1120,10 +1120,8 @@ Then(/^I should see the correct timestamp for task "([^"]*)"/) do |task_name|
     page.find_all(:xpath, "//table[@class='table table-responsive']//td").each do |td|
       # if a text matching the format xx:xx is found, get and save the text
       next unless td.text.match(/\d{2}:\d{2}/)
-      if td.text.match(/\d{2}:\d{2}/)
-        # Text from cell, parsed to a Time object must match now +- 5 seconds
-        Time.parse(td.text).to_i.between?(now.to_i - 5, now.to_i + 5)
-      end
+      # Text from cell, parsed to a Time object must match now +- 5 seconds
+      Time.parse(td.text).to_i.between?(now.to_i - 5, now.to_i + 5)
     end
   end
 end

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -1109,3 +1109,21 @@ end
 Then(/^I should see the text "(.*?)" in the (Operating System|Architecture|Channel Label) field/) do |text, field|
   page.has_field?(text, with: field)
 end
+
+Then(/^I should see the correct timestamp for task "([^"]*)"/) do |task_name|
+  now = Time.now
+  execute_script 'window.stop()'
+  # find row with corresponding task name
+  page.find_all(:xpath, "//table[@class='table table-responsive']//tr").each do |tr|
+    next unless tr.has_text?(task_name)
+    # if task name is found, iterate through the columns to find the timestamp
+    page.find_all(:xpath, "//table[@class='table table-responsive']//td").each do |td|
+      # if a text matching the format xx:xx is found, get and save the text
+      next unless td.text.match(/\d{2}:\d{2}/)
+      if td.text.match(/\d{2}:\d{2}/)
+        # Text from cell, parsed to a Time object must match now +- 5 seconds
+        Time.parse(td.text).to_i.between?(now.to_i - 5, now.to_i + 5)
+      end
+    end
+  end
+end

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -38,6 +38,7 @@
 - features/secondary/srv_push_package.feature
 - features/secondary/srv_reportdb.feature
 - features/secondary/srv_dist_channel_mapping.feature
+- features/secondary/srv_task_status_engine.feature
 
 - features/secondary/proxy_retail_pxeboot_and_mass_import.feature
 - features/secondary/allcli_overview_systems_details.feature


### PR DESCRIPTION
## What does this PR change?

Add automated test for Task Engine Status Page

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were added

- [x] **DONE**

## Links

Partially Fixes [#10287](https://github.com/SUSE/spacewalk/issues/10287)
Master 4.2 https://github.com/SUSE/spacewalk/pull/19630
Master 4.3 https://github.com/SUSE/spacewalk/pull/19628

- [x] **DONE**

## Changelogs

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
