### PR TITLE
CI: check if the sync was successful

### DIFF
--- a/susemanager-utils/testing/automation/wait-for-syncs.sh
+++ b/susemanager-utils/testing/automation/wait-for-syncs.sh
@@ -59,9 +59,14 @@ i=0
 rm -f sync-started
 echo "Waiting for the sync to end"
 while [ ${i} -lt ${tries} ]; do
-  wget -S http://${host}/sync-obs/sync-finished 2>/dev/null
+  wget -S http://${host}/sync-obs/sync-finished.successful 2>/dev/null
   if [ ${?} -eq 0 ];then
-    echo "Sync finished"
+    echo "Sync finished successfully"
+    break
+  fi
+  wget -S http://${host}/sync-obs/sync-finished.fail 2>/dev/null
+  if [ ${?} -eq 0 ];then
+    echo "Sync finished unsuccesfully"
     break
   fi
   i=$((${i}+1))
@@ -71,6 +76,13 @@ if [ ${i} -eq ${tries} ]; then
   echo "Reached max number of tries"
   exit -5
 fi
+if [ -f sync-finished.fail ];then
+    rm -f sync-finished.fail
+    exit -6
+else
+    rm -f sync-finished.successful
+    exit 0
+fi
 
-rm -f sync-finished
+
 


### PR DESCRIPTION
## What does this PR change?

Make the wait-for-sync script to return an exit code if the sync was not successful

## GUI diff

No difference.


- [X] **DONE**

## Documentation
- No documentation needed: this is for the CI

- [X] **DONE**

## Test coverage
- No tests: this is for the CI

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19246


- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
