### PR TITLE
Uyuni-2022.10: Trigger fix of posible wrong "autoinstall" value from Cobbler collections (bsc#1203478)

### DIFF
--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,5 @@
+- Fix possible wrong autoinstall value from Cobbler collections (bsc#1203478)
+
 -------------------------------------------------------------------
 Fri Nov 04 17:14:50 CET 2022 - jgonzalez@suse.com
 

--- a/spacewalk/setup/spacewalk-setup.spec
+++ b/spacewalk/setup/spacewalk-setup.spec
@@ -278,6 +278,14 @@ if [ ! -f /etc/cobbler/settings.rpmsave -a -f /etc/cobbler/settings.before-migra
     touch /var/lib/cobbler/v2_migration_done
 fi
 
+# Wrong execution of v2 script happened, so we fix autoinstall attribute of collections.
+if test -f /var/lib/cobbler/v2_migration_done && ! grep -q autoinstall_fixed /var/lib/cobbler/v2_migration_done; then
+    echo "* Check and fix autoinstall attributes from Cobbler collections"
+    echo "  (a backup of the collections will be created at /var/lib/cobbler/)"
+    /usr/share/cobbler/bin/migrate-data-v2-to-v3.py -c /var/lib/cobbler/collections --only-fix-autoinstall || exit 1
+    echo "autoinstall_fixed" >> /var/lib/cobbler/v2_migration_done
+fi
+
 exit 0
 
 %check


### PR DESCRIPTION
## What does this PR change?

This PR, together with [1], should make `spacewalk-setup` to fix the possible wrong `autoinstall` attribute from Cobbler collections caused by the failing v2-to-v3 collection migration that was executed.

In case `spacewalk-setup` notices the v2-to-v3 migration was executed, then it will trigger a new command to fix the possible inconsistencies for "autoinstall" in the stored collections:

```
# /usr/share/cobbler/bin/migrate-data-v2-to-v3.py -c /var/lib/cobbler/collections --only-fix-autoinstall
```

This command will only take care of migrating and fixing the `autoinstall` attribute from the stored collections. In cases where automatic migration of "autoinstall" is not possible, the script will warn the user to manually fix it.user 

[1] https://build.opensuse.org/request/show/1035233

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **tested manually**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/19357

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
