### PR TITLE
CI: Fix again wait for build script

### DIFF
--- a/susemanager-utils/testing/automation/wait-for-builds.sh
+++ b/susemanager-utils/testing/automation/wait-for-builds.sh
@@ -12,7 +12,7 @@ lock="yes"
 osc_timeout="2h"
 extres=""
 
-while getopts ":a:c:p:u:r:x" o;do
+while getopts ":a:c:p:ur:x:" o;do
     case "${o}" in
         a)
             api=${OPTARG}


### PR DESCRIPTION
## What does this PR change?

I did a mistake in the syntax of getops...

## GUI diff

No difference.



- [ ] **DONE**

## Documentation
- No documentation needed

- [ ] **DONE**

## Test coverage
- No tests

- [ ] **DONE**



## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
