### PR TITLE
Enable source package syncing for the whole feature

### DIFF
--- a/testsuite/features/core/srv_create_repository.feature
+++ b/testsuite/features/core/srv_create_repository.feature
@@ -9,6 +9,7 @@ Feature: Add a repository to a channel
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
+    And I enable source package syncing
 
   Scenario: Add a test repository for x86_64
     When I follow the left menu "Software > Manage > Repositories"
@@ -39,8 +40,7 @@ Feature: Add a repository to a channel
     Then I should see a "Test-Channel-x86_64 repository information was successfully updated" text
 
   Scenario: Synchronize the repository in the x86_64 channel
-    When I enable source package syncing
-    And I follow the left menu "Software > Manage > Channels"
+    When I follow the left menu "Software > Manage > Channels"
     And I follow "Test-Channel-x86_64"
     And I follow "Repositories" in the content area
     And I follow "Sync"
@@ -48,7 +48,6 @@ Feature: Add a repository to a channel
     And I click on "Sync Now"
     Then I should see a "Repository sync scheduled for Test-Channel-x86_64." text
     And I wait until the channel "test-channel-x86_64" has been synced
-    And I disable source package syncing
 
   Scenario: Add a test repository for i586
     When I follow the left menu "Software > Manage > Repositories"
@@ -136,3 +135,6 @@ Feature: Add a repository to a channel
     And I follow "Test-Channel-Deb-AMD64"
     And I follow "Packages" in the content area
     And I wait until I see "blackhole-dummy" text, refreshing the page
+
+  Scenario: Cleanup disable source package syncing
+    Then I disable source package syncing


### PR DESCRIPTION
## What does this PR change?

prevent race conditions that other channels are still synced while we expect source packages been synced for Test-Channel-x86_64

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/19521 https://github.com/SUSE/spacewalk/pull/19522

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
