### PR TITLE
Do not execute actions on minion that are not in pending status

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -1043,6 +1043,12 @@ public class ActionFactory extends HibernateFactory {
             lookupActionStatusByName("Failed");
 
     /**
+     * All the possible action statuses
+     */
+    public static final List<ActionStatus> ALL_STATUSES = List.of(STATUS_QUEUED, STATUS_PICKED_UP, STATUS_COMPLETED,
+        STATUS_FAILED);
+
+    /**
      * The constant representing Package Refresh List action.  [ID:1]
      */
     public static final ActionType TYPE_PACKAGES_REFRESH_LIST =

--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -668,12 +668,20 @@ select {ra.*}
 
     <query name="Action.findMinionSummaries">
     <![CDATA[
-        SELECT sa.server.id, s.minionId, s.digitalServerId, s.machineId, c.label, s.os
+        SELECT new com.redhat.rhn.domain.server.MinionSummary(
+                    sa.server.id,
+                    s.minionId,
+                    s.digitalServerId,
+                    s.machineId,
+                    c.label,
+                    s.os
+               )
             FROM ServerAction AS sa
                 JOIN sa.server AS s
                 JOIN s.contactMethod AS c
             WHERE type(s) = com.redhat.rhn.domain.server.MinionServer
                 AND action_id = :id
+                AND sa.status IN (:allowedStatues)
     ]]>
     </query>
     

--- a/java/code/src/com/redhat/rhn/domain/action/test/ActionFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/test/ActionFactoryTest.java
@@ -22,6 +22,7 @@ import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.util.test.TimeUtilsTest;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
+import com.redhat.rhn.domain.action.ActionStatus;
 import com.redhat.rhn.domain.action.ActionType;
 import com.redhat.rhn.domain.action.config.ConfigAction;
 import com.redhat.rhn.domain.action.config.ConfigDateDetails;
@@ -581,12 +582,21 @@ public class ActionFactoryTest extends RhnBaseTestCase {
      * @param newS new system
      * @param newA new action
      * @return ServerAction created
-     * @throws Exception something bad happened
      */
-    public static ServerAction createServerAction(Server newS, Action newA)
-        throws Exception {
+    public static ServerAction createServerAction(Server newS, Action newA) {
+        return createServerAction(newS, newA, ActionFactory.STATUS_QUEUED);
+    }
+
+    /**
+     * Create a new ServerAction
+     * @param newS new system
+     * @param newA new action
+     * @param status the status
+     * @return ServerAction created
+     */
+    public static ServerAction createServerAction(Server newS, Action newA, ActionStatus status) {
         ServerAction sa = new ServerAction();
-        sa.setStatus(ActionFactory.STATUS_QUEUED);
+        sa.setStatus(status);
         sa.setRemainingTries(10L);
         sa.setCreated(new Date());
         sa.setModified(new Date());

--- a/java/code/src/com/redhat/rhn/domain/server/MinionServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServerFactory.java
@@ -18,6 +18,8 @@ import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.domain.action.ActionFactory;
+import com.redhat.rhn.domain.action.ActionStatus;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
@@ -28,6 +30,7 @@ import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
+import org.hibernate.query.Query;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -197,29 +200,44 @@ public class MinionServerFactory extends HibernateFactory {
    }
 
     /**
-     * Retrieve a summary of the minions involved in one Action.
+     * Retrieve a summary of all the minions involved in one Action.
      *
      * @param actionId the Action id
      * @return a list minion summaries of the minions involved in the given Action
      */
-    @SuppressWarnings("unchecked")
-    public static List<MinionSummary> findMinionSummaries(Long actionId) {
-        return ((List<Object[]>) HibernateFactory.getSession()
-                .getNamedQuery("Action.findMinionSummaries")
-                .setParameter("id", actionId)
-                .getResultList()).stream()
-                .map(row -> new MinionSummary(
-                        (Long)row[0],
-                        row[1].toString(),
-                        row[2].toString(),
-                        row[3].toString(),
-                        Optional.ofNullable(row[4].toString()),
-                        row[5].toString()))
-                .collect(toList());
+    public static List<MinionSummary> findAllMinionSummaries(Long actionId) {
+        return findMinionSummariesInStatus(actionId, ActionFactory.ALL_STATUSES);
     }
 
     /**
-     * Find all minions by a their server ids.
+     * Retrieve a summary of the minions involved in one Action that are in the queued status.
+     *
+     * @param actionId the Action id
+     * @return a list minion summaries of the minions involved in the given Action with the queued status
+     */
+    public static List<MinionSummary> findQueuedMinionSummaries(Long actionId) {
+        return findMinionSummariesInStatus(actionId, List.of(ActionFactory.STATUS_QUEUED));
+    }
+
+    /**
+     * Retrieve a summary of the minions involved in one Action that are in one of the specified statuses
+     *
+     * @param actionId the Action id
+     * @param allowedStatues the list of status to filter the minions
+     * @return a list minion summaries of the minions involved in the given Action in one of the specified statuses
+     */
+    private static List<MinionSummary> findMinionSummariesInStatus(Long actionId, List<ActionStatus> allowedStatues) {
+        Session session = HibernateFactory.getSession();
+
+        Query<MinionSummary> query = session.createNamedQuery("Action.findMinionSummaries", MinionSummary.class)
+                                            .setParameter("id", actionId)
+                                            .setParameter("allowedStatues", allowedStatues);
+
+        return query.getResultList();
+    }
+
+    /**
+     * Find all minions by their server ids.
      *
      * @param serverIds the list of server ids
      * @return a list of minions

--- a/java/code/src/com/redhat/rhn/domain/server/MinionSummary.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionSummary.java
@@ -15,25 +15,22 @@
 package com.redhat.rhn.domain.server;
 
 import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
-import com.suse.utils.Opt;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-
-import java.util.Optional;
 
 /**
  * This class represents a summary of a minion.
  */
 public class MinionSummary {
 
-    private Long serverId;
-    private String minionId;
-    private String digitalServerId;
-    private String machineId;
-    private String os;
-    private Optional<String> contactMethodLabel;
-    private Boolean transactionalUpdate;
+    private final Long serverId;
+    private final String minionId;
+    private final String digitalServerId;
+    private final String machineId;
+    private final String os;
+    private final String contactMethodLabel;
+    private final boolean transactionalUpdate;
 
     /**
      * Convenience constructor from a MinionServer instance.
@@ -42,7 +39,7 @@ public class MinionSummary {
      */
     public MinionSummary(MinionServer minion) {
         this(minion.getId(), minion.getMinionId(), minion.getDigitalServerId(),
-                minion.getMachineId(), minion.getContactMethodLabel(), minion.getOs(),
+                minion.getMachineId(), minion.getContactMethodLabel().orElse(null), minion.getOs(),
                 minion.doesOsSupportsTransactionalUpdate());
     }
 
@@ -57,9 +54,9 @@ public class MinionSummary {
      * @param osIn the minion os
      */
     public MinionSummary(Long serverIdIn, String minionIdIn, String digitalServerIdIn, String machineIdIn,
-            Optional<String> contactMethodLabelIn, String osIn) {
+            String contactMethodLabelIn, String osIn) {
         this(serverIdIn, minionIdIn, digitalServerIdIn, machineIdIn, contactMethodLabelIn, osIn,
-                ServerConstants.SLEMICRO.equals(osIn) ? true : false);
+            ServerConstants.SLEMICRO.equals(osIn));
     }
 
     /**
@@ -75,7 +72,7 @@ public class MinionSummary {
 
      */
     public MinionSummary(Long serverIdIn, String minionIdIn, String digitalServerIdIn, String machineIdIn,
-            Optional<String> contactMethodLabelIn, String osIn, Boolean transactionalUpdateIn) {
+            String contactMethodLabelIn, String osIn, boolean transactionalUpdateIn) {
         this.serverId = serverIdIn;
         this.minionId = minionIdIn;
         this.digitalServerId = digitalServerIdIn;
@@ -86,9 +83,9 @@ public class MinionSummary {
     }
 
     /**
-     * @return true is minion is transactiona update
+     * @return true is minion is transactional update
      */
-    public Boolean isTransactionalUpdate() {
+    public boolean isTransactionalUpdate() {
         return transactionalUpdate;
     }
 
@@ -132,7 +129,11 @@ public class MinionSummary {
      * @return true if the minion contact method is ssh-push
      */
     public boolean isSshPush() {
-        return Opt.fold(contactMethodLabel, () -> false, ContactMethodUtil::isSSHPushContactMethod);
+        if (contactMethodLabel == null) {
+            return false;
+        }
+
+        return ContactMethodUtil.isSSHPushContactMethod(contactMethodLabel);
     }
 
     @Override

--- a/java/code/src/com/redhat/rhn/domain/server/test/MinionServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/MinionServerFactoryTest.java
@@ -17,8 +17,13 @@ package com.redhat.rhn.domain.server.test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.redhat.rhn.domain.action.Action;
+import com.redhat.rhn.domain.action.ActionFactory;
+import com.redhat.rhn.domain.action.server.ServerAction;
+import com.redhat.rhn.domain.action.test.ActionFactoryTest;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
+import com.redhat.rhn.domain.server.MinionSummary;
 import com.redhat.rhn.domain.server.ServerConstants;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.user.User;
@@ -26,8 +31,12 @@ import com.redhat.rhn.testing.BaseTestCaseWithUser;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * MinionServerFactoryTest
@@ -40,10 +49,8 @@ public class MinionServerFactoryTest extends BaseTestCaseWithUser {
     @Test
     public void testFindByMachineId() throws Exception {
         MinionServer minionServer = createTestMinionServer(user);
-        Optional<MinionServer> minion = MinionServerFactory
-                .findByMachineId(minionServer.getMachineId());
-        assertTrue(minion.isPresent());
-        assertEquals(minionServer, minion.get());
+        Optional<MinionServer> minion = MinionServerFactory.findByMachineId(minionServer.getMachineId());
+        assertEquals(minionServer, minion.orElse(null));
     }
 
     /**
@@ -52,10 +59,8 @@ public class MinionServerFactoryTest extends BaseTestCaseWithUser {
     @Test
     public void testFindByMinionId() throws Exception {
         MinionServer minionServer = createTestMinionServer(user);
-        Optional<MinionServer> minion = MinionServerFactory
-                .findByMinionId(minionServer.getMinionId());
-        assertTrue(minion.isPresent());
-        assertEquals(minionServer, minion.get());
+        Optional<MinionServer> minion = MinionServerFactory.findByMinionId(minionServer.getMinionId());
+        assertEquals(minionServer, minion.orElse(null));
     }
 
     /**
@@ -74,10 +79,8 @@ public class MinionServerFactoryTest extends BaseTestCaseWithUser {
     @Test
     public void testLookupById() throws Exception {
         MinionServer minionServer = createTestMinionServer(user);
-        Optional<MinionServer> minion = MinionServerFactory
-                .lookupById(minionServer.getId());
-        assertTrue(minion.isPresent());
-        assertEquals(minionServer, minion.get());
+        Optional<MinionServer> minion = MinionServerFactory.lookupById(minionServer.getId());
+        assertEquals(minionServer, minion.orElse(null));
     }
 
     @Test
@@ -91,11 +94,41 @@ public class MinionServerFactoryTest extends BaseTestCaseWithUser {
         assertEquals("ssh-push", minions.stream()
                 .filter(m -> m.getId().equals(minionServer1.getId()))
                 .map(m -> minionServer1.getContactMethod().getLabel())
-                .findFirst().get());
+                .findFirst().orElse(null));
         assertEquals("ssh-push-tunnel", minions.stream()
                 .filter(m -> m.getId().equals(minionServer2.getId()))
                 .map(m -> minionServer2.getContactMethod().getLabel())
-                .findFirst().get());
+                .findFirst().orElse(null));
+    }
+    @Test
+    public void testListMinionsByActions() throws Exception {
+        MinionServer minion1 = createTestMinionServer(user);
+        MinionServer minion2 = createTestMinionServer(user);
+        MinionServer minion3 = createTestMinionServer(user);
+
+        Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_REBOOT);
+
+        ServerAction failed = ActionFactoryTest.createServerAction(minion1, action, ActionFactory.STATUS_FAILED);
+        ServerAction completed = ActionFactoryTest.createServerAction(minion2, action, ActionFactory.STATUS_COMPLETED);
+        ServerAction queued = ActionFactoryTest.createServerAction(minion3, action, ActionFactory.STATUS_QUEUED);
+
+        action.setServerActions(new HashSet<>(Set.of(failed, completed, queued)));
+
+        List<MinionSummary> allSummariesExpected = Stream.of(minion1, minion2, minion3)
+                                                         .map(MinionSummary::new)
+                                                         .collect(Collectors.toList());
+        List<MinionSummary> allSummariesActual = MinionServerFactory.findAllMinionSummaries(action.getId());
+
+        assertEquals(allSummariesExpected.size(), allSummariesActual.size());
+        assertTrue(allSummariesExpected.containsAll(allSummariesActual));
+        assertTrue(allSummariesActual.containsAll(allSummariesExpected));
+
+        List<MinionSummary> queuedSummariesExpected = List.of(new MinionSummary(minion3));
+        List<MinionSummary> queuedSummariesActual = MinionServerFactory.findQueuedMinionSummaries(action.getId());
+
+        assertEquals(queuedSummariesExpected.size(), queuedSummariesActual.size());
+        assertTrue(queuedSummariesExpected.containsAll(queuedSummariesActual));
+        assertTrue(queuedSummariesActual.containsAll(queuedSummariesExpected));
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/action/MinionActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/MinionActionManager.java
@@ -100,7 +100,7 @@ public class MinionActionManager {
 
             if (org.getOrgConfig().isStagingContentEnabled()) {
 
-             List<MinionSummary> minionSummaries = MinionServerFactory.findMinionSummaries(action.getId());
+             List<MinionSummary> minionSummaries = MinionServerFactory.findAllMinionSummaries(action.getId());
 
             ZonedDateTime earliestAction =
                     action.getEarliestAction().toInstant().atZone(ZoneId.systemDefault());

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -275,7 +275,7 @@ public class SaltServerActionService {
      * @return map of Salt local call to list of targeted minion summaries
      */
     public Map<LocalCall<?>, List<MinionSummary>> callsForAction(Action actionIn) {
-        List<MinionSummary> minionSummaries = MinionServerFactory.findMinionSummaries(actionIn.getId());
+        List<MinionSummary> minionSummaries = MinionServerFactory.findAllMinionSummaries(actionIn.getId());
         return callsForAction(actionIn, minionSummaries);
     }
 
@@ -483,7 +483,7 @@ public class SaltServerActionService {
     public void execute(Action actionIn, boolean forcePackageListRefresh,
             boolean isStagingJob, Optional<Long> stagingJobMinionServerId) {
 
-        List<MinionSummary> allMinions = MinionServerFactory.findMinionSummaries(actionIn.getId());
+        List<MinionSummary> allMinions = MinionServerFactory.findQueuedMinionSummaries(actionIn.getId());
 
         // split minions into regular and salt-ssh
         Map<Boolean, List<MinionSummary>> partitionBySSHPush = allMinions.stream()
@@ -840,7 +840,7 @@ public class SaltServerActionService {
                 .sorted(Comparator.comparingInt(ActionChainEntry::getSortOrder))
                 .map(ActionChainEntry::getAction)
                 .forEach(actionIn -> {
-                    List<MinionSummary> minions = MinionServerFactory.findMinionSummaries(actionIn.getId());
+                    List<MinionSummary> minions = MinionServerFactory.findAllMinionSummaries(actionIn.getId());
 
                     if (minions.isEmpty()) {
                         // When an Action Chain contains an Action which does not target

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -97,6 +97,8 @@ import com.suse.salt.netapi.utils.Xor;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
 import org.jmock.Expectations;
 import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.junit.jupiter.api.BeforeEach;
@@ -115,6 +117,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -126,7 +129,6 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
     private MinionServer minion;
     private SaltServerActionService saltServerActionService;
     private SystemEntitlementManager systemEntitlementManager;
-    private ServerGroupManager serverGroupManager;
     private TaskomaticApi taskomaticMock;
 
     @Override
@@ -153,7 +155,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         minion = MinionServerFactoryTest.createTestMinionServer(user);
         saltServerActionService = createSaltServerActionService(saltService, saltService);
         MonitoringManager monitoringManager = new FormulaMonitoringManager(saltService);
-        serverGroupManager = new ServerGroupManager(saltService);
+        ServerGroupManager serverGroupManager = new ServerGroupManager(saltService);
         systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
                 new SystemEntitler(saltService, virtManager, monitoringManager, serverGroupManager)
@@ -1078,14 +1080,38 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
 
     }
 
-    private void assertActionWillBeRetried() throws Exception {
-        Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_SCRIPT_RUN);
-        ServerAction serverAction = createChildServerAction(action, STATUS_QUEUED, 5L);
+    @Test
+    public void testDoNotReExecuteDoneActions() throws Exception {
+        MinionServer firstMinion = MinionServerFactoryTest.createTestMinionServer(user);
+        MinionServer secondMinion = MinionServerFactoryTest.createTestMinionServer(user);
 
-        saltServerActionService.executeSSHAction(action, minion);
+        Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_REBOOT);
 
-        assertEquals(Long.valueOf(4L), serverAction.getRemainingTries());
-        assertEquals(STATUS_QUEUED, serverAction.getStatus());
+        createChildServerAction(action, STATUS_COMPLETED, firstMinion, 5L);
+        createChildServerAction(action, STATUS_QUEUED, secondMinion, 5L);
+
+        HibernateFactory.getSession().flush();
+
+        SaltService saltServiceMock = mock(SaltService.class);
+        SaltServerActionService testService = createSaltServerActionService(saltServiceMock, saltServiceMock);
+        testService.setTaskomaticApi(taskomaticMock);
+
+        context().checking(new Expectations() { {
+            oneOf(saltServiceMock).callAsync(
+                with(any(LocalCall.class)),
+                with((new MinionListMatcher(List.of(secondMinion.getMinionId())))),
+                with(any(Optional.class))
+            );
+            LocalAsyncResult<?> result = new LocalAsyncResult<>() {
+                @Override
+                public List<String> getMinions() {
+                    return List.of(secondMinion.getMinionId());
+                }
+            };
+            will(returnValue(Optional.of(result)));
+        } });
+
+        testService.execute(action, false, false, Optional.empty());
     }
 
     private void successWorker() throws IOException {
@@ -1128,5 +1154,45 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         assertStateApplyWithPillar("ansible.runplaybook", "playbook_path", "/path/to/myplaybook.yml", saltCall);
         assertStateApplyWithPillar("ansible.runplaybook", "rundir", "/path/to", saltCall);
         assertStateApplyWithPillar("ansible.runplaybook", "inventory_path", "/path/to/my/hosts", saltCall);
+    }
+
+    private static class MinionListMatcher extends BaseMatcher<MinionList> {
+
+        private final List<String> expectedMinionIds;
+
+        private MinionListMatcher(List<String> minionIds) {
+            this.expectedMinionIds = minionIds;
+        }
+
+        @Override
+        public boolean matches(Object actualValue) {
+            if (!(actualValue instanceof MinionList)) {
+                return false;
+            }
+
+            MinionList actualMinionList = (MinionList) actualValue;
+            return Objects.equals(expectedMinionIds, actualMinionList.getTarget());
+
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("MinionList").appendValue(this.expectedMinionIds);
+        }
+
+        @Override
+        public void describeMismatch(Object item, Description description) {
+            if (item instanceof MinionList) {
+                MinionList minionList = (MinionList) item;
+                description.appendText("was MinionList").appendValue(minionList.getTarget());
+            }
+            else {
+                description.appendText(" was not ")
+                           .appendText(MinionList.class.getName())
+                           .appendText(" but ")
+                           .appendText(item.getClass().getName())
+                           .appendValue(item);
+            }
+        }
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Run only minion actions that are in the pending status (bsc#1205012)
 - Fix ClassCastException
 - Migrate formulas with default values to database (bsc#1204932)
 - Improved reboot needed handling for transactional systems


### PR DESCRIPTION
## What does this PR change?

This PR make sure that an action is executed only on minions having a pending entry in the `ServerAction` table. Currently, if the user tries to reschedule the action on all the failed servers (through the web ui or the api), the taskomatic job actually executes the action on all of them. This is because the target minions were extracted without checking their action status.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19445
Tracks https://github.com/SUSE/spacewalk/pull/19529 https://github.com/SUSE/spacewalk/pull/19528

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
