### PR TITLE
CI: fix wait-for-sync

### DIFF
--- a/susemanager-utils/testing/automation/wait-for-syncs.sh
+++ b/susemanager-utils/testing/automation/wait-for-syncs.sh
@@ -38,6 +38,35 @@ if [ "${host}" == "" ]; then
     exit -3
 fi
 
+echo "Wait for last sync to finish"
+i=0
+echo "Waiting for the sync to end"
+while [ ${i} -lt ${tries} ]; do
+  wget -S http://${host}/sync-obs/sync-finished.successful 2>/dev/null
+  if [ ${?} -eq 0 ];then
+    echo "Previous sync finished successfully"
+    rm -f sync-finished.successful
+    break
+  fi
+  wget -S http://${host}/sync-obs/sync-finished.fail 2>/dev/null
+  if [ ${?} -eq 0 ];then
+    echo "Previous sync finished unsuccesfully"
+    rm -f sync-finished.fail
+    break
+  fi
+  i=$((${i}+1))
+  sleep ${wait}
+done
+if [ ${i} -eq ${tries} ]; then
+  echo "Reached max number of tries"
+  exit -7
+fi
+
+
+echo "Triggering a sync...this can take several minutes"
+curl http://${host}/cgi-bin/sync-obs.cgi
+
+
 echo "Wait for sync to start and finish"
 i=0
 echo "Waiting for the sync to start"


### PR DESCRIPTION


## What does this PR change?

Wait for sync should wait for the last sync to finish and then trigger a new sync. Otherwise, the job could start in the middle of a previous sync and we would not know, making the packages not being updated.



## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
