### PR TITLE
Fixed traditional stack warning message to be displayed only when the system has enterprise entitlement

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/servlets/SystemDetailsMessageFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/SystemDetailsMessageFilter.java
@@ -19,6 +19,7 @@ import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.frontend.struts.StrutsDelegate;
+import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.SystemManager;
 
 import org.apache.struts.Globals;
@@ -44,7 +45,7 @@ import javax.servlet.http.HttpServletRequest;
 public class SystemDetailsMessageFilter implements Filter {
 
     private static final String REBOOT_MESSAGE_KEY = "overview.jsp.transactionalupdate.reboot";
-    private static final String TRADITIONAL_STACK_MESSAGE_KEY = "overview.jsp.traditionalstack.deprecated";
+    public static final String TRADITIONAL_STACK_MESSAGE_KEY = "overview.jsp.traditionalstack.deprecated";
 
     @Override
     public void doFilter(
@@ -57,10 +58,22 @@ public class SystemDetailsMessageFilter implements Filter {
         RequestContext rctx = new RequestContext(req);
         Long sid = rctx.getRequiredParam("sid");
         User user = rctx.getCurrentUser();
-        Server s  = SystemManager.lookupByIdAndUser(sid, user);
-        s.asMinionServer().ifPresentOrElse(
+        Server s = SystemManager.lookupByIdAndUser(sid, user);
+        this.processSystemMessages(req, s);
+    }
+
+    /**
+     * Process a system and add the necessary warning messages for it if necessary
+     * @param req - the servlet request
+     * @param server - the system to be processed
+     */
+    public void processSystemMessages(HttpServletRequest req, Server server) {
+        server.asMinionServer().ifPresentOrElse(
             minion -> processMinionMessages(req, minion),
-            () -> addMessageIfNecessary(req, true, TRADITIONAL_STACK_MESSAGE_KEY)
+            () -> addMessageIfNecessary(req,
+                    server.getEntitlements().stream()
+                            .anyMatch(e -> e.getLabel().equals(EntitlementManager.ENTERPRISE_ENTITLED)),
+                    TRADITIONAL_STACK_MESSAGE_KEY)
         );
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/servlets/test/SystemDetailsMessageFilterTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/test/SystemDetailsMessageFilterTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.frontend.servlets.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
+import com.redhat.rhn.domain.server.test.ServerFactoryTest;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.servlets.SystemDetailsMessageFilter;
+import com.redhat.rhn.testing.MockObjectTestCase;
+import com.redhat.rhn.testing.RhnMockHttpServletRequest;
+import com.redhat.rhn.testing.UserTestUtils;
+
+import com.google.common.collect.Iterators;
+
+import org.apache.struts.action.ActionMessage;
+import org.apache.struts.action.ActionMessages;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class SystemDetailsMessageFilterTest extends MockObjectTestCase {
+    private User user;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        user = UserTestUtils.findNewUser("testUser", "testOrg" +
+                this.getClass().getSimpleName());
+    }
+
+    @Test
+    public void shouldAddTraditionalStackDeprecationMessage() throws Exception {
+        // The server is created as a traditional system (enterprise entitled)
+        Server server = ServerFactoryTest.createTestServer(user);
+        HttpServletRequest request = new RhnMockHttpServletRequest();
+        SystemDetailsMessageFilter filter = new SystemDetailsMessageFilter();
+        filter.processSystemMessages(request, server);
+        ActionMessages messages =
+                ((ActionMessages) request.getSession().getAttribute("org.apache.struts.action.ERROR"));
+        assertEquals(1, Iterators.size(messages.get(ActionMessages.GLOBAL_MESSAGE)));
+        ActionMessage message = (ActionMessage) messages.get(ActionMessages.GLOBAL_MESSAGE).next();
+        assertEquals(SystemDetailsMessageFilter.TRADITIONAL_STACK_MESSAGE_KEY, message.getKey());
+    }
+
+    @Test
+    public void shouldNotAddTraditionalStackDeprecationMessage() throws Exception {
+        // The server is created as a salt system (salt entitled)
+        MinionServer minionServer = MinionServerFactoryTest.createTestMinionServer(user);
+        HttpServletRequest request = new RhnMockHttpServletRequest();
+        SystemDetailsMessageFilter filter = new SystemDetailsMessageFilter();
+        filter.processSystemMessages(request, minionServer);
+        ActionMessages messages =
+                ((ActionMessages) request.getSession().getAttribute("org.apache.struts.action.ERROR"));
+        assertNull(messages);
+    }
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Fixed traditional stack warning message to be displayed only when the system
+  has enterprise entitlement (bsc#1205350)
 - Update jackson-databind version
 - adapt permissions of temporary ssh key directory
 - format results for package, errata and image build actions in


### PR DESCRIPTION
## What does this PR change?

It fixes the traditional stack deprecation warning message to be shown considering the entitlements of the system. It was only checking if the system was a salt minion, but there are some systems that are neither salt minions nor traditional ones, like containerized proxies.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19551

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
