### PR TITLE
Hardening suggestion: permissions for

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- adapt permissions of temporary ssh key directory
 - format results for package, errata and image build actions in
   system history similar to state apply results
 - Run only minion actions that are in the pending status (bsc#1205012)

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -713,7 +713,7 @@ chown tomcat:%{apache_group} /var/log/rhn/gatherer.log
 %dir %{_localstatedir}/lib/spacewalk
 %defattr(644,tomcat,tomcat,775)
 %attr(775, %{salt_user_group}, %{salt_user_group}) %dir %{serverdir}/susemanager/salt/salt_ssh
-%attr(775, %{salt_user_group}, %{salt_user_group}) %dir %{serverdir}/susemanager/salt/salt_ssh/temp_bootstrap_keys
+%attr(700, %{salt_user_group}, %{salt_user_group}) %dir %{serverdir}/susemanager/salt/salt_ssh/temp_bootstrap_keys
 %attr(775, root, tomcat) %dir %{serverdir}/tomcat/webapps
 %dir %{serverdir}/susemanager
 %dir %{serverdir}/susemanager/salt


### PR DESCRIPTION
## What does this PR change?

/srv/susemanager/salt/salt_ssh/temp_bootstrap_keys directory can be 0700 instead of 0755. In this directory SUMA will store ssh private key files and it will create them with 0700 permission, so the directory itself can have the same.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17695
Rebase of https://github.com/uyuni-project/uyuni/pull/4903
Tracks https://github.com/SUSE/spacewalk/pull/19556 https://github.com/SUSE/spacewalk/pull/19557

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
