### PR TITLE
Bump openSUSE to 15.4

### DIFF
--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -163,7 +163,7 @@ LABEL_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.3-Pool' => 'sle-prod
                           'debian-9-pool' => 'debian-9-pool-amd64',
                           'debian-10-pool' => 'debian-10-pool-amd64',
                           'debian-11-pool' => 'debian-11-pool-amd64',
-                          'openSUSE-Leap-15.3-Pool for aarch64' => 'opensuse-leap-15.3-pool-aarch64' }.freeze
+                          'openSUSE-Leap-15.4-Pool for aarch64' => 'opensuse-leap-15.4-pool-aarch64' }.freeze
 
 CHANNEL_TO_SYNC_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.3-Pool' => 'SUMA-43-PROXY-x86_64',
                                     'SLES12-SP4-Pool' => 'SLE-12-SP4-x86_64',
@@ -181,7 +181,7 @@ CHANNEL_TO_SYNC_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.3-Pool' =>
                                     'debian-9-pool' => 'debian9-amd64',
                                     'debian-10-pool' => 'debian10-amd64',
                                     'debian-11-pool' => 'debian11-amd64',
-                                    'openSUSE-Leap-15.3-Pool for aarch64' => 'openSUSE-Leap-15.3-aarch64' }.freeze
+                                    'openSUSE-Leap-15.4-Pool for aarch64' => 'openSUSE-Leap-15.4-aarch64' }.freeze
 
 PARENT_CHANNEL_TO_SYNC_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.3-Pool' => 'sle-product-suse-manager-proxy-4.3-pool-x86_64',
                                            'SLES12-SP4-Pool' => nil,
@@ -199,7 +199,7 @@ PARENT_CHANNEL_TO_SYNC_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.3-P
                                            'debian-9-pool' => 'debian-9-pool-amd64',
                                            'debian-10-pool' => 'debian-10-pool-amd64',
                                            'debian-11-pool' => 'debian-11-pool-amd64',
-                                           'openSUSE-Leap-15.3-Pool for aarch64' => nil }.freeze
+                                           'openSUSE-Leap-15.4-Pool for aarch64' => nil }.freeze
 
 PKGARCH_BY_CLIENT = { 'proxy' => 'x86_64',
                       'sle_minion' => 'x86_64',


### PR DESCRIPTION
## What does this PR change?

This PR fixes the constants for openSUSE 15.4 minion


## Links

Ports:
* 4.2: SUSE/spacewalk#19547
* 4.3: SUSE/spacewalk#19546


## Changelogs

- [x] No changelog needed
