### PR TITLE
Install new products with 'no-recommends' option (bsc#1204330)

### DIFF
--- a/susemanager-utils/susemanager-sls/src/states/product.py
+++ b/susemanager-utils/susemanager-sls/src/states/product.py
@@ -100,4 +100,4 @@ def all_installed(name, refresh=False, **kwargs):
         log.debug("All products are already installed. Nothing to do.")
         return ret
 
-    return __states__['pkg.installed'](name, pkgs=to_install)
+    return __states__['pkg.installed'](name, pkgs=to_install, no_recommends=True)

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Avoid installing recommended packages from assigned products (bsc#1204330)
 - Add beacon to check if a reboot is required in transactional systems
 - Manager reboot in transactional update action chain (bsc#1201476)
 - Fix kiwi inspect regexp to allow image names with "-" (bsc#1204541)


### PR DESCRIPTION
Add `--no-recommends` option when installing missing products via the `product` state.

See: https://bugzilla.suse.com/show_bug.cgi?id=1204330

Port of: https://github.com/SUSE/spacewalk/pull/19548

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
