### PR TITLE
do not try to get a mirror list when file url is used

### DIFF
--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -523,9 +523,12 @@ class ContentSource:
                         self.proxy_pass = zypper_cfg.get(section_name, 'proxy_password')
 
     def _get_mirror_list(self, repo, url):
-        mirrorlist_path = os.path.join(repo.root, 'mirrorlist.txt')
         returnlist = []
         content = []
+        if url.startswith('file:/'):
+            return returnlist
+
+        mirrorlist_path = os.path.join(repo.root, 'mirrorlist.txt')
         # If page not plaintext or xml, is not a valid mirrorlist or metalink,
         # so continue without it.
         proxies = get_proxies(self.proxy_url, self.proxy_user, self.proxy_pass)

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- do not fetch mirrorlist when a file url is given
 - Exclude invalid mirror urls for reposync (bsc#1203826)
 - require python3-debian version which support new compression
   methods to sync ubuntu22-04 repositories (bsc#1205212)


### PR DESCRIPTION
## What does this PR change?

```
2022/11/15 06:58:02 +02:00 Command: ['/usr/bin/spacewalk-repo-sync', '--channel', 'test-channel-i586', '--type', 'yum', '--non-interactive']
2022/11/15 06:58:02 +02:00 Sync of channel started.
ERROR: Failed to reach repo url: file:///srv/www/htdocs/pub/TestRepoRpmUpdates/ - No connection adapters were found for 'file:///srv/www/htdocs/pub/TestRepoRpmUpdates/'
```
The reason for this error is the GET request for a mirror list:

```
> /usr/lib/python3.6/site-packages/spacewalk/satellite_tools/repo_plugins/yum_src.py(536)_get_mirror_list()
-> webpage = requests.get(url, proxies=proxies, cert=cert, verify=verify)
(Pdb) url
'file:///srv/www/htdocs/pub/TestRepoRpmUpdates/'
(Pdb) proxies
{}
(Pdb) n
requests.exceptions.InvalidSchema: No connection adapters were found for 'file:///srv/www/htdocs/pub/TestRepoRpmUpdates/'
> /usr/lib/python3.6/site-packages/spacewalk/satellite_tools/repo_plugins/yum_src.py(536)_get_mirror_list()
-> webpage = requests.get(url, proxies=proxies, cert=cert, verify=verify)
```

As our testsuite search for errors in reposync logs this make the test fail.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/19554 https://github.com/SUSE/spacewalk/pull/19555

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
