### PR TITLE
make automatic channel selection for cloned channels configurable

### DIFF
--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -133,6 +133,8 @@ public class ConfigDefaults {
     private static final String COBBLER_NAME_SEPARATOR = "cobbler.name.separator";
     public static final String POWER_MANAGEMENT_TYPES = "java.power_management.types";
 
+    private static final String CLONED_CHANNEL_AUTO_SELECTION = "java.cloned_channel_auto_selection";
+
     private static final String COBBLER_BOOTSTRAP_KERNEL = "java.cobbler_bootstrap.kernel";
     private static final String COBBLER_BOOTSTRAP_INITRD = "java.cobbler_bootstrap.initrd";
     private static final String COBBLER_BOOTSTRAP_BREED = "java.cobbler_bootstrap.breed";
@@ -717,6 +719,14 @@ public class ConfigDefaults {
      */
     public String getCobblerBootstrapInitrd() {
         return Config.get().getString(COBBLER_BOOTSTRAP_INITRD);
+    }
+
+    /**
+     * @return return if cloned vendor channels should use automatic dependency
+     * selection
+     */
+    public boolean getClonedChannelAutoSelection() {
+        return Config.get().getBoolean(CLONED_CHANNEL_AUTO_SELECTION);
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- disable cloned vendor channel auto selection by default (bsc#1204186) 
+
 -------------------------------------------------------------------
 Fri Nov 18 15:14:35 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Disables the automatic channel selection for cloned vendor channels by default for now until better default behavior has been implemented. The selection can be reenabled with a config setting.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19248

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
