### PR TITLE
Handle ZERO RETURN better in rhn/SSL (bsc#1204032)

### DIFF
--- a/python/rhn/SSL.py
+++ b/python/rhn/SSL.py
@@ -303,6 +303,8 @@ class SSLSocket:
 
             try:
                 data = self._connection.recv(bufsize)
+                if len(data) == 0:
+                    break
                 self._buffer = self._buffer + data
             except SSL.SSLError as err:
                 if err.args[0] == SSL.SSL_ERROR_ZERO_RETURN:

--- a/python/rhn/rhnlib.changes
+++ b/python/rhn/rhnlib.changes
@@ -1,3 +1,5 @@
+- Don't get stuck at the end of SSL transfers (bsc#1204032)
+
 -------------------------------------------------------------------
 Wed Sep 28 11:06:09 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Ensure that `readline()` stops when no data was received.

Apparently an SSL_ERROR_ZERO_RETURN is not always raised when there is no data. We saw this happening on a SLE12 SP5 client running Python 2.7.

Co-authored-by:  Victor Zhestkov <vzhestkov@gmail.com>

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: The behavior is hard to reproduce, we only saw it for a traditional SLE12 SP5 client. There are no existing tests that could extended without a lot of effort.

- [x] **DONE**

## Links

Internal tracker: https://github.com/SUSE/spacewalk/issues/19188
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
