### PR TITLE
Fix jackson-databind version in ivy config

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -47,7 +47,7 @@
         <dependency org="suse" name="ical4j" rev="3.0.18" />
         <dependency org="suse" name="jackson-annotations" rev="2.13.0" />
         <dependency org="suse" name="jackson-core" rev="2.13.0" />
-        <dependency org="suse" name="jackson-databind" rev="2.13.0" />
+        <dependency org="suse" name="jackson-databind" rev="2.13.4.2" />
         <dependency org="suse" name="jade4j" rev="1.2.7" />
         <dependency org="suse" name="jakarta-persistence-api" rev="2.2.2" />
         <dependency org="suse" name="java-saml" rev="2.4.0" />

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Update jackson-databind version
 - adapt permissions of temporary ssh key directory
 - format results for package, errata and image build actions in
   system history similar to state apply results


### PR DESCRIPTION
## What does this PR change?

Sync `jackson-databind` version in ivy config with the package version.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered
- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
