### PR TITLE
Fix contents of certificates show up on web UI logs

### DIFF
--- a/java/code/src/com/suse/manager/api/LoggingInvocationProcessor.java
+++ b/java/code/src/com/suse/manager/api/LoggingInvocationProcessor.java
@@ -66,7 +66,7 @@ public abstract class LoggingInvocationProcessor {
         RESTRICTED_ARGS.put(
             "proxy.container_config",
             Map.of(
-                6, "caCrt",
+                6, "caCertificate",
                 7, "caKey",
                 8, "caPassword"
             )

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -122,6 +122,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -173,6 +174,12 @@ public class SaltService implements SystemQuery, SaltApi {
     public enum KeyStatus {
         ACCEPTED, DENIED, UNACCEPTED, REJECTED
     }
+
+    private static final String CA_CERT_REGEX =
+            "(?m)^-{3,}BEGIN CERTIFICATE-{3,}$(?s).*?^-{3,}END CERTIFICATE-{3,}$";
+    private static final String RSA_KEY_REGEX =
+            "(?m)^-{3,}BEGIN RSA PRIVATE KEY-{3,}$(?s).*?^-{3,}END RSA PRIVATE KEY-{3,}$";
+    private static final Pattern SENSITIVE_DATA_PATTERN = Pattern.compile(CA_CERT_REGEX + "|" + RSA_KEY_REGEX);
 
     /**
      * Default constructor
@@ -320,8 +327,24 @@ public class SaltService implements SystemQuery, SaltApi {
         return String.format("[%s.%s]", call.getModuleName(), call.getFunctionName());
     }
 
+    private static Map<String, Object> filterPayload(Map<String, Object> payload) {
+        var kwarg = payload.get("kwarg");
+        if (kwarg == null) {
+            return payload;
+        }
+        Function<Entry<?, ?>, Object> filterValue = e -> SENSITIVE_DATA_PATTERN
+                .matcher(e.getValue().toString()).find() ? "HIDDEN" : e.getValue();
+        var kwargFiltered = kwarg instanceof Map ?
+                ((Map<?, ?>) kwarg).entrySet().stream()
+                        .filter(e -> e.getValue() != null)
+                        .collect(Collectors.toMap(Entry::getKey, filterValue)) :
+                kwarg;
+        payload.put("kwarg", kwargFiltered);
+        return payload;
+    }
+
     private String runnerCallToString(RunnerCall<?> call) {
-        return String.format(PAYLOAD_CALL_TEMPLATE, call, call.getPayload());
+        return String.format(PAYLOAD_CALL_TEMPLATE, call.getModuleName(), filterPayload(call.getPayload()));
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/services/impl/test/service/ssh_cert_check.json
+++ b/java/code/src/com/suse/manager/webui/services/impl/test/service/ssh_cert_check.json
@@ -1,0 +1,5 @@
+{
+  "return": [
+    "\nPassed invalid arguments: 'NoneType' object does not support item assignment\n\nUsage:\n\n    Check that the provided certificates are valid and return the certificate and key to deploy.\n    "
+  ]
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Removed contents of certificates from the web UI logs (bsc#1204715)
 - Add SUSE Liberty Linux support for RHEL9 based clients
 - Don't persist the YAML parser in FormulaFactory (bsc#1205754)
 - check for NULL in DEB package install size value


### PR DESCRIPTION
## What does this PR change?

Fix contents of certificates show up on `web_ui` logs

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19395

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [x] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
