### PR TITLE
use correct https port when using ssh tunnel

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/channels.repo
+++ b/susemanager-utils/susemanager-sls/salt/channels/channels.repo
@@ -4,6 +4,10 @@
 {% for chan, args in pillar.get(pillar.get('_mgr_channels_items_name', 'channels'), {}).items() %}
 {%- set protocol = salt['pillar.get']('pkg_download_point_protocol', 'https')%}
 {%- set hostname = salt['pillar.get']('pkg_download_point_host', args['host'])%}
+
+{%- if salt['pillar.get']('contact_method') in ['ssh-push', 'ssh-push-tunnel'] %}
+{%- set port = salt['pillar.get']('ssh_push_port_https', args.get('port', 1233))%}
+{%- else %}
 {%- set port = salt['pillar.get']('pkg_download_point_port', args.get('port', 443))%}
 {%- if grains['os_family'] == 'Debian' %}
 {%- set apt_version = salt['pkg.version']("apt") %}

--- a/susemanager-utils/susemanager-sls/salt/channels/channels.repo
+++ b/susemanager-utils/susemanager-sls/salt/channels/channels.repo
@@ -5,7 +5,7 @@
 {%- set protocol = salt['pillar.get']('pkg_download_point_protocol', 'https')%}
 {%- set hostname = salt['pillar.get']('pkg_download_point_host', args['host'])%}
 
-{%- if salt['pillar.get']('contact_method') in ['ssh-push', 'ssh-push-tunnel'] %}
+{%- if salt['pillar.get']('contact_method') in ['ssh-push-tunnel'] %}
 {%- set port = salt['pillar.get']('ssh_push_port_https', args.get('port', 1233))%}
 {%- else %}
 {%- set port = salt['pillar.get']('pkg_download_point_port', args.get('port', 443))%}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- use correct https port when using ssh tunnel
 - Avoid installing recommended packages from assigned products (bsc#1204330)
 - Add beacon to check if a reboot is required in transactional systems
 - Manager reboot in transactional update action chain (bsc#1201476)


### PR DESCRIPTION
## What does this PR change?

Currently when a minion use contact method `Push via Salt SSH` (without an activation key) and some channels are subscribed, the `*repo` are set for using https port (443), instead they should use set in `ssh_push_port_https` (default 1233).

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
