### PR TITLE
QE: Fix checking for empty CLM in CLM test

### DIFF
--- a/testsuite/features/secondary/srv_content_lifecycle.feature
+++ b/testsuite/features/secondary/srv_content_lifecycle.feature
@@ -156,4 +156,4 @@ Feature: Content lifecycle
     And I follow "clp_name"
     And I click on "Delete"
     And I click on "Delete" in "Delete Project" modal
-    Then I should see a "There are no entries to show." text
+    Then I should not see a "clp_name" text


### PR DESCRIPTION
## What does this PR change?

Rocky 8 testing introduced a new CLM project for filter the appstream contents of the DVD. Since we cannot be 100% sure after which tested feature the filtered project can be deleted, this PR simply adjusts the general CLM test scenario.
![image](https://user-images.githubusercontent.com/12104291/202453595-2aeaabb4-cce5-452c-80cc-53a770be26df.png)


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links

No ports needed, Rocky 8 testing ins only done in HEAD/Uyuni.
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
