### PR TITLE
drop legacy way to prevent disabling local repos

### DIFF
--- a/.github/workflows/susemanager-sls-unit-tests.yml
+++ b/.github/workflows/susemanager-sls-unit-tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "3.10"
 
       - name: Install Python dependencies
         run: |

--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -123,10 +123,6 @@ REGISTER_THIS_BOX=1
 #     PROFILENAME=`hostname -f`      # FQDN
 PROFILENAME=""   # Empty by default to let it be set automatically.
 
-# After registration, before updating the system (or at least the installer)
-# disable all repos not provided by SUSE Manager.
-DISABLE_LOCAL_REPOS=1
-
 # SUSE Manager Specific settings:
 #
 # - Alternate location of the client tool repos providing 
@@ -855,12 +851,6 @@ enable_fqdns_grains: False
 start_event_grains: [machine_id, saltboot_initrd, susemanager]
 mine_enabled: False
 EOF
-    if [ "$DISABLE_LOCAL_REPOS" -eq 0 ]; then
-        echo "Do not disable local repos"
-        cat <<EOF >>"$SUSEMANAGER_MASTER_FILE"
-disable_local_repos: False
-EOF
-    fi
     cat <<EOF >> "$SUSEMANAGER_MASTER_FILE"
 
 grains:

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,5 @@
+- drop legacy way to prevent disabling local repos
+
 -------------------------------------------------------------------
 Fri Nov 18 15:04:43 CET 2022 - jgonzalez@suse.com
 

--- a/susemanager-utils/susemanager-sls/salt/channels/disablelocalrepos.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/disablelocalrepos.sls
@@ -5,7 +5,6 @@
 {% endif %}
 {% do repos_disabled.update({'count': 0}) %}
 
-{% if salt['config.get']('disable_local_repos', True) %}
 {% set repos = salt['pkg.list_repos']() %}
 {% for alias, data in repos.items() %}
 {% if grains['os_family'] == 'Debian' %}
@@ -38,4 +37,3 @@ disable_repo_{{ alias }}:
 {% endif %}
 {% endif %}
 {% endfor %}
-{% endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- drop legacy way to prevent disabling local repos
+
 -------------------------------------------------------------------
 Fri Nov 18 15:13:42 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

We have currently 2 ways to change behavior of disabling local repositories.
This PR drop the old one using a grain. We now prefer to set the pillar data on the server.
The new behavior is documented, the old is not.

See also https://github.com/SUSE/spacewalk/issues/19293

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- https://github.com/uyuni-project/uyuni-docs/pull/1902

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
