### PR TITLE
check for null for install size

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  *
@@ -91,7 +92,7 @@ public class DebPackageWriter implements Closeable {
         out.write(vendor);
         out.newLine();
 
-        Long packagePayloadSize = pkgDto.getPayloadSize();
+        Long packagePayloadSize = Optional.ofNullable(pkgDto.getPayloadSize()).orElse(0L);
         if (packagePayloadSize > 0) {
             out.write("Installed-Size: ");
             out.write(pkgDto.getPayloadSize().toString());

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/DebPackageWriterTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/DebPackageWriterTest.java
@@ -90,6 +90,9 @@ public class DebPackageWriterTest extends JMockBaseTestCaseWithUser {
 
         Package pkg3 = PackageManagerTest.addPackageToChannel("pkg_3", channel);
 
+        Package pkg4 = PackageManagerTest.addPackageToChannel("pkg_4", channel);
+        pkg4.setPayloadSize(null);
+
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
 
@@ -143,6 +146,16 @@ public class DebPackageWriterTest extends JMockBaseTestCaseWithUser {
                         "Maintainer: Rhn-Java\n" +
                         "Installed-Size: 42\n" +
                         "Filename: channel/getPackage/pkg_3_1:1.0.0-1.noarch.deb\n" +
+                        "Size: 42\n" +
+                        "MD5sum: some-md5sum\n" +
+                        "Section: some-section\n" +
+                        "Description: RHN-JAVA Package Test\n" +
+                        "\n" +
+                        "Package: pkg_4\n" +
+                        "Version: 1:1.0.0-1\n" +
+                        "Architecture: noarch\n" +
+                        "Maintainer: Rhn-Java\n" +
+                        "Filename: channel/getPackage/pkg_4_1:1.0.0-1.noarch.deb\n" +
                         "Size: 42\n" +
                         "MD5sum: some-md5sum\n" +
                         "Section: some-section\n" +

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- check for NULL in DEB package install size value
 - Add vendor_advisory to errata.getDetails (bsc#1205207)
 - Allow usage of one FQDN to deploy containerized proxy in VM (#19586)
 - disable cloned vendor channel auto selection by default (bsc#1204186)


### PR DESCRIPTION
## What does this PR change?

There are some invalid debian package descriptions out there. They do not provide correct metadata and this cause Uyuni to fail with a NPE.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19202
Fixes https://github.com/uyuni-project/uyuni/issues/6002
Tracks https://github.com/SUSE/spacewalk/pull/19657 https://github.com/SUSE/spacewalk/pull/19659

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
