### PR TITLE
Remove AppStream variant from treeinfo files

### DIFF
--- a/python/spacewalk/satellite_tools/reposync.py
+++ b/python/spacewalk/satellite_tools/reposync.py
@@ -1716,7 +1716,7 @@ class RepoSync(object):
             family = treeinfo_parser.get_family()
             if family == 'Fedora':
                 self.ks_install_type = 'fedora18'
-            elif family == 'CentOS':
+            elif family in ['CentOS', 'Rocky Linux', 'AlmaLinux']:
                 self.ks_install_type = 'rhel_' + treeinfo_parser.get_major_version()
             else:
                 self.ks_install_type = 'generic_rpm'

--- a/python/spacewalk/satellite_tools/reposync.py
+++ b/python/spacewalk/satellite_tools/reposync.py
@@ -184,7 +184,7 @@ class TreeInfoParser(object):
         fp = open(filename)
         try:
             try:
-                self.parser.readfp(fp)
+                self.parser.read_file(fp)
             except configparser.ParsingError:
                 raise TreeInfoError("Could not parse treeinfo file!")
         finally:
@@ -243,6 +243,22 @@ class TreeInfoParser(object):
 
         return addons_dirs
 
+    def remove_broken_variants(self):
+        try:
+            variants = self.parser.get("tree", "variants").split(",")
+            for variant in variants:
+                section_name = "variant-" + variant
+                if self.parser.get(section_name, "repository").startswith(".."):
+                    variants.remove(variant)
+                    self.parser.remove_section(section_name)
+            self.parser.set("tree", "variants", ",".join(variants))
+        except (configparser.NoOptionError, configparser.NoSectionError):
+            # This section and value may not exist in older version of the treeinfo
+            pass
+
+    def save(self, file_name):
+        with open(file_name, "w") as fd:
+            self.parser.write(fd)
 
 def set_filter_opt(option, opt_str, value, parser):
     # pylint: disable=W0613
@@ -1801,7 +1817,13 @@ class RepoSync(object):
             downloader.run()
             log2background(0, "Download finished.")
             for item in to_download:
-                st = os.stat(os.path.join(mount_point, ks_path, item))
+                file_path = os.path.join(mount_point, ks_path, item)
+                if item in ["treeinfo", ".treeinfo"]:
+                    # Remove the appstream variant if possible as it will point to nowhere
+                    parser = TreeInfoParser(file_path)
+                    parser.remove_broken_variants()
+                    parser.save(file_path)
+                st = os.stat(file_path)
                 # update entity about current file in a database
                 delete_h.execute(id=ks_id, path=item)
                 insert_h.execute(id=ks_id, path=item,

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Remove AppStream variant from EL8 and derivatives treeinfos
+
 -------------------------------------------------------------------
 Fri Nov 18 15:11:50 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

When synchronizing a repository with the --sync-kickstart option on a RHEL8 or clone BaseOS channel the treeinfo file is just copied to the installation tree.
However the AppStream variant path is relative to this file and may not even exist if the user hasn't synchronized the AppStream repo.

To address this issuem it has been agreed with the reporter and user that AppStream variant should be removed from the generated treeinfo. To install AppStream packages in a kickstart the user then has to manually add the repo to the anaconda configuration file.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: kickstart is not tested at all yet

- [X] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/5677

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
