### PR TITLE
Add reboot needed/scheduled indications

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -353,6 +353,25 @@ public class ActionFactory extends HibernateFactory {
     }
 
     /**
+     * Check if the server has a scheudled reboot action. Return the action
+     * if available or null otherwise
+     * @param serverId server
+     * @return reboot Action or null otherwise
+     */
+    public static Action isRebootScheduled(Long serverId) {
+        Action ret = null;
+        Session session = HibernateFactory.getSession();
+        Query query = session.getNamedQuery("ServerAction.findPendingActionsForServer");
+        query.setParameter("serverId", serverId);
+        query.setParameter("label", "reboot.reboot");
+        List list = query.list();
+        if (list != null && list.size() > 0) {
+            ret = ((ServerAction) list.get(0)).getParentAction();
+        }
+        return ret;
+    }
+
+    /**
      * Create a new Action from scratch.
      * @param typeIn the type of Action we want to create
      * @return the Action created

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -37,6 +37,7 @@ import com.redhat.rhn.domain.product.Tuple2;
 import com.redhat.rhn.domain.rhnpackage.PackageEvr;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.dto.HistoryEvent;
+import com.redhat.rhn.frontend.dto.SystemOverview;
 import com.redhat.rhn.frontend.xmlrpc.ChannelSubscriptionException;
 import com.redhat.rhn.frontend.xmlrpc.ServerNotInGroupException;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
@@ -57,6 +58,7 @@ import org.hibernate.criterion.MatchMode;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.criterion.Subqueries;
+import org.hibernate.query.Query;
 import org.hibernate.type.StandardBasicTypes;
 
 import java.util.ArrayList;
@@ -536,6 +538,19 @@ public class ServerFactory extends HibernateFactory {
                         Collectors.mapping(row -> Long.valueOf(row[1].toString()), Collectors.toList())
                         )
                 );
+    }
+
+    /**
+     * Look for servers that have a reboot action scheduled
+     * @param systems the systems to check
+     * @return list of servers pending reoot action
+     */
+    public static List<Long> findSystemsPendingRebootActions(List<SystemOverview> systems) {
+        List<Long> sids = systems.stream().map(SystemOverview::getId).collect(Collectors.toList());
+        Session session = HibernateFactory.getSession();
+        Query query = session.getNamedQuery("Server.findServersPendingRebootAction");
+        query.setParameter("systemIds", sids);
+        return query.list();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
@@ -602,4 +602,12 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                   WHERE s.id IN (:systemIds)]]>
     </query>
 
+
+    <query name="Server.findServersPendingRebootAction">
+        <![CDATA[SELECT distinct(sa.server.id) FROM ServerAction sa
+                      WHERE sa.server.id IN (:systemIds)
+                        AND sa.parentAction.actionType.label = 'reboot.reboot'
+                        AND status in ( 0, 1 )]]>
+    </query>
+
 </hibernate-mapping>

--- a/java/code/src/com/redhat/rhn/frontend/action/ssm/RebootSystemAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/ssm/RebootSystemAction.java
@@ -16,6 +16,7 @@
 package com.redhat.rhn.frontend.action.ssm;
 
 import com.redhat.rhn.domain.rhnset.RhnSet;
+import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.frontend.dto.SystemOverview;
 import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.frontend.struts.RhnHelper;
@@ -88,6 +89,12 @@ public class RebootSystemAction
     public List<SystemOverview> getResult(RequestContext context) {
         List<SystemOverview> systems = SystemManager.inSet(context.getCurrentUser(),
                 RhnSetDecl.SYSTEMS.getLabel());
+
+        List<Long> sids = ServerFactory.findSystemsPendingRebootActions(systems);
+        if (!sids.isEmpty()) {
+            getStrutsDelegate().saveMessage("ssm.misc.reboot.message.scheduled", context.getRequest());
+        }
+
         for (SystemOverview systemOverview : systems) {
             systemOverview.setSelectable(1);
         }

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SystemListHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SystemListHelper.java
@@ -77,6 +77,11 @@ public class SystemListHelper {
             i.setType("system-kickstarting");
             i.setTitle("systemlist.jsp.kickstart");
         }
+        else if (type.equals(SystemOverview.STATUS_TYPE_REBOOT_NEEDED)) {
+            url.setAttribute("href", "/rhn/systems/details/RebootSystem.do?sid=" + next.getId());
+            i.setType("system-reboot");
+            i.setTitle("systemlist.jsp.rebootneeded");
+        }
         else if (type.equals(SystemOverview.STATUS_TYPE_UPDATES_SCHEDULED)) {
             url.setAttribute("href",
                     "/rhn/systems/details/history/Pending.do?sid=" +

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemOverviewAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemOverviewAction.java
@@ -111,6 +111,14 @@ public class SystemOverviewAction extends RhnAction {
         // Reboot needed after certain types of updates
         boolean rebootRequired = SystemManager.requiresReboot(user, sid);
 
+        // Check if reboot is scheduled
+        boolean rebootScheduled = false;
+        Action rebootAction = ActionFactory.isRebootScheduled(sid);
+        if (rebootAction != null) {
+            request.setAttribute("rebootActionId", rebootAction.getId());
+            rebootScheduled = true;
+        }
+
         if (!processLock(user, s, rctx)) {
             request.setAttribute("serverLock", s.getLock());
         }
@@ -132,6 +140,7 @@ public class SystemOverviewAction extends RhnAction {
         }
 
         request.setAttribute("rebootRequired", rebootRequired);
+        request.setAttribute("rebootScheduled", rebootScheduled);
         request.setAttribute("unentitled", s.getEntitlements().isEmpty());
         request.setAttribute("entitlements", entitlements);
         request.setAttribute("systemInactive", s.isInactive());

--- a/java/code/src/com/redhat/rhn/frontend/dto/SystemOverview.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/SystemOverview.java
@@ -97,6 +97,7 @@ public class SystemOverview extends BaseTupleDto implements Serializable {
     public static final String STATUS_TYPE_UP2DATE = "up2date";
     public static final String STATUS_TYPE_CRITICAL = "critical";
     public static final String STATUS_TYPE_UPDATES = "updates";
+    public static final String STATUS_TYPE_REBOOT_NEEDED = "reboot needed";
 
 
     /**
@@ -181,10 +182,13 @@ public class SystemOverview extends BaseTupleDto implements Serializable {
         else if (Optional.ofNullable(kickstarting).orElse(SystemManager.isKickstarting(user, sid))) {
             type = STATUS_TYPE_KICKSTARTING;
         }
+        else if (SystemManager.requiresReboot(user, sid)) {
+            type = STATUS_TYPE_REBOOT_NEEDED;
+        }
         else if (getEnhancementErrata() + getBugErrata() +
-                     getSecurityErrata() > 0 &&
-                     Optional.ofNullable(unscheduledErrataCount).map(count -> count == 0)
-                             .orElse(SystemManager.hasUnscheduledErrata(user, sid))) {
+                getSecurityErrata() > 0 &&
+                Optional.ofNullable(unscheduledErrataCount).map(count -> count == 0)
+                        .orElse(SystemManager.hasUnscheduledErrata(user, sid))) {
             type = STATUS_TYPE_UPDATES_SCHEDULED;
         }
         else if (Optional.ofNullable(actionsCount).orElse(Long.valueOf(SystemManager.countActions(sid))) > 0) {

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -20878,6 +20878,12 @@ The Tree Path, Base Channel, and Installer Generation should always match. This 
           <context context-type="sourcefile">/systems/details/Overview.do</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sdc.details.overview.rebootaction" xml:space="preserve">
+        <source>(&lt;a href="{0}"&gt;System Reboot Action&lt;/a&gt;)</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/systems/details/Overview.do</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sdc.details.overview.sysproperties" xml:space="preserve">
         <source>System Properties (&lt;a href="{0}"&gt;Edit These Properties&lt;/a&gt;)</source>
         <context-group name="ctx">
@@ -21000,6 +21006,12 @@ The Tree Path, Base Channel, and Installer Generation should always match. This 
       </trans-unit>
       <trans-unit id="sdc.details.overview.requires_reboot" xml:space="preserve">
         <source>The system requires a reboot</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/systems/details/Overview.do</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sdc.details.overview.rebootscheduled" xml:space="preserve">
+        <source>System reboot scheduled</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/systems/details/Overview.do</context>
         </context-group>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -5469,6 +5469,12 @@ organization. You may grant or remove the organization administrator role in the
           <context context-type="sourcefile">/rhn/systems/ssm/misc/Index.do</context>
         </context-group>
         </trans-unit>
+        <trans-unit id="ssm.misc.reboot.message.scheduled">
+          <source>Some systems already have a reboot scheduled.</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/systems/ssm/misc/Index.do</context>
+        </context-group>
+        </trans-unit>
         <trans-unit id="ssm.misc.reboot.no-system">
           <source>There are no selected systems.</source>
         <context-group name="ctx">
@@ -5803,6 +5809,13 @@ organization. You may grant or remove the organization administrator role in the
       </trans-unit>
       <trans-unit id="systemlist.jsp.updates" xml:space="preserve">
         <source>Updates available</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/systems/SystemList</context>
+          <context context-type="sourcefile">/systems/SystemEntitlements</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="systemlist.jsp.rebootneeded" xml:space="preserve">
+        <source>System requires reboot</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemList</context>
           <context context-type="sourcefile">/systems/SystemEntitlements</context>

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
@@ -54,8 +54,16 @@
               <c:if test="${rebootRequired}">
                 <div class="systeminfo">
                   <div class="systeminfo-full">
-                    <rhn:icon type="system-reboot" /><bean:message key="sdc.details.overview.requires_reboot"/>
-                    <bean:message key="sdc.details.overview.schedulereboot" arg0="/rhn/systems/details/RebootSystem.do?sid=${system.id}"/>
+                    <c:choose>
+                      <c:when test="${rebootScheduled}">
+                        <rhn:icon type="system-reboot" /><bean:message key="sdc.details.overview.rebootscheduled"/>
+                        <bean:message key="sdc.details.overview.rebootaction" arg0="/rhn/systems/details/history/Event.do?sid=${system.id}&aid=${rebootActionId}"/>
+                      </c:when>
+                      <c:otherwise>
+                        <rhn:icon type="system-reboot" /><bean:message key="sdc.details.overview.requires_reboot"/>
+                        <bean:message key="sdc.details.overview.schedulereboot" arg0="/rhn/systems/details/RebootSystem.do?sid=${system.id}"/>
+                      </c:otherwise>
+                    </c:choose>
                   </div>
                 </div>
               </c:if>
@@ -277,7 +285,9 @@
             <td><rhn:formatDate humanStyle="from" value="${system.lastBootAsDate}" type="both" dateStyle="short" timeStyle="long"/><br/>
                   <rhn:require acl="system_feature(ftr_reboot)"
                        mixins="com.redhat.rhn.common.security.acl.SystemAclHandler">
-                <bean:message key="sdc.details.overview.schedulereboot" arg0="/rhn/systems/details/RebootSystem.do?sid=${system.id}"/>
+                    <c:if test="${!rebootScheduled}">
+                      <bean:message key="sdc.details.overview.schedulereboot" arg0="/rhn/systems/details/RebootSystem.do?sid=${system.id}"/>
+                    </c:if>
                   </rhn:require>
             </td>
           </tr>

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
@@ -285,9 +285,7 @@
             <td><rhn:formatDate humanStyle="from" value="${system.lastBootAsDate}" type="both" dateStyle="short" timeStyle="long"/><br/>
                   <rhn:require acl="system_feature(ftr_reboot)"
                        mixins="com.redhat.rhn.common.security.acl.SystemAclHandler">
-                    <c:if test="${!rebootScheduled}">
-                      <bean:message key="sdc.details.overview.schedulereboot" arg0="/rhn/systems/details/RebootSystem.do?sid=${system.id}"/>
-                    </c:if>
+                    <bean:message key="sdc.details.overview.schedulereboot" arg0="/rhn/systems/details/RebootSystem.do?sid=${system.id}"/>
                   </rhn:require>
             </td>
           </tr>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add reboot needed indicator to systems list
 - Move web dependencies from susemanager-frontend-libs to
   spacewalk-web
 - Fix server error while bootstrapping SSH-managed Red Hat-like minion (bsc#1205890)

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Add reboot needed indicator to systems list
 - add subscription warning info pane
 - Remove data related to RHEL below 6 
 - Increase cron_expr varchar length to 120 in suseRecurringAction

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.2-to-susemanager-schema-4.4.3/002-systems-overview.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.2-to-susemanager-schema-4.4.3/002-systems-overview.sql
@@ -1,20 +1,8 @@
---
--- Copyright (c) 2022 SUSE, LLC
---
--- This software is licensed to you under the GNU General Public License,
--- version 2 (GPLv2). There is NO WARRANTY for this software, express or
--- implied, including the implied warranties of MERCHANTABILITY or FITNESS
--- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
--- along with this software; if not, see
--- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
---
--- Red Hat trademarks are not licensed under GPLv2. No permission is
--- granted to use or replicate Red Hat trademarks that are incorporated
--- in this software or its documentation.
---
+-------------------
+-- Update procedure
+-------------------
 
-create or replace
-function update_system_overview (
+create or replace function update_system_overview (
     sid in numeric
 ) returns void as
 $$
@@ -212,12 +200,6 @@ begin
                   AND (to_date('1970-01-01', 'YYYY-MM-DD')
                        + numtodsinterval(S.last_boot, 'second')) < SP.installtime at time zone 'UTC'
                 )
-         OR EXISTS
-               (SELECT 1
-                FROM suseMinionInfo smi
-                WHERE smi.server_id = S.id
-                AND smi.reboot_needed = 'Y'
-               )
         );
 
     SELECT TRUE into new_kickstarting

--- a/web/html/src/components/systems.tsx
+++ b/web/html/src/components/systems.tsx
@@ -76,6 +76,11 @@ function statusDisplay(system: any, isAdmin: boolean) {
       iconTitle: "Kickstart in progress",
       url: "/rhn/systems/details/kickstart/SessionStatus.do?sid=" + sid,
     },
+    "reboot needed": {
+      iconType: "system-reboot",
+      iconTitle: "System requires reboot",
+      url: "/rhn/systems/details/RebootSystem.do?sid=" + sid,
+    },
     "updates scheduled": {
       iconType: "action-pending",
       iconTitle: "All updates scheduled",

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Add reboot needed indicator to systems list
 - Move web dependencies from susemanager-frontend-libs to
   spacewalk-web
 


### PR DESCRIPTION
## What does this PR change?

Add indications to the the system overview that a reboot is scheduled and to the system list that a reboot is needed

## GUI diff

Before:

After:

- [ ] **DONE**

## Documentation

- No documentation needed:

- [x] **DONE**

## Test coverage

- No tests: 

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/5309

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
