### PR TITLE
Disable the EL 9 products for now

### DIFF
--- a/testsuite/features/build_validation/add_custom_repositories/add_rocky9_repositories.feature
+++ b/testsuite/features/build_validation/add_custom_repositories/add_rocky9_repositories.feature
@@ -17,11 +17,7 @@ Feature: Add the Rocky 9 distribution custom repositories
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
     And I enter "Custom Channel for Rocky 9 DVD" as "Channel Name"
-    And I enter "rocky-9-iso" as "Channel Label"
-    And I select "RHEL9-Pool for x86_64" from "Parent Channel"
-    And I enter "Custom channel" as "Channel Summary"
-    And I click on "Create Channel"
-    Then I should see a "Channel Custom Channel for Rocky 9 DVD created" text
+    # TODO: the EL9 products are not ready yet
 
   Scenario: Add the Rocky 9 Appstream DVD repository
     When I follow the left menu "Software > Manage > Repositories"
@@ -92,23 +88,4 @@ Feature: Add the Rocky 9 distribution custom repositories
     And I click on "Create"
     Then I should see a "Content Lifecycle Project - Remove AppStream metadata" text
     When I click on "Attach/Detach Sources"
-    And I select "RHEL9-Pool for x86_64" from "selectedBaseChannel"
-    And I check "Custom Channel for Rocky 9 DVD"
-    And I check "RES-AS-9-Updates for x86_64"
-    And I click on "Save"
-    Then I should see a "Custom Channel for Rocky 9 DVD" text
-    When I click on "Attach/Detach Filters"
-    And I check "python-3.6: enable module python36:3.6"
-    And I check "ruby-2.7: enable module ruby:2.7"
-    And I click on "Save"
-    Then I should see a "python-3.6: enable module python36:3.6" text
-    When I click on "Add Environment"
-    And I enter "result" as "name"
-    And I enter "result" as "label"
-    And I enter "Filtered channels without AppStream channels" as "description"
-    And I click on "Save"
-    Then I should see a "not built" text
-    When I click on "Build"
-    And I enter "Initial build" as "message"
-    And I click the environment build button
-    Then I should see a "Version 1: Initial build" text
+    # TODO: the EL9 products are not ready yet

--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -147,17 +147,10 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I see "RHEL or SLES ES or CentOS 8 Base" product has been added
 
 @rocky9_minion
-  Scenario: Add SUSE Linux Enterprise Server with Expanded Support 9
+  Scenario: Add SUSE Liberty Linux 9
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
-    And I enter "RHEL or SLES ES or CentOS 9 Base" as the filtered product description
-    And I select "RHEL or SLES ES or CentOS 9 Base" as a product
-    Then I should see the "RHEL or SLES ES or CentOS 9 Base" selected
-    When I open the sub-list of the product "RHEL or SLES ES or CentOS 9 Base"
-    And I select "SUSE Linux Enterprise Server with Expanded Support 9" as a product
-    Then I should see the "SUSE Linux Enterprise Server with Expanded Support 9" selected
-    When I click the Add Product button
-    And I wait until I see "RHEL or SLES ES or CentOS 9 Base" product has been added
+    # TODO: the EL9 products are not ready yet
 
 @ubuntu1804_minion
   Scenario: Add Ubuntu 18.04

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -136,8 +136,7 @@ BASE_CHANNEL_BY_CLIENT = { 'proxy' => 'SLE-Product-SUSE-Manager-Proxy-4.3-Pool',
                            'centos7_ssh_minion' => 'RHEL x86_64 Server 7',
                            'rocky8_minion' => 'no-appstream-result-RHEL8-Pool for x86_64',
                            'rocky8_ssh_minion' => 'no-appstream-result-RHEL8-Pool for x86_64',
-                           'rocky9_minion' => 'no-appstream-result-RHEL9-Pool for x86_64',
-                           'rocky9_ssh_minion' => 'no-appstream-result-RHEL9-Pool for x86_64',
+                           # TODO: the EL9 products are not ready yet
                            'ubuntu1804_minion' => 'ubuntu-18.04-pool',
                            'ubuntu1804_ssh_minion' => 'ubuntu-18.04-pool',
                            'ubuntu2004_minion' => 'ubuntu-2004-amd64-main',
@@ -163,6 +162,7 @@ LABEL_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.3-Pool' => 'sle-prod
                           'SLES15-SP4-Pool' => 'sle-product-sles15-sp4-pool-x86_64',
                           'RHEL x86_64 Server 7' => 'rhel-x86_64-server-7',
                           'no-appstream-result-RHEL8-Pool for x86_64' => 'no-appstream-result-rhel8-pool-x86_64',
+                          # TODO: the EL9 products are not ready yet
                           'ubuntu-18.04-pool' => 'ubuntu-18.04-pool-amd64',
                           'ubuntu-2004-amd64-main' => 'ubuntu-2004-amd64-main-amd64',
                           'ubuntu-2204-amd64-main' => 'ubuntu-2204-amd64-main-amd64',
@@ -181,6 +181,7 @@ CHANNEL_TO_SYNC_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.3-Pool' =>
                                     'SLES15-SP4-Pool' => 'SLE-15-SP4-x86_64',
                                     'RHEL x86_64 Server 7' => 'RES7-x86_64',
                                     'no-appstream-result-RHEL8-Pool for x86_64' => 'SLE-ES8-x86_64',
+                                    # TODO: the EL9 products are not ready yet
                                     'ubuntu-18.04-pool' => 'ubuntu-18.04-amd64',
                                     'ubuntu-2004-amd64-main' => 'ubuntu-20.04-amd64',
                                     'ubuntu-2204-amd64-main' => 'ubuntu-22.04-amd64',
@@ -199,6 +200,7 @@ PARENT_CHANNEL_TO_SYNC_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.3-P
                                            'SLES15-SP4-Pool' => 'sle-product-sles15-sp4-pool-x86_64',
                                            'RHEL x86_64 Server 7' => 'rhel-x86_64-server-7',
                                            'no-appstream-result-RHEL8-Pool for x86_64' => nil,
+                                           # TODO: the EL9 products are not ready yet
                                            'ubuntu-18.04-pool' => nil,
                                            'ubuntu-2004-amd64-main' => nil,
                                            'ubuntu-2204-amd64-main' => nil,

--- a/testsuite/run_sets/build_validation_add_common_channels.yml
+++ b/testsuite/run_sets/build_validation_add_common_channels.yml
@@ -5,6 +5,8 @@
 - features/build_validation/add_custom_repositories/srv_common_channels.feature
 - features/build_validation/add_custom_repositories/add_centos7_repositories.feature
 - features/build_validation/add_custom_repositories/add_rocky8_repositories.feature
+# TODO: the EL9 products are not ready yet
+# - features/build_validation/add_custom_repositories/add_rocky9_repositories.feature
 
 ## Add common channels and special repositories END ###
 


### PR DESCRIPTION
## What does this PR change?

Temporary cleanup before we have usable SCC products for EL 9 tools / Rocky 9 / SUSE Liberty Linux 9 (even as beta) and know how to use them.

Note: on uyuni branch we might already have them, so I might come with a second PR on top of this one. But at least it will be on top of "clean" code.


## Links

* 4.2: no rocky 9 support
* 4.3: SUSE/spacewalk#19639


## Changelogs

- [x] No changelog needed
