### PR TITLE
QE: Add test to run cobbler sync via WebUI

### DIFF
--- a/testsuite/features/secondary/srv_cobbler_sync.feature
+++ b/testsuite/features/secondary/srv_cobbler_sync.feature
@@ -6,7 +6,7 @@ Feature: Run Cobbler Sync via WebUI
   Scenario: Login as admin
     Given I am authorized for the "Admin" section
 
-  Scenario: Sanity check for page existance
+  Scenario: Sanity check if the Cobbler Sync page exists
     When I follow the left menu "Admin > Manager Configuration > Cobbler"
     Then I should see a "Uyuni Configuration - Cobbler. " text
     And I should see a "Setup your Uyuni Cobbler settings below. " text
@@ -15,7 +15,7 @@ Feature: Run Cobbler Sync via WebUI
     And I should see a "Run Cobbler Sync" text in the content area
     And I should see a "Update" button
 
-  Scenario: Run Cobbler Sync via button and validate the task ran
+  Scenario: Run Cobbler Sync via button and validate the result
     When I follow the left menu "Admin > Manager Configuration > Cobbler"
     And I click on "Update"
     Then I should see a "Cobbler Sync action was successfully executed. Look at /var/log/cobbler/*.log for more information" text

--- a/testsuite/features/secondary/srv_cobbler_sync.feature
+++ b/testsuite/features/secondary/srv_cobbler_sync.feature
@@ -6,7 +6,7 @@ Feature: Run Cobbler Sync via WebUI
   Scenario: Login as admin
     Given I am authorized for the "Admin" section
 
-  Scenario: Sanity check if the Cobbler Sync page exists
+  Scenario: Cobbler Settings Page exists
     When I follow the left menu "Admin > Manager Configuration > Cobbler"
     Then I should see a "Uyuni Configuration - Cobbler. " text
     And I should see a "Setup your Uyuni Cobbler settings below. " text

--- a/testsuite/features/secondary/srv_cobbler_sync.feature
+++ b/testsuite/features/secondary/srv_cobbler_sync.feature
@@ -6,10 +6,21 @@ Feature: Run Cobbler Sync via WebUI
   Scenario: Login as admin
     Given I am authorized for the "Admin" section
 
+  @uyuni
   Scenario: Cobbler Settings Page exists
     When I follow the left menu "Admin > Manager Configuration > Cobbler"
     Then I should see a "Uyuni Configuration - Cobbler. " text
     And I should see a "Setup your Uyuni Cobbler settings below. " text
+    And I should see a "Cobbler sync is used to repair or rebuild the contents /srv/tftpboot or /srv/www/cobbler when manual modification of cobbler has occurred. " text
+    And I should see a "For more information refer to the 'cobbler' man page. " text
+    And I should see a "Run Cobbler Sync" text in the content area
+    And I should see a "Update" button
+  
+  @susemanager
+  Scenario: Cobbler Settings Page exists
+    When I follow the left menu "Admin > Manager Configuration > Cobbler"
+    Then I should see a "SUSE Manager Configuration - Cobbler. " text
+    And I should see a "Setup your SUSE Manager Cobbler settings below. " text
     And I should see a "Cobbler sync is used to repair or rebuild the contents /srv/tftpboot or /srv/www/cobbler when manual modification of cobbler has occurred. " text
     And I should see a "For more information refer to the 'cobbler' man page. " text
     And I should see a "Run Cobbler Sync" text in the content area

--- a/testsuite/features/secondary/srv_cobbler_sync.feature
+++ b/testsuite/features/secondary/srv_cobbler_sync.feature
@@ -1,0 +1,21 @@
+# Copyright (c) 2022 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Run Cobbler Sync via WebUI
+
+  Scenario: Login as admin
+    Given I am authorized for the "Admin" section
+
+  Scenario: Sanity check for page existance
+    When I follow the left menu "Admin > Manager Configuration > Cobbler"
+    Then I should see a "Uyuni Configuration - Cobbler. " text
+    And I should see a "Setup your Uyuni Cobbler settings below. " text
+    And I should see a "Cobbler sync is used to repair or rebuild the contents /srv/tftpboot or /srv/www/cobbler when manual modification of cobbler has occurred. " text
+    And I should see a "For more information refer to the 'cobbler' man page. " text
+    And I should see a "Run Cobbler Sync" text in the content area
+    And I should see a "Update" button
+
+  Scenario: Run Cobbler Sync via button and validate the task ran
+    When I follow the left menu "Admin > Manager Configuration > Cobbler"
+    And I click on "Update"
+    Then I should see a "Cobbler Sync action was successfully executed. Look at /var/log/cobbler/*.log for more information" text

--- a/testsuite/features/secondary/srv_cobbler_sync.feature
+++ b/testsuite/features/secondary/srv_cobbler_sync.feature
@@ -7,7 +7,7 @@ Feature: Run Cobbler Sync via WebUI
     Given I am authorized for the "Admin" section
 
   @uyuni
-  Scenario: Cobbler Settings Page exists
+  Scenario: Check that the Cobbler Settings Page exists
     When I follow the left menu "Admin > Manager Configuration > Cobbler"
     Then I should see a "Uyuni Configuration - Cobbler. " text
     And I should see a "Setup your Uyuni Cobbler settings below. " text
@@ -17,7 +17,7 @@ Feature: Run Cobbler Sync via WebUI
     And I should see a "Update" button
   
   @susemanager
-  Scenario: Cobbler Settings Page exists
+  Scenario: Check that the Cobbler Settings Page exists
     When I follow the left menu "Admin > Manager Configuration > Cobbler"
     Then I should see a "SUSE Manager Configuration - Cobbler. " text
     And I should see a "Setup your SUSE Manager Cobbler settings below. " text

--- a/testsuite/features/secondary/srv_cobbler_sync.feature
+++ b/testsuite/features/secondary/srv_cobbler_sync.feature
@@ -19,3 +19,5 @@ Feature: Run Cobbler Sync via WebUI
     When I follow the left menu "Admin > Manager Configuration > Cobbler"
     And I click on "Update"
     Then I should see a "Cobbler Sync action was successfully executed. Look at /var/log/cobbler/*.log for more information" text
+    When I follow the left menu "Admin > Task Engine Status > Last Execution Times"
+    Then I should see the correct timestamp for task "Cobbler Sync:"

--- a/testsuite/features/secondary/srv_cobbler_sync.feature
+++ b/testsuite/features/secondary/srv_cobbler_sync.feature
@@ -15,9 +15,13 @@ Feature: Run Cobbler Sync via WebUI
     And I should see a "Run Cobbler Sync" text in the content area
     And I should see a "Update" button
 
-  Scenario: Run Cobbler Sync via button and validate the result
+  Scenario: Run Cobbler Sync via button and validate UI output
     When I follow the left menu "Admin > Manager Configuration > Cobbler"
     And I click on "Update"
     Then I should see a "Cobbler Sync action was successfully executed. Look at /var/log/cobbler/*.log for more information" text
-    When I follow the left menu "Admin > Task Engine Status > Last Execution Times"
+
+  Scenario: Run Cobbler Sync via button and verify task timestamp in Last Execution Times Page
+    When I follow the left menu "Admin > Manager Configuration > Cobbler"
+    And I click on "Update"
+    And I follow the left menu "Admin > Task Engine Status > Last Execution Times"
     Then I should see the correct timestamp for task "Cobbler Sync:"

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -39,6 +39,7 @@
 - features/secondary/srv_reportdb.feature
 - features/secondary/srv_dist_channel_mapping.feature
 - features/secondary/srv_task_status_engine.feature
+- features/secondary/srv_cobbler_sync.feature
 
 - features/secondary/proxy_retail_pxeboot_and_mass_import.feature
 - features/secondary/allcli_overview_systems_details.feature


### PR DESCRIPTION
## What does this PR change?

Add test to run cobbler sync via `Admin > Manager Configuration > Cobbler`.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes [#18806](https://github.com/SUSE/spacewalk/issues/18806)
Manager-4.3: https://github.com/SUSE/spacewalk/pull/19642
Manager-4.2: https://github.com/SUSE/spacewalk/pull/19643

- [x] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
