### PR TITLE
QE: Live patching

### DIFF
--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -89,9 +89,6 @@ Feature: Be able to list available channels and enable them
     And I should get "    [I] SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp4]"
     And I should get "    [I] SLE-Module-Containers12-Updates for x86_64 Containers Module 12 x86_64 [sle-module-containers12-updates-x86_64-sp4]"
 
-  Scenario: Enable Live Patching Product
-    When I execute mgr-sync "add channel sle-module-live-patching15-sp4-pool-x86_64"
-
   Scenario: Let mgr-sync time out
     When I remove the mgr-sync cache file
     And I execute mgr-sync refresh

--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -93,3 +93,10 @@ Feature: Be able to list available channels and enable them
     When I remove the mgr-sync cache file
     And I execute mgr-sync refresh
     Then I should get "Timeout. No user input for 60 seconds. Exiting..."
+
+  Scenario: Enable Live Patching Product
+    When I execute mgr-sync "add channel sle-product-hpc-15-sp4-pool-x86_64"
+    And I execute mgr-sync "add channel sle-module-live-patching15-sp4-pool-x86_64-hpc"
+    And I execute mgr-sync "list channels"
+    Then I should get "[I] SUSE Linux Enterprise High Performance Computing 15 SP4 x86_64 x86_64 [sle-product-hpc-15-sp4-pool-x86_64]"
+    And I should get "    [I] SUSE Linux Enterprise Live Patching 15 SP4 x86_64 [sle-module-live-patching15-sp4-pool-x86_64-hpc]"

--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -89,10 +89,10 @@ Feature: Be able to list available channels and enable them
     And I should get "    [I] SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp4]"
     And I should get "    [I] SLE-Module-Containers12-Updates for x86_64 Containers Module 12 x86_64 [sle-module-containers12-updates-x86_64-sp4]"
 
+  Scenario: Enable Live Patching Product
+    When I execute mgr-sync "add channel sle-module-live-patching15-sp4-pool-x86_64"
+
   Scenario: Let mgr-sync time out
     When I remove the mgr-sync cache file
     And I execute mgr-sync refresh
     Then I should get "Timeout. No user input for 60 seconds. Exiting..."
-
-  Scenario: Enable Live Patching Product
-    When I execute mgr-sync "add channel sle-module-live-patching15-sp4-pool-x86_64"

--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -95,5 +95,4 @@ Feature: Be able to list available channels and enable them
     Then I should get "Timeout. No user input for 60 seconds. Exiting..."
 
   Scenario: Enable Live Patching Product
-    When I execute mgr-sync "add channel sle-product-hpc-15-sp4-pool-x86_64"
-    And I execute mgr-sync "add channel sle-module-live-patching15-sp4-pool-x86_64-hpc"
+    When I execute mgr-sync "add channel sle-module-live-patching15-sp4-pool-x86_64"

--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -97,6 +97,3 @@ Feature: Be able to list available channels and enable them
   Scenario: Enable Live Patching Product
     When I execute mgr-sync "add channel sle-product-hpc-15-sp4-pool-x86_64"
     And I execute mgr-sync "add channel sle-module-live-patching15-sp4-pool-x86_64-hpc"
-    And I execute mgr-sync "list channels"
-    Then I should get "[I] SUSE Linux Enterprise High Performance Computing 15 SP4 x86_64 x86_64 [sle-product-hpc-15-sp4-pool-x86_64]"
-    And I should get "    [I] SUSE Linux Enterprise Live Patching 15 SP4 x86_64 [sle-module-live-patching15-sp4-pool-x86_64-hpc]"

--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -62,10 +62,12 @@ Feature: Synchronize products in the products page of the Setup Wizard
     Then I should see the "SUSE Linux Enterprise Server 15 SP4 x86_64" selected
     And I should see the "Basesystem Module 15 SP4 x86_64" selected
     When I open the sub-list of the product "Basesystem Module 15 SP4 x86_64"
+    And I select "SUSE Linux Enterprise Live Patching 15 SP4 x86_64" as a product
     And I select "Desktop Applications Module 15 SP4 x86_64" as a product
     And I open the sub-list of the product "Desktop Applications Module 15 SP4 x86_64"
     And I select "Development Tools Module 15 SP4 x86_64" as a product
-    Then I should see the "Desktop Applications Module 15 SP4 x86_64" selected
+    Then I should see the "SUSE Linux Enterprise Live Patching 15 SP4 x86_64" selected
+    And I should see the "Desktop Applications Module 15 SP4 x86_64" selected
     And I should see the "Development Tools Module 15 SP4 x86_64" selected
     When I select "Containers Module 15 SP4 x86_64" as a product
     Then I should see the "Containers Module 15 SP4 x86_64" selected

--- a/testsuite/features/secondary/min_live_patching.feature
+++ b/testsuite/features/secondary/min_live_patching.feature
@@ -10,5 +10,7 @@ Feature: Live Patching on a SLE Minion
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  Scenario: Pre-requisite: downgrade milkyway-dummy to lower version
+  Scenario: Pre-requisite: create an activation key with Live Patching product
+    When
+    # Create Activation Key with API
     

--- a/testsuite/features/secondary/min_live_patching.feature
+++ b/testsuite/features/secondary/min_live_patching.feature
@@ -10,7 +10,17 @@ Feature: Live Patching on a SLE Minion
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  Scenario: Pre-requisite: create an activation key with Live Patching product
-    When
-    # Create Activation Key with API
-    
+  Scenario: Pre-requisite: Delete SLES minion system profile
+    Given I am authorized for the "Admin" section
+    And I am on the Systems overview page of this "sle_minion"
+    When I follow "Delete System"
+    Then I should see a "Confirm System Profile Deletion" text
+    When I click on "Delete Profile"
+    And I wait until I see "has been deleted" text
+    Then "sle_minion" should not be registered
+
+  Scenario: Bootstrap SLES minion with an activation key containing Live Patching product
+    Given I am logged in API as user "admin" and password "admin"
+    When I create an activation key including Live Patching product via API
+    When I call system.bootstrap() on host "sle_minion" with activation key "live_patch_key"
+    And I logout from API

--- a/testsuite/features/secondary/min_live_patching.feature
+++ b/testsuite/features/secondary/min_live_patching.feature
@@ -19,8 +19,16 @@ Feature: Live Patching on a SLE Minion
     And I wait until I see "has been deleted" text
     Then "sle_minion" should not be registered
 
+  # Maybe we can just reuse the regular key
   Scenario: Bootstrap SLES minion with an activation key containing Live Patching product
     Given I am logged in API as user "admin" and password "admin"
     When I create an activation key including Live Patching product via API
     When I call system.bootstrap() on host "sle_minion" with activation key "live_patch_key"
     And I logout from API
+
+  Scenario: Check that kernel livepatch is installed on the minion
+    # TODO
+
+
+ 
+  Scenario: downgrade

--- a/testsuite/features/secondary/min_live_patching.feature
+++ b/testsuite/features/secondary/min_live_patching.feature
@@ -31,4 +31,16 @@ Feature: Live Patching on a SLE Minion
 
 
  
-  Scenario: downgrade
+  Scenario: Pre-requisite: downgrade packages before action chain test on several systems
+    When I enable repository "test_repo_rpm_pool" on this "sle_minion"
+    And I remove package "andromeda-dummy" from this "sle_minion" without error control
+    And I install package "andromeda-dummy-1.0" on this "sle_minion"
+    And I refresh the metadata for "sle_minion"
+
+
+
+
+
+  Scenario: Cleanup: remove package and repository used in action chain for several systems
+    When I remove package "andromeda-dummy" from this "sle_minion" without error control
+    And I disable repository "test_repo_rpm_pool" on this "sle_minion" without error control

--- a/testsuite/features/secondary/min_live_patching.feature
+++ b/testsuite/features/secondary/min_live_patching.feature
@@ -1,0 +1,14 @@
+# Copyright (c) 2022 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@sle_minion
+Feature: Live Patching on a SLE Minion
+  In order to check if systems are patched against certain vulnerabilities
+  As an authorized user
+  I want to see the Salt Minions that need to be patched
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Pre-requisite: downgrade milkyway-dummy to lower version
+    

--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -262,31 +262,11 @@ When(/^I create an activation key including Live Patching product via API$/) do
   # Create a key with the base channel for this client
   id = description = "live_patch_key"
 
-  # TODO : GET CORRECT LIVE PATCHING PRODUCT
-
-  base_channel = LABEL_BY_BASE_CHANNEL[BASE_CHANNEL_BY_CLIENT[client]]
+  base_channel = 'SLE-Product-HPC-15-SP4-Pool for x86_64'
   key = $api_test.activationkey.create(id, description, base_channel, 100)
   raise if key.nil?
 
-  is_ssh_minion = client.include? 'ssh_minion'
-  $api_test.activationkey.set_details(key, description, base_channel, 100, is_ssh_minion ? 'ssh-push' : 'default')
-
-  # Get the list of child channels for this base channel
-  child_channels = $api_test.channel.software.list_child_channels(base_channel)
-
-  # Select all the child channels for this client
-  client.sub! 'ssh_minion', 'minion'
-  if client.include? 'buildhost'
-    selected_child_channels = ["custom_channel_#{client.sub('buildhost', 'minion')}", "custom_channel_#{client.sub('buildhost', 'client')}"]
-  elsif client.include? 'terminal'
-    selected_child_channels = ["custom_channel_#{client.sub('terminal', 'minion')}", "custom_channel_#{client.sub('terminal', 'client')}"]
-  else
-    custom_channel = "custom_channel_#{client}"
-    selected_child_channels = [custom_channel]
-  end
-  child_channels.each do |child_channel|
-    selected_child_channels.push(child_channel) unless child_channel.include? 'custom_channel'
-  end
+  selected_child_channels = 'SLE-Module-Live-Patching15-SP4-Pool for x86_64'
 
   $api_test.activationkey.add_child_channels(key, selected_child_channels)
 end

--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -53,6 +53,12 @@ but with activation key with default contact method, I should get an API fault$/
   assert(exception_thrown, 'Exception must be thrown for non-compatible activation keys.')
 end
 
+When(/^I call system\.bootstrap\(\) on host "([^"]*)" with activation key "([^"]*)"$/) do |host, akey|
+  system_name = get_system_name(host)
+  result = $api_test.system.bootstrap_system(system_name, akey, false)
+  assert(result == 1, 'Bootstrap return code not equal to 1.')
+end
+
 When(/^I schedule a highstate for "([^"]*)" via API$/) do |host|
   system_name = get_system_name(host)
   node_id = $api_test.system.retrieve_server_id(system_name)

--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -268,7 +268,7 @@ When(/^I create an activation key including Live Patching product via API$/) do
   # Create a key with the base channel for this client
   id = description = "live_patch_key"
 
-  base_channel = 'SLE-Product-HPC-15-SP4-Pool for x86_64'
+  base_channel = 'SLE-Product-SLES15-SP4-Pool for x86_64'
   key = $api_test.activationkey.create(id, description, base_channel, 100)
   raise if key.nil?
 

--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -258,6 +258,39 @@ When(/^I create an activation key including custom channels for "([^"]*)" via AP
   $api_test.activationkey.add_child_channels(key, selected_child_channels)
 end
 
+When(/^I create an activation key including Live Patching product via API$/) do
+  # Create a key with the base channel for this client
+  id = description = "live_patch_key"
+
+  # TODO : GET CORRECT LIVE PATCHING PRODUCT
+
+  base_channel = LABEL_BY_BASE_CHANNEL[BASE_CHANNEL_BY_CLIENT[client]]
+  key = $api_test.activationkey.create(id, description, base_channel, 100)
+  raise if key.nil?
+
+  is_ssh_minion = client.include? 'ssh_minion'
+  $api_test.activationkey.set_details(key, description, base_channel, 100, is_ssh_minion ? 'ssh-push' : 'default')
+
+  # Get the list of child channels for this base channel
+  child_channels = $api_test.channel.software.list_child_channels(base_channel)
+
+  # Select all the child channels for this client
+  client.sub! 'ssh_minion', 'minion'
+  if client.include? 'buildhost'
+    selected_child_channels = ["custom_channel_#{client.sub('buildhost', 'minion')}", "custom_channel_#{client.sub('buildhost', 'client')}"]
+  elsif client.include? 'terminal'
+    selected_child_channels = ["custom_channel_#{client.sub('terminal', 'minion')}", "custom_channel_#{client.sub('terminal', 'client')}"]
+  else
+    custom_channel = "custom_channel_#{client}"
+    selected_child_channels = [custom_channel]
+  end
+  child_channels.each do |child_channel|
+    selected_child_channels.push(child_channel) unless child_channel.include? 'custom_channel'
+  end
+
+  $api_test.activationkey.add_child_channels(key, selected_child_channels)
+end
+
 ## actionchain namespace
 
 When(/^I call actionchain\.create_chain\(\) with chain label "(.*?)"$/) do |label|

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -274,6 +274,8 @@ CHANNEL_TO_SYNCH_BY_OS_VERSION = {
     sle-module-devtools15-sp4-updates-x86_64
     sle-module-containers15-sp4-pool-x86_64
     sle-module-containers15-sp4-updates-x86_64
+    sle-module-live-patching15-sp4-pool-x86_64
+    sle-module-live-patching15-sp4-updates-x86_64
   ],
   '12-SP4' =>
   %w[
@@ -364,6 +366,8 @@ CHANNEL_TO_SYNCH_BY_OS_VERSION = {
     sle-module-server-applications15-sp4-updates-x86_64
     sle-module-containers15-sp4-pool-x86_64
     sle-module-containers15-sp4-updates-x86_64
+    sle-module-live-patching15-sp4-pool-x86_64
+    sle-module-live-patching15-sp4-updates-x86_64
   ],
   '8.6' =>
   %w[


### PR DESCRIPTION
## What does this PR change?

Live patching automation

Current status: we are missing a way to mock a live kernel update - note that it should be re-applicable to render the feature idempotent.

## GUI diff
No difference.
- [ ] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [ ] **DONE**

## Test coverage
- Cucumber tests were added
- [ ] **DONE**

## Links
Fixes #
Tracks # **add downstream PR, if any**
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
