### PR TITLE
QE: Split sanity checks to distinguish between products

### DIFF
--- a/testsuite/features/secondary/srv_task_status_engine.feature
+++ b/testsuite/features/secondary/srv_task_status_engine.feature
@@ -6,6 +6,16 @@ Feature: Task Engine Status
   Scenario: Login as admin
     Given I am authorized for the "Admin" section
     
+  @susemanager
+  Scenario: Check if the Task Engine Status page exists
+    When I follow the left menu "Admin > Task Engine Status > Last Execution Times"
+    Then I should see a "Task Engine Status" text
+    And I should see a "The following is a status report for the various tasks run by the SUSE Manager task engine:" text
+    And I should see a "Runtime Status" text
+    And I should see a "Last Execution Times" link in the left menu
+    And I should see a "Runtime Status" link in the left menu
+  
+  @uyuni
   Scenario: Check if the Task Engine Status page exists
     When I follow the left menu "Admin > Task Engine Status > Last Execution Times"
     Then I should see a "Task Engine Status" text


### PR DESCRIPTION
## What does this PR change?

The sanity checks in `srv_task_status_engine.feature` need to be split with tags to distinguish between suma and uyuni

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #https://github.com/SUSE/spacewalk/issues/10287
Manager-4.3: https://github.com/SUSE/spacewalk/pull/19649
Manager-4.2:

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
