### PR TITLE
Don't use random strings in tests where we have unique constraints

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/errata/test/ErrataFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/test/ErrataFactoryTest.java
@@ -83,6 +83,8 @@ import java.util.stream.Collectors;
  */
 public class ErrataFactoryTest extends BaseTestCaseWithUser {
 
+    private static int advisorySeq = 1000;
+
     @Test
     public void testAddToChannel()  throws Exception {
         Errata e = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
@@ -261,7 +263,7 @@ public class ErrataFactoryTest extends BaseTestCaseWithUser {
     }
 
     private static void fillOutErrata(Errata e, Long orgId, Optional<String> advisory) throws Exception {
-        String name = Opt.fold(advisory, () -> "JAVA-Test-" + TestUtils.randomNumeric(4), Function.identity());
+        String name = Opt.fold(advisory, () -> "JAVA-Test-" + advisorySeq++, Function.identity());
         Org org = null;
         if (orgId != null) {
             org = OrgFactory.lookupById(orgId);


### PR DESCRIPTION
## What does this PR change?

Fix `RendererHelperTest` Java unit test flakiness

## GUI diff

No difference
- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
