### PR TITLE
Add missing bsc reference to "susemanager-sls" changelog

### DIFF
--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -21,7 +21,7 @@ Wed Sep 28 11:14:52 CEST 2022 - jgonzalez@suse.com
 
 - version 4.4.1-1
   * Prevent possible tracebacks on reading postgres opts
-    with suma_minion salt pillar extension module
+    with suma_minion salt pillar extension module (bsc#1205255)
   * Fix mgrnet availability check
   * Remove dependence on Kiwi libraries
   * disable always the bootstrap repository also when


### PR DESCRIPTION
## What does this PR change?

This PR adds a missing bsc to a changelog entry that was already included by https://github.com/uyuni-project/uyuni/pull/5949. 

This bsc reference was not added at the time the mentioned PR was created as it was not existing. We got an L3 and provided the PR as PTF while this was been released. That is why we are adjunsting this now for consistency and also in order to prevent issues with Maintenance.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/19496

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
