### PR TITLE
Don't store Yaml parser statically in FormulaFactory

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
@@ -102,7 +102,6 @@ public class FormulaFactory {
             .registerTypeAdapter(Date.class, new ECMAScriptDateAdapter())
             .serializeNulls()
             .create();
-    private static final Yaml YAML = new Yaml(new SafeConstructor());
 
     private static SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
 
@@ -478,15 +477,16 @@ public class FormulaFactory {
         File layoutFileManager = new File(metadataDirManager + layoutFilePath);
         File layoutFileCustom = new File(METADATA_DIR_CUSTOM + layoutFilePath);
 
+        Yaml yaml = new Yaml(new SafeConstructor());
         try {
             if (layoutFileStandalone.exists()) {
-                return Optional.of((Map<String, Object>) YAML.load(new FileInputStream(layoutFileStandalone)));
+                return Optional.of((Map<String, Object>) yaml.load(new FileInputStream(layoutFileStandalone)));
             }
             else if (layoutFileManager.exists()) {
-                return Optional.of((Map<String, Object>) YAML.load(new FileInputStream(layoutFileManager)));
+                return Optional.of((Map<String, Object>) yaml.load(new FileInputStream(layoutFileManager)));
             }
             else if (layoutFileCustom.exists()) {
-                return Optional.of((Map<String, Object>) YAML.load(new FileInputStream(layoutFileCustom)));
+                return Optional.of((Map<String, Object>) yaml.load(new FileInputStream(layoutFileCustom)));
             }
             else {
                 return Optional.empty();
@@ -857,15 +857,17 @@ public class FormulaFactory {
         File metadataFileStandalone = new File(METADATA_DIR_STANDALONE_SALT + metadataFilePath);
         File metadataFileManager = new File(metadataDirManager + metadataFilePath);
         File metadataFileCustom = new File(METADATA_DIR_CUSTOM + metadataFilePath);
+
+        Yaml yaml = new Yaml(new SafeConstructor());
         try {
             if (metadataFileStandalone.isFile()) {
-                return (Map<String, Object>) YAML.load(new FileInputStream(metadataFileStandalone));
+                return (Map<String, Object>) yaml.load(new FileInputStream(metadataFileStandalone));
             }
             else if (metadataFileManager.isFile()) {
-                return (Map<String, Object>) YAML.load(new FileInputStream(metadataFileManager));
+                return (Map<String, Object>) yaml.load(new FileInputStream(metadataFileManager));
             }
             else if (metadataFileCustom.isFile()) {
-                return (Map<String, Object>) YAML.load(new FileInputStream(metadataFileCustom));
+                return (Map<String, Object>) yaml.load(new FileInputStream(metadataFileCustom));
             }
             else {
                 return Collections.emptyMap();
@@ -900,15 +902,16 @@ public class FormulaFactory {
         File pillarExampleFileManager = new File(metadataDirManager + pillarExamplePath);
         File pillarExampleFileCustom = new File(METADATA_DIR_CUSTOM + pillarExamplePath);
 
+        Yaml yaml = new Yaml(new SafeConstructor());
         try {
             if (pillarExampleFileStandalone.isFile()) {
-                return (Map<String, Object>) YAML.load(new FileInputStream(pillarExampleFileStandalone));
+                return (Map<String, Object>) yaml.load(new FileInputStream(pillarExampleFileStandalone));
             }
             else if (pillarExampleFileManager.isFile()) {
-                return (Map<String, Object>) YAML.load(new FileInputStream(pillarExampleFileManager));
+                return (Map<String, Object>) yaml.load(new FileInputStream(pillarExampleFileManager));
             }
             else if (pillarExampleFileCustom.isFile()) {
-                return (Map<String, Object>) YAML.load(new FileInputStream(pillarExampleFileCustom));
+                return (Map<String, Object>) yaml.load(new FileInputStream(pillarExampleFileCustom));
             }
             else {
                 return Collections.emptyMap();

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Don't persist the YAML parser in FormulaFactory (bsc#1205754)
 - check for NULL in DEB package install size value
 - Add vendor_advisory to errata.getDetails (bsc#1205207)
 - Allow usage of one FQDN to deploy containerized proxy in VM (#19586)


### PR DESCRIPTION
## What does this PR change?

Fix weird yaml parsing the formula metadata by not store the YAML parser in a static member.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
