### PR TITLE
Honor user page size preference in new system list pages

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/SystemsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/SystemsController.java
@@ -21,6 +21,7 @@ import static com.suse.manager.webui.utils.SparkApplicationHelper.withCsrfToken;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withDocsLocale;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withUserAndServer;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUserPreferences;
 import static spark.Spark.get;
 import static spark.Spark.post;
 
@@ -132,9 +133,9 @@ public class SystemsController {
      */
     public void initRoutes(JadeTemplateEngine jade) {
         get("/manager/systems/list/virtual",
-                withCsrfToken(withDocsLocale(withUser(this::virtualListPage))), jade);
+                withUserPreferences(withCsrfToken(withDocsLocale(withUser(this::virtualListPage)))), jade);
         get("/manager/systems/list/all",
-                withCsrfToken(withDocsLocale(withUser(this::allListPage))), jade);
+                withUserPreferences(withCsrfToken(withDocsLocale(withUser(this::allListPage)))), jade);
         get("/manager/systems/details/mgr-server-info/:sid",
                 withCsrfToken(withDocsLocale(withUserAndServer(this::mgrServerInfoPage))),
                 jade);

--- a/java/code/src/com/suse/manager/webui/templates/systems/all-list.jade
+++ b/java/code/src/com/suse/manager/webui/templates/systems/all-list.jade
@@ -1,9 +1,11 @@
+include ../common.jade
 #systems-all-list
 
 script(src='/javascript/momentjs/moment-with-langs.min.js?cb=#{webBuildtimestamp}', type='text/javascript')
 
 script(type='text/javascript').
     window.csrfToken = "#{csrf_token}";
++userPreferences
 
 script(type='text/javascript').
     spaImportReactPage('systems/list/all')

--- a/java/code/src/com/suse/manager/webui/templates/systems/virtual-list.jade
+++ b/java/code/src/com/suse/manager/webui/templates/systems/virtual-list.jade
@@ -1,9 +1,11 @@
+include ../common.jade
 #systems-virtual-list
 
 script(src='/javascript/momentjs/moment-with-langs.min.js?cb=#{webBuildtimestamp}', type='text/javascript')
 
 script(type='text/javascript').
     window.csrfToken = "#{csrf_token}";
++userPreferences
 
 script(type='text/javascript').
     spaImportReactPage('systems/list/virtual')

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Honor page size preference in new system lists
 - Fix kickstart for RHEL 9 to not add install command
 - Remove RHEL kickstart types below 6
 - Removed contents of certificates from the web UI logs (bsc#1204715)


### PR DESCRIPTION
## What does this PR change?

Take user preferences into account in page size of (virtual) systems lists.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [X] **DONE**

## Test coverage
- No tests: Do we really want integration tests for such a tiny change?

- [X] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/6188

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
