### PR TITLE
Remove RHEL < 6 code in ChannelManager

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -122,15 +122,6 @@ public class ChannelManager extends BaseManager {
 
     public static final String QRY_ROLE_MANAGE = "manage";
     public static final String QRY_ROLE_SUBSCRIBE = "subscribe";
-
-    // Valid RHEL 4 EUS Channel Versions (from rhnReleaseChannelMap):
-    public static final Set<String> RHEL4_EUS_VERSIONS;
-    static {
-        RHEL4_EUS_VERSIONS = new HashSet<>();
-        RHEL4_EUS_VERSIONS.add("4AS");
-        RHEL4_EUS_VERSIONS.add("4ES");
-    }
-
     public static final String RHEL7_EUS_VERSION = "7Server";
 
 
@@ -1547,19 +1538,15 @@ public class ChannelManager extends BaseManager {
      * Convert redhat-release release values to those that are stored in the
      * rhnReleaseChannelMap table.
      *
-     * RHEL 4 release samples: 7.6, 8, 9
-     * RHEL 5 release samples: 5.1.0.1, 5.2.0.2, 5.3.0.3
      * RHEL 6 release samples: 6.7.0.3.el6
      * RHEL 7 release samples: 7.2-9.el7 7.3-1.el7 7.4-1.el7
-     * RHEL 4 must be treated specially, if the release is X.Y, we only wish to look at
-     * the X portion.
      *
      * For RHEL 5 and presumably all future releases, we only look at the W.X.Y portion of
      * W.X.Y.Z. (works only for RHEL5 and 6)
      *
      * For RHEL7, format is W.X-Y.noise, all we need is W.X
      *
-     * @param rhelVersion RHEL version we're comparing release for. (5Server, 4AS, 4ES)
+     * @param rhelVersion RHEL version we're comparing release for.
      * @param originalRelease Original package release.
      * @return Release version for rhnReleaseChannelMap.
      */
@@ -1568,13 +1555,7 @@ public class ChannelManager extends BaseManager {
 
         String [] tokens = originalRelease.split("\\.");
 
-        if (RHEL4_EUS_VERSIONS.contains(rhelVersion)) {
-            if (tokens.length <= 1) {
-                return originalRelease;
-            }
-            return tokens[0];
-        }
-        else if (RHEL7_EUS_VERSION.equals(rhelVersion)) {
+        if (RHEL7_EUS_VERSION.equals(rhelVersion)) {
             // rhnreleasechnnelmap release like '7.1-1.el7' - PackageEvr will be
             // returned as 7.1.1.el7. We might be normalizing either.
             // Replace '-' with '.', then split and use [0].[1]

--- a/java/code/src/com/redhat/rhn/manager/channel/EusReleaseComparator.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/EusReleaseComparator.java
@@ -36,11 +36,6 @@ import java.util.Comparator;
  * Additionally, for all versions of RHEL, we may need to trim pieces of the version
  * off to do the comparison.
  * <p>
- * Sample releases:<br>
- * <pre>
- *   RHEL 4: 7.6, 8, 9
- *   RHEL 5: 5.1.0.1, 5.2.0.2, 5.3.0.3
- * </pre>
  */
 public class EusReleaseComparator implements Comparator<EssentialChannelDto> {
     private final String rhelVersion;
@@ -48,7 +43,7 @@ public class EusReleaseComparator implements Comparator<EssentialChannelDto> {
     /**
      * Constructor
      *
-     * @param rhelVersionIn RHEL version we're comparing release for. (5Server, 4AS, 4ES)
+     * @param rhelVersionIn RHEL version we're comparing release for.
      */
     public EusReleaseComparator(String rhelVersionIn) {
         this.rhelVersion = rhelVersionIn;

--- a/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerTest.java
@@ -610,17 +610,6 @@ public class ChannelManagerTest extends BaseTestCaseWithUser {
     }
 
     @Test
-    public void testEusReleaseCmpRhel4() {
-        EusReleaseComparator comparator = new EusReleaseComparator("4AS");
-        assertEquals(0, comparator.compare("4.6", "4"));
-        assertEquals(0, comparator.compare("4.6", "4.2"));
-        assertEquals(1, comparator.compare("9", "8"));
-        assertEquals(-1, comparator.compare("8", "9"));
-        assertEquals(-1, comparator.compare("8.7", "9.5"));
-        assertEquals(-1, comparator.compare("8.7", "10.10"));
-    }
-
-    @Test
     public void testEusReleaseCmpRhel5() {
         EusReleaseComparator comparator = new EusReleaseComparator("5Server");
         assertEquals(0, comparator.compare("5.3.0.1", "5.3.0.5"));
@@ -810,10 +799,6 @@ public class ChannelManagerTest extends BaseTestCaseWithUser {
 
     @Test
     public void testNormalizeRhelReleaseForMapping() {
-        assertEquals("4", ChannelManager.normalizeRhelReleaseForMapping("4AS", "4.6"));
-        assertEquals("4", ChannelManager.normalizeRhelReleaseForMapping("4AS", "4.6.9"));
-        assertEquals("3", ChannelManager.normalizeRhelReleaseForMapping("4AS", "3"));
-
         assertEquals("4.6.9", ChannelManager.normalizeRhelReleaseForMapping("5Server",
                 "4.6.9"));
         assertEquals("5.0.0", ChannelManager.normalizeRhelReleaseForMapping("5Server",


### PR DESCRIPTION
## What does this PR change?

Remove more old RHEL-related code

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
