### PR TITLE
spacewalk-hostname-rename changes report_db_host (bsc#1200801)

### DIFF
--- a/utils/spacewalk-hostname-rename
+++ b/utils/spacewalk-hostname-rename
@@ -99,7 +99,6 @@ function default_or_input() {
             INPUT="$DEFAULT"
         fi
     fi
-    ACCUMULATED_ANSWERS+=$(printf "\n%q=%q" "$VARIABLE" "${INPUT:-$DEFAULT}")
     eval "$(printf "%q=%q" "$VARIABLE" "$INPUT")"
 }
 

--- a/utils/spacewalk-hostname-rename
+++ b/utils/spacewalk-hostname-rename
@@ -71,9 +71,52 @@ IPADDR_REGEX="($IPV4ADDR_REGEX)|($IPV6ADDR_REGEX)"
 
 ###############################################################################
 
+function default_or_input() {
+    local MSG="$1"
+    local VARIABLE="$2"
+    local DEFAULT="$3"
+    local SILENT="$4"
+
+    local INPUT
+    local CURRENT_VALUE=${!VARIABLE}
+    #in following code is used not so common expansion
+    #var_a=${var_b:-word}
+    #which is like: var_a = $var_b ? word
+    DEFAULT=${CURRENT_VALUE:-$DEFAULT}
+    local VARIABLE_ISSET=$(set | grep "^$VARIABLE=")
+
+    
+    echo -n "$MSG [$DEFAULT]: "
+
+    if [ -z "$VARIABLE_ISSET" ]; then
+        MANUAL_ANSWERS=1
+        read INPUT
+    fi
+    if [ -z "$INPUT" ]; then
+        if [ "$DEFAULT" = "y/N" ] || [ "$DEFAULT" = "Y/n" ]; then
+            INPUT=$(yes_no "$DEFAULT")
+        else
+            INPUT="$DEFAULT"
+        fi
+    fi
+    ACCUMULATED_ANSWERS+=$(printf "\n%q=%q" "$VARIABLE" "${INPUT:-$DEFAULT}")
+    eval "$(printf "%q=%q" "$VARIABLE" "$INPUT")"
+}
+
+function yes_no() {
+    case "$1" in
+        Y|y|Y/n|n/Y|1)
+            echo 1
+            ;;
+        *)
+            echo 0
+            ;;
+    esac
+}
+
 function echo_usage {
     echo "Usage:"
-    echo "   $(basename $0) <IP_ADDRESS> [ --ssl-country=<SSL_COUNTRY> --ssl-state=<SSL_STATE> --ssl-city=<SSL_CITY> --ssl-org=<SSL_ORG> --ssl-orgunit=<SSL_ORGUNIT> --ssl-email=<SSL_EMAIL> --ssl-ca-password=<SSL_CA_PASSWORD> --ssl-ca-cert=<PATH> --ssl-server-key=<PATH> --ssl-server-cert=<PATH>]"
+    echo "   $(basename $0) <IP_ADDRESS> [ --ssl-country=<SSL_COUNTRY> --ssl-state=<SSL_STATE> --ssl-city=<SSL_CITY> --ssl-org=<SSL_ORG> --ssl-orgunit=<SSL_ORGUNIT> --ssl-email=<SSL_EMAIL> --ssl-ca-password=<SSL_CA_PASSWORD> --ssl-ca-cert=<PATH> --ssl-server-key=<PATH> --ssl-server-cert=<PATH> --overwrite_report_db_host=[y/n]]"
     echo "   $(basename $0) { -h | --help }"
     exit 1
 }
@@ -195,12 +238,34 @@ function update_rhn_conf {
     #    --dest=/etc
     #    --conf=$SAT_LOCAL_RULES_CONF
     #    >> $LOG 2>&1
-    backup_file ${RHN_CONF_FILE}
     /usr/bin/rhn-config-satellite.pl \
         --target=${RHN_CONF_FILE} \
         --option=server.jabber_server=$HOSTNAME \
         --option=osa-dispatcher.jabber_server=$HOSTNAME \
         --option=cobbler.host=$HOSTNAME >> $LOG 2>&1
+}
+
+function re-generate_report_db_host {
+  REPORTDBNAME=$(sed  -n '/#/!s/\(report_db_host[[:space:]]*=[[:space:]]*\)\(.*\)/\2/p' $RHN_CONF_FILE)
+  echo "Currently Report DB Host is: $REPORTDBNAME" | tee -a $LOG
+  
+  if [ "$REPORTDBNAME" == "$HOSTNAME" ]; then
+    echo "$REPORTDBNAME is already correct. Nothing to do." | tee -a $LOG
+  fi 
+
+  if [ -z "$OVERWRITE_REPORT_DB_HOST"  ] ; then
+    default_or_input "Do you want to change it to $HOSTNAME ?" CONFIRM "y/N" "N"
+    RET=$(yes_no $CONFIRM)
+  else
+    RET=$(yes_no $OVERWRITE_REPORT_DB_HOST)
+  fi
+  
+  if [ "$RET"  == 1 ]; then
+    echo "Overwrite Report DB Host with hostname: $HOSTNAME"
+    sed -i "/#/!s/\(report_db_host[[:space:]]*=[[:space:]]*\)\(.*\)/\1${HOSTNAME}/" $RHN_CONF_FILE
+  else
+    echo "Report DB Host will remain: $REPORTDBNAME"
+  fi
 }
 
 function re-generate_server_ssl_certificate {
@@ -413,6 +478,7 @@ while [ $# -ge 1 ]; do
             --ssl-ca-cert=*) CML_SSL_CA_CERT=$(echo $1 | cut -d= -f2-);;
             --ssl-server-cert=*) CML_SSL_SERVER_CERT=$(echo $1 | cut -d= -f2-);;
             --ssl-server-key=*) CML_SSL_SERVER_KEY=$(echo $1 | cut -d= -f2-);;
+            --overwrite_report_db_host=*) OVERWRITE_REPORT_DB_HOST=$(echo $1 | cut -d= -f2-);;
             *) echo_err "Error: Invalid option $1"
                echo_usage;;
     esac
@@ -465,6 +531,9 @@ initial_system_hostname_check || bye
 echo "=============================================" | tee -a $LOG
 echo "hostname: $HOSTNAME" | tee -a $LOG
 echo "=============================================" | tee -a $LOG
+
+backup_file $RHN_CONF_FILE
+re-generate_report_db_host
 
 # stop services
 echo -n "Stopping spacewalk services ... " | tee -a $LOG

--- a/utils/spacewalk-hostname-rename
+++ b/utils/spacewalk-hostname-rename
@@ -89,8 +89,7 @@ function default_or_input() {
     echo -n "$MSG [$DEFAULT]: "
 
     if [ -z "$VARIABLE_ISSET" ]; then
-        MANUAL_ANSWERS=1
-        read INPUT
+        read -r INPUT
     fi
     if [ -z "$INPUT" ]; then
         if [ "$DEFAULT" = "y/N" ] || [ "$DEFAULT" = "Y/n" ]; then

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- spacewalk-hostname-rename changes also report db host(bsc#1200801)
+
 -------------------------------------------------------------------
 Fri Nov 18 15:02:27 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

`spacewalk-hostname-rename` should also changes `report_db_host`. Since the parameter can be changed by the user (default is uyuni server), spacewalk-hostname-rename can work interactively or using the parameter `--overwrite_report_db_host=[y/n]`

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18224

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
