### PR TITLE
spacewalk-report: fix missing param

### DIFF
--- a/reporting/spacewalk-report
+++ b/reporting/spacewalk-report
@@ -188,11 +188,12 @@ if __name__ == '__main__':
 
             # Convert the parameters into a dict
             params = {}
-            for param_value in options.params:
-                matcher = re.match("^([^=]+)=([^=]+)$", param_value)
-                if not matcher:
-                    systemExit(-5, 'Invalid parameter value: ' + param_value)
-                params[matcher.group(1)] = matcher.group(2)
+            if options.params is not None:
+                for param_value in options.params:
+                    matcher = re.match("^([^=]+)=([^=]+)$", param_value)
+                    if not matcher:
+                        systemExit(-5, 'Invalid parameter value: ' + param_value)
+                    params[matcher.group(1)] = matcher.group(2)
 
             try:
                 report = reports.report(report_name, dataDir, params)

--- a/reporting/spacewalk-reports.changes
+++ b/reporting/spacewalk-reports.changes
@@ -1,3 +1,5 @@
+- Check if options.params is empty
+
 -------------------------------------------------------------------
 Fri Nov 18 15:05:43 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fix missing param using spacewalk-report

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/6189
Fixes: https://github.com/SUSE/spacewalk/issues/19679

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
