### PR TITLE
Fix CLM to not remove necessary packages when filtering erratas

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -1064,7 +1064,7 @@ public class ContentManager {
         // Truncate extra errata in target channel
         ErrataManager.truncateErrata(includedErrata, tgt, user);
         // Remove packages from excluded errata
-        ErrataManager.removeErratumAndPackagesFromChannel(excludedErrata, tgt, user);
+        ErrataManager.removeErratumAndPackagesFromChannel(excludedErrata, includedErrata, tgt, user);
         // Merge the included errata
         ErrataManager.mergeErrataToChannel(user, includedErrata, tgt, src, false, false);
     }

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -305,7 +305,7 @@ public class ErrataManager extends BaseManager {
                 .map(er -> srcErrata.contains(er.getOriginal())).orElse(false)))
                 .collect(Collectors.toUnmodifiableSet());
 
-        removeErratumAndPackagesFromChannel(filteredErrata, tgtChannel, user);
+        removeErratumAndPackagesFromChannel(filteredErrata, srcErrata, tgtChannel, user);
     }
 
     private static Optional<ClonedErrata> asCloned(Errata e) {
@@ -1307,25 +1307,31 @@ public class ErrataManager extends BaseManager {
      * Remove an erratum and its packages from a channel and updates the errata cache accordingly.
      * The errata is not removed from child channels if they exist!
      *
-     * @param errata the errata to remove
+     * @param excludedErrata the erratas to remove
+     * @param includedErrata the erratas to keep
      * @param chan the channel to remove the erratum from
      * @param user the user doing the removing
      */
-    public static void removeErratumAndPackagesFromChannel(Set<Errata> errata, Channel chan, User user) {
+    public static void removeErratumAndPackagesFromChannel(Set<Errata> excludedErrata, Set<Errata> includedErrata,
+                                                           Channel chan, User user) {
         if (!user.hasRole(RoleFactory.CHANNEL_ADMIN)) {
             throw new PermissionException(RoleFactory.CHANNEL_ADMIN);
         }
 
 
         //Remove the errata from the channel
-        chan.getErratas().removeAll(errata);
-        List<Long> eList = errata.stream().map(Errata::getId).collect(toList());
+        chan.getErratas().removeAll(excludedErrata);
+        List<Long> eList = excludedErrata.stream().map(Errata::getId).collect(toList());
         //First delete the cache entries
         ErrataCacheManager.deleteCacheEntriesForChannelErrata(chan.getId(), eList);
 
-        Set<Package> packages = new HashSet<>();
-        errata.forEach(e -> packages.addAll(e.getPackages()));
-        List<Long> pids = packages.stream().map(Package::getId).collect(Collectors.toList());
+        //Packages to remove should be all of excluded errata except if it is also present in any included errata.
+        Set<Package> packagesToRemove = excludedErrata.stream().flatMap(
+            e -> e.getPackages().stream().filter(
+                p -> includedErrata.stream().noneMatch(included -> included.getPackages().contains(p))
+            )
+        ).collect(Collectors.toUnmodifiableSet());
+        List<Long> pids = packagesToRemove.stream().map(Package::getId).collect(Collectors.toList());
         ErrataCacheManager.deleteCacheEntriesForChannelPackages(chan.getId(), pids);
 
         // remove packages

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix CLM to not remove necessary packages when filtering erratas (bsc#1195979)
 - Remove invalid errata selection after patch installation (bsc#1204235)
 - Ignore insert conflicts during reporting database update (bsc#1202150)
 - Honor page size preference in new system lists


### PR DESCRIPTION
## What does this PR change?

It fixes CLM to not remove necessary packages when filtering erratas. Some packages can be present in multiple erratas. When CLM uses a errata issue date filter, it takes the packages out of the resultant channel, compromising the integrity of the included errata where the package is also present. This patch changes the behavior to only remove the packages that are not present in any remaining errata.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/17015

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
