### PR TITLE
Remove invalid errata selection after patch installation

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Errata_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Errata_queries.xml
@@ -887,6 +887,16 @@ ORDER BY E.update_date, E.id
   <elaborator name="errata_flags" />
 </mode>
 
+<write-mode name="delete_invalid_erratas_from_set">
+  <query params="label">
+    DELETE FROM rhnSet
+      WHERE label = :label
+        AND element not in (
+          select errata_id from rhnServerNeededErrataCache where errata_id is not null
+        )
+    </query>
+</write-mode>
+
 <mode name="in_set_details" class="com.redhat.rhn.frontend.dto.ErrataOverview">
         <query params="user_id, set_label">
         SELECT DISTINCT E.id,

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -2195,4 +2195,18 @@ public class ErrataManager extends BaseManager {
         // update search index via XMLRPC
         updateSearchIndex();
     }
+
+    /**
+     * Remove from RhnSet erratas that are not needed for the server.
+     * This is useful to remove elements that were included when the errata was needed and remained.
+     *
+     * @param serverId the server id
+     */
+    public static void updateErrataSet(Long serverId) {
+        String errataLabel = RhnSetDecl.generateCustomSetName(RhnSetDecl.ERRATA, serverId);
+        Map<String, Object> params = new HashMap<>();
+        params.put("label", errataLabel);
+        WriteMode m = ModeFactory.getWriteMode("Errata_queries", "delete_invalid_erratas_from_set");
+        m.executeUpdate(params);
+    }
 }

--- a/java/code/src/com/redhat/rhn/manager/errata/cache/UpdateErrataCacheCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/cache/UpdateErrataCacheCommand.java
@@ -25,6 +25,7 @@ import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.manager.BaseTransactionCommand;
+import com.redhat.rhn.manager.errata.ErrataManager;
 import com.redhat.rhn.manager.system.SystemManager;
 
 import org.apache.logging.log4j.LogManager;
@@ -192,6 +193,7 @@ public class UpdateErrataCacheCommand extends BaseTransactionCommand {
 
     private void processServer(Long serverId) {
         ServerFactory.updateServerNeededCache(serverId);
+        ErrataManager.updateErrataSet(serverId);
     }
 
     private void processImage(Long imageId) {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Remove invalid errata selection after patch installation (bsc#1204235)
 - Ignore insert conflicts during reporting database update (bsc#1202150)
 - Honor page size preference in new system lists
 - Fix kickstart for RHEL 9 to not add install command


### PR DESCRIPTION
## What does this PR change?

After a successful patch installation, an update to `rhnServerNeededCache` table is scheduled to run, but it takes up to a minute to effectively run and reflect on the screen. In this interval, the already installed patch is available for selection on the screen. Selecting it at this moment persists the selection into the rhnSet table, after some seconds the patch will disappear from the screen and there is no chance to remove it after that.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/19273
Related to https://github.com/SUSE/spacewalk/issues/19239

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
