### PR TITLE
Display package summary

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
@@ -537,19 +537,22 @@ SELECT PN.name as NAME,
 
 <mode name="system_package_list" class="com.redhat.rhn.frontend.dto.PackageListItem">
   <query params="sid">
-  SELECT (SELECT max(p.id) FROM rhnPackage p
-                           JOIN rhnChannelPackage cp on p.id = cp.package_id
-                           JOIN rhnServerChannel sc on cp.channel_id = sc.channel_id
-                          WHERE p.name_id = pn.id
-                            AND p.evr_id = pe.id
-                            AND p.package_arch_id = pa.id
-                            AND (p.org_id = s.org_id or p.org_id is null)
-                            AND sc.server_id = :sid
-          ) as package_id,
+    WITH highest_id_packages AS (
+        SELECT p.name_id, p.evr_id, p.package_arch_id, max(p.id) AS id
+          FROM rhnServerPackage sp
+                    INNER JOIN rhnServer s ON sp.server_id = s.id
+                    INNER JOIN rhnServerChannel sc on sc.server_id = s.id
+                    INNER JOIN rhnChannelPackage cp on cp.channel_id = sc.channel_id
+                    INNER JOIN rhnpackage p ON sp.evr_id = p.evr_id AND sp.name_id = p.name_id AND sp.package_arch_id = p.package_arch_id AND p.id = cp.package_id
+         WHERE sp.server_id = :sid AND (p.org_id = s.org_id or p.org_id is null)
+        GROUP BY p.name_id, p.evr_id, p.package_arch_id
+    )
+    SELECT p.id AS package_id,
          pn.id || '|' || pe.id || '|' || pa.id as id_combo,
          pn.name || '-' || evr_t_as_vre_simple(pe.evr) as nvre,
          pn.name || '-' || evr_t_as_vre_simple(pe.evr) || '.' || pa.label as nvrea,
          pn.name as name,
+         p.summary AS summary,
          pe.version as version,
          pe.release as release,
          pe.epoch as epoch,
@@ -558,16 +561,14 @@ SELECT PN.name as NAME,
          pa.label as arch,
          sp.installtime
     FROM rhnPackageName pn
-    JOIN rhnServerPackage sp
-      ON sp.name_id = pn.id
-    JOIN rhnServer s
-      ON sp.server_id = s.id
-    JOIN rhnPackageEvr pe
-      ON sp.evr_id = pe.id
-    LEFT JOIN rhnPackageArch pa
-      ON sp.package_arch_id = pa.id
-   WHERE sp.server_id = :sid
-   ORDER BY nvre
+            INNER JOIN rhnServerPackage sp ON sp.name_id = pn.id
+            INNER JOIN rhnServer s ON sp.server_id = s.id
+            INNER JOIN rhnPackageEvr pe ON sp.evr_id = pe.id
+            LEFT JOIN rhnPackageArch pa ON sp.package_arch_id = pa.id
+            LEFT JOIN highest_id_packages hp ON hp.name_id = sp.name_id AND hp.evr_id = sp.evr_id AND hp.package_arch_id = sp.package_arch_id
+            LEFT JOIN rhnpackage p ON hp.id = p.id
+    WHERE sp.server_id = :sid
+    ORDER BY nvre
   </query>
   <elaborator name="package_retracted_and_ptf_details" />
 </mode>
@@ -828,6 +829,7 @@ SELECT P.id, P.summary, PP.name as provider
   <query params="sid">
 SELECT rp.id AS package_id,
        pn.name || '-' || evr_t_as_vre_simple(latest.evr) AS NVRE,
+       rp.summary AS summary,
        latest.arch_label as arch,
        pn.id || '|' || rp.evr_id || '|' || latest.arch_id AS ID_COMBO
   FROM (

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -2907,6 +2907,12 @@ button below, and &lt;b&gt;will be unable to log back in&lt;/b&gt;.</source>
           <context context-type="sourcefile">/rhn/errata/manage/AddPackagesConfirm.do</context>
         </context-group>
       </trans-unit>
+        <trans-unit id="packagelist.jsp.packagesummary" xml:space="preserve">
+        <source>Summary</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/systems/details/packages/InstallPackages</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="packagelist.jsp.packagearch" xml:space="preserve">
         <source>Architecture</source>
         <context-group name="ctx">

--- a/java/code/webapp/WEB-INF/pages/systems/details/packages/packagelist.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/details/packages/packagelist.jsp
@@ -48,50 +48,45 @@
             </div>
         </div>
     </c:if>
-        <rl:list dataset="pageList"
-         width="100%"
-         name="packageList"
-         emptykey="packagelist.jsp.nopackages"
-         alphabarcolumn="nvre">
-                        <rl:decorator name="PageSizeDecorator"/>
-                <rl:decorator name="SelectableDecorator"/>
-                        <rl:selectablecolumn value="${current.selectionKey}"
-                                selected="${current.selected}"
-                                disabled="${not current.selectable}"/>
 
-                  <rl:column headerkey="packagelist.jsp.packagename" bound="false"
-                        sortattr="nvre"
-                        sortable="true" filterattr="nvre" defaultsort="asc">
-                    <c:if test="${current.retracted}">
-                        <rhn:icon type="errata-retracted" title="errata.jsp.retracted-package-tooltip" />
-                    </c:if>
+    <rl:list dataset="pageList" width="100%" name="packageList" emptykey="packagelist.jsp.nopackages" alphabarcolumn="nvre">
+        <rl:decorator name="PageSizeDecorator"/>
+        <rl:decorator name="SelectableDecorator"/>
+        <rl:selectablecolumn value="${current.selectionKey}" selected="${current.selected}" disabled="${not current.selectable}"/>
+
+        <rl:column headerkey="packagelist.jsp.packagename" bound="false" sortattr="nvre" sortable="true" filterattr="nvre" defaultsort="asc">
+            <c:if test="${current.retracted}">
+                <rhn:icon type="errata-retracted" title="errata.jsp.retracted-package-tooltip" />
+            </c:if>
             <c:choose>
                 <c:when test="${not empty current.packageId}">
-                    <a href="/rhn/software/packages/Details.do?pid=${current.packageId}">
-                            ${current.nvre}</a>
+                    <a href="/rhn/software/packages/Details.do?pid=${current.packageId}">${current.nvre}</a>
                 </c:when>
                 <c:otherwise>
                     <c:out value="${current.nvre}"/>
                 </c:otherwise>
             </c:choose>
-                  </rl:column>
-    <rl:column headerkey="packagelist.jsp.packagearch" bound="false">
-        <c:choose>
+        </rl:column>
+        <rl:column headerkey="packagelist.jsp.packagesummary" bound="false" sortable="true" sortattr="summary">
+            <c:choose>
+                <c:when test="${not empty current.summary}">${current.summary}</c:when>
+            </c:choose>
+        </rl:column>
+        <rl:column headerkey="packagelist.jsp.packagearch" bound="false">
+            <c:choose>
                 <c:when test ="${not empty current.arch}">${current.arch}</c:when>
                 <c:otherwise><bean:message key="packagelist.jsp.notspecified"/></c:otherwise>
-        </c:choose>
-    </rl:column>
-    <rl:column headerkey="packagelist.jsp.installtime" bound="false"
-                sortattr="installTimeObj" sortable="true">
-                <c:choose>
-            <c:when test ="${not empty current.installTime}">
-                <rhn:formatDate humanStyle="calendar" value="${current.installTimeObj}"
-                              type="both" dateStyle="short" timeStyle="long"/>
-            </c:when>
-            <c:otherwise><bean:message key="packagelist.jsp.notspecified"/></c:otherwise>
-        </c:choose>
-    </rl:column>
-        </rl:list>
+            </c:choose>
+        </rl:column>
+        <rl:column headerkey="packagelist.jsp.installtime" bound="false" sortattr="installTimeObj" sortable="true">
+            <c:choose>
+                <c:when test ="${not empty current.installTime}">
+                    <rhn:formatDate humanStyle="calendar" value="${current.installTimeObj}" type="both" dateStyle="short" timeStyle="long"/>
+                </c:when>
+                <c:otherwise><bean:message key="packagelist.jsp.notspecified"/></c:otherwise>
+            </c:choose>
+        </rl:column>
+    </rl:list>
 </rl:listset>
 </body>
 </html>

--- a/java/code/webapp/WEB-INF/pages/systems/details/packages/packagelist.jspf
+++ b/java/code/webapp/WEB-INF/pages/systems/details/packages/packagelist.jspf
@@ -41,41 +41,39 @@
         </div>
     </c:if>
 
-        <rl:list dataset="pageList"
-         width="100%"
-         name="packageList"
-         styleclass="list"
-         emptykey="packagelist.jsp.nopackages"
-         alphabarcolumn="nvre">
-                        <rl:decorator name="PageSizeDecorator"/>
-                        <rl:decorator name="ElaborationDecorator"/>
-                <rl:decorator name="SelectableDecorator"/>
-                        <rl:selectablecolumn value="${current.selectionKey}"
-                                selected="${current.selected}"
-                                disabled="${not current.selectable}"/>
+      <rl:list dataset="pageList" width="100%" name="packageList" styleclass="list" emptykey="packagelist.jsp.nopackages" alphabarcolumn="nvre">
+        <rl:decorator name="PageSizeDecorator"/>
+        <rl:decorator name="ElaborationDecorator"/>
+        <rl:decorator name="SelectableDecorator"/>
 
-                  <rl:column headerkey="packagelist.jsp.packagename" bound="false"
-                        sortattr="nvre"
-                        sortable="true" filterattr="nvre" styleclass="${nameStyle}" defaultsort="asc">
-            <c:choose>
-                <c:when test="${not checkPackageId or not empty current.packageId}">
-                  <a href="/rhn/software/packages/Details.do?pid=${current.packageId}">
-                    ${current.nvre}</a>
-                </c:when>
-                <c:otherwise>
-                    <c:out value="${current.nvre}"/>
-                </c:otherwise>
-            </c:choose>
-                  </rl:column>
-        <c:if test="${not empty showArch}">
-        <rl:column headerkey="packagelist.jsp.packagearch" bound="false" styleclass="thin-column last-column">
-                <c:choose>
-                        <c:when test ="${not empty current.arch}">${current.arch}</c:when>
-                        <c:otherwise><bean:message key="packagelist.jsp.notspecified"/></c:otherwise>
-                </c:choose>
+        <rl:selectablecolumn value="${current.selectionKey}" selected="${current.selected}" disabled="${not current.selectable}"/>
+
+        <rl:column headerkey="packagelist.jsp.packagename" bound="false" sortattr="nvre" sortable="true" filterattr="nvre" styleclass="${nameStyle}" defaultsort="asc">
+          <c:choose>
+              <c:when test="${not checkPackageId or not empty current.packageId}">
+                <a href="/rhn/software/packages/Details.do?pid=${current.packageId}">${current.nvre}</a>
+              </c:when>
+              <c:otherwise>
+                  <c:out value="${current.nvre}"/>
+              </c:otherwise>
+          </c:choose>
         </rl:column>
-    </c:if>
-        </rl:list>
+
+        <rl:column headerkey="packagelist.jsp.packagesummary" bound="false" sortable="true" sortattr="summary">
+          <c:choose>
+            <c:when test="${not empty current.summary}">${current.summary}</c:when>
+          </c:choose>
+        </rl:column>
+
+        <c:if test="${not empty showArch}">
+          <rl:column headerkey="packagelist.jsp.packagearch" bound="false" styleclass="thin-column last-column">
+                  <c:choose>
+                    <c:when test="${not empty current.arch}">${current.arch}</c:when>
+                    <c:otherwise><bean:message key="packagelist.jsp.notspecified"/></c:otherwise>
+                  </c:choose>
+          </rl:column>
+        </c:if>
+      </rl:list>
 </rl:listset>
 </body>
 </html>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Show the package summary where applicable to better describe PTF packages
 - Added CLM filters to match product temporary fixes packages
 - Restrict product temporary fixes visibility in the UI and in the
   APIs responses


### PR DESCRIPTION
## What does this PR change?

This PR adds the summary column for the package list in the following pages:

- List / Remove
- Install
- Verify

## GUI diff

After:

![image](https://user-images.githubusercontent.com/2292684/204554751-be58b9ab-a4e7-4a75-bc59-bde2d8d9ab44.png)
![image](https://user-images.githubusercontent.com/2292684/204555006-1387bf83-0700-4501-89bc-8452a9cccbca.png)
![image](https://user-images.githubusercontent.com/2292684/204557340-ac96336d-acbd-49fd-beca-7aa047687796.png)



- [X] **DONE**

## Documentation
- No documentation needed: improvement on existing documented features

- [ ] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18968

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
