### PR TITLE
Fix ssm keyword parsing for scap scheduling in spacecmd

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Correctly understand 'ssm' keyword on scap scheduling
 - Add vendor_advisory information to errata_details call (bsc#1205207)
 * Change default port of "Containerized Proxy configuration" 8022 (#19543)
 

--- a/spacecmd/src/spacecmd/scap.py
+++ b/spacecmd/src/spacecmd/scap.py
@@ -195,15 +195,16 @@ def do_scap_schedulexccdfscan(self, args):
         self.help_scap_schedulexccdfscan()
         return 1
 
-    path = args[0]
-    param = "--"
-    param += args[1]
-
     # use the systems listed in the SSM
     if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
+        args.pop(0)
     else:
         systems = self.expand_systems(args[2:])
+
+    path = args[0]
+    param = "--"
+    param += args[1]
 
     if not systems:
         logging.warning(_N('No systems selected'))


### PR DESCRIPTION
## What does this PR change?

Fix ssm keyword parsing for scap scheduling in spacecmd

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests: **add explanation**

- [ ] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/6225

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
