### PR TITLE
Changing omitted test channel name for RH like client

### DIFF
--- a/testsuite/features/secondary/min_rhlike_salt_install_package_and_patch.feature
+++ b/testsuite/features/secondary/min_rhlike_salt_install_package_and_patch.feature
@@ -24,7 +24,7 @@ Feature: Install a patch on the Red Hat-like minion via Salt through the UI
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "Test-Channel-x86_64"
+    And I check radio button "Fake-RH-Like-Channel"
     And I wait until I do not see "Loading..." text
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text


### PR DESCRIPTION
## What does this PR change?

The RedHat-like minion does not need `Test-Channel-x86_64` anymore since it now has its dedicated test channel.
Miss from the base-poduct PR.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were edited

- [x] **DONE**

## Links

Fixes #
Tracks # 
4.3 https://github.com/SUSE/spacewalk/pull/19716

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
