### PR TITLE
QE: Move virthost init from secondary to core

### DIFF
--- a/testsuite/features/init_clients/min_virthost.feature
+++ b/testsuite/features/init_clients/min_virthost.feature
@@ -1,0 +1,73 @@
+# Copyright (c) 2022 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+# This feature is not idempotent, we leave the system registered in order to have the history of events available
+# and as a dependency for the KVM and Salt bundle tests in secondary.
+
+@virthost_kvm
+Feature: Bootstrap a virtualization host minion and set it up for virtualization
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Create KVM activation key
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "Create Key"
+    When I enter "KVM testing" as "description"
+    And I enter "KVM-TEST" as "key"
+    And I enter "20" as "usageLimit"
+    And I select "Test-Channel-x86_64" from "selectedBaseChannel"
+    And I click on "Create Activation Key"
+    Then I should see a "Activation key KVM testing has been created" text
+
+  Scenario: Bootstrap KVM virtual host
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I enter the hostname of "kvm_server" as "hostname"
+    And I enter "22" as "port"
+    And I enter "root" as "user"
+    And I enter KVM Server password
+    And I select "1-KVM-TEST" from "activationKeys"
+    And I select the hostname of "proxy" from "proxies" if present
+    And I click on "Bootstrap"
+    And I wait until I see "Successfully bootstrapped host!" text
+    And I wait until onboarding is completed for "kvm_server"
+
+  Scenario: Show the KVM host system overview
+    Given I am on the Systems overview page of this "kvm_server"
+
+  Scenario: Set the virtualization entitlement for KVM
+    When I follow "Details" in the content area
+    And I follow "Properties" in the content area
+    And I check "virtualization_host"
+    And I click on "Update Properties"
+    Then I should see a "Since you added a Virtualization system type to the system" text
+
+  Scenario: Enable the virtualization host formula for KVM
+    When I follow "Formulas" in the content area
+    Then I should see a "Choose formulas" text
+    And I should see a "Virtualization" text
+    When I check the "virtualization-host" formula
+    And I click on "Save"
+    And I wait until I see "Formula saved." text
+    Then the "virtualization-host" formula should be checked
+
+  Scenario: Parametrize the KVM virtualization host
+    When I follow "Formulas" in the content area
+    And I follow first "Virtualization Host" in the content area
+    And I click on "Expand All Sections"
+    And I select "NAT" in virtual network mode field
+    And I enter "192.168.124.1" in virtual network IPv4 address field
+    And I enter "192.168.124.2" in first IPv4 address for DHCP field
+    And I enter "192.168.124.254" in last IPv4 address for DHCP field
+    And I click on "Save Formula"
+    Then I should see a "Formula saved" text
+
+  Scenario: Apply the KVM virtualization host formula via the highstate
+    When I follow "States" in the content area
+    And I click on "Apply Highstate"
+    And I wait until event "Apply highstate scheduled by admin" is completed
+    Then service "libvirtd" is enabled on "kvm_server"
+
+  Scenario: Restart the minion to enable libvirt_events engine configuration
+    Then I restart salt-minion on "kvm_server"

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -1,10 +1,10 @@
 # Copyright (c) 2018-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-# This feature is not idempotent, we leave the system registered in order to have available the history of events,
-# but there are no other features testing KVM.
+# This feature is not idempotent, we leave the system registered in order to have the history of events
+# available.
 
-# This feature has not dependencies and it can run in parallel with other features
+# This feature has not dependencies and it can run in parallel with other features.
 
 @scope_virtualization
 @virthost_kvm
@@ -13,68 +13,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
-
-  Scenario: Create KVM activation key
-    When I follow the left menu "Systems > Activation Keys"
-    And I follow "Create Key"
-    When I enter "KVM testing" as "description"
-    And I enter "KVM-TEST" as "key"
-    And I enter "20" as "usageLimit"
-    And I select "Test-Channel-x86_64" from "selectedBaseChannel"
-    And I click on "Create Activation Key"
-    Then I should see a "Activation key KVM testing has been created" text
-
-  Scenario: Bootstrap KVM virtual host
-    When I follow the left menu "Systems > Bootstrapping"
-    Then I should see a "Bootstrap Minions" text
-    When I enter the hostname of "kvm_server" as "hostname"
-    And I enter "22" as "port"
-    And I enter "root" as "user"
-    And I enter KVM Server password
-    And I select "1-KVM-TEST" from "activationKeys"
-    And I select the hostname of "proxy" from "proxies" if present
-    And I click on "Bootstrap"
-    And I wait until I see "Successfully bootstrapped host!" text
-    And I wait until onboarding is completed for "kvm_server"
-
-  Scenario: Show the KVM host system overview
-    Given I am on the Systems overview page of this "kvm_server"
-
-  Scenario: Set the virtualization entitlement for KVM
-    When I follow "Details" in the content area
-    And I follow "Properties" in the content area
-    And I check "virtualization_host"
-    And I click on "Update Properties"
-    Then I should see a "Since you added a Virtualization system type to the system" text
-
-  Scenario: Enable the virtualization host formula for KVM
-    When I follow "Formulas" in the content area
-    Then I should see a "Choose formulas" text
-    And I should see a "Virtualization" text
-    When I check the "virtualization-host" formula
-    And I click on "Save"
-    And I wait until I see "Formula saved." text
-    Then the "virtualization-host" formula should be checked
-
-  Scenario: Parametrize the KVM virtualization host
-    When I follow "Formulas" in the content area
-    And I follow first "Virtualization Host" in the content area
-    And I click on "Expand All Sections"
-    And I select "NAT" in virtual network mode field
-    And I enter "192.168.124.1" in virtual network IPv4 address field
-    And I enter "192.168.124.2" in first IPv4 address for DHCP field
-    And I enter "192.168.124.254" in last IPv4 address for DHCP field
-    And I click on "Save Formula"
-    Then I should see a "Formula saved" text
-
-  Scenario: Apply the KVM virtualization host formula via the highstate
-    When I follow "States" in the content area
-    And I click on "Apply Highstate"
-    And I wait until event "Apply highstate scheduled by admin" is completed
-    Then service "libvirtd" is enabled on "kvm_server"
-
-  Scenario: Restart the minion to enable libvirt_events engine configuration
-    Then I restart salt-minion on "kvm_server"
 
   Scenario: Prepare a KVM test virtual machine and list it
     When I delete default virtual network on "kvm_server"

--- a/testsuite/run_sets/init_clients.yml
+++ b/testsuite/run_sets/init_clients.yml
@@ -12,6 +12,7 @@
 - features/init_clients/sle_ssh_minion.feature
 - features/init_clients/min_rhlike_salt.feature
 - features/init_clients/min_deblike_salt.feature
+- features/init_clients/min_virthost.feature
 - features/init_clients/buildhost_bootstrap.feature
 
 ## Post run Core - Initialize clients END ##


### PR DESCRIPTION
## What does this PR change?

The initialization of the virthosts is done in `minkvm_guest.features` which is executed during secondary_parallelizable. With the upcoming Salt bundle tests we need in already in secondary. The solution was to move the initialization into core and just leave the KVM tests in `minkvm_guest.feature` in secondary_parallelizable. This PR adds a new `min_virthost.feature` to init_clients in the core stage.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**

- [x] **DONE**

## Test coverage

- Cucumber tests were adjusted

- [x] **DONE**

## Links

Manager 4.3
Manager 4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
