### PR TITLE
Add 'octet-stream' to accepted mirrorlist content-types

### DIFF
--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -537,7 +537,8 @@ class ContentSource:
         try:
             webpage = requests.get(url, proxies=proxies, cert=cert, verify=verify)
             content_type = webpage.headers["Content-Type"]
-            if "text/plain" not in content_type and "xml" not in content_type:
+            # amazonlinux core channels content-type = binary/octet-stream
+            if "text/plain" not in content_type and "xml" not in content_type and "octet-stream" not in content_type:
                 # Not a valid mirrorlist or metalink; continue without it
                 return returnlist
         except requests.exceptions.RequestException as exc:

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Add 'octet-stream' to accepted content-types for reposync mirrorlists
 - Add rhel_9 as Salt-enabled kickstart installation
 - Remove AppStream variant from EL8 and derivatives treeinfos
 


### PR DESCRIPTION
## What does this PR change?

This commit adds 'octet-stream' to the list of acceptable content-types for urls pointing to mirrorlists. This fixes:
https://github.com/uyuni-project/uyuni/issues/6244 and ensures that amazonlinux channels will continue to work.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
