### PR TITLE
QE: Temporary stop/start tftp service until spacewalk-proxy handle it

### DIFF
--- a/testsuite/features/build_validation/containerization/proxy_as_pod_basic_tests.feature
+++ b/testsuite/features/build_validation/containerization/proxy_as_pod_basic_tests.feature
@@ -33,9 +33,12 @@ Feature: Register and test a Containerized Proxy
   Scenario: Pre-requisite: Stop traditional proxy service
     When I stop salt-minion on "proxy"
     And I run "spacewalk-proxy stop" on "proxy"
+    # workaround for bsc#1205976
+    And I stop "tftp" service on "proxy"
     And I wait until "squid" service is inactive on "proxy"
     And I wait until "apache2" service is inactive on "proxy"
     And I wait until "jabberd" service is inactive on "proxy"
+    And I wait until "tftp" service is inactive on "proxy"
 
   Scenario: Generate Containerized Proxy configuration
     When I generate the configuration "/tmp/proxy_container_config.tar.gz" of Containerized Proxy on the server
@@ -247,9 +250,12 @@ Feature: Register and test a Containerized Proxy
   Scenario: Cleanup: Start traditional proxy service
     When I start salt-minion on "proxy"
     And I run "spacewalk-proxy start" on "proxy"
+    # workaround for bsc#1205976
+    And I start "tftp" service on "proxy"
     And I wait until "squid" service is active on "proxy"
     And I wait until "apache2" service is active on "proxy"
     And I wait until "jabberd" service is active on "proxy"
+    And I wait until "tftp" service is active on "proxy"
 
   Scenario: Cleanup: Bootstrap a Salt minion in the traditional proxy
     When I follow the left menu "Systems > Bootstrapping"

--- a/testsuite/features/core/proxy_register_as_pod.feature
+++ b/testsuite/features/core/proxy_register_as_pod.feature
@@ -20,9 +20,12 @@ Feature: Setup Containerized Proxy
   Scenario: Pre-requisite: Stop traditional proxy service
     When I stop salt-minion on "proxy"
     And I run "spacewalk-proxy stop" on "proxy"
+    # workaround for bsc#1205976
+    And I stop "tftp" service on "proxy"
     And I wait until "squid" service is inactive on "proxy"
     And I wait until "apache2" service is inactive on "proxy"
     And I wait until "jabberd" service is inactive on "proxy"
+    And I wait until "tftp" service is inactive on "proxy"
 
   Scenario: Generate Containerized Proxy configuration
     When I generate the configuration "/tmp/proxy_container_config.tar.gz" of Containerized Proxy on the server

--- a/testsuite/features/secondary/proxy_as_pod_basic_tests.feature
+++ b/testsuite/features/secondary/proxy_as_pod_basic_tests.feature
@@ -32,9 +32,12 @@ Feature: Register and test a Containerized Proxy
   Scenario: Pre-requisite: Stop traditional proxy service
     When I stop salt-minion on "proxy"
     And I run "spacewalk-proxy stop" on "proxy"
+    # workaround for bsc#1205976
+    And I stop "tftp" service on "proxy"
     And I wait until "squid" service is inactive on "proxy"
     And I wait until "apache2" service is inactive on "proxy"
     And I wait until "jabberd" service is inactive on "proxy"
+    And I wait until "tftp" service is inactive on "proxy"
 
   Scenario: Generate Containerized Proxy configuration
     When I generate the configuration "/tmp/proxy_container_config.tar.gz" of Containerized Proxy on the server
@@ -246,9 +249,12 @@ Feature: Register and test a Containerized Proxy
   Scenario: Cleanup: Start traditional proxy service
     When I start salt-minion on "proxy"
     And I run "spacewalk-proxy start" on "proxy"
+    # workaround for bsc#1205976
+    And I start "tftp" service on "proxy"
     And I wait until "squid" service is active on "proxy"
     And I wait until "apache2" service is active on "proxy"
     And I wait until "jabberd" service is active on "proxy"
+    And I wait until "tftp" service is active on "proxy"
 
   Scenario: Cleanup: Bootstrap a Salt minion in the traditional proxy
     When I follow the left menu "Systems > Bootstrapping"


### PR DESCRIPTION
## What does this PR change?

Temporary stop/start tftp service until spacewalk-proxy handle it

Related bug: https://bugzilla.suse.com/show_bug.cgi?id=1205976

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.3 https://github.com/SUSE/spacewalk/pull/19740

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
