### PR TITLE
Fix "Feature:Bootstrap a SSH-managed Red Hat-like minion" fails with server error

### DIFF
--- a/java/code/src/com/suse/manager/reactor/utils/test/RhelUtilsTest.java
+++ b/java/code/src/com/suse/manager/reactor/utils/test/RhelUtilsTest.java
@@ -221,7 +221,7 @@ public class RhelUtilsTest extends JMockBaseTestCaseWithUser {
         String whatProvidesRes = map.get("cmd_|-respkgquery_|-rpm -q --whatprovides 'sles_es-release-server'_|-run")
                 .getChanges(CmdResult.class)
                 .getStdout();
-        String whatProvidesSLL = map.get("cmd_|-respkgquery_|-rpm -q --whatprovides 'sll-release'_|-run")
+        String whatProvidesSLL = map.get("cmd_|-sllpkgquery_|-rpm -q --whatprovides 'sll-release'_|-run")
                 .getChanges(CmdResult.class)
                 .getStdout();
         MinionServer minionServer = MinionServerFactoryTest.createTestMinionServer(user);

--- a/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_alibaba.json
+++ b/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_alibaba.json
@@ -9,7 +9,7 @@
     "__run_num__": 2,
     "changes": {}
   },
-  "cmd_|-respkgquery_|-rpm -q --whatprovides 'sll-release'_|-run": {
+  "cmd_|-sllpkgquery_|-rpm -q --whatprovides 'sll-release'_|-run": {
     "comment": "onlyif execution failed",
     "name": "rpm -q --whatprovides 'sll-release'",
     "start_time": "14:04:57.901731",

--- a/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_almalinux.json
+++ b/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_almalinux.json
@@ -9,7 +9,7 @@
     "__run_num__": 2,
     "changes": {}
   },
-  "cmd_|-respkgquery_|-rpm -q --whatprovides 'sll-release'_|-run": {
+  "cmd_|-sllpkgquery_|-rpm -q --whatprovides 'sll-release'_|-run": {
     "comment": "onlyif execution failed",
     "name": "rpm -q --whatprovides 'sll-release'",
     "start_time": "07:57:57.503534",

--- a/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_amazon.json
+++ b/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_amazon.json
@@ -9,7 +9,7 @@
     "__run_num__": 2,
     "changes": {}
   },
-  "cmd_|-respkgquery_|-rpm -q --whatprovides 'sll-release'_|-run": {
+  "cmd_|-sllpkgquery_|-rpm -q --whatprovides 'sll-release'_|-run": {
     "comment": "onlyif execution failed",
     "name": "rpm -q --whatprovides 'sll-release'",
     "start_time": "07:57:57.503534",

--- a/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_centos.json
+++ b/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_centos.json
@@ -9,7 +9,7 @@
     "__run_num__": 2,
     "changes": {}
   },
-  "cmd_|-respkgquery_|-rpm -q --whatprovides 'sll-release'_|-run": {
+  "cmd_|-sllpkgquery_|-rpm -q --whatprovides 'sll-release'_|-run": {
     "comment": "onlyif execution failed",
     "name": "rpm -q --whatprovides 'sll-release'",
     "start_time": "14:04:57.901731",

--- a/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_centos_res.json
+++ b/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_centos_res.json
@@ -10,9 +10,9 @@
     "changes": {},
     "result": true
   },
-  "cmd_|-respkgquery_|-rpm -q --whatprovides 'sll-release'_|-run": {
+  "cmd_|-sllpkgquery_|-rpm -q --whatprovides 'sll-release'_|-run": {
     "comment": "onlyif execution failed",
-    "__id__": "respkgquery",
+    "__id__": "sllpkgquery",
     "name": "rpm -q --whatprovides 'sll-release'",
     "duration": 86.271,
     "__run_num__": 3,

--- a/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_oracle.json
+++ b/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_oracle.json
@@ -9,7 +9,7 @@
     "__run_num__": 2,
     "changes": {}
   },
-  "cmd_|-respkgquery_|-rpm -q --whatprovides 'sll-release'_|-run": {
+  "cmd_|-sllpkgquery_|-rpm -q --whatprovides 'sll-release'_|-run": {
     "comment": "onlyif execution failed",
     "name": "rpm -q --whatprovides 'sll-release'",
     "start_time": "14:04:57.901731",

--- a/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_res.json
+++ b/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_res.json
@@ -43,7 +43,7 @@
       "result": true,
       "start_time": "06:54:14.789762"
     },
-    "cmd_|-respkgquery_|-rpm -q --whatprovides 'sll-release'_|-run": {
+    "cmd_|-sllpkgquery_|-rpm -q --whatprovides 'sll-release'_|-run": {
       "__run_num__": 2,
       "changes": {},
       "comment": "Command \"rpm -q --whatprovides 'sll-release'\" run",

--- a/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_rhel.json
+++ b/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_rhel.json
@@ -9,7 +9,7 @@
     "__run_num__": 2,
     "changes": {}
   },
-  "cmd_|-respkgquery_|-rpm -q --whatprovides 'sll-release'_|-run": {
+  "cmd_|-sllpkgquery_|-rpm -q --whatprovides 'sll-release'_|-run": {
     "comment": "onlyif execution failed",
     "name": "rpm -q --whatprovides 'sll-release'",
     "start_time": "07:57:57.503534",

--- a/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_rockylinux.json
+++ b/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_rockylinux.json
@@ -9,7 +9,7 @@
     "__run_num__": 2,
     "changes": {}
   },
-  "cmd_|-respkgquery_|-rpm -q --whatprovides 'sll-release'_|-run": {
+  "cmd_|-sllpkgquery_|-rpm -q --whatprovides 'sll-release'_|-run": {
     "comment": "onlyif execution failed",
     "name": "rpm -q --whatprovides 'sll-release'",
     "start_time": "07:57:57.503534",

--- a/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_sll.json
+++ b/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_sll.json
@@ -38,7 +38,7 @@
       "result": true,
       "start_time": "06:54:14.789762"
     },
-    "cmd_|-respkgquery_|-rpm -q --whatprovides 'sll-release'_|-run": {
+    "cmd_|-sllpkgquery_|-rpm -q --whatprovides 'sll-release'_|-run": {
       "__run_num__": 2,
       "changes": {
         "pid": 477,

--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/PkgProfileUpdateSlsResult.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/PkgProfileUpdateSlsResult.java
@@ -51,7 +51,7 @@ public class PkgProfileUpdateSlsResult {
     public static final String PKG_PROFILE_WHATPROVIDES_SLES_RELEASE =
             "cmd_|-respkgquery_|-rpm -q --whatprovides 'sles_es-release-server'_|-run";
     public static final String PKG_PROFILE_WHATPROVIDES_SLL_RELEASE =
-            "cmd_|-respkgquery_|-rpm -q --whatprovides 'sll-release'_|-run";
+            "cmd_|-sllpkgquery_|-rpm -q --whatprovides 'sll-release'_|-run";
 
     @SerializedName("mgrcompat_|-kernel_live_version_|-sumautil.get_kernel_live_version_|" +
             "-module_run")

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix server error while bootstrapping SSH-managed Red Hat-like minion (bsc#1205890)
 - send notifications also as email if email notifications are enabled
 - remove jabberd and osa-dispatcher
 - Add subscription warning notification to overview page

--- a/susemanager-utils/susemanager-sls/salt/packages/redhatproductinfo.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/redhatproductinfo.sls
@@ -31,4 +31,8 @@ respkgquery:
   cmd.run:
     - name: rpm -q --whatprovides 'sles_es-release-server'
     - onlyif: rpm -q --whatprovides 'sles_es-release-server'
+sllpkgquery:
+  cmd.run:
+    - name: rpm -q --whatprovides 'sll-release'
+    - onlyif: rpm -q --whatprovides 'sll-release'
 {% endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix server error while bootstrapping SSH-managed Red Hat-like minion (bsc#1205890)
 - drop legacy way to prevent disabling local repos
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Fix "Feature:Bootstrap a SSH-managed Red Hat-like minion" fails with server error

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19713

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
