### PR TITLE
QE: Fix broken call to a step definition

### DIFF
--- a/testsuite/features/secondary/srv_handle_config_channels_with_ISS_v2.feature
+++ b/testsuite/features/secondary/srv_handle_config_channels_with_ISS_v2.feature
@@ -33,8 +33,8 @@ Feature: Export and import configuration channels with new ISS implementation
     And file "/srv/susemanager/salt/manager_org_1/testconfigchannel/etc/s-mgr/config" should exist on server
 
   Scenario: Export data with ISS v2
-    When I ensure folder "/tmp/export_iss_v2" doesn't exist
-    Then export folder "/tmp/export_iss_v2" shouldn't exist on server
+    When I ensure folder "/tmp/export_iss_v2" doesn't exist on "server"
+    Then export folder "/tmp/export_iss_v2" shouldn't exist on "server"
     When I export config channels "testconfigchannel" with ISS v2 to "/tmp/export_iss_v2"
     Then "/tmp/export_iss_v2" folder on server is ISS v2 export directory
 
@@ -64,5 +64,5 @@ Feature: Export and import configuration channels with new ISS implementation
     And I should not see a "Test Config Channel" link
 
   Scenario: Cleanup: remove ISS v2 export folder
-    When I ensure folder "/tmp/export_iss_v2" doesn't exist
-    Then export folder "/tmp/export_iss_v2" shouldn't exist on server
+    When I ensure folder "/tmp/export_iss_v2" doesn't exist on "server"
+    Then export folder "/tmp/export_iss_v2" shouldn't exist on "server"

--- a/testsuite/features/secondary/srv_handle_software_channels_with_ISS_v2.feature
+++ b/testsuite/features/secondary/srv_handle_software_channels_with_ISS_v2.feature
@@ -34,8 +34,8 @@ Feature: Export and import software channels with new ISS implementation
     And I should see a "CL-andromeda-dummy-6789" link
 
   Scenario: Export data with ISS v2
-    When I ensure folder "/tmp/export_iss_v2" doesn't exist
-    Then export folder "/tmp/export_iss_v2" shouldn't exist on server
+    When I ensure folder "/tmp/export_iss_v2" doesn't exist on "server"
+    Then export folder "/tmp/export_iss_v2" shouldn't exist on "server"
     When I export software channels "clone-fake-rpm-sles-channel" with ISS v2 to "/tmp/export_iss_v2"
     Then "/tmp/export_iss_v2" folder on server is ISS v2 export directory
 
@@ -69,5 +69,5 @@ Feature: Export and import software channels with new ISS implementation
     Then I should see a "Clone of Fake-RPM-SLES-Channel" text
 
   Scenario: Cleanup: remove ISS v2 export folder
-    When I ensure folder "/tmp/export_iss_v2" doesn't exist
-    Then export folder "/tmp/export_iss_v2" shouldn't exist on server
+    When I ensure folder "/tmp/export_iss_v2" doesn't exist on "server"
+    Then export folder "/tmp/export_iss_v2" shouldn't exist on "server"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1546,8 +1546,9 @@ Then(/^"(.*?)" folder on server is ISS v2 export directory$/) do |folder|
   raise "Folder #{folder} not found" unless file_exists?($server, folder + "/sql_statements.sql.gz")
 end
 
-Then(/^export folder "(.*?)" shouldn't exist on server$/) do |folder|
-  raise "Folder exists" if folder_exists?($server, folder)
+Then(/^export folder "(.*?)" shouldn't exist on "(.*?)"$/) do |folder, host|
+  node = get_target(host)
+  raise "Folder exists" if folder_exists?(node, folder)
 end
 
 When(/^I ensure folder "(.*?)" doesn't exist on "(.*?)"$/) do |folder, host|


### PR DESCRIPTION
## What does this PR change?

On a previous PR I refactor a step to support passing a different host by parameter.
But I missed to refactor a scenario using the old step definition.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were fixed

- [x] **DONE**

## Links

Ports:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
