### PR TITLE
Update the API doc and check if filter already exists

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
@@ -606,7 +606,7 @@ public class ContentManagementHandler extends BaseHandler {
      *   #item("by type - field: advisory_type (e.g. 'Security Advisory'); matcher: equals")
      *   #item("by synopsis - field: synopsis; matcher: equals, contains or matches")
      *   #item("by keyword - field: keyword; matcher: contains")
-     *   #item("by date - field: issue_date; matcher: greater or greatereq")
+     *   #item("by date - field: issue_date; matcher: greater or greatereq; value needs to be in ISO format e.g 2022-12-10T12:00:00Z")
      *   #item("by affected package name - field: package_name; matcher: contains_pkg_name or matches_pkg_name")
      *   #item("by affected package with version - field: package_nevr; matcher: contains_pkg_lt_evr,
      *   contains_pkg_le_evr, contains_pkg_eq_evr, contains_pkg_ge_evr or contains_pkg_gt_evr")

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
@@ -606,7 +606,8 @@ public class ContentManagementHandler extends BaseHandler {
      *   #item("by type - field: advisory_type (e.g. 'Security Advisory'); matcher: equals")
      *   #item("by synopsis - field: synopsis; matcher: equals, contains or matches")
      *   #item("by keyword - field: keyword; matcher: contains")
-     *   #item("by date - field: issue_date; matcher: greater or greatereq; value needs to be in ISO format e.g 2022-12-10T12:00:00Z")
+     *   #item("by date - field: issue_date; matcher: greater or greatereq; value needs to be in ISO format e.g
+     *   2022-12-10T12:00:00Z")
      *   #item("by affected package name - field: package_name; matcher: contains_pkg_name or matches_pkg_name")
      *   #item("by affected package with version - field: package_nevr; matcher: contains_pkg_lt_evr,
      *   contains_pkg_le_evr, contains_pkg_eq_evr, contains_pkg_ge_evr or contains_pkg_gt_evr")
@@ -635,8 +636,11 @@ public class ContentManagementHandler extends BaseHandler {
      * @apidoc.returntype $ContentFilterSerializer
      */
     public ContentFilter createFilter(User loggedInUser, String name, String rule, String entityType,
-            Map<String, Object> criteria) {
+                                      Map<String, Object> criteria) {
         ensureOrgAdmin(loggedInUser);
+        ContentManager.lookupFilterByNameAndOrg(name, loggedInUser).ifPresent(cp -> {
+            throw new EntityExistsFaultException(cp);
+        });
 
         ContentFilter.Rule ruleObj = ContentFilter.Rule.lookupByLabel(rule);
         ContentFilter.EntityType entityTypeObj = ContentFilter.EntityType.lookupByLabel(entityType);


### PR DESCRIPTION
## What does this PR change?

- Add a note in docs that expected date is ISO format.
- Return a proper exception in case filter already exist

Before this change error like below was thrown.

```
xmlrpc.client.Fault: <Fault -1: 'redstone.xmlrpc.XmlRpcFault: unhandled internal exception: com.redhat.rhn.domain.contentmgmt.ErrataFilter@4c017b33[pattern=<null>,criteria=com.redhat.rhn.domain.contentmgmt.FilterCriteria@27d71d3c[matcher=GREATEREQ,field=issue_date,value=2022-12-01T18:35:12Z],id=8,name=filter_name2,org=com.redhat.rhn.domain.org.Org@1d96f234[id=1,name=Suse],rule=DENY,created=2022-12-01 18:35:09.892,modified=2022-12-01 18:35:09.892]'>

```


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **API docs will get created automatically**

- [x] **DONE**

## Test coverage
- No tests: already covered


- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
