### PR TITLE
Add a subscription warning to the overview page

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/notification/NotificationMessage.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/NotificationMessage.java
@@ -24,6 +24,7 @@ import com.redhat.rhn.domain.notification.types.NotificationType;
 import com.redhat.rhn.domain.notification.types.OnboardingFailed;
 import com.redhat.rhn.domain.notification.types.PaygAuthenticationUpdateFailed;
 import com.redhat.rhn.domain.notification.types.StateApplyFailed;
+import com.redhat.rhn.domain.notification.types.SubscriptionWarning;
 
 import com.google.gson.Gson;
 
@@ -131,6 +132,8 @@ public class NotificationMessage implements Serializable {
                 return new Gson().fromJson(getData(), PaygAuthenticationUpdateFailed.class);
             case EndOfLifePeriod:
                 return new Gson().fromJson(getData(), EndOfLifePeriod.class);
+            case SubscriptionWarning:
+                return new Gson().fromJson(getData(), SubscriptionWarning.class);
             default: throw new RuntimeException("should not happen!");
         }
     }

--- a/java/code/src/com/redhat/rhn/domain/notification/types/NotificationType.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/NotificationType.java
@@ -25,4 +25,5 @@ public enum NotificationType {
     StateApplyFailed,
     PaygAuthenticationUpdateFailed,
     EndOfLifePeriod,
+    SubscriptionWarning,
 }

--- a/java/code/src/com/redhat/rhn/domain/notification/types/SubscriptionWarning.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/SubscriptionWarning.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.domain.notification.types;
+
+import static com.redhat.rhn.common.hibernate.HibernateFactory.getSession;
+
+import com.redhat.rhn.common.localization.LocalizationService;
+import com.redhat.rhn.domain.notification.NotificationMessage;
+
+import java.util.List;
+
+
+public class SubscriptionWarning implements NotificationData {
+
+    private static final LocalizationService LOCALIZATION_SERVICE = LocalizationService.getInstance();
+
+    /**
+     * returns true if subscriptions that are expired within 30 days or will expire in within 90 days.
+     * @return boolean
+     **/
+    public boolean expiresSoon() {
+        List<Object[]> rows = getSession().createSQLQuery(
+        "select exists (select name,  expires_at, status, subtype " +
+                "from susesccsubscription where subtype != 'internal' " +
+                " and (status = 'ACTIVE' and expires_at < now() + interval '90 day') " +
+                "or (status = 'EXPIRED' and expires_at > now() - interval '30 day'))").list();
+
+        return !rows.isEmpty();
+    }
+
+    @Override
+    public NotificationMessage.NotificationMessageSeverity getSeverity() {
+        return null;
+    }
+
+    @Override
+    public NotificationType getType() {
+        return NotificationType.SubscriptionWarning;
+    }
+
+    @Override
+    public String getSummary() {
+         if (expiresSoon()) {
+             return LOCALIZATION_SERVICE.getMessage("notification.subscriptionwarning.summary");
+         }
+        return null;
+    }
+
+    @Override
+    public String getDetails() {
+        if (expiresSoon()) {
+            return LOCALIZATION_SERVICE.getMessage("notification.subscriptionwarning.detail");
+        }
+        return null;
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/notification/types/SubscriptionWarning.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/SubscriptionWarning.java
@@ -42,7 +42,7 @@ public class SubscriptionWarning implements NotificationData {
 
     @Override
     public NotificationMessage.NotificationMessageSeverity getSeverity() {
-        return null;
+        return NotificationMessage.NotificationMessageSeverity.warning;
     }
 
     @Override

--- a/java/code/src/com/redhat/rhn/domain/notification/types/test/SubscriptionWarningTest.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/test/SubscriptionWarningTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.domain.notification.types.test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.redhat.rhn.domain.notification.types.SubscriptionWarning;
+import com.redhat.rhn.testing.RhnBaseTestCase;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SubscriptionWarningTest extends RhnBaseTestCase {
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @Test
+    public void testGetNullStrings() {
+        SubscriptionWarning sw = new SubscriptionWarning() {
+            @Override
+            public boolean expiresSoon() {
+                return false;
+            }
+        };
+        assertNull(sw.getSummary());
+        assertNull(sw.getDetails());
+    }
+
+    @Test
+     public void testGetStrings() {
+        SubscriptionWarning sw = new SubscriptionWarning() {
+            @Override
+            public boolean expiresSoon() {
+                return true;
+            }
+        };
+        assertNotNull(sw.getSummary());
+        assertNotNull(sw.getDetails());
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/user/Pane.java
+++ b/java/code/src/com/redhat/rhn/domain/user/Pane.java
@@ -33,9 +33,10 @@ public class Pane {
     public static final String INACTIVE_SYSTEMS = "inactive-systems";
     public static final String PENDING_ACTIONS = "pending-actions";
     public static final String RECENTLY_REGISTERED_SYSTEMS = "recently-registered-systems";
+    public static final String SUBSCRIPTION_WARNING = "subscription-warning";
 
     public static final String[] ALL_PANES = { TASKS, CRITICAL_SYSTEMS, SYSTEM_GROUPS,
-            LATEST_ERRATA, INACTIVE_SYSTEMS, PENDING_ACTIONS, RECENTLY_REGISTERED_SYSTEMS };
+            LATEST_ERRATA, INACTIVE_SYSTEMS, PENDING_ACTIONS, RECENTLY_REGISTERED_SYSTEMS, SUBSCRIPTION_WARNING };
     /**
      * Maps to RHNINFOPANE.LABEL
      * This is more of a label prefix

--- a/java/code/src/com/redhat/rhn/frontend/action/YourRhnAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/YourRhnAction.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.frontend.action;
 
+import com.redhat.rhn.domain.notification.types.SubscriptionWarning;
 import com.redhat.rhn.domain.user.Pane;
 import com.redhat.rhn.domain.user.PaneFactory;
 import com.redhat.rhn.domain.user.User;
@@ -23,6 +24,7 @@ import com.redhat.rhn.frontend.action.renderers.InactiveSystemsRenderer;
 import com.redhat.rhn.frontend.action.renderers.LatestErrataRenderer;
 import com.redhat.rhn.frontend.action.renderers.PendingActionsRenderer;
 import com.redhat.rhn.frontend.action.renderers.RecentSystemsRenderer;
+import com.redhat.rhn.frontend.action.renderers.SubscriptionWarningRenderer;
 import com.redhat.rhn.frontend.action.renderers.SystemGroupsRenderer;
 import com.redhat.rhn.frontend.action.renderers.TasksRenderer;
 import com.redhat.rhn.frontend.listview.PageControl;
@@ -50,12 +52,14 @@ public class YourRhnAction extends RhnAction {
 
     public static final String ANY_LISTS_SELECTED = "anyListsSelected";
 
+
     /**
      * No-arg constructor
      */
     public YourRhnAction() {
         Map renderers = new HashMap();
 
+        SubscriptionWarning sw = new SubscriptionWarning();
         List tasks = Arrays.asList(Pane.ALL_PANES);
         for (Object taskIn : tasks) {
             String key = (String) taskIn;
@@ -83,6 +87,9 @@ public class YourRhnAction extends RhnAction {
             }
             else if (key.equals(Pane.TASKS)) {
                 renderer = new TasksRenderer();
+            }
+            else if (key.equals(Pane.SUBSCRIPTION_WARNING) && sw.expiresSoon()) {
+                renderer = new SubscriptionWarningRenderer();
             }
             if (renderer != null) {
                 renderers.put(key, renderer);

--- a/java/code/src/com/redhat/rhn/frontend/action/renderers/SubscriptionWarningRenderer.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/renderers/SubscriptionWarningRenderer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.action.renderers;
+
+import com.redhat.rhn.domain.notification.types.SubscriptionWarning;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.listview.PageControl;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Renders YourRhn fragment for tasks
+ *
+ */
+public class SubscriptionWarningRenderer extends BaseFragmentRenderer {
+
+    private static final String SUBSCRIPTION_WARNING = "subscriptionwarning";
+    private SubscriptionWarning sw = new SubscriptionWarning();
+
+    /**
+     * {@inheritDoc}
+     */
+    protected void render(User user, PageControl pc, HttpServletRequest request) {
+        request.setAttribute(SUBSCRIPTION_WARNING, sw.expiresSoon());
+        RendererHelper.setTableStyle(request, null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected String getPageUrl() {
+        return "/WEB-INF/pages/common/fragments/yourrhn/subwarn.jsp";
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -9402,6 +9402,12 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
       <trans-unit id="bootstrap.minion.error.generatekey.failed">
         <source>Generating salt-ssh public key failed: {0}.</source>
       </trans-unit>
+      <trans-unit id="notification.subscriptionwarning.summary">
+        <source>You have subscriptions that need attention.</source>
+      </trans-unit>
+      <trans-unit id="notification.subscriptionwarning.detail">
+        <source>You have subscriptions that are expiring soon or already expired. Please check the &lt;a href="/rhn/manager/subscription-matching"&gt;Subscription Matching&lt;/a&gt; page.</source>
+      </trans-unit>
       <trans-unit id="notification.endoflife.expired.summary">
         <source>@@PRODUCT_NAME@@ {0} has reached end of life</source>
       </trans-unit>

--- a/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
@@ -23,6 +23,7 @@ import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.notification.NotificationMessage;
 import com.redhat.rhn.domain.notification.UserNotificationFactory;
 import com.redhat.rhn.domain.notification.types.EndOfLifePeriod;
+import com.redhat.rhn.domain.notification.types.SubscriptionWarning;
 import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.frontend.dto.ActionMessage;
@@ -83,6 +84,7 @@ public class DailySummary extends RhnJavaJob {
         throws JobExecutionException {
 
         processEndOfLifeNotification();
+        processSubscriptionWarningNotification();
 
         processEmails();
     }
@@ -118,6 +120,16 @@ public class DailySummary extends RhnJavaJob {
                 new EndOfLifePeriod(endOfLifeDate));
             UserNotificationFactory.storeNotificationMessageFor(notification,
                 Collections.singleton(RoleFactory.ORG_ADMIN), Optional.empty());
+        }
+    }
+
+    private void  processSubscriptionWarningNotification() {
+        SubscriptionWarning sw = new SubscriptionWarning();
+        if (sw.expiresSoon()) {
+            NotificationMessage notificationMessage =
+                    UserNotificationFactory.createNotificationMessage(new SubscriptionWarning());
+            UserNotificationFactory.storeNotificationMessageFor(notificationMessage,
+                    Collections.singleton(RoleFactory.ORG_ADMIN), Optional.empty());
         }
     }
 

--- a/java/code/webapp/WEB-INF/dwr.xml
+++ b/java/code/webapp/WEB-INF/dwr.xml
@@ -52,6 +52,10 @@
         </create>
 
         <!-- SUSE specific -->
+         <create creator="new" javascript="SubscriptionWarningRenderer">
+            <param name="class" value="com.redhat.rhn.frontend.action.renderers.SubscriptionWarningRenderer" />
+            <include method="renderAsync" />
+        </create>
         <create creator="new" javascript="MirrorCredentialsRenderer">
             <param name="class"
                 value="com.redhat.rhn.frontend.action.renderers.setupwizard.MirrorCredentialsRenderer" />

--- a/java/code/webapp/WEB-INF/pages/common/fragments/yourrhn/subwarn.jsp
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/yourrhn/subwarn.jsp
@@ -1,0 +1,18 @@
+<%@ taglib uri="http://struts.apache.org/tags-html" prefix="html"%>
+<%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean"%>
+<%@ taglib uri="http://rhn.redhat.com/rhn" prefix="rhn"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+
+
+<c:if test="${requestScope.subscriptionwarning}">
+  <div class="panel panel-warning">
+    <div class="panel-heading">
+      <h3 class="panel-title">
+        <bean:message key="notification.subscriptionwarning.summary" />
+      </h3>
+  </div>
+  <div class="panel panel-body">
+    <bean:message key="notification.subscriptionwarning.detail" />
+  </div>
+  <div class="panel-footer"></div>
+</c:if>

--- a/java/code/webapp/WEB-INF/pages/yourrhn.jsp
+++ b/java/code/webapp/WEB-INF/pages/yourrhn.jsp
@@ -7,7 +7,9 @@
 <body>
 
 <c:set var="cb_version" value="${rhn:getConfig('web.buildtimestamp')}" />
-
+<c:if test="${requestScope.subscriptionWarning == 'y'}">
+  <script type="text/javascript" src="/rhn/dwr/interface/SubscriptionWarningRenderer.js?cb=${cb_version}"></script>
+</c:if>
 <c:if test="${requestScope.inactiveSystems == 'y'}">
   <script type="text/javascript" src="/rhn/dwr/interface/InactiveSystemsRenderer.js?cb=${cb_version}"></script>
 </c:if>
@@ -46,6 +48,13 @@
       <div class="col-md-6" id="tasks-pane" >
         <script type="text/javascript">
           TasksRenderer.renderAsync(makeRendererHandler('tasks-pane', false));
+        </script>
+      </div>
+      </c:if>
+      <c:if test="${requestScope.subscriptionWarning == 'y'}">
+      <div id="subscription-warning" class="col-md-12">
+        <script type="text/javascript">
+          SubscriptionWarningRenderer.renderAsync(makeRendererHandler("subscription-warning", false));
         </script>
       </div>
       </c:if>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add subscription warning notification to overview page
 - Fix CLM to not remove necessary packages when filtering erratas (bsc#1195979)
 - Remove invalid errata selection after patch installation (bsc#1204235)
 - Ignore insert conflicts during reporting database update (bsc#1202150)

--- a/schema/spacewalk/common/data/rhnInfoPane.sql
+++ b/schema/spacewalk/common/data/rhnInfoPane.sql
@@ -18,4 +18,5 @@ insert into RHNINFOPANE(ID,LABEL,ACL) values (sequence_nextval('rhn_info_pane_id
 insert into RHNINFOPANE(ID,LABEL,ACL) values (sequence_nextval('rhn_info_pane_id_seq'),'latest-errata',null);
 insert into RHNINFOPANE(ID,LABEL,ACL) values (sequence_nextval('rhn_info_pane_id_seq'),'inactive-systems',null);
 insert into RHNINFOPANE(ID,LABEL,ACL) values (sequence_nextval('rhn_info_pane_id_seq'),'pending-actions',null);
-insert into RHNINFOPANE(ID,LABEL,ACL) values (sequence_nextval('rhn_info_pane_id_seq'), 'recently-registered-systems', null);
+insert into RHNINFOPANE(ID,LABEL,ACL) values (sequence_nextval('rhn_info_pane_id_seq'),'recently-registered-systems', null);
+insert into RHNINFOPANE(ID,LABEL,ACL) values (sequence_nextval('rhn_info_pane_id_seq'),'subscription-warning', null);

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- add subscription warning info pane
 - Remove data related to RHEL below 6 
 - Increase cron_expr varchar length to 120 in suseRecurringAction
   table (bsc#1205040)

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.2-to-susemanager-schema-4.4.3/900-add-pane-subwarn-rhnInfoPane.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.2-to-susemanager-schema-4.4.3/900-add-pane-subwarn-rhnInfoPane.sql
@@ -1,0 +1,3 @@
+insert into RHNINFOPANE(ID,LABEL,ACL) 
+select sequence_nextval('rhn_info_pane_id_seq'),'subscription-warning', null  
+where not exists( select label from RHNINFOPANE where label = 'subscription-warning');  

--- a/web/html/src/manager/notifications/notification-messages.tsx
+++ b/web/html/src/manager/notifications/notification-messages.tsx
@@ -53,6 +53,10 @@ const _MESSAGE_TYPE = {
     id: "EndOfLifePeriod",
     text: t("End of Life Period"),
   },
+  SubscriptionWarning: {
+    id: "SubscriptionWarning",
+    text: t("Subscription Warning"),
+  },
 };
 
 function reloadData(dataUrlSlice: string) {


### PR DESCRIPTION
## What does this PR change?
This is a port of https://github.com/SUSE/spacewalk/pull/19532
#11008 
This adds a new type of notification for subscriptions that are close to expiring or will expire. 
This warning will show on the overview page also with a link to the subscription matcher. 
The code is ready for review but I need to add unit tests.
## GUI diff

Before:

After:
![image](https://user-images.githubusercontent.com/729087/201634638-c0d997f1-ce74-40d2-805e-f2b87ff2048e.png)
![image](https://user-images.githubusercontent.com/729087/201635446-b730734d-e2ef-4dff-9265-a40fa4a24255.png)

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage

- Unit tests will be added.
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql" 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
