### PR TITLE
QE: Login/Logout from API in order to enable the use of API calls during the steps

### DIFF
--- a/testsuite/features/secondary/min_activationkey.feature
+++ b/testsuite/features/secondary/min_activationkey.feature
@@ -6,6 +6,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
+    And I am logged in API as user "admin" and password "admin"
 
   Scenario: Delete SLES minion system profile
     Given I am on the Systems overview page of this "sle_minion"
@@ -121,3 +122,6 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
   Scenario: Check events history for failures on SLES minion with activation key
     Given I am on the Systems overview page of this "sle_minion"
     Then I check for failed events on history event page
+
+  Scenario: Cleanup: Logout from API
+    When I logout from API

--- a/testsuite/features/secondary/min_baremetal_discovery.feature
+++ b/testsuite/features/secondary/min_baremetal_discovery.feature
@@ -6,6 +6,7 @@ Feature: Bare metal discovery
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
+    And I am logged in API as user "admin" and password "admin"
 
   Scenario: Delete the Salt Minion for bare metal feature
     Given I am on the Systems overview page of this "sle_minion"
@@ -151,3 +152,6 @@ Feature: Bare metal discovery
 
   Scenario: Cleanup: remove remaining systems from SSM after bare metal tests
     When I click on "Clear"
+
+  Scenario: Cleanup: Logout from API
+    When I logout from API

--- a/testsuite/features/secondary/min_bootstrap_api.feature
+++ b/testsuite/features/secondary/min_bootstrap_api.feature
@@ -6,6 +6,7 @@ Feature: Register a Salt minion via API
 
   Scenario: Delete SLES minion system profile before API bootstrap test
     Given I am authorized for the "Admin" section
+    And I am logged in API as user "admin" and password "admin"
     And I am on the Systems overview page of this "sle_minion"
     When I follow "Delete System"
     Then I should see a "Confirm System Profile Deletion" text

--- a/testsuite/features/secondary/min_bootstrap_reactivation.feature
+++ b/testsuite/features/secondary/min_bootstrap_reactivation.feature
@@ -10,6 +10,7 @@ Feature: bootstrapping with reactivation key
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
+    And I am logged in API as user "admin" and password "admin"
 
   Scenario: Generate a re-activation key
     Given I am on the Systems overview page of this "sle_minion"
@@ -99,3 +100,6 @@ Feature: bootstrapping with reactivation key
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
     When I wait until event "Subscribe channels scheduled by admin" is completed
+
+  Scenario: Cleanup: Logout from API
+    When I logout from API

--- a/testsuite/features/secondary/min_bootstrap_script.feature
+++ b/testsuite/features/secondary/min_bootstrap_script.feature
@@ -12,6 +12,7 @@ Feature: Register a Salt minion via Bootstrap-script
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
+    And I am logged in API as user "admin" and password "admin"
 
   Scenario: Delete SLES minion system profile before script bootstrap test
     Given I am on the Systems overview page of this "sle_minion"
@@ -83,3 +84,6 @@ Feature: Register a Salt minion via Bootstrap-script
   Scenario: Cleanup: remove package from script-bootstrapped SLES minion
    When I remove package "orion-dummy-1.1-1.1" from this "sle_minion"
    Then "orion-dummy-1.1-1.1" should not be installed on "sle_minion"
+
+  Scenario: Cleanup: Logout from API
+    When I logout from API

--- a/testsuite/features/secondary/min_bootstrap_ssh_key.feature
+++ b/testsuite/features/secondary/min_bootstrap_ssh_key.feature
@@ -6,6 +6,7 @@ Feature: Bootstrap a Salt minion via the GUI using SSH key
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
+    And I am logged in API as user "admin" and password "admin"
 
   Scenario: Delete SLES minion system profile before bootstrap with SSH key test
     Given I am on the Systems overview page of this "sle_minion"
@@ -64,3 +65,6 @@ Feature: Bootstrap a Salt minion via the GUI using SSH key
 
   Scenario: Cleanup: restore authorized keys
     When I restore the SSH authorized_keys file of host "sle_minion"
+
+  Scenario: Cleanup: Logout from API
+    When I logout from API

--- a/testsuite/features/secondary/min_deblike_ssh.feature
+++ b/testsuite/features/secondary/min_deblike_ssh.feature
@@ -12,6 +12,7 @@ Feature: Bootstrap a SSH-managed Debian-like minion and do some basic operations
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
+    And I am logged in API as user "admin" and password "admin"
 
   Scenario: Delete the Debian-like minion
     When I am on the Systems overview page of this "deblike_minion"
@@ -115,3 +116,6 @@ Feature: Bootstrap a SSH-managed Debian-like minion and do some basic operations
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
     And I wait until event "Subscribe channels scheduled by admin" is completed
+
+  Scenario: Cleanup: Logout from API
+    When I logout from API

--- a/testsuite/features/secondary/min_move_from_and_to_proxy.feature
+++ b/testsuite/features/secondary/min_move_from_and_to_proxy.feature
@@ -7,6 +7,7 @@ Feature: Move a minion from a proxy to direct connection
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
+    And I am logged in API as user "admin" and password "admin"
 
   Scenario: Delete minion system profile before bootstrap
     Given I am on the Systems overview page of this "sle_minion"
@@ -100,3 +101,6 @@ Feature: Move a minion from a proxy to direct connection
   Scenario: Check events history for failures on the minion
     Given I am on the Systems overview page of this "sle_minion"
     Then I check for failed events on history event page
+
+  Scenario: Cleanup: Logout from API
+    When I logout from API

--- a/testsuite/features/secondary/min_rhlike_ssh.feature
+++ b/testsuite/features/secondary/min_rhlike_ssh.feature
@@ -11,6 +11,7 @@ Feature: Bootstrap a SSH-managed Red Hat-like minion and do some basic operation
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
+    And I am logged in API as user "admin" and password "admin"
 
   Scenario: Delete the Red Hat-like minion before SSH minion tests
     When I am on the Systems overview page of this "rhlike_minion"
@@ -115,3 +116,6 @@ Feature: Bootstrap a SSH-managed Red Hat-like minion and do some basic operation
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
     And I wait until event "Subscribe channels scheduled by admin" is completed
+
+  Scenario: Cleanup: Logout from API
+    When I logout from API

--- a/testsuite/features/secondary/min_salt_mgrcompat_state.feature
+++ b/testsuite/features/secondary/min_salt_mgrcompat_state.feature
@@ -7,6 +7,7 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
+    And I am logged in API as user "admin" and password "admin"
 
   Scenario: Remove mgrcompat module from minion synced modules and schedule Hardware Refresh
     Given I remove "minion/extmods/states/mgrcompat.py" from salt cache on "sle_minion"
@@ -104,3 +105,6 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
     And I wait until event "Subscribe channels scheduled by admin" is completed
+
+  Scenario: Cleanup: Logout from API
+    When I logout from API

--- a/testsuite/features/secondary/min_salt_minions_page.feature
+++ b/testsuite/features/secondary/min_salt_minions_page.feature
@@ -9,6 +9,7 @@ Feature: Management of minion keys
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
+    And I am logged in API as user "admin" and password "admin"
 
   Scenario: Delete SLES minion system profile before exploring the onboarding page
     Given I am on the Systems overview page of this "sle_minion"
@@ -95,3 +96,6 @@ Feature: Management of minion keys
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
     And I wait until event "Subscribe channels scheduled by admin" is completed
+
+  Scenario: Cleanup: Logout from API
+    When I logout from API

--- a/testsuite/features/secondary/min_ssh_tunnel.feature
+++ b/testsuite/features/secondary/min_ssh_tunnel.feature
@@ -7,6 +7,7 @@ Feature: Register a Salt system to be managed via SSH tunnel
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
+    And I am logged in API as user "admin" and password "admin"
 
   Scenario: Delete the Salt minion for SSH tunnel bootstrap
     Given I am on the Systems overview page of this "ssh_minion"
@@ -85,3 +86,6 @@ Feature: Register a Salt system to be managed via SSH tunnel
     And I accept "ssh_minion" key in the Salt master
     Then I should see "ssh_minion" via spacecmd
     And I wait until onboarding is completed for "ssh_minion"
+
+  Scenario: Cleanup: Logout from API
+    When I logout from API

--- a/testsuite/features/secondary/minssh_bootstrap_api.feature
+++ b/testsuite/features/secondary/minssh_bootstrap_api.feature
@@ -8,6 +8,7 @@ Feature: Register a salt-ssh system via API
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
+    And I am logged in API as user "admin" and password "admin"
 
   Scenario: Delete SSH minion system profile before API bootstrap test
     Given I am on the Systems overview page of this "ssh_minion"
@@ -69,3 +70,6 @@ Feature: Register a salt-ssh system via API
 @proxy
   Scenario: cleanup and flush the firewall rules
     When I flush firewall on "ssh_minion"
+
+  Scenario: Cleanup: Logout from API
+    When I logout from API

--- a/testsuite/features/secondary/minssh_move_from_and_to_proxy.feature
+++ b/testsuite/features/secondary/minssh_move_from_and_to_proxy.feature
@@ -8,6 +8,7 @@ Feature: Move a ssh minion from a proxy to direct connection
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
+    And I am logged in API as user "admin" and password "admin"
 
   Scenario: Delete minion system profile before bootstrap
     Given I am on the Systems overview page of this "ssh_minion"
@@ -89,3 +90,6 @@ Feature: Move a ssh minion from a proxy to direct connection
   Scenario: Check events history for failures on the minion
     Given I am on the Systems overview page of this "ssh_minion"
     Then I check for failed events on history event page
+
+  Scenario: Cleanup: Logout from API
+    When I logout from API

--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -13,6 +13,7 @@ Feature: PXE boot a terminal with Cobbler
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
+    And I am logged in API as user "admin" and password "admin"
 
   Scenario: Configure PXE part of DHCP on the proxy
     Given I am on the Systems overview page of this "proxy"
@@ -148,3 +149,6 @@ Feature: PXE boot a terminal with Cobbler
     When I follow "States" in the content area
     And I click on "Apply Highstate"
     And I wait until event "Apply highstate scheduled by admin" is completed
+
+  Scenario: Cleanup: Logout from API
+    When I logout from API

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -32,6 +32,7 @@ Feature: PXE boot a Retail terminal
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
+    And I am logged in API as user "admin" and password "admin"
 
   Scenario: Enable the PXE formulas on the branch server
     Given I am on the Systems overview page of this "proxy"
@@ -429,3 +430,6 @@ Feature: PXE boot a Retail terminal
   Scenario: Reset TFTP defaults
     When I stop tftp on the proxy
     And I reset tftp defaults on the proxy
+
+  Scenario: Cleanup: Logout from API
+    When I logout from API


### PR DESCRIPTION
## What does this PR change?

Fix this issue: https://github.com/SUSE/spacewalk/issues/19755

In a previous PR I decoupled the responsibility of login/logout from our API handler in a step that had these actions in an atomic way inside the step. I made that way, to be consistent to the way we were handling API calls in the rest of step definitions.

Applying this PR, will fix missing login/logout actions from outside the step, at the beginning and at the end of each feature using that step. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.3 (It was only ported in 4.3)

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
