### PR TITLE
enable Tools Channels for OES 2023

### DIFF
--- a/susemanager-sync-data/additional_products.json
+++ b/susemanager-sync-data/additional_products.json
@@ -1030,7 +1030,7 @@
                 "name" : "OES2023-SLE-Manager-Tools15-Pool",
                 "distro_target" : "sle-15-x86_64",
                 "description" : "SLE-Manager-Tools15-Pool for sle-15-x86_64",
-                "enabled" : false,
+                "enabled" : true,
                 "autorefresh" : false,
                 "installer_updates" : false
             },
@@ -1040,7 +1040,7 @@
                 "name" : "OES2023-SLE-Manager-Tools15-Updates",
                 "distro_target" : "sle-15-x86_64",
                 "description" : "SLE-Manager-Tools15-Updates for sle-15-x86_64",
-                "enabled" : false,
+                "enabled" : true,
                 "autorefresh" : true,
                 "installer_updates" : false
             },

--- a/susemanager-sync-data/susemanager-sync-data.changes
+++ b/susemanager-sync-data/susemanager-sync-data.changes
@@ -1,4 +1,5 @@
-- change OES 2023 URL to https (bsc#1205644)
+- change OES 2023 URL to https and make the tools channels mandatory
+  (bsc#1205644)
 - remove version from product names as they are held separate
 - change "EL 9 Base" to "RHEL and Liberty 9 Base"
 


### PR DESCRIPTION
## What does this PR change?

Tools Channels for OES 2023 need to be mandatory.
Additional fix for https://github.com/uyuni-project/uyuni/pull/6251

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
