### PR TITLE
jabberd service was removed

### DIFF
--- a/testsuite/features/build_validation/containerization/proxy_as_pod_basic_tests.feature
+++ b/testsuite/features/build_validation/containerization/proxy_as_pod_basic_tests.feature
@@ -37,7 +37,6 @@ Feature: Register and test a Containerized Proxy
     And I stop "tftp" service on "proxy"
     And I wait until "squid" service is inactive on "proxy"
     And I wait until "apache2" service is inactive on "proxy"
-    And I wait until "jabberd" service is inactive on "proxy"
     And I wait until "tftp" service is inactive on "proxy"
 
   Scenario: Generate Containerized Proxy configuration
@@ -254,7 +253,6 @@ Feature: Register and test a Containerized Proxy
     And I start "tftp" service on "proxy"
     And I wait until "squid" service is active on "proxy"
     And I wait until "apache2" service is active on "proxy"
-    And I wait until "jabberd" service is active on "proxy"
     And I wait until "tftp" service is active on "proxy"
 
   Scenario: Cleanup: Bootstrap a Salt minion in the traditional proxy

--- a/testsuite/features/core/proxy_register_as_pod.feature
+++ b/testsuite/features/core/proxy_register_as_pod.feature
@@ -24,7 +24,6 @@ Feature: Setup Containerized Proxy
     And I stop "tftp" service on "proxy"
     And I wait until "squid" service is inactive on "proxy"
     And I wait until "apache2" service is inactive on "proxy"
-    And I wait until "jabberd" service is inactive on "proxy"
     And I wait until "tftp" service is inactive on "proxy"
 
   Scenario: Generate Containerized Proxy configuration

--- a/testsuite/features/secondary/proxy_as_pod_basic_tests.feature
+++ b/testsuite/features/secondary/proxy_as_pod_basic_tests.feature
@@ -36,7 +36,6 @@ Feature: Register and test a Containerized Proxy
     And I stop "tftp" service on "proxy"
     And I wait until "squid" service is inactive on "proxy"
     And I wait until "apache2" service is inactive on "proxy"
-    And I wait until "jabberd" service is inactive on "proxy"
     And I wait until "tftp" service is inactive on "proxy"
 
   Scenario: Generate Containerized Proxy configuration
@@ -253,7 +252,6 @@ Feature: Register and test a Containerized Proxy
     And I start "tftp" service on "proxy"
     And I wait until "squid" service is active on "proxy"
     And I wait until "apache2" service is active on "proxy"
-    And I wait until "jabberd" service is active on "proxy"
     And I wait until "tftp" service is active on "proxy"
 
   Scenario: Cleanup: Bootstrap a Salt minion in the traditional proxy


### PR DESCRIPTION
## What does this PR change?

Jabberd Service was removed in master.
Additional fix for https://github.com/uyuni-project/uyuni/pull/6216

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
