### PR TITLE
Fix products controller to keep loading mandatory channels

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/product/SUSEProductFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/product/SUSEProductFactory.java
@@ -278,6 +278,9 @@ public class SUSEProductFactory extends HibernateFactory {
      */
     public static Stream<Channel> findSyncedMandatoryChannels(String channelLabel) {
         Channel channel = ChannelFactory.lookupByLabel(channelLabel);
+        if (channel == null) {
+            throw new NoSuchElementException("Broken channel " + channelLabel);
+        }
         Channel baseChannel = Optional.ofNullable(channel.getParentChannel()).orElse(channel);
         if (channel.isCloned()) {
             if (ConfigDefaults.get().getClonedChannelAutoSelection()) {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Fix products controller to keep loading mandatory channels even when there are
+  broken channels (bsc#1204270)
 - Remove DWR library
 - Add reboot needed indicator to systems list
 - Move web dependencies from susemanager-frontend-libs to


### PR DESCRIPTION
## What does this PR change?

When loading mandatory channels, if there is any broken channel in the database a `NoSuchElementException` is thrown and the remaining channel are not processed. This makes CLM stop working even when the user don't want to use these broken channels.

This PR fixes this problem by allowing the mandatory channels map to be loaded for channels that are not broken.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19250

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
