### PR TITLE
QE: fixup for moving the virthost to init_clients

### DIFF
--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -14,6 +14,9 @@ Feature: Be able to manage KVM virtual machines via the GUI
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
+  Scenario: Show the KVM host system overview
+    Given I am on the Systems overview page of this "kvm_server"
+
   Scenario: Prepare a KVM test virtual machine and list it
     When I delete default virtual network on "kvm_server"
     And I create test-net0 virtual network on "kvm_server"
@@ -23,9 +26,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I create "test-vm" virtual machine on "kvm_server"
     And I follow "Virtualization" in the content area
     And I wait until I see "test-vm" text
-
-  Scenario: Show the KVM host virtualization tab
-    Given I follow "Virtualization" in the content area
 
   Scenario: Start a KVM virtual machine
     When I click on "Start" in row "test-vm"


### PR DESCRIPTION
## What does this PR change?

The step for beeing on the KVM virthost before accessing the virtualization content area was missing.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links

- Manager 4.3
- Manager 4.2
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
