### PR TITLE
Fix internal server error when transferring system between organizations

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/servlets/SystemDetailsMessageFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/SystemDetailsMessageFilter.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.frontend.servlets;
 
+import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
@@ -58,8 +59,13 @@ public class SystemDetailsMessageFilter implements Filter {
         RequestContext rctx = new RequestContext(req);
         Long sid = rctx.getRequiredParam("sid");
         User user = rctx.getCurrentUser();
-        Server s = SystemManager.lookupByIdAndUser(sid, user);
-        this.processSystemMessages(req, s);
+        try {
+            Server s = SystemManager.lookupByIdAndUser(sid, user);
+            this.processSystemMessages(req, s);
+        }
+        catch (LookupException e) {
+            // Expected to happen when transferring systems between orgs, nothing to do.
+        }
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix internal server error when transferring system between organizations
 - Fix products controller to keep loading mandatory channels even when there are
   broken channels (bsc#1204270)
 - Remove DWR library


### PR DESCRIPTION
## What does this PR change?

It fixes system details message filter in order to avoid internal server error when transferring system between organizations.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
