### PR TITLE
Remove duplicate debug information

### DIFF
--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -127,7 +127,6 @@ $nodes.each do |node|
   os_version, os_family = get_os_version(node)
   node.init_os_family(os_family)
   node.init_os_version(os_version)
-  STDOUT.puts "'#{$named_nodes[node.hash]}' is running OS #{node.os_family} #{node.os_version}"
 end
 
 # This function is used to get one of the nodes based on its type


### PR DESCRIPTION
## What does this PR change?

This PR mitigates this pain:
```
Node: suma-bv-43-ctl, OS Version: 15.4, Family: opensuse-leap
'suma-bv-43-ctl' is running OS opensuse-leap 15.4
Node: suma-bv-43-srv, OS Version: 15-SP4, Family: sles
'suma-bv-43-srv.mgr.prv.suse.net' is running OS sles 15-SP4
Node: suma-bv-43-pxy, OS Version: 15-SP4, Family: sles
'suma-bv-43-pxy.mgr.prv.suse.net' is running OS sles 15-SP4
Node: suma-bv-43-cli-sles12sp4, OS Version: 12-SP4, Family: sles
'suma-bv-43-cli-sles12sp4.mgr.prv.suse.net' is running OS sles 12-SP4
Node: suma-bv-43-min-sles12sp4, OS Version: 12-SP4, Family: sles
'suma-bv-43-min-sles12sp4.mgr.prv.suse.net' is running OS sles 12-SP4
Node: suma-bv-43-minssh-sles12sp4, OS Version: 12-SP4, Family: sles
'suma-bv-43-minssh-sles12sp4.mgr.prv.suse.net' is running OS sles 12-SP4
Node: suma-bv-43-cli-sles12sp5, OS Version: 12-SP5, Family: sles
'suma-bv-43-cli-sles12sp5.mgr.prv.suse.net' is running OS sles 12-SP5
Node: suma-bv-43-min-sles12sp5, OS Version: 12-SP5, Family: sles
'suma-bv-43-min-sles12sp5.mgr.prv.suse.net' is running OS sles 12-SP5
Node: suma-bv-43-minssh-sles12sp5, OS Version: 12-SP5, Family: sles
'suma-bv-43-minssh-sles12sp5.mgr.prv.suse.net' is running OS sles 12-SP5
Node: suma-bv-43-cli-sles15, OS Version: 15, Family: sles
'suma-bv-43-cli-sles15.mgr.prv.suse.net' is running OS sles 15
Node: suma-bv-43-min-sles15, OS Version: 15, Family: sles
'suma-bv-43-min-sles15.mgr.prv.suse.net' is running OS sles 15
Node: suma-bv-43-minssh-sles15, OS Version: 15, Family: sles
'suma-bv-43-minssh-sles15.mgr.prv.suse.net' is running OS sles 15
Node: suma-bv-43-cli-sles15sp1, OS Version: 15-SP1, Family: sles
'suma-bv-43-cli-sles15sp1.mgr.prv.suse.net' is running OS sles 15-SP1
Node: suma-bv-43-min-sles15sp1, OS Version: 15-SP1, Family: sles
'suma-bv-43-min-sles15sp1.mgr.prv.suse.net' is running OS sles 15-SP1
Node: suma-bv-43-minssh-sles15sp1, OS Version: 15-SP1, Family: sles
'suma-bv-43-minssh-sles15sp1.mgr.prv.suse.net' is running OS sles 15-SP1
Node: suma-bv-43-cli-sles15sp2, OS Version: 15-SP2, Family: sles
'suma-bv-43-cli-sles15sp2.mgr.prv.suse.net' is running OS sles 15-SP2
Node: suma-bv-43-min-sles15sp2, OS Version: 15-SP2, Family: sles
'suma-bv-43-min-sles15sp2.mgr.prv.suse.net' is running OS sles 15-SP2
Node: suma-bv-43-minssh-sles15sp2, OS Version: 15-SP2, Family: sles
'suma-bv-43-minssh-sles15sp2.mgr.prv.suse.net' is running OS sles 15-SP2
Node: suma-bv-43-cli-sles15sp3, OS Version: 15-SP3, Family: sles
'suma-bv-43-cli-sles15sp3.mgr.prv.suse.net' is running OS sles 15-SP3
Node: suma-bv-43-min-sles15sp3, OS Version: 15-SP4, Family: sles
'suma-bv-43-min-sles15sp3.mgr.prv.suse.net' is running OS sles 15-SP4
Node: suma-bv-43-minssh-sles15sp3, OS Version: 15-SP4, Family: sles
'suma-bv-43-minssh-sles15sp3.mgr.prv.suse.net' is running OS sles 15-SP4
Node: suma-bv-43-cli-sles15sp4, OS Version: 15-SP4, Family: sles
'suma-bv-43-cli-sles15sp4.mgr.prv.suse.net' is running OS sles 15-SP4
Node: suma-bv-43-min-sles15sp4, OS Version: 15-SP4, Family: sles
'suma-bv-43-min-sles15sp4.mgr.prv.suse.net' is running OS sles 15-SP4
Node: suma-bv-43-minssh-sles15sp4, OS Version: 15-SP4, Family: sles
'suma-bv-43-minssh-sles15sp4.mgr.prv.suse.net' is running OS sles 15-SP4
Node: suma-bv-43-cli-centos7, OS Version: 7, Family: centos
'suma-bv-43-cli-centos7.mgr.prv.suse.net' is running OS centos 7
Node: suma-bv-43-min-centos7, OS Version: 7, Family: centos
'suma-bv-43-min-centos7.mgr.prv.suse.net' is running OS centos 7
Node: suma-bv-43-minssh-centos7, OS Version: 7, Family: centos
'suma-bv-43-minssh-centos7.mgr.prv.suse.net' is running OS centos 7
Node: suma-bv-43-min-rocky8, OS Version: 8.6, Family: rocky
'suma-bv-43-min-rocky8.mgr.prv.suse.net' is running OS rocky 8.6
Node: suma-bv-43-minssh-rocky8, OS Version: 8.6, Family: rocky
'suma-bv-43-minssh-rocky8.mgr.prv.suse.net' is running OS rocky 8.6
Node: suma-bv-43-min-rocky9, OS Version: 9.1, Family: rocky
'suma-bv-43-min-rocky9.mgr.prv.suse.net' is running OS rocky 9.1
Node: suma-bv-43-minssh-rocky9, OS Version: 9.1, Family: rocky
'suma-bv-43-minssh-rocky9.mgr.prv.suse.net' is running OS rocky 9.1
Node: suma-bv-43-min-ubuntu1804, OS Version: 18.04, Family: ubuntu
'suma-bv-43-min-ubuntu1804.mgr.prv.suse.net' is running OS ubuntu 18.04
Node: suma-bv-43-minssh-ubuntu1804, OS Version: 18.04, Family: ubuntu
'suma-bv-43-minssh-ubuntu1804.mgr.prv.suse.net' is running OS ubuntu 18.04
Node: suma-bv-43-min-ubuntu2004, OS Version: 20.04, Family: ubuntu
'suma-bv-43-min-ubuntu2004.mgr.prv.suse.net' is running OS ubuntu 20.04
Node: suma-bv-43-minssh-ubuntu2004, OS Version: 20.04, Family: ubuntu
'suma-bv-43-minssh-ubuntu2004.mgr.prv.suse.net' is running OS ubuntu 20.04
Node: suma-bv-43-min-ubuntu2204, OS Version: 22.04, Family: ubuntu
'suma-bv-43-min-ubuntu2204.mgr.prv.suse.net' is running OS ubuntu 22.04
Node: suma-bv-43-minssh-ubuntu2204, OS Version: 22.04, Family: ubuntu
'suma-bv-43-minssh-ubuntu2204.mgr.prv.suse.net' is running OS ubuntu 22.04
Node: suma-bv-43-min-debian10, OS Version: 10, Family: debian
'suma-bv-43-min-debian10.mgr.prv.suse.net' is running OS debian 10
Node: suma-bv-43-minssh-debian10, OS Version: 10, Family: debian
'suma-bv-43-minssh-debian10.mgr.prv.suse.net' is running OS debian 10
Node: suma-bv-43-min-debian11, OS Version: 11, Family: debian
'suma-bv-43-min-debian11.mgr.prv.suse.net' is running OS debian 11
Node: suma-bv-43-minssh-debian11, OS Version: 11, Family: debian
'suma-bv-43-minssh-debian11.mgr.prv.suse.net' is running OS debian 11
Node: suma-bv-43-min-opensuse154arm, OS Version: 15.4, Family: opensuse-leap
'suma-bv-43-min-opensuse154arm.mgr.prv.suse.net' is running OS opensuse-leap 15.4
Node: suma-bv-43-minssh-opensuse154arm, OS Version: 15.4, Family: opensuse-leap
'suma-bv-43-minssh-opensuse154arm.mgr.prv.suse.net' is running OS opensuse-leap 15.4
Node: suma-bv-43-build-sles12sp5, OS Version: 12-SP5, Family: sles
'suma-bv-43-build-sles12sp5.mgr.prv.suse.net' is running OS sles 12-SP5
Node: suma-bv-43-build-sles15sp4, OS Version: 15-SP4, Family: sles
'suma-bv-43-build-sles15sp4.mgr.prv.suse.net' is running OS sles 15-SP4
```

## Links

Ports:
* 4.2: SUSE/spacewalk#19796
* 4.3: SUSE/spacewalk#19794


## Changelogs

- [x] No changelog needed
