### PR TITLE
Fix Rocky 9 bootstrap repo

### DIFF
--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -184,7 +184,7 @@ CHANNEL_TO_SYNC_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.3-Pool' =>
                                     'RHEL x86_64 Server 7' => 'RES7-x86_64',
                                     'no-appstream-result-RHEL8-Pool for x86_64' => 'SLE-ES8-x86_64',
                                     'no-appstream-8-result-RHEL8-Pool for x86_64' => 'SLE-ES8-x86_64',
-                                    'no-appstream-9-result-Rocky Linux 9' => 'rockylinux9-x86_64',
+                                    'no-appstream-9-result-Rocky Linux 9' => 'rockylinux-9-x86_64',
                                     'ubuntu-18.04-pool' => 'ubuntu-18.04-amd64',
                                     'ubuntu-2004-amd64-main' => 'ubuntu-20.04-amd64',
                                     'ubuntu-2204-amd64-main' => 'ubuntu-22.04-amd64',


### PR DESCRIPTION
## What does this PR change?

This PR fixes the channel name for mgr-create-bootstrap-repo in case of Rocky 9.



## Links

Ports:
* 4.2: N/A
* 4.3: SUSE/spacewalk#19793


## Changelogs

- [x] No changelog needed
