### PR TITLE
Project lotus fix crash

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/product/SUSEProduct.java
+++ b/java/code/src/com/redhat/rhn/domain/product/SUSEProduct.java
@@ -26,6 +26,7 @@ import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.StringJoiner;
 
 /**
  * POJO for a suseProducts row.
@@ -368,5 +369,17 @@ public class SUSEProduct extends BaseDomainHelper implements Serializable {
             .append(getRelease())
             .append(getArch())
             .toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", SUSEProduct.class.getSimpleName() + "[", "]")
+                .add(Long.toString(getId()))
+                .add(getName())
+                .add(getVersion())
+                .add(getRelease())
+                .add(getArch().getLabel())
+                .add("SCCid=" + Long.toString(getProductId()))
+                .toString();
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -1034,7 +1034,7 @@ public class ContentSyncManager {
                });
         if (StringUtils.isBlank(prodRepoLink.getChannelLabel())) {
             // mandatory field is missing. This happens when a product does not have suseProductSCCRepositories
-            log.info("Product '" + root.toString() + "' does not have repositories. Skipping.");
+            log.info("Product '{}' does not have repositories. Skipping.", root);
             return null;
         }
         return prodRepoLink;

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -98,6 +98,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -937,8 +938,9 @@ public class ContentSyncManager {
             }
 
             rootProducts.stream()
-                        .map(root -> convertToProductSCCRepository(root, ptfInfo))
-                        .forEach(productReposToSave::add);
+                    .map(root -> convertToProductSCCRepository(root, ptfInfo))
+                    .filter(Objects::nonNull)
+                    .forEach(productReposToSave::add);
 
             reposToSave.add(ptfInfo.getRepository());
         }
@@ -1030,7 +1032,11 @@ public class ContentSyncManager {
                    prodRepoLink.setChannelLabel(String.join("-", cList).toLowerCase().replaceAll("( for | )", "-"));
                    prodRepoLink.setChannelName(String.join(" ", cList));
                });
-
+        if (StringUtils.isBlank(prodRepoLink.getChannelLabel())) {
+            // mandatory field is missing. This happens when a product does not have suseProductSCCRepositories
+            log.info("Product '" + root.toString() + "' does not have repositories. Skipping.");
+            return null;
+        }
         return prodRepoLink;
     }
 


### PR DESCRIPTION
## What does this PR change?

Fix crash when a product with a PTF repo had no repositories defined.
Happens as I used the product tag "Uyuni" while we had a PTF repo for SUSE Manager.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
