### PR TITLE
Fix activation key for Rocky 9

### DIFF
--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -164,7 +164,7 @@ LABEL_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.3-Pool' => 'sle-prod
                           'RHEL x86_64 Server 7' => 'rhel-x86_64-server-7',
                           'no-appstream-result-RHEL8-Pool for x86_64' => 'no-appstream-result-rhel8-pool-x86_64',
                           'no-appstream-8-result-RHEL8-Pool for x86_64' => 'no-appstream-8-result-rhel8-pool-x86_64',
-                          'no-appstream-9-result-rockylinux-9 for x86_64' => 'no-appstream-9-result-rockylinux9-x86_64',
+                          'no-appstream-9-result-rockylinux-9 for x86_64' => 'no-appstream-9-result-rockylinux-9-x86_64',
                           'ubuntu-18.04-pool' => 'ubuntu-18.04-pool-amd64',
                           'ubuntu-2004-amd64-main' => 'ubuntu-2004-amd64-main-amd64',
                           'ubuntu-2204-amd64-main' => 'ubuntu-2204-amd64-main-amd64',


### PR DESCRIPTION
## What does this PR change?

Again a fix to Rocky 9 channels.

Why can't we use an unified naming scheme everywhere and that would be consistent between versions ???


## Links

Ports:
* 4.2: N/A
* 4.3: SUSE/spacewalk#19813


## Changelogs

- [x] No changelog needed
