### PR TITLE
Testsuite: Correct features to have them be idempotent

### DIFF
--- a/testsuite/features/secondary/allcli_software_channels.feature
+++ b/testsuite/features/secondary/allcli_software_channels.feature
@@ -144,6 +144,7 @@ Feature: Channel subscription via SSM
     And I check radio button "SLE-Product-SLES15-SP4-Pool for x86_64"
     And I include the recommended child channels
     And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"
+    And I check "SLE-Module-Containers15-SP4-Pool for x86_64"
     And I check "Fake-RPM-SLES-Channel"
     And I wait until I do not see "Loading..." text
     And I wait until I see "SLE15-SP4-Installer-Updates for x86_64" text

--- a/testsuite/features/secondary/proxy_as_pod_basic_tests.feature
+++ b/testsuite/features/secondary/proxy_as_pod_basic_tests.feature
@@ -261,6 +261,7 @@ Feature: Register and test a Containerized Proxy
     And I enter "22" as "port"
     And I enter "root" as "user"
     And I enter "linux" as "password"
+    And I select "1-SUSE-KEY-x86_64" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text


### PR DESCRIPTION
## What does this PR change?

Add the use of activation key for the bootstrap of sle minion in a cleanup scenario to have the same state as at the start.
Add a missing subscription to a channel to make a feature idempotent again.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/19821
Tracks # 
4.2 https://github.com/SUSE/spacewalk/pull/19823 (only on software channels feature)
4.3 https://github.com/SUSE/spacewalk/pull/19825

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
