### PR TITLE
Testsuite: Remove extra login

### DIFF
--- a/testsuite/features/secondary/min_bootstrap_reactivation.feature
+++ b/testsuite/features/secondary/min_bootstrap_reactivation.feature
@@ -3,7 +3,7 @@
 
 @sle_minion
 @scope_onboarding
-Feature: bootstrapping with reactivation key
+Feature: Bootstrapping with reactivation key
   In order to re-register valid minions
   As an authorized user
   I want to avoid re-registration with invalid input parameters

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1239,10 +1239,8 @@ end
 
 When(/^I enter the reactivation key of "([^"]*)"$/) do |host|
   system_name = get_system_name(host)
-  $api_test.auth.login('admin', 'admin')
   node_id = $api_test.system.retrieve_server_id(system_name)
   react_key = $api_test.system.obtain_reactivation_key(node_id)
-  $api_test.auth.logout
   log "Reactivation Key: #{react_key}"
   step %(I enter "#{react_key}" as "reactivationKey")
 end


### PR DESCRIPTION
## What does this PR change?

Removes api login and logout in `I enter the reactivation key of ` step to avoid conflict with a previous authentication.
Conflicts with https://github.com/uyuni-project/uyuni/blob/master/testsuite/features/secondary/min_bootstrap_reactivation.feature#L13
This affects only one scenario.

Fix case in related feature name as well.

## GUI diff

No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited

- [x] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/19829
Tracks #
4.3 https://github.com/SUSE/spacewalk/pull/19832
Only case change for 4.2 https://github.com/SUSE/spacewalk/pull/19833
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
