### PR TITLE
QE: Advanced search, using name instead of label to find checkboxes

### DIFF
--- a/testsuite/features/secondary/srv_advanced_search.feature
+++ b/testsuite/features/secondary/srv_advanced_search.feature
@@ -15,7 +15,7 @@ Feature: Advanced Search
     When I follow the left menu "Systems > Advanced Search"
     And I enter "sle_minion" hostname on the search field
     And I select "Hostname" from "Field to Search"
-    And I check "invertlabel"
+    And I check "invert"
     And I click on the search button
     Then I should see a "No results found." text
 
@@ -24,7 +24,7 @@ Feature: Advanced Search
     When I follow the left menu "Systems > Advanced Search"
     And I enter "Little Whinging" on the search field
     And I select "City" from "Field to Search"
-    And I check "fineGrainedlabel"
+    And I check "fineGrained"
     And I click on the search button
     Then I should land on system's overview page
 
@@ -33,7 +33,7 @@ Feature: Advanced Search
     When I follow the left menu "Systems > Advanced Search"
     And I enter "Surrey" on the search field
     And I select "State/Province" from "Field to Search"
-    And I check "fineGrainedlabel"
+    And I check "fineGrained"
     And I click on the search button
     Then I should land on system's overview page
 
@@ -42,7 +42,7 @@ Feature: Advanced Search
     When I follow the left menu "Systems > Advanced Search"
     And I enter "PT" on the search field
     And I select "Country Code" from "Field to Search"
-    And I check "fineGrainedlabel"
+    And I check "fineGrained"
     And I click on the search button
     Then I should land on system's overview page
 
@@ -50,7 +50,7 @@ Feature: Advanced Search
     When I follow the left menu "Systems > Advanced Search"
     And I enter "sle_minion" hostname on the search field
     And I select "Hostname" from "Field to Search"
-    And I check "fineGrainedlabel"
+    And I check "fineGrained"
     And I click on the search button
     Then I should land on system's overview page
 

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -166,16 +166,14 @@ end
 #
 # Check a checkbox of the given id
 #
-When(/^I check "([^"]*)"$/) do |arg1|
-  check(arg1)
+When(/^I check "([^"]*)"$/) do |identifier|
+  check(identifier)
+  raise "Checkbox #{identifier} not checked." unless has_checked_field?(identifier)
 end
 
-When(/^I uncheck "([^"]*)"$/) do |arg1|
-  uncheck(arg1)
-end
-
-When(/^I check "([^"]*)" if not checked$/) do |arg1|
-  check(arg1) unless has_checked_field?(arg1)
+When(/^I uncheck "([^"]*)"$/) do |identifier|
+  uncheck(identifier)
+  raise "Checkbox #{identifier} not unchecked." if has_checked_field?(identifier)
 end
 
 When(/^I select "([^"]*)" from "([^"]*)"$/) do |option, field|
@@ -988,7 +986,7 @@ end
 
 # Check a Prometheus exporter
 When(/^I check "([^"]*)" exporter$/) do |exporter_type|
-  step %(I check "exporters##{exporter_type}_exporter#enabled" if not checked)
+  step %(I check "exporters##{exporter_type}_exporter#enabled")
 end
 
 # Navigate to a service endpoint


### PR DESCRIPTION
## What does this PR change?

Related to https://github.com/SUSE/spacewalk/issues/19820

![image](https://user-images.githubusercontent.com/2827771/207265127-4a06d34b-9dd0-4715-97ae-38d0642ca47f.png)

![image](https://user-images.githubusercontent.com/2827771/207268342-94b40285-39de-462c-a471-6eddfb070020.png)


As you can see here, we are using the label, instead of the name, and the label is not unique, we have the same label text at three different web elements. That's causing our issue.

I will instead use the name.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.2
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
