### PR TITLE
port reportdb idempotency script to python3

### DIFF
--- a/susemanager-utils/testing/docker/scripts/reportdb_schema_idempotency_test_pgsql.py
+++ b/susemanager-utils/testing/docker/scripts/reportdb_schema_idempotency_test_pgsql.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 import argparse
 import difflib
 import distutils.version as DV
@@ -70,7 +70,7 @@ def find_next_version(schema_path):
     return last_version.rsplit('.', 1)[0] + '.' + str(int(last_version.rsplit('.', 1)[1])+1)
 
 def get_ordered_files(path, start, end, schema_path):
-    n = path[start].keys()[0]
+    n = list(path[start].keys())[0]
     res = []
     d = "%s/%s-to-%s" % (schema_path, start, n)
     for f in sorted(os.listdir(d)):


### PR DESCRIPTION
## What does this PR change?

Fix also the repotdb script

Additional fix for https://github.com/uyuni-project/uyuni/pull/6305

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/19871

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
