### PR TITLE
Fix sql script idempotency for rhnServerOverview

### DIFF
--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.9-to-susemanager-schema-4.3.10/006-update-rhnServerOverview.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.9-to-susemanager-schema-4.3.10/006-update-rhnServerOverview.sql
@@ -14,6 +14,7 @@
 --
 --
 --
+DROP VIEW rhnServerOverview;
 
 create or replace view
 rhnServerOverview

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.1-to-susemanager-schema-4.4.2/002-rhnServerOverview-bools.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.1-to-susemanager-schema-4.4.2/002-rhnServerOverview-bools.sql
@@ -98,4 +98,3 @@ select
 from
     rhnServer S
 ;
-


### PR DESCRIPTION
## What does this PR change?

This PR fixes the idempotency for a SQL script updating the table `rhnServerOverview` which was not working correctly when starting the migration from a version >= 4.3.0.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: no code change

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
