### PR TITLE
Testsuite: Enable error detection in SMDBA feature

### DIFF
--- a/testsuite/features/finishing/srv_debug.feature
+++ b/testsuite/features/finishing/srv_debug.feature
@@ -16,4 +16,4 @@ Feature: Debug the server after the testsuite has run
     Then the taskomatic logs should not contain errors
 
   Scenario: Check for out of memory errors
-   Then the log messages should not contain out of memory errors
+    Then the log messages should not contain out of memory errors

--- a/testsuite/features/finishing/srv_smdba.feature
+++ b/testsuite/features/finishing/srv_smdba.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2015-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: SMBDA database helper tool
+Feature: SMDBA database helper tool
   In order to protect the data in Uyuni
   As a database administrator
   I want to easily take backups and snapshots

--- a/testsuite/features/finishing/srv_smdba.feature
+++ b/testsuite/features/finishing/srv_smdba.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2021 SUSE LLC
+# Copyright (c) 2015-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: SMDBA database helper tool

--- a/testsuite/features/finishing/srv_smdba.feature
+++ b/testsuite/features/finishing/srv_smdba.feature
@@ -1,6 +1,7 @@
 # Copyright (c) 2015-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@scope_smdba
 Feature: SMDBA database helper tool
   In order to protect the data in Uyuni
   As a database administrator

--- a/testsuite/features/finishing/srv_smdba.feature
+++ b/testsuite/features/finishing/srv_smdba.feature
@@ -87,7 +87,7 @@ Feature: SMDBA database helper tool
     And I destroy "/var/lib/pgsql/data/pg_wal" directory on server
     And I restore database from the backup
     And I issue command "smdba db-status"
-    Then I should not see error messages in the output
+    Then the database should be "online"
 
   Scenario: Cleanup: remove backup directory
     Given a postgresql database is running

--- a/testsuite/features/finishing/srv_smdba.feature
+++ b/testsuite/features/finishing/srv_smdba.feature
@@ -86,6 +86,7 @@ Feature: SMDBA database helper tool
     And I destroy "/var/lib/pgsql/data/pg_wal" directory on server
     And I restore database from the backup
     And I issue command "smdba db-status"
+    Then I should not see error messages in the output
 
   Scenario: Cleanup: remove backup directory
     Given a postgresql database is running

--- a/testsuite/features/step_definitions/smdba_steps.rb
+++ b/testsuite/features/step_definitions/smdba_steps.rb
@@ -65,7 +65,7 @@ Then(/^the configuration should not be set to "(.*?)"$/) do |value|
 end
 
 Then(/^I issue command "(.*?)"$/) do |command|
-  $output, _code = $server.run(command, check_errors: false)
+  $output, _code = $server.run(command, check_errors: true)
 end
 
 Then(/^tablespace "([^"]*)" should be listed$/) do |ts|

--- a/testsuite/features/step_definitions/smdba_steps.rb
+++ b/testsuite/features/step_definitions/smdba_steps.rb
@@ -1,4 +1,4 @@
-# Copyright 2011-2020 SUSE LLC.
+# Copyright 2011-2022 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 Given(/^a postgresql database is running$/) do

--- a/testsuite/features/step_definitions/smdba_steps.rb
+++ b/testsuite/features/step_definitions/smdba_steps.rb
@@ -65,7 +65,7 @@ Then(/^the configuration should not be set to "(.*?)"$/) do |value|
 end
 
 Then(/^I issue command "(.*?)"$/) do |command|
-  $output, _code = $server.run(command, check_errors: true)
+  $output, _code = $server.run(command, check_errors: false)
 end
 
 Then(/^tablespace "([^"]*)" should be listed$/) do |ts|
@@ -105,6 +105,10 @@ end
 Then(/^I should see error message that asks "(.*?)" has same permissions as "(.*?)" directory$/) do |bkp_dir, data_dir|
   assert_includes($output,
                   "The \"#{bkp_dir}\" directory must have the same permissions as \"#{data_dir}\" directory.")
+end
+
+Then(/^I should not see error messages in the output$/) do
+  raise "Error detected: #{$output}" if $output.include? 'error'
 end
 
 Then(/^I remove backup directory "(.*?)"$/) do |bkp_dir|

--- a/testsuite/features/step_definitions/smdba_steps.rb
+++ b/testsuite/features/step_definitions/smdba_steps.rb
@@ -107,10 +107,6 @@ Then(/^I should see error message that asks "(.*?)" has same permissions as "(.*
                   "The \"#{bkp_dir}\" directory must have the same permissions as \"#{data_dir}\" directory.")
 end
 
-Then(/^I should not see error messages in the output$/) do
-  raise "Error detected: #{$output}" if $output.include? 'error'
-end
-
 Then(/^I remove backup directory "(.*?)"$/) do |bkp_dir|
   $server.run("test -d #{bkp_dir} && rm -rf #{bkp_dir}")
 end


### PR DESCRIPTION
## What does this PR change?

Add a step checking the database status output to detect potential errors.

## GUI diff

No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited

- [x] **DONE**

## Links

Tracks # 
4.2 https://github.com/SUSE/spacewalk/pull/19900
4.3 https://github.com/SUSE/spacewalk/pull/19901

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
