### PR TITLE
Prevent proxy data from being logged

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/setup/ProxySettingsManager.java
+++ b/java/code/src/com/redhat/rhn/manager/setup/ProxySettingsManager.java
@@ -43,7 +43,6 @@ public final class ProxySettingsManager {
         ProxySettingsDto settings = new ProxySettingsDto();
         settings.setHostname(Config.get().getString(KEY_PROXY_HOSTNAME));
         settings.setUsername(Config.get().getString(KEY_PROXY_USERNAME));
-        settings.setPassword(Config.get().getString(KEY_PROXY_PASSWORD));
         return settings;
     }
 

--- a/java/code/src/com/redhat/rhn/manager/setup/test/ProxySettingsManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/setup/test/ProxySettingsManagerTest.java
@@ -14,7 +14,8 @@
  */
 package com.redhat.rhn.manager.setup.test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.manager.setup.ProxySettingsDto;
@@ -33,13 +34,16 @@ public class ProxySettingsManagerTest extends RhnBaseTestCase {
      * @throws Exception if something goes wrong
      */
     @Test
-    public void testGetProxySettings() throws Exception {
+    public void testGetProxySettings() {
         ProxySettingsDto proxy = new ProxySettingsDto();
         proxy.setHostname("proxy.foobar.com");
         proxy.setUsername("foobaruser");
         proxy.setPassword("foobarpassword");
         setProxySettings(proxy);
-        assertTrue(proxy.equals(ProxySettingsManager.getProxySettings()));
+        ProxySettingsDto proxySettingsResult = ProxySettingsManager.getProxySettings();
+        assertEquals(proxy.getHostname(), proxySettingsResult.getHostname());
+        assertEquals(proxy.getUsername(), proxySettingsResult.getUsername());
+        assertNull(proxySettingsResult.getPassword());
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Changed proxy settings retrieval to not include password (bsc#1205339)
+
 -------------------------------------------------------------------
 Fri Nov 18 15:14:35 CET 2022 - jgonzalez@suse.com
 

--- a/web/html/javascript/susemanager-setup-wizard-proxy-settings.js
+++ b/web/html/javascript/susemanager-setup-wizard-proxy-settings.js
@@ -48,7 +48,11 @@ function setProxySettings(settings) {
   jQuery('#http-proxy-input-username').val(settings.username);
   jQuery('p.http-proxy-username').html(settings.username);
 
-  jQuery('p.http-proxy-password').html(Array(8).join('&#9679'));
+  if (settings.hostname) {
+    jQuery('p.http-proxy-password').html(Array(8).join('&#9679'));
+  } else {
+    jQuery('p.http-proxy-password').html("");
+  }
 }
 
 // Sets the spinner, retrieves the settings from the server

--- a/web/html/javascript/susemanager-setup-wizard-proxy-settings.js
+++ b/web/html/javascript/susemanager-setup-wizard-proxy-settings.js
@@ -48,8 +48,7 @@ function setProxySettings(settings) {
   jQuery('#http-proxy-input-username').val(settings.username);
   jQuery('p.http-proxy-username').html(settings.username);
 
-  jQuery('#http-proxy-input-password').val(settings.password);
-  jQuery('p.http-proxy-password').html(Array(settings.password.length).join('&#9679'));
+  jQuery('p.http-proxy-password').html(Array(8).join('&#9679'));
 }
 
 // Sets the spinner, retrieves the settings from the server

--- a/web/html/javascript/susemanager-setup-wizard-proxy-settings.js
+++ b/web/html/javascript/susemanager-setup-wizard-proxy-settings.js
@@ -60,7 +60,6 @@ function retrieveProxySettings() {
   ProxySettingsRenderer.retrieveProxySettings(
     makeAjaxHandler(function(settings) {
       setProxySettings(settings);
-      console.log(JSON.stringify(settings));
 
       if (settings.hostname) {
         verifyProxySettings(false);

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Prevent proxy data from being logged (bsc#1205339)
+
 -------------------------------------------------------------------
 Fri Nov 18 15:14:52 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

It removes console.log used to print the proxy data in browser logs in order to avoid expose sensitive data. It also changes proxy settings retrieval to not include password.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/19587

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
