### PR TITLE
Rename monitoring enablement

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -25144,7 +25144,7 @@ given channel.</source>
         <source>OS Image Build Host</source>
       </trans-unit>
       <trans-unit id="monitoring_entitled" xml:space="preserve">
-        <source>Monitoring</source>
+        <source>Monitored Host</source>
       </trans-unit>
       <trans-unit id="ansible_control_node" xml:space="preserve">
         <source>Ansible Control Node</source>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Rename monitoring entitlement
 - Remove outdated advice from errata mail
 - Fix name for autoinstall snippets after Cobbler 3.3.3
 - prevent ISE on activation key page when selected base channel value is null

--- a/schema/spacewalk/common/data/rhnServerGroupType.sql
+++ b/schema/spacewalk/common/data/rhnServerGroupType.sql
@@ -77,7 +77,7 @@ insert into rhnServerGroupType ( id, label, name, permanent, is_base)
 
 insert into rhnServerGroupType (id, label, name, permanent, is_base)
    values (sequence_nextval('rhn_servergroup_type_seq'),
-      'monitoring_entitled', 'Monitoring',
+      'monitoring_entitled', 'Monitored Host',
       'N', 'N'
    );
 

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Rename monitoring entitlement
 - Added view to handle ptf packages and updated the procedures
   to refresh the updatable/installable packages
 - migration to fix invalid Oracle Linux 9 URLs

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.2-to-susemanager-schema-4.4.3/100-rename_monitoring_entitlement.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.2-to-susemanager-schema-4.4.3/100-rename_monitoring_entitlement.sql
@@ -1,0 +1,20 @@
+--------------------------------------------------------------------------------
+-- rhnServerGroupType ----------------------------------------------------------
+--------------------------------------------------------------------------------
+UPDATE rhnServerGroupType
+SET name = 'Monitored Host'
+WHERE label = 'monitoring_entitled';
+
+
+--------------------------------------------------------------------------------
+-- existing server groups update -----------------------------------------------
+--------------------------------------------------------------------------------
+UPDATE rhnServerGroup sg
+SET
+    name = sgt.name,
+    description = sgt.name
+FROM rhnServerGroupType sgt
+WHERE
+    sg.group_type = sgt.id AND
+    sgt.label = 'monitoring_entitled'
+;


### PR DESCRIPTION
## What does this PR change?

Rename the entitlement _Monitoring_ to _Monitored Host_.

## GUI diff

Before: 
![](https://user-images.githubusercontent.com/12249576/203272774-c4dfc525-1609-4f50-8513-4306384bda61.png)

After:
![](https://user-images.githubusercontent.com/12249576/207325477-554f473c-4bc5-4e0d-9322-3be4af227522.png)


- [x] **DONE**

## Documentation
- No documentation needed: Entitlement name is not mentioned in documentation.
- [x] **DONE**

## Test coverage
- No tests: Minor change not covered by the tests.

- [x] **DONE**

## Links

Fixes SUSE/spacewalk#19615

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
