### PR TITLE
QE: Refactor get_system_name

### DIFF
--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -142,9 +142,6 @@ end
 #   and a fingerprint, e.g. example.Intel-Genuine-None-d6df84cca6f478cdafe824e35bbb6e3b
 # rubocop:disable Metrics/MethodLength
 def get_system_name(host)
-  # If the system is not known, just return the parameter
-  system_name = host
-
   case host
   # The PXE boot minion and the terminals are not directly accessible on the network,
   # therefore they are not represented by a twopence node
@@ -169,8 +166,13 @@ def get_system_name(host)
   when 'containerized_proxy'
     system_name = $proxy.full_hostname.sub('pxy', 'pod-pxy')
   else
-    node = get_target(host)
-    system_name = node.full_hostname
+    begin
+      node = get_target(host)
+      system_name = node.full_hostname
+    rescue RuntimeError
+      # If the node for that host is not defined, just return the host parameter as system_name
+      system_name = host
+    end
   end
   system_name
 end


### PR DESCRIPTION
## What does this PR change?

In a previous changes I refactored the method get_system_name so it raised and error if the node did not exist, I did it so we could catch easily some issues with not defined host.
But I missed a case where we are actually relying on not having it defined to return the text of the host parameter. I recovered this with some extra adjustments.

![image](https://user-images.githubusercontent.com/2827771/207332854-ae8baa3c-1d69-4b6d-8258-99b13de12e33.png)


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
