### PR TITLE
QE: Waiting for some web elements to be loaded

### DIFF
--- a/testsuite/features/secondary/min_config_state_channel_subscriptions.feature
+++ b/testsuite/features/secondary/min_config_state_channel_subscriptions.feature
@@ -60,7 +60,7 @@ Feature: State Configuration channels
     And I check "statechannel-cbox"
     And I check "statechannel2-cbox"
     When I click on "Save Changes"
-    Then I should see a "Edit Channel Ranks" text
+    And I wait until I see "Edit Channel Ranks" text
     And I should see a "My State Channel (statechannel)" link
     And I should see a "My State Channel (statechannel2)" link
     When I click on "Confirm"
@@ -70,7 +70,7 @@ Feature: State Configuration channels
     And I follow "States" in the content area
     And I follow "Configuration Channels" in the content area
     And I click on "Search" in element "search-row"
-    Then I should see a "Execute States" button
+    And I wait until I see "Execute States" text
     When I click on "Execute States"
     Then I should see a "Applying the config channels has been scheduled" text
     When I wait until event "Apply states [custom] scheduled by admin" is completed
@@ -84,7 +84,7 @@ Feature: State Configuration channels
     And I should see a "statechannel3" text
     And I check "statechannel3-cbox"
     When I click on "Save Changes"
-    Then I should see a "Edit Channel Ranks" text
+    And I wait until I see "Edit Channel Ranks" text
     And I should see a "My State Channel (statechannel)" link
     And I should see a "My State Channel (statechannel2)" link
     And I should see a "statechannel3 (statechannel3)" link


### PR DESCRIPTION
## What does this PR change?

Waiting for some web elements to be loaded, as we have several errors in `Feature:State Configuration channels`

https://github.com/SUSE/spacewalk/issues/19882


## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.3
- Manager-4.2 ?

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
