### PR TITLE
Revert temporarily DWR frontend changes for ProxySettingsRenderer component

### DIFF
--- a/web/html/javascript/susemanager-setup-wizard-proxy-settings.js
+++ b/web/html/javascript/susemanager-setup-wizard-proxy-settings.js
@@ -59,15 +59,17 @@ function setProxySettings(settings) {
 function retrieveProxySettings() {
   showSpinner('http-proxy-verify');
   
-  function onSuccess(settings) {
-    setProxySettings(settings);
+  ProxySettingsRenderer.retrieveProxySettings(
+    makeAjaxHandler(function(settings) {
+      setProxySettings(settings);
 
-    if (settings.hostname) {
-      verifyProxySettings(false);
-    } else {
-      setProxySettingsEditable(true);
-    }
-  }
+      if (settings.hostname) {
+        verifyProxySettings(false);
+      } else {
+        setProxySettingsEditable(true);
+      }
+    })
+  )
 
   ajax('retrieve-proxy-settings', '', onSuccess, 'application/json')
 }


### PR DESCRIPTION
## What does this PR change?

It reverts temporarily DWR frontend changes for ProxySettingsRenderer component to avoid merge conflict with Uyuni-2022.11

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
