### PR TITLE
Make dbtest more reliable

### DIFF
--- a/testsuite/features/finishing/srv_smdba.feature
+++ b/testsuite/features/finishing/srv_smdba.feature
@@ -82,6 +82,7 @@ Feature: SMBDA database helper tool
     When I set a checkpoint
     And I issue command "smdba backup-hot"
     And in the database I create dummy table "dummy" with column "test" and value "bogus data"
+    And I stop the database with the command "smdba db-stop"
     And I destroy "/var/lib/pgsql/data/pg_xlog" directory on server
     And I destroy "/var/lib/pgsql/data/pg_wal" directory on server
     And I restore database from the backup

--- a/testsuite/features/step_definitions/smdba_steps.rb
+++ b/testsuite/features/step_definitions/smdba_steps.rb
@@ -162,7 +162,9 @@ end
 
 When(/^I restore database from the backup$/) do
   log "\n*** Restoring database from the backup. This will may take a while. ***\n\n"
-  $server.run('smdba backup-restore')
+  output, code = $server.run('smdba backup-restore')
+  log "#{output}\n\n"
+  raise 'Restore Failed' unless code.zero?
 end
 
 Then(/^I disable backup in the directory "(.*?)"$/) do |_arg1|


### PR DESCRIPTION
## What does this PR change?

We have a running DB where we destroy its storage by removing files.
Then we call "restore" which takes some time. During this time it can happen that somebody ask the DB
and it coredump because of the broken data. This also prevent a successful restore.

Before destroying the storage, we better stop the DB

Port of https://github.com/SUSE/spacewalk/pull/19892

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
