### PR TITLE
QE: Temporary adding an extra refresh of the product catalog to workaround a PAYG bug

### DIFF
--- a/testsuite/features/secondary/srv_payg_ssh_connection.feature
+++ b/testsuite/features/secondary/srv_payg_ssh_connection.feature
@@ -122,3 +122,7 @@ Feature: Pay as you go
     And I click on "Delete" in "Delete Pay-as-you-go" modal
     Then I should not see a "my-bastion.local" link
     And I should not see a "my-host.local" text
+
+  # workaround for bsc#1205943
+  Scenario: Cleanup: Trigger a refresh of the product catalog
+    When I refresh SCC


### PR DESCRIPTION
## What does this PR change?

Due to this PAYG bug https://github.com/SUSE/spacewalk/issues/19730, the PAYG tests are not idempotent as they let the product catalog empty. This is causing troubles on next Cucumber features.
To mitigate this issue, we forced a refresh of the product catalog at the end of PAYG Cucumber feature.

Related to https://github.com/SUSE/spacewalk/issues/19726

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were fixed

- [x] **DONE**

## Links

Ports:
- Manager-4.2
- Manager-4.3


- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
