### PR TITLE
Fix internal server error in SP migration

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SPMigrationAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SPMigrationAction.java
@@ -43,6 +43,8 @@ import com.redhat.rhn.manager.distupgrade.DistUpgradeManager;
 import com.redhat.rhn.manager.errata.ErrataManager;
 import com.redhat.rhn.manager.rhnpackage.PackageManager;
 
+import com.suse.manager.maintenance.NotInMaintenanceModeException;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -81,6 +83,8 @@ public class SPMigrationAction extends RhnAction {
     private static final String LATEST_SP = "latestServicePack";
     private static final String MISSING_SUCCESSOR_EXTENSIONS = "missingSuccessorExtensions";
     private static final String TARGET_PRODUCTS = "targetProducts";
+
+    private static final String NO_MAINTENANCE_WINDOW = "noMaintenanceWindow";
     private static final String CHANNEL_MAP = "channelMap";
     private static final String UPDATESTACK_UPDATE_NEEDED = "updateStackUpdateNeeded";
     private static final String IS_MINION = "isMinion";
@@ -300,25 +304,8 @@ public class SPMigrationAction extends RhnAction {
             request.setAttribute(CHANNEL_MAP, channelMap);
         }
         else if (forward.getName().equals(CONFIRM)) {
-            // Put product data
-            SUSEProductSet targetProductSet = createProductSet(targetBaseProduct, targetAddonProducts);
-            setMissingSuccessorsInfo(request,  server.getInstalledProductSet(), List.of(targetProductSet));
-            request.setAttribute(TARGET_PRODUCTS, targetProductSet);
-            request.setAttribute(BASE_PRODUCT, targetProductSet.getBaseProduct());
-            request.setAttribute(ADDON_PRODUCTS, targetProductSet.getAddonProducts());
-            request.setAttribute(ALLOW_VENDOR_CHANGE, allowVendorChange);
-            // Put channel data
-            Channel baseChannel = ChannelFactory.lookupByIdAndUser(targetBaseChannel, ctx.getCurrentUser());
-            request.setAttribute(BASE_CHANNEL, baseChannel);
-            // Add those child channels that will be subscribed
-            List<EssentialChannelDto> childChannels = getChannelDTOs(ctx, baseChannel,
-                    Arrays.asList(targetChildChannels));
-            request.setAttribute(CHILD_CHANNELS, childChannels);
-
-            // Pre-populate the date picker
-            DatePicker picker = getStrutsDelegate().prepopulateDatePicker(request, form,
-                    "date", DatePicker.YEAR_RANGE_POSITIVE);
-            request.setAttribute("date", picker);
+            setConfirmAttributes(request, ctx, server, form, targetBaseProduct, targetAddonProducts,
+                    targetBaseChannel, targetChildChannels, allowVendorChange);
         }
         else if (forward.getName().equals(SCHEDULE)) {
             // Create target product set from parameters
@@ -332,20 +319,73 @@ public class SPMigrationAction extends RhnAction {
             // Schedule the dist upgrade action
             Date earliest = getStrutsDelegate().readScheduleDate(form, "date",
                     DatePicker.YEAR_RANGE_POSITIVE);
-            Long actionID = DistUpgradeManager.scheduleDistUpgrade(ctx.getCurrentUser(),
-                    server, targetProductSet, channelIDs, dryRun, allowVendorChange, earliest);
+            try {
+                Long actionID = DistUpgradeManager.scheduleDistUpgrade(ctx.getCurrentUser(),
+                        server, targetProductSet, channelIDs, dryRun, allowVendorChange, earliest);
 
-            // Display a message to the user
-            String product = targetProductSet.getBaseProduct().getFriendlyName();
-            String msgKey = dryRun ? MSG_SCHEDULED_DRYRUN : MSG_SCHEDULED_MIGRATION;
-            String[] msgParams = new String[] {server.getId().toString(), actionID.toString(), product};
-            getStrutsDelegate().saveMessage(msgKey, msgParams, request);
-            Map<String, Long> params = new HashMap<>();
-            params.put("sid", server.getId());
-            return getStrutsDelegate().forwardParams(forward, params);
+                // Display a message to the user
+                String product = targetProductSet.getBaseProduct().getFriendlyName();
+                String msgKey = dryRun ? MSG_SCHEDULED_DRYRUN : MSG_SCHEDULED_MIGRATION;
+                String[] msgParams = new String[]{server.getId().toString(), actionID.toString(), product};
+                getStrutsDelegate().saveMessage(msgKey, msgParams, request);
+                Map<String, Long> params = new HashMap<>();
+                params.put("sid", server.getId());
+                return getStrutsDelegate().forwardParams(forward, params);
+            }
+            catch (NotInMaintenanceModeException e) {
+                setConfirmAttributes(request, ctx, server, form, targetBaseProduct, targetAddonProducts,
+                        targetBaseChannel, targetChildChannels, allowVendorChange);
+                request.setAttribute(NO_MAINTENANCE_WINDOW, true);
+                forward = actionMapping.findForward(CONFIRM);
+            }
         }
 
         return forward;
+    }
+
+    /**
+     * Set in the request the parameters for the confirm forward. Public only for testing
+     *
+     * @param request - the request
+     * @param ctx - request context
+     * @param server - the server
+     * @param form - dyna form
+     * @param targetBaseProduct - target base product
+     * @param targetAddonProducts - target addon products
+     * @param targetBaseChannel - target base channel
+     * @param targetChildChannels - target child channels
+     * @param allowVendorChange - allow vendor change
+     */
+    public void setConfirmAttributes(
+            HttpServletRequest request,
+            RequestContext ctx,
+            Server server,
+            DynaActionForm form,
+            Long targetBaseProduct,
+            Long[] targetAddonProducts,
+            Long targetBaseChannel,
+            Long[] targetChildChannels,
+            boolean allowVendorChange
+    ) {
+        // Put product data
+        SUSEProductSet targetProductSet = createProductSet(targetBaseProduct, targetAddonProducts);
+        setMissingSuccessorsInfo(request,  server.getInstalledProductSet(), List.of(targetProductSet));
+        request.setAttribute(TARGET_PRODUCTS, targetProductSet);
+        request.setAttribute(BASE_PRODUCT, targetProductSet.getBaseProduct());
+        request.setAttribute(ADDON_PRODUCTS, targetProductSet.getAddonProducts());
+        request.setAttribute(ALLOW_VENDOR_CHANGE, allowVendorChange);
+        // Put channel data
+        Channel baseChannel = ChannelFactory.lookupByIdAndUser(targetBaseChannel, ctx.getCurrentUser());
+        request.setAttribute(BASE_CHANNEL, baseChannel);
+        // Add those child channels that will be subscribed
+        List<EssentialChannelDto> childChannels = getChannelDTOs(ctx, baseChannel,
+                Arrays.asList(targetChildChannels));
+        request.setAttribute(CHILD_CHANNELS, childChannels);
+
+        // Pre-populate the date picker
+        DatePicker picker = getStrutsDelegate().prepopulateDatePicker(request, form,
+                "date", DatePicker.YEAR_RANGE_POSITIVE);
+        request.setAttribute("date", picker);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/test/SPMigrationActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/test/SPMigrationActionTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.frontend.action.systems.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.test.ChannelFamilyFactoryTest;
+import com.redhat.rhn.domain.product.SUSEProduct;
+import com.redhat.rhn.domain.product.SUSEProductSet;
+import com.redhat.rhn.domain.product.test.SUSEProductTestUtils;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerConstants;
+import com.redhat.rhn.domain.server.test.ServerFactoryTest;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.action.systems.SPMigrationAction;
+import com.redhat.rhn.frontend.struts.RequestContext;
+import com.redhat.rhn.manager.user.UserManager;
+import com.redhat.rhn.testing.ChannelTestUtils;
+import com.redhat.rhn.testing.RhnMockDynaActionForm;
+import com.redhat.rhn.testing.RhnMockHttpServletRequest;
+import com.redhat.rhn.testing.TestUtils;
+
+import com.mockobjects.servlet.MockHttpServletResponse;
+
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Unit test for {@link SPMigrationAction}
+ */
+public class SPMigrationActionTest {
+
+    private Server server;
+    private RhnMockHttpServletRequest request;
+    private RequestContext requestContext;
+    private SUSEProduct baseProduct;
+    private SUSEProduct addonProduct;
+    private RhnMockDynaActionForm form;
+    private Channel baseChannel;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        request = TestUtils.getRequestWithSessionAndUser();
+        requestContext = new RequestContext(request);
+        User user = requestContext.getCurrentUser();
+        server = ServerFactoryTest.createTestServer(user, true,
+                ServerConstants.getServerGroupTypeEnterpriseEntitled());
+        UserManager.storeUser(user);
+        baseProduct = SUSEProductTestUtils.createTestSUSEProduct(ChannelFamilyFactoryTest.createTestChannelFamily());
+        addonProduct = SUSEProductTestUtils.createTestSUSEProduct(ChannelFamilyFactoryTest.createTestChannelFamily());
+        form = new RhnMockDynaActionForm();
+        baseChannel = ChannelTestUtils.createBaseChannel(user);
+
+        form.set("step", "confirm");
+        form.set("addonProducts", new Long[]{5L});
+        form.set("baseProduct", baseProduct.getId());
+        form.set("childChannels", new Long[]{});
+        form.set("baseChannel", baseChannel.getId());
+
+        server.setInstalledProducts(Set.of(SUSEProductTestUtils.getInstalledProduct(baseProduct)));
+    }
+
+    @Test
+    public void testExecuteSchedule() throws Exception {
+        ActionMapping mapping = new ActionMapping();
+        ActionForward target = new ActionForward("schedule", "path", false);
+
+        String sid = server.getId().toString();
+        request.setupAddParameter("sid", sid);
+        request.setupAddParameter(RequestContext.DISPATCH, "schedule");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        mapping.addForwardConfig(target);
+        SPMigrationAction action = new SPMigrationAction();
+        ActionForward result = action.execute(mapping, form, request, response);
+        assertEquals(result.getName(), "schedule");
+    }
+
+    @Test
+    public void testSetConfirmAttributes() {
+        SPMigrationAction action = new SPMigrationAction();
+        Long[] targetAddonProducts = new Long[] {addonProduct.getId()};
+        action.setConfirmAttributes(
+            request,
+            requestContext,
+            server,
+            form,
+            baseProduct.getId(),
+            targetAddonProducts,
+            baseChannel.getId(),
+            new Long[] {},
+            true
+        );
+        assertEquals(
+            new SUSEProductSet(baseProduct.getId(), List.of(targetAddonProducts)).toString(),
+            request.getAttribute("targetProducts").toString()
+        );
+        assertEquals(baseProduct, request.getAttribute("baseProduct"));
+        assertEquals(List.of(addonProduct), request.getAttribute("addonProducts"));
+        assertTrue((Boolean) request.getAttribute("allowVendorChange"));
+        assertEquals(baseChannel, request.getAttribute("baseChannel"));
+        assertEquals(Collections.emptyList(), request.getAttribute("childChannels"));
+        assertNotNull(request.getAttribute("date"));
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -24995,6 +24995,9 @@ given channel.</source>
       <trans-unit id="spmigration.jsp.confirm.channels-after-migration" xml:space="preserve">
         <source>Channel subscriptions after the migration:</source>
       </trans-unit>
+      <trans-unit id="spmigration.jsp.error.no-maintenance-window" xml:space="preserve">
+        <source>Systems assigned to these schedules do not have a maintenance window at {0}</source>
+      </trans-unit>
       <trans-unit id="spmigration.jsp.confirm.note" xml:space="preserve">
         <source>In order to detect any possible problems it is recommended to always do a &lt;strong&gt;Dry Run&lt;/strong&gt; before scheduling the actual Product Migration.</source>
       </trans-unit>

--- a/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-confirm.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-confirm.jsp
@@ -12,6 +12,12 @@
   <link rel="stylesheet" type="text/css" href="/css/susemanager-sp-migration.css?cb=${rhn:getConfig('web.buildtimestamp')}" />
   <%@ include file="/WEB-INF/pages/common/fragments/systems/system-header.jspf"%>
 
+  <c:if test="${not empty noMaintenanceWindow}">
+    <div class="alert alert-danger">
+      <bean:message key="spmigration.jsp.error.no-maintenance-window" arg0="${requestScope.date.date}" />
+    </div>
+  </c:if>
+
   <rhn:toolbar base="h2" icon="header-channel">
     <bean:message key="spmigration.jsp.confirm.title" />
   </rhn:toolbar>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix server error in product migration outside maintenance window (bsc#1206276)
 - Show the package summary where applicable to better describe PTF packages
 - Added CLM filters to match product temporary fixes packages
 - Restrict product temporary fixes visibility in the UI and in the


### PR DESCRIPTION
## What does this PR change?

It fixes internal server error when scheduling a product migration via Web UI and the systems assigned to the schedule do not have a maintenance window at the time informed.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19845

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
