### PR TITLE
Limit changelog data in generated metadata to 20 entries. SUSE/spacewalk#19711

### DIFF
--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -225,7 +225,8 @@ java.mgr_sync_max_connections = 4
 
 # Maximal number of changelog entries added to repo metadata
 # 0 means unlimited
-java.max_changelog_entries = 0
+# 20 is the default in SUSE Linux Enterprise
+java.max_changelog_entries = 20
 
 # Determins which product tree variation to use.
 java.product_tree_tag = SUMA4.3

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Limit changelog data in generated metadata to 20 entries
+
 -------------------------------------------------------------------
 Wed Dec 14 14:16:07 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Limit the default changelog data in generated metadata. Instead of using unlimited(0) as default, use the same default as SUSE Linux Enterprise (20 entries).

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pull/1945)

- [x] **DONE**

## Test coverage
No tests: **no tests added**

- [x] **DONE**

## Links

Tracks SUSE/spacewalk#19711

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
