### PR TITLE
The order of the bootstrap events can be random

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -832,9 +832,9 @@ When(/^I wait until onboarding is completed for "([^"]*)"$/) do |host|
     When I follow the left menu "Systems > System List > All"
     And I wait until I see the name of "#{host}", refreshing the page
     And I follow this "#{host}" link
-    And I wait at most 500 seconds until event "Hardware List Refresh" is completed
-    And I wait at most 500 seconds until event "Apply states" is completed
-    And I wait at most 500 seconds until event "Package List Refresh" is completed
+    And I wait 180 seconds until the event is picked up and 500 seconds until the event "Apply states" is completed
+    And I wait 180 seconds until the event is picked up and 500 seconds until the event "Hardware List Refresh" is completed
+    And I wait 180 seconds until the event is picked up and 500 seconds until the event "Package List Refresh" is completed
   )
 end
 


### PR DESCRIPTION
## What does this PR change?

Co-authored with @vandabarata .

The order of the events can be random.
That makes the timeout to pick them up too strict, especially for the slower SSH minions.
In this PR, we double that timeout to 3 minutes.
Ideally, we would have a global timeout for all of 3 bootstrap events. Something like:
```
And 500 seconds until the events "Apply states", "Hardware List Refresh", and "Package List Refresh" are completed
```
but that would be a much bigger fix.


## Links

Ports:
* 4.2:
* 4.3: https://github.com/SUSE/spacewalk/pull/19917


## Changelogs

- [x] No changelog needed
