### PR TITLE
extract the csrf token from the windows variable if not available as element

### DIFF
--- a/web/html/src/core/log/index.ts
+++ b/web/html/src/core/log/index.ts
@@ -2,9 +2,13 @@
 import LoggerheadInstance from "./loggerhead";
 
 const setHeaders = function (headers) {
-  const csrf_token = document.getElementsByName("csrf_token") as NodeListOf<HTMLInputElement>;
-  if (csrf_token?.[0]) {
-    headers["X-CSRF-Token"] = csrf_token[0].value;
+  if (window.csrfToken) {
+    headers["X-CSRF-Token"] = window.csrfToken;
+  } else {
+    const csrf_token = document.getElementsByName("csrf_token") as NodeListOf<HTMLInputElement>;
+    if (csrf_token?.[0]) {
+      headers["X-CSRF-Token"] = csrf_token[0].value;
+    }
   }
   return headers;
 };

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- fix frontend logging in react pages
 - Fix virtual systems list for unentitled systems
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

In JSP pages we inject CSRF Tokens as hidden fields into the page.
In REACT packages we often set a global variable.
Parse this variable if the token cannot be found in a hidden field.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **no idea how**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/19925 https://github.com/SUSE/spacewalk/pull/19926

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
