### PR TITLE
Use java parameter names instead a hash in apidocs

### DIFF
--- a/java/code/internal/src/com/redhat/rhn/internal/doclet/ApiCall.java
+++ b/java/code/internal/src/com/redhat/rhn/internal/doclet/ApiCall.java
@@ -31,6 +31,7 @@ public class ApiCall implements Comparable<ApiCall> {
     private String name;
     private String doc;
     private List<String> params = new ArrayList<>();
+    private List<String> paramNames = new ArrayList<>();
     private String returnDoc;
     private boolean deprecated = false;
     private String deprecatedVersion;
@@ -139,7 +140,7 @@ public class ApiCall implements Comparable<ApiCall> {
      * @return the ID
      */
     public String getId() {
-        return name + "-" + getMethod().hashCode();
+        return name + "-" + String.join("-", paramNames);
     }
 
     /**
@@ -164,6 +165,15 @@ public class ApiCall implements Comparable<ApiCall> {
      */
     public void addParam(String param) {
         this.params.add(param);
+    }
+
+    /**
+     * Adds a Java parameter name.
+     *
+     * @param paramName the parameter name to add
+     */
+    public void addParamName(String paramName) {
+        paramNames.add(paramName);
     }
 
     /**

--- a/java/code/internal/src/com/redhat/rhn/internal/doclet/ApiDoclet.java
+++ b/java/code/internal/src/com/redhat/rhn/internal/doclet/ApiDoclet.java
@@ -20,6 +20,7 @@ import com.sun.source.doctree.DeprecatedTree;
 import com.sun.source.doctree.DocCommentTree;
 import com.sun.source.doctree.EntityTree;
 import com.sun.source.doctree.IdentifierTree;
+import com.sun.source.doctree.ParamTree;
 import com.sun.source.doctree.SinceTree;
 import com.sun.source.doctree.TextTree;
 import com.sun.source.doctree.UnknownBlockTagTree;
@@ -363,6 +364,13 @@ public abstract class ApiDoclet implements Doclet {
             call.setSinceAvailable(true);
             String text = new TextExtractor().scan(node.getBody(), null);
             call.setSinceVersion(text);
+            return null;
+        }
+
+        @Override
+        public Void visitParam(ParamTree node, ApiCall call) {
+            log("Visiting param tag: " + node.getName().getName());
+            call.addParamName(node.getName().getName().toString());
             return null;
         }
 

--- a/java/manager-build.xml
+++ b/java/manager-build.xml
@@ -449,7 +449,7 @@
     <mkdir dir="${report.dir}/apidocs/${template.dir}/" />
     <mkdir dir="${report.dir}/apidocs/${template.dir}/handlers/" />
     <javadoc doclet="com.redhat.rhn.internal.doclet.${doclet.class}" docletpathref="javadocpath" classpathref="libjars" sourcepath="code/src"
-        additionalparam="-d ${apidoc.output} -templates buildconf/apidoc/${template.dir} -product '${product.name}' -apiversion '${java.apiversion}'">
+        additionalparam="-debug -d ${apidoc.output} -templates buildconf/apidoc/${template.dir} -product '${product.name}' -apiversion '${java.apiversion}'">
       <fileset dir="code" >
         <include name="**/src/com/redhat/rhn/frontend/xmlrpc/**/*Handler.java" />
         <include name="**/src/com/redhat/rhn/frontend/xmlrpc/serializer/*Serializer.java" />

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Don't use hash in apidoc links
+
 -------------------------------------------------------------------
 Thu Dec 15 14:31:15 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Using a hash that changes every time for the function links forces to update the index at every build. Instead this commit uses the java

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: api doc

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19915

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
