### PR TITLE
Revert Select2 and jQuery UI to old sources

### DIFF
--- a/java/code/src/com/suse/manager/webui/templates/groups/custom.jade
+++ b/java/code/src/com/suse/manager/webui/templates/groups/custom.jade
@@ -20,7 +20,7 @@ script(type='text/javascript').
 
 script(src='/javascript/legacy/ace-editor/ace.js?cb=#{webBuildtimestamp}')
 script(src='/javascript/legacy/ace-editor/ext-modelist.js?cb=#{webBuildtimestamp}')
-script(src='/javascript/legacy/jquery-ui.js?cb=#{webBuildtimestamp}')
+script(src='/javascript/jquery-ui.js?cb=#{webBuildtimestamp}')
 
 script(type='text/javascript').
     spaImportReactPage('groups/config-channels/group-config-channels')

--- a/java/code/src/com/suse/manager/webui/templates/minion/custom.jade
+++ b/java/code/src/com/suse/manager/webui/templates/minion/custom.jade
@@ -8,7 +8,7 @@ script(type='text/javascript').
 
 script(src='/javascript/legacy/ace-editor/ace.js?cb=#{webBuildtimestamp}')
 script(src='/javascript/legacy/ace-editor/ext-modelist.js?cb=#{webBuildtimestamp}')
-script(src='/javascript/legacy/jquery-ui.js?cb=#{webBuildtimestamp}')
+script(src='/javascript/jquery-ui.js?cb=#{webBuildtimestamp}')
 
 script(type='text/javascript').
     spaImportReactPage('minion/config-channels/minion-config-channels')

--- a/java/code/src/com/suse/manager/webui/templates/org/custom.jade
+++ b/java/code/src/com/suse/manager/webui/templates/org/custom.jade
@@ -16,7 +16,7 @@ script(type='text/javascript').
 
 script(src='/javascript/legacy/ace-editor/ace.js?cb=#{webBuildtimestamp}')
 script(src='/javascript/legacy/ace-editor/ext-modelist.js?cb=#{webBuildtimestamp}')
-script(src='/javascript/legacy/jquery-ui.js?cb=#{webBuildtimestamp}')
+script(src='/javascript/jquery-ui.js?cb=#{webBuildtimestamp}')
 
 script(type='text/javascript').
     spaImportReactPage('organizations/config-channels/org-config-channels')

--- a/java/code/src/com/suse/manager/webui/templates/yourorg/custom.jade
+++ b/java/code/src/com/suse/manager/webui/templates/yourorg/custom.jade
@@ -14,7 +14,7 @@ script(type='text/javascript').
 
 script(src='/javascript/legacy/ace-editor/ace.js?cb=#{webBuildtimestamp}')
 script(src='/javascript/legacy/ace-editor/ext-modelist.js?cb=#{webBuildtimestamp}')
-script(src='/javascript/legacy/jquery-ui.js?cb=#{webBuildtimestamp}')
+script(src='/javascript/jquery-ui.js?cb=#{webBuildtimestamp}')
 
 script(type='text/javascript').
     spaImportReactPage('organizations/config-channels/org-config-channels')

--- a/java/code/webapp/WEB-INF/decorators/layout_error.jsp
+++ b/java/code/webapp/WEB-INF/decorators/layout_error.jsp
@@ -44,7 +44,7 @@
 
     <script src="/javascript/jquery.js?cb=${cb_version}"></script>
     <script src="/javascript/bootstrap.js?cb=${cb_version}"></script>
-    <script src="/javascript/legacy/select2/select2.js?cb=${cb_version}"></script>
+    <script src="/javascript/select2/select2.js?cb=${cb_version}"></script>
     <script src="/javascript/spacewalk-essentials.js?cb=${cb_version}"></script>
     <script src="/javascript/spacewalk-checkall.js?cb=${cb_version}"></script>
 

--- a/java/code/webapp/WEB-INF/decorators/layout_head.jsp
+++ b/java/code/webapp/WEB-INF/decorators/layout_head.jsp
@@ -29,8 +29,8 @@
     <!-- import plugins styles -->
     <link rel="stylesheet" href="/css/legacy/jquery.timepicker.css?cb=${cb_version}" />
     <link rel="stylesheet" href="/css/bootstrap-datepicker.css?cb=${cb_version}" />
-    <link rel="stylesheet" href="/javascript/legacy/select2/select2.css?cb=${cb_version}" />
-    <link rel="stylesheet" href="/javascript/legacy/select2/select2-bootstrap.css?cb=${cb_version}" />
+    <link rel="stylesheet" href="/javascript/select2/select2.css?cb=${cb_version}" />
+    <link rel="stylesheet" href="/javascript/select2/select2-bootstrap.css?cb=${cb_version}" />
 
     <!-- import styles -->
     <c:set var="webTheme" value="${GlobalInstanceHolder.USER_PREFERENCE_UTILS.getCurrentWebTheme(pageContext)}"/>
@@ -60,7 +60,7 @@
 
     <script src="/javascript/legacy/jquery.min.js?cb=${cb_version}"></script>
     <script src="/javascript/legacy/bootstrap.min.js?cb=${cb_version}"></script>
-    <script src="/javascript/legacy/select2/select2.js?cb=${cb_version}"></script>
+    <script src="/javascript/select2/select2.js?cb=${cb_version}"></script>
     <script src="/javascript/spacewalk-essentials.js?cb=${cb_version}"></script>
     <script src="/javascript/spacewalk-checkall.js?cb=${cb_version}"></script>
     <script src="/javascript/ajax.js?cb=${cb_version}"></script>

--- a/java/code/webapp/WEB-INF/pages/schedule/actionchain.jsp
+++ b/java/code/webapp/WEB-INF/pages/schedule/actionchain.jsp
@@ -8,7 +8,7 @@
 <head>
 </head>
 <body>
-    <script type="text/javascript" src="/javascript/legacy/jquery-ui.js?cb=${rhn:getConfig('web.buildtimestamp')}"></script>
+    <script type="text/javascript" src="/javascript/jquery-ui.js?cb=${rhn:getConfig('web.buildtimestamp')}"></script>
     <script type="text/javascript" src="/javascript/actionchain.js?cb=${rhn:getConfig('web.buildtimestamp')}"></script>
     <rhn:toolbar base="h1" icon="header-chain"
         helpUrl="/docs/${rhn:getDocsLocale(pageContext)}/reference/schedule/action-chains.html">

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Source Select2 and jQuery UI from susemanager-frontend-libs
+
 -------------------------------------------------------------------
 Fri Dec 16 17:36:28 CET 2022 - jgonzalez@suse.com
 

--- a/web/html/src/styleguide/template.js
+++ b/web/html/src/styleguide/template.js
@@ -15,8 +15,8 @@ module.exports = {
       `/fonts/font-spacewalk/css/spacewalk-font.css?cb=${noCache}`,
       `/css/jquery.timepicker.css?cb=${noCache}`,
       `/css/bootstrap-datepicker.css?cb=${noCache}`,
-      `/javascript/legacy/select2/select2.css?cb=${noCache}`,
-      `/javascript/legacy/select2/select2-bootstrap.css?cb=${noCache}`,
+      `/javascript/select2/select2.css?cb=${noCache}`,
+      `/javascript/select2/select2-bootstrap.css?cb=${noCache}`,
     ]
       .map(relativeToProxyUrl)
       .map((url) => ({

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Source Select2 and jQuery UI from susemanager-frontend-libs
+
 -------------------------------------------------------------------
 Wed Dec 14 14:16:24 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Revert the sources updated in https://github.com/uyuni-project/uyuni/pull/6012 until we figure out while the build is borked.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/19882

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
