### PR TITLE
QE: Adjust KVM image template name

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/test/virtcreate.failure.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/virtcreate.failure.json
@@ -15,7 +15,7 @@
             {
               "device": "disk",
               "format": "qcow2",
-              "image": "/var/testsuite-data/disk-image-template.qcow2",
+              "image": "/var/testsuite-data/leap-disk-image-template.qcow2",
               "model": "virtio",
               "name": "system",
               "pool": "default"

--- a/testsuite/documentation/optional.md
+++ b/testsuite/documentation/optional.md
@@ -253,12 +253,12 @@ export VIRTHOST_KVM_PASSWORD=therootpwd
 ```
 
 Make sure the image to use for the test virtual machines is located in
-`/var/testsuite-data/disk-image-template.qcow2` on the virtual hosts.
+`/var/testsuite-data/` on the virtual hosts.
 
 In order for the virtual hosts to be able to report to the test server,
 use a bridge virtual network for the test machines.
 
-The `disk-image-template.qcow2` virtual disk image should
+The `leap-disk-image-template.qcow2` virtual disk image should
 have avahi daemon installed and running at first boot, and should be capable to be booted
 as a KVM guest. The disk images used by sumaform are good candidates
 for this.

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -135,7 +135,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     When I follow "Create Guest"
     And I wait until I see "General" text
     And I enter "test-vm2" as "name"
-    And I enter "/var/testsuite-data/disk-image-template.qcow2" as "disk0_source_template"
+    And I enter "/var/testsuite-data/leap-disk-image-template.qcow2" as "disk0_source_template"
     And I select "test-net0" from "network0_source"
     And I select "Spice" from "graphicsType"
     And I click on "add_disk"
@@ -175,7 +175,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     When I follow "Create Guest"
     And I wait until I see "General" text
     And I enter "test-vm2" as "name"
-    And I enter "/var/testsuite-data/disk-image-template.qcow2" as "disk0_source_template"
+    And I enter "/var/testsuite-data/leap-disk-image-template.qcow2" as "disk0_source_template"
     And I select "test-net0" from "network0_source"
     And I check "uefi"
     And I enter "/usr/share/qemu/ovmf-x86_64-ms.bin" as "uefiLoader"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1082,8 +1082,8 @@ When(/^I create "([^"]*)" virtual machine on "([^"]*)"$/) do |vm_name, host|
   disk_path = "/tmp/#{vm_name}_disk.qcow2"
 
   # Create the throwable overlay image
-  raise '/var/testsuite-data/disk-image-template.qcow2 not found' unless file_exists?(node, '/var/testsuite-data/disk-image-template.qcow2')
-  node.run("cp /var/testsuite-data/disk-image-template.qcow2 #{disk_path}")
+  raise '/var/testsuite-data/leap-disk-image-template.qcow2 not found' unless file_exists?(node, '/var/testsuite-data/leap-disk-image-template.qcow2')
+  node.run("cp /var/testsuite-data/leap-disk-image-template.qcow2 #{disk_path}")
 
   # Actually define the VM, but don't start it
   raise 'not found: virt-install' unless file_exists?(node, '/usr/bin/virt-install')


### PR DESCRIPTION
## What does this PR change?

This will adjust the KVM image template name for the upcoming sumaform changes.

See https://github.com/uyuni-project/sumaform/pull/1197
## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links

- Manager 4.3
- Manager 4.2
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"