### PR TITLE
fix oracle linux 9 repository definitions

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,5 @@
+- migration to fix invalid Oracle Linux 9 URLs
+
 -------------------------------------------------------------------
 Wed Dec 14 14:09:35 CET 2022 - jgonzalez@suse.com
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.3-to-susemanager-schema-4.4.4/000-uyuni-fix-ol9-repos.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.3-to-susemanager-schema-4.4.4/000-uyuni-fix-ol9-repos.sql
@@ -34,3 +34,11 @@ INSERT INTO rhnChannelContentSource (source_id, channel_id)
   FROM rhnChannel C
   WHERE C.label = 'oraclelinux9-aarch64';
 
+UPDATE rhnContentSource
+   SET label = 'External - Oracle Linux 9 (x86_64)'
+ WHERE label = 'Extern - Oracle Linux 9 (x86_64)';
+
+UPDATE rhnContentSource
+   SET label = 'External - Oracle Linux 9 (aarch64)'
+ WHERE label = 'Extern - Oracle Linux 9 (aarch64)';
+

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.3-to-susemanager-schema-4.4.4/000-uyuni-fix-ol9-repos.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.3-to-susemanager-schema-4.4.4/000-uyuni-fix-ol9-repos.sql
@@ -1,0 +1,36 @@
+INSERT INTO rhnContentSource (id, org_id, type_id, source_url, label, metadata_signed)
+  SELECT sequence_nextval('rhn_chan_content_src_id_seq'), CS.org_id, CS.type_id,
+         'https://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/x86_64/', 'Extern - Oracle Linux 9 (x86_64)', 'N'
+    FROM rhnContentSource CS
+    JOIN rhnChannelContentSource CCS ON CS.id = CCS.source_id
+    JOIN rhnChannel C ON CCS.channel_id = C.id
+   WHERE CS.source_url = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle'
+     AND C.label = 'oraclelinux9-x86_64';
+
+INSERT INTO rhnContentSource (id, org_id, type_id, source_url, label, metadata_signed)
+  SELECT sequence_nextval('rhn_chan_content_src_id_seq'), CS.org_id, CS.type_id,
+         'https://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/aarch64/', 'Extern - Oracle Linux 9 (aarch64)', 'N'
+    FROM rhnContentSource CS
+    JOIN rhnChannelContentSource CCS ON CS.id = CCS.source_id
+    JOIN rhnChannel C ON CCS.channel_id = C.id
+   WHERE CS.source_url = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle'
+     AND C.label = 'oraclelinux9-aarch64';
+
+DELETE FROM rhnChannelContentSource
+WHERE channel_id in (SELECT id FROM rhnChannel WHERE label IN ('oraclelinux9-x86_64', 'oraclelinux9-aarch64'));
+
+DELETE FROM rhnContentSource
+WHERE source_url = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle';
+
+INSERT INTO rhnChannelContentSource (source_id, channel_id)
+  SELECT (SELECT id FROM rhnContentSource WHERE label = 'Extern - Oracle Linux 9 (x86_64)'),
+         C.id
+  FROM rhnChannel C
+  WHERE C.label = 'oraclelinux9-x86_64';
+
+INSERT INTO rhnChannelContentSource (source_id, channel_id)
+  SELECT (SELECT id FROM rhnContentSource WHERE label = 'Extern - Oracle Linux 9 (aarch64)'),
+         C.id
+  FROM rhnChannel C
+  WHERE C.label = 'oraclelinux9-aarch64';
+

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1474,22 +1474,22 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 archs    = x86_64, aarch64
 name     = Oracle Linux 9 (%(arch)s)
 checksum = sha256
-gpgkey_url = 
+gpgkey_url = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
 gpgkey_id  = 8D8B756F
 gpgkey_fingerprint = 3E6D 826D 3FBA B389 C2F3 8E34 BC4D 06A0 8D8B 756F
-repo_url = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
-dist_map_release = 8
+repo_url = https://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/%(arch)s/
+dist_map_release = 9
 
 [oraclelinux9-appstream]
 archs    = x86_64, aarch64
 name     = Oracle Linux 9 AppStream (%(arch)s)
 base_channels = oraclelinux9-%(arch)s
 checksum = sha256
-gpgkey_url = 
+gpgkey_url = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
 gpgkey_id  = 8D8B756F
 gpgkey_fingerprint = 3E6D 826D 3FBA B389 C2F3 8E34 BC4D 06A0 8D8B 756F
 repo_url = https://yum.oracle.com/repo/OracleLinux/OL9/appstream/%(arch)s/
-dist_map_release = 8
+dist_map_release = 9
 
 [oraclelinux9-addons]
 label    = %(base_channel)s-addons

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- fix Oracle Linux 9 repository definition
+
 -------------------------------------------------------------------
 Wed Dec 14 14:08:09 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

- repourl was wrongly pointing to a GPG key and the GPG key field was empty
- fixed also the distchannelmap setting

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/6266
Fixes https://github.com/SUSE/spacewalk/issues/19799


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
