### PR TITLE
Update logrotate configurations

### DIFF
--- a/java/conf/logrotate/gatherer
+++ b/java/conf/logrotate/gatherer
@@ -2,12 +2,11 @@
 #
 
 /var/log/rhn/gatherer.log {
-    weekly
     rotate 5
     copytruncate
     nocompress
     notifempty
     create tomcat www
-    size=1M
+    size 1M
     su tomcat www
 }

--- a/java/conf/logrotate/rhn_web_api
+++ b/java/conf/logrotate/rhn_web_api
@@ -2,12 +2,11 @@
 #
 
 /var/log/rhn/rhn_web_api.log {
-    weekly
     rotate 5
     copytruncate
     compress
     notifempty
     missingok
-    size=10M
+    size 10M
     su tomcat www
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Updated logrotate configuration (bsc#1206470)
 - Only remove product catalog if PAYG ssh credentials are defined (bsc#1205943)
 - Virtual systems list performance improvements
 - Do not show systems from other organizations in virtual systems list

--- a/proxy/proxy/logrotate/rhn-proxy-broker
+++ b/proxy/proxy/logrotate/rhn-proxy-broker
@@ -2,12 +2,11 @@
 #
 
 /var/log/rhn/rhn_proxy_broker.log {
-    weekly
     rotate 5
     copytruncate
     compress
     notifempty
-    size=10M
+    size 10M
     missingok
     su wwwrun www
 }

--- a/proxy/proxy/logrotate/rhn-proxy-redirect
+++ b/proxy/proxy/logrotate/rhn-proxy-redirect
@@ -2,12 +2,11 @@
 #
 
 /var/log/rhn/rhn_proxy_redirect.log {
-    weekly
     rotate 5
     copytruncate
     compress
     notifempty
-    size=10M
+    size 10M
     missingok
     su wwwrun www
 }

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,5 @@
+- Updated logrotate configuration (bsc#1206470)
+
 -------------------------------------------------------------------
 Wed Dec 14 14:07:53 CET 2022 - jgonzalez@suse.com
 

--- a/python/spacewalk/logrotate/spacewalk-backend-app
+++ b/python/spacewalk/logrotate/spacewalk-backend-app
@@ -2,12 +2,11 @@
 #
 
 /var/log/rhn/rhn_server_app.log {
-    weekly
     rotate 5
     copytruncate
     compress
     notifempty
     missingok
-    size=10M
+    size 10M
     su wwwrun www
 }

--- a/python/spacewalk/logrotate/spacewalk-backend-applet
+++ b/python/spacewalk/logrotate/spacewalk-backend-applet
@@ -2,12 +2,11 @@
 #
 
 /var/log/rhn/rhn_server_applet.log {
-    weekly
     rotate 5
     copytruncate
     compress
     notifempty
     missingok
-    size=10M
+    size 10M
     su wwwrun www
 }

--- a/python/spacewalk/logrotate/spacewalk-backend-cdn
+++ b/python/spacewalk/logrotate/spacewalk-backend-cdn
@@ -2,23 +2,21 @@
 #
 
 /var/log/rhn/cdnsync.log {
-    weekly
     rotate 5
     copytruncate
     compress
     notifempty
     missingok
-    size=10M
+    size 10M
 #LOGROTATE-3.8#    su root apache
 }
 
 /var/log/rhn/cdnsync/*.log {
-    weekly
     rotate 5
     copytruncate
     compress
     delaycompress
     notifempty
     missingok
-    size=10M
+    size 10M
 }

--- a/python/spacewalk/logrotate/spacewalk-backend-config-files
+++ b/python/spacewalk/logrotate/spacewalk-backend-config-files
@@ -2,12 +2,10 @@
 #
 
 /var/log/rhn/rhn_config_management.log {
-    weekly
-    rotate 5
     copytruncate
     compress
     notifempty
     missingok
-    size=10M
+    size 10M
     su wwwrun www
 }

--- a/python/spacewalk/logrotate/spacewalk-backend-config-files-tool
+++ b/python/spacewalk/logrotate/spacewalk-backend-config-files-tool
@@ -2,12 +2,11 @@
 #
 
 /var/log/rhn/rhn_config_management_tool.log {
-    weekly
     rotate 5
     copytruncate
     compress
     notifempty
     missingok
-    size=10M
+    size 10M
     su wwwrun www
 }

--- a/python/spacewalk/logrotate/spacewalk-backend-iss
+++ b/python/spacewalk/logrotate/spacewalk-backend-iss
@@ -2,12 +2,11 @@
 #
 
 /var/log/rhn/rhn_server_sat.log {
-    weekly
     rotate 5
     copytruncate
     compress
     notifempty
     missingok
-    size=10M
+    size 10M
     su wwwrun www
 }

--- a/python/spacewalk/logrotate/spacewalk-backend-iss-export
+++ b/python/spacewalk/logrotate/spacewalk-backend-iss-export
@@ -2,11 +2,11 @@
 #
 
 /var/log/rhn/rhn_sat_export_internal.log {
-    weekly
     rotate 5
     copytruncate
     compress
     notifempty
     missingok
+    size 10M
     su wwwrun www
 }

--- a/python/spacewalk/logrotate/spacewalk-backend-package-push-server
+++ b/python/spacewalk/logrotate/spacewalk-backend-package-push-server
@@ -2,12 +2,11 @@
 #
 
 /var/log/rhn/rhn_upload_package_push.log {
-    weekly
     rotate 5
     copytruncate
     compress
     notifempty
     missingok
-    size=10M
+    size 10M
     su wwwrun www
 }

--- a/python/spacewalk/logrotate/spacewalk-backend-server
+++ b/python/spacewalk/logrotate/spacewalk-backend-server
@@ -2,12 +2,11 @@
 #
 
 /var/log/rhn/rhn_server.log {
-    weekly
     rotate 5
     copytruncate
     compress
     notifempty
     missingok
-    size=10M
+    size 10M
     su wwwrun www
 }

--- a/python/spacewalk/logrotate/spacewalk-backend-tools
+++ b/python/spacewalk/logrotate/spacewalk-backend-tools
@@ -2,45 +2,41 @@
 #
 
 /var/log/rhn/activation.log {
-    weekly
     rotate 5
     copytruncate
     compress
     notifempty
     missingok
-    size=10M
+    size 10M
 #LOGROTATE-3.8#    su root apache
 }
 
 /var/log/rhn/rhn_server_satellite.log {
-    weekly
     rotate 5
     copytruncate
     compress
     notifempty
     missingok
-    size=10M
+    size 10M
     su wwwrun www
 }
 
 /var/log/rhn/reposync.log {
-    weekly
     rotate 5
     copytruncate
     compress
     notifempty
     missingok
-    size=10M
+    size 10M
 #LOGROTATE-3.8#    su root apache
 }
 
 /var/log/rhn/reposync/*.log {
-    weekly
     rotate 5
     copytruncate
     compress
     delaycompress
     notifempty
     missingok
-    size=10M
+    size 10M
 }

--- a/python/spacewalk/logrotate/spacewalk-backend-xmlrpc
+++ b/python/spacewalk/logrotate/spacewalk-backend-xmlrpc
@@ -2,12 +2,11 @@
 #
 
 /var/log/rhn/rhn_server_xmlrpc.log {
-    weekly
     rotate 5
     copytruncate
     compress
     notifempty
     missingok
-    size=10M
+    size 10M
     su wwwrun www
 }

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Updated logrotate configuration (bsc#1206470)
+
 -------------------------------------------------------------------
 Wed Dec 14 14:14:34 CET 2022 - jgonzalez@suse.com
 

--- a/search-server/spacewalk-search/spacewalk-search.changes
+++ b/search-server/spacewalk-search/spacewalk-search.changes
@@ -1,3 +1,5 @@
+- Updated logrotate configuration (bsc#1206470)
+
 -------------------------------------------------------------------
 Wed Dec 14 14:17:08 CET 2022 - jgonzalez@suse.com
 

--- a/search-server/spacewalk-search/src/config/etc/logrotate.d/rhn-search
+++ b/search-server/spacewalk-search/src/config/etc/logrotate.d/rhn-search
@@ -1,9 +1,8 @@
 /var/log/rhn/search/rhn_search.log {
-    weekly
     rotate 5
     copytruncate
     compress
     notifempty
     missingok
-    size=10M
+    size 10M
 }  

--- a/susemanager-utils/susemanager-sls/salt/services/salt-minion.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/salt-minion.sls
@@ -43,8 +43,8 @@ logrotate_configuration:
     - contents: |
         /var/log/salt-ssh.log {
                 su root root
-                weekly
                 missingok
+                size 10M
                 rotate 7
                 compress
                 notifempty

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Updated logrotate configuration (bsc#1206470)
+
 -------------------------------------------------------------------
 Wed Dec 14 14:15:05 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes the logrotate configuration files fixing the format of the `size` directive and removing the unneeded `weekly`.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: no code change, only configuration files

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19919
Tracks [Manager 4.3](https://github.com/SUSE/spacewalk/pull/19944) [Manager-4.2](https://github.com/SUSE/spacewalk/pull/19945)

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
