### PR TITLE
QE: Additional screenshot in Advanced Search tests to debug a flaky test

### DIFF
--- a/testsuite/features/secondary/srv_advanced_search.feature
+++ b/testsuite/features/secondary/srv_advanced_search.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
-@scope_monitoring
+@scope_spacewalk_utils
 @sle_minion
 Feature: Advanced Search
   In order to check and maintain the minions
@@ -16,6 +16,7 @@ Feature: Advanced Search
     And I enter "sle_minion" hostname on the search field
     And I select "Hostname" from "Field to Search"
     And I check "invert"
+    And I save a screenshot as "inverse_results.png"
     And I click on the search button
     Then I should see a "No results found." text
 


### PR DESCRIPTION
## What does this PR change?

Additional screenshot in Advanced Search tests to debug a flaky test

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

No ports.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
