### PR TITLE
QE: Adjust RuboCop GitHub Actions workflow

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -3,8 +3,10 @@ name: RuboCop
 on:
   pull_request:
     paths:
-      - 'testsuite/features/**.rb'
       - '.github/workflows/rubocop.yml'
+      - 'testsuite/features/**.rb'
+      - 'testsuite/.rubocop.yml'
+      - 'testsuite/.rubocop_todo.yml'
 
 jobs:
   rubocop:


### PR DESCRIPTION
## What does this PR change?

This includes the 2 RuboCop configuration files that when changed should also trigger a RuboCop run in a pull request.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links

- Manager 4.3
- Manager 4.2
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
