### PR TITLE
Fix CVE Audit ignoring errata in parent channels if patch in successor exists

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/audit/CVEAuditManager.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/CVEAuditManager.java
@@ -1078,10 +1078,16 @@ public class CVEAuditManager {
             return newerPatch;
         }).orElse(
                 // The CVE is not patched against
-                // Compare channel ranks to find the top channel (assigned channels come first)
+                // Compare channel ranks to find the top channel. Assigned channels come first.
+                // Vendor and cloned channels next. Last come successor channels.
                 packageResults.stream().max(Comparator.comparing(CVEPatchStatus::isChannelAssigned)
-                .thenComparing(Comparator.nullsLast(Comparator.comparingLong(r -> r.getChannelRank().orElse(null))))));
-
+                        .thenComparingLong(r -> {
+                            Long rank = r.getChannelRank().orElse(0L);
+                            return rank < SUCCESSOR_PRODUCT_RANK_BOUNDARY ? rank : 0L;
+                        })
+                        .thenComparingLong(r -> r.getChannelRank().orElse(0L))
+                )
+        );
         return result;
     }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Fix CVE Audit ignoring errata in parent channels if patch in successor
+  product exists (bsc#1206168)
 - Fix CVE Audit incorrectly displaying predecessor product (bsc#1205663)
 - Rename monitoring entitlement
 - Remove outdated advice from errata mail


### PR DESCRIPTION
## What does this PR change?

Change behavior of CVE Audit to display patches from parent of cloned channel instead of from the successor product if it also has a patch for given CVE available.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: **Bugfix**

- [x] **DONE**

## Test coverage

- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/19846

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
