### PR TITLE
QE: Fix a rename of SCC channel for Containers sles12 sp4

### DIFF
--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -53,7 +53,7 @@ Feature: Be able to list available channels and enable them
     And I execute mgr-sync "list channels"
     Then I should get "[I] SLES12-SP4-Pool for x86_64 SUSE Linux Enterprise Server 12 SP4 x86_64 [sles12-sp4-pool-x86_64]"
     And I should get "    [I] SLES12-SP4-Updates for x86_64 SUSE Linux Enterprise Server 12 SP4 x86_64 [sles12-sp4-updates-x86_64]"
-    And I should get "    [ ] SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp4]"
+    And I should get "    [ ] SLE-Module-Containers12-Pool for x86_64 SP4 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp4]"
 
 @susemanager
   Scenario: Enable RHEL 8 channels for Rocky 8
@@ -86,7 +86,7 @@ Feature: Be able to list available channels and enable them
     When I execute mgr-sync "add channel sle-module-containers12-pool-x86_64-sp4"
     And I execute mgr-sync "list channels"
     Then I should get "[I] SLES12-SP4-Pool for x86_64 SUSE Linux Enterprise Server 12 SP4 x86_64 [sles12-sp4-pool-x86_64]"
-    And I should get "    [I] SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp4]"
+    And I should get "    [I] SLE-Module-Containers12-Pool for x86_64 SP4 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp4]"
     And I should get "    [I] SLE-Module-Containers12-Updates for x86_64 Containers Module 12 x86_64 [sle-module-containers12-updates-x86_64-sp4]"
 
   Scenario: Let mgr-sync time out


### PR DESCRIPTION
## What does this PR change?

We are checking that we have selected a channel `SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp4]` but today it suddenly started to fail, and we noticed that the text has changed `SLE-Module-Containers12-Pool for x86_64 SP4 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp4]`  notice the additional SP4 text appended.

This PR aims to adapt our tests with the changes in SCC.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.2
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
