### PR TITLE
Testsuite: fix the name of saltboot state

### DIFF
--- a/testsuite/features/build_validation/retail/sle12sp5_terminal_deploy.feature
+++ b/testsuite/features/build_validation/retail/sle12sp5_terminal_deploy.feature
@@ -19,7 +19,7 @@ Feature: PXE boot a SLES 12 SP5 retail terminal
     And I follow the left menu "Systems > System List > All"
     And I wait until I see the name of "sle12sp5_terminal", refreshing the page
     And I follow this "sle12sp5_terminal" link
-    And I wait until event "Apply states [util.syncstates, saltboot] scheduled" is completed
+    And I wait until event "Apply states [saltboot] scheduled" is completed
     And I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until radio button "SLES12-SP5-Pool" is checked, refreshing the page

--- a/testsuite/features/build_validation/retail/sle15sp4_terminal_deploy.feature
+++ b/testsuite/features/build_validation/retail/sle15sp4_terminal_deploy.feature
@@ -19,7 +19,7 @@ Feature: PXE boot a SLES 15 SP4 retail terminal
     And I follow the left menu "Systems > System List > All"
     And I wait until I see the name of "sle15sp4_terminal", refreshing the page
     And I follow this "sle15sp4_terminal" link
-    And I wait until event "Apply states [util.syncstates, saltboot] scheduled" is completed
+    And I wait until event "Apply states [saltboot] scheduled" is completed
     And I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until radio button "SLE-Product-SLES15-SP4-Pool" is checked, refreshing the page

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -191,7 +191,7 @@ Feature: PXE boot a Retail terminal
     And I wait until I see the name of "pxeboot_minion", refreshing the page
     And I follow this "pxeboot_minion" link
     # Workaround: Increase timeout temporarily get rid of timeout issues
-    And I wait at most 350 seconds until event "Apply states [util.syncstates, saltboot] scheduled by (none)" is completed
+    And I wait at most 350 seconds until event "Apply states [saltboot] scheduled by (none)" is completed
     And I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until radio button "SLE-Product-SLES15-SP4-Pool for x86_64" is checked, refreshing the page


### PR DESCRIPTION
## What does this PR change?

PR https://github.com/uyuni-project/uyuni/pull/6191 changed the name of saltboot state
from [util.syncstates, saltboot] to [saltboot]. 
util.syncstates is called earlier, as part of systeminfo state.

## Links

Depends on  https://github.com/uyuni-project/uyuni/pull/6191

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
