### PR TITLE
Fix RuboCop issues introduces with #6347

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -190,11 +190,11 @@ end
 
 def generate_repository_name(repo_url)
   repo_name = repo_url.strip
-  repo_name.sub!(/http:\/\/download.suse.de\/ibs\/SUSE:\/Maintenance:\//,'')
-  repo_name.sub!(/http:\/\/download.suse.de\/download\/ibs\/SUSE:\/Maintenance:\//,'')
-  repo_name.sub!(/http:\/\/download.suse.de\/download\/ibs\/SUSE:\//,'')
-  repo_name.sub!(/http:\/\/.*compute.internal\/SUSE:\//,'')
-  repo_name.sub!(/http:\/\/.*compute.internal\/SUSE:\/Maintenance:\//,'')
+  repo_name.sub!(%r{http:\/\/download.suse.de\/ibs\/SUSE:\/Maintenance:\/}, '')
+  repo_name.sub!(%r{http:\/\/download.suse.de\/download\/ibs\/SUSE:\/Maintenance:\/}, '')
+  repo_name.sub!(%r{http:\/\/download.suse.de\/download\/ibs\/SUSE:\/}, '')
+  repo_name.sub!(%r{http:\/\/.*compute.internal\/SUSE:\/}, '')
+  repo_name.sub!(%r{http:\/\/.*compute.internal\/SUSE:\/Maintenance:\/}, '')
   repo_name.gsub!('/', '_')
   repo_name.gsub!(':', '_')
   repo_name[0...64] # HACK: Due to the 64 characters size limit of a repository label

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -167,7 +167,7 @@ LABEL_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.3-Pool' => 'sle-prod
                           'RHEL x86_64 Server 7' => 'rhel-x86_64-server-7',
                           'RHEL8-Pool for x86_64' => 'no-appstream-8-result-rhel8-pool-x86_64',
                           'rockylinux-9 for x86_64' => 'no-appstream-9-result-rockylinux-9-x86_64',
-                          'EL9-Pool'=> 'el9-pool-x86_64',
+                          'EL9-Pool' => 'el9-pool-x86_64',
                           'ubuntu-18.04-pool' => 'ubuntu-18.04-pool-amd64',
                           'ubuntu-2004-amd64-main' => 'ubuntu-2004-amd64-main-amd64',
                           'ubuntu-2204-amd64-main' => 'ubuntu-2204-amd64-main-amd64',


### PR DESCRIPTION
## What does this PR change?

Fixes RuboCop issues introduces with #6347

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links

- Manager: 4.3: https://github.com/SUSE/spacewalk/pull/19968
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
