### PR TITLE
Rename the channel SLE-Module-Containers12-Updates

### DIFF
--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -87,7 +87,7 @@ Feature: Be able to list available channels and enable them
     And I execute mgr-sync "list channels"
     Then I should get "[I] SLES12-SP4-Pool for x86_64 SUSE Linux Enterprise Server 12 SP4 x86_64 [sles12-sp4-pool-x86_64]"
     And I should get "    [I] SLE-Module-Containers12-Pool for x86_64 SP4 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp4]"
-    And I should get "    [I] SLE-Module-Containers12-Updates for x86_64 Containers Module 12 x86_64 [sle-module-containers12-updates-x86_64-sp4]"
+    And I should get "    [I] SLE-Module-Containers12-Updates for x86_64 SP4 Containers Module 12 x86_64 [sle-module-containers12-updates-x86_64-sp4]"
 
   Scenario: Let mgr-sync time out
     When I remove the mgr-sync cache file


### PR DESCRIPTION
## What does this PR change?

Rename the channel SLE-Module-Containers12-Updates

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

- Manager-4.3 https://github.com/SUSE/spacewalk/pull/19970

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
