### PR TITLE
Fix link to documentation in monitoring page

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/admin/AdminViewsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/admin/AdminViewsController.java
@@ -20,6 +20,7 @@ import static com.suse.manager.webui.utils.SparkApplicationHelper.withOrgAdmin;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withUserPreferences;
 import static spark.Spark.get;
 
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.cloudpayg.PaygSshData;
 import com.redhat.rhn.domain.cloudpayg.PaygSshDataFactory;
 import com.redhat.rhn.domain.user.User;
@@ -82,6 +83,7 @@ public class AdminViewsController {
      */
     public static ModelAndView showMonitoring(Request request, Response response, User user) {
         Map<String, Object> data = new HashMap<>();
+        data.put("isUyuni", ConfigDefaults.get().isUyuni());
         return new ModelAndView(data, "controllers/admin/templates/monitoring.jade");
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/admin/templates/monitoring.jade
+++ b/java/code/src/com/suse/manager/webui/controllers/admin/templates/monitoring.jade
@@ -7,4 +7,4 @@ script(type='text/javascript').
 
 script(type='text/javascript').
     spaImportReactPage('admin/config/monitoring')
-        .then(function (module) { module.renderer('monitoring') });
+        .then(function (module) { module.renderer('monitoring', JSON.parse("#{isUyuni}")) });

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix link to documentation in monitoring page
 - Fix server error in product migration outside maintenance window (bsc#1206276)
 - Show the package summary where applicable to better describe PTF packages
 - Added CLM filters to match product temporary fixes packages

--- a/web/html/src/manager/admin/config/monitoring-admin.tsx
+++ b/web/html/src/manager/admin/config/monitoring-admin.tsx
@@ -146,7 +146,12 @@ const ListPlaceholder = (props) => {
   );
 };
 
-const HelpPanel = (props) => {
+type HelpPanelProps = {
+  isUyuni: boolean;
+};
+
+const HelpPanel = (props: HelpPanelProps) => {
+  const docsDirectory = props.isUyuni ? "/uyuni" : "/suse-manager";
   return (
     <div className="col-sm-3 hidden-xs" id="wizard-faq">
       <h4>{t("Server Monitoring")}</h4>
@@ -160,7 +165,7 @@ const HelpPanel = (props) => {
       <p>
         {t("Refer to the ")}
         <a
-          href={"/docs/" + docsLocale + "/suse-manager/administration/monitoring.html"}
+          href={"/docs/" + docsLocale + docsDirectory + "/administration/monitoring.html"}
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -197,7 +202,11 @@ const ExportersMessages = (props: {
   }
 };
 
-const MonitoringAdmin = (props) => {
+type MonitoringAdminProps = {
+  isUyuni: boolean;
+};
+
+const MonitoringAdmin = (props: MonitoringAdminProps) => {
   const {
     action,
     fetchStatus,
@@ -328,7 +337,7 @@ const MonitoringAdmin = (props) => {
         <h1>
           <i className="fa fa-info-circle"></i>
           {t("SUSE Manager Configuration - Monitoring")}
-          <HelpLink url="suse-manager/administration/monitoring.html" />
+          <HelpLink url={`${props.isUyuni ? "uyuni" : "suse-manager"}/administration/monitoring.html`} />
         </h1>
       </div>
       <div className="page-summary">
@@ -402,7 +411,7 @@ const MonitoringAdmin = (props) => {
               <ExportersMessages messages={exportersMessages} />
             </div>
           </div>
-          <HelpPanel />
+          <HelpPanel isUyuni={props.isUyuni} />
         </div>
       </Panel>
     </div>

--- a/web/html/src/manager/admin/config/monitoring.renderer.tsx
+++ b/web/html/src/manager/admin/config/monitoring.renderer.tsx
@@ -4,6 +4,6 @@ import SpaRenderer from "core/spa/spa-renderer";
 
 import MonitoringAdmin from "./monitoring-admin";
 
-export const renderer = (id: string) => {
-  SpaRenderer.renderNavigationReact(<MonitoringAdmin />, document.getElementById(id));
+export const renderer = (id: string, isUyuni: boolean) => {
+  SpaRenderer.renderNavigationReact(<MonitoringAdmin isUyuni={isUyuni} />, document.getElementById(id));
 };

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix link to documentation in monitoring page
 - Added CLM filters to match product temporary fixes packages
 - fix frontend logging in react pages
 - Fix virtual systems list for unentitled systems


### PR DESCRIPTION
## What does this PR change?

It fixes link to documentation in monitoring page when running Uyuni. The link was hard coded to use `suse-manager` path and now it will consider the running instance to point to the correct file.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19733
Fixes https://github.com/uyuni-project/uyuni/issues/6242

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
