### PR TITLE
Fix unexpected unauthorized in HTTP API

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/satellite/test/BootstrapSystemConfigActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/satellite/test/BootstrapSystemConfigActionTest.java
@@ -18,11 +18,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.frontend.action.satellite.BootstrapSystemConfigAction;
 import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.testing.RhnMockStrutsTestCase;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -47,6 +49,15 @@ public class BootstrapSystemConfigActionTest extends RhnMockStrutsTestCase {
         user.getOrg().addRole(RoleFactory.SAT_ADMIN);
         user.addPermanentRole(RoleFactory.SAT_ADMIN);
         setRequestPathInfo("/admin/config/BootstrapSystems");
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+        // clean activation keys after running the tests to avoid side effects in other tests
+        HibernateFactory.getSession().createQuery("DELETE FROM ActivationKey").executeUpdate();
+        HibernateFactory.commitTransaction();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/test/CobblerEnableBootstrapCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/test/CobblerEnableBootstrapCommandTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.redhat.rhn.common.conf.ConfigDefaults;
-import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.server.ServerGroupType;
 import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.domain.token.ActivationKeyFactory;
@@ -33,7 +32,6 @@ import org.cobbler.CobblerConnection;
 import org.cobbler.Distro;
 import org.cobbler.Profile;
 import org.cobbler.SystemRecord;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.AbstractMap;
@@ -47,14 +45,6 @@ import java.util.Set;
  * Tests Cobbler default PXE configuration for bare-metal server registration.
  */
 public class CobblerEnableBootstrapCommandTest extends BaseTestCaseWithUser {
-
-    @Override
-    @AfterEach
-    public void tearDown() throws Exception {
-        super.tearDown();
-        HibernateFactory.getSession().createQuery("DELETE FROM ActivationKey").executeUpdate();
-        HibernateFactory.commitTransaction();
-    }
 
     /**
      * Tests the execution of this Cobbler command.

--- a/java/code/src/com/redhat/rhn/manager/token/test/ActivationKeyManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/token/test/ActivationKeyManagerTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.config.ConfigChannel;
 import com.redhat.rhn.domain.config.ConfigChannelListProcessor;
@@ -42,7 +41,6 @@ import com.redhat.rhn.testing.ConfigTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -63,15 +61,6 @@ public class ActivationKeyManagerTest extends BaseTestCaseWithUser {
         super.setUp();
         manager = ActivationKeyManager.getInstance();
     }
-
-    @Override
-    @AfterEach
-    public void tearDown() throws Exception {
-        super.tearDown();
-        HibernateFactory.getSession().createQuery("DELETE FROM ActivationKey").executeUpdate();
-        HibernateFactory.commitTransaction();
-    }
-
     @Test
     public void testDelete() throws Exception {
         user.addPermanentRole(RoleFactory.ACTIVATION_KEY_ADMIN);


### PR DESCRIPTION
## What does this PR change?

It fixes unexpected unauthorized in HTTP API when making a request immediately after authenticating, because there is no time to persist the changes to the database. Calling a `commitTransaction` solves the issue.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19848

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
