### PR TITLE
Fix HTTP API login status code when using wrong credentials

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/login/LoginController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/login/LoginController.java
@@ -44,6 +44,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.servlet.http.HttpServletResponse;
+
 import spark.ModelAndView;
 import spark.Request;
 import spark.Response;
@@ -168,6 +170,7 @@ public class LoginController {
         }
         else {
             log.error("LOCAL AUTH FAILURE: [{}]", creds.getLogin());
+            response.status(HttpServletResponse.SC_UNAUTHORIZED);
             return json(response, new LoginResult(false, errors.toArray(new String[0])));
         }
     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix HTTP API login status code when using wrong credentials (bsc#1206666)
 - Fix physical systems list
 - Configure the reboot action for transactional systems appropriately
 - Fix link to documentation in monitoring page


### PR DESCRIPTION
## What does this PR change?

It changes the status code returned by HTTP API authentication endpoint when wrong credentials are provided. Before it was returning HTTP 200 and it will be changed to return HTTP 401.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19996

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
