### PR TITLE
QE: Ignore rocky subversion for reposync

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -36,7 +36,8 @@ def compute_channels_to_leave_running
     os_version = node.os_version
     os_family = node.os_family
     next unless ['sles', 'rocky'].include?(os_family)
-    raise "Can't build list of reposyncs to leave running" unless %w[12-SP4 12-SP5 15-SP3 15-SP4 8.6].include? os_version
+    os_version = os_version.split('.')[0] if os_family == 'rocky'
+    raise "Can't build list of reposyncs to leave running" unless %w[12-SP4 12-SP5 15-SP3 15-SP4 8].include? os_version
     do_not_kill += CHANNEL_TO_SYNCH_BY_OS_VERSION[os_version]
   end
   do_not_kill += CHANNEL_TO_SYNCH_BY_OS_VERSION[MIGRATE_SSH_MINION_FROM]

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -372,7 +372,7 @@ CHANNEL_TO_SYNCH_BY_OS_VERSION = {
     sle-module-containers15-sp4-pool-x86_64
     sle-module-containers15-sp4-updates-x86_64
   ],
-  '8.6' =>
+  '8' =>
   %w[
     res8-manager-tools-pool-x86_64
     res8-manager-tools-updates-x86_64


### PR DESCRIPTION
## What does this PR change?
Considers only that Rocky is at version 8, without filtering by the subversion, making our code more resilient to minor version upgrades.

## Ports
No ports needed.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
