### PR TITLE
Fix reboot info beacon installation

### DIFF
--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix reboot info beacon installation
 - Add state to properly configure the reboot action for transactional systems
 - enforce installation of the PTF GPG key package
 - Optimize the number of salt calls on minion startup (bsc#1203532)

--- a/susemanager-utils/susemanager-sls/susemanager-sls.spec
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.spec
@@ -102,7 +102,7 @@ cp -R reactor/* %{buildroot}/usr/share/susemanager/reactor
 cp -R scap/* %{buildroot}/usr/share/susemanager/scap
 
 # Manually install Python part to already prepared structure
-cp src/beacons/pkgset.py %{buildroot}/usr/share/susemanager/salt/_beacons
+cp src/beacons/*.py %{buildroot}/usr/share/susemanager/salt/_beacons
 cp src/grains/*.py %{buildroot}/usr/share/susemanager/salt/_grains/
 rm %{buildroot}/usr/share/susemanager/salt/_grains/__init__.py
 cp src/modules/*.py %{buildroot}/usr/share/susemanager/salt/_modules


### PR DESCRIPTION
## What does this PR change?

It fixes reboot info beacon installation by adapting the command that copies the beacons to the proper directory.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/19909
Related to https://github.com/SUSE/spacewalk/issues/19908

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
