### PR TITLE
QE: Temporarily disable Rocky 8 reposync

### DIFF
--- a/testsuite/run_sets/reposync.yml
+++ b/testsuite/run_sets/reposync.yml
@@ -13,6 +13,6 @@
 - features/reposync/srv_sync_products.feature
 - features/reposync/srv_enable_sync_products.feature
 - features/reposync/srv_wait_for_reposync.feature
-- features/reposync/srv_add_rocky8_repositories.feature
+# - features/reposync/srv_add_rocky8_repositories.feature
 
 ## Channels and Product synchronization features END ###


### PR DESCRIPTION
## What does this PR change?

Temporarily disables Rocky 8 reposync until further debugging can happen on what the issue is, so we can have test results beyond Core.

## Ports
No ports needed.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
