### PR TITLE
QE: Revert changes to clicking on Clear step, except the fixed feature

### DIFF
--- a/testsuite/features/secondary/allcli_action_chain.feature
+++ b/testsuite/features/secondary/allcli_action_chain.feature
@@ -108,4 +108,4 @@ Feature: Action chains on several systems at once
     And I run "rm /tmp/action_chain_done" on "ssh_minion" without error control
 
   Scenario: Cleanup: remove remaining systems from SSM after action chain tests on several systems
-    When I follow "clear-ssm"
+    When I click on "Clear"

--- a/testsuite/features/secondary/allcli_config_channel.feature
+++ b/testsuite/features/secondary/allcli_config_channel.feature
@@ -224,4 +224,4 @@ Feature: Management of configuration of all types of clients in a single channel
     When I destroy "/etc/s-mgr" directory on "sle_minion"
 
   Scenario: Cleanup: remove remaining systems from SSM after tests of configuration channel on all clients
-    When I follow "clear-ssm"
+    When I click on "Clear"

--- a/testsuite/features/secondary/allcli_software_channels.feature
+++ b/testsuite/features/secondary/allcli_software_channels.feature
@@ -160,4 +160,4 @@ Feature: Channel subscription via SSM
     Then channel "SLE15-SP4-Installer-Updates for x86_64" should not be enabled on "sle_minion"
 
   Scenario: Cleanup: remove remaining systems from SSM after channel subscription tests
-    When I follow "clear-ssm"
+    When I click on "Clear"

--- a/testsuite/features/secondary/allcli_software_channels_dependencies.feature
+++ b/testsuite/features/secondary/allcli_software_channels_dependencies.feature
@@ -49,4 +49,4 @@ Feature: Channel subscription with recommended or required dependencies
     And I should see "No change" "unselected" for the "SLE-Module-Basesystem15-SP3-Pool for x86_64" channel
 
   Scenario: Cleanup: remove remaining systems from SSM after software channel tests
-    When I follow "clear-ssm"
+    When I click on "Clear"

--- a/testsuite/features/secondary/min_cve_audit.feature
+++ b/testsuite/features/secondary/min_cve_audit.feature
@@ -59,7 +59,7 @@ Feature: CVE Audit on SLE Salt Minions
     Then I should see a "The specified CVE number was not found" text
 
   Scenario: Select a system for the System Set Manager
-    When I follow "clear-ssm"
+    When I click on "Clear"
     And I follow the left menu "Audit > CVE Audit"
     And I select "1999" from "cveIdentifierYear"
     And I enter "9999" as "cveIdentifierId"
@@ -104,4 +104,4 @@ Feature: CVE Audit on SLE Salt Minions
     And I remove package "milkyway-dummy" from this "sle_minion" without error control
 
   Scenario: Cleanup: remove remaining systems from SSM after CVE audit tests
-    When I follow "clear-ssm"
+    When I click on "Clear"

--- a/testsuite/features/secondary/min_salt_formulas.feature
+++ b/testsuite/features/secondary/min_salt_formulas.feature
@@ -164,4 +164,4 @@ Feature: Use salt formulas
      When I manually uninstall the "locale" formula from the server
 
   Scenario: Cleanup: remove remaining systems from SSM after formula tests
-     When I follow "clear-ssm"
+     When I click on "Clear"

--- a/testsuite/features/secondary/srv_clone_channel_npn.feature
+++ b/testsuite/features/secondary/srv_clone_channel_npn.feature
@@ -127,4 +127,4 @@ Feature: Clone a channel
     And I should see a "has been deleted." text
 
   Scenario: Cleanup: remove remaining systems from SSM after channel cloning tests
-    When I follow "clear-ssm"
+    When I click on "Clear"

--- a/testsuite/features/secondary/srv_group_union_intersection.feature
+++ b/testsuite/features/secondary/srv_group_union_intersection.feature
@@ -128,4 +128,4 @@ Feature: Work with Union and Intersection buttons in the group list
     Then I should see a "deleted" text
 
   Scenario: Cleanup: remove remaining systems from SSM after group union and intersection tests
-    When I follow "clear-ssm"
+    When I click on "Clear"

--- a/testsuite/features/secondary/srv_power_management.feature
+++ b/testsuite/features/secondary/srv_power_management.feature
@@ -95,4 +95,4 @@ Feature: IPMI Power management
     When the server stops mocking an IPMI host
 
   Scenario: Cleanup: remove remaining systems from SSM after power management tests
-    When I follow "clear-ssm"
+    When I click on "Clear"

--- a/testsuite/features/secondary/srv_power_management_redfish.feature
+++ b/testsuite/features/secondary/srv_power_management_redfish.feature
@@ -92,4 +92,4 @@ Feature: Redfish Power management
     When the server stops mocking a Redfish host
 
   Scenario: Cleanup: remove remaining systems from SSM after Redfish power management tests
-    When I follow "clear-ssm"
+    When I click on "Clear"


### PR DESCRIPTION
## What does this PR change?
Reverts the changes to clicking on Clear step, except the Cleanup for the Baremetal discovery feature, where it fixed the issue.

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19899
Reverts most of #6400 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
