### PR TITLE
assign correct list to request

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/channel/ChannelDeployConfirmAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/channel/ChannelDeployConfirmAction.java
@@ -118,7 +118,7 @@ public class ChannelDeployConfirmAction extends RhnAction implements Maintenance
         DataList<ConfigSystemDto> configSystemsList = new DataList<>(systems);
         configSystemsList.setMode(systems.getMode());
         configSystemsList.setElaboratorParams(systems.getElaborationParams());
-        request.setAttribute("selectedSystems", list);
+        request.setAttribute("selectedSystems", configSystemsList);
 
         ActionErrors errs = new ActionErrors();
         if (files.getTotalSize() == 0) {


### PR DESCRIPTION
## What does this PR change?

Sonarcloud refactoring caused assigning the config file list to systems variable.
This cause property not found errors

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Only in master

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
