### PR TITLE
Add condition to apply transactional reboot config state

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/transactional_reboot/config.sls
+++ b/susemanager-utils/susemanager-sls/salt/transactional_reboot/config.sls
@@ -1,3 +1,5 @@
+{%- if grains['transactional'] %}
+
 copy_conf_file_to_etc_if_not_there:
   file.copy:
     - name: /etc/transactional-update.conf
@@ -14,3 +16,5 @@ transactional_update_set_rebootmethod_systemd:
     # Only change the reboot method if it is not in default configuration
     - unless:
       - grep -P '^(?=[\s]*+[^#])[^#]*(REBOOT_METHOD=(?!auto))' /etc/transactional-update.conf
+
+{%- endif %}


### PR DESCRIPTION
## What does this PR change?

Changes transactional reboot config state to be applied only in transactional systems.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Related to https://github.com/uyuni-project/uyuni/pull/6370

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
