### PR TITLE
Fix name for "autoinstall" snippets after Cobbler 3.3.3

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartFormatter.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartFormatter.java
@@ -33,7 +33,6 @@ import com.redhat.rhn.domain.token.ActivationKeyFactory;
 import com.redhat.rhn.domain.token.Token;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.domain.user.UserFactory;
-import com.redhat.rhn.manager.kickstart.cobbler.CobblerXMLRPCHelper;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartFormatter.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartFormatter.java
@@ -231,14 +231,7 @@ public class KickstartFormatter {
         buf.append("%" + KickstartScript.TYPE_PRE);
         buf.append(NEWLINE);
 
-        if (CobblerXMLRPCHelper.getCobblerVersion() >= 2.2) {
-            addCobblerSnippet(buf, "kickstart_start");
-        }
-        else {
-            buf.append("$kickstart_start");
-            buf.append(NEWLINE);
-        }
-
+        addCobblerSnippet(buf, "autoinstall_start");
         buf.append(NEWLINE);
         addCobblerSnippet(buf, "pre_install_network_config");
         buf.append(NEWLINE);
@@ -282,12 +275,7 @@ public class KickstartFormatter {
         addCobblerSnippet(buf, "koan_environment");
         buf.append(NEWLINE);
 
-        if (CobblerXMLRPCHelper.getCobblerVersion() >= 2.2) {
-            addCobblerSnippet(buf, "kickstart_done");
-        }
-        else {
-            buf.append("$kickstart_done");
-        }
+        addCobblerSnippet(buf, "autoinstall_done");
 
         buf.append(NEWLINE);
         buf.append(END + NEWLINE);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix name for autoinstall snippets after Cobbler 3.3.3
 - prevent ISE on activation key page when selected base channel value is null
 - Add systems and hibernate metrics collectors (#14240)
 - Fix HTTP API login status code when using wrong credentials (bsc#1206666)


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue with the snippets used by Uyuni when generating autoinstallation profiles.

After the upgrade to Cobbler 3.3.3, the `kickstart_*` snippets were renamed to `autoinstall_*`, so we need to adjust Java to use the proper ones to prevent errors when generating autoinstallation files:

```
...
# Error: no snippet data for kickstart_start
...
# Error: no snippet data for kickstart_done
...
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **bugfix**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/19792

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
