### PR TITLE
QE: Wait until the custom channel has been synchronized

### DIFF
--- a/testsuite/features/init_clients/srv_check_reposync.feature
+++ b/testsuite/features/init_clients/srv_check_reposync.feature
@@ -4,5 +4,6 @@
 Feature: Reposync works as expected
 
   Scenario: Check reposync of custom channel
+    When I wait until the channel "fake-rpm-sles-channel" has been synced
     Then "orion-dummy-1.1-1.1.x86_64.rpm" package should have been stored
     And solver file for "fake-rpm-sles-channel" should reference "orion-dummy-1.1-1.1.x86_64.rpm"


### PR DESCRIPTION
## What does this PR change?

Wait until the custom channel has been synchronized. As otherwise it fails sometimes when checking for solv file.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.3
- Manager-4.2?

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
