### PR TITLE
Fix ise activation key create

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/token/ActivationKeyDetailsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/token/ActivationKeyDetailsAction.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.frontend.action.token;
 
+import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.validator.ValidatorException;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
@@ -331,7 +332,10 @@ public class ActivationKeyDetailsAction extends RhnAction {
 
     private Channel lookupChannel(DynaActionForm daForm, User user) {
         Long selectedChannel = (Long)daForm.get(SELECTED_BASE_CHANNEL);
-
+        if (selectedChannel == null) {
+            throw new ValidatorException(
+                    LocalizationService.getInstance().getMessage("activation-key.java.nochannel"));
+        }
         if (!DEFAULT_CHANNEL_ID.equals(selectedChannel)) {
             return ChannelManager.lookupByIdAndUser(
                                 selectedChannel, user);

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -5836,6 +5836,12 @@ Follow this url to see the full list of inactive systems:
           <context context-type="sourcefile">Activation Key Pages</context>
         </context-group>
         </trans-unit>
+        <trans-unit id="activation-key.java.nochannel">
+          <source>No Base Channel selected.</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">Activation Key Pages</context>
+        </context-group>
+        </trans-unit>
         <trans-unit id="system.sdc.missing.config_deploy1">
           <source>This system does not yet have configuration deployment capability. Configuration deployment requires that particular software is installed and enabled on your system.</source>
         <context-group name="ctx">

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- prevent ISE on activation key page when selected base channel value is null
 - Add systems and hibernate metrics collectors (#14240)
 - Fix HTTP API login status code when using wrong credentials (bsc#1206666)
 - Fix physical systems list

--- a/testsuite/features/core/srv_create_activationkey.feature
+++ b/testsuite/features/core/srv_create_activationkey.feature
@@ -12,6 +12,7 @@ Feature: Create activation keys
   Scenario: Create an activation key with a channel
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
+    And I wait until I do not see "Loading..." text
     And I enter "SUSE Test Key x86_64" as "description"
     And I enter "SUSE-KEY-x86_64" as "key"
     And I enter "20" as "usageLimit"
@@ -27,6 +28,7 @@ Feature: Create activation keys
   Scenario: Create an activation key for RedHat-like minion
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
+    And I wait until I do not see "Loading..." text
     And I enter "RedHat like Test Key" as "description"
     And I enter "RH-LIKE-KEY" as "key"
     And I select "Fake-RH-Like-Channel" from "selectedBaseChannel"
@@ -37,6 +39,7 @@ Feature: Create activation keys
   Scenario: Create an activation key for Debian-like minion
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
+    And I wait until I do not see "Loading..." text
     And I enter "Debian-like Test Key" as "description"
     And I enter "DEBLIKE-KEY" as "key"
     And I select "Fake-Deb-AMD64-Channel" from "selectedBaseChannel"
@@ -46,6 +49,7 @@ Feature: Create activation keys
   Scenario: Create an activation key with a channel for salt-ssh
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
+    And I wait until I do not see "Loading..." text
     And I enter "SUSE SSH Test Key x86_64" as "description"
     And I enter "SUSE-SSH-KEY-x86_64" as "key"
     And I enter "20" as "usageLimit"
@@ -56,6 +60,7 @@ Feature: Create activation keys
   Scenario: Create an activation key with a channel for salt-ssh via tunnel
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
+    And I wait until I do not see "Loading..." text
     And I enter "SUSE SSH Tunnel Test Key x86_64" as "description"
     And I enter "SUSE-SSH-TUNNEL-KEY-x86_64" as "key"
     And I enter "20" as "usageLimit"

--- a/testsuite/features/init_clients/allcli_update_activationkeys.feature
+++ b/testsuite/features/init_clients/allcli_update_activationkeys.feature
@@ -47,7 +47,7 @@ Feature: Update activation keys
   Scenario: Update SLE key with synced base product
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE Test Key x86_64" in the content area
-    And I wait until I do not see "Loading" text 
+    And I wait until I do not see "Loading..." text
     And I select "SLE-Product-SLES15-SP4-Pool for x86_64" from "selectedBaseChannel"
     And I include the recommended child channels
     And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"
@@ -59,7 +59,7 @@ Feature: Update activation keys
   Scenario: Update SSH key with synced base product
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE SSH Test Key x86_64" in the content area
-    And I wait until I do not see "Loading" text 
+    And I wait until I do not see "Loading..." text
     And I select "SLE-Product-SLES15-SP4-Pool for x86_64" from "selectedBaseChannel"
     And I include the recommended child channels
     And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"
@@ -70,7 +70,7 @@ Feature: Update activation keys
   Scenario: Update SSH tunnel key with synced base product
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE SSH Tunnel Test Key x86_64" in the content area
-    And I wait until I do not see "Loading" text 
+    And I wait until I do not see "Loading..." text
     And I select "SLE-Product-SLES15-SP4-Pool for x86_64" from "selectedBaseChannel"
     And I include the recommended child channels
     And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"

--- a/testsuite/features/init_clients/min_virthost.feature
+++ b/testsuite/features/init_clients/min_virthost.feature
@@ -13,6 +13,7 @@ Feature: Bootstrap a virtualization host minion and set it up for virtualization
   Scenario: Create KVM activation key
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
+    And I wait until I do not see "Loading..." text
     When I enter "KVM testing" as "description"
     And I enter "KVM-TEST" as "key"
     And I enter "20" as "usageLimit"

--- a/testsuite/features/secondary/min_activationkey.feature
+++ b/testsuite/features/secondary/min_activationkey.feature
@@ -35,6 +35,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
   Scenario: Create a complete minion activation key
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
+    And I wait until I do not see "Loading..." text
     And I enter "Minion testing" as "description"
     And I enter "MINION-TEST" as "key"
     And I enter "20" as "usageLimit"

--- a/testsuite/features/secondary/srv_manage_activationkey.feature
+++ b/testsuite/features/secondary/srv_manage_activationkey.feature
@@ -12,6 +12,7 @@ Feature: Manipulate activation keys
   Scenario: Create an activation key for i586
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
+    And I wait until I do not see "Loading..." text
     And I enter "SUSE Test Key i586" as "description"
     And I enter "SUSE-TEST-i586" as "key"
     And I check "virtualization_host"
@@ -21,6 +22,7 @@ Feature: Manipulate activation keys
   Scenario: Change limit of the i586 activation key
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE Test Key i586"
+    And I wait until I do not see "Loading..." text
     And I enter "20" as "usageLimit"
     And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE Test Key i586 has been modified." text
@@ -29,6 +31,7 @@ Feature: Manipulate activation keys
   Scenario: Change the base channel of the i586 activation key
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE Test Key i586"
+    And I wait until I do not see "Loading..." text
     And I select "Fake-i586-Channel" from "selectedBaseChannel"
     And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE Test Key i586 has been modified." text
@@ -36,6 +39,7 @@ Feature: Manipulate activation keys
   Scenario: Delete the i586 activation key
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE Test Key i586" in the content area
+    And I wait until I do not see "Loading..." text
     And I follow "Delete Key"
     And I click on "Delete Activation Key"
     Then I should see a "Activation key SUSE Test Key i586 has been deleted." text
@@ -43,6 +47,7 @@ Feature: Manipulate activation keys
   Scenario: Create an activation key with a channel and a package list for i586
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
+    And I wait until I do not see "Loading..." text
     And I enter "SUSE Test PKG Key i586" as "description"
     And I enter "SUSE-TEST-2-i586" as "key"
     And I enter "20" as "usageLimit"
@@ -63,6 +68,7 @@ Feature: Manipulate activation keys
   Scenario: Create an activation key with a channel and a package list for x86_64
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
+    And I wait until I do not see "Loading..." text
     And I enter "SUSE Test PKG Key x86_64" as "description"
     And I enter "SUSE-TEST-x86_64" as "key"
     And I enter "20" as "usageLimit"

--- a/web/html/src/manager/content-management/shared/components/panels/sources/channels/channels-selection.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/channels/channels-selection.tsx
@@ -151,7 +151,7 @@ const ChannelsSelection = (props: PropsType) => {
   if (isLoading || props.isSourcesApiLoading) {
     return (
       <div className="form-group">
-        <Loading text={props.isSourcesApiLoading ? "Adding sources..." : "Loading.."} />
+        <Loading text={props.isSourcesApiLoading ? "Adding sources..." : "Loading..."} />
       </div>
     );
   }

--- a/web/html/src/manager/minion/ansible/ansible-control-node.test.tsx
+++ b/web/html/src/manager/minion/ansible/ansible-control-node.test.tsx
@@ -29,7 +29,7 @@ describe("Ansible control node path configuration", () => {
 
     render(<AnsibleControlNode minionServerId={1000} />); // load the component at initial state
 
-    screen.getByText("Loading..");
+    screen.getByText("Loading...");
 
     // wait until the render loads and changes, then check for content
     await waitFor(() => {

--- a/web/html/src/manager/minion/ansible/ansible-control-node.tsx
+++ b/web/html/src/manager/minion/ansible/ansible-control-node.tsx
@@ -159,7 +159,7 @@ export class AnsibleControlNode extends React.Component<PropsType, StateType> {
           {t("Ansible Control Node Configuration: add paths for Playbook discovery and Inventory files introspection.")}
         </p>
         {this.state.loading ? (
-          <Loading text="Loading.." />
+          <Loading text="Loading..." />
         ) : (
           <div>
             <div className="col-md-6">

--- a/web/html/src/manager/minion/ansible/ansible-path-content.tsx
+++ b/web/html/src/manager/minion/ansible/ansible-path-content.tsx
@@ -67,7 +67,7 @@ class AnsiblePathContent extends React.Component<PropsType, StateType> {
       <div>
         {errors}
         {this.state.loading ? (
-          <Loading text={t("Loading..")} />
+          <Loading text={t("Loading...")} />
         ) : this.state.pathList?.length > 0 ? (
           this.state.pathList.map((p) => (
             <AccordionPathContent

--- a/web/html/src/manager/systems/activation-key/activation-key-channels.tsx
+++ b/web/html/src/manager/systems/activation-key/activation-key-channels.tsx
@@ -96,7 +96,7 @@ class ActivationKeyChannels extends React.Component<ActivationKeyChannelsProps, 
           if (loading) {
             return (
               <div className="form-group">
-                <Loading text={t("Loading..")} />
+                <Loading text={t("Loading...")} />
               </div>
             );
           }


### PR DESCRIPTION
## What does this PR change?

When creating an activation key it might happen that Loading the channels takes a while.
The testsuite does not always wait for the page being fully loaded.
This PR detect this case and throw a better message than an ISE and change the testsuite to wait for the 
"Loading..." text to disappear.
Additionally it align all occurrence of "Loading..." to use the same number of dots (3 dots)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were adapted

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/20026 https://github.com/SUSE/spacewalk/pull/20027

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
