### PR TITLE
Convert API provided form data to their expected types

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
@@ -661,6 +661,11 @@ public class FormulaFactory {
             else if (value instanceof Map) {
                 convertIntegers((Map<String, Object>) value);
             }
+            else if (value instanceof List) {
+                for (Map<String, Object> v: (List<Map<String, Object>>)value) {
+                    convertIntegers(v);
+                }
+            }
         }
         return map;
     }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/formula/FormulaHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/formula/FormulaHandler.java
@@ -307,6 +307,8 @@ public class FormulaHandler extends BaseHandler {
             boolean assigned = formulaManager.hasSystemFormulaAssignedCombined(formulaName, server);
             if (assigned) {
                 formulaManager.validateInput(formulaName, content);
+                FormulaManager.convertTypes(formulaName, content);
+                FormulaFactory.convertIntegers(content);
                 formulaManager.saveServerFormulaData(loggedInUser, systemId.longValue(), formulaName, content);
             }
             else {
@@ -348,6 +350,8 @@ public class FormulaHandler extends BaseHandler {
             boolean assigned = formulaManager.hasGroupFormulaAssigned(formulaName, group);
             if (assigned) {
                 formulaManager.validateInput(formulaName, content);
+                FormulaManager.convertTypes(formulaName, content);
+                FormulaFactory.convertIntegers(content);
                 formulaManager.saveGroupFormulaData(loggedInUser, groupId.longValue(), formulaName, content);
             }
             else {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Fix integer conversions for list of values
+- Convert passed data to expected class when saving form values through API (bsc#1204442)
 - Add systems and hibernate metrics collectors (#14240)
 - Fix HTTP API login status code when using wrong credentials (bsc#1206666)
 - Fix physical systems list


### PR DESCRIPTION
## What does this PR change?
Form data updated using API are not type checked for what forms expects. Thus it was possible to store numbers (as Ints or Doubles) where String was expected and vice versa. This would then be provided in pillar data and may break states.

This PR fixes this and if String/Number mismatch is found, it will automatically convert the values.

Forward port of https://github.com/SUSE/spacewalk/pull/20022

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19281

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
