### PR TITLE
use visit with relative URL to stay logged-in

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -406,7 +406,7 @@ end
 Given(/^I am on the Systems overview page of this "([^"]*)"$/) do |host|
   node = get_target(host)
   system_id = get_system_id(node)
-  visit("https://#{$server.full_hostname}/rhn/systems/details/Overview.do?sid=#{system_id}")
+  visit("/rhn/systems/details/Overview.do?sid=#{system_id}")
 end
 
 Given(/^I navigate to the Systems overview page of this "([^"]*)"$/) do |host|


### PR DESCRIPTION
## What does this PR change?

Using the current code I end up always on the login page and the test fail:

![image](https://user-images.githubusercontent.com/1038917/210387255-5843990f-773e-4718-a763-37b725b5ee87.png)

When I use a relative URL, I stay logged-in and the test pass.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links


- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
