### PR TITLE
Fix transaction commit behavior for Spark routes

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/servlets/SessionFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/SessionFilter.java
@@ -34,11 +34,11 @@ import javax.servlet.ServletResponse;
 /**
  * SessionFilter is a simple servlet filter to handle cleaning up the Hibernate
  * Session after each request.
+ *
+ * See also {@link com.suse.manager.webui.utils.SparkApplicationHelper#setupHibernateSessionFilter()}
  */
 public class SessionFilter implements Filter {
 
-
-private static final String ROLLBACK_MSG = "Error during transaction. Rolling back";
     private static final Logger LOG = LogManager.getLogger(SessionFilter.class);
 
     /** {@inheritDoc} */
@@ -46,6 +46,7 @@ private static final String ROLLBACK_MSG = "Error during transaction. Rolling ba
     public void init(FilterConfig config) {
         // no-op
     }
+
 
     /** {@inheritDoc} */
     @Override
@@ -56,41 +57,29 @@ private static final String ROLLBACK_MSG = "Error during transaction. Rolling ba
             logHere("Calling doFilter");
             // pass up stack
             chain.doFilter(request, response);
-            HibernateFactory.commitTransaction();
+
+            if (HibernateFactory.inTransaction()) {
+                HibernateFactory.commitTransaction();
+            }
             logHere("Transaction committed");
             committed = true;
         }
         catch (IOException | AssertionError | ServletException e) {
-            LOG.error(ROLLBACK_MSG, e);
+            LOG.error(HibernateFactory.ROLLBACK_MSG, e);
             throw e;
         }
         catch (HibernateException e) {
-            LOG.error(ROLLBACK_MSG, e);
-            throw new HibernateRuntimeException(ROLLBACK_MSG, e);
+            LOG.error(HibernateFactory.ROLLBACK_MSG, e);
+            throw new HibernateRuntimeException(HibernateFactory.ROLLBACK_MSG, e);
         }
         catch (RuntimeException e) {
-            LOG.error(ROLLBACK_MSG, e);
+            LOG.error(HibernateFactory.ROLLBACK_MSG, e);
             request.setAttribute("exception", LocalizationService.getInstance()
                     .getMessage("errors.unexpected"));
             throw e;
         }
         finally {
-            try {
-                if (!committed) {
-                    try {
-                        logHere("Rolling back transaction");
-                        HibernateFactory.rollbackTransaction();
-                    }
-                    catch (HibernateException e) {
-                        final String msg = "Additional error during rollback";
-                        LOG.warn(msg, e);
-                    }
-                }
-            }
-            finally {
-                // cleanup the session
-                HibernateFactory.closeSession();
-            }
+            HibernateFactory.rollbackTransactionAndCloseSession(committed);
         }
 
     }

--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -18,6 +18,7 @@ import static com.suse.manager.webui.utils.SparkApplicationHelper.isApiRequest;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.isJson;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.setup;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.setupHibernateSessionFilter;
 import static spark.Spark.exception;
 import static spark.Spark.get;
 import static spark.Spark.notFound;
@@ -97,6 +98,7 @@ public class Router implements SparkApplication {
     @Override
     public void init() {
         JadeTemplateEngine jade = setup();
+        setupHibernateSessionFilter();
 
         initNotFoundRoutes(jade);
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix transaction commit behavior for Spark routes
 - Trigger a package profile update when a new live-patch is installed (bsc#1206249)
 - Fix CVE Audit ignoring errata in parent channels if patch in successor
   product exists (bsc#1206168)


### PR DESCRIPTION
## What does this PR change?

It adds a Spark after filter to deal with hibernate sessions for spark routes compatible with `SessionFilter`. Without this patch, responses are send back without having the transaction commited because Spark closes response stream for the requests it handles before `SessionFilter` finishes running. It was even possible to have an HTTP 200 response and a failure when committing the transaction.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
