### PR TITLE
Trigger package refresh when a new live-patch is installed (bsc#1206249)

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/test/pkg_install.live_patch.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/pkg_install.live_patch.json
@@ -1,0 +1,14 @@
+{
+  "kernel-livepatch-5_14_21-150400_22-default": {
+    "old": "",
+    "new": [
+      {
+        "install_date_time_t": 1498636531,
+        "version": "9",
+        "release": "150400.4.24.1",
+        "arch": "x86_64"
+      }
+    ]
+  }
+}
+

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -340,10 +340,12 @@ public class SaltUtils {
         boolean fullRefreshNeeded = changes.entrySet().stream().anyMatch(
             e ->
                 e.getKey().endsWith("-release") ||
+                // Live patching requires refresh to fetch the updated LP version
+                e.getKey().startsWith("kernel-livepatch-") ||
                 (e.getValue().getNewValue().isLeft() &&
                  e.getValue().getOldValue().isLeft())
-
         );
+
         if (fullRefreshNeeded) {
             return PackageChangeOutcome.NEEDS_REFRESHING;
         }

--- a/java/code/src/com/suse/manager/utils/test/SaltUtilsTest.java
+++ b/java/code/src/com/suse/manager/utils/test/SaltUtilsTest.java
@@ -21,14 +21,24 @@ import com.redhat.rhn.domain.rhnpackage.PackageEvr;
 import com.redhat.rhn.domain.rhnpackage.PackageName;
 import com.redhat.rhn.domain.rhnpackage.PackageType;
 import com.redhat.rhn.domain.server.InstalledPackage;
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.testing.UserTestUtils;
 
 import com.suse.manager.utils.SaltUtils;
 import com.suse.salt.netapi.calls.modules.Pkg;
+import com.suse.salt.netapi.results.Change;
+import com.suse.salt.netapi.utils.Xor;
 import com.suse.utils.Json;
 
 import com.google.gson.reflect.TypeToken;
 
 import org.junit.jupiter.api.Test;
+
+import java.io.InputStreamReader;
+import java.util.List;
+import java.util.Map;
 
 public class SaltUtilsTest  {
 
@@ -86,5 +96,33 @@ public class SaltUtilsTest  {
         Pkg.Info initramfsToolsInfo = Json.GSON.fromJson(initramfsToolsJson, new TypeToken<Pkg.Info>() { }.getType());
         assertEquals("initramfs-tools-0.130ubuntu3.8.all",
                 SaltUtils.packageToKey("initramfs-tools", initramfsToolsInfo));
+    }
+
+    /**
+     * Test if the package change outcome is reported as "needs refreshing"
+     * after installation of a new live patch package
+     */
+    @Test
+    public void testPackageChangeOutcomeWithLivePatchPackages() throws Exception {
+        User user = UserTestUtils.createSatAdminInOrgOne();
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+
+        Map<String, Change<Xor<String, List<Pkg.Info>>>> installLivePatch =
+                Json.GSON.fromJson(new InputStreamReader(getClass().getResourceAsStream(
+                                "/com/suse/manager/reactor/messaging/test/pkg_install.live_patch.json")),
+                        new TypeToken<Map<String, Change<Xor<String, List<Pkg.Info>>>>>() { }.getType());
+
+        Map<String, Change<Xor<String, List<Pkg.Info>>>> installOther =
+                Json.GSON.fromJson(new InputStreamReader(getClass().getResourceAsStream(
+                                "/com/suse/manager/reactor/messaging/test/pkg_install.new_format.json")),
+                        new TypeToken<Map<String, Change<Xor<String, List<Pkg.Info>>>>>() { }.getType());
+
+        // Other packages mustn't trigger refresh
+        SaltUtils.PackageChangeOutcome outcome = SaltUtils.applyChangesFromStateModule(installOther, minion);
+        assertEquals(SaltUtils.PackageChangeOutcome.DONE, outcome);
+
+        // Live patch packages must trigger refresh
+        outcome = SaltUtils.applyChangesFromStateModule(installLivePatch, minion);
+        assertEquals(SaltUtils.PackageChangeOutcome.NEEDS_REFRESHING, outcome);
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Trigger a package profile update when a new live-patch is installed (bsc#1206249)
 - Fix CVE Audit ignoring errata in parent channels if patch in successor
   product exists (bsc#1206168)
 - Fix CVE Audit incorrectly displaying predecessor product (bsc#1205663)


### PR DESCRIPTION
We don't run a full profile update after simple package install/upgrade operations because of performance reasons. However, the live patch data is only updated with a package profile update.

This patch will trigger a package profile update whenever a new live patch is installed, so the LP data shown on the system overview page will update automatically.

See: https://bugzilla.suse.com/show_bug.cgi?id=1206249

Port of: https://github.com/SUSE/spacewalk/pull/19980

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
