### PR TITLE
Add activation key in feature

### DIFF
--- a/testsuite/features/secondary/min_bootstrap_reactivation.feature
+++ b/testsuite/features/secondary/min_bootstrap_reactivation.feature
@@ -78,25 +78,9 @@ Feature: Bootstrapping with reactivation key
     And I enter "22" as "port"
     And I enter "root" as "user"
     And I enter "linux" as "password"
+    And I select "1-SUSE-KEY-x86_64" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
     And I follow the left menu "Systems > System List > All"
     And I wait until I see the name of "sle_minion", refreshing the page
-
-  Scenario: Cleanup: subscribe again to base channel after reactivation tests
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Software" in the content area
-    And I follow "Software Channels" in the content area
-    And I wait until I do not see "Loading..." text
-    And I wait until I see "SUSE Channels" text, refreshing the page
-    And I check radio button "SLE-Product-SLES15-SP4-Pool for x86_64"
-    And I wait until I do not see "Loading..." text
-    And I include the recommended child channels
-    And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"
-    And I check "Fake-RPM-SLES-Channel"
-    And I click on "Next"
-    Then I should see a "Confirm Software Channel Change" text
-    When I click on "Confirm"
-    Then I should see a "Changing the channels has been scheduled." text
-    When I wait until event "Subscribe channels scheduled by admin" is completed

--- a/testsuite/features/secondary/min_bootstrap_reactivation.feature
+++ b/testsuite/features/secondary/min_bootstrap_reactivation.feature
@@ -50,6 +50,7 @@ Feature: Bootstrapping with reactivation key
     And I enter "root" as "user"
     And I enter "linux" as "password"
     And I enter the reactivation key of "sle_minion"
+    And I select "1-SUSE-KEY-x86_64" from "activationKeys"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
     And I follow the left menu "Systems > System List > All"

--- a/testsuite/features/secondary/min_salt_mgrcompat_state.feature
+++ b/testsuite/features/secondary/min_salt_mgrcompat_state.feature
@@ -84,23 +84,8 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     And I enter "22" as "port"
     And I enter "root" as "user"
     And I enter "linux" as "password"
+    And I select "1-SUSE-KEY-x86_64" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "sle_minion"
-
-  Scenario: Cleanup: restore channels on the minion after mgrcompat tests
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Software" in the content area
-    Then I follow "Software Channels" in the content area
-    And I wait until I do not see "Loading..." text
-    And I check radio button "SLE-Product-SLES15-SP4-Pool for x86_64"
-    And I wait until I do not see "Loading..." text
-    And I include the recommended child channels
-    And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"
-    And I check "Fake-RPM-SLES-Channel"
-    And I click on "Next"
-    Then I should see a "Confirm Software Channel Change" text
-    When I click on "Confirm"
-    Then I should see a "Changing the channels has been scheduled." text
-    And I wait until event "Subscribe channels scheduled by admin" is completed

--- a/testsuite/features/secondary/min_salt_minions_page.feature
+++ b/testsuite/features/secondary/min_salt_minions_page.feature
@@ -75,23 +75,8 @@ Feature: Management of minion keys
     And I enter "22" as "port"
     And I enter "root" as "user"
     And I enter "linux" as "password"
+    And I select "1-SUSE-KEY-x86_64" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "sle_minion"
-
-  Scenario: Cleanup: restore channels on the minion
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Software" in the content area
-    Then I follow "Software Channels" in the content area
-    And I wait until I do not see "Loading..." text
-    And I check radio button "SLE-Product-SLES15-SP4-Pool for x86_64"
-    And I wait until I do not see "Loading..." text
-    And I include the recommended child channels
-    And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"
-    And I check "Fake-RPM-SLES-Channel"
-    And I click on "Next"
-    Then I should see a "Confirm Software Channel Change" text
-    When I click on "Confirm"
-    Then I should see a "Changing the channels has been scheduled." text
-    And I wait until event "Subscribe channels scheduled by admin" is completed


### PR DESCRIPTION
## What does this PR change?
Add activation key bootstrap in features in order to get better idempotency.
Remove some cleanup scenarios that became unnecessary.
Includes port of https://github.com/SUSE/spacewalk/pull/20015

## GUI diff

No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks # 
4.2
4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
