### PR TITLE
install SUSE Liberty v2 GPG key

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/gpg-keys.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/gpg-keys.sls
@@ -40,6 +40,13 @@ mgr_deploy_res_gpg_key:
     - makedirs: True
     - mode: 644
 
+mgr_deploy_liberty_v2_gpg_key:
+  file.managed:
+    - name: /etc/pki/rpm-gpg/suse-liberty-v2-gpg-pubkey-177086FAB0F9C64F.key
+    - source: salt://gpg/suse-liberty-v2-gpg-pubkey-177086FAB0F9C64F.key
+    - makedirs: True
+    - mode: 644
+
 mgr_deploy_tools_rhel_gpg_key:
   file.managed:
     - name: /etc/pki/rpm-gpg/el-tools-gpg-pubkey-39db7c82.key

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- install SUSE Liberty v2 GPG key
 - Detect bootstrap repository path for SLE Micro
 - Fix reboot info beacon installation
 - Add state to properly configure the reboot action for transactional systems


### PR DESCRIPTION
## What does this PR change?

SUSE Liberty Linux 9 comes with a new gpg key which needs to be installed.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/20048

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
