### PR TITLE
QE: Add step to clean search index before doing first search

### DIFF
--- a/testsuite/features/secondary/srv_advanced_search.feature
+++ b/testsuite/features/secondary/srv_advanced_search.feature
@@ -12,11 +12,11 @@ Feature: Advanced Search
     Given I am authorized for the "Admin" section
 
   Scenario: No search results - inverse results
+    Given I clean the search index on the server
     When I follow the left menu "Systems > Advanced Search"
     And I enter "sle_minion" hostname on the search field
     And I select "Hostname" from "Field to Search"
     And I check "invert"
-    And I save a screenshot as "inverse_results.png"
     And I click on the search button
     Then I should see a "No results found." text
 


### PR DESCRIPTION
## What does this PR change?
Adds a step to clean the search index before performing the first search.

## Links
Might fix https://github.com/SUSE/spacewalk/issues/19820

- 4.3 https://github.com/SUSE/spacewalk/pull/20049
- 4.2 https://github.com/SUSE/spacewalk/pull/20050

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
