### PR TITLE
Fix salt keys page keeps loading when no key exists

### DIFF
--- a/web/html/src/components/table/TableDataHandler.tsx
+++ b/web/html/src/components/table/TableDataHandler.tsx
@@ -204,6 +204,9 @@ export class TableDataHandler extends React.Component<Props, State> {
     if (!_isEqual(this.props.data, prevProps.data)) {
       this.setState({ provider: this.getProvider() }, () => this.getData());
     }
+    if (this.props.loading !== prevProps.loading) {
+      this.setState({ loading: Boolean(this.props.loading) });
+    }
   }
 
   componentWillUnmount() {

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix salt keys page keeps loading when no key exists (bsc#1206799)
 - Fix link to documentation in monitoring page
 - Added CLM filters to match product temporary fixes packages
 - fix frontend logging in react pages


### PR DESCRIPTION
## What does this PR change?

When the state of a component that uses `Table.tsx` component doesn't change after fetching data from the backend (keeping the state as an empty list, for example - as in the concrete case), the `loading` state doesn't get update.

This patch adds an additional verification to keep the `loading` state up to date with the `loading` prop.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20034

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
