### PR TITLE
Testsuite: Deprecate injected repos in features

### DIFF
--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -14,7 +14,8 @@ Feature: Operate an Ansible control node in a normal minion
   Scenario: Enable "Ansible control node" system type
     Given I am on the Systems overview page of this "sle_minion"
     When I enable client tools repositories on "sle_minion"
-    And I follow "Properties" in the content area    And I check "ansible_control_node"
+    And I follow "Properties" in the content area
+    And I check "ansible_control_node"
     And I click on "Update Properties"
     Then I should see a "Ansible Control Node type has been applied." text
 

--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -82,7 +82,7 @@ Feature: Operate an Ansible control node in a normal minion
     And I remove package "orion-dummy" from this "sle_minion" without error control
     And I remove "/tmp/file.txt" from "sle_minion"
 
-  Scenario: Cleanup: Disable client tools channel
+  Scenario: Cleanup: Disable client tools repositories
     Given I am on the Systems overview page of this "sle_minion"
     When I disable the repositories "tools_update_repo tools_pool_repo" on this "sle_minion"
     And I refresh the metadata for "sle_minion"

--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 SUSE LLC
+# Copyright (c) 2021-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_ansible

--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -13,8 +13,7 @@ Feature: Operate an Ansible control node in a normal minion
 
   Scenario: Enable "Ansible control node" system type
     Given I am on the Systems overview page of this "sle_minion"
-    When I enable client tools repositories on "sle_minion"
-    And I follow "Properties" in the content area
+    When I follow "Properties" in the content area
     And I check "ansible_control_node"
     And I click on "Update Properties"
     Then I should see a "Ansible Control Node type has been applied." text

--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -8,13 +8,15 @@ Feature: Operate an Ansible control node in a normal minion
     Given I am authorized for the "Admin" section
 
   Scenario: Pre-requisite: Deploy test playbooks and inventory file
-    Given I am on the Systems overview page of this "sle_minion"
     When I deploy testing playbooks and inventory files to "sle_minion"
+
+  Scenario: Pre-requisite: Enable client tools repositories
+    When I enable the repositories "tools_update_repo tools_pool_repo" on this "sle_minion"
+    And I refresh the metadata for "sle_minion"
 
   Scenario: Enable "Ansible control node" system type
     Given I am on the Systems overview page of this "sle_minion"
-    When I enable the repositories "tools_update_repo tools_pool_repo" on this "sle_minion"
-    And I follow "Properties" in the content area
+    When I follow "Properties" in the content area
     And I check "ansible_control_node"
     And I click on "Update Properties"
     Then I should see a "Ansible Control Node type has been applied." text
@@ -77,6 +79,10 @@ Feature: Operate an Ansible control node in a normal minion
     And I uncheck "ansible_control_node"
     And I click on "Update Properties"
     Then I should see a "System properties changed" text
-    And I disable the repositories "tools_update_repo tools_pool_repo" on this "sle_minion"
     And I remove package "orion-dummy" from this "sle_minion" without error control
     And I remove "/tmp/file.txt" from "sle_minion"
+
+  Scenario: Cleanup: Disable client tools channel
+    Given I am on the Systems overview page of this "sle_minion"
+    When I disable the repositories "tools_update_repo tools_pool_repo" on this "sle_minion"
+    And I refresh the metadata for "sle_minion"

--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -13,8 +13,8 @@ Feature: Operate an Ansible control node in a normal minion
 
   Scenario: Enable "Ansible control node" system type
     Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Properties" in the content area
-    And I check "ansible_control_node"
+    When I enable client tools repositories on "sle_minion"
+    And I follow "Properties" in the content area    And I check "ansible_control_node"
     And I click on "Update Properties"
     Then I should see a "Ansible Control Node type has been applied." text
 

--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -13,7 +13,7 @@ Feature: Operate an Ansible control node in a normal minion
 
   Scenario: Enable "Ansible control node" system type
     Given I am on the Systems overview page of this "sle_minion"
-    When I enable client tools repositories on "sle_minion"
+    When I enable the repositories "tools_update_repo tools_pool_repo" on this "sle_minion"
     And I follow "Properties" in the content area
     And I check "ansible_control_node"
     And I click on "Update Properties"
@@ -77,5 +77,6 @@ Feature: Operate an Ansible control node in a normal minion
     And I uncheck "ansible_control_node"
     And I click on "Update Properties"
     Then I should see a "System properties changed" text
+    And I disable the repositories "tools_update_repo tools_pool_repo" on this "sle_minion"
     And I remove package "orion-dummy" from this "sle_minion" without error control
     And I remove "/tmp/file.txt" from "sle_minion"

--- a/testsuite/features/secondary/min_deblike_openscap_audit.feature
+++ b/testsuite/features/secondary/min_deblike_openscap_audit.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2022 SUSE LLC
+# Copyright (c) 2017-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_openscap

--- a/testsuite/features/secondary/min_deblike_openscap_audit.feature
+++ b/testsuite/features/secondary/min_deblike_openscap_audit.feature
@@ -14,7 +14,7 @@ Feature: OpenSCAP audit of Debian-like Salt minion
 
   Scenario: Enable all the necessary repositories for OpenSCAP on Debian-like minion
     When I enable Debian-like "universe" repository on "deblike_minion"
-    And I enable client tools repositories on "deblike_minion"
+    And I enable the repositories "tools_update_repo tools_pool_repo" on this "deblike_minion"
 
   Scenario: Install the OpenSCAP packages on the Debian-like minion
     Given I am on the Systems overview page of this "deblike_minion"
@@ -77,5 +77,5 @@ Feature: OpenSCAP audit of Debian-like Salt minion
     When I remove OpenSCAP dependencies from "deblike_minion"
 
   Scenario: Cleanup: remove all the necessary repositories for OpenSCAP on Debian-like minion
-    When I disable client tools repositories on "deblike_minion"
+    When I disable the repositories "tools_update_repo tools_pool_repo" on this "deblike_minion"
     And I disable Debian-like "universe" repository on "deblike_minion"

--- a/testsuite/features/secondary/min_rhlike_openscap_audit.feature
+++ b/testsuite/features/secondary/min_rhlike_openscap_audit.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2022 SUSE LLC
+# Copyright (c) 2017-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_openscap

--- a/testsuite/features/secondary/min_rhlike_openscap_audit.feature
+++ b/testsuite/features/secondary/min_rhlike_openscap_audit.feature
@@ -26,7 +26,7 @@ Feature: OpenSCAP audit of Red Hat-like Salt minion
     Then I should see a "Changing the channels has been scheduled." text
     And I wait until event "Subscribe channels scheduled by admin" is completed
     When I enable repository "Rocky-BaseOS" on this "rhlike_minion"
-    And I enable client tools repositories on "rhlike_minion"
+    And I enable the repositories "tools_update_repo tools_pool_repo" on this "rhlike_minion"
     And I refresh the metadata for "rhlike_minion"
 
   Scenario: Install the OpenSCAP packages on the Red Hat-like minion
@@ -88,7 +88,7 @@ Feature: OpenSCAP audit of Red Hat-like Salt minion
   Scenario: Cleanup: remove the OpenSCAP packages from the Red Hat-like minion
     When I remove OpenSCAP dependencies from "rhlike_minion"
     And I disable repository "Rocky-BaseOS" on this "rhlike_minion"
-    And I disable client tools repositories on "rhlike_minion"
+    And I disable the repositories "tools_update_repo tools_pool_repo" on this "rhlike_minion"
 
   Scenario: Cleanup: restore the base channel for the Red Hat-like minion
     Given I am on the Systems overview page of this "rhlike_minion"

--- a/testsuite/features/secondary/minssh_ansible_control_node.feature
+++ b/testsuite/features/secondary/minssh_ansible_control_node.feature
@@ -15,8 +15,7 @@ Feature: Operate an Ansible control node in SSH minion
 
   Scenario: Enable "Ansible control node" system type
     Given I am on the Systems overview page of this "ssh_minion"
-    When I enable client tools repositories on "ssh_minion"
-    And I follow "Properties" in the content area
+    When I follow "Properties" in the content area
     And I check "ansible_control_node"
     And I click on "Update Properties"
     Then I should see a "Ansible Control Node type has been applied." text

--- a/testsuite/features/secondary/minssh_ansible_control_node.feature
+++ b/testsuite/features/secondary/minssh_ansible_control_node.feature
@@ -15,8 +15,8 @@ Feature: Operate an Ansible control node in SSH minion
 
   Scenario: Enable "Ansible control node" system type
     Given I am on the Systems overview page of this "ssh_minion"
-    When I follow "Properties" in the content area
-    And I check "ansible_control_node"
+    When I enable client tools repositories on "sle_minion"
+    And I follow "Properties" in the content area    And I check "ansible_control_node"
     And I click on "Update Properties"
     Then I should see a "Ansible Control Node type has been applied." text
 

--- a/testsuite/features/secondary/minssh_ansible_control_node.feature
+++ b/testsuite/features/secondary/minssh_ansible_control_node.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 SUSE LLC
+# Copyright (c) 2021-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_ansible

--- a/testsuite/features/secondary/minssh_ansible_control_node.feature
+++ b/testsuite/features/secondary/minssh_ansible_control_node.feature
@@ -16,7 +16,8 @@ Feature: Operate an Ansible control node in SSH minion
   Scenario: Enable "Ansible control node" system type
     Given I am on the Systems overview page of this "ssh_minion"
     When I enable client tools repositories on "sle_minion"
-    And I follow "Properties" in the content area    And I check "ansible_control_node"
+    And I follow "Properties" in the content area
+    And I check "ansible_control_node"
     And I click on "Update Properties"
     Then I should see a "Ansible Control Node type has been applied." text
 

--- a/testsuite/features/secondary/minssh_ansible_control_node.feature
+++ b/testsuite/features/secondary/minssh_ansible_control_node.feature
@@ -15,7 +15,7 @@ Feature: Operate an Ansible control node in SSH minion
 
   Scenario: Enable "Ansible control node" system type
     Given I am on the Systems overview page of this "ssh_minion"
-    When I enable client tools repositories on "sle_minion"
+    When I enable client tools repositories on "ssh_minion"
     And I follow "Properties" in the content area
     And I check "ansible_control_node"
     And I click on "Update Properties"

--- a/testsuite/features/secondary/minssh_ansible_control_node.feature
+++ b/testsuite/features/secondary/minssh_ansible_control_node.feature
@@ -85,7 +85,7 @@ Feature: Operate an Ansible control node in SSH minion
     And I remove package "orion-dummy" from this "ssh_minion" without error control
     And I remove "/tmp/file.txt" from "ssh_minion"
 
-  Scenario: Cleanup: Disable client tools channel
+  Scenario: Cleanup: Disable client tools repositories
     Given I am on the Systems overview page of this "ssh_minion"
     When I disable the repositories "tools_update_repo tools_pool_repo" on this "ssh_minion"
     And I refresh the metadata for "ssh_minion"

--- a/testsuite/features/secondary/minssh_ansible_control_node.feature
+++ b/testsuite/features/secondary/minssh_ansible_control_node.feature
@@ -10,13 +10,15 @@ Feature: Operate an Ansible control node in SSH minion
     Given I am authorized for the "Admin" section
 
   Scenario: Pre-requisite: Deploy test playbooks and inventory file
-    Given I am on the Systems overview page of this "ssh_minion"
     When I deploy testing playbooks and inventory files to "ssh_minion"
+
+  Scenario: Pre-requisite: Enable client tools repositories
+    When I enable the repositories "tools_update_repo tools_pool_repo" on this "ssh_minion"
+    And I refresh the metadata for "ssh_minion"
 
   Scenario: Enable "Ansible control node" system type
     Given I am on the Systems overview page of this "ssh_minion"
-    When I enable the repositories "tools_update_repo tools_pool_repo" on this "ssh_minion"
-    And I follow "Properties" in the content area
+    When I follow "Properties" in the content area
     And I check "ansible_control_node"
     And I click on "Update Properties"
     Then I should see a "Ansible Control Node type has been applied." text
@@ -82,3 +84,8 @@ Feature: Operate an Ansible control node in SSH minion
     And I disable the repositories "tools_update_repo tools_pool_repo" on this "ssh_minion"
     And I remove package "orion-dummy" from this "ssh_minion" without error control
     And I remove "/tmp/file.txt" from "ssh_minion"
+
+  Scenario: Cleanup: Disable client tools channel
+    Given I am on the Systems overview page of this "ssh_minion"
+    When I disable the repositories "tools_update_repo tools_pool_repo" on this "ssh_minion"
+    And I refresh the metadata for "ssh_minion"

--- a/testsuite/features/secondary/minssh_ansible_control_node.feature
+++ b/testsuite/features/secondary/minssh_ansible_control_node.feature
@@ -15,7 +15,7 @@ Feature: Operate an Ansible control node in SSH minion
 
   Scenario: Enable "Ansible control node" system type
     Given I am on the Systems overview page of this "ssh_minion"
-    When I enable client tools repositories on "ssh_minion"
+    When I enable the repositories "tools_update_repo tools_pool_repo" on this "ssh_minion"
     And I follow "Properties" in the content area
     And I check "ansible_control_node"
     And I click on "Update Properties"
@@ -79,5 +79,6 @@ Feature: Operate an Ansible control node in SSH minion
     And I uncheck "ansible_control_node"
     And I click on "Update Properties"
     Then I should see a "System properties changed" text
+    And I disable the repositories "tools_update_repo tools_pool_repo" on this "ssh_minion"
     And I remove package "orion-dummy" from this "ssh_minion" without error control
     And I remove "/tmp/file.txt" from "ssh_minion"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -802,12 +802,10 @@ When(/^I (enable|disable) (the repositories|repository) "([^"]*)" on this "([^"]
   cmd = ''
   if os_family =~ /^opensuse/ || os_family =~ /^sles/
     mand_repos = ''
-    opt_repos = ''
     repos.split(' ').map do |repo|
       mand_repos = "#{mand_repos} #{repo}"
     end
-    cmd = "zypper mr --#{action} #{opt_repos} ||:;" unless opt_repos.empty?
-    cmd += "zypper mr --#{action} #{mand_repos}" unless mand_repos.empty?
+    cmd = "zypper mr --#{action} #{mand_repos}" unless mand_repos.empty?
   elsif os_family =~ /^centos/ || os_family =~ /^rocky/
     repos.split(' ').each do |repo|
       cmd = "#{cmd} && " unless cmd.empty?

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2022 SUSE LLC.
+# Copyright (c) 2014-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'timeout'

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -804,11 +804,7 @@ When(/^I (enable|disable) (the repositories|repository) "([^"]*)" on this "([^"]
     mand_repos = ''
     opt_repos = ''
     repos.split(' ').map do |repo|
-      if repo =~ /_ltss_/
-        opt_repos = "#{opt_repos} #{repo}"
-      else
-        mand_repos = "#{mand_repos} #{repo}"
-      end
+      mand_repos = "#{mand_repos} #{repo}"
     end
     cmd = "zypper mr --#{action} #{opt_repos} ||:;" unless opt_repos.empty?
     cmd += "zypper mr --#{action} #{mand_repos}" unless mand_repos.empty?
@@ -1481,7 +1477,6 @@ When(/^I (enable|disable) the necessary repositories before installing Prometheu
   os_family = node.os_family
   repositories = 'tools_pool_repo tools_update_repo'
   if os_family =~ /^opensuse/ || os_family =~ /^sles/
-    repositories.concat(' os_pool_repo os_update_repo')
     if $product != 'Uyuni'
       repositories.concat(' tools_additional_repo')
       # Needed because in SLES15SP3 and openSUSE 15.3 and higher, firewalld will replace this package.

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -720,6 +720,9 @@ When(/^I enable client tools repositories on "([^"]*)"$/) do |host|
   node = get_target(host)
   os_family = node.os_family
   case os_family
+  when /^(opensuse|sles)/
+    repos, _code = node.run('zypper lr | grep "tools" | cut -d"|" -f2')
+    node.run("zypper mr --enable #{repos.gsub(/\s/, ' ')}")
   when /^(centos|rocky)/
     repos, _code = node.run('yum repolist disabled 2>/dev/null | grep "tools_" | cut -d" " -f1')
     repos.gsub(/\s/, ' ').split.each do |repo|
@@ -739,6 +742,9 @@ When(/^I disable client tools repositories on "([^"]*)"$/) do |host|
   node = get_target(host)
   os_family = node.os_family
   case os_family
+  when /^(opensuse|sles)/
+    repos, _code = node.run('zypper lr | grep "tools" | cut -d"|" -f2')
+    node.run("zypper mr --disable #{repos.gsub(/\s/, ' ')}")
   when /^(centos|rocky)/
     repos, _code = node.run('yum repolist enabled 2>/dev/null | grep "tools_" | cut -d" " -f1')
     repos.gsub(/\s/, ' ').split.each do |repo|

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -764,7 +764,7 @@ end
 
 Given(/^I update the profile of "([^"]*)"$/) do |client|
   node = get_target(client)
-  node.run('rhn-profile-gsync', timeout: 500)
+  node.run('rhn-profile-sync', timeout: 500)
 end
 
 When(/^I wait until onboarding is completed for "([^"]*)"$/) do |host|

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2022 SUSE LLC.
+# Copyright (c) 2010-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'jwt'

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -713,53 +713,6 @@ Then(/^I remove server hostname from hosts file on "([^"]*)"$/) do |host|
   node.run("sed -i \'s/#{$server.full_hostname}//\' /etc/hosts")
 end
 
-# Repository steps
-
-# Enable tools repositories (both stable and development)
-When(/^I enable client tools repositories on "([^"]*)"$/) do |host|
-  node = get_target(host)
-  os_family = node.os_family
-  case os_family
-  when /^(opensuse|sles)/
-    repos, _code = node.run('zypper lr | grep "tools" | cut -d"|" -f2')
-    node.run("zypper mr --enable #{repos.gsub(/\s/, ' ')}")
-  when /^(centos|rocky)/
-    repos, _code = node.run('yum repolist disabled 2>/dev/null | grep "tools_" | cut -d" " -f1')
-    repos.gsub(/\s/, ' ').split.each do |repo|
-      node.run("sed -i 's/enabled=.*/enabled=1/g' /etc/yum.repos.d/#{repo}.repo")
-    end
-  when /^ubuntu/
-    repos, _code = node.run("ls /etc/apt/sources.list.d | grep tools")
-    repos.gsub(/\s/, ' ').split.each do |repo|
-      node.run("sed -i '/^#\\s*deb.*/ s/^#\\s*deb /deb /' /etc/apt/sources.list.d/#{repo}")
-    end
-  else
-    raise "This step has no implementation for #{os_family} system."
-  end
-end
-
-When(/^I disable client tools repositories on "([^"]*)"$/) do |host|
-  node = get_target(host)
-  os_family = node.os_family
-  case os_family
-  when /^(opensuse|sles)/
-    repos, _code = node.run('zypper lr | grep "tools" | cut -d"|" -f2')
-    node.run("zypper mr --disable #{repos.gsub(/\s/, ' ')}")
-  when /^(centos|rocky)/
-    repos, _code = node.run('yum repolist enabled 2>/dev/null | grep "tools_" | cut -d" " -f1')
-    repos.gsub(/\s/, ' ').split.each do |repo|
-      node.run("sed -i 's/enabled=.*/enabled=0/g' /etc/yum.repos.d/#{repo}.repo")
-    end
-  when /^ubuntu/
-    repos, _code = node.run("ls /etc/apt/sources.list.d | grep tools")
-    repos.gsub(/\s/, ' ').split.each do |repo|
-      node.run("sed -i '/^deb.*/ s/^deb /# deb /' /etc/apt/sources.list.d/#{repo}")
-    end
-  else
-    raise "This step has no implementation for #{os_family} system."
-  end
-end
-
 # Register client
 
 Given(/^I update the profile of "([^"]*)"$/) do |client|

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2022 SUSE LLC.
+# Copyright (c) 2013-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'tempfile'

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -204,9 +204,7 @@ end
 def extract_logs_from_node(node)
   os_family = node.os_family
   if os_family =~ /^opensuse/
-    node.run('zypper mr --enable os_pool_repo os_update_repo') unless $build_validation
     node.run('zypper --non-interactive install tar')
-    node.run('zypper mr --disable os_pool_repo os_update_repo') unless $build_validation
   end
   node.run('journalctl > /var/log/messages', check_errors: false) # Some clients might not support systemd
   node.run("tar cfvJP /tmp/#{node.full_hostname}-logs.tar.xz /var/log/ || [[ $? -eq 1 ]]")

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -203,9 +203,7 @@ end
 
 def extract_logs_from_node(node)
   os_family = node.os_family
-  if os_family =~ /^opensuse/
-    node.run('zypper --non-interactive install tar')
-  end
+  node.run('zypper --non-interactive install tar') if os_family =~ /^opensuse/
   node.run('journalctl > /var/log/messages', check_errors: false) # Some clients might not support systemd
   node.run("tar cfvJP /tmp/#{node.full_hostname}-logs.tar.xz /var/log/ || [[ $? -eq 1 ]]")
   `mkdir logs` unless Dir.exist?('logs')


### PR DESCRIPTION
## What does this PR change?

Remove the use of injected repositories in the testsuite for SLES nodes
The use of some repositories remains:

`tools_update_repo`
`tools_pool_repo`
`tools_additional_repo`
`test_repo_rpm_pool ` 

These repositories do not have any equivalent in the base product channels even though they could be potentially integrated to a custom channel.

`os_pool_repo`
`os_update_repo`

These repositories are used to configure the proxy as a branch server. At that point, the channels have not be synced.
This could be solved by changing the order of features and/or with the future use of the proxy product. 

## GUI diff
No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were edited

- [x] **DONE**

## Links
Fixes # https://github.com/SUSE/spacewalk/issues/13869
Tracks # 
4.2 https://github.com/SUSE/spacewalk/pull/20141
4.3 https://github.com/SUSE/spacewalk/pull/20140
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
