### PR TITLE
Introduce threadpool for tftpsync to increase performance while syncing files to proxies (bsc#1205489)

### DIFF
--- a/tftpsync/susemanager-tftpsync/susemanager-tftpsync.changes
+++ b/tftpsync/susemanager-tftpsync/susemanager-tftpsync.changes
@@ -1,3 +1,6 @@
+- Introduce threadpool for tftpsync to increase performance
+  while syncing files to proxies (bsc#1205489)
+
 -------------------------------------------------------------------
 Wed Sep 28 11:03:42 CEST 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR introduces a threadpool to increase the performance of Cobbler sync while syncing files to proxies.

Before this PR, pushing individual files is done sequentially, which is a bottleneck in case of large deployments.

With this PR, files are pushed by a threadpool, increasing the performance of this operation.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/19577

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
