### PR TITLE
Revert "QE: Temporarily disable Rocky 8 reposync"

### DIFF
--- a/testsuite/run_sets/reposync.yml
+++ b/testsuite/run_sets/reposync.yml
@@ -13,6 +13,6 @@
 - features/reposync/srv_sync_products.feature
 - features/reposync/srv_enable_sync_products.feature
 - features/reposync/srv_wait_for_reposync.feature
-# - features/reposync/srv_add_rocky8_repositories.feature
+- features/reposync/srv_add_rocky8_repositories.feature
 
 ## Channels and Product synchronization features END ###


### PR DESCRIPTION
Reverts uyuni-project/uyuni#6403 to be able to see why core fails when this is enabled.