### PR TITLE
Standardize the login response format with other HTTP API endpoints

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/test/LoginControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/LoginControllerTest.java
@@ -158,7 +158,7 @@ public class LoginControllerTest extends BaseControllerTestCase {
         assertFalse(result.isSuccess());
         assertEquals(
                 LocalizationService.getInstance().getMessage("error.invalid_login"),
-                String.join("", result.getMessages())
+                String.join("", result.getMessage())
         );
     }
 
@@ -178,7 +178,7 @@ public class LoginControllerTest extends BaseControllerTestCase {
         assertFalse(result.isSuccess());
         assertEquals(
                 LocalizationService.getInstance().getMessage("error.invalid_login"),
-                String.join("", result.getMessages())
+                String.join("", result.getMessage())
         );
     }
 
@@ -198,7 +198,7 @@ public class LoginControllerTest extends BaseControllerTestCase {
         assertFalse(result.isSuccess());
         assertEquals(
                 LocalizationService.getInstance().getMessage("error.invalid_login"),
-                String.join("", result.getMessages())
+                String.join("", result.getMessage())
         );
     }
 
@@ -218,7 +218,7 @@ public class LoginControllerTest extends BaseControllerTestCase {
         assertFalse(result.isSuccess());
         assertEquals(
                 LocalizationService.getInstance().getMessage("error.invalid_login"),
-                String.join("", result.getMessages()));
+                String.join("", result.getMessage()));
     }
 
     @Test
@@ -240,7 +240,7 @@ public class LoginControllerTest extends BaseControllerTestCase {
         assertFalse(result.isSuccess());
         assertEquals(
                 LocalizationService.getInstance().getMessage("account.disabled"),
-                String.join("", result.getMessages())
+                String.join("", result.getMessage())
         );
     }
 }

--- a/java/code/src/com/suse/manager/webui/utils/LoginHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/LoginHelper.java
@@ -58,7 +58,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import javax.security.auth.login.LoginException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -428,26 +427,6 @@ public class LoginHelper {
         SystemCommandExecutor ce = new SystemCommandExecutor();
         return ce.execute(rpmCommand) == 0 ?
             ce.getLastCommandOutput().replace("\n", "") : null;
-    }
-
-    /**
-     * Log a user into the site and create the user's session.
-     *
-     * @param username login name
-     * @param password unencrypted password
-     * @param errors list of error messages to be populated
-     * @return the user object
-     */
-    public static User loginUser(String username, String password, List<String> errors) {
-        User user = null;
-
-        try {
-            user = UserManager.loginUser(username, password);
-        }
-        catch (LoginException e) {
-            errors.add(LocalizationService.getInstance().getMessage(e.getMessage()));
-        }
-        return user;
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Standardize the login response format with other HTTP API endpoints (bsc#1206800)
 - Add `mgr_server_is_uyuni` minion pillar item
 - Improve logs when sls action chain file is missing
 - Fix modular channel check during system update via XMLRPC (bsc#1206613)


### PR DESCRIPTION
## What does this PR change?

HTTP API routes typically are wrapped trough the  `HttpApiResponse` class. However, the login endpoint is using an specific class: `LoginResult`. This patch changes the `LoginResult` to have the attribute as `message` instead of `messages` in the same way as `HttpApiResponse`.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20025

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"           
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
