### PR TITLE
take common channel naming into account for auto selection

### DIFF
--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -726,7 +726,7 @@ public class ConfigDefaults {
      * selection
      */
     public boolean getClonedChannelAutoSelection() {
-        return Config.get().getBoolean(CLONED_CHANNEL_AUTO_SELECTION);
+        return Config.get().getBoolean(CLONED_CHANNEL_AUTO_SELECTION, true);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/channel/test/ChannelFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/test/ChannelFactoryTest.java
@@ -393,14 +393,20 @@ public class ChannelFactoryTest extends RhnBaseTestCase {
      * @return a test cloned channel
      */
     public static Channel createTestClonedChannel(Channel original, User user) {
+        return createTestClonedChannel(original, user, "clone-", "",
+                "Clone of ", "", null);
+    }
+
+    public static Channel createTestClonedChannel(Channel original, User user, String labelPrefix, String labelSuffix,
+                                                  String namePrefix, String nameSuffix, Channel parent) {
         Org org = user.getOrg();
         ClonedChannel clone = new ClonedChannel();
         ChannelFamily cfam = ChannelFamilyFactory.lookupOrCreatePrivateFamily(org);
 
         clone.setOrg(org);
-        clone.setLabel("clone-" + original.getLabel());
+        clone.setLabel(labelPrefix + original.getLabel() + labelSuffix);
         clone.setBaseDir(original.getBaseDir());
-        clone.setName("Clone of " + original.getName());
+        clone.setName(namePrefix + original.getName() + nameSuffix);
         clone.setSummary(original.getSummary());
         clone.setDescription(original.getDescription());
         clone.setLastModified(new Date());
@@ -416,6 +422,7 @@ public class ChannelFactoryTest extends RhnBaseTestCase {
 
         /* clone specific calls */
         clone.setOriginal(original);
+        clone.setParentChannel(parent);
 
         ChannelFactory.save(clone);
 
@@ -425,6 +432,7 @@ public class ChannelFactoryTest extends RhnBaseTestCase {
 
         return clone;
     }
+
     @Test
     public void testAccessibleChildChannels() throws Exception {
         User user = UserTestUtils.findNewUser("testUser",

--- a/java/code/src/com/redhat/rhn/domain/product/SUSEProductFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/product/SUSEProductFactory.java
@@ -285,13 +285,25 @@ public class SUSEProductFactory extends HibernateFactory {
         if (channel.isCloned()) {
             if (ConfigDefaults.get().getClonedChannelAutoSelection()) {
                 return channel.originChain().filter(c -> !c.isCloned()).findFirst().map(original -> {
-                    return findSyncedMandatoryChannels(original.getLabel())
-                            .flatMap(c -> c.allClonedChannels())
-                            .filter(c ->
-                                    (c.getParentChannel() != null && c.getParentChannel()
-                                            .equals(channel.getParentChannel())) || c.equals(channel.getParentChannel())
-                            )
-                            .map(c -> (Channel) c);
+                    List<String> originalParts = List.of(original.getLabel().split("-"));
+                    List<String> selectedParts = List.of(channel.getLabel().split("-"));
+                    List<String> uniqueParts = selectedParts.stream()
+                            .filter(s -> !originalParts.contains(s))
+                            .collect(Collectors.toList());
+
+                    if (channel.isBaseChannel()) {
+                        return Stream.<Channel>empty();
+                    }
+                    else {
+                        return findSyncedMandatoryChannels(original.getLabel())
+                                .flatMap(c -> {
+                                    return c.allClonedChannels().filter(clone -> {
+                                        List<String> cloneParts = List.of(clone.getLabel().split("-"));
+                                        return cloneParts.containsAll(uniqueParts);
+                                    });
+                                })
+                                .map(c -> (Channel) c);
+                    }
                 }).orElse(Stream.empty());
             }
             else {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Improve automatic dependency selection for vendor clones
 - Fix taskomatic logging (bsc#1207867)
 - Added APIs to allow frontend to install and remove ptf
 - Fix not being able to delete CLM environment if there are custom child


### PR DESCRIPTION
## What does this PR change?

This PR implements an enhanced way of selecting recommended cloned vendor channels by taking into account common naming schemes. As long as every channel contains the original label plus some additional parts separated with - that are common across all related clones, they will be selected together.

There are a few improvements that can be made before merging this. I.e the initial selection of the base channel won't auto select any child channels since its shared and does not contain the common naming of every group of child channels it contains so its not possible to determine which group of child channels should be selected. However for the common base case where customers won't have multiple clones of the same child channel in one base channel it would be good if we detect that there is only 1 option available per recommended channel and select those by default.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
