### PR TITLE
Fix modular channel check during system update via XMLRPC (bsc#1206613)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/channel/test/ChannelTest.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/test/ChannelTest.java
@@ -253,11 +253,9 @@ public class ChannelTest extends BaseTestCaseWithUser {
     @Test
     public void testIsModular() throws Exception {
         Channel c = ChannelFactoryTest.createTestChannel(user);
-        assertNull(c.getModules());
         assertFalse(c.isModular());
 
         c.addModules(new Modules("filename", new Date()));
-        assertNotNull(c.getModules());
         assertTrue(c.isModular());
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -3666,7 +3666,7 @@ public class SystemHandler extends BaseHandler {
             for (Long sid : serverIds) {
                 Server server = SystemManager.lookupByIdAndUser(sid, loggedInUser);
                 for (Channel channel : server.getChannels()) {
-                    if (channel.getModules() != null) {
+                    if (channel.isModular()) {
                         throw new ModulesNotAllowedException();
                     }
                 }
@@ -3975,7 +3975,7 @@ public class SystemHandler extends BaseHandler {
             for (Integer sid : sids) {
                 Server server = SystemManager.lookupByIdAndUser(sid.longValue(), loggedInUser);
                 for (Channel channel : server.getChannels()) {
-                    if (channel.getModules() != null) {
+                    if (channel.isModular()) {
                         hasModules = true;
                         break;
                     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix modular channel check during system update via XMLRPC (bsc#1206613)
 - Fix transaction commit behavior for Spark routes
 - Trigger a package profile update when a new live-patch is installed (bsc#1206249)
 - Fix CVE Audit ignoring errata in parent channels if patch in successor


### PR DESCRIPTION
Check if a channel is modular using the proper `isModular()` method.

Port of: https://github.com/SUSE/spacewalk/pull/20041

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
