### PR TITLE
Do not include pillar_only formulas in highstate

### DIFF
--- a/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
+++ b/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
@@ -288,7 +288,8 @@ def formula_pillars(system_formulas, group_formulas, all_pillar):
         formula_metadata = load_formula_metadata(formula_name)
         if formula_name in out_formulas:
             continue # already processed
-        out_formulas.append(formula_name)
+        if not formula_metadata.get('pillar_only', False):
+            out_formulas.append(formula_name)
         pillar = salt.utils.dictupdate.merge(pillar,
                        load_formula_pillar(system_formulas.get(formula_name, {}),
                            group_formulas[formula_name],
@@ -300,16 +301,18 @@ def formula_pillars(system_formulas, group_formulas, all_pillar):
     for formula_name in system_formulas:
         if formula_name in out_formulas:
             continue # already processed
-        out_formulas.append(formula_name)
+        formula_metadata = load_formula_metadata(formula_name)
+        if not formula_metadata.get('pillar_only', False):
+            out_formulas.append(formula_name)
         pillar = salt.utils.dictupdate.merge(pillar,
                 load_formula_pillar(system_formulas[formula_name], {}, formula_name), strategy='recurse')
 
     # Loading the formula order
     order = get_formula_order(all_pillar)
     if order:
-        pillar["formulas"] = [formula for formula in order if formula in out_formulas]
-    else:
-        pillar["formulas"] = out_formulas
+        out_formulas = [formula for formula in order if formula in out_formulas]
+
+    pillar['formulas'] = out_formulas
 
     return pillar
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Do not include pillar_only formulas in highstate
 - Allow KiwiNG to be used on SLE12 buildhosts (bsc#1204089)
 - Add kiwi supported disk images to be collectable (bsc#1208522)
 - disable salt-minion and remove its config file on cleanup (bsc#1209277)


### PR DESCRIPTION
## What does this PR change?

Do not include pillar_only formulas in highstate

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**

- [X] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
