### PR TITLE
Testsuite: Cleanup content lifecycle feature to remove created channels

### DIFF
--- a/testsuite/features/secondary/srv_content_lifecycle.feature
+++ b/testsuite/features/secondary/srv_content_lifecycle.feature
@@ -151,12 +151,14 @@ Feature: Content lifecycle
     And I wait for "1" second
     Then I wait at most 600 seconds until I see "Built" text in the environment "prod_name"
 
-  Scenario: Clean up the Content Lifecycle Management feature
+  Scenario: Cleanup: remove the Content Lifecycle Management project
     When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
     And I click on "Delete"
     And I click on "Delete" in "Delete Project" modal
     Then I should not see a "clp_name" text
+  
+  Scenario: Cleanup: remove the created channels
     When I delete these channels with spacewalk-remove-channel:
       |clp_label-prod_label-fake_base_channel|
       |clp_label-prod_label-sles12-sp5-updates-x86_64|
@@ -168,3 +170,5 @@ Feature: Content lifecycle
       |clp_label-prod_label-sles12-sp5-pool-x86_64|
       |clp_label-qa_label-sles12-sp5-pool-x86_64|
       |clp_label-dev_label-sles12-sp5-pool-x86_64|
+    When I list channels with spacewalk-remove-channel
+    Then I shouldn't get "clp_label"

--- a/testsuite/features/secondary/srv_content_lifecycle.feature
+++ b/testsuite/features/secondary/srv_content_lifecycle.feature
@@ -157,3 +157,14 @@ Feature: Content lifecycle
     And I click on "Delete"
     And I click on "Delete" in "Delete Project" modal
     Then I should not see a "clp_name" text
+    When I delete these channels with spacewalk-remove-channel:
+      |clp_label-dev_label-fake_base_channel|
+      |clp_label-dev_label-sles12-sp5-updates-x86_64|
+      |clp_label-prod_label-fake_base_channel|
+      |clp_label-prod_label-sles12-sp5-updates-x86_64|
+      |clp_label-qa_label-fake_base_channel|
+      |clp_label-qa_label-sles12-sp5-updates-x86_64|
+    And I delete these channels with spacewalk-remove-channel:
+      |clp_label-dev_label-sles12-sp5-pool-x86_64|
+      |clp_label-prod_label-sles12-sp5-pool-x86_64|
+      |clp_label-qa_label-sles12-sp5-pool-x86_64|

--- a/testsuite/features/secondary/srv_content_lifecycle.feature
+++ b/testsuite/features/secondary/srv_content_lifecycle.feature
@@ -158,13 +158,13 @@ Feature: Content lifecycle
     And I click on "Delete" in "Delete Project" modal
     Then I should not see a "clp_name" text
     When I delete these channels with spacewalk-remove-channel:
-      |clp_label-dev_label-fake_base_channel|
-      |clp_label-dev_label-sles12-sp5-updates-x86_64|
       |clp_label-prod_label-fake_base_channel|
       |clp_label-prod_label-sles12-sp5-updates-x86_64|
       |clp_label-qa_label-fake_base_channel|
       |clp_label-qa_label-sles12-sp5-updates-x86_64|
+      |clp_label-dev_label-fake_base_channel|
+      |clp_label-dev_label-sles12-sp5-updates-x86_64|
     And I delete these channels with spacewalk-remove-channel:
-      |clp_label-dev_label-sles12-sp5-pool-x86_64|
       |clp_label-prod_label-sles12-sp5-pool-x86_64|
       |clp_label-qa_label-sles12-sp5-pool-x86_64|
+      |clp_label-dev_label-sles12-sp5-pool-x86_64|


### PR DESCRIPTION
## What does this PR change?

The content lifecycle feature was not completely idempotent as the channels created during that feature are not deleted and are never used either later on.
Channels are deleted in a certain order to avoid deletion conflicts between channel clones.

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were added
- [x] **DONE**
## Links

Fixes #
Tracks # 
4.2 https://github.com/SUSE/spacewalk/pull/20123
4.3 https://github.com/SUSE/spacewalk/pull/20122
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
