### PR TITLE
Testsuite: Add a check for enabled channels

### DIFF
--- a/testsuite/features/init_clients/allcli_update_activationkeys.feature
+++ b/testsuite/features/init_clients/allcli_update_activationkeys.feature
@@ -51,7 +51,7 @@ Feature: Update activation keys
     And I select "SLE-Product-SLES15-SP4-Pool for x86_64" from "selectedBaseChannel"
     And I include the recommended child channels
     And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"
-    And I check "SLE-Module-Containers15-SP4-Updates for x86_64"
+    And I check "SLE-Module-Containers15-SP4-Pool for x86_64"
     And I check "Fake-RPM-SLES-Channel"
     Then I should see "SLE-Module-Basesystem15-SP4-Pool for x86_64" as checked
     And I should see "SLE-Module-Basesystem15-SP4-Updates for x86_64" as checked

--- a/testsuite/features/init_clients/allcli_update_activationkeys.feature
+++ b/testsuite/features/init_clients/allcli_update_activationkeys.feature
@@ -53,7 +53,18 @@ Feature: Update activation keys
     And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"
     And I check "SLE-Module-Containers15-SP4-Updates for x86_64"
     And I check "Fake-RPM-SLES-Channel"
-    And I click on "Update Activation Key"
+    Then I should see "SLE-Module-Basesystem15-SP4-Pool for x86_64" as checked
+    And I should see "SLE-Module-Basesystem15-SP4-Updates for x86_64" as checked
+    And I should see "SLE-Module-Server-Applications15-SP4-Pool for x86_64" as checked
+    And I should see "SLE-Module-Server-Applications15-SP4-Updates for x86_64" as checked
+    And I should see "SLE-Module-DevTools15-SP4-Pool for x86_64" as checked
+    And I should see "SLE-Module-DevTools15-SP4-Updates for x86_64" as checked
+    And I should see "SLE-Module-Desktop-Applications15-SP4-Pool for x86_64" as checked
+    And I should see "SLE-Module-Desktop-Applications15-SP4-Updates for x86_64" as checked
+    And I should see "SLE-Module-Containers15-SP4-Pool for x86_64" as checked
+    And I should see "SLE-Module-Containers15-SP4-Updates for x86_64" as checked
+    And I should see "Fake-RPM-SLES-Channel" as checked
+    When I click on "Update Activation Key"
     Then I should see a "Activation key SUSE Test Key x86_64 has been modified" text
 
   Scenario: Update SSH key with synced base product

--- a/testsuite/features/init_clients/allcli_update_activationkeys.feature
+++ b/testsuite/features/init_clients/allcli_update_activationkeys.feature
@@ -57,13 +57,10 @@ Feature: Update activation keys
     And I should see "SLE-Module-Basesystem15-SP4-Updates for x86_64" as checked
     And I should see "SLE-Module-Server-Applications15-SP4-Pool for x86_64" as checked
     And I should see "SLE-Module-Server-Applications15-SP4-Updates for x86_64" as checked
-    And I should see "SLE-Module-DevTools15-SP4-Pool for x86_64" as checked
     And I should see "SLE-Module-DevTools15-SP4-Updates for x86_64" as checked
     And I should see "SLE-Module-Desktop-Applications15-SP4-Pool for x86_64" as checked
     And I should see "SLE-Module-Desktop-Applications15-SP4-Updates for x86_64" as checked
-    And I should see "SLE-Module-Containers15-SP4-Pool for x86_64" as checked
     And I should see "SLE-Module-Containers15-SP4-Updates for x86_64" as checked
-    And I should see "Fake-RPM-SLES-Channel" as checked
     When I click on "Update Activation Key"
     Then I should see a "Activation key SUSE Test Key x86_64 has been modified" text
 

--- a/testsuite/features/init_clients/allcli_update_activationkeys.feature
+++ b/testsuite/features/init_clients/allcli_update_activationkeys.feature
@@ -53,6 +53,8 @@ Feature: Update activation keys
     And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"
     And I check "SLE-Module-Containers15-SP4-Pool for x86_64"
     And I check "Fake-RPM-SLES-Channel"
+
+  Scenario: Check that sub-channels are automatically selected
     Then I should see "SLE-Module-Basesystem15-SP4-Pool for x86_64" as checked
     And I should see "SLE-Module-Basesystem15-SP4-Updates for x86_64" as checked
     And I should see "SLE-Module-Server-Applications15-SP4-Pool for x86_64" as checked


### PR DESCRIPTION
## What does this PR change?

Following https://suse.slack.com/archives/C02D12TNYLS/p1673352576688079 , adding a check to verify that all expected channels are enabled in the activation key update (including those automatically enabled).
`SLE-Product-SLES15-SP4-Updates for x86_64` is mandatory and - despite being included - is not considered as checked.

Two more channels are checked in 4.2 and 4.3: `SLE-Manager-Tools15-Updates for x86_64 SP4` and `SLE-Manager-Tools15-Pool for x86_64 SP4`

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were added
- [x] **DONE**

## Links

Fixes #
Tracks # 
4.2 https://github.com/SUSE/spacewalk/pull/20106
4.3 https://github.com/SUSE/spacewalk/pull/20105

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
