### PR TITLE
Remove python3-simplejson dependency

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,5 @@
+- Remove python3-simplejson dependency
+
 -------------------------------------------------------------------
 Wed Dec 14 14:07:34 CET 2022 - jgonzalez@suse.com
 

--- a/spacecmd/spacecmd.spec
+++ b/spacecmd/spacecmd.spec
@@ -85,7 +85,6 @@ BuildRequires:  python3-rpm-macros
 %endif
 Requires:       python3
 Requires:       python3-rpm
-Requires:       python3-simplejson
 %else
 BuildRequires:  %{python2prefix}
 %if "%{_vendor}" == "debbuild"


### PR DESCRIPTION

## What does this PR change?

The spacecmd specfile lists python3-simplejson as a dependency, but this makes no sense, as simplejson is only used when python is < 2.6. The requirement is causing install errors. This patch removes the dependency. There should be no code that expects it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
