### PR TITLE
Fix failing to delete CLM environment without error

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -20,6 +20,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Optional.empty;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.channel.ClonedChannel;
@@ -238,6 +239,23 @@ public class ContentProjectFactory extends HibernateFactory {
      * @param toRemove environment to remove.
      */
     public static void removeEnvironment(ContentEnvironment toRemove) {
+
+        // Check for custom child channels that were not built by the environment to be removed
+        List<Channel> channels = toRemove.getTargets().stream()
+                .map(EnvironmentTarget::asSoftwareTarget).flatMap(Optional::stream)
+                .map(SoftwareEnvironmentTarget::getChannel).collect(Collectors.toList());
+
+        List<Channel> childChannels = channels.stream().filter(c -> !c.isBaseChannel()).collect(Collectors.toList());
+        channels.stream().filter(Channel::isBaseChannel).findAny().ifPresent(bc -> {
+            List<String> rogueChannels = ChannelFactory.listAllChildrenForChannel(bc).stream()
+                    .filter(b -> !childChannels.contains(b))
+                    .map(Channel::getName).collect(Collectors.toList());
+            if (!rogueChannels.isEmpty()) {
+                throw  new ContentManagementException(LocalizationService.getInstance().getMessage(
+                        "contentmanagement.non_environment_channels_found", rogueChannels));
+            }
+        });
+
         // let's purge all the targets in the environment firstly
         new ArrayList<>(toRemove.getTargets()).stream()
                 .sorted((t1, t2) -> Boolean.compare(// make sure a parent channel goes first
@@ -300,8 +318,10 @@ public class ContentProjectFactory extends HibernateFactory {
                 .orElse(false);
 
         if (hasDistributions) {
-            throw new ContentManagementException("The target " + target +
-                    " is being used in an autoinstallation profile. Cannot remove.");
+            log.error("The target " + target + " is being used in an autoinstallation profile. Cannot remove.");
+            throw new ContentManagementException(LocalizationService.getInstance().getMessage(
+                    "contentmanagement.used_in_autoinstallation_profile"
+            ));
         }
 
         // firstly fix the original/clone relations of channels

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
@@ -614,8 +614,7 @@ public class ContentProjectFactoryTest extends BaseTestCaseWithUser {
             fail("Must not purge.");
         }
         catch (ContentManagementException e) {
-            assertEquals("The target " + target +
-                    " is being used in an autoinstallation profile. Cannot remove.", e.getMessage());
+            assertEquals("The target is being used in an autoinstallation profile. Cannot remove.", e.getMessage());
         }
         finally {
             assertEquals(1, envdev.getTargets().size());

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -8955,6 +8955,12 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
       <trans-unit id="contentmanagement.modules_error" xml:space="preserve">
         <source>Cannot get channel modules. Please check the server logs for detailed information.</source>
       </trans-unit>
+      <trans-unit id="contentmanagement.non_environment_channels_found" xml:space="preserve">
+        <source>Cannot remove. There are custom channels that are not part of the channels built by the environment. Please remove these channels first: {0}</source>
+      </trans-unit>
+      <trans-unit id="contentmanagement.used_in_autoinstallation_profile" xml:space="preserve">
+        <source>The target is being used in an autoinstallation profile. Cannot remove.</source>
+      </trans-unit>
       <trans-unit id="payg.description_required" xml:space="preserve">
         <source>Description is required.</source>
       </trans-unit>

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/EnvironmentApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/EnvironmentApiController.java
@@ -21,6 +21,7 @@ import static spark.Spark.post;
 import static spark.Spark.put;
 
 import com.redhat.rhn.common.validator.ValidatorException;
+import com.redhat.rhn.domain.contentmgmt.ContentManagementException;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.contentmgmt.ContentManager;
 
@@ -127,12 +128,17 @@ public class EnvironmentApiController {
     public static String removeContentEnvironemnt(Request req, Response res, User user) {
         EnvironmentRequest removeEnvironmentRequest = EnvironmentHandler.getEnvironmentRequest(req);
 
-        CONTENT_MGR.removeEnvironment(
-                removeEnvironmentRequest.getLabel(),
-                removeEnvironmentRequest.getProjectLabel(),
-                user
-        );
-
+        try {
+            CONTENT_MGR.removeEnvironment(
+                    removeEnvironmentRequest.getLabel(),
+                    removeEnvironmentRequest.getProjectLabel(),
+                    user
+            );
+        }
+        catch (ContentManagementException e) {
+            return json(GSON, res, HttpStatus.SC_BAD_REQUEST,
+                    ResultJson.error(e.getMessage()));
+        }
         return ControllerApiUtils.fullProjectJsonResponse(res, removeEnvironmentRequest.getProjectLabel(), user);
     }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Fix not being able to delete CLM environment if there are custom child
+  channels that where not built by the environment (bsc#1206932)
 - Makes systems column sortable on relevant patch page, to list by most affected systems
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Display an error message when trying to delete a CLM environment if there are custom child channels not built through the environment.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: **Bugfix**

- [x] **DONE**

## Test coverage

- No tests: existing tests adapted

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/20091

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
