### PR TITLE
add ptfutils with removed state

### DIFF
--- a/susemanager-utils/susemanager-sls/src/states/ptfutils.py
+++ b/susemanager-utils/susemanager-sls/src/states/ptfutils.py
@@ -1,0 +1,125 @@
+"""
+PTF Utility states
+"""
+
+from salt.exceptions import CommandExecutionError
+from salt.states.pkg import _find_remove_targets
+
+__virtualname__ = 'ptfutils'
+
+
+def __virtual__():
+    '''
+    This module is always enabled when 'pkg.removeptf' is available.
+    '''
+    if 'pkg.removeptf' in __salt__:
+        return __virtualname__
+    return (False, "Removing PTFs not supported by execution module")
+
+
+def removed(name, pkgs=None, **kwargs):
+    '''
+    Verify that a ptf package is not installed, calling ``pkg.removeptf`` if necessary
+    to remove the packages.
+    It will install the latest normal package versions available in the repositories
+
+    name
+        The name of the package to be removed.
+
+    Multiple Package Options:
+
+    pkgs
+        A list of ptf packages to remove. Must be passed as a python list. The
+        ``name`` parameter will be ignored if this option is passed.
+
+    '''
+    action = "remove"
+    try:
+        pkg_params = __salt__["pkg_resource.parse_targets"](
+            name, pkgs, normalize=True
+        )[0]
+    except MinionError as exc:
+        return {
+            "name": name,
+            "changes": {},
+            "result": False,
+            "comment": "An error was encountered while parsing targets: {}".format(exc),
+        }
+    targets = _find_remove_targets(
+        name, version, pkgs, normalize, ignore_epoch=ignore_epoch, **kwargs
+    )
+    if isinstance(targets, dict) and "result" in targets:
+        return targets
+    elif not isinstance(targets, list):
+        return {
+            "name": name,
+            "changes": {},
+            "result": False,
+            "comment": "An error was encountered while checking targets: {}".format(
+                targets
+            ),
+        }
+    targets.sort()
+
+    if not targets:
+        return {
+            "name": name,
+            "changes": {},
+            "result": True,
+            "comment": "None of the targeted packages are installed",
+        }
+
+    if __opts__["test"]:
+
+        _changes = {}
+        _changes.update({x: {"new": "{}d".format(action), "old": ""} for x in targets})
+
+        return {
+            "name": name,
+            "changes": _changes,
+            "result": None,
+            "comment": "The following ptf packages will be {}d: {}.".format(
+                action, ", ".join(targets)
+            ),
+        }
+
+    changes = __salt__["pkg.removeptf"](name, pkgs=pkgs, **kwargs)
+    new = __salt__["pkg.list_pkgs"](versions_as_list=True, **kwargs)
+    failed = []
+    for param in pkg_params:
+        if param in new:
+            failed.append(param)
+
+    failed.sort()
+
+    if failed:
+        return {
+            "name": name,
+            "changes": changes,
+            "result": False,
+            "comment": "The following packages failed to {}: {}.".format(
+                action, ", ".join(failed)
+            ),
+        }
+
+    comments = []
+    not_installed = sorted([x for x in pkg_params if x not in targets])
+    if not_installed:
+        comments.append(
+            "The following packages were not installed: {}".format(
+                ", ".join(not_installed)
+            )
+        )
+        comments.append(
+            "The following packages were {}d: {}.".format(action, ", ".join(targets))
+        )
+    else:
+        comments.append("All targeted packages were {}d.".format(action))
+
+    return {
+        "name": name,
+        "changes": changes,
+        "result": True,
+        "comment": " ".join(comments),
+    }
+


### PR DESCRIPTION
## What does this PR change?

PTF handling for project lotus require a special handling when we want to remove a ptf.
This is supported by a special zypper command.
salt will get an enhancement to provide a new function in the zypper execution module.
This is a state which make use of it to remove ptf packages and replace the referenced packages with the latest available update

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
