### PR TITLE
Use a volume to cache obs-to-maven parsed primary.xml data

### DIFF
--- a/susemanager-utils/testing/automation/java-checkstyle.sh
+++ b/susemanager-utils/testing/automation/java-checkstyle.sh
@@ -41,5 +41,6 @@ CHOWN_CMD="/manager/susemanager-utils/testing/automation/chown-objects.sh $(id -
 
 docker pull $REGISTRY/$PGSQL_CONTAINER
 docker run --privileged --rm=true -v "$GITROOT:/manager" \
+    -v "${HOME}/.obs-to-maven-cache:/manager/java/.obs-to-maven-cache" \
     $REGISTRY/$PGSQL_CONTAINER \
     /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CHOWN_CMD} && exit \${RET}"

--- a/susemanager-utils/testing/automation/java-unittests-pgsql.sh
+++ b/susemanager-utils/testing/automation/java-unittests-pgsql.sh
@@ -54,5 +54,6 @@ CHOWN_CMD="/manager/susemanager-utils/testing/automation/chown-objects.sh $(id -
 
 $EXECUTOR pull $REGISTRY/$PGSQL_CONTAINER
 $EXECUTOR run --privileged --rm=true -v "$GITROOT:/manager" \
+    -v "${HOME}/.obs-to-maven-cache:/manager/java/.obs-to-maven-cache" \
     $REGISTRY/$PGSQL_CONTAINER \
     /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CHOWN_CMD} && exit \${RET}"


### PR DESCRIPTION
## What does this PR change?

Use a volume to cache the obs-to-maven data in CI.

## GUI diff

No difference.

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
