### PR TITLE
QE: Update copyright headers and add missing one

### DIFF
--- a/testsuite/features/build_validation/core/allcli_sanity.feature
+++ b/testsuite/features/build_validation/core/allcli_sanity.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022 SUSE LLC
+# Copyright (c) 2019-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Sanity checks

--- a/testsuite/features/build_validation/create_bootstrap_repositories/srv_create_bootstrap_repositories.feature
+++ b/testsuite/features/build_validation/create_bootstrap_repositories/srv_create_bootstrap_repositories.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 SUSE LLC
+# Copyright (c) 2021-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Create bootstrap repositories

--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 SUSE LLC
+# Copyright 2017-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Synchronize products in the products page of the Setup Wizard

--- a/testsuite/features/core/proxy_branch_network.feature
+++ b/testsuite/features/core/proxy_branch_network.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022 SUSE LLC
+# Copyright (c) 2018-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # The scenarios in this feature are skipped if there is no proxy

--- a/testsuite/features/core/srv_create_activationkey.feature
+++ b/testsuite/features/core/srv_create_activationkey.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2022 SUSE LLC
+# Copyright (c) 2010-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Create activation keys

--- a/testsuite/features/init_clients/allcli_update_activationkeys.feature
+++ b/testsuite/features/init_clients/allcli_update_activationkeys.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 SUSE LLC
+# Copyright (c) 2022-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Update activation keys

--- a/testsuite/features/init_clients/min_virthost.feature
+++ b/testsuite/features/init_clients/min_virthost.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 SUSE LLC
+# Copyright (c) 2022-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 # This feature is not idempotent, we leave the system registered in order to have the history of events available

--- a/testsuite/features/init_clients/srv_check_reposync.feature
+++ b/testsuite/features/init_clients/srv_check_reposync.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022 SUSE LLC
+# Copyright (c) 2020-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Reposync works as expected

--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022 SUSE LLC
+# Copyright (c) 2018-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature relies on having properly configured

--- a/testsuite/features/secondary/min_activationkey.feature
+++ b/testsuite/features/secondary/min_activationkey.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022 SUSE LLC
+# Copyright (c) 2018-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_onboarding

--- a/testsuite/features/secondary/min_bootstrap_reactivation.feature
+++ b/testsuite/features/secondary/min_bootstrap_reactivation.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 SUSE LLC
+# Copyright (c) 2021-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle_minion

--- a/testsuite/features/secondary/min_salt_mgrcompat_state.feature
+++ b/testsuite/features/secondary/min_salt_mgrcompat_state.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2022 SUSE LLC.
+# Copyright (c) 2015-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 @sle_minion

--- a/testsuite/features/secondary/min_salt_minions_page.feature
+++ b/testsuite/features/secondary/min_salt_minions_page.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2022 SUSE LLC
+# Copyright (c) 2015-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_salt

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022 SUSE LLC
+# Copyright (c) 2018-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # Idempotency note:

--- a/testsuite/features/secondary/srv_advanced_search.feature
+++ b/testsuite/features/secondary/srv_advanced_search.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 SUSE LLC.
+# Copyright (c) 2022-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 @scope_spacewalk_utils

--- a/testsuite/features/secondary/srv_manage_activationkey.feature
+++ b/testsuite/features/secondary/srv_manage_activationkey.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2021 SUSE LLC
+# Copyright (c) 2010-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Manipulate activation keys

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2022 SUSE LLC.
+# Copyright (c) 2014-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'timeout'

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2022 SUSE LLC.
+# Copyright (c) 2010-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'jwt'

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2022 SUSE LLC.
+# Copyright (c) 2010-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 #

--- a/testsuite/features/step_definitions/security_steps.rb
+++ b/testsuite/features/step_definitions/security_steps.rb
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 SUSE LLC.
+# Copyright 2017-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'open-uri'

--- a/testsuite/features/step_definitions/security_steps.rb
+++ b/testsuite/features/step_definitions/security_steps.rb
@@ -1,3 +1,6 @@
+# Copyright 2017-2022 SUSE LLC.
+# Licensed under the terms of the MIT license.
+
 require 'open-uri'
 require 'uri'
 require 'openssl'

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022 SUSE LLC
+# Copyright (c) 2019-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 ADDRESSES = { 'network'           => '0',

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2022 SUSE LLC
+# Copyright (c) 2010-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 require 'English'

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2022 SUSE LLC.
+# Copyright (c) 2016-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'require_all'


### PR DESCRIPTION
## What does this PR change?

Update the copyright headers of files we already edited this year.
Also, `security_steps.rb` was missing a copyright header. This adds it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: Only comments edited

- [x] **DONE**

## Links

Manager-4.3: https://github.com/SUSE/spacewalk/pull/20135
Manager-4.2: https://github.com/SUSE/spacewalk/pull/20136

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
