### PR TITLE
Add python-dateutil dependency

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,5 @@
+- Add python-dateutil dependency, required to process date values in
+  spacecmd api calls
 - Remove python3-simplejson dependency
 
 -------------------------------------------------------------------

--- a/spacecmd/spacecmd.spec
+++ b/spacecmd/spacecmd.spec
@@ -85,6 +85,7 @@ BuildRequires:  python3-rpm-macros
 %endif
 Requires:       python3
 Requires:       python3-rpm
+Requires:       python3-dateutil
 %else
 BuildRequires:  %{python2prefix}
 %if "%{_vendor}" == "debbuild"
@@ -93,6 +94,7 @@ BuildRequires:  %{python2prefix}-dev
 BuildRequires:  %{python2prefix}-devel
 %endif
 Requires:       %{python2prefix}-simplejson
+Requires:       %{python2prefix}-dateutil
 %if "%{_vendor}" == "debbuild"
 Requires:       python-rpm
 %else


### PR DESCRIPTION
## What does this PR change?

Add python-dateutil dependency for spacecmd.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [X] **DONE**

## Test coverage

- No tests: already covered

- [X] **DONE**

## Links

Fixes #6217


- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
