### PR TITLE
Add Doc headers in all the Class and Module methods

### DIFF
--- a/testsuite/features/support/api_test.rb
+++ b/testsuite/features/support/api_test.rb
@@ -17,6 +17,11 @@ require_relative 'http_client'
 
 # Abstract parent class describing an API test
 class ApiTest
+  ##
+  # It creates a bunch of objects that are used to interact with the API
+  #
+  # Args:
+  #   _host: The hostname of the Spacewalk server.
   def initialize(_host)
     @actionchain = NamespaceActionchain.new(self)
     @activationkey = NamespaceActivationkey.new(self)
@@ -48,6 +53,13 @@ class ApiTest
   attr_reader :token
   attr_writer :token
 
+  ##
+  # It takes a name and a list of parameters, and calls the function with the given name and parameters, and returns the
+  # response
+  #
+  # Args:
+  #   name: The name of the method you want to call.
+  #   *params: The parameters to pass to the API call.
   def call(name, *params)
     thread =
       Thread.new do
@@ -65,16 +77,24 @@ end
 
 # Derived class for an XML-RPC test
 class ApiTestXmlrpc < ApiTest
+  ##
+  # It creates a new instance of the XmlrpcClient class, and assigns it to the @connection instance variable
+  #
+  # Args:
+  #   host: The hostname of the server.
   def initialize(host)
     super
     @connection = XmlrpcClient.new(host)
   end
 
+  ##
   # during XML-RPC tests, dates are XMLRPC::DateTime's
   def date?(attribute)
     attribute.class == XMLRPC::DateTime
   end
 
+  ##
+  # It returns the current date and time as an XMLRPC::DateTime object
   def date_now
     now = Time.now
     XMLRPC::DateTime.new(now.year, now.month, now.day, now.hour, now.min, now.sec)
@@ -83,12 +103,19 @@ end
 
 # Derived class for an HTTP test
 class ApiTestHttp < ApiTest
+  ##
+  # It creates a new instance of the HttpClient class.
+  #
+  # Args:
+  #   host: The hostname of the server.
   def initialize(host)
     super
     @connection = HttpClient.new(host)
   end
 
-  # during HTTP tests, dates are strings
+  ##
+  # XML-RPC uses Date class for dates, while HTTP RPC uses simple strings for dates.
+  # This function provides a string containing a date that can be swallowed by HTTP RPC
   def date?(attribute)
     begin
       ok = true
@@ -99,6 +126,8 @@ class ApiTestHttp < ApiTest
     ok
   end
 
+  ##
+  # It returns a string with the current date and time in the format `YYYY-MM-DDTHH:MM:SS.LLL+HHMM`
   def date_now
     now = Time.now
     now.strftime('%Y-%m-%dT%H:%M:%S.%L%z')

--- a/testsuite/features/support/api_test.rb
+++ b/testsuite/features/support/api_test.rb
@@ -18,7 +18,7 @@ require_relative 'http_client'
 # Abstract parent class describing an API test
 class ApiTest
   ##
-  # It creates objects that are used to interact with the API
+  # Creates objects that are used to interact with the API.
   #
   # Args:
   #   _host: The hostname of the Spacewalk server.
@@ -54,8 +54,7 @@ class ApiTest
   attr_writer :token
 
   ##
-  # It takes a name and a list of parameters, and calls the function with the given name and parameters, and returns the
-  # response
+  # Calls a function with the given name and parameters, and returns its response.
   #
   # Args:
   #   name: The name of the method you want to call.
@@ -78,7 +77,7 @@ end
 # Derived class for an XML-RPC test
 class ApiTestXmlrpc < ApiTest
   ##
-  # It creates a new instance of the XmlrpcClient class, and assigns it to the @connection instance variable
+  # Creates a new instance of the XmlrpcClient class, and assigns it to the @connection instance variable.
   #
   # Args:
   #   host: The hostname of the server.
@@ -94,7 +93,7 @@ class ApiTestXmlrpc < ApiTest
   end
 
   ##
-  # It returns the current date and time as an XMLRPC::DateTime object
+  # Returns the current date and time as an XMLRPC::DateTime object.
   def date_now
     now = Time.now
     XMLRPC::DateTime.new(now.year, now.month, now.day, now.hour, now.min, now.sec)

--- a/testsuite/features/support/api_test.rb
+++ b/testsuite/features/support/api_test.rb
@@ -18,7 +18,7 @@ require_relative 'http_client'
 # Abstract parent class describing an API test
 class ApiTest
   ##
-  # It creates a bunch of objects that are used to interact with the API
+  # It creates objects that are used to interact with the API
   #
   # Args:
   #   _host: The hostname of the Spacewalk server.

--- a/testsuite/features/support/api_test.rb
+++ b/testsuite/features/support/api_test.rb
@@ -87,7 +87,7 @@ class ApiTestXmlrpc < ApiTest
   end
 
   ##
-  # during XML-RPC tests, dates are XMLRPC::DateTime's
+  # Returns a boolean on whether the given attribute is an XMLRPC::DateTime object or not
   def date?(attribute)
     attribute.class == XMLRPC::DateTime
   end
@@ -113,8 +113,8 @@ class ApiTestHttp < ApiTest
   end
 
   ##
-  # XML-RPC uses Date class for dates, while HTTP RPC uses simple strings for dates.
-  # This function provides a string containing a date that can be swallowed by HTTP RPC.
+  # Attempts to parse a given string as a Date object, to validate it.
+  # Returns a boolean on whether it's a string containing a valid Date or not.
   #
   # Args:
   #     attribute: The date object to be parsed.

--- a/testsuite/features/support/api_test.rb
+++ b/testsuite/features/support/api_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 SUSE LLC.
+# Copyright (c) 2022-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require_relative 'namespaces/actionchain'

--- a/testsuite/features/support/api_test.rb
+++ b/testsuite/features/support/api_test.rb
@@ -115,7 +115,10 @@ class ApiTestHttp < ApiTest
 
   ##
   # XML-RPC uses Date class for dates, while HTTP RPC uses simple strings for dates.
-  # This function provides a string containing a date that can be swallowed by HTTP RPC
+  # This function provides a string containing a date that can be swallowed by HTTP RPC.
+  #
+  # Args:
+  #     attribute: The date object to be parsed.
   def date?(attribute)
     begin
       ok = true

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -13,7 +13,7 @@ require 'pp'
 # Class for clobber test
 class CobblerTest
   ##
-  # It creates a new XMLRPC client object, and then checks to see if the server is running
+  # It creates a new XMLRPC::client object, and then checks to see if the server is running
   def initialize
     server_address = ENV['SERVER']
     @server = XMLRPC::Client.new2('http://' + server_address + '/cobbler_api', nil, DEFAULT_TIMEOUT)

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -33,7 +33,7 @@ class CobblerTest
   end
 
   ##
-  # Returns true or false depending on whether the server is running
+  # Returns true or false depending on whether the server is running.
   def running?
     result = true
     begin

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -193,7 +193,7 @@ class CobblerTest
   end
 
   ##
-  # `return get('repo', name, key) if repo_exists(name)`
+  # Gets a key's value from a repository.
   #
   # Args:
   #   name: The name of the repo

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -24,7 +24,7 @@ class CobblerTest
   # It logs into cobbler and returns the token
   #
   # Args:
-  #   user: the username to login with
+  #   user: The username used to log in.
   #   pass: the password for the user
   def login(user, pass)
     @token = @server.call('login', user, pass)

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -69,7 +69,7 @@ class CobblerTest
   #   name: The name of the distribution.
   #   kernel: The path to the kernel file.
   #   initrd: The initrd file for the distribution.
-  #   breed: The type of distribution.  This can be one of the following:. Defaults to suse
+  #   breed: The type of distribution.  This can be one of the following: redhat, debian, suse. Defaults to suse.
   def distro_create(name, kernel, initrd, breed = 'suse')
     begin
       distro_id = @server.call('new_distro', @token)

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -185,7 +185,7 @@ class CobblerTest
   end
 
   ##
-  # > This function checks if a repo exists in the database
+  # Checks if a repository exists in the database by using 'repos' as the table name, 'name' as the column and the name of the repo.
   #
   # Args:
   #   name: The name of the repository.

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -13,7 +13,7 @@ require 'pp'
 # Class for clobber test
 class CobblerTest
   ##
-  # It creates a new XMLRPC::client object, and then checks to see if the server is running
+  # Creates a new XMLRPC::client object, and then checks to see if the server is running.
   def initialize
     server_address = ENV['SERVER']
     @server = XMLRPC::Client.new2('http://' + server_address + '/cobbler_api', nil, DEFAULT_TIMEOUT)

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -167,7 +167,6 @@ class CobblerTest
 
   ##
   # `exists` is a function that takes three arguments: a table name, a column name, and a value. It returns true if the
-  # value exists in the column of the table, and false otherwise
   #
   # Args:
   #   name: The name of the profile.

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2017 SUSE LLC.
+# Copyright (c) 2010-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'xmlrpc/client'

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -166,7 +166,7 @@ class CobblerTest
   end
 
   ##
-  # `exists` is a function that takes three arguments: a table name, a column name, and a value. It returns true if the
+  # Checks if a profile exists in the database by using 'profiles' as the table name, 'name' as the column and the name of the profile.
   #
   # Args:
   #   name: The name of the profile.

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -210,8 +210,8 @@ class CobblerTest
   # It returns true if the value of the key in the hash is equal to the value passed in
   #
   # Args:
-  #   what: the name of the object you want to check for.
-  #   key: the key to check for
+  #   what: The name of the object you want to check for.
+  #   key: The key to check for.
   #   value: The value to check for.
   def exists(what, key, value)
     result = false
@@ -223,12 +223,12 @@ class CobblerTest
   end
 
   ##
-  # It takes a string, a string, and a string, and returns a string
+  # Retrieves an object from the server based on its type, name and key.
   #
   # Args:
-  #   what: the type of object you want to get.  This can be one of the following:
+  #   what: the type of object you want to get. This can be one of the following:
   #   name: The name of the object you want to get the ID of.
-  #   key: the key to look for in the hash
+  #   key: The key to look for in the hash.
   def get(what, name, key)
     result = nil
     ret = @server.call('get_' + what)

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -21,7 +21,7 @@ class CobblerTest
   end
 
   ##
-  # It logs into Cobbler and returns the token
+  # Logs into Cobbler and returns the session token.
   #
   # Args:
   #   user: The username used to log in.

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -113,7 +113,7 @@ class CobblerTest
   end
 
   ##
-  # Create a system, set its name and profile, and save it
+  # Creates a system, sets its name and profile, and saves it.
   # every system needs at least a name and a profile
   #
   # Args:

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -45,7 +45,7 @@ class CobblerTest
   end
 
   ##
-  # It returns a list of the names of the systems, profiles, or distros in the database
+  # Returns a list of the names of the systems, profiles, or distros in the database.
   #
   # Args:
   #   what: The type of list you want to get.  Valid values are:
@@ -63,7 +63,7 @@ class CobblerTest
   end
 
   ##
-  # It creates a new distribution, sets the name, kernel, initrd, and breed, and then saves the distribution
+  # Creates a new distribution with a specific name, kernel, initrd, and breed, and saves it.
   #
   # Args:
   #   name: The name of the distribution.
@@ -85,7 +85,7 @@ class CobblerTest
   end
 
   ##
-  # It creates a new profile, modifies it, and saves it
+  # Creates a new profile, modifies it, and saves it.
   #
   # Args:
   #   name: The name of the profile.
@@ -143,7 +143,7 @@ class CobblerTest
   # Removes a system from the Spacewalk server.
   #
   # The first thing this function does is check to see if the system exists. If it doesn't, it raises an error. If it
-  # does, it calls the remove_system function on the Spacewalk server. If that fails, it raises an error
+  # does, it calls the remove_system function on the Spacewalk server. If that fails, it raises an error.
   #
   # Args:
   #   name: The name of the system to be removed.
@@ -207,7 +207,7 @@ class CobblerTest
   end
 
   ##
-  # It returns true if the value of the key in the hash is equal to the value passed in
+  # Checks if a specific object with a certain key and value exists in the database.
   #
   # Args:
   #   what: The name of the object you want to check for.
@@ -226,7 +226,7 @@ class CobblerTest
   # Retrieves an object from the server based on its type, name and key.
   #
   # Args:
-  #   what: the type of object you want to get. This can be one of the following:
+  #   what: The type of object you want to get. This can be one of the following: # TODO
   #   name: The name of the object you want to get the ID of.
   #   key: The key to look for in the hash.
   def get(what, name, key)

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -21,7 +21,7 @@ class CobblerTest
   end
 
   ##
-  # It logs into cobbler and returns the token
+  # It logs into Cobbler and returns the token
   #
   # Args:
   #   user: The username used to log in.

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -25,7 +25,7 @@ class CobblerTest
   #
   # Args:
   #   user: The username used to log in.
-  #   pass: the password for the user
+  #   pass: The password for the user.
   def login(user, pass)
     @token = @server.call('login', user, pass)
   rescue

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -114,7 +114,7 @@ class CobblerTest
 
   ##
   # Creates a system, sets its name and profile, and saves it.
-  # every system needs at least a name and a profile
+  # Every system needs at least a name and a profile.
   #
   # Args:
   #   name: The name of the system.

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -157,7 +157,7 @@ class CobblerTest
   end
 
   ##
-  # > This function checks if a distro exists in the database
+  # Checks if a distribution exists in the database by using 'distro' as the table name, 'name' as the column and the name of the distro.
   #
   # Args:
   #   name: The name of the distro.

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -140,7 +140,7 @@ class CobblerTest
   end
 
   ##
-  # *This function removes a system from the Spacewalk server.*
+  # Removes a system from the Spacewalk server.
   #
   # The first thing this function does is check to see if the system exists. If it doesn't, it raises an error. If it
   # does, it calls the remove_system function on the Spacewalk server. If that fails, it raises an error

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -212,7 +212,7 @@ class CobblerTest
   # Args:
   #   what: the name of the object you want to check for.
   #   key: the key to check for
-  #   value: The value to check for
+  #   value: The value to check for.
   def exists(what, key, value)
     result = false
     ret = @server.call('get_' + what)

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -176,7 +176,7 @@ class CobblerTest
   end
 
   ##
-  # > This function checks if a system exists in the database
+  # Checks if a system exists in the database by using 'systems' as the table name, 'name' as the column and the name of the system.
   #
   # Args:
   #   name: The name of the system.

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -48,7 +48,10 @@ class CobblerTest
   # It returns a list of the names of the systems, profiles, or distros in the database
   #
   # Args:
-  #   what: the type of list you want to get.  Valid values are:
+  #   what: The type of list you want to get.  Valid values are:
+  #        - systems
+  #        - profiles
+  #        - distros
   def get_list(what)
     result = []
     unless %w[systems profiles distros].include?(what)

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -33,7 +33,7 @@ class CobblerTest
   end
 
   ##
-  # If the server is running, the function will return true. If the server is not running, the function will return false
+  # Returns true or false depending on whether the server is running
   def running?
     result = true
     begin

--- a/testsuite/features/support/custom_formatter.rb
+++ b/testsuite/features/support/custom_formatter.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 SUSE LLC
+# Copyright (c) 2019-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 module CustomFormatter

--- a/testsuite/features/support/custom_formatter.rb
+++ b/testsuite/features/support/custom_formatter.rb
@@ -4,20 +4,42 @@
 module CustomFormatter
   # Extend the Cucumber Pretty Formatter and prepends the feature name on each step
   module PrependsFeatureName
+    # A class method that takes a formatter class as an argument.
     def self.formatter(formatter_class)
       Class.new(formatter_class) { include PrependsFeatureName }
     end
 
+    ##
+    # It takes the feature file name and stores it in a variable called @current_feature_name
+    #
+    # Args:
+    #   feature: The feature object
     def before_feature(feature)
       @current_feature_name = feature.location.file
       super(feature)
     end
 
+    ##
+    # It takes the keyword, prepends the feature name to it, and then calls the super function
+    #
+    # Args:
+    #   keyword: The keyword of the step (Given, When, Then, etc)
+    #   step_match: The step match object
+    #   status: :passed, :failed, :undefined, :skipped, :pending, :exception
+    #   source_indent: The indentation of the step definition
+    #   background: true if the step is in a background
+    #   file_colon_line: "features/step_definitions/my_steps.rb:7"
     def step_name(keyword, step_match, status, source_indent, background, file_colon_line)
       keyword_changed = prepend_feature_name_to(keyword)
       super(keyword_changed, step_match, status, source_indent, background, file_colon_line)
     end
 
+    ##
+    # It takes a string as an argument and returns a new string that is the original string prepended with the current
+    # feature name
+    #
+    # Args:
+    #   text: The text to be prepended with the feature name
     def prepend_feature_name_to(text)
       "[#{@current_feature_name}] #{text}"
     end

--- a/testsuite/features/support/custom_formatter.rb
+++ b/testsuite/features/support/custom_formatter.rb
@@ -24,7 +24,7 @@ module CustomFormatter
     #
     # Args:
     #   keyword: The keyword of the step (Given, When, Then, etc)
-    #   step_match: The step match object
+    #   step_match: The step match object.
     #   status: The status, which can be: passed, failed, undefined, skipped, pending, exception.
     #   source_indent: The indentation of the step definition.
     #   background: Whether the step is running in the background or not.

--- a/testsuite/features/support/custom_formatter.rb
+++ b/testsuite/features/support/custom_formatter.rb
@@ -36,7 +36,6 @@ module CustomFormatter
 
     ##
     # Adds a given text after the feature name.
-    # feature name
     #
     # Args:
     #   text: The text to be prepended with the feature name.

--- a/testsuite/features/support/custom_formatter.rb
+++ b/testsuite/features/support/custom_formatter.rb
@@ -10,7 +10,7 @@ module CustomFormatter
     end
 
     ##
-    # It takes the feature file name and stores it in a variable called @current_feature_name
+    # It takes the feature file name and stores it in a variable called @current_feature_name.
     #
     # Args:
     #   feature: The feature object.
@@ -20,10 +20,10 @@ module CustomFormatter
     end
 
     ##
-    # It takes the keyword, prepends the feature name to it, and then calls the super function
+    # It takes the keyword, prepends the feature name to it, and then calls the super function.
     #
     # Args:
-    #   keyword: The keyword of the step (Given, When, Then, etc)
+    #   keyword: The keyword of the step (Given, When, Then, etc).
     #   step_match: The step match object.
     #   status: The status, which can be: passed, failed, undefined, skipped, pending, exception.
     #   source_indent: The indentation of the step definition.

--- a/testsuite/features/support/custom_formatter.rb
+++ b/testsuite/features/support/custom_formatter.rb
@@ -20,7 +20,7 @@ module CustomFormatter
     end
 
     ##
-    # It takes the keyword, prepends the feature name to it, and then calls the super function.
+    # This method override the step name value by prepending the feature name. This helps to identify each step in the console output when we run features in parallel.
     #
     # Args:
     #   keyword: The keyword of the step (Given, When, Then, etc).

--- a/testsuite/features/support/custom_formatter.rb
+++ b/testsuite/features/support/custom_formatter.rb
@@ -35,7 +35,7 @@ module CustomFormatter
     end
 
     ##
-    # It takes a string as an argument and returns a new string that is the original string prepended with the current
+    # Adds a given text after the feature name.
     # feature name
     #
     # Args:

--- a/testsuite/features/support/custom_formatter.rb
+++ b/testsuite/features/support/custom_formatter.rb
@@ -39,7 +39,7 @@ module CustomFormatter
     # feature name
     #
     # Args:
-    #   text: The text to be prepended with the feature name
+    #   text: The text to be prepended with the feature name.
     def prepend_feature_name_to(text)
       "[#{@current_feature_name}] #{text}"
     end

--- a/testsuite/features/support/custom_formatter.rb
+++ b/testsuite/features/support/custom_formatter.rb
@@ -27,7 +27,7 @@ module CustomFormatter
     #   step_match: The step match object
     #   status: :passed, :failed, :undefined, :skipped, :pending, :exception
     #   source_indent: The indentation of the step definition.
-    #   background: true if the step is in a background
+    #   background: Whether the step is running in the background or not.
     #   file_colon_line: "features/step_definitions/my_steps.rb:7"
     def step_name(keyword, step_match, status, source_indent, background, file_colon_line)
       keyword_changed = prepend_feature_name_to(keyword)

--- a/testsuite/features/support/custom_formatter.rb
+++ b/testsuite/features/support/custom_formatter.rb
@@ -25,7 +25,7 @@ module CustomFormatter
     # Args:
     #   keyword: The keyword of the step (Given, When, Then, etc)
     #   step_match: The step match object
-    #   status: :passed, :failed, :undefined, :skipped, :pending, :exception
+    #   status: The status, which can be: passed, failed, undefined, skipped, pending, exception.
     #   source_indent: The indentation of the step definition.
     #   background: Whether the step is running in the background or not.
     #   file_colon_line: "features/step_definitions/my_steps.rb:7"

--- a/testsuite/features/support/custom_formatter.rb
+++ b/testsuite/features/support/custom_formatter.rb
@@ -13,7 +13,7 @@ module CustomFormatter
     # It takes the feature file name and stores it in a variable called @current_feature_name
     #
     # Args:
-    #   feature: The feature object
+    #   feature: The feature object.
     def before_feature(feature)
       @current_feature_name = feature.location.file
       super(feature)

--- a/testsuite/features/support/custom_formatter.rb
+++ b/testsuite/features/support/custom_formatter.rb
@@ -26,7 +26,7 @@ module CustomFormatter
     #   keyword: The keyword of the step (Given, When, Then, etc)
     #   step_match: The step match object
     #   status: :passed, :failed, :undefined, :skipped, :pending, :exception
-    #   source_indent: The indentation of the step definition
+    #   source_indent: The indentation of the step definition.
     #   background: true if the step is in a background
     #   file_colon_line: "features/step_definitions/my_steps.rb:7"
     def step_name(keyword, step_match, status, source_indent, background, file_colon_line)

--- a/testsuite/features/support/custom_formatter.rb
+++ b/testsuite/features/support/custom_formatter.rb
@@ -24,11 +24,11 @@ module CustomFormatter
     #
     # Args:
     #   keyword: The keyword of the step (Given, When, Then, etc).
-    #   step_match: The step match object.
+    #   step_match: Represents the match found between a Test Step and its activation
     #   status: The status, which can be: passed, failed, undefined, skipped, pending, exception.
-    #   source_indent: The indentation of the step definition.
-    #   background: Whether the step is running in the background or not.
-    #   file_colon_line: "features/step_definitions/my_steps.rb:7"
+    #   source_indent: The source code of the step definition indented
+    #   background: The background object in case this step is part of a background
+    #   file_colon_line: The line number where the step is defined
     def step_name(keyword, step_match, status, source_indent, background, file_colon_line)
       keyword_changed = prepend_feature_name_to(keyword)
       super(keyword_changed, step_match, status, source_indent, background, file_colon_line)

--- a/testsuite/features/support/http_client.rb
+++ b/testsuite/features/support/http_client.rb
@@ -8,7 +8,7 @@ class HttpClient
   ##
   # `@http_client = Faraday.new('https://' + host, request: { timeout: DEFAULT_TIMEOUT })`
   #
-  # This function creates a new HTTP client using the Faraday library
+  # This function creates a new HTTP client using the Faraday library.
   #
   # Args:
   #   host: The hostname of the server you want to connect to.
@@ -19,11 +19,11 @@ class HttpClient
 
   ##
   # It takes a name of a Spacewalk API call and a hash of parameters and returns a tuple of the HTTP method and the URL to
-  # call
+  # call.
   #
   # Args:
   #   name: The name of the API call.
-  #   params: a hash of parameters to pass to the API call.
+  #   params: A hash of parameters to pass to the API call.
   def prepare_call(name, params)
     short_name = name.split('.')[-1]
     call_type =

--- a/testsuite/features/support/http_client.rb
+++ b/testsuite/features/support/http_client.rb
@@ -6,7 +6,6 @@ require 'faraday'
 # Wrapper class for HTTP client library (Faraday)
 class HttpClient
   ##
-  # `@http_client = Faraday.new('https://' + host, request: { timeout: DEFAULT_TIMEOUT })`
   #
   # This function creates a new HTTP client using the Faraday library.
   #
@@ -48,7 +47,7 @@ class HttpClient
   end
 
   ##
-  # It takes a name and a hash of parameters, calls the API, and returns the result
+  # It takes a name and a hash of parameters, calls the API, and returns the result.
   #
   # Args:
   #   name: The name of the API call, e.g. 'auth.login'

--- a/testsuite/features/support/http_client.rb
+++ b/testsuite/features/support/http_client.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 SUSE LLC.
+# Copyright (c) 2022-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'faraday'

--- a/testsuite/features/support/http_client.rb
+++ b/testsuite/features/support/http_client.rb
@@ -5,11 +5,25 @@ require 'faraday'
 
 # Wrapper class for HTTP client library (Faraday)
 class HttpClient
+  ##
+  # `@http_client = Faraday.new('https://' + host, request: { timeout: DEFAULT_TIMEOUT })`
+  #
+  # This function creates a new HTTP client using the Faraday library
+  #
+  # Args:
+  #   host: The hostname of the server you want to connect to.
   def initialize(host)
     puts 'Activating HTTP API'
     @http_client = Faraday.new('https://' + host, request: { timeout: DEFAULT_TIMEOUT })
   end
 
+  ##
+  # It takes a name of a Spacewalk API call and a hash of parameters and returns a tuple of the HTTP method and the URL to
+  # call
+  #
+  # Args:
+  #   name: The name of the API call.
+  #   params: a hash of parameters to pass to the API call.
   def prepare_call(name, params)
     short_name = name.split('.')[-1]
     call_type =
@@ -33,6 +47,12 @@ class HttpClient
     [call_type, url]
   end
 
+  ##
+  # It takes a name and a hash of parameters, calls the API, and returns the result
+  #
+  # Args:
+  #   name: The name of the API call, e.g. 'auth.login'
+  #   params: a hash of parameters to pass to the API call.
   def call(name, params)
     # Get session cookie from previous calls
     if params.nil?

--- a/testsuite/features/support/http_client.rb
+++ b/testsuite/features/support/http_client.rb
@@ -7,7 +7,7 @@ require 'faraday'
 class HttpClient
   ##
   #
-  # This function creates a new HTTP client using the Faraday library.
+  # Creates a new HTTP client using the Faraday library.
   #
   # Args:
   #   host: The hostname of the server you want to connect to.

--- a/testsuite/features/support/http_client.rb
+++ b/testsuite/features/support/http_client.rb
@@ -52,7 +52,7 @@ class HttpClient
   #
   # Args:
   #   name: The name of the API call, e.g. 'auth.login'
-  #   params: a hash of parameters to pass to the API call.
+  #   params: A hash of parameters to pass to the API call.
   def call(name, params)
     # Get session cookie from previous calls
     if params.nil?

--- a/testsuite/features/support/lavanda.rb
+++ b/testsuite/features/support/lavanda.rb
@@ -15,7 +15,7 @@ module LavandaBasic
 
   ##
   # This function takes a fully qualified domain name (FQDN) as an argument and sets the instance variable
-  # @in_full_hostname to the value of the FQDN
+  # @in_full_hostname to the value of the FQDN.
   #
   # Args:
   #   fqdn: The fully qualified domain name of the host.
@@ -51,7 +51,7 @@ module LavandaBasic
   end
 
   ##
-  # It sets the value of the instance variable `@in_public_interface` to the value of the parameter `public_interface`
+  # It sets the value of the instance variable `@in_public_interface` to the value of the parameter `public_interface`.
   #
   # Args:
   #   public_interface: The name of the public interface.
@@ -63,7 +63,7 @@ module LavandaBasic
   # It sets the value of the instance variable @in_os_family to the value of the parameter os_family.
   #
   # Args:
-  #   os_family: The OS family to check against.
+  #   os_family: The OS family to initialize.
   def init_os_family(os_family)
     @in_os_family = os_family
   end
@@ -84,21 +84,21 @@ module LavandaBasic
   end
 
   ##
-  # It raises an exception if the hostname is empty, otherwise it returns the hostname
+  # It raises an exception if the hostname is empty, otherwise it returns the hostname.
   def full_hostname
     raise 'empty hostname, something wrong' if @in_full_hostname.empty?
     @in_full_hostname
   end
 
   ##
-  # It raises an exception if the private_ip is empty, otherwise it returns the private_ip
+  # It raises an exception if the private_ip is empty, otherwise it returns the private_ip.
   def private_ip
     raise 'empty private_ip, something wrong' if @in_private_ip.empty?
     @in_private_ip
   end
 
   ##
-  # It returns the public ip address of the machine.
+  # It returns the public IP address of the machine.
   def public_ip
     raise 'empty public_ip, something wrong' if @in_public_ip.empty?
     @in_public_ip
@@ -133,10 +133,10 @@ module LavandaBasic
   end
 
   ##
-  # It runs a command, and returns the output, error, and exit code
+  # It runs a command, and returns the output, error, and exit code.
   #
   # Args:
-  #   cmd: the command to run
+  #   cmd: The command to run
   def run(cmd, separated_results: false, check_errors: true, timeout: DEFAULT_TIMEOUT, user: 'root', successcodes: [0], buffer_size: 65536, verbose: false)
     if separated_results
       out, err, _lo, _rem, code = test_and_store_results_separately(cmd, user, timeout, buffer_size)
@@ -155,7 +155,7 @@ module LavandaBasic
   end
 
   ##
-  # It runs a command until it succeeds or times out
+  # It runs a command until it succeeds or times out.
   #
   # Args:
   #   cmd: The command to run.
@@ -169,7 +169,7 @@ module LavandaBasic
   end
 
   ##
-  # It runs a command until it fails, or until it times out
+  # It runs a command until it fails, or until it times out.
   #
   # Args:
   #   cmd: The command to run.
@@ -183,7 +183,7 @@ module LavandaBasic
   end
 
   ##
-  # It waits until the process is no longer running
+  # It waits until the process is no longer running.
   #
   # Args:
   #   process: The name of the process to wait for.

--- a/testsuite/features/support/lavanda.rb
+++ b/testsuite/features/support/lavanda.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2020 SUSE LLC.
+# Copyright (c) 2016-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'twopence'

--- a/testsuite/features/support/lavanda.rb
+++ b/testsuite/features/support/lavanda.rb
@@ -13,30 +13,66 @@ module LavandaBasic
     @in_hostname = hostname.strip
   end
 
+  ##
+  # This function takes a fully qualified domain name (FQDN) as an argument and sets the instance variable
+  # @in_full_hostname to the value of the FQDN
+  #
+  # Args:
+  #   fqdn: The fully qualified domain name of the host.
   def init_full_hostname(fqdn)
     @in_full_hostname = fqdn.strip
   end
 
+  ##
+  # It sets the instance variable @in_private_ip to the value of the private_ip parameter.
+  #
+  # Args:
+  #   private_ip: The private IP address of the instance.
   def init_private_ip(private_ip)
     @in_private_ip = private_ip
   end
 
+  ##
+  # It initializes the instance variable @in_public_ip to the value of the argument public_ip.
+  #
+  # Args:
+  #   public_ip: The public IP address of the server.
   def init_public_ip(public_ip)
     @in_public_ip = public_ip
   end
 
+  ##
+  # It sets the instance variable @in_private_interface to the value of the private_interface parameter.
+  #
+  # Args:
+  #   private_interface: A boolean value that indicates whether the interface is private or not.
   def init_private_interface(private_interface)
     @in_private_interface = private_interface
   end
 
+  ##
+  # It sets the value of the instance variable `@in_public_interface` to the value of the parameter `public_interface`
+  #
+  # Args:
+  #   public_interface: The name of the public interface.
   def init_public_interface(public_interface)
     @in_public_interface = public_interface
   end
 
+  ##
+  # It sets the value of the instance variable @in_os_family to the value of the parameter os_family.
+  #
+  # Args:
+  #   os_family: The OS family to check against.
   def init_os_family(os_family)
     @in_os_family = os_family
   end
 
+  ##
+  # It initializes the variable @in_os_version to the value of the parameter os_version.
+  #
+  # Args:
+  #   os_version: The version of the operating system.
   def init_os_version(os_version)
     @in_os_version = os_version
   end
@@ -47,42 +83,60 @@ module LavandaBasic
     @in_hostname
   end
 
+  ##
+  # It raises an exception if the hostname is empty, otherwise it returns the hostname
   def full_hostname
     raise 'empty hostname, something wrong' if @in_full_hostname.empty?
     @in_full_hostname
   end
 
+  ##
+  # It raises an exception if the private_ip is empty, otherwise it returns the private_ip
   def private_ip
     raise 'empty private_ip, something wrong' if @in_private_ip.empty?
     @in_private_ip
   end
 
+  ##
+  # It returns the public ip address of the machine.
   def public_ip
     raise 'empty public_ip, something wrong' if @in_public_ip.empty?
     @in_public_ip
   end
 
+  ##
+  # It raises an error if the private interface is empty
   def private_interface
     raise 'empty private_interface, something wrong' if @in_private_interface.empty?
     @in_private_interface
   end
 
+  ##
+  # It raises an error if the public interface is empty
   def public_interface
     raise 'empty public_interface, something wrong' if @in_public_interface.empty?
     @in_public_interface
   end
 
+  ##
+  # It raises an exception if the `@in_os_family` variable is empty
   def os_family
     raise 'empty os_family, something wrong' if @in_os_family.empty?
     @in_os_family
   end
 
+  ##
+  # It raises an error if the os_version is empty.
   def os_version
     raise 'empty os_version, something wrong' if @in_os_version.empty?
     @in_os_version
   end
 
-  # run functions
+  ##
+  # It runs a command, and returns the output, error, and exit code
+  #
+  # Args:
+  #   cmd: the command to run
   def run(cmd, separated_results: false, check_errors: true, timeout: DEFAULT_TIMEOUT, user: 'root', successcodes: [0], buffer_size: 65536, verbose: false)
     if separated_results
       out, err, _lo, _rem, code = test_and_store_results_separately(cmd, user, timeout, buffer_size)
@@ -100,8 +154,12 @@ module LavandaBasic
     end
   end
 
+  ##
+  # It runs a command until it succeeds or times out
+  #
+  # Args:
+  #   cmd: The command to run.
   def run_until_ok(cmd)
-    result = nil
     repeat_until_timeout(report_result: true) do
       result, code = run(cmd, check_errors: false)
       break if code.zero?
@@ -110,8 +168,12 @@ module LavandaBasic
     end
   end
 
+  ##
+  # It runs a command until it fails, or until it times out
+  #
+  # Args:
+  #   cmd: The command to run.
   def run_until_fail(cmd)
-    result = nil
     repeat_until_timeout(report_result: true) do
       result, code = run(cmd, check_errors: false)
       break if code.nonzero?
@@ -120,8 +182,12 @@ module LavandaBasic
     end
   end
 
+  ##
+  # It waits until the process is no longer running
+  #
+  # Args:
+  #   process: The name of the process to wait for.
   def wait_while_process_running(process)
-    result = nil
     repeat_until_timeout(report_result: true) do
       result, code = run("pgrep -x #{process} >/dev/null", check_errors: false)
       break if code.nonzero?

--- a/testsuite/features/support/lavanda.rb
+++ b/testsuite/features/support/lavanda.rb
@@ -105,28 +105,28 @@ module LavandaBasic
   end
 
   ##
-  # It raises an error if the private interface is empty
+  # Verifies the private interface instance variable. Raises an error if it's empty.
   def private_interface
     raise 'empty private_interface, something wrong' if @in_private_interface.empty?
     @in_private_interface
   end
 
   ##
-  # It raises an error if the public interface is empty
+  # Verifies the public interface instance variable. Raises an error if it's empty.
   def public_interface
     raise 'empty public_interface, something wrong' if @in_public_interface.empty?
     @in_public_interface
   end
 
   ##
-  # It raises an exception if the `@in_os_family` variable is empty
+  # Verifies the os_family instance variable. Raises an error if it's empty.
   def os_family
     raise 'empty os_family, something wrong' if @in_os_family.empty?
     @in_os_family
   end
 
   ##
-  # It raises an error if the os_version is empty.
+  # Verifies the os_version instance variable. Raises an error if it's empty.
   def os_version
     raise 'empty os_version, something wrong' if @in_os_version.empty?
     @in_os_version
@@ -136,7 +136,14 @@ module LavandaBasic
   # It runs a command, and returns the output, error, and exit code.
   #
   # Args:
-  #   cmd: The command to run
+  #   cmd: The command to run.
+  #   separated_results: Whether the results should be stored separately. Defaults to false.
+  #   check_errors: Whether to check for errors or not. Defaults to true.
+  #   timeout: The timeout to be used, in seconds. Defaults to 250 or the value of the DEFAULT_TIMEOUT environment variable.
+  #   user: The user to be used to run the command. Defaults to root.
+  #   successcodes: An array with the values to be accepted as success codes from the command run.
+  #   buffer_size: The maximum buffer size in bytes. Defaults to 65536.
+  #   verbose: Whether to log the output of the command in case of success. Defaults to false.
   def run(cmd, separated_results: false, check_errors: true, timeout: DEFAULT_TIMEOUT, user: 'root', successcodes: [0], buffer_size: 65536, verbose: false)
     if separated_results
       out, err, _lo, _rem, code = test_and_store_results_separately(cmd, user, timeout, buffer_size)

--- a/testsuite/features/support/namespaces/actionchain.rb
+++ b/testsuite/features/support/namespaces/actionchain.rb
@@ -13,13 +13,13 @@ class NamespaceActionchain
   end
 
   ##
-  # > This function returns a list of all the action chains in the account
+  # This function returns a list of all the action chains in the account
   def list_chains
     @test.call('actionchain.listChains', sessionKey: @test.token).map { |x| x['label'] }
   end
 
   ##
-  # This function creates a new action chain with the label specified in the function call
+  # This function creates a new action chain with the label specified in the function call.
   #
   # Args:
   #   label: The name of the chain you want to create.
@@ -28,7 +28,7 @@ class NamespaceActionchain
   end
 
   ##
-  # > This function deletes a chain with the label specified in the function call
+  # This function deletes a chain with the label specified in the function call
   #
   # Args:
   #   label: The label of the chain you want to delete.
@@ -37,7 +37,7 @@ class NamespaceActionchain
   end
 
   ##
-  # This function removes an action from an action chain
+  # This function removes an action from an action chain.
   #
   # Args:
   #   label: The label of the action chain you want to remove an action from.
@@ -47,17 +47,17 @@ class NamespaceActionchain
   end
 
   ##
-  # Rename a chain
+  # Renames an action chain.
   #
   # Args:
-  #   old_label: The label of the chain you want to rename.
-  #   new_label: The new name of the chain.
+  #   old_label: The name of the action chain you want to rename.
+  #   new_label: The new name of the action chain.
   def rename_chain(old_label, new_label)
     @test.call('actionchain.renameChain', sessionKey: @test.token, previousLabel: old_label, newLabel: new_label)
   end
 
   ##
-  # This function adds a script run action to the action chain
+  # This function adds a script run action to the action chain.
   #
   # Args:
   #   system: The system ID of the system you want to run the action chain on.
@@ -71,7 +71,7 @@ class NamespaceActionchain
   end
 
   ##
-  # > This function lists all the actions in a given chain
+  # This function lists all the actions in a given chain
   #
   # Args:
   #   label: The label of the chain you want to list the actions for.
@@ -80,7 +80,7 @@ class NamespaceActionchain
   end
 
   ##
-  # This function adds a system reboot action to the action chain
+  # This function adds a system reboot action to the action chain.
   #
   # Args:
   #   system: The system ID of the system you want to reboot.
@@ -90,7 +90,7 @@ class NamespaceActionchain
   end
 
   ##
-  # Adds a package install action to the action chain for the given system
+  # Adds a package install action to the action chain for the given system.
   #
   # Args:
   #   system: The system ID of the system you want to add the package to.
@@ -101,7 +101,7 @@ class NamespaceActionchain
   end
 
   ##
-  # This function adds a package upgrade action to the action chain
+  # This function adds a package upgrade action to the action chain.
   #
   # Args:
   #   system: The system ID of the system you want to upgrade.
@@ -112,7 +112,7 @@ class NamespaceActionchain
   end
 
   ##
-  # This function adds a package verify action to the action chain
+  # This function adds a package verify action to the action chain.
   #
   # Args:
   #   system: The system ID of the system you want to add the package to.
@@ -123,7 +123,7 @@ class NamespaceActionchain
   end
 
   ##
-  # This function adds a package removal action to the action chain for the specified system
+  # This function adds a package removal action to the action chain for the specified system.
   #
   # Args:
   #   system: The ID of the system you want to add the package removal to.
@@ -134,7 +134,7 @@ class NamespaceActionchain
   end
 
   ##
-  # > Schedule a chain to run at a specific time
+  # Schedule a chain to run at a specific time.
   #
   # Args:
   #   label: The label of the chain you want to schedule.

--- a/testsuite/features/support/namespaces/actionchain.rb
+++ b/testsuite/features/support/namespaces/actionchain.rb
@@ -80,7 +80,7 @@ class NamespaceActionchain
   end
 
   ##
-  # This function adds a system reboot action to the action chain.
+  # Adds a system reboot action to the action chain.
   #
   # Args:
   #   system: The system ID of the system you want to reboot.

--- a/testsuite/features/support/namespaces/actionchain.rb
+++ b/testsuite/features/support/namespaces/actionchain.rb
@@ -134,7 +134,7 @@ class NamespaceActionchain
   end
 
   ##
-  # Schedule a chain to run at a specific time.
+  # Schedules a chain to run at a specific time.
   #
   # Args:
   #   label: The label of the chain you want to schedule.

--- a/testsuite/features/support/namespaces/actionchain.rb
+++ b/testsuite/features/support/namespaces/actionchain.rb
@@ -112,7 +112,7 @@ class NamespaceActionchain
   end
 
   ##
-  # This function adds a package verify action to the action chain.
+  # Adds a package verify action to the action chain.
   #
   # Args:
   #   system: The system ID of the system you want to add the package to.

--- a/testsuite/features/support/namespaces/actionchain.rb
+++ b/testsuite/features/support/namespaces/actionchain.rb
@@ -1,7 +1,7 @@
-# Copyright (c) 2022 SUSE LLC.
+# Copyright (c) 2022-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
-# "actionchain" namespace
+# Action Chain namespace
 class NamespaceActionchain
   ##
   # It initializes the api_test variable.

--- a/testsuite/features/support/namespaces/actionchain.rb
+++ b/testsuite/features/support/namespaces/actionchain.rb
@@ -13,13 +13,13 @@ class NamespaceActionchain
   end
 
   ##
-  # This function returns a list of all the action chains in the account
+  # Returns a list of all the action chains in the account.
   def list_chains
     @test.call('actionchain.listChains', sessionKey: @test.token).map { |x| x['label'] }
   end
 
   ##
-  # This function creates a new action chain with the label specified in the function call.
+  # Creates a new action chain with the given label.
   #
   # Args:
   #   label: The name of the chain you want to create.
@@ -28,7 +28,7 @@ class NamespaceActionchain
   end
 
   ##
-  # This function deletes a chain with the label specified in the function call
+  # Deletes an action chain with the specified label.
   #
   # Args:
   #   label: The label of the chain you want to delete.
@@ -37,7 +37,7 @@ class NamespaceActionchain
   end
 
   ##
-  # This function removes an action from an action chain.
+  # Removes an action from an action chain.
   #
   # Args:
   #   label: The label of the action chain you want to remove an action from.
@@ -57,7 +57,7 @@ class NamespaceActionchain
   end
 
   ##
-  # This function adds a script run action to the action chain.
+  # Adds a script run action to the action chain.
   #
   # Args:
   #   system: The system ID of the system you want to run the action chain on.
@@ -123,7 +123,7 @@ class NamespaceActionchain
   end
 
   ##
-  # This function adds a package removal action to the action chain for the specified system.
+  # Adds a package removal action to the action chain for the specified system.
   #
   # Args:
   #   system: The ID of the system you want to add the package removal to.

--- a/testsuite/features/support/namespaces/actionchain.rb
+++ b/testsuite/features/support/namespaces/actionchain.rb
@@ -101,7 +101,7 @@ class NamespaceActionchain
   end
 
   ##
-  # This function adds a package upgrade action to the action chain.
+  # Adds a package upgrade action to the action chain.
   #
   # Args:
   #   system: The system ID of the system you want to upgrade.

--- a/testsuite/features/support/namespaces/actionchain.rb
+++ b/testsuite/features/support/namespaces/actionchain.rb
@@ -71,7 +71,7 @@ class NamespaceActionchain
   end
 
   ##
-  # This function lists all the actions in a given chain
+  # Lists all the actions in a given chain.
   #
   # Args:
   #   label: The label of the chain you want to list the actions for.

--- a/testsuite/features/support/namespaces/actionchain.rb
+++ b/testsuite/features/support/namespaces/actionchain.rb
@@ -3,58 +3,142 @@
 
 # "actionchain" namespace
 class NamespaceActionchain
+  ##
+  # It initializes the api_test variable.
+  #
+  # Args:
+  #   api_test: This is the test object that is passed to the initialize method.
   def initialize(api_test)
     @test = api_test
   end
 
+  ##
+  # > This function returns a list of all the action chains in the account
   def list_chains
     @test.call('actionchain.listChains', sessionKey: @test.token).map { |x| x['label'] }
   end
 
+  ##
+  # This function creates a new action chain with the label specified in the function call
+  #
+  # Args:
+  #   label: The name of the chain you want to create.
   def create_chain(label)
     @test.call('actionchain.createChain', sessionKey: @test.token, chainLabel: label)
   end
 
+  ##
+  # > This function deletes a chain with the label specified in the function call
+  #
+  # Args:
+  #   label: The label of the chain you want to delete.
   def delete_chain(label)
     @test.call('actionchain.deleteChain', sessionKey: @test.token, chainLabel: label)
   end
 
+  ##
+  # This function removes an action from an action chain
+  #
+  # Args:
+  #   label: The label of the action chain you want to remove an action from.
+  #   action_id: The ID of the action to remove.
   def remove_action(label, action_id)
     @test.call('actionchain.removeAction', sessionKey: @test.token, chainLabel: label, actionId: action_id)
   end
 
+  ##
+  # Rename a chain
+  #
+  # Args:
+  #   old_label: The label of the chain you want to rename.
+  #   new_label: The new name of the chain.
   def rename_chain(old_label, new_label)
     @test.call('actionchain.renameChain', sessionKey: @test.token, previousLabel: old_label, newLabel: new_label)
   end
 
+  ##
+  # This function adds a script run action to the action chain
+  #
+  # Args:
+  #   system: The system ID of the system you want to run the action chain on.
+  #   label: The label of the action chain.
+  #   uid: The user ID to run the script as.
+  #   gid: The group ID of the user that will run the script.
+  #   timeout: The number of seconds to wait for the script to complete.
+  #   script: The script to run.
   def add_script_run(system, label, uid, gid, timeout, script)
     @test.call('actionchain.addScriptRun', sessionKey: @test.token, sid: system, chainLabel: label, uid: uid, gid: gid, timeout: timeout, scriptBody: Base64.strict_encode64(script))
   end
 
+  ##
+  # > This function lists all the actions in a given chain
+  #
+  # Args:
+  #   label: The label of the chain you want to list the actions for.
   def list_chain_actions(label)
     @test.call('actionchain.listChainActions', sessionKey: @test.token, chainLabel: label)
   end
 
+  ##
+  # This function adds a system reboot action to the action chain
+  #
+  # Args:
+  #   system: The system ID of the system you want to reboot.
+  #   label: The label of the action chain to add the action to.
   def add_system_reboot(system, label)
     @test.call('actionchain.addSystemReboot', sessionKey: @test.token, sid: system, chainLabel: label)
   end
 
+  ##
+  # Adds a package install action to the action chain for the given system
+  #
+  # Args:
+  #   system: The system ID of the system you want to add the package to.
+  #   packages: This is an array of package IDs. You can get these IDs by running the following command:
+  #   label: This is the name of the action chain.
   def add_package_install(system, packages, label)
     @test.call('actionchain.addPackageInstall', sessionKey: @test.token, sid: system, packageIds: packages, chainLabel: label)
   end
 
+  ##
+  # This function adds a package upgrade action to the action chain
+  #
+  # Args:
+  #   system: The system ID of the system you want to upgrade.
+  #   packages: This is an array of package IDs.
+  #   label: The name of the action chain.
   def add_package_upgrade(system, packages, label)
     @test.call('actionchain.addPackageUpgrade', sessionKey: @test.token, sid: system, packageIds: packages, chainLabel: label)
   end
 
+  ##
+  # This function adds a package verify action to the action chain
+  #
+  # Args:
+  #   system: The system ID of the system you want to add the package to.
+  #   packages: This is the package ID of the package you want to add to the action chain.
+  #   label: The label of the action chain.
   def add_package_verify(system, packages, label)
     @test.call('actionchain.addPackageVerify', sessionKey: @test.token, sid: system, packageIds: packages, chainLabel: label)
   end
 
+  ##
+  # This function adds a package removal action to the action chain for the specified system
+  #
+  # Args:
+  #   system: The ID of the system you want to add the package removal to.
+  #   packages: The package ID of the package you want to remove.
+  #   label: The label for the action chain.
   def add_package_removal(system, packages, label)
     @test.call('actionchain.addPackageRemoval', sessionKey: @test.token, sid: system, packageIds: packages, chainLabel: label)
   end
 
+  ##
+  # > Schedule a chain to run at a specific time
+  #
+  # Args:
+  #   label: The label of the chain you want to schedule.
+  #   earliest: The earliest time to run the chain.
   def schedule_chain(label, earliest)
     @test.call('actionchain.scheduleChain', sessionKey: @test.token, chainLabel: label, date: earliest)
   end

--- a/testsuite/features/support/namespaces/activationkey.rb
+++ b/testsuite/features/support/namespaces/activationkey.rb
@@ -63,10 +63,10 @@ class NamespaceActivationkey
   end
 
   ##
-  # It returns the id of the user.
+  # Verifies if the ID of the user is valid and active.
   #
   # Args:
-  #   id: The id of the user to verify.
+  #   id: The ID of the user to verify.
   def verify(id)
     @test.call('activationkey.listActivationKeys', sessionKey: @test.token)
          .map { |key| key['key'] }
@@ -74,41 +74,41 @@ class NamespaceActivationkey
   end
 
   ##
-  # It adds config channels to a system.
+  # Adds configuration channels to a system.
   #
   # Args:
-  #   id: The id of the system to add the config channels to.
+  #   id: The ID of the system to add the config channels to.
   #   config_channels: A list of config channels to add to the system.
   def add_config_channels(id, config_channels)
     @test.call('activationkey.addConfigChannels', sessionKey: @test.token, keys: id, configChannelLabels: config_channels, addToTop: false)
   end
 
   ##
-  # It adds child channels to a channel.
+  # Adds child channels to a channel.
   #
   # Args:
-  #   id: The id of the channel you want to add child channels to.
-  #   child_channels: An array of channel ids that you want to add to the parent channel.
+  #   id: The ID of the channel you want to add child channels to.
+  #   child_channels: An array of channel IDs that you want to add to the parent channel.
   def add_child_channels(id, child_channels)
     @test.call('activationkey.addChildChannels', sessionKey: @test.token, key: id, childChannelLabels: child_channels)
   end
 
   ##
-  # It returns the details of the user with the given id.
+  # Returns the details of the user with the given ID.
   #
   # Args:
-  #   id: The id of the user you want to get details for.
+  #   id: The ID of the user you want to get details for.
   def get_details(id)
     @test.call('activationkey.getDetails', sessionKey: @test.token, key: id)
   end
 
   ##
-  # It sets the details of a channel.
+  # Sets the details of a channel, such as its description, base channel, usage limit and contact method.
   #
   # Args:
-  #   id: The id of the subscription.
-  #   description: A description of the subscription.
-  #   base_channel_label: The base channel label of the channel you want to subscribe to.
+  #   id: The ID of the channel.
+  #   description: A description of the channel.
+  #   base_channel_label: The label of the base channel you want to subscribe to.
   #   usage_limit: The number of times this key can be used.
   #   contact_method:
   def set_details(id, description, base_channel_label, usage_limit, contact_method)

--- a/testsuite/features/support/namespaces/activationkey.rb
+++ b/testsuite/features/support/namespaces/activationkey.rb
@@ -43,20 +43,20 @@ class NamespaceActivationkey
   end
 
   ##
-  # It returns the number of activated systems for a given user.
+  # Returns the number of activated systems for a given user.
   #
   # Args:
-  #   id: The id of the user
+  #   id: The ID of the user.
   def get_activated_systems_count(id)
     systems = @test.call('activationkey.listActivatedSystems', sessionKey: @test.token, key: id)
     systems.nil? ? 0 : systems.length
   end
 
   ##
-  # It returns the number of channels in the configuration with the given id.
+  # Returns the number of channels in the configuration with the given ID.
   #
   # Args:
-  #   id: The id of the configuration.
+  #   id: The ID of the configuration.
   def get_config_channels_count(id)
     channels = @test.call('activationkey.listConfigChannels', sessionKey: @test.token, key: id)
     channels.nil? ? 0 : channels.length

--- a/testsuite/features/support/namespaces/activationkey.rb
+++ b/testsuite/features/support/namespaces/activationkey.rb
@@ -1,7 +1,7 @@
-# Copyright (c) 2022 SUSE LLC.
+# Copyright (c) 2022-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
-# "activationkey" namespace
+# Activation Key namespace
 class NamespaceActivationkey
   ##
   # It initializes the function.
@@ -17,8 +17,8 @@ class NamespaceActivationkey
   # It creates an activation key.
   #
   # Args:
-  #   id: The name of the activation key
-  #   descr: The description of the activation key
+  #   id: The name of the activation key.
+  #   descr: The description of the activation key.
   #   base_channel: The channel you want to use as the base for the activation key.
   #   limit: The number of systems that can be registered to this activation key.
   def create(id, descr, base_channel, limit)
@@ -111,7 +111,10 @@ class NamespaceActivationkey
   #   base_channel_label: The label of the base channel you want to subscribe to.
   #   usage_limit: The number of times this key can be used.
   #   contact_method: Contact method to use when onboarding a system using this AK.
-  #                   Valid values are: default, ssh-push, ssh-push-tunnel
+  #                   Valid values are:
+  #                   - default
+  #                   - ssh-push
+  #                   - ssh-push-tunnel
   def set_details(id, description, base_channel_label, usage_limit, contact_method)
     details = {
       description: description,

--- a/testsuite/features/support/namespaces/activationkey.rb
+++ b/testsuite/features/support/namespaces/activationkey.rb
@@ -26,7 +26,7 @@ class NamespaceActivationkey
   end
 
   ##
-  # This function deletes an activation key.
+  # Deletes an activation key.
   #
   # Args:
   #   id: The ID of the activation key you want to delete.
@@ -36,7 +36,7 @@ class NamespaceActivationkey
   end
 
   ##
-  # Get Activation keys count
+  # Returns the number of activation keys.
   def get_activation_keys_count
     @keys = @test.call('activationkey.listActivationKeys', sessionKey: @test.token)
     @keys.nil? ? 0 : @keys.length

--- a/testsuite/features/support/namespaces/activationkey.rb
+++ b/testsuite/features/support/namespaces/activationkey.rb
@@ -3,53 +3,114 @@
 
 # "activationkey" namespace
 class NamespaceActivationkey
+  ##
+  # It initializes the function.
+  #
+  # Args:
+  #   api_test: This is the test object that is passed in from the test script.
   def initialize(api_test)
     @test = api_test
     @keys = nil
   end
 
+  ##
+  # It creates an activation key.
+  #
+  # Args:
+  #   id: The name of the activation key
+  #   descr: The description of the activation key
+  #   base_channel: The channel you want to use as the base for the activation key.
+  #   limit: The number of systems that can be registered to this activation key.
   def create(id, descr, base_channel, limit)
     @test.call('activationkey.create', sessionKey: @test.token, key: id, description: descr, baseChannelLabel: base_channel, usageLimit: limit, entitlements: [], universalDefault: false)
   end
 
+  ##
+  # This function deletes an activation key
+  #
+  # Args:
+  #   id: The ID of the activation key you want to delete.
   def delete(id)
     @test.call('activationkey.delete', sessionKey: @test.token, key: id)
     @keys = @test.call('activationkey.listActivationKeys', sessionKey: @test.token)
   end
 
+  ##
+  # Get Activation keys count
   def get_activation_keys_count
     @keys = @test.call('activationkey.listActivationKeys', sessionKey: @test.token)
     @keys.nil? ? 0 : @keys.length
   end
 
+  ##
+  # It returns the number of activated systems for a given user.
+  #
+  # Args:
+  #   id: The id of the user
   def get_activated_systems_count(id)
     systems = @test.call('activationkey.listActivatedSystems', sessionKey: @test.token, key: id)
     systems.nil? ? 0 : systems.length
   end
 
+  ##
+  # It returns the number of channels in the configuration with the given id.
+  #
+  # Args:
+  #   id: The id of the configuration.
   def get_config_channels_count(id)
     channels = @test.call('activationkey.listConfigChannels', sessionKey: @test.token, key: id)
     channels.nil? ? 0 : channels.length
   end
 
+  ##
+  # It returns the id of the user.
+  #
+  # Args:
+  #   id: The id of the user to verify.
   def verify(id)
     @test.call('activationkey.listActivationKeys', sessionKey: @test.token)
          .map { |key| key['key'] }
          .include?(id)
   end
 
+  ##
+  # It adds config channels to a system.
+  #
+  # Args:
+  #   id: The id of the system to add the config channels to.
+  #   config_channels: A list of config channels to add to the system.
   def add_config_channels(id, config_channels)
     @test.call('activationkey.addConfigChannels', sessionKey: @test.token, keys: id, configChannelLabels: config_channels, addToTop: false)
   end
 
+  ##
+  # It adds child channels to a channel.
+  #
+  # Args:
+  #   id: The id of the channel you want to add child channels to.
+  #   child_channels: An array of channel ids that you want to add to the parent channel.
   def add_child_channels(id, child_channels)
     @test.call('activationkey.addChildChannels', sessionKey: @test.token, key: id, childChannelLabels: child_channels)
   end
 
+  ##
+  # It returns the details of the user with the given id.
+  #
+  # Args:
+  #   id: The id of the user you want to get details for.
   def get_details(id)
     @test.call('activationkey.getDetails', sessionKey: @test.token, key: id)
   end
 
+  ##
+  # It sets the details of a channel.
+  #
+  # Args:
+  #   id: The id of the subscription.
+  #   description: A description of the subscription.
+  #   base_channel_label: The base channel label of the channel you want to subscribe to.
+  #   usage_limit: The number of times this key can be used.
+  #   contact_method:
   def set_details(id, description, base_channel_label, usage_limit, contact_method)
     details = {
       description: description,

--- a/testsuite/features/support/namespaces/activationkey.rb
+++ b/testsuite/features/support/namespaces/activationkey.rb
@@ -26,7 +26,7 @@ class NamespaceActivationkey
   end
 
   ##
-  # This function deletes an activation key
+  # This function deletes an activation key.
   #
   # Args:
   #   id: The ID of the activation key you want to delete.

--- a/testsuite/features/support/namespaces/activationkey.rb
+++ b/testsuite/features/support/namespaces/activationkey.rb
@@ -110,7 +110,8 @@ class NamespaceActivationkey
   #   description: A description of the channel.
   #   base_channel_label: The label of the base channel you want to subscribe to.
   #   usage_limit: The number of times this key can be used.
-  #   contact_method:
+  #   contact_method: Contact method to use when onboarding a system using this AK.
+  #                   Valid values are: default, ssh-push, ssh-push-tunnel
   def set_details(id, description, base_channel_label, usage_limit, contact_method)
     details = {
       description: description,

--- a/testsuite/features/support/namespaces/api.rb
+++ b/testsuite/features/support/namespaces/api.rb
@@ -1,7 +1,7 @@
-# Copyright (c) 2022 SUSE LLC.
+# Copyright (c) 2022-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
-# "api" namespace
+# API namespace
 class NamespaceApi
   ##
   # It initializes the api_test variable.
@@ -13,20 +13,21 @@ class NamespaceApi
   end
 
   ##
-  # This function calls the `api.getApiNamespaces` method of the API and returns the number of namespaces returned
+  # Returns the amount of API namespaces.
   def get_count_of_api_namespaces
     namespaces = @test.call('api.getApiNamespaces', sessionKey: @test.token)
     namespaces.nil? ? 0 : namespaces.length
   end
 
-  # list all available api calls grouped by namespace
+  ##
+  # List all available api calls grouped by namespace.
   def get_count_of_api_call_list_groups
     call_list = @test.call('api.getApiCallList', sessionKey: @test.token)
     call_list.nil? ? 0 : call_list.length
   end
 
   ##
-  # It gets the count of the number of API calls in the API namespace call list
+  # It gets the count of the number of API calls in the API namespace call list.
   def get_count_of_api_namespace_call_list
     count = 0
     namespaces = @test.call('api.getApiNamespaces', sessionKey: @test.token)

--- a/testsuite/features/support/namespaces/api.rb
+++ b/testsuite/features/support/namespaces/api.rb
@@ -3,10 +3,17 @@
 
 # "api" namespace
 class NamespaceApi
+  ##
+  # It initializes the api_test variable.
+  #
+  # Args:
+  #   api_test: This is the test object that is passed to the initialize method.
   def initialize(api_test)
     @test = api_test
   end
 
+  ##
+  # This function calls the `api.getApiNamespaces` method of the API and returns the number of namespaces returned
   def get_count_of_api_namespaces
     namespaces = @test.call('api.getApiNamespaces', sessionKey: @test.token)
     namespaces.nil? ? 0 : namespaces.length
@@ -18,6 +25,8 @@ class NamespaceApi
     call_list.nil? ? 0 : call_list.length
   end
 
+  ##
+  # It gets the count of the number of API calls in the API namespace call list
   def get_count_of_api_namespace_call_list
     count = 0
     namespaces = @test.call('api.getApiNamespaces', sessionKey: @test.token)

--- a/testsuite/features/support/namespaces/api.rb
+++ b/testsuite/features/support/namespaces/api.rb
@@ -20,7 +20,7 @@ class NamespaceApi
   end
 
   ##
-  # List all available api calls grouped by namespace.
+  # Returns the amount of available API calls.
   def get_count_of_api_call_list_groups
     call_list = @test.call('api.getApiCallList', sessionKey: @test.token)
     call_list.nil? ? 0 : call_list.length

--- a/testsuite/features/support/namespaces/audit.rb
+++ b/testsuite/features/support/namespaces/audit.rb
@@ -13,7 +13,7 @@ class NamespaceAudit
   end
 
   ##
-  # List of systems that are affected by a given CVE.
+  # Lists the systems that are affected by a given CVE.
   #
   # Args:
   #   cve_identifier: The CVE identifier for the vulnerability you want to check.

--- a/testsuite/features/support/namespaces/audit.rb
+++ b/testsuite/features/support/namespaces/audit.rb
@@ -3,10 +3,20 @@
 
 # "audit" namespace
 class NamespaceAudit
+  ##
+  # It initializes the api_test variable.
+  #
+  # Args:
+  #   api_test: This is the test object that is passed to the initialize method.
   def initialize(api_test)
     @test = api_test
   end
 
+  ##
+  # `list_systems_by_patch_status` returns a list of systems that are affected by a given CVE
+  #
+  # Args:
+  #   cve_identifier: The CVE identifier for the vulnerability you want to check.
   def list_systems_by_patch_status(cve_identifier)
     @test.call('audit.listSystemsByPatchStatus', sessionKey: @test.token, cveIdentifier: cve_identifier)
   end

--- a/testsuite/features/support/namespaces/audit.rb
+++ b/testsuite/features/support/namespaces/audit.rb
@@ -1,7 +1,7 @@
-# Copyright (c) 2022 SUSE LLC.
+# Copyright (c) 2022-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
-# "audit" namespace
+# Audit namespace
 class NamespaceAudit
   ##
   # It initializes the api_test variable.
@@ -13,7 +13,7 @@ class NamespaceAudit
   end
 
   ##
-  # `list_systems_by_patch_status` returns a list of systems that are affected by a given CVE
+  # List of systems that are affected by a given CVE.
   #
   # Args:
   #   cve_identifier: The CVE identifier for the vulnerability you want to check.

--- a/testsuite/features/support/namespaces/channel.rb
+++ b/testsuite/features/support/namespaces/channel.rb
@@ -83,7 +83,7 @@ class NamespaceChannelSoftware
   end
 
   ##
-  # > Associate a repo with a channel
+  # Associate a repo with a channel
   #
   # Args:
   #   channel_label: The label of the channel you want to associate the repo with.
@@ -93,7 +93,7 @@ class NamespaceChannelSoftware
   end
 
   ##
-  # "Remove a repository from the list of repositories to be processed."
+  # Remove a repository from the list of repositories to be processed.
   #
   # The first line of the function is a comment.  It's a comment because it starts with a `#` character.  Comments are
   # ignored by the Ruby interpreter.  They're for humans to read.  The comment is a one sentence summary of the function.

--- a/testsuite/features/support/namespaces/channel.rb
+++ b/testsuite/features/support/namespaces/channel.rb
@@ -4,7 +4,7 @@
 # Channel namespace
 class NamespaceChannel
   ##
-  # This function initializes the NamespaceChannelSoftware class.
+  # Initializes the NamespaceChannelSoftware class.
   #
   # Args:
   #   api_test: This is the test object that is passed in from the test script.
@@ -23,7 +23,7 @@ class NamespaceChannel
   end
 
   ##
-  # It checks if the label is a valid channel.
+  # Checks if a channel is valid, based on its label.
   #
   # Args:
   #   label: The label of the channel you want to verify.
@@ -51,39 +51,39 @@ class NamespaceChannelSoftware
   end
 
   ##
-  # Create a new repository
+  # Creates a new repository.
   #
   # Args:
   #   label: The label of the repository.
   #   name: The name of the repository.
   #   summary: A short description of the repository.
-  #   arch: The architecture of the package.
+  #   arch: The architecture of the packages in the repo.
   #   parent: The parent of the new repository. This is a Repository object.
   def create(label, name, summary, arch, parent)
     @test.call('channel.software.create', sessionKey: @test.token, label: label, name: name, summary: summary, archLabel: arch, parentLabel: parent)
   end
 
   ##
-  # Delete the node with the given label.
+  # Deletes the repository with the given label.
   #
   # Args:
-  #   label: The label of the button to delete.
+  #   label: The label of the repository to delete.
   def delete(label)
     @test.call('channel.software.delete', sessionKey: @test.token, channelLabel: label)
   end
 
   ##
-  # `create_repo` creates a new repository.
+  # Creates a new repository, with a given label and URL.
   #
   # Args:
-  #   label: The name of the repo.
+  #   label: The name of the repository.
   #   url: The URL of the repository.
   def create_repo(label, url)
     @test.call('channel.software.createRepo', sessionKey: @test.token, label: label, type: 'yum', url: url)
   end
 
   ##
-  # Associate a repo with a channel
+  # Associates a repository with a channel.
   #
   # Args:
   #   channel_label: The label of the channel you want to associate the repo with.
@@ -93,11 +93,7 @@ class NamespaceChannelSoftware
   end
 
   ##
-  # Remove a repository from the list of repositories to be processed.
-  #
-  # The first line of the function is a comment.  It's a comment because it starts with a `#` character.  Comments are
-  # ignored by the Ruby interpreter.  They're for humans to read.  The comment is a one sentence summary of the function.
-  # It's a good idea to write a comment like this for every function you write
+  # Removes a repository from the list of repositories to be processed.
   #
   # Args:
   #   label: The label of the repo you want to remove.
@@ -111,11 +107,11 @@ class NamespaceChannelSoftware
   end
 
   ##
-  # Given a child channel and a parent channel, return true if the child channel is a child of the parent channel.
+  # Verifies if a given channel is a child of the given parent channel.
   #
   # Args:
   #   child: The channel you want to check if it's a child of the parent channel.
-  #   parent: the parent channel
+  #   parent: The possible parent channel.
   def parent_channel?(child, parent)
     channel = @test.call('channel.software.getDetails', sessionKey: @test.token, channelLabel: child)
     channel['parent_channel_label'] == parent

--- a/testsuite/features/support/namespaces/channel.rb
+++ b/testsuite/features/support/namespaces/channel.rb
@@ -3,6 +3,11 @@
 
 # "channel" namespace
 class NamespaceChannel
+  ##
+  # This function initializes the NamespaceChannelSoftware class
+  #
+  # Args:
+  #   api_test: This is the test object that is passed in from the test script.
   def initialize(api_test)
     @test = api_test
     @software = NamespaceChannelSoftware.new(api_test)
@@ -10,11 +15,18 @@ class NamespaceChannel
 
   attr_reader :software
 
+  ##
+  # It returns the number of software channels in the system
   def get_software_channels_count
     channels = @test.call('channel.listSoftwareChannels', sessionKey: @test.token)
     channels.nil? ? 0 : channels.length
   end
 
+  ##
+  # It checks if the label is a valid channel.
+  #
+  # Args:
+  #   label: The label of the channel you want to verify.
   def verify_channel(label)
     @test.call('channel.listSoftwareChannels', sessionKey: @test.token)
          .map { |c| c['label'] }
@@ -29,30 +41,81 @@ end
 
 # "channel.software" namespace
 class NamespaceChannelSoftware
+  ##
+  # It initializes the class.
+  #
+  # Args:
+  #   api_test: This is the name of the test. It's used to create the test's directory.
   def initialize(api_test)
     @test = api_test
   end
 
+  ##
+  # Create a new repository
+  #
+  # Args:
+  #   label: The label of the repository.
+  #   name: The name of the repository.
+  #   summary: A short description of the repository.
+  #   arch: The architecture of the package.
+  #   parent: The parent of the new repository. This is a Repository object.
   def create(label, name, summary, arch, parent)
     @test.call('channel.software.create', sessionKey: @test.token, label: label, name: name, summary: summary, archLabel: arch, parentLabel: parent)
   end
 
+  ##
+  # Delete the node with the given label.
+  #
+  # Args:
+  #   label: The label of the button to delete.
   def delete(label)
     @test.call('channel.software.delete', sessionKey: @test.token, channelLabel: label)
   end
 
+  ##
+  # `create_repo` creates a new repository
+  #
+  # Args:
+  #   label: The name of the repo.
+  #   url: The URL of the repository.
   def create_repo(label, url)
     @test.call('channel.software.createRepo', sessionKey: @test.token, label: label, type: 'yum', url: url)
   end
 
+  ##
+  # > Associate a repo with a channel
+  #
+  # Args:
+  #   channel_label: The label of the channel you want to associate the repo with.
+  #   repo_label: The label of the repository you want to associate with the channel.
   def associate_repo(channel_label, repo_label)
     @test.call('channel.software.associateRepo', sessionKey: @test.token, channelLabel: channel_label, repoLabel: repo_label)
   end
 
+  ##
+  # "Remove a repository from the list of repositories to be processed."
+  #
+  # The first line of the function is a comment.  It's a comment because it starts with a `#` character.  Comments are
+  # ignored by the Ruby interpreter.  They're for humans to read.  The comment is a one sentence summary of the function.
+  # It's a good idea to write a comment like this for every function you write
+  #
+  # Args:
+  #   label: The label of the repo you want to remove.
+  ##
+  # It returns the value of the key in the hash that matches the label.
+  #
+  # Args:
+  #   label: The label of the item you want to get details for.
   def remove_repo(label)
     @test.call('channel.software.removeRepo', sessionKey: @test.token, label: label)
   end
 
+  ##
+  # Given a child channel and a parent channel, return true if the child channel is a child of the parent channel
+  #
+  # Args:
+  #   child: The channel you want to check if it's a child of the parent channel.
+  #   parent: the parent channel
   def parent_channel?(child, parent)
     channel = @test.call('channel.software.getDetails', sessionKey: @test.token, channelLabel: child)
     channel['parent_channel_label'] == parent
@@ -62,12 +125,19 @@ class NamespaceChannelSoftware
     @test.call('channel.software.getDetails', sessionKey: @test.token, channelLabel: label)
   end
 
+  ##
+  # `list_child_channels` returns a list of child channels for a given parent channel
+  #
+  # Args:
+  #   parent_channel: The channel you want to list the children of.
   def list_child_channels(parent_channel)
     channels = @test.call('channel.listSoftwareChannels', sessionKey: @test.token)
     channel_labels = channels.map { |channel| channel['label'] }
     channel_labels.select { |channel| parent_channel?(channel, parent_channel) }
   end
 
+  ##
+  # > This function lists all the repos that the user has access to
   def list_user_repos
     repos = @test.call('channel.software.listUserRepos', sessionKey: @test.token)
     repos.map { |key| key['label'] }

--- a/testsuite/features/support/namespaces/channel.rb
+++ b/testsuite/features/support/namespaces/channel.rb
@@ -1,10 +1,10 @@
-# Copyright (c) 2022 SUSE LLC.
+# Copyright (c) 2022-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
-# "channel" namespace
+# Channel namespace
 class NamespaceChannel
   ##
-  # This function initializes the NamespaceChannelSoftware class
+  # This function initializes the NamespaceChannelSoftware class.
   #
   # Args:
   #   api_test: This is the test object that is passed in from the test script.
@@ -16,7 +16,7 @@ class NamespaceChannel
   attr_reader :software
 
   ##
-  # It returns the number of software channels in the system
+  # It returns the number of software channels in the system.
   def get_software_channels_count
     channels = @test.call('channel.listSoftwareChannels', sessionKey: @test.token)
     channels.nil? ? 0 : channels.length
@@ -39,7 +39,7 @@ class NamespaceChannel
   end
 end
 
-# "channel.software" namespace
+# Software Channel namespace
 class NamespaceChannelSoftware
   ##
   # It initializes the class.
@@ -73,7 +73,7 @@ class NamespaceChannelSoftware
   end
 
   ##
-  # `create_repo` creates a new repository
+  # `create_repo` creates a new repository.
   #
   # Args:
   #   label: The name of the repo.
@@ -111,7 +111,7 @@ class NamespaceChannelSoftware
   end
 
   ##
-  # Given a child channel and a parent channel, return true if the child channel is a child of the parent channel
+  # Given a child channel and a parent channel, return true if the child channel is a child of the parent channel.
   #
   # Args:
   #   child: The channel you want to check if it's a child of the parent channel.
@@ -126,7 +126,7 @@ class NamespaceChannelSoftware
   end
 
   ##
-  # `list_child_channels` returns a list of child channels for a given parent channel
+  # Lists the child channels for a given parent channel.
   #
   # Args:
   #   parent_channel: The channel you want to list the children of.
@@ -137,7 +137,7 @@ class NamespaceChannelSoftware
   end
 
   ##
-  # > This function lists all the repos that the user has access to
+  # Lists all the repos that the user has access to.
   def list_user_repos
     repos = @test.call('channel.software.listUserRepos', sessionKey: @test.token)
     repos.map { |key| key['label'] }

--- a/testsuite/features/support/namespaces/configchannel.rb
+++ b/testsuite/features/support/namespaces/configchannel.rb
@@ -31,18 +31,7 @@ class NamespaceConfigchannel
   end
 
   ##
-  # "Returns a list of systems subscribed to the given channel."
-  #
-  # The first line of the function is the function signature. It's a single line that contains the function name, the
-  ##
-  # `get_file_revision` returns the contents of a file at a given revision
-  #
-  # Args:
-  #   channel: The channel to get the file from.
-  #   file_path: The path to the file you want to get the revision of.
-  #   revision: The revision number of the file you want to get.
-  # arguments, and the return type. The function name is `list_subscribed_systems`. The arguments are `channel`, which is
-  # a `Channel` object. The return type is `Array[System]`
+  # Returns a list of systems subscribed to the given channel.
   #
   # Args:
   #   channel: The channel you want to list the subscribed systems for.

--- a/testsuite/features/support/namespaces/configchannel.rb
+++ b/testsuite/features/support/namespaces/configchannel.rb
@@ -74,7 +74,7 @@ class NamespaceConfigchannel
   #   label: The label of the field. This is what will be displayed to the user.
   #   name: The name of the field. This is the name that will be used to access the field's value in the form's data hash.
   #   description: A short description of the parameter.
-  #   type:
+  #   type: TODO
   #   info: a hash of information about the field.  The following keys are used:
   def create_with_pathinfo(label, name, description, type, info)
     @test.call('configchannel.create', sessionKey: @test.token, label: label, name: name, description: description, type: type, pathInfo: info)

--- a/testsuite/features/support/namespaces/configchannel.rb
+++ b/testsuite/features/support/namespaces/configchannel.rb
@@ -40,7 +40,7 @@ class NamespaceConfigchannel
   end
 
   ##
-  # Get a file revision of a configuration channel.
+  # Gets a file revision of a configuration channel.
   #
   # Args:
   #   channel: The configuration channel name.
@@ -63,20 +63,20 @@ class NamespaceConfigchannel
   end
 
   ##
-  # It creates a new configuration channel with a path info.
+  # Creates a new configuration channel with path information.
   #
   # Args:
   #   label: The label of the configuration channel.
   #   name: The name of the configuration channel.
   #   description: A short description of the configuration channel.
   #   type: TODO
-  #   info: A path info
+  #   info: Path information.
   def create_with_pathinfo(label, name, description, type, info)
     @test.call('configchannel.create', sessionKey: @test.token, label: label, name: name, description: description, type: type, pathInfo: info)
   end
 
   ##
-  # Creates or update a file in a channel
+  # Creates or updates a file in a channel.
   #
   # Args:
   #   channel: The configuration channel to create or update the file in.
@@ -96,7 +96,7 @@ class NamespaceConfigchannel
   end
 
   ##
-  # Deploy all systems to the given configuration channel.
+  # Deploys all systems to the given configuration channel.
   #
   # Args:
   #   channel: The configuration channel to deploy to.

--- a/testsuite/features/support/namespaces/configchannel.rb
+++ b/testsuite/features/support/namespaces/configchannel.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 SUSE LLC.
+# Copyright (c) 2022-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 # Configuration Channel namespace
@@ -13,7 +13,7 @@ class NamespaceConfigchannel
   end
 
   ##
-  # Returns true if the configuration channel exists, false otherwise
+  # Returns true if the configuration channel exists, false otherwise.
   #
   # Args:
   #   channel: The channel to check for existence.
@@ -22,7 +22,7 @@ class NamespaceConfigchannel
   end
 
   ##
-  # Lists the files in a configuration channel
+  # Lists the files in a configuration channel.
   #
   # Args:
   #   channel: The configuration channel to list files from.
@@ -40,12 +40,12 @@ class NamespaceConfigchannel
   end
 
   ##
-  # Get a file revision of a configuration channel
+  # Get a file revision of a configuration channel.
   #
   # Args:
-  #   channel: The configuration channel name
-  #   file_path: A file path
-  #   revision: A revision number
+  #   channel: The configuration channel name.
+  #   file_path: A file path.
+  #   revision: A revision number.
   def get_file_revision(channel, file_path, revision)
     @test.call('configchannel.getFileRevision', sessionKey: @test.token, label: channel, filePath: file_path, revision: revision)
   end
@@ -76,9 +76,7 @@ class NamespaceConfigchannel
   end
 
   ##
-  # "Create or update a file in a channel."
-  #
-  # The first line of the function is a comment. It's a comment because it starts with a `#`
+  # Creates or update a file in a channel
   #
   # Args:
   #   channel: The configuration channel to create or update the file in.
@@ -107,7 +105,7 @@ class NamespaceConfigchannel
   end
 
   ##
-  # Deletes the specified channels
+  # Deletes the specified channels.
   #
   # Args:
   #   channels: A list of configuration channel names to delete.

--- a/testsuite/features/support/namespaces/configchannel.rb
+++ b/testsuite/features/support/namespaces/configchannel.rb
@@ -69,7 +69,7 @@ class NamespaceConfigchannel
   #   label: The label of the configuration channel.
   #   name: The name of the configuration channel.
   #   description: A short description of the configuration channel.
-  #   type: TODO
+  #   type: normal, local_override, server_import, state
   #   info: Path information.
   def create_with_pathinfo(label, name, description, type, info)
     @test.call('configchannel.create', sessionKey: @test.token, label: label, name: name, description: description, type: type, pathInfo: info)

--- a/testsuite/features/support/namespaces/configchannel.rb
+++ b/testsuite/features/support/namespaces/configchannel.rb
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
-# "configchannel" namespace
+# Configuration Channel namespace
 class NamespaceConfigchannel
   ##
   # It initializes the api_test variable.
@@ -13,7 +13,7 @@ class NamespaceConfigchannel
   end
 
   ##
-  # Returns true if the channel exists, false otherwise
+  # Returns true if the configuration channel exists, false otherwise
   #
   # Args:
   #   channel: The channel to check for existence.
@@ -22,49 +22,55 @@ class NamespaceConfigchannel
   end
 
   ##
-  # `list_files` lists the files in a channel
+  # Lists the files in a configuration channel
   #
   # Args:
-  #   channel: The channel to list files from.
+  #   channel: The configuration channel to list files from.
   def list_files(channel)
     @test.call('configchannel.listFiles', sessionKey: @test.token, label: channel)
   end
 
   ##
-  # Returns a list of systems subscribed to the given channel.
+  # Returns a list of systems subscribed to the given configuration channel.
   #
   # Args:
-  #   channel: The channel you want to list the subscribed systems for.
+  #   channel: The configuration channel you want to list the subscribed systems for.
   def list_subscribed_systems(channel)
     @test.call('configchannel.listSubscribedSystems', sessionKey: @test.token, label: channel)
   end
 
+  ##
+  # Get a file revision of a configuration channel
+  #
+  # Args:
+  #   channel: The configuration channel name
+  #   file_path: A file path
+  #   revision: A revision number
   def get_file_revision(channel, file_path, revision)
     @test.call('configchannel.getFileRevision', sessionKey: @test.token, label: channel, filePath: file_path, revision: revision)
   end
 
   ##
-  # `create` creates a new
-  # resource
+  # Creates a new configuration channel.
   #
   # Args:
-  #   label: The label of the field. This is what will be displayed on the form.
-  #   name: The name of the field. This is the name that will be used to access the field's value in the form.
-  #   description: A description of the parameter.
-  #   type:
+  #   label: The label of the configuration channel.
+  #   name: The name of the configuration channel.
+  #   description: A description of the configuration channel.
+  #   type: TODO
   def create(label, name, description, type)
     @test.call('configchannel.create', sessionKey: @test.token, label: label, name: name, description: description, type: type)
   end
 
   ##
-  # It creates a new question with the given label, name, description, type, and info.
+  # It creates a new configuration channel with a path info.
   #
   # Args:
-  #   label: The label of the field. This is what will be displayed to the user.
-  #   name: The name of the field. This is the name that will be used to access the field's value in the form's data hash.
-  #   description: A short description of the parameter.
+  #   label: The label of the configuration channel.
+  #   name: The name of the configuration channel.
+  #   description: A short description of the configuration channel.
   #   type: TODO
-  #   info: a hash of information about the field.  The following keys are used:
+  #   info: A path info
   def create_with_pathinfo(label, name, description, type, info)
     @test.call('configchannel.create', sessionKey: @test.token, label: label, name: name, description: description, type: type, pathInfo: info)
   end
@@ -75,7 +81,7 @@ class NamespaceConfigchannel
   # The first line of the function is a comment. It's a comment because it starts with a `#`
   #
   # Args:
-  #   channel: The channel to create or update the file in.
+  #   channel: The configuration channel to create or update the file in.
   #   file: The file name, including the path.
   #   contents: The contents of the file.
   def create_or_update_path(channel, file, contents)
@@ -92,19 +98,19 @@ class NamespaceConfigchannel
   end
 
   ##
-  # Deploy all systems to the given channel.
+  # Deploy all systems to the given configuration channel.
   #
   # Args:
-  #   channel: The channel to deploy to.
+  #   channel: The configuration channel to deploy to.
   def deploy_all_systems(channel)
     @test.call('configchannel.deployAllSystems', sessionKey: @test.token, label: channel)
   end
 
   ##
-  # `delete_channels` deletes the specified channels
+  # Deletes the specified channels
   #
   # Args:
-  #   channels: A list of channel names to delete.
+  #   channels: A list of configuration channel names to delete.
   def delete_channels(channels)
     @test.call('configchannel.deleteChannels', sessionKey: @test.token, labels: channels)
   end

--- a/testsuite/features/support/namespaces/configchannel.rb
+++ b/testsuite/features/support/namespaces/configchannel.rb
@@ -3,18 +3,49 @@
 
 # "configchannel" namespace
 class NamespaceConfigchannel
+  ##
+  # It initializes the api_test variable.
+  #
+  # Args:
+  #   api_test: This is the test object that is passed in from the test script.
   def initialize(api_test)
     @test = api_test
   end
 
+  ##
+  # > Returns true if the channel exists, false otherwise
+  #
+  # Args:
+  #   channel: The channel to check for existence.
   def channel_exists(channel)
     @test.call('configchannel.channelExists', sessionKey: @test.token, label: channel)
   end
 
+  ##
+  # `list_files` lists the files in a channel
+  #
+  # Args:
+  #   channel: The channel to list files from.
   def list_files(channel)
     @test.call('configchannel.listFiles', sessionKey: @test.token, label: channel)
   end
 
+  ##
+  # "Returns a list of systems subscribed to the given channel."
+  #
+  # The first line of the function is the function signature. It's a single line that contains the function name, the
+  ##
+  # `get_file_revision` returns the contents of a file at a given revision
+  #
+  # Args:
+  #   channel: The channel to get the file from.
+  #   file_path: The path to the file you want to get the revision of.
+  #   revision: The revision number of the file you want to get.
+  # arguments, and the return type. The function name is `list_subscribed_systems`. The arguments are `channel`, which is
+  # a `Channel` object. The return type is `Array[System]`
+  #
+  # Args:
+  #   channel: The channel you want to list the subscribed systems for.
   def list_subscribed_systems(channel)
     @test.call('configchannel.listSubscribedSystems', sessionKey: @test.token, label: channel)
   end
@@ -23,14 +54,41 @@ class NamespaceConfigchannel
     @test.call('configchannel.getFileRevision', sessionKey: @test.token, label: channel, filePath: file_path, revision: revision)
   end
 
+  ##
+  # `create` creates a new
+  # resource
+  #
+  # Args:
+  #   label: The label of the field. This is what will be displayed on the form.
+  #   name: The name of the field. This is the name that will be used to access the field's value in the form.
+  #   description: A description of the parameter.
+  #   type:
   def create(label, name, description, type)
     @test.call('configchannel.create', sessionKey: @test.token, label: label, name: name, description: description, type: type)
   end
 
+  ##
+  # It creates a new question with the given label, name, description, type, and info.
+  #
+  # Args:
+  #   label: The label of the field. This is what will be displayed to the user.
+  #   name: The name of the field. This is the name that will be used to access the field's value in the form's data hash.
+  #   description: A short description of the parameter.
+  #   type:
+  #   info: a hash of information about the field.  The following keys are used:
   def create_with_pathinfo(label, name, description, type, info)
     @test.call('configchannel.create', sessionKey: @test.token, label: label, name: name, description: description, type: type, pathInfo: info)
   end
 
+  ##
+  # "Create or update a file in a channel."
+  #
+  # The first line of the function is a comment. It's a comment because it starts with a `#`
+  #
+  # Args:
+  #   channel: The channel to create or update the file in.
+  #   file: The file name, including the path.
+  #   contents: The contents of the file.
   def create_or_update_path(channel, file, contents)
     @test.call('configchannel.createOrUpdatePath',
                sessionKey: @test.token,
@@ -44,10 +102,20 @@ class NamespaceConfigchannel
               )
   end
 
+  ##
+  # Deploy all systems to the given channel.
+  #
+  # Args:
+  #   channel: The channel to deploy to.
   def deploy_all_systems(channel)
     @test.call('configchannel.deployAllSystems', sessionKey: @test.token, label: channel)
   end
 
+  ##
+  # `delete_channels` deletes the specified channels
+  #
+  # Args:
+  #   channels: A list of channel names to delete.
   def delete_channels(channels)
     @test.call('configchannel.deleteChannels', sessionKey: @test.token, labels: channels)
   end

--- a/testsuite/features/support/namespaces/configchannel.rb
+++ b/testsuite/features/support/namespaces/configchannel.rb
@@ -13,7 +13,7 @@ class NamespaceConfigchannel
   end
 
   ##
-  # > Returns true if the channel exists, false otherwise
+  # Returns true if the channel exists, false otherwise
   #
   # Args:
   #   channel: The channel to check for existence.

--- a/testsuite/features/support/namespaces/image.rb
+++ b/testsuite/features/support/namespaces/image.rb
@@ -13,7 +13,7 @@ class NamespaceImage
   attr_reader :store
 
   ##
-  # This function deletes an image
+  # Deletes an image based on its ID.
   #
   # Args:
   #   imageid: The ID of the image you want to delete.
@@ -22,7 +22,7 @@ class NamespaceImage
   end
 
   ##
-  # This function takes an imageid as an argument and returns the details of the image
+  # Gets an image's details based on its ID.
   #
   # Args:
   #   imageid: The ID of the image you want to get details for.
@@ -31,20 +31,20 @@ class NamespaceImage
   end
 
   ##
-  # This function schedules an image build for a given profile, version, build host, and date
+  # This function schedules an image build for a given profile, version, build host, and date.
   #
   # Args:
   #   profile_label: The label of the profile you want to build.
   #   version_build: The version of the image you want to build.
   #   build_hostid: This is the ID of the build host you want to use. You can get this by running the following command:
   #   date: The date and time you want the build to start.  This is in the format of YYYY-MM-DD HH:MM:SS.  For example, if
-  # you wanted to start the build at 5:00 PM on January 1, 2015, you would use the following:
+  # you wanted to start the build at 5:00 PM on January 1, 2015, you would use the following: 2015-01-01 17:00:00.
   def schedule_image_build(profile_label, version_build, build_hostid, date)
     @test.call('image.scheduleImageBuild', sessionKey: @test.token, profileLabel: profile_label, version: version_build, buildHostId: build_hostid, earliestOccurrence: date)
   end
 
   ##
-  # Returns a list of images
+  # Returns a list of images.
   def list_images
     @test.call('image.listImages', sessionKey: @test.token)
   end
@@ -85,7 +85,7 @@ class NamespaceImageProfile
   end
 
   ##
-  # Sets custom values for a given label.
+  # Sets custom values for an image profile, based on its label.
   #
   # Args:
   #   label: The label of the image profile
@@ -126,7 +126,7 @@ class NamespaceImageProfile
   end
 
   ##
-  # This function will return the details of the profile with the label you pass in.
+  # Returns the details of an image profile based on its label.
   #
   # Args:
   #   label: The label of the image profile you want to get details for.
@@ -135,7 +135,7 @@ class NamespaceImageProfile
   end
 
   ##
-  # It sets the details of the label and values.
+  # Sets the label and values for an image profile.
   #
   # Args:
   #   label: The label for the details.
@@ -157,7 +157,7 @@ class NamespaceImageStore
   end
 
   ##
-  # Create a new image store.
+  # Creates a new image store.
   #
   # Args:
   #   label: The name of the image store.
@@ -190,7 +190,7 @@ class NamespaceImageStore
   end
 
   ##
-  # Get the details of an image store.
+  # Gets the details of an image store.
   #
   # Args:
   #   label: The name of the image store.
@@ -199,7 +199,7 @@ class NamespaceImageStore
   end
 
   ##
-  # Set the details of an image store.
+  # Sets the details of an image store.
   #
   # Args:
   #   label: The name of the image store.

--- a/testsuite/features/support/namespaces/image.rb
+++ b/testsuite/features/support/namespaces/image.rb
@@ -13,7 +13,7 @@ class NamespaceImage
   attr_reader :store
 
   ##
-  # This function deletes an image from the Splunk server
+  # This function deletes an image
   #
   # Args:
   #   imageid: The ID of the image you want to delete.

--- a/testsuite/features/support/namespaces/image.rb
+++ b/testsuite/features/support/namespaces/image.rb
@@ -44,13 +44,13 @@ class NamespaceImage
   end
 
   ##
-  # `list_images` returns a list of images
+  # Returns a list of images
   def list_images
     @test.call('image.listImages', sessionKey: @test.token)
   end
 end
 
-# "image.profile" namespace
+# Image Profile namespace
 # It's a Ruby class that wraps the API calls for the image.profile namespace
 class NamespaceImageProfile
   ##
@@ -63,11 +63,11 @@ class NamespaceImageProfile
   end
 
   ##
-  # Create a new image profile
+  # Create a new image profile.
   #
   # Args:
   #   label: The name of the profile
-  #   type: The type of profile to create.  Valid values are:
+  #   type: The type of profile to create.  Valid values are: TODO
   #   store_label: The label of the store you want to use.
   #   path: The path to the kickstart file.
   #   actkey: The activation key to use for the profile.
@@ -76,7 +76,7 @@ class NamespaceImageProfile
   end
 
   ##
-  # > Deletes a profile from the system
+  # Deletes a profile from the system.
   #
   # Args:
   #   label: The name of the profile to delete.
@@ -85,17 +85,17 @@ class NamespaceImageProfile
   end
 
   ##
-  # `set_custom_values` sets custom values for a given label
+  # Sets custom values for a given label.
   #
   # Args:
-  #   label: The label of the custom field.
+  #   label: The label of the image profile
   #   values: A JSON object containing the custom values to set.
   def set_custom_values(label, values)
     @test.call('image.profile.setCustomValues', sessionKey: @test.token, label: label, values: values)
   end
 
   ##
-  # Delete custom values from a profile
+  # Delete custom values from an image profile.
   #
   # Args:
   #   label: The label of the image profile you want to delete custom values from.
@@ -108,7 +108,7 @@ class NamespaceImageProfile
   # This function returns the custom values for a given label
   #
   # Args:
-  #   label: The label of the profile you want to get the custom values for.
+  #   label: The label of the image profile you want to get the custom values for.
   def get_custom_values(label)
     @test.call('image.profile.getCustomValues', sessionKey: @test.token, label: label)
   end
@@ -129,7 +129,7 @@ class NamespaceImageProfile
   # This function will return the details of the profile with the label you pass in
   #
   # Args:
-  #   label: The label of the profile you want to get details for.
+  #   label: The label of the image profile you want to get details for.
   def get_details(label)
     @test.call('image.profile.getDetails', sessionKey: @test.token, label: label)
   end
@@ -145,32 +145,65 @@ class NamespaceImageProfile
   end
 end
 
-# "image.store" namespace
+# Image Store namespace
 class NamespaceImageStore
+  ##
+  # This function initializes the NamespaceChannelSoftware class
+  #
+  # Args:
+  #   api_test: This is the test object that is passed in from the test script.
   def initialize(api_test)
     @test = api_test
   end
 
+  ##
+  # Create a new image store.
+  #
+  # Args:
+  #   label: The name of the image store
+  #   uri: The URI path of the image store
+  #   type: The type of the store. Valid values are: TODO
+  #   creds: Credentials
   def create(label, uri, type, creds = {})
     @test.call('image.store.create', sessionKey: @test.token, label: label, uri: uri, storeType: type, credentials: creds)
   end
 
+  ##
+  # Deletes an image store from the system.
+  #
+  # Args:
+  #   label: The name of the image store
   def delete(label)
     @test.call('image.store.delete', sessionKey: @test.token, label: label)
   end
 
+  ##
+  # Lists the image store types available in the system
   def list_image_store_types
     @test.call('image.store.listImageStoreTypes', sessionKey: @test.token)
   end
 
+  ##
+  # Lists the image stores available in the system
   def list_image_stores
     @test.call('image.store.listImageStores', sessionKey: @test.token)
   end
 
+  ##
+  # Get the details of an image store.
+  #
+  # Args:
+  #   label: The name of the image store
   def get_details(label)
     @test.call('image.store.getDetails', sessionKey: @test.token, label: label)
   end
 
+  ##
+  # Set the details of an image store.
+  #
+  # Args:
+  #   label: The name of the image store
+  #   details: Details of the image store
   def set_details(label, details)
     @test.call('image.store.setDetails', sessionKey: @test.token, label: label, details: details)
   end

--- a/testsuite/features/support/namespaces/image.rb
+++ b/testsuite/features/support/namespaces/image.rb
@@ -105,7 +105,7 @@ class NamespaceImageProfile
   end
 
   ##
-  # > This function returns the custom values for a given label
+  # This function returns the custom values for a given label
   #
   # Args:
   #   label: The label of the profile you want to get the custom values for.
@@ -114,7 +114,7 @@ class NamespaceImageProfile
   end
 
   ##
-  # * Lists the image profile types available in the system
+  # Lists the image profile types available in the system
   def list_image_profile_types
     @test.call('image.profile.listImageProfileTypes', sessionKey: @test.token)
   end

--- a/testsuite/features/support/namespaces/image.rb
+++ b/testsuite/features/support/namespaces/image.rb
@@ -1,7 +1,7 @@
-# Copyright (c) 2022 SUSE LLC.
+# Copyright (c) 2022-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
-# "image" namespace
+# Image namespace
 class NamespaceImage
   def initialize(api_test)
     @test = api_test
@@ -105,7 +105,7 @@ class NamespaceImageProfile
   end
 
   ##
-  # This function returns the custom values for a given label
+  # Returns the custom values for a given label.
   #
   # Args:
   #   label: The label of the image profile you want to get the custom values for.
@@ -114,7 +114,7 @@ class NamespaceImageProfile
   end
 
   ##
-  # Lists the image profile types available in the system
+  # Lists the image profile types available in the system.
   def list_image_profile_types
     @test.call('image.profile.listImageProfileTypes', sessionKey: @test.token)
   end
@@ -126,7 +126,7 @@ class NamespaceImageProfile
   end
 
   ##
-  # This function will return the details of the profile with the label you pass in
+  # This function will return the details of the profile with the label you pass in.
   #
   # Args:
   #   label: The label of the image profile you want to get details for.
@@ -148,7 +148,7 @@ end
 # Image Store namespace
 class NamespaceImageStore
   ##
-  # This function initializes the NamespaceChannelSoftware class
+  # This function initializes the NamespaceChannelSoftware class.
   #
   # Args:
   #   api_test: This is the test object that is passed in from the test script.
@@ -160,10 +160,10 @@ class NamespaceImageStore
   # Create a new image store.
   #
   # Args:
-  #   label: The name of the image store
-  #   uri: The URI path of the image store
-  #   type: The type of the store. Valid values are: TODO
-  #   creds: Credentials
+  #   label: The name of the image store.
+  #   uri: The URI path of the image store.
+  #   type: The type of the store. Valid values are: TODO.
+  #   creds: Credentials.
   def create(label, uri, type, creds = {})
     @test.call('image.store.create', sessionKey: @test.token, label: label, uri: uri, storeType: type, credentials: creds)
   end
@@ -172,19 +172,19 @@ class NamespaceImageStore
   # Deletes an image store from the system.
   #
   # Args:
-  #   label: The name of the image store
+  #   label: The name of the image store.
   def delete(label)
     @test.call('image.store.delete', sessionKey: @test.token, label: label)
   end
 
   ##
-  # Lists the image store types available in the system
+  # Lists the image store types available in the system.
   def list_image_store_types
     @test.call('image.store.listImageStoreTypes', sessionKey: @test.token)
   end
 
   ##
-  # Lists the image stores available in the system
+  # Lists the image stores available in the system.
   def list_image_stores
     @test.call('image.store.listImageStores', sessionKey: @test.token)
   end
@@ -193,7 +193,7 @@ class NamespaceImageStore
   # Get the details of an image store.
   #
   # Args:
-  #   label: The name of the image store
+  #   label: The name of the image store.
   def get_details(label)
     @test.call('image.store.getDetails', sessionKey: @test.token, label: label)
   end
@@ -202,8 +202,8 @@ class NamespaceImageStore
   # Set the details of an image store.
   #
   # Args:
-  #   label: The name of the image store
-  #   details: Details of the image store
+  #   label: The name of the image store.
+  #   details: Details of the image store.
   def set_details(label, details)
     @test.call('image.store.setDetails', sessionKey: @test.token, label: label, details: details)
   end

--- a/testsuite/features/support/namespaces/image.rb
+++ b/testsuite/features/support/namespaces/image.rb
@@ -12,61 +12,134 @@ class NamespaceImage
   attr_reader :profile
   attr_reader :store
 
+  ##
+  # This function deletes an image from the Splunk server
+  #
+  # Args:
+  #   imageid: The ID of the image you want to delete.
   def delete(imageid)
     @test.call('image.delete', sessionKey: @test.token, imageId: imageid)
   end
 
+  ##
+  # This function takes an imageid as an argument and returns the details of the image
+  #
+  # Args:
+  #   imageid: The ID of the image you want to get details for.
   def get_details(imageid)
     @test.call('image.getDetails', sessionKey: @test.token, imageId: imageid)
   end
 
+  ##
+  # This function schedules an image build for a given profile, version, build host, and date
+  #
+  # Args:
+  #   profile_label: The label of the profile you want to build.
+  #   version_build: The version of the image you want to build.
+  #   build_hostid: This is the ID of the build host you want to use. You can get this by running the following command:
+  #   date: The date and time you want the build to start.  This is in the format of YYYY-MM-DD HH:MM:SS.  For example, if
+  # you wanted to start the build at 5:00 PM on January 1, 2015, you would use the following:
   def schedule_image_build(profile_label, version_build, build_hostid, date)
     @test.call('image.scheduleImageBuild', sessionKey: @test.token, profileLabel: profile_label, version: version_build, buildHostId: build_hostid, earliestOccurrence: date)
   end
 
+  ##
+  # `list_images` returns a list of images
   def list_images
     @test.call('image.listImages', sessionKey: @test.token)
   end
 end
 
 # "image.profile" namespace
+# It's a Ruby class that wraps the API calls for the image.profile namespace
 class NamespaceImageProfile
+  ##
+  # It initializes the api_test variable.
+  #
+  # Args:
+  #   api_test: This is the test object that is passed to the initialize method.
   def initialize(api_test)
     @test = api_test
   end
 
+  ##
+  # Create a new image profile
+  #
+  # Args:
+  #   label: The name of the profile
+  #   type: The type of profile to create.  Valid values are:
+  #   store_label: The label of the store you want to use.
+  #   path: The path to the kickstart file.
+  #   actkey: The activation key to use for the profile.
   def create(label, type, store_label, path, actkey)
     @test.call('image.profile.create', sessionKey: @test.token, label: label, type: type, storeLabel: store_label, path: path, activationKey: actkey)
   end
 
+  ##
+  # > Deletes a profile from the system
+  #
+  # Args:
+  #   label: The name of the profile to delete.
   def delete(label)
     @test.call('image.profile.delete', sessionKey: @test.token, label: label)
   end
 
+  ##
+  # `set_custom_values` sets custom values for a given label
+  #
+  # Args:
+  #   label: The label of the custom field.
+  #   values: A JSON object containing the custom values to set.
   def set_custom_values(label, values)
     @test.call('image.profile.setCustomValues', sessionKey: @test.token, label: label, values: values)
   end
 
+  ##
+  # Delete custom values from a profile
+  #
+  # Args:
+  #   label: The label of the image profile you want to delete custom values from.
+  #   keys: The keys of the custom values to delete.
   def delete_custom_values(label, keys)
     @test.call('image.profile.deleteCustomValues', sessionKey: @test.token, label: label, keys: keys)
   end
 
+  ##
+  # > This function returns the custom values for a given label
+  #
+  # Args:
+  #   label: The label of the profile you want to get the custom values for.
   def get_custom_values(label)
     @test.call('image.profile.getCustomValues', sessionKey: @test.token, label: label)
   end
 
+  ##
+  # * Lists the image profile types available in the system
   def list_image_profile_types
     @test.call('image.profile.listImageProfileTypes', sessionKey: @test.token)
   end
 
+  ##
+  # It lists all the image profiles.
   def list_image_profiles
     @test.call('image.profile.listImageProfiles', sessionKey: @test.token)
   end
 
+  ##
+  # This function will return the details of the profile with the label you pass in
+  #
+  # Args:
+  #   label: The label of the profile you want to get details for.
   def get_details(label)
     @test.call('image.profile.getDetails', sessionKey: @test.token, label: label)
   end
 
+  ##
+  # It sets the details of the label and values.
+  #
+  # Args:
+  #   label: The label for the details.
+  #   values: A hash of values to be displayed in the details section.
   def set_details(label, values)
     @test.call('image.profile.setDetails', sessionKey: @test.token, label: label, details: values)
   end

--- a/testsuite/features/support/namespaces/kickstart.rb
+++ b/testsuite/features/support/namespaces/kickstart.rb
@@ -3,6 +3,11 @@
 
 # "kickstart" namespace
 class NamespaceKickstart
+  ##
+  # It initializes the function.
+  #
+  # Args:
+  #   api_test: This is the test object that is passed to the initialize method.
   def initialize(api_test)
     @test = api_test
     @tree = NamespaceKickstartTree.new(api_test)
@@ -13,10 +18,20 @@ end
 
 # "kickstart.tree" namespace
 class NamespaceKickstartTree
+  ##
+  # It initializes the api_test variable.
+  #
+  # Args:
+  #   api_test: This is the test object that is passed to the initialize method.
   def initialize(api_test)
     @test = api_test
   end
 
+  ##
+  # This function deletes a tree and all profiles associated with it
+  #
+  # Args:
+  #   distro: The name of the distribution you want to delete.
   def delete_tree_and_profiles(distro)
     @test.call('kickstart.tree.deleteTreeAndProfiles', sessionKey: @test.token, treeLabel: distro)
   end

--- a/testsuite/features/support/namespaces/kickstart.rb
+++ b/testsuite/features/support/namespaces/kickstart.rb
@@ -28,7 +28,7 @@ class NamespaceKickstartTree
   end
 
   ##
-  # Deletes a Kickstart tree and all profiles associated with it
+  # Deletes a Kickstart tree and all profiles associated with it.
   #
   # Args:
   #   distro: The name of the distribution you want to delete.

--- a/testsuite/features/support/namespaces/kickstart.rb
+++ b/testsuite/features/support/namespaces/kickstart.rb
@@ -1,7 +1,7 @@
-# Copyright (c) 2022 SUSE LLC.
+# Copyright (c) 2022-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
-# "kickstart" namespace
+# Kickstart namespace
 class NamespaceKickstart
   ##
   # It initializes the function.
@@ -28,7 +28,7 @@ class NamespaceKickstartTree
   end
 
   ##
-  # This function deletes a tree and all profiles associated with it
+  # Deletes a Kickstart tree and all profiles associated with it
   #
   # Args:
   #   distro: The name of the distribution you want to delete.

--- a/testsuite/features/support/namespaces/schedule.rb
+++ b/testsuite/features/support/namespaces/schedule.rb
@@ -3,38 +3,72 @@
 
 # "schedule" namespace
 class NamespaceSchedule
+  ##
+  # It initializes the api_test variable.
+  #
+  # Args:
+  #   api_test: This is the test object that is passed to the initialize method.
   def initialize(api_test)
     @test = api_test
   end
 
+  ##
+  # It lists all actions
   def list_all_actions
     @test.call('schedule.listAllActions', sessionKey: @test.token)
   end
 
+  ##
+  # > Returns a list of actions that are currently in progress
   def list_in_progress_actions
     @test.call('schedule.listInProgressActions', sessionKey: @test.token)
   end
 
+  ##
+  # > Returns a list of systems that are currently in progress for the given action
+  #
+  # Args:
+  #   action_id: The ID of the action you want to list systems for.
   def list_in_progress_systems(action_id)
     @test.call('schedule.listInProgressSystems', sessionKey: @test.token, actionId: action_id)
   end
 
+  ##
+  # > This function returns a list of completed actions for the current user
   def list_completed_actions
     @test.call('schedule.listCompletedActions', sessionKey: @test.token)
   end
 
+  ##
+  # > This function returns a list of failed actions
   def list_failed_actions
     @test.call('schedule.listFailedActions', sessionKey: @test.token)
   end
 
+  ##
+  # This function returns a list of systems that failed to execute the action
+  #
+  # Args:
+  #   action_id: The ID of the action to list failed systems for.
   def list_failed_systems(action_id)
     @test.call('schedule.listFailedSystems', sessionKey: @test.token, actionId: action_id)
   end
 
+  ##
+  # This function cancels actions in the schedule
+  #
+  # Args:
+  #   actions: An array of action IDs to cancel.
   def cancel_actions(actions)
     @test.call('schedule.cancelActions', sessionKey: @test.token, actionIds: actions)
   end
 
+  ##
+  # > This function will fail a system action
+  #
+  # Args:
+  #   system_id: The ID of the system you want to schedule an action for.
+  #   action_id: The action ID of the action you want to fail.
   def fail_system_action(system_id, action_id)
     @test.call('schedule.failSystemAction', sessionKey: @test.token, sid: system_id, actionId: action_id)
   end

--- a/testsuite/features/support/namespaces/schedule.rb
+++ b/testsuite/features/support/namespaces/schedule.rb
@@ -1,7 +1,7 @@
-# Copyright (c) 2022 SUSE LLC.
+# Copyright (c) 2022-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
-# "schedule" namespace
+# Schedule namespace
 class NamespaceSchedule
   ##
   # It initializes the api_test variable.
@@ -13,19 +13,19 @@ class NamespaceSchedule
   end
 
   ##
-  # It lists all actions
+  # It lists all actions.
   def list_all_actions
     @test.call('schedule.listAllActions', sessionKey: @test.token)
   end
 
   ##
-  # > Returns a list of actions that are currently in progress
+  # Returns a list of actions that are currently in progress.
   def list_in_progress_actions
     @test.call('schedule.listInProgressActions', sessionKey: @test.token)
   end
 
   ##
-  # > Returns a list of systems that are currently in progress for the given action
+  # Returns a list of systems that are currently in progress for the given action.
   #
   # Args:
   #   action_id: The ID of the action you want to list systems for.
@@ -34,19 +34,19 @@ class NamespaceSchedule
   end
 
   ##
-  # > This function returns a list of completed actions for the current user
+  # Returns a list of completed actions for the current user.
   def list_completed_actions
     @test.call('schedule.listCompletedActions', sessionKey: @test.token)
   end
 
   ##
-  # > This function returns a list of failed actions
+  # Returns a list of failed actions.
   def list_failed_actions
     @test.call('schedule.listFailedActions', sessionKey: @test.token)
   end
 
   ##
-  # This function returns a list of systems that failed to execute the action
+  # Returns a list of systems that failed to execute the action.
   #
   # Args:
   #   action_id: The ID of the action to list failed systems for.
@@ -55,7 +55,7 @@ class NamespaceSchedule
   end
 
   ##
-  # This function cancels actions in the schedule
+  # Cancels actions in the schedule.
   #
   # Args:
   #   actions: An array of action IDs to cancel.
@@ -64,7 +64,7 @@ class NamespaceSchedule
   end
 
   ##
-  # > This function will fail a system action
+  # Fails a system action.
   #
   # Args:
   #   system_id: The ID of the system you want to schedule an action for.

--- a/testsuite/features/support/namespaces/system.rb
+++ b/testsuite/features/support/namespaces/system.rb
@@ -31,22 +31,46 @@ class NamespaceSystem
     server_id
   end
 
+  ##
+  # > This function will list all systems in the system
   def list_systems
     @test.call('system.listSystems', sessionKey: @test.token)
   end
 
+  ##
+  # It searches for a name in the system
+  #
+  # Args:
+  #   name: The name of the system you want to search for.
   def search_by_name(name)
     @test.call('system.searchByName', sessionKey: @test.token, regexp: name)
   end
 
+  ##
+  # This function lists all the packages that can be installed on a server
+  #
+  # Args:
+  #   server: The server ID of the server you want to list the packages for.
   def list_all_installable_packages(server)
     @test.call('system.listAllInstallablePackages', sessionKey: @test.token, sid: server)
   end
 
+  ##
+  # `list_latest_upgradable_packages` returns a list of packages that are upgradable on a given server
+  #
+  # Args:
+  #   server: The server ID
   def list_latest_upgradable_packages(server)
     @test.call('system.listLatestUpgradablePackages', sessionKey: @test.token, sid: server)
   end
 
+  ##
+  # If a proxy is defined, use it, otherwise don't
+  #
+  # Args:
+  #   host: The hostname of the system to bootstrap
+  #   activation_key: The activation key to use for the system.
+  #   salt_ssh: true/false
   def bootstrap_system(host, activation_key, salt_ssh)
     if $proxy.nil?
       @test.call('system.bootstrap', sessionKey: @test.token, host: host, sshPort: 22, sshUser: 'root', sshPassword: 'linux', activationKey: activation_key, saltSSH: salt_ssh)
@@ -57,18 +81,58 @@ class NamespaceSystem
     end
   end
 
+  ##
+  # `schedule_apply_highstate` schedules a highstate to be applied to a server at a given date
+  #
+  # Args:
+  #   server: The server ID of the server you want to schedule the highstate on.
+  #   date: The date and time you want the highstate to be applied.
+  #   test: true or false
   def schedule_apply_highstate(server, date, test)
     @test.call('system.scheduleApplyHighstate', sessionKey: @test.token, sid: server, earliestOccurrence: date, test: test)
   end
 
+  ##
+  # This function schedules a package refresh on a server
+  #
+  # Args:
+  #   server: The server ID of the server you want to schedule the package refresh on.
+  #   date: The date and time you want the package to be refreshed.
   def schedule_package_refresh(server, date)
     @test.call('system.schedulePackageRefresh', sessionKey: @test.token, sid: server, earliestOccurrence: date)
   end
 
+  ##
+  # > Schedule a reboot for a server on a specific date
+  #
+  # Args:
+  #   server: The server ID you want to reboot.
+  #   date: The date and time you want the server to reboot.
   def schedule_reboot(server, date)
     @test.call('system.scheduleReboot', sessionKey: @test.token, sid: server, earliestOccurrence: date)
   end
 
+  ##
+  # This function schedules a script to run on a server at a specified date and time
+  #
+  # Args:
+  ##
+  # This function creates a system record in the Satellite 6 server
+  #
+  # Args:
+  #   name: The name of the system record.
+  #   kslabel: The kickstart label you want to use.
+  #   koptions:
+  #   comment: A comment about the system record.
+  #   netdevices: This is a hash of the network devices that you want to use.  The key is the device name, and the value
+  # is the IP address.  For example:
+  #   server: The server ID of the server you want to run the script on.
+  #   uid: The user ID of the user who will run the script.
+  #   gid: The group name of the user that will run the script.
+  #   timeout: The amount of time in seconds that the script is allowed to run before it is killed.
+  #   script: The script to run.
+  #   date: The date and time you want the script to run.  This is in the format of YYYY-MM-DD HH:MM:SS.  For example, to
+  # run the script at 11:30pm on December 31st, 2013, you would use 2013-12-31 23
   def schedule_script_run(server, uid, gid, timeout, script, date)
     @test.call('system.scheduleScriptRun', sessionKey: @test.token, sid: server, username: uid, groupname: gid, timeout: timeout, script: script, earliestOccurrence: date)
   end
@@ -77,14 +141,28 @@ class NamespaceSystem
     @test.call('system.createSystemRecord', sessionKey: @test.token, systemName: name, ksLabel: kslabel, kOptions: koptions, comment: comment, netDevices: netdevices)
   end
 
+  ##
+  # This function creates a system profile with the given name and data
+  #
+  # Args:
+  #   name: The name of the system profile.
+  #   data: This is the data that will be used to create the system profile. It is a JSON object that contains the
+  # following keys:
   def create_system_profile(name, data)
     @test.call('system.createSystemProfile', sessionKey: @test.token, systemName: name, data: data)
   end
 
+  ##
+  # > Returns a list of system profiles that have no systems assigned to them
   def list_empty_system_profiles
     @test.call('system.listEmptySystemProfiles', sessionKey: @test.token)
   end
 
+  ##
+  # This function will obtain a reactivation key for a server
+  #
+  # Args:
+  #   server: The server ID of the server you want to reactivate.
   def obtain_reactivation_key(server)
     @test.call('system.obtainReactivationKey', sessionKey: @test.token, sid: server)
   end
@@ -92,10 +170,21 @@ end
 
 # "system.config" namespace
 class NamespaceSystemConfig
+  ##
+  # It initializes the api_test variable.
+  #
+  # Args:
+  #   api_test: This is the test object that is passed to the initialize method.
   def initialize(api_test)
     @test = api_test
   end
 
+  ##
+  # Remove the specified channels from the specified servers
+  #
+  # Args:
+  #   servers: An array of server IDs
+  #   channels: An array of channel labels to remove from the server.
   def remove_channels(servers, channels)
     @test.call('system.config.removeChannels', sessionKey: @test.token, sids: servers, configChannelLabels: channels)
   end
@@ -103,10 +192,21 @@ end
 
 # "system.custominfo" namespace
 class NamespaceSystemCustominfo
+  ##
+  # It initializes the api_test variable.
+  #
+  # Args:
+  #   api_test: This is the test object that is passed in from the test script.
   def initialize(api_test)
     @test = api_test
   end
 
+  ##
+  # This function creates a custom info key
+  #
+  # Args:
+  #   value: The name of the custom field
+  #   desc: The description of the key.
   def create_key(value, desc)
     @test.call('system.custominfo.createKey', sessionKey: @test.token, keyLabel: value, keyDescription: desc)
   end
@@ -114,6 +214,12 @@ end
 
 # "system.provisioning" namespace
 class NamespaceSystemProvisioning
+  ##
+  # This function initializes the powermanagement namespace
+  #
+  # Args:
+  #   api_test: This is the object that is passed in from the test script. It contains the methods that are used to make
+  # the API calls.
   def initialize(api_test)
     @test = api_test
     @powermanagement = NamespaceSystemProvisioningPowermanagement.new(api_test)
@@ -124,34 +230,72 @@ end
 
 # "system.provisioning.powermanagement" namespace
 class NamespaceSystemProvisioningPowermanagement
+  ##
+  # It initializes the api_test variable.
+  #
+  # Args:
+  #   api_test: This is the test object that is passed to the initialize method.
   def initialize(api_test)
     @test = api_test
   end
 
+  ##
+  # > This function lists the power management types available for a given system
   def list_types
     @test.call('system.provisioning.powermanagement.listTypes', sessionKey: @test.token)
   end
 
+  ##
+  # This function will return the power management details of a server
+  #
+  # Args:
+  #   server: The server ID
   def get_details(server)
     @test.call('system.provisioning.powermanagement.getDetails', sessionKey: @test.token, sid: server)
   end
 
+  ##
+  # This function will return the power status of a server
+  #
+  # Args:
+  #   server: The server ID
   def get_status(server)
     @test.call('system.provisioning.powermanagement.getStatus', sessionKey: @test.token, sid: server)
   end
 
+  ##
+  # This function sets the power management details for a server
+  #
+  # Args:
+  #   server: The server ID
+  #   data: A hash of the data to be set.
   def set_details(server, data)
     @test.call('system.provisioning.powermanagement.setDetails', sessionKey: @test.token, sid: server, data: data)
   end
 
+  ##
+  # This function powers on a server
+  #
+  # Args:
+  #   server: The server ID of the server you want to power on.
   def power_on(server)
     @test.call('system.provisioning.powermanagement.powerOn', sessionKey: @test.token, sid: server)
   end
 
+  ##
+  # This function will power off a server
+  #
+  # Args:
+  #   server: The server ID of the server you want to power off.
   def power_off(server)
     @test.call('system.provisioning.powermanagement.powerOff', sessionKey: @test.token, sid: server)
   end
 
+  ##
+  # This function reboots a server
+  #
+  # Args:
+  #   server: The server ID you want to reboot.
   def reboot(server)
     @test.call('system.provisioning.powermanagement.reboot', sessionKey: @test.token, sid: server)
   end
@@ -159,10 +303,20 @@ end
 
 # "system.scap" namespace
 class NamespaceSystemScap
+  ##
+  # It initializes the api_test variable.
+  #
+  # Args:
+  #   api_test: This is the test object that is passed to the initialize method.
   def initialize(api_test)
     @test = api_test
   end
 
+  ##
+  # > List all XCCDF scans for a given server
+  #
+  # Args:
+  #   server: The server ID of the server you want to list the XCCDF scans for.
   def list_xccdf_scans(server)
     @test.call('system.scap.listXccdfScans', sessionKey: @test.token, sid: server)
   end
@@ -170,10 +324,20 @@ end
 
 # "system.search" namespace
 class NamespaceSystemSearch
+  ##
+  # It initializes the api_test variable.
+  #
+  # Args:
+  #   api_test: This is the test object that is passed to the initialize method.
   def initialize(api_test)
     @test = api_test
   end
 
+  ##
+  # This function takes a server name as an argument and returns the hostname of the server
+  #
+  # Args:
+  #   server: The server name you want to search for.
   def hostname(server)
     @test.call('system.search.hostname', sessionKey: @test.token, searchTerm: server)
   end

--- a/testsuite/features/support/namespaces/system.rb
+++ b/testsuite/features/support/namespaces/system.rb
@@ -1,7 +1,7 @@
-# Copyright (c) 2022 SUSE LLC.
+# Copyright (c) 2022-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
-# "system" namespace
+# System namespace
 class NamespaceSystem
   def initialize(api_test)
     @test = api_test
@@ -32,7 +32,7 @@ class NamespaceSystem
   end
 
   ##
-  # > This function will list all systems in the system
+  # List all systems in the system
   def list_systems
     @test.call('system.listSystems', sessionKey: @test.token)
   end
@@ -47,7 +47,7 @@ class NamespaceSystem
   end
 
   ##
-  # This function lists all the packages that can be installed on a server
+  # Lists all the packages that can be installed on a server
   #
   # Args:
   #   server: The server ID of the server you want to list the packages for.
@@ -56,7 +56,7 @@ class NamespaceSystem
   end
 
   ##
-  # `list_latest_upgradable_packages` returns a list of packages that are upgradable on a given server
+  # List of packages that are upgradable on a given server
   #
   # Args:
   #   server: The server ID
@@ -65,7 +65,7 @@ class NamespaceSystem
   end
 
   ##
-  # If a proxy is defined, use it, otherwise don't
+  # Bootstrap a system
   #
   # Args:
   #   host: The hostname of the system to bootstrap
@@ -82,7 +82,7 @@ class NamespaceSystem
   end
 
   ##
-  # `schedule_apply_highstate` schedules a highstate to be applied to a server at a given date
+  # Schedules a highstate to be applied to a server at a given date
   #
   # Args:
   #   server: The server ID of the server you want to schedule the highstate on.
@@ -93,7 +93,7 @@ class NamespaceSystem
   end
 
   ##
-  # This function schedules a package refresh on a server
+  # Schedules a package refresh on a server
   #
   # Args:
   #   server: The server ID of the server you want to schedule the package refresh on.
@@ -103,7 +103,7 @@ class NamespaceSystem
   end
 
   ##
-  # > Schedule a reboot for a server on a specific date
+  # Schedule a reboot for a server on a specific date
   #
   # Args:
   #   server: The server ID you want to reboot.
@@ -113,19 +113,9 @@ class NamespaceSystem
   end
 
   ##
-  # This function schedules a script to run on a server at a specified date and time
+  # Schedules a script to run on a server at a specified date and time
   #
   # Args:
-  ##
-  # This function creates a system record in the Satellite 6 server
-  #
-  # Args:
-  #   name: The name of the system record.
-  #   kslabel: The kickstart label you want to use.
-  #   koptions:
-  #   comment: A comment about the system record.
-  #   netdevices: This is a hash of the network devices that you want to use.  The key is the device name, and the value
-  # is the IP address.  For example:
   #   server: The server ID of the server you want to run the script on.
   #   uid: The user ID of the user who will run the script.
   #   gid: The group name of the user that will run the script.
@@ -137,12 +127,22 @@ class NamespaceSystem
     @test.call('system.scheduleScriptRun', sessionKey: @test.token, sid: server, username: uid, groupname: gid, timeout: timeout, script: script, earliestOccurrence: date)
   end
 
+  ##
+  # Creates a system record in the Satellite 6 server.
+  #
+  # Args:
+  #   name: The name of the system record.
+  #   kslabel: The kickstart label you want to use.
+  #   koptions:
+  #   comment: A comment about the system record.
+  #   netdevices: This is a hash of the network devices that you want to use.  The key is the device name, and the value
+  # is the IP address.  For example:
   def create_system_record(name, kslabel, koptions, comment, netdevices)
     @test.call('system.createSystemRecord', sessionKey: @test.token, systemName: name, ksLabel: kslabel, kOptions: koptions, comment: comment, netDevices: netdevices)
   end
 
   ##
-  # This function creates a system profile with the given name and data
+  # Creates a system profile with the given name and data.
   #
   # Args:
   #   name: The name of the system profile.
@@ -153,13 +153,13 @@ class NamespaceSystem
   end
 
   ##
-  # > Returns a list of system profiles that have no systems assigned to them
+  # Returns a list of system profiles that have no systems assigned to them.
   def list_empty_system_profiles
     @test.call('system.listEmptySystemProfiles', sessionKey: @test.token)
   end
 
   ##
-  # This function will obtain a reactivation key for a server
+  # This function will obtain a reactivation key for a server.
   #
   # Args:
   #   server: The server ID of the server you want to reactivate.
@@ -168,7 +168,7 @@ class NamespaceSystem
   end
 end
 
-# "system.config" namespace
+# System Configuration namespace
 class NamespaceSystemConfig
   ##
   # It initializes the api_test variable.
@@ -180,7 +180,7 @@ class NamespaceSystemConfig
   end
 
   ##
-  # Remove the specified channels from the specified servers
+  # Remove the specified channels from the specified servers.
   #
   # Args:
   #   servers: An array of server IDs
@@ -190,7 +190,7 @@ class NamespaceSystemConfig
   end
 end
 
-# "system.custominfo" namespace
+# System Custom Information namespace
 class NamespaceSystemCustominfo
   ##
   # It initializes the api_test variable.
@@ -202,7 +202,7 @@ class NamespaceSystemCustominfo
   end
 
   ##
-  # This function creates a custom info key
+  # Creates a custom info key.
   #
   # Args:
   #   value: The name of the custom field
@@ -212,7 +212,7 @@ class NamespaceSystemCustominfo
   end
 end
 
-# "system.provisioning" namespace
+# System Provisioning namespace
 class NamespaceSystemProvisioning
   ##
   # This function initializes the powermanagement namespace
@@ -228,7 +228,7 @@ class NamespaceSystemProvisioning
   attr_reader :powermanagement
 end
 
-# "system.provisioning.powermanagement" namespace
+# System Provisioning Power Management namespace
 class NamespaceSystemProvisioningPowermanagement
   ##
   # It initializes the api_test variable.
@@ -240,41 +240,41 @@ class NamespaceSystemProvisioningPowermanagement
   end
 
   ##
-  # > This function lists the power management types available for a given system
+  # Lists the power management types available for a given system.
   def list_types
     @test.call('system.provisioning.powermanagement.listTypes', sessionKey: @test.token)
   end
 
   ##
-  # This function will return the power management details of a server
+  # Returns the power management details of a server.
   #
   # Args:
-  #   server: The server ID
+  #   server: The server ID.
   def get_details(server)
     @test.call('system.provisioning.powermanagement.getDetails', sessionKey: @test.token, sid: server)
   end
 
   ##
-  # This function will return the power status of a server
+  # Returns the power status of a server.
   #
   # Args:
-  #   server: The server ID
+  #   server: The server ID.
   def get_status(server)
     @test.call('system.provisioning.powermanagement.getStatus', sessionKey: @test.token, sid: server)
   end
 
   ##
-  # This function sets the power management details for a server
+  # Sets the power management details for a server.
   #
   # Args:
-  #   server: The server ID
+  #   server: The server ID.
   #   data: A hash of the data to be set.
   def set_details(server, data)
     @test.call('system.provisioning.powermanagement.setDetails', sessionKey: @test.token, sid: server, data: data)
   end
 
   ##
-  # This function powers on a server
+  # Power on a server.
   #
   # Args:
   #   server: The server ID of the server you want to power on.
@@ -283,7 +283,7 @@ class NamespaceSystemProvisioningPowermanagement
   end
 
   ##
-  # This function will power off a server
+  # Power off a server.
   #
   # Args:
   #   server: The server ID of the server you want to power off.
@@ -292,7 +292,7 @@ class NamespaceSystemProvisioningPowermanagement
   end
 
   ##
-  # This function reboots a server
+  # Reboots a server.
   #
   # Args:
   #   server: The server ID you want to reboot.
@@ -301,7 +301,7 @@ class NamespaceSystemProvisioningPowermanagement
   end
 end
 
-# "system.scap" namespace
+# System SCAP namespace
 class NamespaceSystemScap
   ##
   # It initializes the api_test variable.
@@ -313,7 +313,7 @@ class NamespaceSystemScap
   end
 
   ##
-  # > List all XCCDF scans for a given server
+  # List all XCCDF scans for a given server.
   #
   # Args:
   #   server: The server ID of the server you want to list the XCCDF scans for.
@@ -322,7 +322,7 @@ class NamespaceSystemScap
   end
 end
 
-# "system.search" namespace
+# System Search namespace
 class NamespaceSystemSearch
   ##
   # It initializes the api_test variable.
@@ -334,7 +334,7 @@ class NamespaceSystemSearch
   end
 
   ##
-  # This function takes a server name as an argument and returns the hostname of the server
+  # Takes a server name as an argument and returns the hostname of the server
   #
   # Args:
   #   server: The server name you want to search for.

--- a/testsuite/features/support/namespaces/system.rb
+++ b/testsuite/features/support/namespaces/system.rb
@@ -32,13 +32,13 @@ class NamespaceSystem
   end
 
   ##
-  # List all systems in the system
+  # Lists all systems in the server.
   def list_systems
     @test.call('system.listSystems', sessionKey: @test.token)
   end
 
   ##
-  # It searches for a name in the system
+  # Searches for a system based on its name.
   #
   # Args:
   #   name: The name of the system you want to search for.
@@ -47,7 +47,7 @@ class NamespaceSystem
   end
 
   ##
-  # Lists all the packages that can be installed on a server
+  # Lists all the packages that can be installed on a server.
   #
   # Args:
   #   server: The server ID of the server you want to list the packages for.
@@ -56,21 +56,21 @@ class NamespaceSystem
   end
 
   ##
-  # List of packages that are upgradable on a given server
+  # Lists the packages that are upgradable on a given server.
   #
   # Args:
-  #   server: The server ID
+  #   server: The server ID.
   def list_latest_upgradable_packages(server)
     @test.call('system.listLatestUpgradablePackages', sessionKey: @test.token, sid: server)
   end
 
   ##
-  # Bootstrap a system
+  # Bootstraps a system, given its hostname, activation key and whether it's SSH managed or not.
   #
   # Args:
-  #   host: The hostname of the system to bootstrap
+  #   host: The hostname of the system to bootstrap.
   #   activation_key: The activation key to use for the system.
-  #   salt_ssh: true/false
+  #   salt_ssh: Boolean value determining if the system is SSH managed or not.
   def bootstrap_system(host, activation_key, salt_ssh)
     if $proxy.nil?
       @test.call('system.bootstrap', sessionKey: @test.token, host: host, sshPort: 22, sshUser: 'root', sshPassword: 'linux', activationKey: activation_key, saltSSH: salt_ssh)
@@ -82,12 +82,12 @@ class NamespaceSystem
   end
 
   ##
-  # Schedules a highstate to be applied to a server at a given date
+  # Schedules a highstate to be applied to a server at a given date.
   #
   # Args:
   #   server: The server ID of the server you want to schedule the highstate on.
   #   date: The date and time you want the highstate to be applied.
-  #   test: true or false
+  #   test: Boolean that determines if the highstate is run on test mode or not.
   def schedule_apply_highstate(server, date, test)
     @test.call('system.scheduleApplyHighstate', sessionKey: @test.token, sid: server, earliestOccurrence: date, test: test)
   end
@@ -103,7 +103,7 @@ class NamespaceSystem
   end
 
   ##
-  # Schedule a reboot for a server on a specific date
+  # Schedules a reboot for a server on a specific date.
   #
   # Args:
   #   server: The server ID you want to reboot.
@@ -113,7 +113,7 @@ class NamespaceSystem
   end
 
   ##
-  # Schedules a script to run on a server at a specified date and time
+  # Schedules a script to run on a server at a specified date and time.
   #
   # Args:
   #   server: The server ID of the server you want to run the script on.
@@ -122,7 +122,7 @@ class NamespaceSystem
   #   timeout: The amount of time in seconds that the script is allowed to run before it is killed.
   #   script: The script to run.
   #   date: The date and time you want the script to run.  This is in the format of YYYY-MM-DD HH:MM:SS.  For example, to
-  # run the script at 11:30pm on December 31st, 2013, you would use 2013-12-31 23
+  # run the script at 11:30pm on December 31st, 2013, you would use 2013-12-31 23:30:00.
   def schedule_script_run(server, uid, gid, timeout, script, date)
     @test.call('system.scheduleScriptRun', sessionKey: @test.token, sid: server, username: uid, groupname: gid, timeout: timeout, script: script, earliestOccurrence: date)
   end
@@ -136,7 +136,7 @@ class NamespaceSystem
   #   koptions:
   #   comment: A comment about the system record.
   #   netdevices: This is a hash of the network devices that you want to use.  The key is the device name, and the value
-  # is the IP address.  For example:
+  # is the IP address.  For example: #TODO
   def create_system_record(name, kslabel, koptions, comment, netdevices)
     @test.call('system.createSystemRecord', sessionKey: @test.token, systemName: name, ksLabel: kslabel, kOptions: koptions, comment: comment, netDevices: netdevices)
   end
@@ -147,7 +147,7 @@ class NamespaceSystem
   # Args:
   #   name: The name of the system profile.
   #   data: This is the data that will be used to create the system profile. It is a JSON object that contains the
-  # following keys:
+  # following keys: #TODO
   def create_system_profile(name, data)
     @test.call('system.createSystemProfile', sessionKey: @test.token, systemName: name, data: data)
   end
@@ -159,7 +159,7 @@ class NamespaceSystem
   end
 
   ##
-  # This function will obtain a reactivation key for a server.
+  # Gets the reactivation key of a server.
   #
   # Args:
   #   server: The server ID of the server you want to reactivate.
@@ -180,7 +180,7 @@ class NamespaceSystemConfig
   end
 
   ##
-  # Remove the specified channels from the specified servers.
+  # Removes the specified channels from the specified servers.
   #
   # Args:
   #   servers: An array of server IDs
@@ -215,7 +215,7 @@ end
 # System Provisioning namespace
 class NamespaceSystemProvisioning
   ##
-  # This function initializes the powermanagement namespace
+  # Initializes the Power Management namespace.
   #
   # Args:
   #   api_test: This is the object that is passed in from the test script. It contains the methods that are used to make
@@ -274,7 +274,7 @@ class NamespaceSystemProvisioningPowermanagement
   end
 
   ##
-  # Power on a server.
+  # Powers on a server.
   #
   # Args:
   #   server: The server ID of the server you want to power on.
@@ -283,7 +283,7 @@ class NamespaceSystemProvisioningPowermanagement
   end
 
   ##
-  # Power off a server.
+  # Powers off a server.
   #
   # Args:
   #   server: The server ID of the server you want to power off.

--- a/testsuite/features/support/namespaces/user.rb
+++ b/testsuite/features/support/namespaces/user.rb
@@ -1,7 +1,7 @@
-# Copyright (c) 2022 SUSE LLC.
+# Copyright (c) 2022-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
-# "user" namespace
+# User namespace
 class NamespaceUser
   ##
   # It initializes the api_test variable.
@@ -13,14 +13,13 @@ class NamespaceUser
   end
 
   ##
-  # `list_users` is a function that calls the `user.listUsers` method of the `@test` object, passing in the `sessionKey`
-  # as the `@test.token` value
+  # List all users
   def list_users
     @test.call('user.listUsers', sessionKey: @test.token)
   end
 
   ##
-  # > This function lists the roles of a user
+  # Lists the roles of a user.
   #
   # Args:
   #   user: The user you want to list the roles of.
@@ -29,20 +28,20 @@ class NamespaceUser
   end
 
   ##
-  # This function creates a user with the given parameters
+  # Creates a user with the given parameters.
   #
   # Args:
   #   user: The username of the user you want to create.
-  #   password: password
-  #   first: First name of the user
-  #   last: last name of the user
-  #   email: email address of the user
+  #   password: password.
+  #   first: First name of the user.
+  #   last: last name of the user.
+  #   email: email address of the user.
   def create(user, password, first, last, email)
     @test.call('user.create', sessionKey: @test.token, login: user, password: password, firstName: first, lastName: last, email: email)
   end
 
   ##
-  # This function deletes a user from the system
+  # Deletes a user from the system.
   #
   # Args:
   #   user: The username of the user you want to delete.
@@ -51,30 +50,30 @@ class NamespaceUser
   end
 
   ##
-  # This function adds a role to a user
+  # Adds a role to a user.
   #
   # Args:
-  #   user: The user's login name
+  #   user: The user's login name.
   #   role: The role to add to the user.
   def add_role(user, role)
     @test.call('user.addRole', sessionKey: @test.token, login: user, role: role)
   end
 
   ##
-  # This function removes a role from a user
+  # Removes a role from a user.
   #
   # Args:
-  #   user: The user's login name
+  #   user: The user's login name.
   #   role: The role to add to the user.
   def remove_role(user, role)
     @test.call('user.removeRole', sessionKey: @test.token, login: user, role: role)
   end
 
   ##
-  # It takes a user's login name and returns their details
+  # It takes a user's login name and returns their details.
   #
   # Args:
-  #   user: The user's login name
+  #   user: The user's login name.
   def get_details(user)
     @test.call('user.getDetails', sessionKey: @test.token, login: user)
   end

--- a/testsuite/features/support/namespaces/user.rb
+++ b/testsuite/features/support/namespaces/user.rb
@@ -3,34 +3,78 @@
 
 # "user" namespace
 class NamespaceUser
+  ##
+  # It initializes the api_test variable.
+  #
+  # Args:
+  #   api_test: This is the test object that is passed in from the test script.
   def initialize(api_test)
     @test = api_test
   end
 
+  ##
+  # `list_users` is a function that calls the `user.listUsers` method of the `@test` object, passing in the `sessionKey`
+  # as the `@test.token` value
   def list_users
     @test.call('user.listUsers', sessionKey: @test.token)
   end
 
+  ##
+  # > This function lists the roles of a user
+  #
+  # Args:
+  #   user: The user you want to list the roles of.
   def list_roles(user)
     @test.call('user.listRoles', sessionKey: @test.token, login: user)
   end
 
+  ##
+  # This function creates a user with the given parameters
+  #
+  # Args:
+  #   user: The username of the user you want to create.
+  #   password: password
+  #   first: First name of the user
+  #   last: last name of the user
+  #   email: email address of the user
   def create(user, password, first, last, email)
     @test.call('user.create', sessionKey: @test.token, login: user, password: password, firstName: first, lastName: last, email: email)
   end
 
+  ##
+  # This function deletes a user from the system
+  #
+  # Args:
+  #   user: The username of the user you want to delete.
   def delete(user)
     @test.call('user.delete', sessionKey: @test.token, login: user)
   end
 
+  ##
+  # This function adds a role to a user
+  #
+  # Args:
+  #   user: The user's login name
+  #   role: The role to add to the user.
   def add_role(user, role)
     @test.call('user.addRole', sessionKey: @test.token, login: user, role: role)
   end
 
+  ##
+  # This function removes a role from a user
+  #
+  # Args:
+  #   user: The user's login name
+  #   role: The role to add to the user.
   def remove_role(user, role)
     @test.call('user.removeRole', sessionKey: @test.token, login: user, role: role)
   end
 
+  ##
+  # It takes a user's login name and returns their details
+  #
+  # Args:
+  #   user: The user's login name
   def get_details(user)
     @test.call('user.getDetails', sessionKey: @test.token, login: user)
   end

--- a/testsuite/features/support/pretty_formatter.rb
+++ b/testsuite/features/support/pretty_formatter.rb
@@ -3,6 +3,7 @@
 
 require 'cucumber/formatter/pretty'
 
+# CustomFormatter module
 module CustomFormatter
   PrettyFormatter = PrependsFeatureName.formatter(Cucumber::Formatter::Pretty)
 end

--- a/testsuite/features/support/pretty_formatter.rb
+++ b/testsuite/features/support/pretty_formatter.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2019 SUSE LLC.
+# Copyright (c) 2013-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'cucumber/formatter/pretty'

--- a/testsuite/features/support/xmlrpc_client.rb
+++ b/testsuite/features/support/xmlrpc_client.rb
@@ -5,12 +5,24 @@ require 'xmlrpc/client'
 
 # Wrapper class for XML-RPC client library
 class XmlrpcClient
+  ##
+  # It creates an XMLRPC client object that will be used to communicate with the Spacewalk server
+  #
+  # Args:
+  #   host: The hostname of the Spacewalk server.
   def initialize(host)
     puts 'Activating XML-RPC API'
     protocol = $debug_mode ? 'http://' : 'https://'
     @xmlrpc_client = XMLRPC::Client.new2(protocol + host + '/rpc/api', nil, DEFAULT_TIMEOUT)
   end
 
+  ##
+  # It calls a remote method with a list of parameters
+  #
+  # Args:
+  #   name: The name of the method to call.
+  #   params: A hash of parameters. The keys are the names of the parameters, and the values are the values of the
+  # parameters.
   def call(name, params)
     # TODO: What happens if params.nil?
     @xmlrpc_client.call(name, *params.values)

--- a/testsuite/features/support/xmlrpc_client.rb
+++ b/testsuite/features/support/xmlrpc_client.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 SUSE LLC.
+# Copyright (c) 2022-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'xmlrpc/client'


### PR DESCRIPTION
## What does this PR change?

This PR is part of this card https://github.com/SUSE/spacewalk/issues/14192

This PR only add documentation headers for each method, in order to get rid of Rubocop alarms that we are not ignoring.

**Note:
Be aware that all the documentation is auto-generate by the IDE, so feel free to contribute with suggestion comments and I will apply them directly.**

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- None

- [x] **DONE**

## Links

Ports:
- Manager-4.2
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
