### PR TITLE
Improve logs when _mgractionchains.conf and *sls are missing

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/SaltActionChainGeneratorService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltActionChainGeneratorService.java
@@ -491,13 +491,17 @@ public class SaltActionChainGeneratorService {
      */
     public List<String> findFileRefsToDelete(Path targetFilePath) {
         try {
+            List<String> res = new LinkedList<>();
+            if (!targetFilePath.toFile().exists()) {
+                LOG.debug("{} does not exists", targetFilePath.toFile());
+                return res;
+            }
             String slsContent = FileUtils.readFileToString(targetFilePath.toFile());
             // first remove line containing ssh_extra_filerefs because it contains
             // all the files used for an action chain and we want to delete
             // salt:// refs that belong only to the given file
             slsContent = slsContent.replaceAll("ssh_extra_filerefs.+", "");
             Matcher m = SALT_FILE_REF.matcher(slsContent);
-            List<String> res = new LinkedList<>();
             int start = 0;
             while (m.find(start)) {
                 String ref = m.group(2);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Improve logs when sls action chain file is missing
 - Fix modular channel check during system update via XMLRPC (bsc#1206613)
 - Fix transaction commit behavior for Spark routes
 - Trigger a package profile update when a new live-patch is installed (bsc#1206249)

--- a/susemanager-utils/susemanager-sls/src/modules/mgractionchains.py
+++ b/susemanager-utils/susemanager-sls/src/modules/mgractionchains.py
@@ -82,7 +82,7 @@ def _read_next_ac_chunk(clear=True):
 
 def _read_sls_file(filename):
     if not os.path.isfile(filename):
-        log.error("File {0} not found".format(filename))
+        log.debug("File {0} does not exists".format(filename))
         return None
     ret = None
     try:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Improve _mgractionchains.conf logs
 - install SUSE Liberty v2 GPG key
 - Detect bootstrap repository path for SLE Micro
 - Fix reboot info beacon installation


### PR DESCRIPTION
## What does this PR change?

Currently some logs are misleading e.g. 
from `rhn_web_ui.log`:
```
2023-01-13 12:03:12,252 [salt-event-thread-3] ERROR com.suse.manager.webui.services.SaltActionChainGeneratorService - Could not collect salt:// references from file /srv/susemanager/salt/actionchains/actionchain_0_346f8bf963553ef574a0c65763c03803_1.sls
```
or in minion `/var/log/salt/minion`:
```
2023-01-13 12:03:09,010 [salt.loaded.ext.module.mgractionchains:85  ][ERROR   ][1080] File /etc/salt/minion.d/_mgractionchains.conf not found
```

Fix these messages.
## GUI diff

No difference.


- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/6248

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"   
- [x] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
