### PR TITLE
QE: Add summary headers to step definition files

### DIFF
--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -1,5 +1,7 @@
-# Copyright (c) 2015-2022 SUSE LLC
+# Copyright (c) 2015-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
+
+### This file contains the definitions for all steps concerning the API.
 
 require 'json'
 require 'socket'

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1,6 +1,8 @@
 # Copyright (c) 2014-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
+### This file contains the definitions for all steps concerning the execution of commands on a system.
+
 require 'timeout'
 require 'nokogiri'
 require 'pg'

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1,9 +1,15 @@
 # Copyright (c) 2010-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
+### This file contains all step definitions concerning general product funtionality
+### as well as those which do not fit into any other category or are temporary workarounds.
+###
+### The definitions are divided into blocks marked with a summary headline.
+
 require 'jwt'
 require 'securerandom'
 require 'pathname'
+
 # Used for debugging purposes
 When(/^I save a screenshot as "([^"]+)"$/) do |filename|
   save_screenshot(filename)

--- a/testsuite/features/step_definitions/datepicker_steps.rb
+++ b/testsuite/features/step_definitions/datepicker_steps.rb
@@ -1,5 +1,8 @@
-# Copyright (c) 2017-2021 SUSE LLC.
+# Copyright (c) 2017-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
+
+### This file contains the definitions for all steps concerning the selection,
+### handling or finding of dates and times including timestamps.
 
 require 'date'
 

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -1,5 +1,7 @@
-# Copyright (c) 2017-2022 SUSE LLC.
+# Copyright (c) 2017-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
+
+### This file contains the definitions for all steps concerning Docker and containerization.
 
 require 'time'
 require 'date'

--- a/testsuite/features/step_definitions/lock_packages_on_client.rb
+++ b/testsuite/features/step_definitions/lock_packages_on_client.rb
@@ -1,5 +1,7 @@
-# Copyright (c) 2010-2019 SUSE LLC.
+# Copyright (c) 2010-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
+
+### This file contains the definitions for all steps used to lock packages on a system.
 
 Then(/^"(.*?)" is (locked|unlocked) on "(.*?)"$/) do |pkg, action, system|
   node = get_target(system)

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -1,6 +1,9 @@
 # Copyright (c) 2010-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
+### This file contains the definitions for all steps concerning navigation through the Web UI
+### as well as validating the UI output.
+
 #
 # Texts and links
 #

--- a/testsuite/features/step_definitions/retail_steps.rb
+++ b/testsuite/features/step_definitions/retail_steps.rb
@@ -1,6 +1,9 @@
 # Copyright 2021-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+### This file contains the definitions for all steps concerning the different
+### kinds of minions as well as PXE boot and Retail.
+
 # This function returns the net prefix, caching it
 def net_prefix
   $net_prefix = $private_net.sub(%r{\.0+/24$}, '.') if $net_prefix.nil?

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -1,5 +1,8 @@
-# Copyright 2015-2022 SUSE LLC
+# Copyright 2015-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
+
+### This file contains all step definitions concerning Salt and bootstrapping
+### Salt minions.
 
 require 'timeout'
 require 'open-uri'

--- a/testsuite/features/step_definitions/security_steps.rb
+++ b/testsuite/features/step_definitions/security_steps.rb
@@ -1,6 +1,9 @@
 # Copyright 2017-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
+### This file contains the definitions of all steps concerning
+### URI and SSL integrity.
+
 require 'open-uri'
 require 'uri'
 require 'openssl'

--- a/testsuite/features/step_definitions/smdba_steps.rb
+++ b/testsuite/features/step_definitions/smdba_steps.rb
@@ -1,5 +1,8 @@
-# Copyright 2011-2022 SUSE LLC.
+# Copyright 2011-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
+
+### This file contains the definitions of all steps concerning the configuration of
+### and access to the database.
 
 Given(/^a postgresql database is running$/) do
   $output, _code = $server.run('file /var/lib/pgsql/data/postgresql.conf', check_errors: false)


### PR DESCRIPTION
## What does this PR change?

This PR adds headers to the beginning of each step-definition file to give a rough overview about the function of the steps found within.
This is to make finding the right steps easier, help newcomers find their way around faster, make finding already existing definitions easier and help identifying accidentally misplaced new step-definitions.
## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: This only adds comments

- [x] **DONE**

## Links

Manager-4.3: https://github.com/SUSE/spacewalk/pull/20209
Manager-4.2: https://github.com/SUSE/spacewalk/pull/20210

Fixes: https://github.com/SUSE/spacewalk/issues/17294

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
