### PR TITLE
QE: Rename openSCAP test results

### DIFF
--- a/testsuite/features/secondary/min_deblike_openscap_audit.feature
+++ b/testsuite/features/secondary/min_deblike_openscap_audit.feature
@@ -39,7 +39,7 @@ Feature: OpenSCAP audit of Debian-like Salt minion
   Scenario: Check the results of the OpenSCAP scan on the Debian-like minion
     Given I am on the Systems overview page of this "deblike_minion"
     When I follow "Audit" in the content area
-    And I follow "xccdf_org.open-scap_testresult_standard"
+    And I follow "xccdf_org.open-scap_testresult_xccdf_org.ssgproject.content_profile_standard"
     Then I should see a "Details of XCCDF Scan" text
     And I should see a "Ubuntu" text
     And I should see a "XCCDF Rule Results" text

--- a/testsuite/features/secondary/min_rhlike_openscap_audit.feature
+++ b/testsuite/features/secondary/min_rhlike_openscap_audit.feature
@@ -50,7 +50,7 @@ Feature: OpenSCAP audit of Red Hat-like Salt minion
   Scenario: Check the results of the OpenSCAP scan on the Red Hat-like minion
     Given I am on the Systems overview page of this "rhlike_minion"
     When I follow "Audit" in the content area
-    And I follow "xccdf_org.open-scap_testresult_standard"
+    And I follow "xccdf_org.open-scap_testresult_xccdf_org.ssgproject.content_profile_standard"
     Then I should see a "Details of XCCDF Scan" text
     And I should see a "RHEL-8" text
     And I should see a "XCCDF Rule Results" text


### PR DESCRIPTION
## What does this PR change?

Due to updated openSCAP/scap-security-guide packages, the test suite has to be adapted, too.
![image](https://user-images.githubusercontent.com/12104291/212343807-8bc3266d-e398-44ee-ad02-3723006aa6e9.png)
![image](https://user-images.githubusercontent.com/12104291/212343850-4154c8f1-31a3-4a39-8a7a-fa0cb14e41c8.png)

Fixes https://github.com/SUSE/spacewalk/issues/20151

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were added

- [x] **DONE**

## Links

- Manager 4.3:
- Manager 4.2:
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
