### PR TITLE
QE: Test minimal Rocky 8 image for reposync

### DIFF
--- a/testsuite/features/reposync/srv_add_rocky8_repositories.feature
+++ b/testsuite/features/reposync/srv_add_rocky8_repositories.feature
@@ -8,7 +8,7 @@ Feature: Add the Rocky 8 distribution custom repositories
   I want to filter them out to remove the modules information
 
   Scenario: Download the iso of Rocky 8 DVD and mount it on the server
-    When I mount as "rocky-8-iso" the ISO from "http://minima-mirror.mgr.suse.de/pub/rocky/8/isos/x86_64/Rocky-x86_64-dvd.iso" in the server
+    When I mount as "rocky-8-iso" the ISO from "http://minima-mirror.mgr.suse.de/pub/rocky/8/isos/x86_64/Rocky-x86_64-minimal.iso" in the server
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section


### PR DESCRIPTION
## What does this PR change?

This tests if we can use a smaller Rocky 8 image.

- Rocky 8 DVD: 12GB
- Rocky 8 minimal: 2.2GB


If this is successful, the mirror config has to be adjusted to download the minimal image. For now I downloaded it manual to minima in Nuremberg.
PR test: https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-prs-ci-tests/2089/

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
