### PR TITLE
detect if RHEL target is really connected to the CDN (bsc#1206861)

### DIFF
--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -388,6 +388,12 @@ def list_labels(mgr_bootstrap_data, force=False, do_print=True):
             (all(elem in synced_products for elem in mgr_bootstrap_data.DATA[label]['PDID']) or
                 (force and any(elem in synced_products for elem in mgr_bootstrap_data.DATA[label]['PDID'])))):
 
+            if label in ('RHEL8-x86_64', 'RHEL9-x86_64'):
+                if not connected_to_rhel_cdn(find_root_channel_labels(', '.join(mgr_bootstrap_data.DATA[label]['PDID']))):
+                    # skip native RHEL if not connected to cdn
+                    log("{} not connected to CDN. Skipping".format(label), 1)
+                    continue
+
             if do_print:
                 print("{0}. {1}".format(label_index, label))
             label_map[label_index] = label
@@ -417,6 +423,11 @@ def create_repo(label, options, mgr_bootstrap_data, additional=[]):
 
     if 'PDID' in mgr_bootstrap_data.DATA[label]:
         pdids = ', '.join(mgr_bootstrap_data.DATA[label]['PDID'])
+        if label in ('RHEL8-x86_64', 'RHEL9-x86_64'):
+            if not connected_to_rhel_cdn(find_root_channel_labels(pdids)):
+                log("WARNING: {} not connected to CDN.".format(label))
+
+
         if (label.startswith('RES') or label.startswith('RHEL') or label.lower().startswith('ubuntu')):
             usecustomchannels = True
         if isUyuni():
@@ -628,9 +639,40 @@ def generate_repo_view(mgr_bootstrap_data):
         repos[mgr_bootstrap_data.DATA[dist]['DEST']][dist] = mgr_bootstrap_data.DATA[dist]
     return repos
 
+def connected_to_rhel_cdn(root_channel_labels):
+    # only 1 entry in root_channel_labels expected
+    if len(root_channel_labels) != 1:
+        return False
+    rcl = root_channel_labels.pop()
+    _child_connected_to_redhat_cdn = """
+    select ch.id
+      from rhnchannel ch
+      join rhnchannelcontentsource chcc on ch.id = chcc.channel_id
+      join rhncontentsource cc on chcc.source_id = cc.id
+     where ch.parent_channel in (select c.id
+                                   from rhnchannel c
+                                  where c.label = :parentlabel
+                                    and c.parent_channel is NULL)
+       and ch.org_id IS NOT NULL
+       and (cc.source_url like '%cdn.redhat.com%'
+            or LOWER(cc.source_url) like '%/baseos%'
+            or LOWER(cc.source_url) like '%/appstream%');
+    """
+    h = rhnSQL.prepare(rhnSQL.Statement(_child_connected_to_redhat_cdn))
+    h.execute(parentlabel=rcl)
+    res = h.fetchall_dict() or False
+    if not res:
+        return False
+    return True
+
 def find_dists_for_regeneration(dest, dists, doall=False):
     regenerate = []
     for label, dist in dists.items():
+        if label in ('RHEL8-x86_64', 'RHEL9-x86_64') and 'PDID' in dist:
+            if not connected_to_rhel_cdn(find_root_channel_labels(', '.join(dist['PDID']))):
+                # skip native RHEL if not connected to cdn
+                log("{} not connected to CDN. Skipping".format(label), 1)
+                continue
         destfile = os.path.join(dest, 'repodata', 'repomd.xml')
         if 'TYPE' in dist and dist['TYPE'] == 'deb':
             destfile = os.path.join(dest, 'dists', 'bootstrap', 'Release')

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- show RHEL target for bootstrap repo creation only if it is
+  really connected to the CDN (bsc#1206861)
 - fix bootstrap repo definition for SUSE Liberty Linux 9 and RHEL9
   (bsc#1207136)
 - fix tools channel detection on Uyuni


### PR DESCRIPTION
## What does this PR change?

Show RHEL target for bootstrap repo creation only if it is really connected to the CDN.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/20156

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
