### PR TITLE
Ensure custom Salt modules are still compatible with old Python 2.6

### DIFF
--- a/.github/workflows/susemanager-sls-compatible-python26-syntax.yml
+++ b/.github/workflows/susemanager-sls-compatible-python26-syntax.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     container: centos:6
     steps:
+      # We need to use "checkout@v1" here as is the only version compatible with Python 2.6
       - name: Check out repository code
         uses: actions/checkout@v1
 

--- a/.github/workflows/susemanager-sls-compatible-python26-syntax.yml
+++ b/.github/workflows/susemanager-sls-compatible-python26-syntax.yml
@@ -2,6 +2,7 @@ name: Check for non-compatible Python 2.6 in susemanager-sls Salt modules
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened]
     paths: 'susemanager-utils/susemanager-sls/src/**/*'
 
 jobs:

--- a/.github/workflows/susemanager-sls-compatible-python26-syntax.yml
+++ b/.github/workflows/susemanager-sls-compatible-python26-syntax.yml
@@ -35,5 +35,7 @@ jobs:
       - name: Execute tests to check Python 2.6 compatiblity of custom Salt modules
         run: |
           cd $GITHUB_WORKSPACE/susemanager-utils/susemanager-sls/src/
-          for i in $(find .|grep py$ | grep -v tests); do echo "Testing $i .... "; (python $i && echo "OK") || IS_FAILED=1; echo; done
+          # Exclude tests and uyuni_config.py modules (which are for server and not included in susemanager-sls)
+          TESTS_LIST=$(find .|grep py$ | grep -v "^./tests" | grep -v "uyuni_config.py")
+          for i in $TESTS_LIST; do echo "Testing $i .... "; (python $i && echo "OK") || IS_FAILED=1; echo; done
           exit $IS_FAILED

--- a/.github/workflows/susemanager-sls-compatible-python26-syntax.yml
+++ b/.github/workflows/susemanager-sls-compatible-python26-syntax.yml
@@ -1,0 +1,39 @@
+name: Check for non-compatible Python 2.6 in susemanager-sls Salt modules
+
+on:
+  push:
+    paths: 'susemanager-utils/susemanager-sls/src/**/*'
+  pull_request:
+    paths: 'susemanager-utils/susemanager-sls/src/**/*'
+
+jobs:
+  susemanager_sls_check_non_python26_syntax:
+    runs-on: ubuntu-latest
+    container: centos:6
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v1
+
+      - name: Configure repos from CentOS vault
+        run: |
+          cd /etc/yum.repos.d/
+          sed -i 's/mirror.centos.org\/centos\/$releasever/vault.centos.org\/6.10/g' CentOS-Base.repo
+          sed -i 's/#baseurl/baseurl/g' CentOS-Base.repo
+          sed -i '/mirrorlist.*/d' CentOS-Base.repo
+
+      - name: Configure Salt products:old repos
+        run: |
+          yum install -y git wget
+          cd /etc/yum.repos.d/
+          wget http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/old/RHEL_6/systemsmanagement:saltstack:products:old.repo
+          sed -i 's/gpgcheck=1/gpgcheck=0/g' systemsmanagement:saltstack:products:old.repo
+
+      - name: Install old Salt from products:old
+        run: |
+          yum install -y salt
+
+      - name: Execute tests to check Python 2.6 compatiblity of custom Salt modules
+        run: |
+          cd $GITHUB_WORKSPACE/susemanager-utils/susemanager-sls/src/
+          for i in $(find .|grep py$ | grep -v tests); do echo "Testing $i .... "; python $i; if [ $? -ne 0 ]; then IS_FAILED=1; echo "FAILED"; else echo "OK"; fi; echo; done
+          exit $IS_FAILED

--- a/.github/workflows/susemanager-sls-compatible-python26-syntax.yml
+++ b/.github/workflows/susemanager-sls-compatible-python26-syntax.yml
@@ -1,8 +1,6 @@
 name: Check for non-compatible Python 2.6 in susemanager-sls Salt modules
 
 on:
-  push:
-    paths: 'susemanager-utils/susemanager-sls/src/**/*'
   pull_request:
     paths: 'susemanager-utils/susemanager-sls/src/**/*'
 

--- a/.github/workflows/susemanager-sls-compatible-python26-syntax.yml
+++ b/.github/workflows/susemanager-sls-compatible-python26-syntax.yml
@@ -35,5 +35,5 @@ jobs:
       - name: Execute tests to check Python 2.6 compatiblity of custom Salt modules
         run: |
           cd $GITHUB_WORKSPACE/susemanager-utils/susemanager-sls/src/
-          for i in $(find .|grep py$ | grep -v tests); do echo "Testing $i .... "; python $i; if [ $? -ne 0 ]; then IS_FAILED=1; echo "FAILED"; else echo "OK"; fi; echo; done
+          for i in $(find .|grep py$ | grep -v tests); do echo "Testing $i .... "; (python $i && echo "OK") || IS_FAILED=1; echo; done
           exit $IS_FAILED


### PR DESCRIPTION
## What does this PR change?

This PR is introducing a new GitHub action to ensure we are not introducing new code which is not Python 2.6 compatible.

Even if Python 2.6 is EOL, we want to prevent breaking existing functionality for those old systems that might be running out there. This is why, we want to make the code for these custom Salt modules to be compatible with Python 2.6.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Added new tests via GitHub action.

- [x] **DONE**

## Links

Tracks 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
