### PR TITLE
Add `mgr_server_is_uyuni` minion pillar item

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
@@ -77,6 +77,7 @@ public class MinionGeneralPillarGenerator implements MinionPillarGenerator {
         }
 
         pillar.add("mgr_origin_server", ConfigDefaults.get().getCobblerHost());
+        pillar.add("mgr_server_is_uyuni", ConfigDefaults.get().isUyuni());
         pillar.add("machine_password", MachinePasswordUtils.machinePassword(minion));
 
         Map<String, Object> chanPillar = new HashMap<>();

--- a/java/code/src/com/suse/manager/webui/services/pillar/test/MinionPillarManagerTest.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/test/MinionPillarManagerTest.java
@@ -85,6 +85,8 @@ public class MinionPillarManagerTest extends BaseTestCaseWithUser {
         assertEquals(ConfigDefaults.get().getCobblerHost(), map.get("mgr_server"));
         assertTrue(map.containsKey("mgr_origin_server"));
         assertEquals(ConfigDefaults.get().getCobblerHost(), map.get("mgr_origin_server"));
+        assertTrue(map.containsKey("mgr_server_is_uyuni"));
+        assertEquals(ConfigDefaults.get().isUyuni(), map.get("mgr_server_is_uyuni"));
 
         assertTrue(map.containsKey("channels"));
         Map<String, Object> channels = (Map<String, Object>) map.get("channels");
@@ -214,6 +216,8 @@ public class MinionPillarManagerTest extends BaseTestCaseWithUser {
         assertEquals(proxyHostname, map.get("mgr_server"));
         assertTrue(map.containsKey("mgr_origin_server"));
         assertEquals(ConfigDefaults.get().getCobblerHost(), map.get("mgr_origin_server"));
+        assertTrue(map.containsKey("mgr_server_is_uyuni"));
+        assertEquals(ConfigDefaults.get().isUyuni(), map.get("mgr_server_is_uyuni"));
 
         Map<String, Object> channels = (Map<String, Object>) map.get("channels");
         assertEquals(1, channels.size());

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add `mgr_server_is_uyuni` minion pillar item
 - Improve logs when sls action chain file is missing
 - Fix modular channel check during system update via XMLRPC (bsc#1206613)
 - Fix transaction commit behavior for Spark routes


### PR DESCRIPTION
## What does this PR change?

The new pillar item informs the minion if the server runs Uyuni or SUSE Manager.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Existing unit tests were extended

- [x] **DONE**

## Links

Required for SUSE/spacewalk#19584

- [x] **DONE**

## Changelogs

- [ ] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
