### PR TITLE
Testsuite: CLP cleanup fix

### DIFF
--- a/testsuite/features/secondary/srv_content_lifecycle.feature
+++ b/testsuite/features/secondary/srv_content_lifecycle.feature
@@ -157,7 +157,8 @@ Feature: Content lifecycle
     And I click on "Delete"
     And I click on "Delete" in "Delete Project" modal
     Then I should not see a "clp_name" text
-  
+
+@uyuni
   Scenario: Cleanup: remove the created channels
     When I delete these channels with spacewalk-remove-channel:
       |clp_label-prod_label-fake_base_channel|
@@ -166,6 +167,28 @@ Feature: Content lifecycle
       |clp_label-qa_label-sles12-sp5-updates-x86_64|
       |clp_label-dev_label-fake_base_channel|
       |clp_label-dev_label-sles12-sp5-updates-x86_64|
+    And I delete these channels with spacewalk-remove-channel:
+      |clp_label-prod_label-sles12-sp5-pool-x86_64|
+      |clp_label-qa_label-sles12-sp5-pool-x86_64|
+      |clp_label-dev_label-sles12-sp5-pool-x86_64|
+    When I list channels with spacewalk-remove-channel
+    Then I shouldn't get "clp_label"
+
+@susemanager
+  Scenario: Cleanup: remove the created channels
+    When I delete these channels with spacewalk-remove-channel:
+      |clp_label-prod_label-fake_base_channel|
+      |clp_label-prod_label-sles12-sp5-updates-x86_64|
+      |clp_label-prod_label-sle-manager-tools12-pool-x86_64-sp5|
+      |clp_label-prod_label-sle-manager-tools12-updates-x86_64-sp5|
+      |clp_label-qa_label-fake_base_channel|
+      |clp_label-qa_label-sles12-sp5-updates-x86_64|
+      |clp_label-qa_label-sle-manager-tools12-pool-x86_64-sp5|
+      |clp_label-qa_label-sle-manager-tools12-updates-x86_64-sp5|
+      |clp_label-dev_label-fake_base_channel|
+      |clp_label-dev_label-sles12-sp5-updates-x86_64|
+      |clp_label-dev_label-sle-manager-tools12-pool-x86_64-sp5|
+      |clp_label-dev_label-sle-manager-tools12-updates-x86_64-sp5|
     And I delete these channels with spacewalk-remove-channel:
       |clp_label-prod_label-sles12-sp5-pool-x86_64|
       |clp_label-qa_label-sles12-sp5-pool-x86_64|

--- a/testsuite/features/secondary/srv_content_lifecycle.feature
+++ b/testsuite/features/secondary/srv_content_lifecycle.feature
@@ -159,7 +159,7 @@ Feature: Content lifecycle
     Then I should not see a "clp_name" text
 
 @uyuni
-  Scenario: Cleanup: remove the created channels
+  Scenario: Cleanup: remove the created channels for Uyni
     When I delete these channels with spacewalk-remove-channel:
       |clp_label-prod_label-fake_base_channel|
       |clp_label-prod_label-sles12-sp5-updates-x86_64|
@@ -175,7 +175,7 @@ Feature: Content lifecycle
     Then I shouldn't get "clp_label"
 
 @susemanager
-  Scenario: Cleanup: remove the created channels
+  Scenario: Cleanup: remove the created channels for SUSE Manager
     When I delete these channels with spacewalk-remove-channel:
       |clp_label-prod_label-fake_base_channel|
       |clp_label-prod_label-sles12-sp5-updates-x86_64|


### PR DESCRIPTION
## What does this PR change?
Include the removal of tools channels for susemanager in clp feature for susemanager

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were added
- [x] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/20175
Tracks # 
4.2 https://github.com/SUSE/spacewalk/pull/20177
4.3 https://github.com/SUSE/spacewalk/pull/20176

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
