### PR TITLE
Use a profile coming from scap-security-guide

### DIFF
--- a/testsuite/features/secondary/min_salt_openscap_audit.feature
+++ b/testsuite/features/secondary/min_salt_openscap_audit.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2022 SUSE LLC
+# Copyright (c) 2017-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_openscap
@@ -19,37 +19,34 @@ Feature: OpenSCAP audit of Salt minion
     And I wait until event "Package List Refresh" is completed
 
   Scenario: Schedule an OpenSCAP audit job on the SLE minion
-    Given I disable IPv6 forwarding on all interfaces of the SLE minion
     When I follow "Audit" in the content area
     And I follow "Schedule" in the content area
     And I wait at most 30 seconds until I do not see "This system does not yet have OpenSCAP scan capability." text, refreshing the page
-    And I enter "--profile Default" as "params"
-    And I enter "/usr/share/openscap/scap-yast2sec-xccdf.xml" as "path"
+    And I enter "--profile standard" as "params"
+    And I enter "/usr/share/xml/scap/ssg/content/ssg-sle15-ds-1.2.xml" as "path"
     And I click on "Schedule"
     Then I should see a "XCCDF scan has been scheduled" text
     And I wait at most 500 seconds until event "OpenSCAP xccdf scanning" is completed
 
   Scenario: Check results of the audit job on the minion
     When I follow "Audit" in the content area
-    And I follow "xccdf_org.open-scap_testresult_Default"
+    And I follow "xccdf_org.open-scap_testresult_xccdf_org.ssgproject.content_profile_standard"
     Then I should see a "Details of XCCDF Scan" text
-    And I should see a "Default" text
+    And I should see a "profile standard" text
     And I should see a "XCCDF Rule Results" text
     When I enter "pass" as the filtered XCCDF result type
     And I click on the filter button
-    Then I should see a "rule-pwd-warnage" link
+    Then I should see a "xccdf_org.ssgproject.content_rule_service_httpd_disabled" link
 
   Scenario: Create a second, almost identical, audit job
-    Given I enable IPv6 forwarding on all interfaces of the SLE minion
     When I follow "Audit" in the content area
     And I follow "Schedule" in the content area
     And I wait at most 30 seconds until I do not see "This system does not yet have OpenSCAP scan capability." text, refreshing the page
-    And I enter "--profile Default" as "params"
-    And I enter "/usr/share/openscap/scap-yast2sec-xccdf.xml" as "path"
+    And I enter "--profile standard" as "params"
+    And I enter "/usr/share/xml/scap/ssg/content/ssg-sle15-ds-1.2.xml" as "path"
     And I click on "Schedule"
     Then I should see a "XCCDF scan has been scheduled" text
     When I wait for the OpenSCAP audit to finish
-    And I disable IPv6 forwarding on all interfaces of the SLE minion
 
   Scenario: Compare audit results
     When I follow "Audit" in the content area
@@ -57,7 +54,7 @@ Feature: OpenSCAP audit of Salt minion
     And I click on "Select All"
     And I click on "Compare Selected Scans"
     Then I should see a "XCCDF Rule Results" text
-    And I should see a "rule-sysctl-ipv6-all-forward" text
+    And I should see a "None" text
 
   Scenario: Cleanup: remove audit scans retention period
     When I follow the left menu "Admin > Organizations"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -768,14 +768,6 @@ When(/^I get "(.*?)" file details for channel "(.*?)" via spacecmd$/) do |arg1, 
   @command_output, _code = $server.run("spacecmd -u admin -p admin -q -- configchannel_filedetails #{arg2} '#{arg1}'", check_errors: false)
 end
 
-When(/^I disable IPv6 forwarding on all interfaces of the SLE minion$/) do
-  $minion.run('sysctl net.ipv6.conf.all.forwarding=0')
-end
-
-When(/^I enable IPv6 forwarding on all interfaces of the SLE minion$/) do
-  $minion.run('sysctl net.ipv6.conf.all.forwarding=1')
-end
-
 # Repositories and packages management
 When(/^I migrate the non-SUMA repositories on "([^"]*)"$/) do |host|
   node = get_target(host)


### PR DESCRIPTION
## What does this PR change?
Use a profile coming from scap-security-guide package instead of a profile coming from openscap-content, so to follow our internal documentation https://documentation.suse.com/suma/4.3/en/pdf/suse_manager_administration_guide.pdf page 147

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20139
Tracks # 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
