### PR TITLE
Fix non-compatible Python 2.6 syntax in custom Salt modules (bsc#1206979) (bsc#1206981)

### DIFF
--- a/.github/workflows/susemanager-sls-compatible-python26-syntax.yml
+++ b/.github/workflows/susemanager-sls-compatible-python26-syntax.yml
@@ -37,5 +37,5 @@ jobs:
           cd $GITHUB_WORKSPACE/susemanager-utils/susemanager-sls/src/
           # Exclude tests and uyuni_config.py modules (which are for server and not included in susemanager-sls)
           TESTS_LIST=$(find .|grep py$ | grep -v "^./tests" | grep -v "uyuni_config.py")
-          for i in $TESTS_LIST; do echo "Testing $i .... "; (python $i && echo "OK") || IS_FAILED=1; echo; done
+          for i in $TESTS_LIST; do echo "Testing $i .... "; (python -m py_compile $i && echo "OK") || IS_FAILED=1; echo; done
           exit $IS_FAILED

--- a/susemanager-utils/susemanager-sls/src/modules/mgrnet.py
+++ b/susemanager-utils/susemanager-sls/src/modules/mgrnet.py
@@ -73,7 +73,7 @@ def dns_fqdns():
         # Create a ThreadPoolExecutor to process the underlying calls
         # to resolve DNS FQDNs in parallel.
         with ThreadPoolExecutor(max_workers=8) as executor:
-            results = {executor.submit(_lookup_dns_fqdn, ip): ip for ip in addresses}
+            results = dict((executor.submit(_lookup_dns_fqdn, ip), ip) for ip in addresses)
             for item in as_completed(results):
                 item = item.result()
                 if item:

--- a/susemanager-utils/susemanager-sls/src/modules/mgrnet.py
+++ b/susemanager-utils/susemanager-sls/src/modules/mgrnet.py
@@ -9,6 +9,16 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import salt.utils.network
 
+try:
+    from salt.utils.network import _get_interfaces
+except:
+    from salt.grains.core import _get_interfaces
+
+try:
+    from salt.utils.path import which as _which
+except:
+    from salt.utils import which as _which
+
 log = logging.getLogger(__name__)
 
 
@@ -16,7 +26,7 @@ def __virtual__():
     """
     Only works on POSIX-like systems having 'host' or 'nslookup' available
     """
-    if not (__utils__["path.which"]("host") or __utils__["path.which"]("nslookup")):
+    if not (_which("host") or _which("nslookup")):
         return (False, "Neither 'host' nor 'nslookup' is available on the system")
     return True
 
@@ -32,10 +42,10 @@ def dns_fqdns():
     grains = {}
     fqdns = set()
     cmd_run_all_func = __salt__["cmd.run_all"]
-    if __utils__["path.which"]("host"):
+    if _which("host"):
         cmd = "host"
         cmd_ret_regex = re.compile(r".* domain name pointer (.*)\.$")
-    elif __utils__["path.which"]("nslookup"):
+    elif _which("nslookup"):
         cmd = "nslookup"
         cmd_ret_regex = re.compile(r".*\tname = (.*)\.$")
     else:
@@ -60,11 +70,11 @@ def dns_fqdns():
     start = time.time()
 
     addresses = salt.utils.network.ip_addrs(
-        include_loopback=False, interface_data=salt.utils.network._get_interfaces()
+        include_loopback=False, interface_data=_get_interfaces()
     )
     addresses.extend(
         salt.utils.network.ip_addrs6(
-            include_loopback=False, interface_data=salt.utils.network._get_interfaces()
+            include_loopback=False, interface_data=_get_interfaces()
         )
     )
 

--- a/susemanager-utils/susemanager-sls/src/tests/test_module_mgrnet.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_mgrnet.py
@@ -9,7 +9,6 @@ from ..modules import mgrnet
 
 
 mgrnet.__salt__ = {}
-mgrnet.__utils__ = {}
 
 
 def test_mgrnet_virtual():
@@ -18,9 +17,8 @@ def test_mgrnet_virtual():
     when either 'host' or 'nslookup' is available or none of them
     """
 
-    with patch.dict(
-        mgrnet.__utils__,
-        {"path.which": MagicMock(side_effect=[True, False, True, False, False])},
+    with patch.object(
+        mgrnet, "_which", MagicMock(side_effect=[True, False, True, False, False]),
     ):
         ret = mgrnet.__virtual__()
         assert ret is True
@@ -79,9 +77,8 @@ def test_mgrnet_dns_fqdns():
 
     with patch.dict(
         mgrnet.__salt__, {"cmd.run_all": _cmd_run_host_nslookup}
-    ), patch.dict(
-        mgrnet.__utils__,
-        {"path.which": MagicMock(side_effect=[True, False, True, False, False])},
+    ), patch.object(
+        mgrnet, "_which", MagicMock(side_effect=[True, False, True, False, False]),
     ), patch.object(
         mgrnet.salt.utils.network,
         "ip_addrs",

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix mgrnet custom module to be compatible with old Python 2.6 (bsc#1206979) (bsc#1206981)
 - Fix current limitation on Action Chains for SLE Micro
 - Support SLE Micro migration (bsc#1205011)
 


### PR DESCRIPTION
## What does this PR change?

This is a spin-off PR from https://github.com/uyuni-project/uyuni/pull/6464 that fixes the issues raised by new introduced GH action to check we are not introducing non-compatible Python 2.6 code in our custom Salt modules provided by `susemanager-sls` package.

**UPDATE**: this PR additionally adapts `mgrnet` code to be compatible with old Salt 2016.11.10.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes #
Tracks https://github.com/SUSE/spacewalk/issues/20270

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
