### PR TITLE
Replace transactional reboot call with the class of salt-netapi-client

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -149,6 +149,7 @@ import com.suse.salt.netapi.calls.LocalAsyncResult;
 import com.suse.salt.netapi.calls.LocalCall;
 import com.suse.salt.netapi.calls.modules.State;
 import com.suse.salt.netapi.calls.modules.State.ApplyResult;
+import com.suse.salt.netapi.calls.modules.TransactionalUpdate;
 import com.suse.salt.netapi.datatypes.target.MinionList;
 import com.suse.salt.netapi.errors.GenericError;
 import com.suse.salt.netapi.exception.SaltException;
@@ -1263,21 +1264,10 @@ public class SaltServerActionService {
     private Map<LocalCall<?>, List<MinionSummary>> rebootAction(List<MinionSummary> minionSummaries) {
         return minionSummaries.stream().collect(
             Collectors.groupingBy(
-                m -> m.isTransactionalUpdate() ? transactionalReboot() :
+                m -> m.isTransactionalUpdate() ? TransactionalUpdate.reboot() :
                         com.suse.salt.netapi.calls.modules.System.reboot(Optional.of(3))
             )
         );
-    }
-
-    /**
-     * @deprecated this method is temporarily here until a new version of salt-netapi-client that contains it
-     * is released.
-     */
-    @Deprecated
-    private static LocalCall<String> transactionalReboot() {
-        return new LocalCall<>("transactional_update.reboot", Optional.empty(), Optional.empty(),
-                new TypeToken<>() {
-                });
     }
 
     /**


### PR DESCRIPTION
## What does this PR change?

See title.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
