### PR TITLE
Prevent api parameters parsing as dates if not in ISO-8601 (bsc#1205759)

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,5 @@
+- Prevent string api parameters to be parsed as dates if not in
+  ISO-8601 format (bsc#1205759)
 - Add python-dateutil dependency, required to process date values in
   spacecmd api calls
 - Remove python3-simplejson dependency

--- a/spacecmd/src/spacecmd/utils.py
+++ b/spacecmd/src/spacecmd/utils.py
@@ -51,7 +51,7 @@ from difflib import unified_diff
 from tempfile import mkstemp
 from textwrap import wrap
 from subprocess import Popen, PIPE
-from dateutil.parser import parse as parse_datetime, ParserError
+from dateutil.parser import isoparse
 
 try:
     import json
@@ -691,8 +691,8 @@ def datetime_parser_lst(lst):
     for i, l in enumerate(lst):
         if isinstance(l, str):
             try:
-                lst[i] = parse_datetime(l)
-            except ParserError:
+                lst[i] = isoparse(l)
+            except ValueError:
                 pass
 
 


### PR DESCRIPTION


## What does this PR change?

The dateutil `parse` function parses as date/time stamps some strings that are not in ISO-8601 format which causes trouble in `api` calls in spacecmd when the user passes strings as parameters that are similar to dates (for example, to create a label).

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage

- No tests: already covered


- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19690

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
