### PR TITLE
Fix reconnection of postgres event stream

### DIFF
--- a/java/code/src/com/suse/manager/reactor/PGEventStream.java
+++ b/java/code/src/com/suse/manager/reactor/PGEventStream.java
@@ -21,6 +21,7 @@ import static java.util.stream.Collectors.toList;
 
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.reactor.SaltEvent;
 import com.redhat.rhn.domain.reactor.SaltEventFactory;
 import com.redhat.rhn.frontend.events.TransactionHelper;
@@ -144,11 +145,18 @@ public class PGEventStream extends AbstractEventStream implements PGNotification
                     }
                 }
                 catch (SQLException e) {
+                    // DB connection is probably broken
+                    // make sure that the callback does not use the old session
+                    HibernateFactory.closeSession();
                     cancel();
                     clearListeners(0, "Postgres notification connection was lost");
                 }
                 catch (Exception e) {
                     LOG.error("Unexpected exception:", e);
+                }
+                finally {
+                    // create new session for each run
+                    HibernateFactory.closeSession();
                 }
             }
         }, 0, 5_000);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix reconnection of postgres event stream
 - Standardize the login response format with other HTTP API endpoints (bsc#1206800)
 - Add `mgr_server_is_uyuni` minion pillar item
 - Improve logs when sls action chain file is missing


### PR DESCRIPTION
## What does this PR change?

After restart of postgres service, handling of salt events stops.
Debugging shows, that `salt-event-connection-watchdog` correctly detects that the connection was closed and calls
`SaltReactor::eventStreamClosed` -> `SaltReactor::connectToEventStream` -> `saltApi.getEventStream()` -> `new PGEventStream()`. All this is called with stale hibernate session, so the database access in `PGEventStream` constructor fails and the new connection is not created.

This PR makes sure that the stale session is not used.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: user invisible change
- [x] **DONE**

## Test coverage
- Cucumber test: TBD
- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20143
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
