### PR TITLE
Add 'none' matcher for CLM module filters (bsc#1206817)

### DIFF
--- a/java/buildconf/LICENSE.txt
+++ b/java/buildconf/LICENSE.txt
@@ -1,5 +1,5 @@
 ^/\*$
-^ \* Copyright \(c\) (20([01]\d|20)--)?20(1\d|2[012]) (Red Hat, Inc.|SUSE LLC)$
+^ \* Copyright \(c\) (20([01]\d|20)--)?20(1\d|2[0123]) (Red Hat, Inc.|SUSE LLC)$
 ^ \*$
 ^ \* This software is licensed to you under the GNU General Public License,$
 ^ \* version 2 \(GPLv2\). There is NO WARRANTY for this software, express or$

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
@@ -34,6 +34,7 @@ import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.LOWER;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.LOWEREQ;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.MATCHES;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.MATCHES_PKG_NAME;
+import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.MODULE_NONE;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.PROVIDES_NAME;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.PTF_ALL;
 import static com.redhat.rhn.domain.contentmgmt.PtfFilter.FIELD_PTF_ALL;
@@ -102,6 +103,7 @@ public class FilterCriteria {
         Triple.of(ERRATUM, CONTAINS_PKG_GE_EVR, "package_nevr"),
         Triple.of(ERRATUM, CONTAINS_PKG_GT_EVR, "package_nevr"),
         Triple.of(MODULE, EQUALS, "module_stream"),
+        Triple.of(MODULE, MODULE_NONE, "module_stream"),
         Triple.of(PACKAGE, PROVIDES_NAME, "provides_name"),
         Triple.of(ERRATUM, CONTAINS_PROVIDES_NAME, "package_provides_name"),
         Triple.of(PTF, PTF_ALL, FIELD_PTF_ALL),
@@ -135,6 +137,7 @@ public class FilterCriteria {
         MATCHES("matches"),
         PROVIDES_NAME("provides_name"),
         CONTAINS_PROVIDES_NAME("contains_provides_name"),
+        MODULE_NONE("module_none"),
         PTF_ALL("ptf_all");
 
         private final String label;

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ModularityDisabledException.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ModularityDisabledException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.domain.contentmgmt.modulemd;
+
+/**
+ * Exception thrown when a module is selected while the modularity is disabled via the 'none' matcher
+ */
+public class ModularityDisabledException extends ModulemdApiException {
+
+    /**
+     * Initialize a new instance
+     */
+    public ModularityDisabledException() {
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/ModularDependencyValidator.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/ModularDependencyValidator.java
@@ -24,6 +24,7 @@ import com.redhat.rhn.domain.contentmgmt.ContentProject;
 import com.redhat.rhn.domain.contentmgmt.ModuleFilter;
 import com.redhat.rhn.domain.contentmgmt.SoftwareProjectSource;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ConflictingStreamsException;
+import com.redhat.rhn.domain.contentmgmt.modulemd.ModularityDisabledException;
 import com.redhat.rhn.domain.contentmgmt.modulemd.Module;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ModuleNotFoundException;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ModulemdApi;
@@ -79,11 +80,17 @@ public class ModularDependencyValidator implements ContentValidator {
         try {
             DependencyResolutionResult result = resolver.resolveFilters(project.getActiveFilters());
 
-            // Add a message with the list of resolved modules
-            String selectedModules =
-                    result.getModules().stream().map(Module::getFullName).distinct().collect(Collectors.joining(", "));
-            messages.add(ContentValidationMessage.contentFiltersMessage(
-                    loc.getMessage("contentmanagement.validation.selectedmodules", selectedModules), TYPE_INFO));
+            if (DependencyResolver.isModulesDisabled(result.getFilters())) {
+                messages.add(ContentValidationMessage.contentFiltersMessage(
+                        loc.getMessage("contentmanagement.validation.nomodules"), TYPE_INFO));
+            }
+            else {
+                // Add a message with the list of resolved modules
+                String selectedModules = result.getModules().stream()
+                        .map(Module::getFullName).distinct().collect(Collectors.joining(", "));
+                messages.add(ContentValidationMessage.contentFiltersMessage(
+                        loc.getMessage("contentmanagement.validation.selectedmodules", selectedModules), TYPE_INFO));
+            }
         }
         catch (DependencyResolutionException e) {
             if (e.getCause() instanceof ModuleNotFoundException) {
@@ -101,6 +108,10 @@ public class ModularDependencyValidator implements ContentValidator {
                 messages.add(ContentValidationMessage.contentFiltersMessage(
                         loc.getMessage("contentmanagement.validation.moduleconflict",
                                 module.getFullName(), other.getFullName()), TYPE_ERROR));
+            }
+            else if (e.getCause() instanceof ModularityDisabledException) {
+                messages.add(ContentValidationMessage.contentFiltersMessage(
+                        loc.getMessage("contentmanagement.validation.modularitydisabled"), TYPE_ERROR));
             }
             else {
                 messages.add(ContentValidationMessage.contentFiltersMessage(

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/test/ContentValidatorTestBase.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/test/ContentValidatorTestBase.java
@@ -21,6 +21,7 @@ import static com.redhat.rhn.domain.contentmgmt.ContentFilter.Rule.ALLOW;
 import static com.redhat.rhn.domain.contentmgmt.ContentFilter.Rule.DENY;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.CONTAINS;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.EQUALS;
+import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.MODULE_NONE;
 import static com.redhat.rhn.domain.contentmgmt.ProjectSource.Type.SW_CHANNEL;
 import static java.util.Optional.empty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -122,6 +123,12 @@ public abstract class ContentValidatorTestBase extends BaseTestCaseWithUser {
      */
     final void attachModularFilter(String value) {
         FilterCriteria criteria = new FilterCriteria(EQUALS, "module_stream", value);
+        ContentFilter filter = manager.createFilter(TestUtils.randomString(), ALLOW, MODULE, criteria, user);
+        manager.attachFilter("cplabel", filter.getId(), user);
+    }
+
+    final void attachModuleNoneFilter() {
+        FilterCriteria criteria = new FilterCriteria(MODULE_NONE, "module_stream", null);
         ContentFilter filter = manager.createFilter(TestUtils.randomString(), ALLOW, MODULE, criteria, user);
         manager.attachFilter("cplabel", filter.getId(), user);
     }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/test/ModularDependencyValidatorTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/test/ModularDependencyValidatorTest.java
@@ -78,4 +78,21 @@ public class ModularDependencyValidatorTest extends ContentValidatorTestBase {
         assertSingleMessage(getLoc().getMessage("contentmanagement.validation.moduleconflict", "postgresql:10",
                 "postgresql:12"), TYPE_ERROR, ENTITY_FILTERS, validator.validate(getProject()));
     }
+
+    @Test
+    public void testDisabledModularity() throws Exception {
+        attachModularSource();
+        attachModuleNoneFilter();
+        assertSingleMessage(getLoc().getMessage("contentmanagement.validation.nomodules"), TYPE_INFO,
+                ENTITY_FILTERS, validator.validate(getProject()));
+    }
+
+    @Test
+    public void testModuleFiltersWithDisabledModularity() throws Exception {
+        attachModularSource();
+        attachModuleNoneFilter();
+        attachModularFilter();
+        assertSingleMessage(getLoc().getMessage("contentmanagement.validation.modularitydisabled"), TYPE_ERROR,
+                ENTITY_FILTERS, validator.validate(getProject()));
+    }
 }

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -8877,6 +8877,18 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
           <context context-type="sourcefile">com.redhat.rhn.domain.contentmgmt.validation.ModularDependencyValidator</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="contentmanagement.validation.modularitydisabled" xml:space="preserve">
+        <source>Modularity is currently disabled. To enable modules, please remove the 'disable all modules' filter.</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">com.redhat.rhn.domain.contentmgmt.validation.ModularDependencyValidator</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="contentmanagement.validation.nomodules" xml:space="preserve">
+        <source>Modularity is disabled. No modules will be included in the target repositories.</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">com.redhat.rhn.domain.contentmgmt.validation.ModularDependencyValidator</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="contentmanagement.validation.nomodulefilters" xml:space="preserve">
         <source>No module filters attached. Module metadata will be cloned to target.</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
@@ -759,14 +759,13 @@ public class ContentManagementHandler extends BaseHandler {
         if (criteria.isEmpty()) {
             return empty();
         }
-        if (!criteria.containsKey("matcher") || !criteria.containsKey("field") ||
-                !criteria.containsKey("value")) {
+        if (!criteria.containsKey("matcher") || !criteria.containsKey("field")) {
             throw new InvalidArgsException("Incomplete filter criteria");
         }
         return of(new FilterCriteria(
                 FilterCriteria.Matcher.lookupByLabel((String) criteria.get("matcher")),
                 (String) criteria.get("field"),
-                (String) criteria.get("value")));
+                StringUtils.trimToNull((String) criteria.get("value"))));
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/DependencyResolver.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/DependencyResolver.java
@@ -25,12 +25,14 @@ import com.redhat.rhn.domain.contentmgmt.FilterCriteria;
 import com.redhat.rhn.domain.contentmgmt.ModuleFilter;
 import com.redhat.rhn.domain.contentmgmt.PackageFilter;
 import com.redhat.rhn.domain.contentmgmt.ProjectSource;
+import com.redhat.rhn.domain.contentmgmt.modulemd.ModularityDisabledException;
 import com.redhat.rhn.domain.contentmgmt.modulemd.Module;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ModulePackagesResponse;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ModulemdApi;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ModulemdApiException;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -98,9 +100,14 @@ public class DependencyResolver {
     public DependencyResolutionResult resolveFilters(List<ContentFilter> filters) throws DependencyResolutionException {
 
         List<ModuleFilter> moduleFilters = filters.stream()
-                                                  .filter(f -> f instanceof ModuleFilter)
-                                                  .map(ModuleFilter.class::cast)
-                                                  .collect(toList());
+                .filter(f -> f instanceof ModuleFilter)
+                .map(ModuleFilter.class::cast)
+                .filter(f -> FilterCriteria.Matcher.EQUALS.equals(f.getCriteria().getMatcher()))
+                .collect(toList());
+
+        if (isModulesDisabled(filters) && !moduleFilters.isEmpty()) {
+            throw new DependencyResolutionException("Modularity is disabled.", new ModularityDisabledException());
+        }
 
         List<ContentFilter> updatedFilters = new ArrayList<>(filters);
 
@@ -170,6 +177,16 @@ public class DependencyResolver {
         // Concatenate filter streams into the list
         return new DependencyResolutionResult(Stream.of(pkgDenyFilters, providedRpmApiFilters, pkgAllowFilters)
                 .flatMap(s -> s).collect(toList()), resolvedModules);
+    }
+
+    /**
+     * Returns true if modularity is disabled via the 'Module(Stream): None' filter
+     * @param filters the list of enabled filters
+     * @return true if modularity is disabled
+     */
+    public static boolean isModulesDisabled(Collection<ContentFilter> filters) {
+        return filters.stream()
+                .anyMatch(f -> FilterCriteria.Matcher.MODULE_NONE.equals(f.getCriteria().getMatcher()));
     }
 
     private static PackageFilter initFilterFromPackageNevra(String nevra, ContentFilter.Rule rule) {

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/DependencyResolverTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/DependencyResolverTest.java
@@ -24,6 +24,8 @@ import static com.redhat.rhn.domain.role.RoleFactory.ORG_ADMIN;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -33,6 +35,7 @@ import com.redhat.rhn.domain.contentmgmt.ContentProject;
 import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
 import com.redhat.rhn.domain.contentmgmt.FilterCriteria;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ConflictingStreamsException;
+import com.redhat.rhn.domain.contentmgmt.modulemd.ModularityDisabledException;
 import com.redhat.rhn.domain.contentmgmt.modulemd.Module;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ModuleNotFoundException;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ModulePackagesResponse;
@@ -210,9 +213,25 @@ public class DependencyResolverTest extends BaseTestCaseWithUser {
         assertEquals(10, result.size());
         // There should be one and only one "perl" api filter
         assertEquals(1, result.stream().filter(f -> isDenyNameMatches(f, "perl")).count());
-        // There should be allow filters for both versions
+        // There should be "allow" filters for both versions
         assertTrue(result.stream().anyMatch(f -> isAllowNevraEquals(f, "perl-0:5.24.0-xxx.x86_64")));
         assertTrue(result.stream().anyMatch(f -> isAllowNevraEquals(f, "perl-0:5.24.1-yyy.x86_64")));
+    }
+
+    /**
+     * Test the resolver with modularity disabled
+     */
+    @Test
+    public void testResolveModuleFiltersDisabled() {
+        FilterCriteria criteria1 = new FilterCriteria(FilterCriteria.Matcher.MODULE_NONE, "module_stream", null);
+        ContentFilter noModules = contentManager.createFilter("no-modules", ALLOW, MODULE, criteria1, user);
+        FilterCriteria criteria2 = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "module_stream", "perl:5.26");
+        ContentFilter moduleFilter = contentManager.createFilter("perl-5.26-filter", ALLOW, MODULE, criteria2, user);
+
+        DependencyResolutionException exception = assertThrows(DependencyResolutionException.class,
+                () -> resolver.resolveFilters(List.of(moduleFilter, noModules)));
+
+        assertTrue(exception.getCause() instanceof ModularityDisabledException);
     }
 
     /**
@@ -276,6 +295,22 @@ public class DependencyResolverTest extends BaseTestCaseWithUser {
         catch (DependencyResolutionException e) {
             assertTrue(e.getCause() instanceof ConflictingStreamsException);
         }
+    }
+
+    /**
+     * Test if the modularity is disabled via a module:none filter
+     */
+    @Test
+    public void testIsModulesDisabled() {
+        FilterCriteria criteria1 = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "module_stream", "perl:5.24");
+        ContentFilter moduleFilter = contentManager.createFilter("perl-5.24-filter", ALLOW, MODULE, criteria1, user);
+        FilterCriteria criteria2 = new FilterCriteria(FilterCriteria.Matcher.MODULE_NONE, "module_stream", null);
+        ContentFilter noModules = contentManager.createFilter("no-modules", ALLOW, MODULE, criteria2, user);
+
+        assertFalse(DependencyResolver.isModulesDisabled(emptyList()));
+        assertFalse(DependencyResolver.isModulesDisabled(List.of(moduleFilter)));
+        assertTrue(DependencyResolver.isModulesDisabled(List.of(noModules)));
+        assertTrue(DependencyResolver.isModulesDisabled(List.of(moduleFilter, noModules)));
     }
 
     private boolean isAllowNevraEquals(ContentFilter f, String value) {

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/FilterApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/FilterApiController.java
@@ -223,7 +223,7 @@ public class FilterApiController {
         FilterCriteria filterCriteria = new FilterCriteria(
                 FilterCriteria.Matcher.lookupByLabel(createFilterRequest.getMatcher()),
                 createFilterRequest.getCriteriaKey(),
-                createFilterRequest.getCriteriaValue());
+                StringUtils.trimToNull(createFilterRequest.getCriteriaValue()));
 
 
         ContentFilter createdFilter;
@@ -274,7 +274,7 @@ public class FilterApiController {
         FilterCriteria filterCriteria = new FilterCriteria(
                 FilterCriteria.Matcher.lookupByLabel(updateFilterRequest.getMatcher()),
                 updateFilterRequest.getCriteriaKey(),
-                updateFilterRequest.getCriteriaValue());
+                StringUtils.trimToNull(updateFilterRequest.getCriteriaValue()));
         try {
             CONTENT_MGR.updateFilter(
                     Long.parseLong(req.params("filterId")),

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add 'none' matcher to CLM AppStream filters (bsc#1206817)
 - Include missing 'gpg' states to avoid issues on SSH minions.
 - Fix reconnection of postgres event stream
 - Standardize the login response format with other HTTP API endpoints (bsc#1206800)

--- a/schema/spacewalk/common/tables/suseContentFilter.sql
+++ b/schema/spacewalk/common/tables/suseContentFilter.sql
@@ -25,7 +25,7 @@ CREATE TABLE suseContentFilter(
     name     VARCHAR(128) NOT NULL,
     matcher  VARCHAR(32) NOT NULL,
     field    VARCHAR(32) NOT NULL,
-    value    VARCHAR(128) NOT NULL,
+    value    VARCHAR(128),
     created  TIMESTAMPTZ
                  DEFAULT (current_timestamp) NOT NULL,
     modified TIMESTAMPTZ

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Add 'none' matcher to CLM AppStream filters (bsc#1206817)
 - Rename monitoring entitlement
 - Added view to handle ptf packages and updated the procedures
   to refresh the updatable/installable packages

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.3-to-susemanager-schema-4.4.4/100-suseContentFilter-null-values.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.3-to-susemanager-schema-4.4.4/100-suseContentFilter-null-values.sql
@@ -1,0 +1,1 @@
+ALTER TABLE susecontentfilter ALTER COLUMN value DROP NOT NULL;

--- a/web/html/src/manager/content-management/list-filters/appstreams/appstreams.test.tsx
+++ b/web/html/src/manager/content-management/list-filters/appstreams/appstreams.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, server } from "utils/test-utils";
+
+import AppStreamsForm from "./appstreams";
+
+describe("AppStreams filter form", () => {
+  test("Render form", () => {
+    const { rerender } = render(<AppStreamsForm matcher={null} />);
+
+    expect(screen.queryByLabelText("Module Name")).toBeNull();
+    expect(screen.queryByLabelText("Stream")).toBeNull();
+
+    rerender(<AppStreamsForm matcher={"module_none"} />);
+
+    expect(screen.queryByLabelText("Module Name")).toBeNull();
+    expect(screen.queryByLabelText("Stream")).toBeNull();
+
+    rerender(<AppStreamsForm matcher={"equals"} />);
+
+    expect(screen.getByLabelText("Module Name")).toBeTruthy();
+    expect(screen.getByLabelText("Stream")).toBeTruthy();
+  });
+
+  test("Browse available modules", () => {
+    server.mockGetJson("/rhn/manager/api/channels/modular", {
+      success: true,
+      data: [],
+    });
+
+    render(<AppStreamsForm matcher={"equals"} />);
+
+    screen.getByRole("button", { name: "Browse available modules" }).click();
+    expect(screen.findByLabelText("Channel", { exact: false })).toBeTruthy();
+  });
+});

--- a/web/html/src/manager/content-management/list-filters/appstreams/appstreams.tsx
+++ b/web/html/src/manager/content-management/list-filters/appstreams/appstreams.tsx
@@ -8,7 +8,7 @@ import Network from "utils/network";
 import SelectInput from "./select-input";
 import TextInput from "./text-input";
 
-export default function AppStreams() {
+export default function AppStreams({ matcher }) {
   const [channels, setChannels] = useState<{ id: string; name: string }[]>([]);
   const [isBrowse, setBrowse] = useState(false);
   const [isLoading, setLoading] = useState(false);
@@ -24,19 +24,23 @@ export default function AppStreams() {
       .catch((xhr) => showErrorToastr(Network.responseErrorMessage(xhr).map((msg) => msg.text)));
   };
 
-  return isBrowse ? (
-    <SelectInput channels={channels} />
-  ) : (
-    <>
-      <div className="form-group">
-        <div className="col-md-offset-3 col-md-6">
-          <button className="btn-link" onClick={enableBrowse}>
-            {isLoading ? <i className="fa fa-refresh fa-spin fa-fw" /> : <i className="fa fa-search fa-fw" />}
-            Browse available modules
-          </button>
+  if (isBrowse) {
+    return <SelectInput channels={channels} />;
+  } else if (matcher === "equals") {
+    return (
+      <>
+        <div className="form-group">
+          <div className="col-md-offset-3 col-md-6">
+            <button className="btn-link" onClick={enableBrowse}>
+              {isLoading ? <i className="fa fa-refresh fa-spin fa-fw" /> : <i className="fa fa-search fa-fw" />}
+              Browse available modules
+            </button>
+          </div>
         </div>
-      </div>
-      <TextInput />
-    </>
-  );
+        <TextInput />
+      </>
+    );
+  } else {
+    return null;
+  }
 }

--- a/web/html/src/manager/content-management/list-filters/filter-form.tsx
+++ b/web/html/src/manager/content-management/list-filters/filter-form.tsx
@@ -258,7 +258,7 @@ const FilterForm = (props: Props) => {
 
             {clmFilterOptions.STREAM.key === filterType && (
               <>
-                <AppStreamsForm />
+                <AppStreamsForm matcher={filter.matcher} />
               </>
             )}
 

--- a/web/html/src/manager/content-management/shared/business/filters.enum.test.ts
+++ b/web/html/src/manager/content-management/shared/business/filters.enum.test.ts
@@ -273,4 +273,21 @@ describe("Testing filters enum and descriptions", () => {
       "filter by fixed package: deny ptf matches regular expression vim-data (ptf_package)"
     );
   });
+
+  test("test module stream description", () => {
+    const filter = {
+      name: "my module filter",
+      criteriaKey: "module_stream",
+      criteriaValue: "mymodule:stream",
+      entityType: "module",
+      rule: "allow",
+      matcher: "equals",
+    };
+
+    expect(getClmFilterDescription(filter)).toEqual("my module filter: enable module mymodule:stream");
+
+    filter.matcher = "module_none";
+
+    expect(getClmFilterDescription(filter)).toEqual("my module filter: disable all modules");
+  });
 });

--- a/web/html/src/manager/content-management/shared/business/filters.enum.ts
+++ b/web/html/src/manager/content-management/shared/business/filters.enum.ts
@@ -120,6 +120,11 @@ const filterMatchers: FilterMatcherEnumType = {
     text: t("provides name"),
     longDescription: t("provides name equal"),
   },
+  MODULE_NONE: {
+    key: "module_none",
+    text: t("none (disable modularity)"),
+    longDescription: t("none (disable modularity)"),
+  },
   PTF_ALL: {
     key: "ptf_all",
     text: t("all"),
@@ -210,7 +215,7 @@ export const clmFilterOptions: ClmFilterOptionsEnumType = {
     key: "module_stream",
     text: t("Stream"),
     entityType: filterEntity.MODULE,
-    matchers: [filterMatchers.EQUALS],
+    matchers: [filterMatchers.EQUALS, filterMatchers.MODULE_NONE],
   },
   PTF_ALL: {
     key: "ptf_all",
@@ -253,7 +258,8 @@ function findFilterMatcherByKey(key: string | undefined): FilterMatcherType | Pa
 export function getClmFilterDescription(filter: any): string {
   const filterMatcher = findFilterMatcherByKey(filter.matcher);
   if (filter.entityType === "module") {
-    return `${filter.name}: ${t("enable module")} ${filter.criteriaValue}`;
+    if (filter.matcher === "equals") return `${filter.name}: ${t("enable module")} ${filter.criteriaValue}`;
+    else return `${filter.name}: ${t("disable all modules")}`;
   }
   return `${filter.name}: ${filter.rule} ${filter.entityType} ${filterMatcher.longDescription || ""} ${
     filter.criteriaValue

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Add 'none' matcher to CLM AppStream filters (bsc#1206817)
 - Fix salt keys page keeps loading when no key exists (bsc#1206799)
 - Fix link to documentation in monitoring page
 - Added CLM filters to match product temporary fixes packages


### PR DESCRIPTION
In RHEL 9, the default streams of modules are now included as regular packages instead of modules. To allow users to set up CLM with all the default streams, we must allow creating of regular repositories without having to add any module filters.

This PR adds a new matcher type `none` to AppStream filters. When used, it strips the modular metadata from the channel without having to specify any modules.

See also: [Documentation PR (#2007)](https://github.com/uyuni-project/uyuni-docs/pull/2007)

## GUI diff

Before:
![Screenshot from 2023-01-17 20-43-31](https://user-images.githubusercontent.com/1103552/212996649-e44424f7-2bf4-4d32-8489-2bf6a4991143.png)

After:
![Screenshot from 2023-01-17 20-41-07](https://user-images.githubusercontent.com/1103552/212996462-f00c1fda-a34c-4f59-8f2a-6738cee79038.png)
![Screenshot from 2023-01-17 20-41-25](https://user-images.githubusercontent.com/1103552/212996474-3ffb516a-e0f3-44a3-9d2c-9892d0fd23cb.png)


## Documentation
- [Documentation PR (#2007)](https://github.com/uyuni-project/uyuni-docs/pull/2007)

## Test coverage
- Unit tests were added

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20032

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
