### PR TITLE
Fix custom "mgrcompat.module_run" state function to work with Salt 3005.1

### DIFF
--- a/susemanager-utils/susemanager-sls/src/states/mgrcompat.py
+++ b/susemanager-utils/susemanager-sls/src/states/mgrcompat.py
@@ -50,21 +50,12 @@ def module_run(**kwargs):
 
     '''
 
-    # The new syntax will be used as the default
-    use_new_syntax = True
+    # We use classic "module.run" syntax by default.
+    use_new_syntax = False
 
-    if __grains__['saltversioninfo'][0] > 3004:
-        # Only new syntax - default behavior for Phosphorus and future releases
-        pass
-    elif __grains__['saltversioninfo'][0] > 2016 and 'module.run' in __opts__.get('use_superseded', []):
+    if 2016 < __grains__['saltversioninfo'][0] < 3005 and 'module.run' in __opts__.get('use_superseded', []):
         # New syntax - explicitely enabled via 'use_superseded' configuration on 2018.3, 2019.2, 3000.x, 3002.x, 3003.x and 3004.x
-        pass
-    elif __grains__['saltversioninfo'][0] > 2016 and not 'module.run' in __opts__.get('use_superseded', []):
-        # Old syntax - default behavior for 2018.3, 2019.2, 3000.x, 3002.x, 3003.x and 3004.x
-        use_new_syntax = False
-    elif __grains__['saltversioninfo'][0] <= 2016:
-        # Only old syntax - the new syntax is not available for 2016.11 and 2015.8
-        use_new_syntax = False
+        use_new_syntax = True
 
     if use_new_syntax:
         log.debug("Minion is using the new syntax for 'module.run' state. Tailoring parameters.")

--- a/susemanager-utils/susemanager-sls/src/tests/test_state_mgrcompat.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_state_mgrcompat.py
@@ -27,7 +27,7 @@ def test_module_run_on_phosphorous():
         mgrcompat.__grains__, {'saltversioninfo': [3005, None, None, None]}
     ), patch.dict(mgrcompat.__states__, {'module.run': mock}):
         mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
-        mock.assert_called_once_with(**TAILORED_MODULE_RUN_KWARGS)
+        mock.assert_called_once_with(**MGRCOMPAT_MODULE_RUN_KWARGS)
 
 def test_module_run_on_silicon():
     mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix custom "mgrcompat.module_run" state module to work with Salt 3005.1
 - Add missing transactional_update.conf for SLE Micro
 - filter out libvirt engine events (bsc#1206146)
 - Improve _mgractionchains.conf logs


### PR DESCRIPTION
## What does this PR change?

On Salt 3005, the `module.run` state function was refactored and, it was finally decided upstream, that there is no deprecation of legacy syntax for `module.run` happening at all. Both syntax will be supported in future Salt versions.

(See NOTE at the beggining of https://docs.saltproject.io/en/latest/ref/states/all/salt.states.module.html)

In fact, after the refactor done by upstream on 3005 codebase for `module.run` (in order to support both syntaxes), if we tailor our parameters from the old syntax to the new syntax, this would cause issues in the execution of some functions.

Examples:

```
'docker.login' failed: login() got an unexpected keyword argument 'registries'
'cp.push' failed: push() got multiple values for argument 'path'
```

So, this PR simply fixes our custom `mgrcompat.module_run` module to not tailor any parameters (at it is not really needed) in case we are running Salt versions higher than 3004.

(This should be fixing some of the issues we currentely see at HEAD acceptance tests)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/19924

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
