### PR TITLE
QE: Adjust server salt error detection

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -206,8 +206,8 @@ Then(/^the salt event log on server should contain no failures$/) do
   count_failures = output.to_s.scan(/false/).length
   output = output.join.to_s if output.respond_to?(:join)
   # Ignore the error if there is only the expected failure from min_salt_lock_packages.feature
-  ignore_error = (count_failures == 1) && output.include?('remove lock')
-  raise "\nFound #{count_failures} failures in salt event log:\n#{output}\n" if count_failures.nonzero?
+  ignore_error = (count_failures == 1) && output.include?('remove lock') && !$build_validation
+  raise "\nFound #{count_failures} failures in salt event log:\n#{output}\n" if count_failures.nonzero? && !ignore_error
 end
 
 # action chains

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -209,7 +209,9 @@ Then(/^the salt event log on server should contain no failures$/) do
   if count_failures == 1 && !$build_validation
     ignore_error = output.include?('remove lock')
   end
-  raise "\nFound #{count_failures} failures in salt event log:\n#{output}\n" if count_failures.nonzero? && !ignore_error
+  if count_failures.nonzero? 
+    raise "\nFound #{count_failures} failures in salt event log:\n#{output}\n" unless ignore_error
+  end
 end
 
 # action chains

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -207,12 +207,8 @@ Then(/^the salt event log on server should contain no failures$/) do
   output = output.join.to_s if output.respond_to?(:join)
   # Ignore the error if there is only the expected failure from min_salt_lock_packages.feature
   ignore_error = false
-  if count_failures == 1 && !$build_validation
-    ignore_error = output.include?('remove lock')
-  end
-  if count_failures.nonzero? and !ignore_error
-    raise "\nFound #{count_failures} failures in salt event log:\n#{output}\n"
-  end
+  ignore_error = output.include?('remove lock') if count_failures == 1 && !$build_validation
+  raise "\nFound #{count_failures} failures in salt event log:\n#{output}\n" if count_failures.nonzero? and !ignore_error
 end
 
 # action chains

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -205,6 +205,8 @@ Then(/^the salt event log on server should contain no failures$/) do
   output, _code = $server.run("python3 /tmp/#{file}")
   count_failures = output.to_s.scan(/false/).length
   output = output.join.to_s if output.respond_to?(:join)
+  # Ignore the error if there is only the expected failure from min_salt_lock_packages.feature
+  ignore_error = (count_failures == 1) && output.include? 'remove lock'
   raise "\nFound #{count_failures} failures in salt event log:\n#{output}\n" if count_failures.nonzero?
 end
 

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -210,7 +210,7 @@ Then(/^the salt event log on server should contain no failures$/) do
   if count_failures == 1 && !$build_validation
     ignore_error = output.include?('remove lock')
   end
-  if count_failures.nonzero? and not ignore_error
+  if count_failures.nonzero? and !ignore_error
     raise "\nFound #{count_failures} failures in salt event log:\n#{output}\n"
   end
 end

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -209,7 +209,7 @@ Then(/^the salt event log on server should contain no failures$/) do
   if count_failures == 1 && !$build_validation
     ignore_error = output.include?('remove lock')
   end
-  if count_failures.nonzero? 
+  if count_failures.nonzero?
     raise "\nFound #{count_failures} failures in salt event log:\n#{output}\n" unless ignore_error
   end
 end

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -206,7 +206,7 @@ Then(/^the salt event log on server should contain no failures$/) do
   count_failures = output.to_s.scan(/false/).length
   output = output.join.to_s if output.respond_to?(:join)
   # Ignore the error if there is only the expected failure from min_salt_lock_packages.feature
-  ignore_error = (count_failures == 1) && output.include? 'remove lock'
+  ignore_error = (count_failures == 1) && output.include?('remove lock')
   raise "\nFound #{count_failures} failures in salt event log:\n#{output}\n" if count_failures.nonzero?
 end
 

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -206,11 +206,12 @@ Then(/^the salt event log on server should contain no failures$/) do
   count_failures = output.to_s.scan(/false/).length
   output = output.join.to_s if output.respond_to?(:join)
   # Ignore the error if there is only the expected failure from min_salt_lock_packages.feature
+  ignore_error = false
   if count_failures == 1 && !$build_validation
     ignore_error = output.include?('remove lock')
   end
-  if count_failures.nonzero?
-    raise "\nFound #{count_failures} failures in salt event log:\n#{output}\n" unless ignore_error
+  if count_failures.nonzero? and not ignore_error
+    raise "\nFound #{count_failures} failures in salt event log:\n#{output}\n"
   end
 end
 

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -197,8 +197,8 @@ end
 Then(/^the salt event log on server should contain no failures$/) do
   # upload salt event parser log
   file = 'salt_event_parser.py'
-  source = File.dirname(__FILE__) + '/../upload_files/' + file
-  dest = "/tmp/" + file
+  source = "#{File.dirname(__FILE__)}/../upload_files/#{file}"
+  dest = "/tmp/#{file}"
   return_code = file_inject($server, source, dest)
   raise 'File injection failed' unless return_code.zero?
   # print failures from salt event log
@@ -206,7 +206,9 @@ Then(/^the salt event log on server should contain no failures$/) do
   count_failures = output.to_s.scan(/false/).length
   output = output.join.to_s if output.respond_to?(:join)
   # Ignore the error if there is only the expected failure from min_salt_lock_packages.feature
-  ignore_error = (count_failures == 1) && output.include?('remove lock') && !$build_validation
+  if count_failures == 1 && !$build_validation
+    ignore_error = output.include?('remove lock')
+  end
   raise "\nFound #{count_failures} failures in salt event log:\n#{output}\n" if count_failures.nonzero? && !ignore_error
 end
 

--- a/testsuite/features/upload_files/salt_event_parser.py
+++ b/testsuite/features/upload_files/salt_event_parser.py
@@ -22,7 +22,7 @@ for error in errors:
     try:
         j = json.loads("".join(error))
         if not "return" in j:
-            break
+            continue
     except ValueError as e:
         print("JSON cannot be parsed due to {0}".format(e))
         continue


### PR DESCRIPTION
## What does this PR change?

The salt error detection was faulty, this PR aims to correct the detection script and exclude the detection of an expected error caused by `min_salt_lock_packages.feature`

We want to ignore the salt failure caused by `Feature: Lock packages on SLES salt minion`

Errors such as 
```
salt/auth       {
    "_stamp": "2023-01-20T17:25:25.501308",
    "id": "suma-pr4-min-sles15.mgr.prv.suse.net",
    "pub": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwEB5emvXG+Db7IuywF0X\njla8N0SopuNZaxNelEpsPucGspjPtuwI0wX60pQunj8bTxeb6krWdUy0sJiOB0Ne\nCkoLRSejQ2y+RtrsVSRGyf34Y9UIR/N/xLSWBF6l1V7zhocbbwHpoCAWbw3A8C1v\neVABiXI5rrQCT11+QJJMsCiAuSiRSHWh8+rB3edl615LjH4VZqDao3I88dRN+vEv\n1Sr5SgJ0KPQAa+8YYFHt+PVSVgAKHbJnIn5kdX6M/Zzhhkt+VyeCLjgpdeDr88Fn\nW+TmfZtymrWofGfm0XhPyrJZtRQ+Ow8Zz09gRRMyvO2QkrKDu4O7jInXqG/jrr3k\nxQIDAQAB\n-----END PUBLIC KEY-----\n",
    "result": false
}
``` 
are ignored by the script.

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Fixes # https://github.com/SUSE/spacewalk/issues/19626
Tracks # 
4.2 https://github.com/SUSE/spacewalk/pull/20273
4.3 https://github.com/SUSE/spacewalk/pull/20274
- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
