### PR TITLE
QE: Retracted patches: Remove Clear button click

### DIFF
--- a/testsuite/features/secondary/allcli_action_chain.feature
+++ b/testsuite/features/secondary/allcli_action_chain.feature
@@ -108,4 +108,4 @@ Feature: Action chains on several systems at once
     And I run "rm /tmp/action_chain_done" on "ssh_minion" without error control
 
   Scenario: Cleanup: remove remaining systems from SSM after action chain tests on several systems
-    When I click on "Clear"
+    When I click on the clear SSM button

--- a/testsuite/features/secondary/allcli_config_channel.feature
+++ b/testsuite/features/secondary/allcli_config_channel.feature
@@ -193,7 +193,7 @@ Feature: Management of configuration of all types of clients in a single channel
 @sle_minion
   Scenario: Re-add SLE Minion via SSM
     When I follow the left menu "Systems > System List > All"
-    And I click on "Clear"
+    And I click on the clear SSM button
     And I check the "sle_minion" client
     And I follow the left menu "Systems > System Set Manager > Overview"
     And I follow "config channel subscriptions" in the content area
@@ -224,4 +224,4 @@ Feature: Management of configuration of all types of clients in a single channel
     When I destroy "/etc/s-mgr" directory on "sle_minion"
 
   Scenario: Cleanup: remove remaining systems from SSM after tests of configuration channel on all clients
-    When I click on "Clear"
+    When I click on the clear SSM button

--- a/testsuite/features/secondary/allcli_software_channels.feature
+++ b/testsuite/features/secondary/allcli_software_channels.feature
@@ -10,7 +10,7 @@ Feature: Channel subscription via SSM
 @sle_minion
   Scenario: Change child channels for SLES minion subscribed to a base channel
     When I follow the left menu "Systems > System List > All"
-    And I click on "Clear"
+    And I click on the clear SSM button
     And I check the "sle_minion" client
     And I should see "1" systems selected for SSM
     And I follow the left menu "Systems > System Set Manager > Overview"
@@ -31,7 +31,7 @@ Feature: Channel subscription via SSM
     And I remember when I scheduled an action
     Then I wait until I see "Channel Changes Actions" text
     And a table line should contain system "sle_minion", "Scheduled"
-    And I click on "Clear"
+    And I click on the clear SSM button
 
 @sle_minion
   Scenario: Check SLES minion is still subscribed to old channels before channel change completes
@@ -78,7 +78,7 @@ Feature: Channel subscription via SSM
 @rhlike_minion
   Scenario: System default channel can't be determined on the Red Hat-like minion
     When I follow the left menu "Systems > System List > All"
-    And I click on "Clear"
+    And I click on the clear SSM button
     And I check the "rhlike_minion" client
     Then I should see "1" systems selected for SSM
     When I follow the left menu "Systems > System Set Manager > Overview"
@@ -96,7 +96,7 @@ Feature: Channel subscription via SSM
     Then I should see a "Channel Changes Actions" text
     And I should see a "Items 1 - 1 of 1" text
     And a table line should contain system "rhlike_minion", "Could not determine system default channel"
-    And I click on "Clear"
+    And I click on the clear SSM button
 
 @rhlike_minion
   Scenario: Cleanup: make sure the Red Hat-like minion is still unchanged
@@ -108,7 +108,7 @@ Feature: Channel subscription via SSM
 @deblike_minion
   Scenario: System default channel can't be determined on the Debian-like minion
     When I follow the left menu "Systems > System List > All"
-    And I click on "Clear"
+    And I click on the clear SSM button
     And I check the "deblike_minion" client
     Then I should see "1" systems selected for SSM
     When I follow the left menu "Systems > System Set Manager > Overview"
@@ -126,7 +126,7 @@ Feature: Channel subscription via SSM
     Then I should see a "Channel Changes Actions" text
     And I should see a "Items 1 - 1 of 1" text
     And a table line should contain system "deblike_minion", "Could not determine system default channel"
-    And I click on "Clear"
+    And I click on the clear SSM button
 
 @deblike_minion
   Scenario: Cleanup: make sure the Debian-like minion is still unchanged
@@ -160,4 +160,4 @@ Feature: Channel subscription via SSM
     Then channel "SLE15-SP4-Installer-Updates for x86_64" should not be enabled on "sle_minion"
 
   Scenario: Cleanup: remove remaining systems from SSM after channel subscription tests
-    When I click on "Clear"
+    When I click on the clear SSM button

--- a/testsuite/features/secondary/allcli_software_channels_dependencies.feature
+++ b/testsuite/features/secondary/allcli_software_channels_dependencies.feature
@@ -49,4 +49,4 @@ Feature: Channel subscription with recommended or required dependencies
     And I should see "No change" "unselected" for the "SLE-Module-Basesystem15-SP3-Pool for x86_64" channel
 
   Scenario: Cleanup: remove remaining systems from SSM after software channel tests
-    When I click on "Clear"
+    When I click on the clear SSM button

--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -54,7 +54,7 @@ Feature: Build OS images
 
   Scenario: Cleanup: remove remaining systems from SSM after OS image tests
     When I go to the home page
-    And I click on "Clear"
+    And I click on the clear SSM button
 
   Scenario: Cleanup: remove OS image profile
     When I follow the left menu "Images > Profiles"

--- a/testsuite/features/secondary/min_baremetal_discovery.feature
+++ b/testsuite/features/secondary/min_baremetal_discovery.feature
@@ -107,7 +107,7 @@ Feature: Bare metal discovery
     And I should see a "Groups" link in the content area
     And I should not see a "Channels" link in the content area
     And I should not see a "Audit" link in the content area
-    And I click on "Clear"
+    And I click on the clear SSM button
 
   Scenario: Cleanup: delete the bare metal system profile
     Given I am on the Systems overview page of this "sle_minion"

--- a/testsuite/features/secondary/min_cve_audit.feature
+++ b/testsuite/features/secondary/min_cve_audit.feature
@@ -59,7 +59,7 @@ Feature: CVE Audit on SLE Salt Minions
     Then I should see a "The specified CVE number was not found" text
 
   Scenario: Select a system for the System Set Manager
-    When I click on "Clear"
+    And I click on the clear SSM button
     And I follow the left menu "Audit > CVE Audit"
     And I select "1999" from "cveIdentifierYear"
     And I enter "9999" as "cveIdentifierId"
@@ -69,7 +69,7 @@ Feature: CVE Audit on SLE Salt Minions
     Then I should see a "system selected" text
     When I follow the left menu "Systems > System List > All"
     Then I should see "sle_minion" as link
-    And I click on "Clear"
+    And I click on the clear SSM button
 
   Scenario: List systems by patch status via API before patch
     When I follow the left menu "Admin > Task Schedules"
@@ -105,4 +105,4 @@ Feature: CVE Audit on SLE Salt Minions
     And I remove package "milkyway-dummy" from this "sle_minion" without error control
 
   Scenario: Cleanup: remove remaining systems from SSM after CVE audit tests
-    When I click on "Clear"
+    When I click on the clear SSM button

--- a/testsuite/features/secondary/min_move_from_and_to_proxy.feature
+++ b/testsuite/features/secondary/min_move_from_and_to_proxy.feature
@@ -69,7 +69,7 @@ Feature: Move a minion from a proxy to direct connection
     # be sure that the old events are older than 1 minute
     Given I wait for "120" seconds
     When I follow the left menu "Systems > System List > All"
-    And I click on "Clear"
+    And I click on the clear SSM button
     And I check the "sle_minion" client
     And I should see "1" systems selected for SSM
     And I follow the left menu "Systems > System Set Manager > Overview"

--- a/testsuite/features/secondary/min_retracted_patches.feature
+++ b/testsuite/features/secondary/min_retracted_patches.feature
@@ -109,7 +109,7 @@ Feature: Retracted patches
 
   Scenario: SSM: Retracted package should not be available for installation
     When I follow the left menu "Systems > System List > All"
-    And I click on "Clear"
+    And I click on the clear SSM button
     And I check the "sle_minion" client 
     And I follow the left menu "Systems > System Set Manager > Overview"
     And I follow "Packages" in the content area
@@ -117,4 +117,4 @@ Feature: Retracted patches
     And I follow "Fake-RPM-SLES-Channel"
     Then I should see a "rute-dummy-2.0-1.2" text
     And I should not see a "rute-dummy-2.1-1.1" text
-    And I click on "Clear"
+    And I click on the clear SSM button

--- a/testsuite/features/secondary/min_salt_formulas.feature
+++ b/testsuite/features/secondary/min_salt_formulas.feature
@@ -164,4 +164,4 @@ Feature: Use salt formulas
      When I manually uninstall the "locale" formula from the server
 
   Scenario: Cleanup: remove remaining systems from SSM after formula tests
-     When I click on "Clear"
+     When I click on the clear SSM button

--- a/testsuite/features/secondary/srv_clone_channel_npn.feature
+++ b/testsuite/features/secondary/srv_clone_channel_npn.feature
@@ -127,4 +127,4 @@ Feature: Clone a channel
     And I should see a "has been deleted." text
 
   Scenario: Cleanup: remove remaining systems from SSM after channel cloning tests
-    When I click on "Clear"
+    When I click on the clear SSM button

--- a/testsuite/features/secondary/srv_group_union_intersection.feature
+++ b/testsuite/features/secondary/srv_group_union_intersection.feature
@@ -128,4 +128,4 @@ Feature: Work with Union and Intersection buttons in the group list
     Then I should see a "deleted" text
 
   Scenario: Cleanup: remove remaining systems from SSM after group union and intersection tests
-    When I click on "Clear"
+    When I click on the clear SSM button

--- a/testsuite/features/secondary/srv_maintenance_windows.feature
+++ b/testsuite/features/secondary/srv_maintenance_windows.feature
@@ -65,7 +65,7 @@ Feature: Maintenance windows
 
   Scenario: Assign systems to a multi schedule using SSM
     When I follow the left menu "Systems > System List > All"
-    And I click on "Clear"
+    And I click on the clear SSM button
     And I check the "rhlike_minion" client
     And I follow the left menu "Systems > System Set Manager > Overview"
     And I follow "Assign" in the content area
@@ -111,7 +111,7 @@ Feature: Maintenance windows
 
   Scenario: Detach systems from schedules
     When I follow the left menu "Systems > System List > All"
-    And I click on "Clear"
+    And I click on the clear SSM button
     And I check the "sle_minion" client
     And I follow the left menu "Systems > System Set Manager > Overview"
     And I follow "Assign" in the content area

--- a/testsuite/features/secondary/srv_power_management.feature
+++ b/testsuite/features/secondary/srv_power_management.feature
@@ -52,7 +52,7 @@ Feature: IPMI Power management
 
   Scenario: Check power management SSM configuration
     When I follow the left menu "Systems > System List > All"
-    And I click on "Clear"
+    And I click on the clear SSM button
     And I check the "sle_minion" client
     And I follow the left menu "Systems > System Set Manager > Overview"
     And I follow "Configure power management" in the content area
@@ -95,4 +95,4 @@ Feature: IPMI Power management
     When the server stops mocking an IPMI host
 
   Scenario: Cleanup: remove remaining systems from SSM after power management tests
-    When I click on "Clear"
+    When I click on the clear SSM button

--- a/testsuite/features/secondary/srv_power_management_redfish.feature
+++ b/testsuite/features/secondary/srv_power_management_redfish.feature
@@ -48,7 +48,7 @@ Feature: Redfish Power management
 
   Scenario: Check power management SSM configuration for Redfish
     When I follow the left menu "Systems > System List > All"
-    And I click on "Clear"
+    And I click on the clear SSM button
     And I check the "sle_minion" client
     And I follow the left menu "Systems > System Set Manager > Overview"
     And I follow "Configure power management" in the content area
@@ -92,4 +92,4 @@ Feature: Redfish Power management
     When the server stops mocking a Redfish host
 
   Scenario: Cleanup: remove remaining systems from SSM after Redfish power management tests
-    When I click on "Clear"
+    When I click on the clear SSM button

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -776,7 +776,7 @@ When(/^I click on the red confirmation button$/) do
 end
 
 When(/^I click on the clear SSM button$/) do
-  find_and_wait_click('a#clear-ssm').click
+  find_and_wait_click(:xpath, "//*[@id='clear-ssm']").click
 end
 
 When(/^I click on the filter button$/) do


### PR DESCRIPTION
## What does this PR change?
![image](https://user-images.githubusercontent.com/12104291/213175227-ec8543cc-857b-4679-ac6c-87d4be1791fe.png)
Fixes: https://github.com/SUSE/spacewalk/issues/20194

ATM this only occurs on 4.2 but we want to keep the test suite in sync. @srbarrios already confirmed that the logic behind the changed step works.

See Discussion in Slack: https://suse.slack.com/archives/C02D12TNYLS/p1674043102403269

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links

- Manager 4.3: 
- Manager 4.2: 
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

