### PR TITLE
Include 'gpg' states and files as "ssh_extra_filerefs" to avoid issues on action chains for SSH minions

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
@@ -126,7 +126,7 @@ public class SaltSSHService {
             "distupgrade", "hardware", "images", "packages/init.sls",
             "packages/patchdownload.sls", "packages/patchinstall.sls", "packages/pkgdownload.sls",
             "packages/pkginstall.sls", "packages/pkgupdate.sls", "packages/pkgremove.sls", "packages/profileupdate.sls",
-            "packages/redhatproductinfo.sls", "remotecommands", "scap", "services",
+            "packages/redhatproductinfo.sls", "remotecommands", "scap", "services", "gpg",
             "custom", "custom_groups", "custom_org", "util", "bootstrap", "formulas.sls");
 
     public static final String ACTION_STATES = ACTION_STATES_LIST

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Include missing 'gpg' states to avoid issues on SSH minions.
 - Fix reconnection of postgres event stream
 - Standardize the login response format with other HTTP API endpoints (bsc#1206800)
 - Add `mgr_server_is_uyuni` minion pillar item


### PR DESCRIPTION
## What does this PR change?

This PR fixes a problem with channels / packages related actions triggered via actions chains on SSH minions that we have seen happening in the HEAD acceptance tests. We need to explicitely add `gpg` as `ssh_extra_filerefs` on SSH executions made by Uyuni, in order to ensure those extra files are available on the context of SSH action chain execution.

As mentioned, this should fix some issues seen at Head acceptance tests:

```
----------
          ID: mgr_deploy_tools_uyuni_key
    Function: file.managed
        Name: /etc/pki/rpm-gpg/uyuni-tools-gpg-pubkey-0d20833e.key
      Result: false
     Comment: Source file salt://gpg/uyuni-tools-gpg-pubkey-0d20833e.key not found in saltenv 'base'
     Started: 13:57:27.009611
    Duration: 2.696
         SLS: channels.gpg-keys
     Changed: {}
----------
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
