### PR TITLE
spacewalk-commonn-channels for SUSE Liberty Linux

### DIFF
--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -75,7 +75,7 @@ Feature: Be able to list available channels and enable them
     And I execute mgr-sync "add channel res-8-updates-x86_64"
     And I execute mgr-sync "add channel res-as-8-updates-x86_64"
     And I execute mgr-sync "add channel res-cb-8-updates-x86_64"
-    And I use spacewalk-common-channel to add channel "el8-uyuni-client" with arch "x86_64"
+    And I use spacewalk-common-channel to add channel "sll8-uyuni-client" with arch "x86_64"
     And I execute mgr-sync "list channels"
     Then I should get "[I] RHEL8-Pool for x86_64 RHEL or SLES ES or CentOS 8 Base [rhel8-pool-x86_64]"
     And I should get "[I] RES-8-Updates for x86_64 SUSE Linux Enterprise Server with Expanded Support 8 x86_64 [res-8-updates-x86_64]"

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -368,7 +368,7 @@ CHANNEL_TO_SYNCH_BY_OS_VERSION = {
   %w[
     res8-manager-tools-pool-x86_64
     res8-manager-tools-updates-x86_64
-    el8-uyuni-client-x86_64
+    sll8-uyuni-client-x86_64
   ]
 }.freeze
 

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -3779,22 +3779,56 @@ gpgkey_id = 3228467C
 gpgkey_fingerprint = FF8A D134 4597 106E CE81 3B91 8A38 72BF 3228 467C
 repo_url = https://mirrors.fedoraproject.org/mirrorlist?repo=epel-9&arch=%(arch)s
 
-[el8-uyuni-client]
-name     = uyuni client tools for %(base_channel_name)s
-archs    = %(_x86_archs)s, aarch64
-checksum = sha256
-base_channels = rhel8-pool-%(arch)s
+[sll7-uyuni-client]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = %(_x86_archs)s
+base_channels =  res7-%(arch)s
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/
+
+[sll7-uyuni-client-devel]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = %(_x86_archs)
+base_channels = res7-%(arch)s
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS7-Uyuni-Client-Tools/CentOS_7/
+
+[sll8-uyuni-client]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = %(_x86_archs)s
+base_channels =  rhel8-pool-%(arch)s
 gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/
 
-[el9-uyuni-client]
-name     = uyuni client tools for %(base_channel_name)s
-archs    = %(_x86_archs)s, aarch64
-checksum = sha256
-base_channels = rhel9-pool-%(arch)s
+[sll8-uyuni-client-devel]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = %(_x86_archs)
+base_channels = rhel8-pool-%(arch)s
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL8-Uyuni-Client-Tools/EL_8/
+
+[sll9-uyuni-client]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = %(_x86_archs)s
+base_channels = el9-pool-%(arch)s
 gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL9-Uyuni-Client-Tools/EL_9/
+
+[sll9-uyuni-client-devel]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = %(_x86_archs)
+base_channels = el9-pool-%(arch)s
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL9-Uyuni-Client-Tools/EL_9/

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- Fix the SUSE Liberty Linux definitions
 - Add Uyuni SLE-Micro Client Tools repositories
 - fix Oracle Linux 9 repository definition
 


### PR DESCRIPTION
## What does this PR change?

spacewalk-commonn-channels for SUSE Liberty Linux

We had `el` channels added, but that was wrong, as the channel names must be specific for the OS (`spacewalk-common-channels` can't reuse channels, only repositories, as of today)

The base channel for the client tools for `el9` was incorrect.

And finally, the devel client tools were missing, as well as the entire SUSE Liberty Linux 7.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Documentation PR: https://github.com/uyuni-project/uyuni-docs/pull/2006

- [x] **DONE**

## Test coverage
- No tests: 8 is already covered by the testsuite. I am testing 9 manually

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/20195

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
