### PR TITLE
Fix typo at SLL client tools devel channels

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -3790,7 +3790,7 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 
 [sll7-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
-archs    = %(_x86_archs)
+archs    = %(_x86_archs)s
 base_channels = res7-%(arch)s
 gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s
@@ -3808,7 +3808,7 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 
 [sll8-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
-archs    = %(_x86_archs)
+archs    = %(_x86_archs)s
 base_channels = rhel8-pool-%(arch)s
 gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s
@@ -3826,7 +3826,7 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 
 [sll9-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
-archs    = %(_x86_archs)
+archs    = %(_x86_archs)s
 base_channels = el9-pool-%(arch)s
 gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s


### PR DESCRIPTION
## What does this PR change?

Fix typo at SLL client tools devel channels, a `s` was missing, so the interpolation was failing.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Internal code change

- [x] **DONE**

## Test coverage
- No tests: already covered for 8 by the testsuite, for 9, manually.

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/20195

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
