### PR TITLE
Do not use non-compatible unique filter in old jinja2 (bsc#1206979) (bsc#1206981)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/gpg-keys.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/gpg-keys.sls
@@ -81,12 +81,12 @@ mgr_deploy_{{ keyname }}:
 
 {%- set gpg_urls = [] %}
 {%- for chan, args in pillar.get(pillar.get('_mgr_channels_items_name', 'channels'), {}).items() %}
-{%- if args['gpgkeyurl'] is defined %}
+{%- if args['gpgkeyurl'] is defined and args['gpgkeyurl'] not in gpg_urls %}
 {{ gpg_urls.append(args['gpgkeyurl']) | default("", True) }}
 {%- endif %}
 {%- endfor %}
 
-{% for url in gpg_urls | unique %}
+{% for url in gpg_urls %}
 {{ url | replace(':', '_') }}:
   mgrcompat.module_run:
     - name: pkg.add_repo_key

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Do not use non-compatible unique filter in old jinja2 (bsc#1206979) (bsc#1206981)
 - Fix custom "mgrcompat.module_run" state module to work with Salt 3005.1
 - Add missing transactional_update.conf for SLE Micro
 - filter out libvirt engine events (bsc#1206146)


### PR DESCRIPTION
## What does this PR change?

This PR simply remove the usage of `unique` filter in our SLS files, as this is not compatible with old jinja2 versions we have in old Python 2.6 systems.

As we really want to prevent breaking compatibility here if possible, this PR simply refactors the template so the `unique` filter is not really needed.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **no checks for this atm**

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
