### PR TITLE
Do not pass server related grains to minions

### DIFF
--- a/susemanager-utils/susemanager-sls/src/grains/mgr_server.py
+++ b/susemanager-utils/susemanager-sls/src/grains/mgr_server.py
@@ -13,6 +13,7 @@ RHNCONF = "/etc/rhn/rhn.conf"
 RHNCONFDEF = "/usr/share/rhn/config-defaults/rhn.conf"
 RHNWEBCONF = "/usr/share/rhn/config-defaults/rhn_web.conf"
 
+
 def _simple_parse_rhn_conf(cfile):
     result = {}
 
@@ -24,7 +25,7 @@ def _simple_parse_rhn_conf(cfile):
             line = line.strip()
             if not line or line[0] == '#':
                 continue
-            k,v = line.split("=", 1)
+            k, v = line.split("=", 1)
             result[k.strip()] = v.strip() or None
     return result
 
@@ -33,7 +34,7 @@ def server_grains():
     """ returns if this minion is a Uyuni/SUSE Manager Server and
         if it has a reporting database configured.
     """
-    grains = {'is_mgr_server': False, 'has_report_db': False, 'is_uyuni': True}
+    grains = {'is_mgr_server': False}
 
     config = _simple_parse_rhn_conf(RHNCONF)
 
@@ -44,9 +45,13 @@ def server_grains():
             grains['report_db_host'] = config.get('report_db_host')
             grains['report_db_name'] = config.get('report_db_name')
             grains['report_db_port'] = config.get('report_db_port', '5432')
+        else:
+            grains['has_report_db'] = False
         rhndef = _simple_parse_rhn_conf(RHNCONFDEF)
         if rhndef.get('product_name', 'uyuni') == 'SUSE Manager':
             grains['is_uyuni'] = False
+        else:
+            grains['is_uyuni'] = True
         webconfig = _simple_parse_rhn_conf(RHNWEBCONF)
         if grains['is_uyuni']:
             version = webconfig.get('web.version.uyuni')

--- a/susemanager-utils/susemanager-sls/src/grains/mgr_server.py
+++ b/susemanager-utils/susemanager-sls/src/grains/mgr_server.py
@@ -2,11 +2,8 @@
 Grains for Mgr Server
 """
 
-import sys
 import logging
 import os
-
-from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 RHNCONF = "/etc/rhn/rhn.conf"

--- a/susemanager-utils/susemanager-sls/src/grains/mgr_server.py
+++ b/susemanager-utils/susemanager-sls/src/grains/mgr_server.py
@@ -31,9 +31,7 @@ def _simple_parse_rhn_conf(cfile):
 
 
 def server_grains():
-    """ returns if this minion is a Uyuni/SUSE Manager Server and
-        if it has a reporting database configured.
-    """
+    """ Returns grains relevant for Uyuni/SUMA server. """
     grains = {'is_mgr_server': False}
 
     config = _simple_parse_rhn_conf(RHNCONF)

--- a/susemanager-utils/susemanager-sls/src/tests/data/rhnconfdef.sample
+++ b/susemanager-utils/susemanager-sls/src/tests/data/rhnconfdef.sample
@@ -1,0 +1,1 @@
+product_name = Uyuni

--- a/susemanager-utils/susemanager-sls/src/tests/test_grains_mgr_server.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_grains_mgr_server.py
@@ -8,33 +8,41 @@ import json
 import pytest
 from unittest.mock import MagicMock, patch, mock_open
 from . import mockery
+
 mockery.setup_environment()
 
 from ..grains import mgr_server
 
+
 def test_server():
-    mgr_server.RHNCONF = os.path.sep.join([os.path.abspath(''), 'data', 'rhnconf.sample'])
+    mgr_server.RHNCONF = os.path.join(os.path.abspath(''), 'data', 'rhnconf.sample')
+    mgr_server.RHNCONFDEF = os.path.join(os.path.abspath(''), 'data', 'rhnconfdef.sample')
 
     grains = mgr_server.server_grains()
     assert type(grains) == dict
     assert 'is_mgr_server' in grains
     assert 'has_report_db' in grains
-    assert grains['is_mgr_server'] == True
-    assert grains['has_report_db'] == True
+    assert 'is_uyuni' in grains
+    assert grains['is_mgr_server']
+    assert grains['has_report_db']
     assert grains['report_db_name'] == 'reportdb'
     assert grains['report_db_host'] == 'localhost'
     assert grains['report_db_port'] == '5432'
+    assert grains['is_uyuni']
 
 
 def test_server_no_reportdb():
-    mgr_server.RHNCONF = os.path.sep.join([os.path.abspath(''), 'data', 'rhnconf2.sample'])
+    mgr_server.RHNCONF = os.path.join(os.path.abspath(''), 'data', 'rhnconf2.sample')
+    mgr_server.RHNCONFDEF = os.path.join(os.path.abspath(''), 'data', 'rhnconfdef.sample')
 
     grains = mgr_server.server_grains()
     assert type(grains) == dict
     assert 'is_mgr_server' in grains
     assert 'has_report_db' in grains
-    assert grains['is_mgr_server'] == True
-    assert grains['has_report_db'] == False
+    assert 'is_uyuni' in grains
+    assert grains['is_mgr_server']
+    assert not grains['has_report_db']
+    assert grains['is_uyuni']
 
 
 def test_no_server():
@@ -43,6 +51,6 @@ def test_no_server():
     grains = mgr_server.server_grains()
     assert type(grains) == dict
     assert 'is_mgr_server' in grains
-    assert 'has_report_db' in grains
-    assert grains['is_mgr_server'] == False
-    assert grains['has_report_db'] == False
+    assert 'has_report_db' not in grains
+    assert 'is_uyuni' not in grains
+    assert not grains['is_mgr_server']

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Do not pass server grains to minions (bsc#1207087)
 - Reuse DB connection on compiling pillar with suma_minion
 - Do not use non-compatible unique filter in old jinja2 (bsc#1206979) (bsc#1206981)
 - Fix custom "mgrcompat.module_run" state module to work with Salt 3005.1


### PR DESCRIPTION
## What does this PR change?

Do not pass server related grains to minions.

The grains `is_uyuni` and `has_report_db` are evaluated by reading server configuration files entries. These configuration files are not available on common clients and the grains were always set to default values and of no use.

In case of missing server configuration files the grains `is_uyuni` and `has_report_db` are not being set now.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Existing tests updated

- [x] **DONE**

## Links

Fixes #SUSE/spacewalk#20145

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
