### PR TITLE
Remove SLL

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -3779,24 +3779,6 @@ gpgkey_id = 3228467C
 gpgkey_fingerprint = FF8A D134 4597 106E CE81 3B91 8A38 72BF 3228 467C
 repo_url = https://mirrors.fedoraproject.org/mirrorlist?repo=epel-9&arch=%(arch)s
 
-[sll7-uyuni-client]
-name     = Uyuni Client Tools for %(base_channel_name)s
-archs    = %(_x86_archs)s
-base_channels =  res7-%(arch)s
-gpgkey_url = %(_uyuni_gpgkey_url)s
-gpgkey_id = %(_uyuni_gpgkey_id)s
-gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/
-
-[sll7-uyuni-client-devel]
-name     = Uyuni Client Tools for %(base_channel_name)s (Development)
-archs    = %(_x86_archs)s
-base_channels = res7-%(arch)s
-gpgkey_url = %(_uyuni_gpgkey_url)s
-gpgkey_id = %(_uyuni_gpgkey_id)s
-gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS7-Uyuni-Client-Tools/CentOS_7/
-
 [sll8-uyuni-client]
 name     = Uyuni Client Tools for %(base_channel_name)s
 archs    = %(_x86_archs)s
@@ -3814,21 +3796,3 @@ gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL8-Uyuni-Client-Tools/EL_8/
-
-[sll9-uyuni-client]
-name     = Uyuni Client Tools for %(base_channel_name)s
-archs    = %(_x86_archs)s
-base_channels = el9-pool-%(arch)s
-gpgkey_url = %(_uyuni_gpgkey_url)s
-gpgkey_id = %(_uyuni_gpgkey_id)s
-gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL9-Uyuni-Client-Tools/EL_9/
-
-[sll9-uyuni-client-devel]
-name     = Uyuni Client Tools for %(base_channel_name)s (Development)
-archs    = %(_x86_archs)s
-base_channels = el9-pool-%(arch)s
-gpgkey_url = %(_uyuni_gpgkey_url)s
-gpgkey_id = %(_uyuni_gpgkey_id)s
-gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL9-Uyuni-Client-Tools/EL_9/

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,4 +1,3 @@
-- Fix the SUSE Liberty Linux definitions
 - Add Uyuni SLE-Micro Client Tools repositories
 - fix Oracle Linux 9 repository definition
 


### PR DESCRIPTION
## What does this PR change?

For now, SLL does not work with Uyuni, as it requires a SUSE Manager subscription, so we are removing the channels from spacewalk-common-channels.

SLL8 should be removed as well, but the testsuite is using it, so I will keep it for now.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- PR TBD

- [ ] **DONE**

## Test coverage
- No tests: Removal

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/20195

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
