### PR TITLE
QE: Add further tests to grafana on BV

### DIFF
--- a/testsuite/features/build_validation/init_clients/monitoring_server.feature
+++ b/testsuite/features/build_validation/init_clients/monitoring_server.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 SUSE LLC
+# Copyright (c) 2022-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @monitoring_server

--- a/testsuite/features/build_validation/init_clients/monitoring_server.feature
+++ b/testsuite/features/build_validation/init_clients/monitoring_server.feature
@@ -56,6 +56,7 @@ Feature: Bootstrap the monitoring server
     And I click on "Expand All Sections"
     And I enter "admin" as "Username"
     And I enter "admin" as "Password"
+    And I check the blackbox exporter
     And I click on "Save Formula"
     Then I should see a "Formula saved" text
     When I follow "States" in the content area

--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022 SUSE LLC.
+# Copyright (c) 2020-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 @<client>

--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -167,3 +167,11 @@ Feature: Smoke tests for <client>
     And I visit "Prometheus apache exporter" endpoint of this "<client>"
     And I wait until "postgres" exporter service is active on "<client>"
     And I visit "Prometheus postgres exporter" endpoint of this "<client>"
+
+  Scenario: Test <client> on Grafana
+    When I visit the grafana dashboards of this "monitoring_server"
+    And I wait until I do not see "Loading Grafana" text
+    When I follow "Client Systems"
+    Then I should see "<client>" hostname
+    When I enter "<client>" hostname on grafana's host field
+    Then I should not see a "No data" text

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -1002,6 +1002,11 @@ When(/^I check "([^"]*)" exporter$/) do |exporter_type|
   step %(I check "exporters##{exporter_type}_exporter#enabled")
 end
 
+# Check the Blackbox Exporter in the Prometheus formula
+When(/^I check the blackbox exporter$/) do
+  step %(I check "prometheus#blackbox_exporter#enabled")
+end
+
 # Navigate to a service endpoint
 When(/^I visit "([^"]*)" endpoint of this "([^"]*)"$/) do |service, host|
   node = get_target(host)
@@ -1110,6 +1115,13 @@ end
 When(/^I enter "([^"]*)" hostname on the search field$/) do |host|
   system_name = get_system_name(host)
   step %(I enter "#{system_name}" on the search field)
+end
+
+When(/^I enter "([^"]*)" hostname on grafana's host field$/) do |host|
+  step %(I click on "var-hostname")
+  system_name = get_system_name(host)
+  step %(I enter "#{system_name}" as "Enter variable value")
+  send_keys(:return)
 end
 
 Then(/^I should see "([^"]*)" hostname as first search result$/) do |host|


### PR DESCRIPTION
## What does this PR change?

Adds another set of tests to validate Grafana working in the BV tests. 
Looks for each minion's section on the client dashboards and validates there's no graph without data.

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19958
Ports:
- 4.2
- 4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
