### PR TITLE
add /etc/passwd to supportutils-plugin-susemanager

### DIFF
--- a/susemanager-utils/supportutils-plugin-susemanager/supportutils-plugin-susemanager.changes
+++ b/susemanager-utils/supportutils-plugin-susemanager/supportutils-plugin-susemanager.changes
@@ -1,3 +1,4 @@
+- add /etc/passwd content
 - update susemanager plugin to export the number of pending salt events
 
 -------------------------------------------------------------------

--- a/susemanager-utils/supportutils-plugin-susemanager/susemanager
+++ b/susemanager-utils/supportutils-plugin-susemanager/susemanager
@@ -78,4 +78,5 @@ plugin_command "echo \"select count(*) from susesaltevent;\" | spacewalk-sql --s
 plugin_command "/sbin/supportconfig-sumalog $LOG"
 plugin_command "cp /var/log/zypper.log $LOG"
 plugin_command "grep \"Client bootstrap script\" /srv/www/htdocs/pub/bootstrap/*.sh"
+plugin_command "cat /etc/passwd"
 


### PR DESCRIPTION
## What does this PR change?

add /etc/passwd to supportutils-plugin-susemanager. It would help to check user information.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests: already covered


- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19477

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
