### PR TITLE
Prevent saving duplicate comps files on repo sync (bsc#1206907)

### DIFF
--- a/python/spacewalk/satellite_tools/reposync.py
+++ b/python/spacewalk/satellite_tools/reposync.py
@@ -902,6 +902,7 @@ class RepoSync(object):
             return abspath
 
         # update or insert
+        # allow multiple rows for modules (comps_type_id = 2)
         hu = rhnSQL.prepare("""
             update rhnChannelComps
             set relative_filename = :relpath,
@@ -909,7 +910,7 @@ class RepoSync(object):
                 last_modified = :last_modified
             where channel_id = :cid
                 and comps_type_id = (select id from rhnCompsType where label = :ctype)
-                and relative_filename = :relpath""")
+                and (comps_type_id <> 2 or relative_filename = :relpath)""")
         hu.execute(cid=self.channel['id'], relpath=relativepath, ctype=comps_type,
                    last_modified=last_modified)
 
@@ -925,7 +926,7 @@ class RepoSync(object):
                     (select 1 from rhnChannelComps
                         where channel_id = :cid
                             and comps_type_id = (select id from rhnCompsType where label = :ctype)
-                            and relative_filename = :relpath))""")
+                            and (comps_type_id <> 2 or relative_filename = :relpath)))""")
         hi.execute(cid=self.channel['id'], relpath=relativepath, ctype=comps_type,
                    last_modified=last_modified)
         return abspath

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Prevent saving duplicate comps files on repo sync (bsc#1206907)
+
 -------------------------------------------------------------------
 Tue Jan 24 13:12:35 CET 2023 - jgonzalez@suse.com
 


### PR DESCRIPTION
A recent change in reposync allowed multiple `modules.yaml` files to be saved in the DB. This follow-up explicitly prevents  duplicates of other types of comps files to be saved.

See: https://bugzilla.suse.com/show_bug.cgi?id=1206907

## GUI diff

Before (renamed to `comps.x86_64.xml`):
```
19:48:27   Renaming non-standard filename dae7e104812099a2f632ea4c5ef2769aca18ca1205abdd2c3ba6d171e319df3d-comps-BaseOS.x86_64.xml to comps.x86_64.xml.
```

After (renamed to `comps.xml`):
```
19:48:27   Renaming non-standard filename dae7e104812099a2f632ea4c5ef2769aca18ca1205abdd2c3ba6d171e319df3d-comps-BaseOS.x86_64.xml to comps.xml.
```

## Documentation
- No documentation needed: Bugfix

## Test coverage
- No tests: reposync :man_shrugging: 

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20072

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
