### PR TITLE
Add Alma and Oracle CLM to run_set

### DIFF
--- a/testsuite/run_sets/build_validation_add_common_channels.yml
+++ b/testsuite/run_sets/build_validation_add_common_channels.yml
@@ -6,6 +6,8 @@
 - features/build_validation/add_custom_repositories/add_centos7_repositories.feature
 - features/build_validation/add_custom_repositories/add_rocky8_repositories.feature
 - features/build_validation/add_custom_repositories/add_rocky9_repositories.feature
+- features/build_validation/add_custom_repositories/add_alma9_repositories.feature
+- features/build_validation/add_custom_repositories/add_oracle9_repositories.feature
 
 ## Add common channels and special repositories END ###
 


### PR DESCRIPTION
## What does this PR change?

CLM does not run for Alma and Oracle if they are not part of the run_set. This PR fixes that. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes no issue, directly from testsuite review
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
