### PR TITLE
Remove @Nonnnull annotations as those don't build at packaging time

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/channel/ReleaseChannelMap.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ReleaseChannelMap.java
@@ -25,8 +25,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
-import javax.annotation.Nonnull;
-
 
 /**
  * ReleaseChannelMap
@@ -142,7 +140,7 @@ public class ReleaseChannelMap implements Serializable, Comparable<ReleaseChanne
      */
     @SuppressWarnings("unchecked")
     @Override
-    public int compareTo(@Nonnull ReleaseChannelMap o) {
+    public int compareTo(ReleaseChannelMap o) {
         List<Comparator<ReleaseChannelMap>> compar = new ArrayList<>();
 
         compar.add(new DynamicComparator<>("channel", true));

--- a/java/code/src/com/redhat/rhn/domain/org/usergroup/ExtGroup.java
+++ b/java/code/src/com/redhat/rhn/domain/org/usergroup/ExtGroup.java
@@ -20,8 +20,6 @@ import com.redhat.rhn.domain.org.Org;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
-import javax.annotation.Nonnull;
-
 
 /**
  * ExtGroup
@@ -78,7 +76,7 @@ public abstract class ExtGroup extends BaseDomainHelper implements Comparable<Ex
      * {@inheritDoc}
      */
     @Override
-    public int compareTo(@Nonnull ExtGroup objectIn) {
+    public int compareTo(ExtGroup objectIn) {
         if (objectIn instanceof UserExtGroup) {
             return 0;
         }


### PR DESCRIPTION
## What does this PR change?

Fixing package build

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
