### PR TITLE
HTTP API: Allow single-value lists in query strings (bsc#1207297)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -4066,8 +4066,13 @@ public class SystemHandler extends BaseHandler {
             Date earliestOccurrence, ActionType acT) {
         HashSet<Long> lsids = new HashSet<>();
         for (Integer sid : sids) {
-            Server server = SystemManager.lookupByIdAndUser(sid.longValue(),
-                    loggedInUser);
+            Server server;
+            try {
+                server = SystemManager.lookupByIdAndUser(sid.longValue(), loggedInUser);
+            }
+            catch (LookupException e) {
+                throw new NoSuchSystemException(e.getMessage());
+            }
 
             // Would be nice to do this check at the Manager layer but upset many tests,
             // some of which were not cooperative when being fixed. Placing here for now.
@@ -4257,7 +4262,7 @@ public class SystemHandler extends BaseHandler {
      *
      * @apidoc.doc Schedule full package update for several systems.
      * @apidoc.param #session_key()
-     * @apidoc.param #array_single("int", "serverId")
+     * @apidoc.param #array_single("int", "sids")
      * @apidoc.param #param("$date", "earliestOccurrence")
      * @apidoc.returntype #param("int", "actionId")
      */

--- a/java/code/src/com/suse/manager/api/RouteFactory.java
+++ b/java/code/src/com/suse/manager/api/RouteFactory.java
@@ -27,6 +27,7 @@ import com.suse.manager.webui.utils.SparkApplicationHelper;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 
 import org.apache.http.HttpStatus;
@@ -223,9 +224,18 @@ public class RouteFactory {
                             args.add(sessionKey);
                         }
                         else {
+                            JsonElement jsonArg = jsonArgs.get(param.getName());
+
+                            // If the method expects a List, try to wrap the value in a JSON array
+                            if (List.class.isAssignableFrom(param.getType()) && !jsonArg.isJsonArray()) {
+                                JsonArray arr = new JsonArray(1);
+                                arr.add(jsonArg);
+                                jsonArg = arr;
+                            }
+
                             try {
                                 // Parse each value and add to the argument list
-                                args.add(requestParser.parseValue(jsonArgs.get(param.getName()), param.getType()));
+                                args.add(requestParser.parseValue(jsonArg, param.getType()));
                             }
                             catch (ParseException e) {
                                 // Type mismatch, skip the method

--- a/java/code/src/com/suse/manager/api/test/RouteFactoryTest.java
+++ b/java/code/src/com/suse/manager/api/test/RouteFactoryTest.java
@@ -353,6 +353,26 @@ public class RouteFactoryTest extends BaseControllerTestCase {
     }
 
     /**
+     * When passed a single value, query string parameters are always interpreted as primitives rather than arrays.
+     * This case tests if a single value is correctly passed to a handler method that expects a {@link List} as the
+     * parameter.
+     *
+     * @see <a href="https://bugzilla.suse.com/show_bug.cgi?id=1207297">bsc#1207297</a>
+     */
+    @Test
+    public void testOneElementListInQueryString() throws Exception {
+        Method sortIntegerList = handler.getClass().getMethod("sortIntegerList", List.class);
+        Route route = routeFactory.createRoute(sortIntegerList, handler);
+
+        Map<String, String> queryParams = Collections.singletonMap("myList", "42");
+        Request req = createRequest("/manager/api/test/sortIntegerList", queryParams);
+        Response res = createResponse();
+        List<Integer> result = getResult((String) route.handle(req, res), List.class);
+
+        assertEquals(List.of(42), result);
+    }
+
+    /**
      * Tests handling of a string array in the request body
      */
     @Test

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Allow single-value lists in query strings in HTTP API (bsc#1207297)
 - Do not include channels from different orgs when listing mandatory channels (bsc#1204270)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
When the parameters are passed via the query string, a single value is always interpreted as a primitive, even if the method expects an array. This PR adds logic to wrap those single values in a List to satisfy the method signature.

See: https://bugzilla.suse.com/show_bug.cgi?id=1207297

### Example:
The API method:
```
myMethod(User user, List<Integer> sids);
```
The calls:
```
# interpreted as a list:
$ curl $API/test/myMethod?sids=101&sids=102
{ "success": true }


# interpreted as a primitive int:
$ curl $API/test/myMethod?sids=101
No method exists with the matching parameters
```

## Documentation
- No documentation needed: Bugfix

## Test coverage
- Unit tests were added

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20245

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
