### PR TITLE
on download errors try a 2nd time

### DIFF
--- a/python/spacewalk/satellite_tools/download.py
+++ b/python/spacewalk/satellite_tools/download.py
@@ -201,6 +201,7 @@ class DownloadThread(Thread):
                                    checksum=params['checksum']):
                 return True
 
+        # 14 => HTTPError (https://github.com/rpm-software-management/urlgrabber/blob/1e6d2debe79efdd1ba2f39913dc808723e51a7f7/urlgrabber/grabber.py#L757)
         retrycodes = URLGrabberOptions().retrycodes
         if 14 not in retrycodes:
             retrycodes.append(14)

--- a/python/spacewalk/satellite_tools/download.py
+++ b/python/spacewalk/satellite_tools/download.py
@@ -201,6 +201,10 @@ class DownloadThread(Thread):
                                    checksum=params['checksum']):
                 return True
 
+        retrycodes = URLGrabberOptions().retrycodes
+        if 14 not in retrycodes:
+            retrycodes.append(14)
+
         opts = URLGrabberOptions(
             ssl_ca_cert=params["ssl_ca_cert"],
             ssl_cert=params["ssl_client_cert"],
@@ -211,6 +215,8 @@ class DownloadThread(Thread):
             timeout=params["timeout"],
             minrate=params["minrate"],
             keepalive=True,
+            retry=3,
+            retrycodes=retrycodes,
         )
 
         mirrors = len(params['urls'])

--- a/python/spacewalk/satellite_tools/download.py
+++ b/python/spacewalk/satellite_tools/download.py
@@ -174,13 +174,13 @@ class DownloadThread(Thread):
             # No codes at all or some specified codes
             # 58, 77 - Couple of curl error codes observed in multithreading on RHEL 7 - probably a bug
             if (retrycode is None and code is None) or (retrycode in opts.retrycodes or code in [58, 77]):
-                log2(0, 2, "ERROR: Download failed: %s - %s. Retrying..." % (url, sys.exc_info()[1]),
+                log2(0, 2, "WARNING: Download failed: %s - %s. Retrying..." % (url, sys.exc_info()[1]),
                      stream=sys.stderr)
                 return True
 
         # 14 - HTTP Error
         if retry < (mirrors - 1) and retrycode == 14:
-            log2(0, 2, "ERROR: Download failed: %s - %s. Trying next mirror..." % (url, sys.exc_info()[1]),
+            log2(0, 2, "WARNING: Download failed: %s - %s. Trying next mirror..." % (url, sys.exc_info()[1]),
                  stream=sys.stderr)
             return True
 


### PR DESCRIPTION
## What does this PR change?

Flaky download server produce `[Errno 14] curl#92 - "HTTP/2 stream 0 was not closed cleanly: PROTOCOL_ERROR (err 1)"`. Give a second try using the same URL.

```
2023/01/21 16:14:39 +02:00 WARNING: Download failed: https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/x86_64/libsodium-debugsource-1.0.18-2.34.uyuni.x86_6
4.rpm - [Errno 14] curl#92 - "HTTP/2 stream 0 was not closed cleanly: PROTOCOL_ERROR (err 1)". Trying next mirror...
2023/01/21 16:14:39 +02:00     19/97 : libsodium-devel-1.0.18-2.34.uyuni.x86_64.rpm
2023/01/21 16:14:39 +02:00     20/97 : libsodium-debuginfo-1.0.18-2.34.uyuni.x86_64.rpm
2023/01/21 16:14:40 +02:00     21/97 : golang-github-wrouesnel-postgres_exporter-0.4.7-2.17.uyuni.x86_64.rpm
2023/01/21 16:14:40 +02:00     22/97 : libsodium-static-1.0.18-2.34.uyuni.x86_64.rpm
2023/01/21 16:14:40 +02:00     23/97 : libsodium-debugsource-1.0.18-2.34.uyuni.x86_64.rpm
```

This try to do a re-try via URLGrabber feature

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Partialy workaround https://github.com/SUSE/spacewalk/issues/20009

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
