### PR TITLE
Fixed subscription warning showing incorrectly

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/notification/types/SubscriptionWarning.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/SubscriptionWarning.java
@@ -19,7 +19,7 @@ import static com.redhat.rhn.common.hibernate.HibernateFactory.getSession;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.notification.NotificationMessage;
 
-import java.util.List;
+import java.util.Optional;
 
 
 public class SubscriptionWarning implements NotificationData {
@@ -31,13 +31,13 @@ public class SubscriptionWarning implements NotificationData {
      * @return boolean
      **/
     public boolean expiresSoon() {
-        List<Object[]> rows = getSession().createSQLQuery(
+        Optional<Boolean> result = getSession().createSQLQuery(
         "select exists (select name,  expires_at, status, subtype " +
                 "from susesccsubscription where subtype != 'internal' " +
-                " and (status = 'ACTIVE' and expires_at < now() + interval '90 day') " +
-                "or (status = 'EXPIRED' and expires_at > now() - interval '30 day'))").list();
+                " and ((status = 'ACTIVE' and expires_at < now() + interval '90 day') " +
+                "or (status = 'EXPIRED' and expires_at > now() - interval '30 day')))").uniqueResultOptional();
 
-        return !rows.isEmpty();
+        return result.orElse(false);
     }
 
     @Override

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Fix issue where subscription warning would show incorrectly
+
 -------------------------------------------------------------------
 Mon Jan 23 08:31:37 CET 2023 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?
Port of https://github.com/SUSE/spacewalk/pull/20260

Fixed issue where subscription warning was showing when no subscriptions were present. Or after being updated.  This should fix the email issue as well as the` SubscriptionWarning.expiresSoon()` that was used for the UI notification  

## GUI diff

No difference.



- [ ] **DONE**

## Documentation 
- No documentation needed:  Nothing changed with bugfix. 

- [ ] **DONE**

## Test coverage
- No tests: already covered


- [ ] **DONE**

## Links

Fixes # 
Tracks # https://github.com/uyuni-project/uyuni/issues/6375



- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
