### PR TITLE
Testsuite: Select 'matcher' value when adding AppStream filters in CLM

### DIFF
--- a/testsuite/features/build_validation/add_custom_repositories/add_rocky8_repositories.feature
+++ b/testsuite/features/build_validation/add_custom_repositories/add_rocky8_repositories.feature
@@ -69,6 +69,7 @@ Feature: Add the Rocky 8 distribution custom repositories
     Then I should see a "Create a new filter" text
     And I enter "ruby-2.7" as "filter_name"
     And I select "Module (Stream)" from "type"
+    And I select "equals" from "matcher"
     And I enter "ruby" as "moduleName"
     And I enter "2.7" as "moduleStream"
     And I click on "Save" in "Create a new filter" modal
@@ -79,6 +80,7 @@ Feature: Add the Rocky 8 distribution custom repositories
     # 3.6 is the version needed by our spacecmd
     When I enter "python-3.6" as "filter_name"
     And I select "Module (Stream)" from "type"
+    And I select "equals" from "matcher"
     And I enter "python36" as "moduleName"
     And I enter "3.6" as "moduleStream"
     And I click on "Save" in "Create a new filter" modal

--- a/testsuite/features/build_validation/add_custom_repositories/add_rocky9_repositories.feature
+++ b/testsuite/features/build_validation/add_custom_repositories/add_rocky9_repositories.feature
@@ -17,6 +17,7 @@ Feature: Add the Rocky 9 distribution custom repositories
     Then I should see a "Create a new filter" text
     And I enter "ruby-3.1" as "filter_name"
     And I select "Module (Stream)" from "type"
+    And I select "equals" from "matcher"
     And I enter "ruby" as "moduleName"
     And I enter "3.1" as "moduleStream"
     And I click on "Save" in "Create a new filter" modal
@@ -26,6 +27,7 @@ Feature: Add the Rocky 9 distribution custom repositories
     Then I should see a "Create a new filter" text
     When I enter "php-8.1" as "filter_name"
     And I select "Module (Stream)" from "type"
+    And I select "equals" from "matcher"
     And I enter "php" as "moduleName"
     And I enter "8.1" as "moduleStream"
     And I click on "Save" in "Create a new filter" modal

--- a/testsuite/features/reposync/srv_add_rocky8_repositories.feature
+++ b/testsuite/features/reposync/srv_add_rocky8_repositories.feature
@@ -66,6 +66,7 @@ Feature: Add the Rocky 8 distribution custom repositories
     Then I should see a "Create a new filter" text
     When I enter "ruby-2.7" as "filter_name"
     And I select "Module (Stream)" from "type"
+    And I select "equals" from "matcher"
     And I enter "ruby" as "moduleName"
     And I enter "2.7" as "moduleStream"
     And I click on "Save" in "Create a new filter" modal
@@ -75,6 +76,7 @@ Feature: Add the Rocky 8 distribution custom repositories
     Then I should see a "Create a new filter" text
     When I enter "python-3.6" as "filter_name"
     And I select "Module (Stream)" from "type"
+    And I select "equals" from "matcher"
     And I enter "python36" as "moduleName"
     And I enter "3.6" as "moduleStream"
     And I click on "Save" in "Create a new filter" modal


### PR DESCRIPTION
With the changes from https://github.com/uyuni-project/uyuni/pull/6485, the "Matcher" field has multiple options to select from, therefore it's not preselected anymore. This PR selects the correct value as an extra step.

![Screenshot from 2023-01-23 12-44-11](https://user-images.githubusercontent.com/1103552/214031697-f02a5bd2-c44a-472b-a0f9-f432fbd12686.png)

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
