### PR TITLE
If after 3min we still have some corrupted JSON report, we delete it and continue

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -125,7 +125,8 @@ namespace :utils do
   desc 'Generate test report'
   task :generate_test_report do
     sh 'rm -rf ./cucumber_report && mkdir cucumber_report', verbose: false
-    sh 'timeout 180 bash -c -- "while find output*.json -type f -size 0 | grep json; do sleep 10;done"', verbose: false
+    sh 'timeout 180 bash -c -- "while find output*.json -type f -size 0 | grep json; do sleep 10;done" ; exit 0', verbose: false
+    sh 'find . -size 0 -delete', verbose: false
     sh 'node index.js &> cucumber_reporter.log', verbose: false
   end
 end


### PR DESCRIPTION
## What does this PR change?

If after 3min we still have some corrupted JSON report, we delete it and continue
Sorry to be a bit drastic here, but I prefer some report than nothing.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were reffactored

- [x] **DONE**

## Links

Ports:
- Manager-4.2
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
