### PR TITLE
Fix reposync content-type key bug

### DIFF
--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -536,11 +536,19 @@ class ContentSource:
         verify = self.sslcacert
         try:
             webpage = requests.get(url, proxies=proxies, cert=cert, verify=verify)
-            content_type = webpage.headers["Content-Type"]
-            # amazonlinux core channels content-type = binary/octet-stream
-            if "text/plain" not in content_type and "xml" not in content_type and "octet-stream" not in content_type:
-                # Not a valid mirrorlist or metalink; continue without it
-                return returnlist
+            # We want to check the page content-type usually, but
+            # we have to wrap the next bit in a try-block for if the resource is
+            # cached and returns a 304; cached page returns no content type
+            # (if page is cached, for now we will assume it is the right type)
+            try:
+                content_type = webpage.headers["Content-Type"]
+                # amazonlinux core channels content-type = binary/octet-stream
+                if "text/plain" not in content_type and "xml" not in content_type and "octet-stream" not in content_type:
+                    # Not a valid mirrorlist or metalink; continue without it
+                    return returnlist
+            except KeyError:
+                # This will then go straight to the next try block.
+                log(1, "No content-type header. Treating as valid.")
         except requests.exceptions.RequestException as exc:
             self.error_msg("ERROR: Failed to reach repo url: {} - {}".format(url, exc))
             return returnlist

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Fix reposync error about missing "content-type" key when syncing certain channels
+
 -------------------------------------------------------------------
 Mon Jan 23 08:29:58 CET 2023 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Reposync fails for certain repos, because it tries to check the details of a content-type header that isn't present in those cases. This commit makes reposync treat urls with no content-type header as valid.
Fixes: https://github.com/uyuni-project/uyuni/issues/6298

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: I think the tests this really needs are integration tests, which are out of scope for now.

- [x] **DONE**

## Links

Fixes #6298 
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
