### PR TITLE
Avoid unnecessary debug messages from proxy backend (bsc#1207490)

### DIFF
--- a/proxy/proxy/apacheHandler.py
+++ b/proxy/proxy/apacheHandler.py
@@ -374,7 +374,7 @@ class apacheHandler(rhnApache):
         # All good; we expect ret to be an HTTP return code
         if not isinstance(ret, type(1)):
             raise rhnException("Invalid status code type %s" % type(ret))
-        log_debug(1, "Leaving with status code %s" % ret)
+        log_debug(2, "Leaving with status code %s" % ret)
         return ret
 
     @staticmethod

--- a/proxy/proxy/apacheHandler.py
+++ b/proxy/proxy/apacheHandler.py
@@ -599,7 +599,7 @@ class apacheHandler(rhnApache):
             called from apacheServer.Cleanup()
         """
 
-        log_debug(1)
+        log_debug(2)
         self.input = None
         # kill all of our child processes (if any)
         while 1:

--- a/proxy/proxy/apacheServer.py
+++ b/proxy/proxy/apacheServer.py
@@ -45,7 +45,7 @@ class HandlerWrap:
             componentType = getComponentType(req)
             initCFG(componentType)
             initLOG(CFG.LOG_FILE, CFG.DEBUG, f"wsgi_{componentType}")
-            log_debug(1, 'New request, component %s' % (componentType, ))
+            log_debug(2, 'New request, component %s' % (componentType, ))
 
         # Instantiate the handlers
         if HandlerWrap.svrHandlers is None:

--- a/proxy/proxy/broker/rhnBroker.py
+++ b/proxy/proxy/broker/rhnBroker.py
@@ -211,7 +211,7 @@ class BrokerHandler(SharedHandler):
         """ Main handler to handle all requests pumped through this server. """
 
         # pylint: disable=R0915
-        log_debug(1)
+        log_debug(2)
         self._prepHandler()
 
         _oto = rhnFlags.get('outputTransportOptions')
@@ -410,7 +410,7 @@ class BrokerHandler(SharedHandler):
     # --- PRIVATE METHODS ---
 
     def __handleAction(self, headers):
-        log_debug(1)
+        log_debug(2)
         # Check if proxy is interested in this action, and execute any
         # action required:
         if 'X-RHN-Action' not in headers:
@@ -516,7 +516,7 @@ class BrokerHandler(SharedHandler):
     @staticmethod
     def __getSessionToken():
         """ Get/test-for session token in headers (rhnFlags) """
-        log_debug(1)
+        log_debug(2)
         if not rhnFlags.test("AUTH_SESSION_TOKEN"):
             raise rhnFault(33, "Missing session token")
         return rhnFlags.get("AUTH_SESSION_TOKEN")
@@ -524,7 +524,7 @@ class BrokerHandler(SharedHandler):
     def __cacheClientSessionToken(self, headers):
         """pull session token from headers and push to caching daemon. """
 
-        log_debug(1)
+        log_debug(2)
         # Get the server ID
         if 'X-RHN-Server-ID' not in headers:
             log_debug(3, "Client server ID not found in headers")

--- a/proxy/proxy/broker/rhnBroker.py
+++ b/proxy/proxy/broker/rhnBroker.py
@@ -325,7 +325,7 @@ class BrokerHandler(SharedHandler):
                 log_error(msg)
                 log_debug(0, msg)
             elif error == '1004':
-                log_debug(1,
+                log_debug(2,
                           "SUSE Manager Proxy Session Token expired, acquiring new one.")
             else: # this should never happen.
                 msg = "SUSE Manager Proxy login failed, error code is %s" % error

--- a/proxy/proxy/rhnShared.py
+++ b/proxy/proxy/rhnShared.py
@@ -211,7 +211,7 @@ class SharedHandler:
             Server (or next proxy) communication.
         """
 
-        log_debug(1)
+        log_debug(2)
 
         # Copy the method from the original request, and use the
         # handler for this server
@@ -285,7 +285,7 @@ class SharedHandler:
         """ Handler part 3
             Forward server's response to the client.
         """
-        log_debug(1)
+        log_debug(2)
 
         try:
             self._forwardServer2Client()
@@ -318,7 +318,7 @@ class SharedHandler:
             For most XMLRPC code, this function is called.
         """
 
-        log_debug(1)
+        log_debug(2)
 
         # Okay, nothing interesting from the server;
         # we'll just forward what we got

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,5 @@
+- Avoid unnecessary debug messages from proxy backend (bsc#1207490)
+
 -------------------------------------------------------------------
 Mon Jan 23 08:24:37 CET 2023 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR just increased the debug level for some messages that are causing lot of unnecessary noise in proxy backend logs files without bringing any valueable information at all. Keep in mind that default log level for rhn backend is `1`.

In some environments, this is causing the logs files to grow massively:

```
# tail /var/log/rhn/rhn_proxy_broker.log
2022/12/21 00:24:45 +02:00 27790 XXXXXXXXXXX: broker/rhnBroker.handler
2022/12/21 00:24:45 +02:00 27790 XXXXXXXXXXX: proxy/rhnShared._serverCommo
2022/12/21 00:24:45 +02:00 27790 XXXXXXXXXXX: broker/rhnBroker.__handleAction
2022/12/21 00:24:45 +02:00 27790 XXXXXXXXXXX: proxy/rhnShared._clientCommo
2022/12/21 00:24:45 +02:00 27790 XXXXXXXXXXX: proxy/rhnShared._forwardServer2Client
2022/12/21 00:24:45 +02:00 27790 XXXXXXXXXXX: proxy/apacheHandler.handler('Leaving with status code 0',)
2022/12/21 00:24:45 +02:00 27790 XXXXXXXXXXX: proxy/apacheHandler.cleanupHandler
2022/12/21 00:24:45 +02:00 27790 XXXXXXXXXXX: proxy/apacheServer.__call__('New request, component proxy.broker',)

# grep XXXXXXXXXXX /var/log/rhn/rhn_proxy_broker.log >XXXXXXXXXXX.log
# catXXXXXXXXXXX.log | cut -d " " -f 6- | sort | uniq -c
     11 broker/rhnBroker.__cacheClientSessionToken
   2464 broker/rhnBroker.__getSessionToken
   2218 broker/rhnBroker.__handleAction
   3450 broker/rhnBroker.handler
   1232 broker/rhnBroker.handler('Leaving handler with status code 404',)
   3450 proxy/apacheHandler.cleanupHandler
   2218 proxy/apacheHandler.handler('Leaving with status code 0',)
   1232 proxy/apacheHandler.handler('Leaving with status code 404',)
   2917 proxy/apacheServer.__call__('New request, component proxy.broker',)
   2218 proxy/rhnShared._clientCommo
   2218 proxy/rhnShared._forwardServer2Client
   3450 proxy/rhnShared._serverCommo
```

In an environment with 400 clients behind the proxy, with certain activity, it seems this excessive logging could even cause to get a 2GB logfile for a single day.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **no tests around logging**

- [x] **DONE**

## Links

Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
