### PR TITLE
QE: Add right product name to Grafana dashboards

### DIFF
--- a/testsuite/features/build_validation/init_clients/monitoring_server.feature
+++ b/testsuite/features/build_validation/init_clients/monitoring_server.feature
@@ -91,5 +91,5 @@ Feature: Bootstrap the monitoring server
     # These are the 4 dashboards created by default when enabling the Grafana formula
     Then I should see a "Apache2" text
     And I should see a "PostgreSQL database insights" text
-    And I should see a "Client Systems" text
-    And I should see a "Server" text
+    And I should see a "Uyuni Client Systems" text
+    And I should see a "Uyuni Server" text


### PR DESCRIPTION
## What does this PR change?

Adds validation of product name in Grafana's dashboard titles.

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20142
- 4.2 https://github.com/SUSE/spacewalk/pull/20299
- 4.3 https://github.com/SUSE/spacewalk/pull/20298

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
