### PR TITLE
Reschedule old failed action

### DIFF
--- a/java/code/src/com/redhat/rhn/common/hibernate/HibernateFactory.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/HibernateFactory.java
@@ -808,7 +808,7 @@ public abstract class HibernateFactory {
      * @param accumulator the operation for the result accumulator
      * @return an accumulated result of executing the query
      */
-    private static <E, T, R> T splitAndExecuteQuery(List<E> list, String parameterName,
+    protected static <E, T, R> T splitAndExecuteQuery(List<E> list, String parameterName,
             Query<R> query, Supplier<T> queryFunction, T identity, BinaryOperator<T> accumulator) {
         int size = list.size();
 

--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -798,6 +798,7 @@ public class ActionFactory extends HibernateFactory {
      * @param tries the number of tries to set (should be set to 5)
      */
     public static void rescheduleFailedServerActions(Action action, Long tries) {
+        updateActionEarliestDate(action);
         HibernateFactory.getSession().getNamedQuery("Action.rescheduleFailedActions")
         .setParameter("action", action)
         .setParameter("tries", tries)
@@ -816,6 +817,7 @@ public class ActionFactory extends HibernateFactory {
      * @param tries the number of tries to set (should be set to 5)
      */
     public static void rescheduleAllServerActions(Action action, Long tries) {
+        updateActionEarliestDate(action);
         HibernateFactory.getSession().getNamedQuery("Action.rescheduleAllActions")
         .setParameter("action", action)
         .setParameter("tries", tries)
@@ -842,6 +844,7 @@ public class ActionFactory extends HibernateFactory {
      */
     public static void rescheduleSingleServerAction(Action action, Long tries,
             Long server) {
+        updateActionEarliestDate(action);
         HibernateFactory.getSession().getNamedQuery("Action.rescheduleSingleServerAction")
         .setParameter("action", action)
         .setParameter("tries", tries)
@@ -870,6 +873,11 @@ public class ActionFactory extends HibernateFactory {
             .setParameter("queued", ActionFactory.STATUS_QUEUED)
             .executeUpdate();
         }
+    }
+
+    private static void updateActionEarliestDate(Action action) {
+        action.setEarliestAction(new Date());
+        HibernateFactory.getSession().save(action);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -84,6 +84,7 @@ import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
+import org.apache.commons.collections.ListUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hibernate.HibernateException;
@@ -153,7 +154,7 @@ public class ActionFactory extends HibernateFactory {
     public static int removeAction(Long actionId) {
 
         List<Long> ids = getSession().getNamedQuery("Action.findServerIds")
-                .setLong("action_id", actionId).list();
+                .setParameter("action_id", actionId).list();
         int failed = 0;
         for (long id : ids) {
             try {
@@ -912,6 +913,23 @@ public class ActionFactory extends HibernateFactory {
 
         udpateByIds(serverIds, "Action.updateServerActions", "server_ids", parameters);
         serverIds.forEach(sid -> SystemManager.updateSystemOverview(sid));
+    }
+
+    /**
+     * Mark queue server actions as failed because the execution has been rejected
+     * @param actionsId list of ids of the action to reject
+     * @param rejectionReason the reason why the scheduled action was not picked up
+     */
+    public static void rejectScheduledActions(List<Long> actionsId, String rejectionReason) {
+        Query<Long> query = getSession().createNamedQuery("Action.rejectAction", Long.class)
+                                            .setParameter("rejection_reason", rejectionReason)
+                                            .setParameter("completion_time", new Date());
+
+        List<Long> updatedServerIds = HibernateFactory.<Long, List<Long>, Long>splitAndExecuteQuery(
+            actionsId, "action_ids", query, query::list, new ArrayList<>(), ListUtils::union
+        );
+
+        updatedServerIds.forEach(SystemManager::updateSystemOverview);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -759,4 +759,17 @@ select sa.server_id
                 AND status NOT IN(2,3)
         ]]>
     </sql-query>
+    <sql-query name="Action.rejectAction">
+        <return-scalar column="server_id" type="long"/>
+        <![CDATA[
+            UPDATE rhnServerAction
+                SET status = 3
+                        , result_code = -1
+                        , result_msg = :rejection_reason
+                        , completion_time = :completion_time
+                        , remaining_tries = 0
+            WHERE action_id IN (:action_ids) AND status = 0
+        RETURNING server_id
+        ]]>
+    </sql-query>
 </hibernate-mapping>

--- a/java/code/src/com/redhat/rhn/domain/action/server/test/ServerActionTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/server/test/ServerActionTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
+import com.redhat.rhn.domain.action.ActionStatus;
 import com.redhat.rhn.domain.action.errata.ActionPackageDetails;
 import com.redhat.rhn.domain.action.errata.ErrataAction;
 import com.redhat.rhn.domain.action.salt.ApplyStatesAction;
@@ -142,9 +143,20 @@ public class ServerActionTest extends RhnBaseTestCase {
      * @return ServerAction created
      */
     public static ServerAction createServerAction(Server newS, Action newA) {
+        return createServerAction(newS, newA, ActionFactory.STATUS_QUEUED);
+    }
+
+    /**
+     * Create a new ServerAction
+     * @param newS new server
+     * @param newA new action
+     * @param status action status
+     * @return ServerAction created
+     */
+    public static ServerAction createServerAction(Server newS, Action newA, ActionStatus status) {
         ServerAction sa = new ServerAction();
-        sa.setStatus(ActionFactory.STATUS_QUEUED);
-        sa.setRemainingTries(10L);
+        sa.setStatus(status);
+        sa.setRemainingTries(ActionFactory.STATUS_FAILED.equals(status) ? 0L : 10L);
         sa.setServerWithCheck(newS);
         sa.setParentActionWithCheck(newA);
         newA.addServerAction(sa);

--- a/java/code/src/com/redhat/rhn/domain/action/test/ActionFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/test/ActionFactoryTest.java
@@ -74,6 +74,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * ActionFactoryTest
@@ -400,6 +402,39 @@ public class ActionFactoryTest extends BaseTestCaseWithUser {
         assertEquals(sa2.getStatus(), ActionFactory.STATUS_COMPLETED);
     }
 
+    @Test
+    public void rejectScheduledActionsMarkPendingServerActionsAsFailed() {
+        Action a1 = ActionFactoryTest.createEmptyAction(user, ActionFactory.TYPE_REBOOT);
+        ServerAction sa1 = addServerAction(user, a1, ActionFactory.STATUS_COMPLETED);
+        ServerAction sa2 = addServerAction(user, a1, ActionFactory.STATUS_QUEUED);
+
+        Action a2 = ActionFactoryTest.createEmptyAction(user, ActionFactory.TYPE_APPLY_STATES);
+        ServerAction sa3 = addServerAction(user, a2, ActionFactory.STATUS_QUEUED);
+        ServerAction sa4 = addServerAction(user, a2, ActionFactory.STATUS_PICKED_UP);
+
+        TestUtils.saveAndReload(a1);
+        TestUtils.saveAndReload(a2);
+
+        List<Long> actionIds = Stream.of(a1, a2).map(Action::getId).collect(Collectors.toList());
+        ActionFactory.rejectScheduledActions(actionIds, "Test Rejection Reason");
+
+        sa1 = HibernateFactory.reload(sa1);
+        sa2 = HibernateFactory.reload(sa2);
+        sa3 = HibernateFactory.reload(sa3);
+        sa4 = HibernateFactory.reload(sa4);
+
+        assertEquals(ActionFactory.STATUS_COMPLETED, sa1.getStatus());
+
+        assertEquals(ActionFactory.STATUS_FAILED, sa2.getStatus());
+        assertEquals("Test Rejection Reason", sa2.getResultMsg());
+        assertEquals(-1, sa2.getResultCode());
+
+        assertEquals(ActionFactory.STATUS_FAILED, sa3.getStatus());
+        assertEquals("Test Rejection Reason", sa3.getResultMsg());
+        assertEquals(-1, sa3.getResultCode());
+
+        assertEquals(ActionFactory.STATUS_PICKED_UP, sa4.getStatus());
+    }
 
     public static Action createAction(User user, ActionType type) throws Exception {
         Action newA = ActionFactory.createAction(type);
@@ -566,7 +601,7 @@ public class ActionFactoryTest extends BaseTestCaseWithUser {
         return newA;
     }
 
-    private static ServerAction addServerAction(User user, Action newA, ActionStatus status) {
+    public static ServerAction addServerAction(User user, Action newA, ActionStatus status) {
         Server newS = ServerFactoryTest.createTestServer(user, true);
         ServerAction serverAction = ServerActionTest.createServerAction(newS, newA, status);
         newA.addServerAction(serverAction);

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -9458,6 +9458,10 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
         <source>&lt;p&gt;@@PRODUCT_NAME@@ {0} is approaching the end of its lifecycle. Please consider upgrading this server instance before general support ends on &lt;strong&gt;{1}&lt;/strong&gt;.&lt;/p&gt;
           &lt;p&gt;For Additional information on how to upgrade @@PRODUCT_NAME@@, please review the section &lt;em&gt;Upgrade&lt;/em&gt; of the &lt;em&gt;Installation/Upgrade Guide&lt;/em&gt; in the official documentation.&lt;/p&gt;</source>
       </trans-unit>
+      <trans-unit id="task.action.rejection.reason">
+        <source>This action was not executed because its earliest execution date was too old. When more than {0} hours pass between the scheduling and the picking up, the action is discarded because it is considered no longer relevant.
+          Please reschedule this action if you really want it to be executed.</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionChainExecutor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionChainExecutor.java
@@ -16,9 +16,11 @@ package com.redhat.rhn.taskomatic.task;
 
 import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.action.ActionChain;
 import com.redhat.rhn.domain.action.ActionChainEntry;
 import com.redhat.rhn.domain.action.ActionChainFactory;
+import com.redhat.rhn.domain.action.ActionFactory;
 
 import com.suse.manager.webui.services.SaltServerActionService;
 
@@ -27,16 +29,35 @@ import org.quartz.JobExecutionContext;
 import java.time.Duration;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Execute SUSE Manager actions via Salt.
  */
 public class MinionActionChainExecutor extends RhnJavaJob {
 
-    private static final int ACTION_DATABASE_GRACE_TIME = 10000;
-    private static final long MAXIMUM_TIMEDELTA_FOR_SCHEDULED_ACTIONS = 24; // hours
+    public static final int ACTION_DATABASE_GRACE_TIME = 10000;
+    public static final long MAXIMUM_TIMEDELTA_FOR_SCHEDULED_ACTIONS = 24; // hours
+    public static final LocalizationService LOCALIZATION = LocalizationService.getInstance();
 
-    private final SaltServerActionService saltServerActionService = GlobalInstanceHolder.SALT_SERVER_ACTION_SERVICE;
+    private final SaltServerActionService saltServerActionService;
+
+    /**
+     * Default constructor.
+     */
+    public MinionActionChainExecutor() {
+        this(GlobalInstanceHolder.SALT_SERVER_ACTION_SERVICE);
+    }
+
+    /**
+     * Constructs an instance specifying the {@link SaltServerActionService}. Meant to be used only for unit test.
+     * @param saltServerActionServiceIn the salt service
+     */
+    public MinionActionChainExecutor(SaltServerActionService saltServerActionServiceIn) {
+        saltServerActionService = saltServerActionServiceIn;
+    }
 
     @Override
     public String getConfigNamespace() {
@@ -77,6 +98,7 @@ public class MinionActionChainExecutor extends RhnJavaJob {
             }
             catch (InterruptedException e) {
                 // never happens
+                Thread.currentThread().interrupt();
             }
             HibernateFactory.getSession().clear();
         }
@@ -90,6 +112,16 @@ public class MinionActionChainExecutor extends RhnJavaJob {
         if (timeDelta >= MAXIMUM_TIMEDELTA_FOR_SCHEDULED_ACTIONS) {
             log.warn("Scheduled action chain {} was scheduled to be executed more than {} hours ago. Skipping it.",
                     actionChain.getId(), MAXIMUM_TIMEDELTA_FOR_SCHEDULED_ACTIONS);
+
+            List<Long> actionsId = actionChain.getEntries()
+                                              .stream()
+                                              .map(ActionChainEntry::getActionId)
+                                              .filter(Objects::nonNull)
+                                              .collect(Collectors.toList());
+
+            ActionFactory.rejectScheduledActions(actionsId,
+                LOCALIZATION.getMessage("task.action.rejection.reason", MAXIMUM_TIMEDELTA_FOR_SCHEDULED_ACTIONS));
+
             return;
         }
 
@@ -104,9 +136,10 @@ public class MinionActionChainExecutor extends RhnJavaJob {
     }
 
     private long countServerActions(ActionChain actionChain) {
-        return actionChain.getEntries().stream()
-                .map(ActionChainEntry::getAction)
-                .flatMap(action -> action.getServerActions().stream())
-                .count();
+        return actionChain.getEntries()
+                          .stream()
+                          .map(ActionChainEntry::getAction)
+                          .mapToLong(action -> action.getServerActions().size())
+                          .sum();
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionChainExecutor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionChainExecutor.java
@@ -15,7 +15,6 @@
 package com.redhat.rhn.taskomatic.task;
 
 import com.redhat.rhn.GlobalInstanceHolder;
-import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.action.ActionChain;
 import com.redhat.rhn.domain.action.ActionChainEntry;
@@ -24,6 +23,7 @@ import com.redhat.rhn.domain.action.ActionFactory;
 
 import com.suse.manager.webui.services.SaltServerActionService;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.quartz.JobExecutionContext;
 
 import java.time.Duration;
@@ -38,7 +38,8 @@ import java.util.stream.Collectors;
  */
 public class MinionActionChainExecutor extends RhnJavaJob {
 
-    public static final int ACTION_DATABASE_GRACE_TIME = 10000;
+    public static final int ACTION_DATABASE_GRACE_TIME = 600_000;
+    public static final int ACTION_DATABASE_POLL_TIME = 100;
     public static final long MAXIMUM_TIMEDELTA_FOR_SCHEDULED_ACTIONS = 24; // hours
     public static final LocalizationService LOCALIZATION = LocalizationService.getInstance();
 
@@ -79,28 +80,28 @@ public class MinionActionChainExecutor extends RhnJavaJob {
         long actionChainId = Long.parseLong((String)context.getJobDetail()
                 .getJobDataMap().get("actionchain_id"));
 
-        ActionChain actionChain = ActionChainFactory
-                .getActionChain(actionChainId)
-                .orElse(null);
+        ActionChain actionChain = ActionChainFactory.getActionChain(actionChainId).orElse(null);
+        int waitedTime = 0;
+        while (countQueuedServerActions(actionChain) == 0 && waitedTime < ACTION_DATABASE_GRACE_TIME) {
+            actionChain = ActionChainFactory.getActionChain(actionChainId).orElse(null);
+            try {
+                Thread.sleep(ACTION_DATABASE_POLL_TIME);
+            }
+            catch (InterruptedException e) {
+                // never happens
+                Thread.currentThread().interrupt();
+            }
+            waitedTime += ACTION_DATABASE_POLL_TIME;
+        }
 
         if (actionChain == null) {
             log.error("Action chain not found id={}", actionChainId);
             return;
         }
 
-        long serverActionsCount = countServerActions(actionChain);
-        if (serverActionsCount == 0) {
-            log.warn("Waiting " + ACTION_DATABASE_GRACE_TIME + "ms for the Tomcat transaction to complete.");
-            // give a second chance, just in case this was scheduled immediately
-            // and the scheduling transaction did not have the time to commit
-            try {
-                Thread.sleep(ACTION_DATABASE_GRACE_TIME);
-            }
-            catch (InterruptedException e) {
-                // never happens
-                Thread.currentThread().interrupt();
-            }
-            HibernateFactory.getSession().clear();
+        if (countQueuedServerActions(actionChain) == 0) {
+            log.error("Action chain with id={} has no server where an action is in status QUEUED", actionChainId);
+            return;
         }
 
         // calculate offset between scheduled time of
@@ -135,11 +136,17 @@ public class MinionActionChainExecutor extends RhnJavaJob {
         }
     }
 
-    private long countServerActions(ActionChain actionChain) {
+    private long countQueuedServerActions(ActionChain actionChain) {
+        if (actionChain == null || CollectionUtils.isEmpty(actionChain.getEntries())) {
+            return 0;
+        }
+
         return actionChain.getEntries()
                           .stream()
                           .map(ActionChainEntry::getAction)
-                          .mapToLong(action -> action.getServerActions().size())
-                          .sum();
+                          .filter(action -> action != null && CollectionUtils.isNotEmpty(action.getServerActions()))
+                          .flatMap(action -> action.getServerActions().stream())
+                          .filter(serverAction -> ActionFactory.STATUS_QUEUED.equals(serverAction.getStatus()))
+                          .count();
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionExecutor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionExecutor.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.taskomatic.task;
 
 import com.redhat.rhn.GlobalInstanceHolder;
+import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.channel.SubscribeChannelsAction;
@@ -40,11 +41,27 @@ import java.util.Optional;
  */
 public class MinionActionExecutor extends RhnJavaJob {
 
-    private static final int ACTION_DATABASE_GRACE_TIME = 600_000;
-    private static final int ACTION_DATABASE_POLL_TIME = 100;
-    private static final long MAXIMUM_TIMEDELTA_FOR_SCHEDULED_ACTIONS = 24; // hours
+    public static final int ACTION_DATABASE_GRACE_TIME = 600_000;
+    public static final int ACTION_DATABASE_POLL_TIME = 100;
+    public static final long MAXIMUM_TIMEDELTA_FOR_SCHEDULED_ACTIONS = 24; // hours
+    private static final LocalizationService LOCALIZATION = LocalizationService.getInstance();
 
-    private SaltServerActionService saltServerActionService = GlobalInstanceHolder.SALT_SERVER_ACTION_SERVICE;
+    private final SaltServerActionService saltServerActionService;
+
+    /**
+     * Default constructor.
+     */
+    public MinionActionExecutor() {
+        this(GlobalInstanceHolder.SALT_SERVER_ACTION_SERVICE);
+    }
+
+    /**
+     * Constructs an instance specifying the {@link SaltServerActionService}. Meant to be used only for unit test.
+     * @param saltServerActionServiceIn the salt service
+     */
+    public MinionActionExecutor(SaltServerActionService saltServerActionServiceIn) {
+        this.saltServerActionService = saltServerActionServiceIn;
+    }
 
     @Override
     public int getDefaultRescheduleTime() {
@@ -100,6 +117,7 @@ public class MinionActionExecutor extends RhnJavaJob {
             }
             catch (InterruptedException e) {
                 // never happens
+                Thread.currentThread().interrupt();
             }
             waitedTime += ACTION_DATABASE_POLL_TIME;
         }
@@ -114,13 +132,17 @@ public class MinionActionExecutor extends RhnJavaJob {
 
         // calculate offset between scheduled time of
         // actions and (now)
-        long timeDelta = Duration
-                .between(ZonedDateTime.ofInstant(action.getEarliestAction().toInstant(),
-                        ZoneId.systemDefault()), ZonedDateTime.now())
-                .toHours();
+        ZonedDateTime earliestInstant = ZonedDateTime.ofInstant(action.getEarliestAction().toInstant(),
+            ZoneId.systemDefault());
+
+        long timeDelta = Duration.between(earliestInstant, ZonedDateTime.now()).toHours();
         if (timeDelta >= MAXIMUM_TIMEDELTA_FOR_SCHEDULED_ACTIONS) {
             log.warn("Scheduled action {} was scheduled to be executed more than {} hours ago. Skipping it.",
                     action.getId(), MAXIMUM_TIMEDELTA_FOR_SCHEDULED_ACTIONS);
+
+            ActionFactory.rejectScheduledActions(List.of(actionId),
+                LOCALIZATION.getMessage("task.action.rejection.reason", MAXIMUM_TIMEDELTA_FOR_SCHEDULED_ACTIONS));
+
             return;
         }
 
@@ -155,11 +177,4 @@ public class MinionActionExecutor extends RhnJavaJob {
         });
     }
 
-    /**
-     * Needed only for unit tests.
-     * @param saltServerActionServiceIn to set
-     */
-    public void setSaltServerActionService(SaltServerActionService saltServerActionServiceIn) {
-        this.saltServerActionService = saltServerActionServiceIn;
-    }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/MinionActionChainExecutorTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/MinionActionChainExecutorTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.taskomatic.task.test;
+
+import static org.jmock.AbstractExpectations.any;
+import static org.jmock.AbstractExpectations.returnValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.common.localization.LocalizationService;
+import com.redhat.rhn.domain.action.Action;
+import com.redhat.rhn.domain.action.ActionChain;
+import com.redhat.rhn.domain.action.ActionChainFactory;
+import com.redhat.rhn.domain.action.ActionFactory;
+import com.redhat.rhn.domain.action.server.ServerAction;
+import com.redhat.rhn.domain.action.test.ActionFactoryTest;
+import com.redhat.rhn.taskomatic.task.MinionActionChainExecutor;
+import com.redhat.rhn.taskomatic.task.MinionActionExecutor;
+import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
+import com.redhat.rhn.testing.TestUtils;
+
+import com.suse.manager.webui.services.SaltServerActionService;
+
+import org.jmock.imposters.ByteBuddyClassImposteriser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.quartz.Calendar;
+import org.quartz.Job;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.TriggerKey;
+import org.quartz.impl.JobExecutionContextImpl;
+import org.quartz.spi.OperableTrigger;
+import org.quartz.spi.TriggerFiredBundle;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.Map;
+
+public class MinionActionChainExecutorTest extends JMockBaseTestCaseWithUser {
+
+    private static final LocalizationService LOCALIZATION = LocalizationService.getInstance();
+
+    private Scheduler scheduler;
+    private JobDetail jobDetail;
+    private Calendar calendar;
+    private OperableTrigger trigger;
+    private Job job;
+    private TriggerFiredBundle firedBundle;
+
+    @BeforeEach
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+
+        scheduler = mock(Scheduler.class);
+        jobDetail = mock(JobDetail.class);
+        calendar = mock(Calendar.class);
+        trigger = mock(OperableTrigger.class);
+        job = mock(Job.class);
+
+        firedBundle = new TriggerFiredBundle(jobDetail, trigger, calendar, false, new Date(), new Date(), null, null);
+    }
+
+    @Test
+    public void rejectsActionChainsWithOldEarliestDate() {
+        ActionChain actionChain = ActionChainFactory.getOrCreateActionChain("testRejectActionChains", user);
+
+        Action a1 = ActionFactoryTest.createEmptyAction(user, ActionFactory.TYPE_REBOOT);
+        a1.setEarliestAction(Date.from(Instant.now().minus(7, ChronoUnit.DAYS)));
+        ServerAction sa1 = ActionFactoryTest.addServerAction(user, a1, ActionFactory.STATUS_QUEUED);
+        TestUtils.saveAndReload(a1);
+        ActionChainFactory.queueActionChainEntry(a1, actionChain, sa1.getServer());
+
+        Action a2 = ActionFactoryTest.createEmptyAction(user, ActionFactory.TYPE_PACKAGES_UPDATE);
+        a2.setEarliestAction(Date.from(Instant.now().minus(7, ChronoUnit.DAYS)));
+        ServerAction sa2 = ActionFactoryTest.addServerAction(user, a2, ActionFactory.STATUS_QUEUED);
+        TestUtils.saveAndReload(a2);
+        ActionChainFactory.queueActionChainEntry(a2, actionChain, sa2.getServer());
+
+        SaltServerActionService saltServerActionService = mock(SaltServerActionService.class);
+
+        checking(expectations -> {
+            expectations.ignoring(jobDetail).getJobDataMap();
+            expectations.will(returnValue(new JobDataMap(Map.of(
+                "actionchain_id", String.valueOf(actionChain.getId()),
+                "user_id", String.valueOf(user.getId()),
+                "staging_job", String.valueOf(false),
+                "force_pkg_list_refresh", String.valueOf(false)
+            ))));
+
+            expectations.ignoring(jobDetail).getKey();
+            expectations.will(returnValue(new JobKey("dummyJob")));
+
+            expectations.ignoring(trigger).getJobDataMap();
+            expectations.will(returnValue(new JobDataMap()));
+
+            expectations.ignoring(trigger).getKey();
+            expectations.will(returnValue(new TriggerKey("dummyTrigger")));
+
+            expectations.never(saltServerActionService).executeActionChain(expectations.with(any(Long.class)));
+        });
+
+        JobExecutionContext context = new JobExecutionContextImpl(scheduler, firedBundle, job);
+
+        MinionActionChainExecutor actionExecutor = new MinionActionChainExecutor(saltServerActionService);
+        actionExecutor.execute(context);
+
+        context().assertIsSatisfied();
+
+        String expectedMessage = LOCALIZATION.getMessage("task.action.rejection.reason",
+            MinionActionExecutor.MAXIMUM_TIMEDELTA_FOR_SCHEDULED_ACTIONS);
+
+        HibernateFactory.commitTransaction();
+        HibernateFactory.closeSession();
+
+        sa1 = HibernateFactory.reload(sa1);
+        sa2 = HibernateFactory.reload(sa2);
+
+        assertEquals(ActionFactory.STATUS_FAILED, sa1.getStatus());
+        assertEquals(expectedMessage, sa1.getResultMsg());
+        assertEquals(-1, sa1.getResultCode());
+
+        assertEquals(ActionFactory.STATUS_FAILED, sa2.getStatus());
+        assertEquals(expectedMessage, sa2.getResultMsg());
+        assertEquals(-1, sa2.getResultCode());
+    }
+}

--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/MinionActionExecutorTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/MinionActionExecutorTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.taskomatic.task.test;
+
+import static org.jmock.AbstractExpectations.returnValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.common.localization.LocalizationService;
+import com.redhat.rhn.domain.action.Action;
+import com.redhat.rhn.domain.action.ActionFactory;
+import com.redhat.rhn.domain.action.server.ServerAction;
+import com.redhat.rhn.domain.action.test.ActionFactoryTest;
+import com.redhat.rhn.taskomatic.task.MinionActionExecutor;
+import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
+import com.redhat.rhn.testing.TestUtils;
+
+import com.suse.manager.webui.services.SaltServerActionService;
+
+import org.jmock.imposters.ByteBuddyClassImposteriser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.quartz.Calendar;
+import org.quartz.Job;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.TriggerKey;
+import org.quartz.impl.JobExecutionContextImpl;
+import org.quartz.spi.OperableTrigger;
+import org.quartz.spi.TriggerFiredBundle;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
+
+public class MinionActionExecutorTest extends JMockBaseTestCaseWithUser {
+
+    private static final LocalizationService LOCALIZATION = LocalizationService.getInstance();
+
+    private Scheduler scheduler;
+    private JobDetail jobDetail;
+    private Calendar calendar;
+    private OperableTrigger trigger;
+    private Job job;
+    private TriggerFiredBundle firedBundle;
+
+    @BeforeEach
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+
+        scheduler = mock(Scheduler.class);
+        jobDetail = mock(JobDetail.class);
+        calendar = mock(Calendar.class);
+        trigger = mock(OperableTrigger.class);
+        job = mock(Job.class);
+
+        firedBundle = new TriggerFiredBundle(jobDetail, trigger, calendar, false, new Date(), new Date(), null, null);
+    }
+
+    @Test
+    public void rejectsActionsWithOldEarliestDate() {
+        Action a1 = ActionFactoryTest.createEmptyAction(user, ActionFactory.TYPE_REBOOT);
+        // Set the earliest action date to one week ago
+        a1.setEarliestAction(Date.from(Instant.now().minus(7, ChronoUnit.DAYS)));
+
+        ServerAction sa1 = ActionFactoryTest.addServerAction(user, a1, ActionFactory.STATUS_COMPLETED);
+        ServerAction sa2 = ActionFactoryTest.addServerAction(user, a1, ActionFactory.STATUS_QUEUED);
+
+        TestUtils.saveAndReload(a1);
+
+        SaltServerActionService saltServerActionService = mock(SaltServerActionService.class);
+
+        checking(expectations -> {
+            expectations.ignoring(jobDetail).getJobDataMap();
+            expectations.will(returnValue(new JobDataMap(Map.of(
+                "action_id", String.valueOf(a1.getId()),
+                "user_id", String.valueOf(user.getId()),
+                "staging_job", String.valueOf(false),
+                "force_pkg_list_refresh", String.valueOf(false)
+            ))));
+
+            expectations.ignoring(jobDetail).getKey();
+            expectations.will(returnValue(new JobKey("dummyJob")));
+
+            expectations.ignoring(trigger).getJobDataMap();
+            expectations.will(returnValue(new JobDataMap()));
+
+            expectations.ignoring(trigger).getKey();
+            expectations.will(returnValue(new TriggerKey("dummyTrigger")));
+
+            expectations.never(saltServerActionService).execute(
+                expectations.with(a1),
+                expectations.with(false),
+                expectations.with(false),
+                expectations.with(Optional.empty())
+            );
+        });
+
+        JobExecutionContext context = new JobExecutionContextImpl(scheduler, firedBundle, job);
+
+        MinionActionExecutor actionExecutor = new MinionActionExecutor(saltServerActionService);
+        actionExecutor.execute(context);
+
+        HibernateFactory.commitTransaction();
+        HibernateFactory.closeSession();
+
+        sa1 = HibernateFactory.reload(sa1);
+        sa2 = HibernateFactory.reload(sa2);
+
+        context().assertIsSatisfied();
+
+        String expectedMessage = LOCALIZATION.getMessage("task.action.rejection.reason",
+            MinionActionExecutor.MAXIMUM_TIMEDELTA_FOR_SCHEDULED_ACTIONS);
+
+        assertEquals(ActionFactory.STATUS_COMPLETED, sa1.getStatus());
+
+        assertEquals(ActionFactory.STATUS_FAILED, sa2.getStatus());
+        assertEquals(expectedMessage, sa2.getResultMsg());
+        assertEquals(-1, sa2.getResultCode());
+    }
+}

--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/SubscribeChannelsActionTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/SubscribeChannelsActionTest.java
@@ -17,6 +17,7 @@ package com.redhat.rhn.taskomatic.task.test;
 
 import static com.redhat.rhn.domain.action.ActionFactory.STATUS_QUEUED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -109,14 +110,14 @@ public class SubscribeChannelsActionTest extends JMockBaseTestCaseWithUser {
             will(returnValue(dataMap));
         }});
 
-        MinionActionExecutor executor = new MinionActionExecutor();
-        executor.setSaltServerActionService(saltServerActionService);
+        MinionActionExecutor executor = new MinionActionExecutor(saltServerActionService);
         executor.execute(ctx);
 
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
 
-        MinionServer server2 = MinionServerFactory.lookupById(serverId).get();
+        MinionServer server2 = MinionServerFactory.lookupById(serverId).orElse(null);
+        assertNotNull(server);
         assertEquals(ActionFactory.STATUS_QUEUED, serverAction.getStatus());
         assertNull(serverAction.getResultCode());
         assertEquals(server2, serverAction.getServer());

--- a/java/code/src/com/redhat/rhn/testing/MockObjectTestCase.java
+++ b/java/code/src/com/redhat/rhn/testing/MockObjectTestCase.java
@@ -15,6 +15,7 @@
 
 package com.redhat.rhn.testing;
 
+import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.States;
 import org.jmock.api.Imposteriser;
@@ -22,6 +23,8 @@ import org.jmock.internal.ExpectationBuilder;
 import org.jmock.junit5.JUnit5Mockery;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.function.Consumer;
 
 /**
  * jMock boilerplate.
@@ -50,6 +53,15 @@ public class MockObjectTestCase {
      * @param expectations expectations to set to the mocks
      */
     public void checking(ExpectationBuilder expectations) {
+        context.checking(expectations);
+    }
+
+    /**
+     * @param expectationsConsumer consumer to build the expectations
+     */
+    public void checking(Consumer<Expectations> expectationsConsumer) {
+        Expectations expectations = new Expectations();
+        expectationsConsumer.accept(expectations);
         context.checking(expectations);
     }
 

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -487,6 +487,10 @@ public class SaltServerActionService {
             boolean isStagingJob, Optional<Long> stagingJobMinionServerId) {
 
         List<MinionSummary> allMinions = MinionServerFactory.findQueuedMinionSummaries(actionIn.getId());
+        if (CollectionUtils.isEmpty(allMinions)) {
+            LOG.warn("Unable to find any minion that have the action id={} in status QUEUED", actionIn.getId());
+            return;
+        }
 
         // split minions into regular and salt-ssh
         Map<Boolean, List<MinionSummary>> partitionBySSHPush = allMinions.stream()

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Update earliest date when rescheduling failed actions (bsc#1206562)
 - Improve automatic dependency selection for vendor clones
 - Fix taskomatic logging (bsc#1207867)
 - Added APIs to allow frontend to install and remove ptf

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Mark as failed actions that cannot be scheduled because earliest
+  date is too old
 - Update earliest date when rescheduling failed actions (bsc#1206562)
 - Improve automatic dependency selection for vendor clones
 - Fix taskomatic logging (bsc#1207867)

--- a/python/test/unit/spacewalk/satellite_tools/test_download.py
+++ b/python/test/unit/spacewalk/satellite_tools/test_download.py
@@ -107,11 +107,13 @@ def test_reposync_download_thread_fetch_url_proxy_pass():
     parent_mock = Mock()
     parent_mock.retries = 0
     url_grabber_opts_mock = Mock()
+    url_grabber_opts_mock.return_value.retrycodes = [-1]
     with patch(
         "spacewalk.satellite_tools.download.URLGrabberOptions", url_grabber_opts_mock
     ):
         DownloadThread(parent_mock, queue).run()
-        assert url_grabber_opts_mock.mock_calls[0].kwargs["proxies"] == proxies
-        assert "proxy" not in url_grabber_opts_mock.mock_calls[0].kwargs
-        assert "username" not in url_grabber_opts_mock.mock_calls[0].kwargs
-        assert "password" not in url_grabber_opts_mock.mock_calls[0].kwargs
+        assert url_grabber_opts_mock.mock_calls[1].kwargs["proxies"] == proxies
+        assert url_grabber_opts_mock.mock_calls[1].kwargs["retrycodes"] == [-1, 14]
+        assert "proxy" not in url_grabber_opts_mock.mock_calls[1].kwargs
+        assert "username" not in url_grabber_opts_mock.mock_calls[1].kwargs
+        assert "password" not in url_grabber_opts_mock.mock_calls[1].kwargs


### PR DESCRIPTION
## What does this PR change?

This PR changes the behaviour when dealing with actions that have an earliest execution date older than 24 hours:

- it makes possible to reschedule these old failed actions. The action earliest date is now updated on rescheduling and that will allow the job to always pick them up;
- when an action is too old to be executed, it is now set as failed with an explanatory error message.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: improvements on existing documented functionality.

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19965

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
