### PR TITLE
Makes the systems column on the relevant patch page sortable

### DIFF
--- a/java/code/webapp/WEB-INF/pages/common/fragments/errata/relevant-errata-list.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/errata/relevant-errata-list.jspf
@@ -60,6 +60,9 @@
             ${current.advisorySynopsis}
         </rl:column>
         <rl:column headerkey="erratalist.jsp.systems"
+                   sortable="true"
+                   sortattr="systems"
+                   defaultsort="desc"
                    styleclass="text-align: center;">
             <a href="/rhn/errata/details/SystemsAffected.do?eid=${current.id}">${current.affectedSystemCount}</a>
         </rl:column>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Makes systems column sortable on relevant patch page, to list by most affected systems
+
 -------------------------------------------------------------------
 Mon Jan 23 14:24:31 CET 2023 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?
Makes the systems column on the relevant patch page sortable
This is a port of https://github.com/SUSE/spacewalk/pull/20289
## GUI diff


After:
![image](https://user-images.githubusercontent.com/729087/214341061-a7f6f2b4-7ba4-4b11-aad1-938ecb54ad51.png)


- [x] **DONE**

## Documentation
- No documentation needed:  the relevant patch docs do not mention anything about sortable columns
- [x] **DONE**

## Test coverage
- No tests:  Just jsp changed, no unit tests and there are no cucumber tests testing sorting things. 

- [ ] **DONE**

## Links

Fixes #13516
Needs to be ported to master

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
