### PR TITLE
QE: Improve hostname/FQDN check in `twopence.rb`

### DIFF
--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -121,13 +121,13 @@ end
 $nodes.each do |node|
   next if node.nil?
 
-  hostname, _local, _remote, code = node.test_and_store_results_together('hostname', 'root', 500)
-  raise "Cannot connect to get hostname for '#{$named_nodes[node.hash]}'. Response code: #{code}" if code.nonzero?
+  hostname, local, remote, code = node.test_and_store_results_together('hostname', 'root', 500)
+  raise "Cannot connect to get hostname for '#{$named_nodes[node.hash]}'. Response code: #{code}" if code.nonzero? || remote.nonzero? || local.nonzero?
   raise "No hostname for '#{$named_nodes[node.hash]}'. Response code: #{code}" if hostname.empty?
   node.init_hostname(hostname)
 
-  fqdn, _local, _remote, code = node.test_and_store_results_together('hostname -f', 'root', 500)
-  raise "Cannot connect to get FQDN for '#{$named_nodes[node.hash]}'. Response code: #{code}" if code.nonzero?
+  fqdn, local, remote, code = node.test_and_store_results_together('hostname -f', 'root', 500)
+  raise "Cannot connect to get FQDN for '#{$named_nodes[node.hash]}'. Response code: #{code}" if code.nonzero? || remote.nonzero? || local.nonzero?
   raise "No FQDN for '#{$named_nodes[node.hash]}'. Response code: #{code}" if fqdn.empty?
   node.init_full_hostname(fqdn)
 

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -122,12 +122,12 @@ $nodes.each do |node|
   next if node.nil?
 
   hostname, local, remote, code = node.test_and_store_results_together('hostname', 'root', 500)
-  raise "Cannot connect to get hostname for '#{$named_nodes[node.hash]}'. Response code: #{code}" if code.nonzero? || remote.nonzero? || local.nonzero?
+  raise "Cannot connect to get hostname for '#{$named_nodes[node.hash]}'. Response code: #{code}, local: #{local}, remote: #{remote}" if code.nonzero? || remote.nonzero? || local.nonzero?
   raise "No hostname for '#{$named_nodes[node.hash]}'. Response code: #{code}" if hostname.empty?
   node.init_hostname(hostname)
 
   fqdn, local, remote, code = node.test_and_store_results_together('hostname -f', 'root', 500)
-  raise "Cannot connect to get FQDN for '#{$named_nodes[node.hash]}'. Response code: #{code}" if code.nonzero? || remote.nonzero? || local.nonzero?
+  raise "Cannot connect to get FQDN for '#{$named_nodes[node.hash]}'. Response code: #{code}, local: #{local}, remote: #{remote}" if code.nonzero? || remote.nonzero? || local.nonzero?
   raise "No FQDN for '#{$named_nodes[node.hash]}'. Response code: #{code}" if fqdn.empty?
   node.init_full_hostname(fqdn)
 


### PR DESCRIPTION
## What does this PR change?

This will now show the correct error if e.g. a wrong SSH key or no key at all is used. Before the wrong error `No hostname for ...` was shown which was not accurate and is misleading when debugging.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links

- Manager 4.2: https://github.com/SUSE/spacewalk/pull/20310
- Manager 4.3: https://github.com/SUSE/spacewalk/pull/20309
- Fixes https://github.com/SUSE/spacewalk/issues/20296 
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
