### PR TITLE
fix postgres user check

### DIFF
--- a/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb
+++ b/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb
@@ -512,8 +512,8 @@ postgresql_service() {
 
 test_postgres_user() {
     set +e
-    POSTGRES_USER_ENABLED=$(su - postgres -c /bin/true)
-    if [ $POSTGRES_USER_ENABLED != "0" ] ; then
+    su - postgres -c /bin/true
+    if [ $? != "0" ] ; then
         echo "Cannot use postgres user. Terminating" >&2 
         exit 1
     fi

--- a/spacewalk/uyuni-setup-reportdb/uyuni-setup-reportdb.changes
+++ b/spacewalk/uyuni-setup-reportdb/uyuni-setup-reportdb.changes
@@ -1,3 +1,5 @@
+- improve postgres user check
+
 -------------------------------------------------------------------
 Mon Jan 23 08:26:26 CET 2023 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

fix postgres user check

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
