### PR TITLE
action chains: recognize transactional_update.reboot as a reboot action

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/SaltActionChainGeneratorService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltActionChainGeneratorService.java
@@ -361,7 +361,8 @@ public class SaltActionChainGeneratorService {
     private boolean isRebootAction(SaltState state) {
         if (state instanceof SaltModuleRun) {
             SaltModuleRun moduleRun = (SaltModuleRun) state;
-            if ("system.reboot".equalsIgnoreCase(moduleRun.getName())) {
+            if ("system.reboot".equalsIgnoreCase(moduleRun.getName()) ||
+                    "transactional_update.reboot".equalsIgnoreCase(moduleRun.getName())) {
                 return true;
             }
         }

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -1018,6 +1018,10 @@ public class SaltServerActionService {
                     Integer time = (Integer)kwargs.get("at_time");
                     return new SaltSystemReboot(stateId,
                             serverAction.getParentAction().getId(), time);
+                case "transactional_update.reboot":
+                    // this function will be excluded to the sls file by createActionChainSLSFiles
+                    return new SaltSystemReboot(stateId,
+                            serverAction.getParentAction().getId(), 0);
                 default:
                     throw new RhnRuntimeException("Salt module call " + fun + " can't be converted to a state.");
             }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- action chains: recognize transactional_update.reboot as a reboot action
+
 -------------------------------------------------------------------
 Mon Jan 23 14:24:31 CET 2023 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

When an action chains is running, all the action are converted to a state file. In case of the transactional update system, the reboot action are removed and handle directly by the action chain logic. After this change https://github.com/uyuni-project/uyuni/commit/d658c32cd73c51df59e2d5f7da7fa78738268487 we need to identify the transactiona_update.reboot function as a reboot action.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20277

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
