### PR TITLE
Handle taskomatic failures during action creation

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Handle taskomatic failures during action creation
 - Reduce taskomatic memory consumption while processing Ubuntu Erratas
 - send virtualization information to SCC
 - Do not execute immediately Package Refresh action for the SSH minion (bsc#1208325)


### PR DESCRIPTION
## What does this PR change?

This fixes handling of taskomatic failures.

`ActionChainManager::scheduleActions` creates an action, saves it to DB (in `ActionManager.createAction`) and calls takomatic API to schedule it.
The caller method (for example `ActionChainManager::scheduleApplyStates`) then adds `ActionDetails`.

If the taskomatic API fails with an exception, it leaves the action as is. It means that it is pending forever and clicking on details fails with NPE.

This PR makes sure that the action is fully created before calling taskomatic API and sets status to FAILED if there is taskomatic error. 


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [ ] **DONE**

## Test coverage
- Cucumber tests: WIP

- [ ] **DONE**

## Links

Part of fix for https://github.com/SUSE/spacewalk/issues/20143
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
