### PR TITLE
Testsuite: test restart of postgres

### DIFF
--- a/testsuite/features/secondary/srv_restart_postgres.feature
+++ b/testsuite/features/secondary/srv_restart_postgres.feature
@@ -1,0 +1,18 @@
+# Copyright (c) 2023 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Restart the PostgreSQL service
+
+  Scenario: Restart the PostgreSQL database service
+    Given I am authorized for the "Admin" section
+    When I restart the "postgresql.service" service on "server"
+    And I wait until "postgresql" service is active on "server"
+    # WORKAROUND for not having something to check for in the logs
+    And I wait for "60" seconds
+    And I am on the Systems overview page of this "sle_minion"
+    And I follow "States" in the content area
+    And I click on "Apply Highstate"
+    Then I should see a "Applying the highstate has been scheduled." text
+    And I wait until event "Apply highstate scheduled by admin" is completed
+    And I wait until I see "MinionActionExecutor" in file "/var/log/rhn/rhn_taskomatic_daemon.log" on "server"
+

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1720,3 +1720,11 @@ When(/^I do a late hostname initialization of host "([^"]*)"$/) do |host|
   node.init_os_family(os_family)
   node.init_os_version(os_version)
 end
+
+When(/^I wait until I see "([^"]*)" in file "([^"]*)" on "([^"]*)"$/) do |text, file, host|
+  node = get_target(host)
+  repeat_until_timeout(message: "Entry #{text} in file #{file} on #{host} not found") do
+    _output, code = node.run("tail -n 10 #{file} | grep '#{text}' ", check_errors: false)
+    break if code.zero?
+  end
+end

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -54,6 +54,7 @@
 - features/secondary/min_timezone.feature
 - features/secondary/min_move_from_and_to_proxy.feature
 - features/secondary/minssh_move_from_and_to_proxy.feature
+- features/secondary/srv_restart_postgres.feature
 - features/secondary/srv_logfile.feature
 - features/secondary/srv_cobbler_sync.feature
 - features/secondary/srv_cobbler_distro.feature

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -54,7 +54,10 @@
 - features/secondary/min_timezone.feature
 - features/secondary/min_move_from_and_to_proxy.feature
 - features/secondary/minssh_move_from_and_to_proxy.feature
-- features/secondary/srv_restart_postgres.feature
+# WORKAROUND:
+# Disabled until https://bugzilla.suse.com/show_bug.cgi?id=1218947
+# gets addressed
+# - features/secondary/srv_restart_postgres.feature
 - features/secondary/srv_logfile.feature
 - features/secondary/srv_cobbler_sync.feature
 - features/secondary/srv_cobbler_distro.feature


### PR DESCRIPTION
## What does this PR change?

This test restarts postgres service and verifies, that it is handled correctly in java and salt - applying highstate must work.

## Links

This should catch the bugs discussed in  https://github.com/SUSE/spacewalk/issues/20143

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
