### PR TITLE
Don't forget to kill the venv when simulating a Salt crash

### DIFF
--- a/testsuite/features/secondary/min_salt_software_states.feature
+++ b/testsuite/features/secondary/min_salt_software_states.feature
@@ -116,8 +116,7 @@ Feature: Salt package states
 
   Scenario: Use Salt presence mechanism on an unreachable minion
     When I follow "States" in the content area
-    And I run "pkill salt-minion" on "sle_minion" without error control
-    And I run "pkill python.original" on "sle_minion" without error control
+    And I simulate a salt-minion crash on "sle_minion"
     And I follow "Highstate" in the content area
     And I click on "Show full highstate output"
     And I wait until I see "No reply from minion" text

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -65,6 +65,11 @@ When(/^I restart salt-minion on "(.*?)"$/) do |minion|
   end
 end
 
+When(/^I simulate a salt-minion crash on "(.*?)"$/) do |minion|
+  node = get_target(minion)
+  node.run("pkill salt-minion; pkill venv-salt-minion; pkill python.original", check_errors: false)
+end
+
 When(/^I refresh salt-minion grains on "(.*?)"$/) do |minion|
   node = get_target(minion)
   salt_call = $use_salt_bundle ? "venv-salt-call" : "salt-call"


### PR DESCRIPTION
## What does this PR change?

Salt was still responding after killing salt-minion process... because of the venv-salt-minion


## Links

CI issue: SUSE/spacewalk#20283

Ports:
* 4.2:
* 4.3:


## Changelogs

- [x] No changelog needed
