### PR TITLE
Add spacecmd function: cryptokey_update

### DIFF
--- a/spacecmd/spacecmd.changes.blu-base.cryptokey_update
+++ b/spacecmd/spacecmd.changes.blu-base.cryptokey_update
@@ -1,0 +1,1 @@
+- Add spacecmd function: cryptokey_update

--- a/spacecmd/tests/test_cryptokey.py
+++ b/spacecmd/tests/test_cryptokey.py
@@ -171,6 +171,164 @@ class TestSCCryptokey:
             assert args == (shell.session, "description", "SSL", "contents")
             assert not kw
 
+    def test_cryptokey_update_no_keytype(self, shell):
+        """
+        Test do_cryptokey_update without correct key type.
+
+        :param shell:
+        :return:
+        """
+        shell.help_cryptokey_update = MagicMock()
+        shell.client.kickstart.keys.update = MagicMock()
+        shell.user_confirm = MagicMock(return_value=True)
+        read_file = MagicMock(return_value="contents")
+        prompt_user = MagicMock(side_effect=["", "interactive descr", "/tmp/file.txt"])
+        editor = MagicMock()
+        logger = MagicMock()
+
+        with patch("spacecmd.cryptokey.prompt_user", prompt_user) as pmu, \
+            patch("spacecmd.cryptokey.read_file", read_file) as rfl, \
+            patch("spacecmd.cryptokey.editor", editor) as edt, \
+            patch("spacecmd.cryptokey.logging", logger) as lgr:
+            spacecmd.cryptokey.do_cryptokey_update(shell, "")
+
+        assert not shell.help_cryptokey_update.called
+        assert not shell.client.kickstart.keys.update.called
+        assert not editor.called
+        assert read_file.called
+        assert prompt_user.called
+        assert logger.error.called
+
+        assert_expect(logger.error.call_args_list, "Invalid key type")
+
+    def test_cryptokey_update_interactive_no_contents(self, shell):
+        """
+        Test do_cryptokey_update without arguments (interactive, no contents given).
+
+        :param shell:
+        :return:
+        """
+        shell.help_cryptokey_update = MagicMock()
+        shell.client.kickstart.keys.update = MagicMock()
+        shell.user_confirm = MagicMock(return_value=True)
+        read_file = MagicMock()
+        prompt_user = MagicMock(side_effect=["g", "interactive descr", ""])
+        editor = MagicMock()
+        logger = MagicMock()
+
+        with patch("spacecmd.cryptokey.prompt_user", prompt_user) as pmu, \
+            patch("spacecmd.cryptokey.read_file", read_file) as rfl, \
+            patch("spacecmd.cryptokey.editor", editor) as edt, \
+            patch("spacecmd.cryptokey.logging", logger) as lgr:
+            spacecmd.cryptokey.do_cryptokey_update(shell, "")
+
+        assert not shell.help_cryptokey_update.called
+        assert not shell.client.kickstart.keys.update.called
+        assert not read_file.called
+        assert not editor.called
+        assert prompt_user.called
+        assert logger.error.called
+
+        assert_expect(logger.error.call_args_list, "No contents of the file")
+
+    def test_cryptokey_update_interactive_wrong_key_type(self, shell):
+        """
+        Test do_cryptokey_update without arguments (interactive, wrong key type).
+
+        :param shell:
+        :return:
+        """
+        shell.help_cryptokey_update = MagicMock()
+        shell.client.kickstart.keys.update = MagicMock()
+        shell.user_confirm = MagicMock(return_value=True)
+        read_file = MagicMock(return_value="contents")
+        prompt_user = MagicMock(side_effect=["x", "interactive descr", "/tmp/file.txt"])
+        editor = MagicMock()
+        logger = MagicMock()
+
+        with patch("spacecmd.cryptokey.prompt_user", prompt_user) as pmu, \
+            patch("spacecmd.cryptokey.read_file", read_file) as rfl, \
+            patch("spacecmd.cryptokey.editor", editor) as edt, \
+            patch("spacecmd.cryptokey.logging", logger) as lgr:
+            spacecmd.cryptokey.do_cryptokey_update(shell, "")
+
+        assert not shell.help_cryptokey_update.called
+        assert not shell.client.kickstart.keys.update.called
+        assert not editor.called
+        assert read_file.called
+        assert prompt_user.called
+        assert logger.error.called
+
+        assert_expect(logger.error.call_args_list, "Invalid key type")
+
+    def test_cryptokey_update_GPG_key(self, shell):
+        """
+        Test do_cryptokey_update with parameters, calling GPG key type.
+
+        :param shell:
+        :return:
+        """
+        shell.help_cryptokey_update = MagicMock()
+        shell.client.kickstart.keys.update = MagicMock()
+        shell.user_confirm = MagicMock(return_value=True)
+        read_file = MagicMock(return_value="contents")
+        prompt_user = MagicMock(side_effect=[])
+        editor = MagicMock()
+        logger = MagicMock()
+
+        with patch("spacecmd.cryptokey.prompt_user", prompt_user) as pmu, \
+            patch("spacecmd.cryptokey.read_file", read_file) as rfl, \
+            patch("spacecmd.cryptokey.editor", editor) as edt, \
+            patch("spacecmd.cryptokey.logging", logger) as lgr:
+            spacecmd.cryptokey.do_cryptokey_update(shell, "-t g -d description -f /tmp/file.txt")
+
+        assert not editor.called
+        assert not shell.help_cryptokey_update.called
+        assert not prompt_user.called
+        assert not logger.error.called
+
+        assert shell.client.kickstart.keys.update.called
+        assert read_file.called
+
+        for call in shell.client.kickstart.keys.update.call_args_list:
+            args, kw = call
+            assert args == (shell.session, "description", "GPG", "contents")
+            assert not kw
+
+    def test_cryptokey_update_SSL_key(self, shell):
+        """
+        Test do_cryptokey_update with parameters, calling SSL key type.
+
+        :param shell:
+        :return:
+        """
+        shell.help_cryptokey_update = MagicMock()
+        shell.client.kickstart.keys.update = MagicMock()
+        shell.user_confirm = MagicMock(return_value=True)
+        read_file = MagicMock(return_value="contents")
+        prompt_user = MagicMock(side_effect=[])
+        editor = MagicMock()
+        logger = MagicMock()
+
+        with patch("spacecmd.cryptokey.prompt_user", prompt_user) as pmu, \
+            patch("spacecmd.cryptokey.read_file", read_file) as rfl, \
+            patch("spacecmd.cryptokey.editor", editor) as edt, \
+            patch("spacecmd.cryptokey.logging", logger) as lgr:
+            spacecmd.cryptokey.do_cryptokey_update(shell, "-t s -d description -f /tmp/file.txt")
+
+        assert not editor.called
+        assert not shell.help_cryptokey_update.called
+        assert not prompt_user.called
+        assert not logger.error.called
+
+        assert shell.client.kickstart.keys.update.called
+        assert read_file.called
+
+        for call in shell.client.kickstart.keys.update.call_args_list:
+            args, kw = call
+            assert args == (shell.session, "description", "SSL", "contents")
+            assert not kw
+
     def test_cryptokey_delete_noargs(self, shell):
         """
         Test do_cryptokey_delete without parameters, so help should be displayed.


### PR DESCRIPTION
## What does this PR change?

`spacecmd` has function for most API calls for managing SSL/GPG keys, such as creating and deleting. There also is an API call [to update](https://www.uyuni-project.org/uyuni-docs-api/uyuni/api/kickstart.keys.html#apidoc-kickstart_keys-update-loggedInUser-description-type-content) keys. However, the function to update a key is missing in `spacecmd`.

This PR adds the function `cryptokey_update` to update SSL/GPG keys in the same way as creating them via `spacecmd`.


Discussion point:  
This mostly duplicates code present in the `cryptokey_create` function, respectively the method `do_cryptokey_create` in `/spacecmd/src/spacecmd/cryptokey.py` and its test. It might be advantageous to extract the common logic between the create, and update function. Would you suggest further such work?


## GUI diff

No difference.

- [x] **DONE**

## Documentation

- Doc strings for new python functions
- Documentation issue was created: Pending

- [ ] **DONE**

## Test coverage

- Unit tests were added

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

spacecmd.changes: - Add spacecmd function: cryptokey_update

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [x] Re-run test "backend_unittests_pgsql"
- [x] Re-run test "java_pgsql_tests"
- [x] Re-run test "schema_migration_test_pgsql"
- [x] Re-run test "susemanager_unittests"
- [x] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"       
