### PR TITLE
Install the reboot info beacon using a conf file instead of using pillars

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
@@ -46,13 +46,10 @@ public class MinionGeneralPillarGenerator implements MinionPillarGenerator {
     public static final String CATEGORY = "general";
 
     private static final int PKGSET_INTERVAL = 5;
-    private static final int REBOOT_INFO_INTERVAL = 10;
 
     private static final Map<String, Object> PKGSET_BEACON_PROPS = new HashMap<>();
-    private static final Map<String, Object> REBOOT_INFO_BEACON_PROPS = new HashMap<>();
     static {
         PKGSET_BEACON_PROPS.put("interval", PKGSET_INTERVAL);
-        REBOOT_INFO_BEACON_PROPS.put("interval", REBOOT_INFO_INTERVAL);
     }
 
     /**
@@ -98,13 +95,9 @@ public class MinionGeneralPillarGenerator implements MinionPillarGenerator {
                 minion.getOsFamily().toLowerCase().equals("debian")) {
             beaconConfig.put("pkgset", PKGSET_BEACON_PROPS);
         }
-        if (minion.doesOsSupportsTransactionalUpdate()) {
-            beaconConfig.put("reboot_info", REBOOT_INFO_BEACON_PROPS);
-        }
         if (!beaconConfig.isEmpty()) {
             pillar.add("beacons", beaconConfig);
         }
-
         return Optional.of(pillar);
     }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Install the reboot info beacon using a conf file instead of using pillars
 - Handle taskomatic failures during action creation
 - Reduce taskomatic memory consumption while processing Ubuntu Erratas
 - send virtualization information to SCC

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/transactional_update.conf
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/transactional_update.conf
@@ -2,3 +2,8 @@
 module_executors:
   - transactional_update
   - direct_call
+
+# Include beacon to check for pending transactions indicating that reboot is necessary
+beacons:
+  reboot_info:
+    - interval: 10

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Install the reboot info beacon using a conf file instead of using pillars
 - add CPU sockets, threads and total number to standard CPU grains
 - Fix mgrnet custom module to be compatible with old Python 2.6 (bsc#1206979) (bsc#1206981)
 - Fix current limitation on Action Chains for SLE Micro


### PR DESCRIPTION
## What does this PR change?

The reboot info beacon, used in transactional systems to notify when a reboot is required in a system, was being installed via pillar data. But, it turns out that salt is currently requiring an additional restart in order to have pillar defined beacons running according with defined in pillars (even after running `saltutil.refresh_pillar`).

To avoid this undesired behavior of having to perform a second reboot in the system to have the beacon running, this PR changes the beacon installation to be via a conf file included in the bootstrap state. With this the beacon should be running after the first reboot.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20278

Related issue created in salt project https://github.com/saltstack/salt/issues/63583

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
