### PR TITLE
Add openSUSE Leap 15.5 as a supported client to Uyuni

### DIFF
--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
@@ -1,3 +1,5 @@
+- Update translation strings
+
 -------------------------------------------------------------------
 Wed Dec 14 14:09:57 CET 2022 - jgonzalez@suse.com
 

--- a/java/code/src/com/redhat/rhn/frontend/dto/kickstart/KickstartableTreeDetail.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/kickstart/KickstartableTreeDetail.java
@@ -36,6 +36,8 @@ public class KickstartableTreeDetail extends KickstartableTree {
         this.setCobblerXenId(tree.getCobblerXenId());
         this.setOrg(tree.getOrg());
         this.setTreeType(tree.getTreeType());
+        this.setKernelOptions(tree.getKernelOptions());
+        this.setKernelOptionsPost(tree.getKernelOptionsPost());
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/tree/KickstartTreeHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/tree/KickstartTreeHandler.java
@@ -123,9 +123,42 @@ public class KickstartTreeHandler extends BaseHandler {
      * KickstartInstallType (rhel_6, rhel_7, rhel_8, rhel_9, fedora_9).")
      * @apidoc.returntype #return_int_success()
      */
+    public int create(User loggedInUser, String treeLabel, String basePath, String channelLabel, String installType) {
+
+        return create(loggedInUser, treeLabel, basePath, channelLabel, installType, "", "");
+    }
+
+    /**
+     * Create a Kickstart Tree (Distribution).
+     *
+     * @param loggedInUser The current user
+     * @param treeLabel Label for the new kickstart tree
+     * @param basePath path to the base/root of the kickstart tree.
+     * @param channelLabel label of channel to associate with ks tree.
+     * @param installType String label for KickstartInstallType (rhel_2.1,
+     * rhel_3, rhel_4, rhel_5, fedora_9)
+     * @param kernelOptions options to be passed to the kernel when booting for the installation
+     * @param postKernelOptions options to be passed to the kernel after installation
+     * @return 1 if successful, exception otherwise.
+     *
+     * @apidoc.doc Create a Kickstart Tree (Distribution) in #product().
+     * @apidoc.param #session_key()
+     * @apidoc.param #param_desc("string", "treeLabel" "The new kickstart tree label.")
+     * @apidoc.param #param_desc("string", "basePath", "Path to the base or
+     * root of the kickstart tree.")
+     * @apidoc.param #param_desc("string", "channelLabel", "Label of channel to
+     * associate with the kickstart tree. ")
+     * @apidoc.param #param_desc("string", "installType", "Label for
+     * KickstartInstallType (rhel_2.1, rhel_3, rhel_4, rhel_5, fedora_9).")
+     * @apidoc.param #param_desc("string", "kernelOptions", "Options to be passed to the kernel
+     * when booting for the installation. ")
+     * @apidoc.param #param_desc("string", "postKernelOptions", "Options to be passed to the kernel
+     * when booting for the installation. ")
+     * @apidoc.returntype #return_int_success()
+     */
     public int create(User loggedInUser, String treeLabel,
             String basePath, String channelLabel,
-            String installType) {
+            String installType, String kernelOptions, String postKernelOptions) {
 
         ensureConfigAdmin(loggedInUser);
 
@@ -135,6 +168,8 @@ public class KickstartTreeHandler extends BaseHandler {
         create.setInstallType(getInstallType(installType));
         create.setLabel(treeLabel);
         create.setServerName(RhnXmlRpcServer.getServerName());
+        create.setKernelOptions(kernelOptions);
+        create.setKernelOptionsPost(postKernelOptions);
 
         ValidatorError ve = create.store();
         if (ve != null) {
@@ -142,7 +177,6 @@ public class KickstartTreeHandler extends BaseHandler {
         }
         return 1;
     }
-
 
     /**
      * Delete a Kickstart Tree (Distribution).
@@ -231,8 +265,46 @@ public class KickstartTreeHandler extends BaseHandler {
      *
      * @apidoc.returntype #return_int_success()
      */
+    public int update(User loggedInUser, String treeLabel, String basePath, String channelLabel, String installType) {
+
+     return update(loggedInUser, treeLabel, basePath, channelLabel, installType, "", "");
+    }
+
+    /**
+     * Edit a kickstarttree.  This method will not edit the label of the tree, see
+     * renameTree().
+     *
+     * @param loggedInUser The current user
+     * @param treeLabel Label for the existing kickstart tree
+     * @param basePath New basepath for tree.
+     * rhn-kickstart.
+     * @param channelLabel New channel label to lookup and assign to
+     * the kickstart tree.
+     * @param installType String label for KickstartInstallType (rhel_2.1,
+     * rhel_3, rhel_4, rhel_5, fedora_9)
+     * @param kernelOptions Options to be passed to the kernel when booting for the installation
+     * @param postKernelOptions Options to be passed to the kernel after installation
+     *
+     * @return 1 if successful, exception otherwise.
+     *
+     * @apidoc.doc Edit a Kickstart Tree (Distribution) in #product().
+     * @apidoc.param #session_key()
+     * @apidoc.param #param_desc("string", "treeLabel" "Label for the kickstart tree.")
+     * @apidoc.param #param_desc("string", "basePath", "Path to the base or
+     * root of the kickstart tree.")
+     * @apidoc.param #param_desc("string", "channelLabel", "Label of channel to
+     * associate with kickstart tree.")
+     * @apidoc.param #param_desc("string", "installType", "Label for
+     * KickstartInstallType (rhel_2.1, rhel_3, rhel_4, rhel_5, fedora_9).")
+     * @apidoc.param #param_desc("string", "kernelOptions", "Options to be passed to the kernel
+     * when booting for the installation. ")
+     * @apidoc.param #param_desc("string", "postKernelOptions", "Options to be passed to the kernel
+     * when booting for the installation. ")
+     *
+     * @apidoc.returntype #return_int_success()
+     */
     public int update(User loggedInUser, String treeLabel, String basePath,
-                 String channelLabel, String installType) {
+                      String channelLabel, String installType, String kernelOptions, String postKernelOptions) {
 
         ensureConfigAdmin(loggedInUser);
 
@@ -243,6 +315,8 @@ public class KickstartTreeHandler extends BaseHandler {
         op.setBasePath(basePath);
         op.setChannel(getChannel(channelLabel, loggedInUser));
         op.setInstallType(getInstallType(installType));
+        op.setKernelOptions(kernelOptions);
+        op.setKernelOptionsPost(postKernelOptions);
 
         ValidatorError ve = op.store();
         if (ve != null) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/tree/test/KickstartTreeHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/tree/test/KickstartTreeHandlerTest.java
@@ -28,6 +28,7 @@ import com.redhat.rhn.domain.kickstart.KickstartInstallType;
 import com.redhat.rhn.domain.kickstart.KickstartableTree;
 import com.redhat.rhn.domain.kickstart.test.KickstartDataTest;
 import com.redhat.rhn.domain.kickstart.test.KickstartableTreeTest;
+import com.redhat.rhn.frontend.dto.kickstart.KickstartableTreeDetail;
 import com.redhat.rhn.frontend.xmlrpc.kickstart.KickstartHandler;
 import com.redhat.rhn.frontend.xmlrpc.kickstart.tree.KickstartTreeHandler;
 import com.redhat.rhn.frontend.xmlrpc.test.BaseHandlerTestCase;
@@ -76,12 +77,19 @@ public class KickstartTreeHandlerTest extends BaseHandlerTestCase {
             origCount = trees.size();
         }
         Channel baseChan = ChannelFactoryTest.createTestChannel(admin);
+        String kernelOptions = "self_update=0";
+        String postKernelOptions = "self_update=1";
         handler.create(admin, label,
                 KickstartableTreeTest.KICKSTART_TREE_PATH.getAbsolutePath(),
-                baseChan.getLabel(), KickstartInstallType.RHEL_6, "self_update=0", "");
+                baseChan.getLabel(), KickstartInstallType.RHEL_6, kernelOptions, postKernelOptions);
+        KickstartableTreeDetail details = handler.getDetails(admin, label);
         assertEquals(origCount + 1, KickstartFactory.
                 lookupAccessibleTreesByOrg(admin.getOrg()).size());
-
+        assertEquals(details.getBasePath(), KickstartableTreeTest.KICKSTART_TREE_PATH.getAbsolutePath());
+        assertEquals(details.getChannel().getLabel(), baseChan.getLabel());
+        assertEquals(details.getInstallType().getLabel(), KickstartInstallType.RHEL_6);
+        assertEquals(details.getKernelOptions(), kernelOptions);
+        assertEquals(details.getKernelOptionsPost(), postKernelOptions);
     }
 
     @Test
@@ -92,13 +100,17 @@ public class KickstartTreeHandlerTest extends BaseHandlerTestCase {
         String newBase = "/tmp/kickstart/new-base-path";
         KickstartableTreeTest.createKickstartTreeItems(new File(newBase), admin);
         Channel newChan = ChannelFactoryTest.createTestChannel(admin);
+        String kernelOptions = "self_update=0";
+        String postKernelOptions = "self_update=1";
         handler.update(admin, testTree.getLabel(),
                 newBase, newChan.getLabel(),
-                testTree.getInstallType().getLabel(), "self_update=0", "");
+                testTree.getInstallType().getLabel(), kernelOptions, postKernelOptions);
 
         assertEquals(testTree.getBasePath(), newBase);
         assertEquals(testTree.getChannel(), newChan);
         assertNotNull(testTree.getInstallType());
+        assertEquals(testTree.getKernelOptions(), kernelOptions);
+        assertEquals(testTree.getKernelOptionsPost(), postKernelOptions);
     }
 
     @Test

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/tree/test/KickstartTreeHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/tree/test/KickstartTreeHandlerTest.java
@@ -78,9 +78,10 @@ public class KickstartTreeHandlerTest extends BaseHandlerTestCase {
         Channel baseChan = ChannelFactoryTest.createTestChannel(admin);
         handler.create(admin, label,
                 KickstartableTreeTest.KICKSTART_TREE_PATH.getAbsolutePath(),
-                baseChan.getLabel(), KickstartInstallType.RHEL_6);
+                baseChan.getLabel(), KickstartInstallType.RHEL_6, "self_update=0", "");
         assertEquals(origCount + 1, KickstartFactory.
                 lookupAccessibleTreesByOrg(admin.getOrg()).size());
+
     }
 
     @Test
@@ -93,7 +94,7 @@ public class KickstartTreeHandlerTest extends BaseHandlerTestCase {
         Channel newChan = ChannelFactoryTest.createTestChannel(admin);
         handler.update(admin, testTree.getLabel(),
                 newBase, newChan.getLabel(),
-                testTree.getInstallType().getLabel());
+                testTree.getInstallType().getLabel(), "self_update=0", "");
 
         assertEquals(testTree.getBasePath(), newBase);
         assertEquals(testTree.getChannel(), newChan);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/KickstartTreeDetailSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/KickstartTreeDetailSerializer.java
@@ -31,6 +31,8 @@ import com.suse.manager.api.SerializedApiResponse;
  *   #prop("string", "label")
  *   #prop("string", "abs_path")
  *   #prop("int", "channel_id")
+ *   #prop("string", "kernel_options")
+ *   #prop("string", "post_kernel_options")
  *   $KickstartInstallTypeSerializer
  * #struct_end()
  */
@@ -49,6 +51,8 @@ public class KickstartTreeDetailSerializer extends ApiResponseSerializer<Kicksta
                 .add("abs_path", src.getAbsolutePath())
                 .add("channel_id", src.getChannel().getId())
                 .add("install_type", src.getInstallType())
+                .add("kernel_options", src.getKernelOptions())
+                .add("post_kernel_options", src.getKernelOptionsPost())
                 .build();
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add the create/update methods for kickstart to accepts kernel and kernel post options(jsc#suma-251)
 - fix NumberFormatException when syncing ubuntu errata (bsc#1207883)
 - Fix duplicate keys in suseImageFile and other tables (bsc#1207799)
 - Fix CLM environments UI for environment labels containing dots (bsc#1207838)

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,6 @@
+- Add make as a BuildRequire for those operating systems that do
+  not have it installed by default
+
 -------------------------------------------------------------------
 Mon Jan 23 08:27:21 CET 2023 - jgonzalez@suse.com
 

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1196,7 +1196,6 @@ DATA = {
     'openSUSE-Leap-15.4-aarch64-uyuni' : {
         'BASECHANNEL' : 'opensuse_leap15_4-aarch64', 'PKGLIST' :  PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensuse/15/4/bootstrap/'
-<<<<<<< HEAD
     },
     'openSUSE-Leap-Micro-5.3-x86_64-uyuni' : {
         'BASECHANNEL' : 'opensuse_micro5_3-x86_64', 'PKGLIST' :  PKGLISTMICRO_BUNDLE_ONLY,

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1196,6 +1196,7 @@ DATA = {
     'openSUSE-Leap-15.4-aarch64-uyuni' : {
         'BASECHANNEL' : 'opensuse_leap15_4-aarch64', 'PKGLIST' :  PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensuse/15/4/bootstrap/'
+<<<<<<< HEAD
     },
     'openSUSE-Leap-Micro-5.3-x86_64-uyuni' : {
         'BASECHANNEL' : 'opensuse_micro5_3-x86_64', 'PKGLIST' :  PKGLISTMICRO_BUNDLE_ONLY,
@@ -1213,6 +1214,14 @@ DATA = {
         'BASECHANNEL' : 'opensuse_microos-aarch64', 'PKGLIST' : PKGLISTUMBLEWEED_SALT_NO_BUNDLE,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensusemicroos/latest/0/bootstrap/'
     },
+    'openSUSE-Leap-15.5-x86_64-uyuni' : {
+        'BASECHANNEL' : 'opensuse_leap15_5-x86_64', 'PKGLIST' :  PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensuse/15/5/bootstrap/'
+    },
+    'openSUSE-Leap-15.5-aarch64-uyuni' : {
+        'BASECHANNEL' : 'opensuse_leap15_5-aarch64', 'PKGLIST' :  PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensuse/15/5/bootstrap/'
+    },    
     'centos-6-x86_64' : {
         'PDID' : [-11, 1682], 'BETAPDID' : [2064], 'PKGLIST' : RES6,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/centos/6/bootstrap/'

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,6 +1,7 @@
 - Create repostories with sha256 instead of sha1.
 - Bootstrap repository definitions for openSUSE Leap Micro 5.3 and
   openSUSE MicroOS for Uyuni
+- Add openSUSE Leap 15.5 uyuni bootstrap repositories
 
 -------------------------------------------------------------------
 Mon Jan 23 08:31:18 CET 2023 - jgonzalez@suse.com

--- a/testsuite/features/secondary/min_deblike_openscap_audit.feature
+++ b/testsuite/features/secondary/min_deblike_openscap_audit.feature
@@ -30,8 +30,7 @@ Feature: OpenSCAP audit of Debian-like Salt minion
     And I follow "Schedule" in the content area
     And I wait at most 30 seconds until I do not see "This system does not yet have OpenSCAP scan capability." text, refreshing the page
     And I enter "--profile standard" as "params"
-    # workaround for bsc#1206586
-    And I enter "/usr/share/xml/scap/ssg/content/ssg-ubuntu2004-xccdf.xml" as "path"
+    And I enter "/usr/share/xml/scap/ssg/content/ssg-ubuntu2204-xccdf.xml" as "path"
     And I click on "Schedule"
     Then I should see a "XCCDF scan has been scheduled" text
     And I wait at most 500 seconds until event "OpenSCAP xccdf scanning" is completed

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -2157,7 +2157,7 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 [uyuni-server-devel-leap]
 name     = Uyuni Server Devel for %(base_channel_name)s (Development)
 archs    = x86_64
-base_channels = opensuse_leap15_5-%(arch)s
+base_channels = opensuse_leap15_4-%(arch)s
 checksum = sha256
 gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s
@@ -2204,20 +2204,10 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/
 
-[uyuni-proxy-stable-leap-155]
-name     = Uyuni Proxy Stable for %(base_channel_name)s
-archs    = x86_64, aarch64
-base_channels = opensuse_leap15_5-%(arch)s
-checksum = sha256
-gpgkey_url = %(_uyuni_gpgkey_url)s
-gpgkey_id = %(_uyuni_gpgkey_id)s
-gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/
-
 [uyuni-proxy-devel-leap]
 name     = Uyuni Proxy Devel for %(base_channel_name)s (Development)
 archs    = x86_64
-base_channels = opensuse_leap15_5-%(arch)s
+base_channels = opensuse_leap15_4-%(arch)s
 checksum = sha256
 gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1208,7 +1208,7 @@ repo_url = https://download.opensuse.org/update/leap-micro/5.3/sle/
 name     = Uyuni Client Tools for %(base_channel_name)s
 archs    = x86_64, aarch64
 base_channels = opensuse_micro5_3-%(arch)s
-=======
+
 [opensuse_leap15_5]
 checksum = sha256
 archs    = x86_64, aarch64
@@ -1264,26 +1264,23 @@ repo_url = http://download.opensuse.org/update/leap/15.5/backports/
 name     = Uyuni Client Tools for %(base_channel_name)s
 archs    = x86_64, aarch64
 base_channels = opensuse_leap15_5-%(arch)s
->>>>>>> a5d671f3388 (Add openSUSE Leap 15.5 repositories to spacewalk-common-channels)
 checksum = sha256
 gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
 
-<<<<<<< HEAD
 # This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap Micro 5.X release
 [opensuse_micro5_3-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
 archs    = x86_64, aarch64
 base_channels = opensuse_micro5_3-%(arch)s
-=======
+
 # This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap 15.X releases
 [opensuse_leap15_5-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
 archs    = x86_64, aarch64
 base_channels = opensuse_leap15_5-%(arch)s
->>>>>>> a5d671f3388 (Add openSUSE Leap 15.5 repositories to spacewalk-common-channels)
 checksum = sha256
 gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1184,6 +1184,7 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
 
+<<<<<<< HEAD
 [opensuse_micro5_3]
 checksum = sha256
 archs    = x86_64, aarch64
@@ -1207,17 +1208,82 @@ repo_url = https://download.opensuse.org/update/leap-micro/5.3/sle/
 name     = Uyuni Client Tools for %(base_channel_name)s
 archs    = x86_64, aarch64
 base_channels = opensuse_micro5_3-%(arch)s
+=======
+[opensuse_leap15_5]
+checksum = sha256
+archs    = x86_64, aarch64
+name     = openSUSE Leap 15.5 (%(arch)s)
+gpgkey_url = http://download.opensuse.org/distribution/leap/15.5/repo/oss/repodata/repomd.xml.key
+gpgkey_id = 3DBDC284
+gpgkey_fingerprint = 22C0 7BA5 3417 8CD0 2EFE  22AA B88B 2FD4 3DBD C284
+repo_url = http://download.opensuse.org/distribution/leap/15.5/repo/oss/
+dist_map_release = 15.5
+
+[opensuse_leap15_5-non-oss]
+label    = %(base_channel)s-non-oss
+name     = openSUSE 15.5 non oss (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_leap15_5-%(arch)s
+repo_url = http://download.opensuse.org/distribution/leap/15.5/repo/non-oss/
+
+[opensuse_leap15_5-updates]
+label    = %(base_channel)s-updates
+name     = openSUSE Leap 15.5 Updates (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_leap15_5-%(arch)s
+repo_url = http://download.opensuse.org/update/leap/15.5/oss/
+
+[opensuse_leap15_5-non-oss-updates]
+label    = %(base_channel)s-non-oss-updates
+name     = openSUSE Leap 15.5 non oss Updates (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_leap15_5-%(arch)s
+repo_url = http://download.opensuse.org/update/leap/15.5/non-oss/
+
+[opensuse_leap15_5-sle-updates]
+label    = %(base_channel)s-sle-updates
+name     = Update repository with updates from SUSE Linux Enterprise 15 (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_leap15_5-%(arch)s
+repo_url = http://download.opensuse.org/update/leap/15.5/sle/
+
+[opensuse_leap15_5-backports-updates]
+label    = %(base_channel)s-backports-updates
+name     = Update repository of openSUSE Backports (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_leap15_5-%(arch)s
+repo_url = http://download.opensuse.org/update/leap/15.5/backports/
+
+# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap 15.X releases
+[opensuse_leap15_5-uyuni-client]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = x86_64, aarch64
+base_channels = opensuse_leap15_5-%(arch)s
+>>>>>>> a5d671f3388 (Add openSUSE Leap 15.5 repositories to spacewalk-common-channels)
 checksum = sha256
 gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
 
+<<<<<<< HEAD
 # This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap Micro 5.X release
 [opensuse_micro5_3-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
 archs    = x86_64, aarch64
 base_channels = opensuse_micro5_3-%(arch)s
+=======
+# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap 15.X releases
+[opensuse_leap15_5-uyuni-client-devel]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = x86_64, aarch64
+base_channels = opensuse_leap15_5-%(arch)s
+>>>>>>> a5d671f3388 (Add openSUSE Leap 15.5 repositories to spacewalk-common-channels)
 checksum = sha256
 gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s
@@ -2078,10 +2144,20 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/
 
+[uyuni-server-stable-leap-155]
+name     = Uyuni Server Stable for %(base_channel_name)s
+archs    = x86_64, aarch64
+base_channels = opensuse_leap15_5-%(arch)s
+checksum = sha256
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/
+
 [uyuni-server-devel-leap]
 name     = Uyuni Server Devel for %(base_channel_name)s (Development)
 archs    = x86_64
-base_channels = opensuse_leap15_4-%(arch)s
+base_channels = opensuse_leap15_5-%(arch)s
 checksum = sha256
 gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s
@@ -2128,10 +2204,20 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/
 
+[uyuni-proxy-stable-leap-155]
+name     = Uyuni Proxy Stable for %(base_channel_name)s
+archs    = x86_64, aarch64
+base_channels = opensuse_leap15_5-%(arch)s
+checksum = sha256
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/
+
 [uyuni-proxy-devel-leap]
 name     = Uyuni Proxy Devel for %(base_channel_name)s (Development)
 archs    = x86_64
-base_channels = opensuse_leap15_4-%(arch)s
+base_channels = opensuse_leap15_5-%(arch)s
 checksum = sha256
 gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1184,31 +1184,6 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
 
-<<<<<<< HEAD
-[opensuse_micro5_3]
-checksum = sha256
-archs    = x86_64, aarch64
-name     = openSUSE Leap Micro 5.3 (%(arch)s)
-gpgkey_url = https://download.opensuse.org/distribution/leap-micro/5.3/product/repo/Leap-Micro-5.3-x86_64-Media1/gpg-pubkey-3dbdc284-53674dd4.asc
-gpgkey_id = 3DBDC284
-gpgkey_fingerprint = 22C0 7BA5 3417 8CD0 2EFE  22AA B88B 2FD4 3DBD C284
-repo_url = https://download.opensuse.org/distribution/leap-micro/5.3/product/repo/Leap-Micro-5.3-%(arch)s-Media1/
-dist_map_release = 15.4
-
-[opensuse_micro5_3-sle-updates]
-label    = %(base_channel)s-sle-updates
-name     = SLE Micro Update Repository (%(arch)s)
-archs    = x86_64, aarch64
-checksum = sha256
-base_channels = opensuse_micro5_3-%(arch)s
-repo_url = https://download.opensuse.org/update/leap-micro/5.3/sle/
-
-# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap Micro 5.X releases
-[opensuse_micro5_3-uyuni-client]
-name     = Uyuni Client Tools for %(base_channel_name)s
-archs    = x86_64, aarch64
-base_channels = opensuse_micro5_3-%(arch)s
-
 [opensuse_leap15_5]
 checksum = sha256
 archs    = x86_64, aarch64
@@ -1270,17 +1245,51 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
 
-# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap Micro 5.X release
-[opensuse_micro5_3-uyuni-client-devel]
-name     = Uyuni Client Tools for %(base_channel_name)s (Development)
-archs    = x86_64, aarch64
-base_channels = opensuse_micro5_3-%(arch)s
-
 # This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap 15.X releases
 [opensuse_leap15_5-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
 archs    = x86_64, aarch64
 base_channels = opensuse_leap15_5-%(arch)s
+checksum = sha256
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+
+[opensuse_micro5_3]
+checksum = sha256
+archs    = x86_64, aarch64
+name     = openSUSE Leap Micro 5.3 (%(arch)s)
+gpgkey_url = https://download.opensuse.org/distribution/leap-micro/5.3/product/repo/Leap-Micro-5.3-x86_64-Media1/gpg-pubkey-3dbdc284-53674dd4.asc
+gpgkey_id = 3DBDC284
+gpgkey_fingerprint = 22C0 7BA5 3417 8CD0 2EFE  22AA B88B 2FD4 3DBD C284
+repo_url = https://download.opensuse.org/distribution/leap-micro/5.3/product/repo/Leap-Micro-5.3-%(arch)s-Media1/
+dist_map_release = 15.4
+
+[opensuse_micro5_3-sle-updates]
+label    = %(base_channel)s-sle-updates
+name     = SLE Micro Update Repository (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_micro5_3-%(arch)s
+repo_url = https://download.opensuse.org/update/leap-micro/5.3/sle/
+
+# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap Micro 5.X releases
+[opensuse_micro5_3-uyuni-client]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = x86_64, aarch64
+base_channels = opensuse_micro5_3-%(arch)s
+checksum = sha256
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+
+# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap Micro 5.X release
+[opensuse_micro5_3-uyuni-client-devel]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = x86_64, aarch64
+base_channels = opensuse_micro5_3-%(arch)s
 checksum = sha256
 gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,4 +1,5 @@
 - Add openSUSE Leap Micro 5.3 and openSUSE MicroOS repositories 
+- openSUSE Leap 15.5 repositories
 
 -------------------------------------------------------------------
 Mon Jan 23 08:24:57 CET 2023 - jgonzalez@suse.com


### PR DESCRIPTION
## What does this PR change?

Add openSUSE Leap 15.5 as a supported client to Uyuni

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- Documentation issue was created: https://github.com/uyuni-project/uyuni-docs/issues/2028

- [X] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [X] **DONE**

## Links

No links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
