### PR TITLE
QE: Update test suite to Ruby 3.1

### DIFF
--- a/testsuite/Gemfile
+++ b/testsuite/Gemfile
@@ -4,7 +4,7 @@
 source 'https://rubygems.org'
 
 gem 'require_all', "~> 3.0"
-gem 'capybara', '3.35.3'
+gem 'capybara', '3.36.0'
 gem 'cucumber', '7.1.0'
 gem 'cucumber-html-formatter', "~> 17.0"
 gem 'selenium-webdriver', "~> 3.142"

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -369,7 +369,7 @@ Given(/^I try to download "([^"]*)" from channel "([^"]*)"$/) do |rpm, channel|
   Tempfile.open(rpm) do |tmpfile|
     @download_path = tmpfile.path
     begin
-      open(url, ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE) do |urlfile|
+      URI.open(url, ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE) do |urlfile|
         tmpfile.write(urlfile.read)
       end
     rescue OpenURI::HTTPError => e

--- a/testsuite/features/step_definitions/security_steps.rb
+++ b/testsuite/features/step_definitions/security_steps.rb
@@ -11,7 +11,7 @@ require 'openssl'
 When(/^I retrieve any static resource$/) do
   resource = %w[/img/action-add.gif /css/susemanager-light.css /fonts/DroidSans.ttf /javascript/actionchain.js].sample
   @url = Capybara.app_host + resource
-  open(@url, ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE) do |f|
+  URI.open(@url, ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE) do |f|
     @headers = f.meta
   end
 end

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -129,7 +129,7 @@ def format_detail(message, last_result, report_result)
 end
 
 def click_button_and_wait(locator = nil, **options)
-  click_button(locator, options)
+  click_button(locator, **options)
   begin
     raise 'Timeout: Waiting AJAX transition (click link)' unless has_no_css?('.senna-loading', wait: 20)
   rescue StandardError, Capybara::ExpectationNotMet => e
@@ -138,7 +138,7 @@ def click_button_and_wait(locator = nil, **options)
 end
 
 def click_link_and_wait(locator = nil, **options)
-  click_link(locator, options)
+  click_link(locator, **options)
   begin
     raise 'Timeout: Waiting AJAX transition (click link)' unless has_no_css?('.senna-loading', wait: 20)
   rescue StandardError, Capybara::ExpectationNotMet => e
@@ -147,7 +147,7 @@ def click_link_and_wait(locator = nil, **options)
 end
 
 def click_link_or_button_and_wait(locator = nil, **options)
-  click_link_or_button(locator, options)
+  click_link_or_button(locator, **options)
   begin
     raise 'Timeout: Waiting AJAX transition (click link)' unless has_no_css?('.senna-loading', wait: 20)
   rescue StandardError, Capybara::ExpectationNotMet => e
@@ -168,7 +168,7 @@ module CapybaraNodeElementExtension
 end
 
 def find_and_wait_click(*args, **options, &optional_filter_block)
-  element = find(*args, options, &optional_filter_block)
+  element = find(*args, **options, &optional_filter_block)
   element.extend(CapybaraNodeElementExtension)
 end
 


### PR DESCRIPTION
## What does this PR change?

See https://github.com/SUSE/spacewalk/issues/17431

## TODO

- [x] Positional arguments
- [ ] Deprecated object #=~

## GUI diff

No difference.


- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were added

- [x] **DONE**

## Links


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
