### PR TITLE
QE: Wait until the credentials are valid

### DIFF
--- a/testsuite/features/core/srv_organization_credentials.feature
+++ b/testsuite/features/core/srv_organization_credentials.feature
@@ -10,4 +10,4 @@ Feature: Organization credentials in the Setup Wizard
     And I ask to add new credentials
     And I enter the SCC credentials
     And I click on "Save"
-    Then the SCC credentials should be valid
+    And I wait until the SCC credentials are valid

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -639,10 +639,10 @@ When(/^I enter the SCC credentials$/) do
   )
 end
 
-Then(/^the SCC credentials should be valid$/) do
+When(/^I wait until the SCC credentials are valid$/) do
   scc_username, scc_password = ENV['SCC_CREDENTIALS'].split('|')
   within(:xpath, "//h3[contains(text(), '#{scc_username}')]/../..") do
-    raise 'Success icon not found' unless find('i.text-success', wait: 5)
+    raise 'Success icon not found' unless find('i.text-success', wait: 30)
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

We had a wrong named step definition where we expected a value, using "it should", but in those cases we should not wait, as much as the time to load the DOM page.
It was the case of the SCC credentials validation. I refactored the step so now it's clear that we need to wait for the SCC credentials to be valid.
I set the timeout of 30 seconds.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were refactored

- [x] **DONE**

## Links

Ports:
- Manager-4.2
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
