### PR TITLE
QE: Update Ruby gems

### DIFF
--- a/testsuite/Gemfile
+++ b/testsuite/Gemfile
@@ -4,10 +4,10 @@
 source 'https://rubygems.org'
 
 gem 'require_all', "~> 3.0"
-gem 'capybara', '3.35.3'
-gem 'cucumber', '7.1.0'
-gem 'cucumber-html-formatter', "~> 17.0"
-gem 'selenium-webdriver', "~> 3.142"
+gem 'capybara', '3.38.0'
+gem 'cucumber', '8.0.0'
+gem 'cucumber-html-formatter', "19.1.0"
+gem 'selenium-webdriver', "3.142.7"
 gem 'rack', "~> 3.0"
 gem 'rack-test', "~> 2.0"
 gem 'nokogiri', "~> 1.12"

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -58,22 +58,20 @@ Capybara.register_driver(:headless_chrome) do |app|
   # Chrome driver options
   chrome_options = %w[no-sandbox disable-dev-shm-usage ignore-certificate-errors disable-gpu window-size=2048,2048, js-flags=--max_old_space_size=2048]
   chrome_options << 'headless' unless $debug_mode
+
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: {
+    'goog:chromeOptions': {
       args: chrome_options,
-      w3c: false,
       prefs: {
         'download.default_directory': '/tmp/downloads'
       }
-    },
-    unexpectedAlertBehaviour: 'accept',
-    unhandledPromptBehavior: 'accept'
+    }
   )
 
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,
-    desired_capabilities: capabilities,
+    capabilities: capabilities,
     http_client: client
   )
 end


### PR DESCRIPTION
## What does this PR change?

This updates the major Ruby gems we use and adjust the test suite code for it.

See https://github.com/SUSE/spacewalk/issues/17431



## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
