### PR TITLE
Fix Rubocop 0.83.0 version in our Gemfile

### DIFF
--- a/testsuite/Gemfile
+++ b/testsuite/Gemfile
@@ -22,7 +22,7 @@ gem 'websocket-driver', "~> 0.7"
 gem 'syntax', "~> 1.2"
 gem 'parallel_tests', "~> 3.12"
 gem 'simplecov', "~> 0.22"
-gem 'rubocop', "~> 1.28"
+gem 'rubocop', '0.83.0'
 # Pre-requisite:
 # Add repository https://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/<your_distro> and install twopence RPMs
 # or build and install from https://github.com/openSUSE/twopence


### PR DESCRIPTION
## What does this PR change?

Fix Rubocop 0.83.0 version in our Gemfile
## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Ports:
- Manager-4.2
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
