### PR TITLE
Create repos with SHA256 instead of SHA1

### DIFF
--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -563,7 +563,7 @@ def create_repo(label, options, mgr_bootstrap_data, additional=[]):
             debs = " ".join([os.path.join(debs_dir, f) for f in os.listdir(debs_dir)])
             log("/usr/bin/reprepro -b {0} includedeb {1} {2}".format(destdirtmp, "bootstrap", debs))
         else:
-            log("createrepo -s sha %s" % destdirtmp)
+            log("createrepo -s sha256 %s" % destdirtmp)
     else:
         if repotype == 'deb':
             reprepro_conf_tmpl = Template("Origin: $origin\n" \
@@ -591,7 +591,7 @@ def create_repo(label, options, mgr_bootstrap_data, additional=[]):
                 log(err, 2)
                 return 1
         else:
-            os.system("createrepo -s sha %s" % destdirtmp)
+            os.system("createrepo -s sha256 %s" % destdirtmp)
         # ensure venv-enabled-{ARCH}.txt doesn't exist in repo with no salt bundle package
         # create venv-enabled-{ARCH}.txt for repos with salt bundle package
         for file_path in glob.glob(os.path.join(destdirtmp, 'venv-enabled-*.txt')):

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- Create repos with sha256 instead of sha1.
+
 -------------------------------------------------------------------
 Mon Jan 23 08:31:18 CET 2023 - jgonzalez@suse.com
 

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,4 +1,4 @@
-- Create repos with sha256 instead of sha1.
+- Create repostories with sha256 instead of sha1.
 
 -------------------------------------------------------------------
 Mon Jan 23 08:31:18 CET 2023 - jgonzalez@suse.com


### PR DESCRIPTION
## What does this PR change?

Create repositories with SHA254 instead of SHA1. SHA1 is considered insecure. Enterprise Linux 9 also has it disabled.

Change credit to H. Hoffmann.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
