### PR TITLE
Default log_level value in proxy containers and helm chart to 1

### DIFF
--- a/containers/proxy-helm/proxy-helm.changes
+++ b/containers/proxy-helm/proxy-helm.changes
@@ -1,3 +1,5 @@
+- Default log_level to 1
+
 -------------------------------------------------------------------
 Mon Jan 23 07:33:12 UTC 2023 - Julio González Gil <jgonzalez@suse.com>
 

--- a/containers/proxy-helm/templates/config.yaml
+++ b/containers/proxy-helm/templates/config.yaml
@@ -10,7 +10,7 @@ data:
     proxy_fqdn: {{ .Values.proxy_fqdn }}
     email: {{ .Values.email }}
     max_cache_size_mb: {{ .Values.max_cache_size_mb }}
-    log_level: {{ .Values.log_level }}
+    log_level: {{ .Values.log_level | default 1 }}
     ca_crt: |
 {{ .Values.ca_crt | indent 6 }}
 ---

--- a/containers/proxy-httpd-image/proxy-httpd-image.changes
+++ b/containers/proxy-httpd-image/proxy-httpd-image.changes
@@ -1,3 +1,5 @@
+- Adapt to log_level default value being 1
+
 -------------------------------------------------------------------
 Mon Jan 23 07:33:34 UTC 2023 - Julio González Gil <jgonzalez@suse.com>
 

--- a/containers/proxy-httpd-image/uyuni-configure.py
+++ b/containers/proxy-httpd-image/uyuni-configure.py
@@ -66,7 +66,7 @@ with open(config_path + "config.yaml") as source:
     config = yaml.safe_load(source)
 
     # log_level is the value for rhn.conf and should be a positive integer
-    log_level = logging.WARNING if config.get("log_level") is None else logging.DEBUG
+    log_level = logging.WARNING if config.get("log_level") == 1 else logging.DEBUG
     logging.getLogger().setLevel(log_level)
 
 with open(config_path + "httpd.yaml") as httpdSource:

--- a/containers/proxy-tftpd-image/proxy-tftpd-image.changes
+++ b/containers/proxy-tftpd-image/proxy-tftpd-image.changes
@@ -1,3 +1,5 @@
+- Adapt to log_level default value being 1
+
 -------------------------------------------------------------------
 Mon Jan 23 07:34:24 UTC 2023 - Julio González Gil <jgonzalez@suse.com>
 

--- a/containers/proxy-tftpd-image/uyuni-configure.py
+++ b/containers/proxy-tftpd-image/uyuni-configure.py
@@ -12,7 +12,7 @@ with open(config_path + "config.yaml") as source:
     config = yaml.safe_load(source)
    
     # log_level is the value for rhn.conf and should be a positive integer
-    log_level = logging.WARNING if config.get("log_level") is None else logging.DEBUG
+    log_level = logging.WARNING if config.get("log_level") == 1 else logging.DEBUG
     logging.getLogger().setLevel(log_level)
 
     # store SSL CA certificate


### PR DESCRIPTION
## What does this PR change?

helm chart deployment fails when there is no `log_level` defined, which is the default with the generated tarball.
Set the default to `1` as in the `rhn.conf` defaults of the proxy WSGI scripts.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: no automated tests for helm chart deployment.

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
