### PR TITLE
Thread.isAlive() has been removed in Python 3.9 in favor for is_alive().

### DIFF
--- a/python/spacewalk/satellite_tools/download.py
+++ b/python/spacewalk/satellite_tools/download.py
@@ -365,12 +365,12 @@ class ThreadedDownloader:
 
             # wait to finish
             try:
-                while any(t.isAlive() for t in started_threads):
+                while any(t.is_alive() for t in started_threads):
                     time.sleep(1)
             except KeyboardInterrupt:
                 e = sys.exc_info()[1]
                 self.fail_download(e)
-                while any(t.isAlive() for t in started_threads):
+                while any(t.is_alive() for t in started_threads):
                     time.sleep(1)
                 break
 


### PR DESCRIPTION
## What does this PR change?

Replaced isAlive with is_alive to run on Python 3.9 (in addition to Python 3.6)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
