### PR TITLE
Bash completion for spacewalk tools

### DIFF
--- a/susemanager/bash-completion/Makefile
+++ b/susemanager/bash-completion/Makefile
@@ -1,0 +1,19 @@
+BUILDDIR=$(CURDIR)/build
+INSTALL_DIR=$(DESTDIR)/usr/share/bash-completion/completions/
+
+TARGETS=mgr-create-bootstrap-repo mgr-sync spacewalk-common-channels \
+	spacewalk-remove-channel spacewalk-repo-sync
+
+all: $(TARGETS)
+
+$(TARGETS): %: completions/_common.bash completions/%.bash | $(BUILDDIR)
+	cat $^ > $(BUILDDIR)/$@
+
+$(BUILDDIR):
+	mkdir $(BUILDDIR)
+
+install:
+	install -d $(INSTALL_DIR)
+	install -m 644 $(addprefix $(BUILDDIR)/,$(TARGETS)) $(INSTALL_DIR)
+clean:
+	rm -r $(BUILDDIR)

--- a/susemanager/bash-completion/README.md
+++ b/susemanager/bash-completion/README.md
@@ -1,0 +1,22 @@
+# Uyuni bash completion
+
+Bash completion scripts for Uyuni CLI tools.
+
+## Manual installation
+
+1. Clone the Git repository into your Uyuni/SUSE Manager server
+2. Go to the `susemanager/bash-completion` directory inside the repository
+3. Execute `make && make install`
+
+```sh
+git clone https://github.com/uyuni-project/uyuni.git
+cd uyuni/susemanager/bash-completion
+make && make install
+```
+
+## Contributing
+
+The completion script for each CLI tool is in a separate file named "tool-name.bash".
+Additionally, all the common functions used by the scripts are in `completions/_common.bash`.
+`make` combines every script file with `_common.bash` to create a standalone bash completion script.
+If you want to create a completion script for a new tool, remember to add your new file as a target in the `Makefile`.

--- a/susemanager/bash-completion/completions/_common.bash
+++ b/susemanager/bash-completion/completions/_common.bash
@@ -1,0 +1,53 @@
+# Adds a trailing space to a word if it does not end with a '=' character
+# The resulting word is assigned to the 'opt' variable
+# 1: the word to be appended
+_add_suffix() {
+    case $1 in
+        *=) opt="$1" ;;
+        *) opt="$1 " ;;
+    esac
+}
+
+# Fills the completion array with the wordlist that start with the word
+# stored in the 'cur' variable
+# @: The word list
+_complete_list() {
+    local wordlist
+    wordlist="$@"
+    wordlist=($(compgen -W "$wordlist" -- "${cur-}"))
+    if [ "${#wordlist[@]}" == "1" ]; then
+        # Append a space if there is only one option
+        COMPREPLY=("${wordlist[0]} ")
+    else
+        COMPREPLY=(${wordlist[@]})
+    fi
+}
+
+# Perform a filename completion for the word stored in the 'cur' variable
+_complete_files() {
+    local files
+    files=($(compgen -f -o filenames -- "${cur-}"))
+    COMPREPLY=(${files[@]})
+
+    # use a hack to enable file mode in bash < 4
+    # see: https://github.com/git/git/commit/3ffa4df4b2a26768938fc6bf1ed0640885b2bdf1
+    compopt -o filenames +o nospace 2>/dev/null ||
+    compgen -f /non-existing-dir/ > /dev/null ||
+    true
+}
+
+# Returns success if the current option matches the option specified in the arguments
+# 1: the short option
+# 2: the matching long option
+_is_option() {
+    local prev pprev
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    pprev="${COMP_WORDS[COMP_CWORD-2]}"
+
+    if [ "$prev" = "-$1" ] || [ "$prev" = "--$2" ] ||
+        $([ "$prev" = "=" ] && [ "$pprev" = "--$2" ]); then
+            return 0
+        else
+            return 1
+    fi
+}

--- a/susemanager/bash-completion/completions/mgr-create-bootstrap-repo.bash
+++ b/susemanager/bash-completion/completions/mgr-create-bootstrap-repo.bash
@@ -1,0 +1,42 @@
+__mgr_create_bootstrap_repo_options="h:help n:dryrun i:interactive l:list c:create= a:auto
+    datamodule= d:debug f:flush no-flush force with-custom-channels with-parent-channel="
+
+_mgr_create_bootstrap_repo_completions() {
+    local cur IFS=$' \t\n'
+    cur="${COMP_WORDS[COMP_CWORD]}"
+
+    # Replace short options with long versions
+    local short long c i
+    for c in $__mgr_create_bootstrap_repo_options; do
+        short="${c%%:*}"
+        long="${c#*:}"
+        if [ "-$short" = "$cur" ]; then
+            _add_suffix $long
+            COMPREPLY[i++]="--$opt"
+            return
+        fi
+    done
+
+    # Complete channels
+    if _is_option c create; then
+        cur="${cur#=}"
+        _complete_list $(mgr-create-bootstrap-repo --list | sed 's/^[^\.]*\. //')
+        return
+    fi
+
+    # Long options
+    case "$cur" in
+        *=) ;;
+        -*)
+            for o in $__mgr_create_bootstrap_repo_options; do
+                o="${o#*:}"
+                if [[ "--$o" = "$cur"* ]]; then
+                    _add_suffix $o
+                    COMPREPLY[i++]="--$opt"
+                fi
+            done
+            ;;
+    esac
+}
+
+complete -o nospace -F _mgr_create_bootstrap_repo_completions mgr-create-bootstrap-repo

--- a/susemanager/bash-completion/completions/mgr-sync.bash
+++ b/susemanager/bash-completion/completions/mgr-sync.bash
@@ -1,0 +1,148 @@
+__mgr_sync_cmds="list add refresh delete sync"
+__mgr_sync_add_cmds="channels credentials products" # list, add
+__mgr_sync_delete_cmds="credentials"
+__mgr_sync_sync_cmds="channels"
+
+__mgr_sync_options="h:help version v:verbose s:store-credentials d:debug"
+__mgr_sync_add_options="h:help from-mirror primary no-optional no-recommends no-sync"
+__mgr_sync_list_options="h:help e:expand f:filter no-optional c:compact"
+__mgr_sync_refresh_options="h:help refresh-channels from-mirror= schedule"
+__mgr_sync_delete_options="h:help"
+__mgr_sync_sync_options="h:help with-children"
+
+__mgr_sync_arg_opts="d:debug f:filter f:from-mirror"
+
+# Returns success if a word is an option that expects an argument
+# 1: The word to be tested
+_is_arg_opt() {
+    local short long o opt
+    opt=${1##+(-)}
+    for o in ${__mgr_sync_arg_opts}; do
+        short="${o%%:*}"
+        long="${o#*:}"
+        if [ "$opt" = "$short" ] || [ "$opt" = "$long" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Perform option completion for the word stored in the 'cur' variable
+# @: List of available options
+_complete_options() {
+    # Replace short options with long versions
+    local short long c i
+    for c in "$@"; do
+        short="${c%%:*}"
+        long="${c#*:}"
+        if [ "-$short" = "$cur" ]; then
+            _add_suffix $long
+            COMPREPLY[i++]="--$opt"
+            return
+        fi
+    done
+
+    # Complete long options
+    local o
+    case "$cur" in
+        --*=) ;;
+        *)
+            for o in "$@"; do
+                o="${o#*:}"
+                if [[ "--$o" = "$cur"* ]]; then
+                    _add_suffix $o
+                    COMPREPLY[i++]="--$opt"
+                fi
+            done
+            ;;
+    esac
+}
+
+# Perform a context-sensitive option completion for the word stored in the
+# 'cur' variable, depending on the command
+# 1: The command
+_complete_cmd_options() {
+    case "$1" in
+        list)
+            _complete_options $__mgr_sync_list_options
+            ;;
+        add)
+            _complete_options $__mgr_sync_add_options
+            ;;
+        refresh)
+            _complete_options $__mgr_sync_refresh_options
+            ;;
+        delete)
+            _complete_options $__mgr_sync_delete_options
+            ;;
+        sync)
+            _complete_options $__mgr_sync_sync_options
+            ;;
+        *)
+            _complete_options $__mgr_sync_options
+            ;;
+    esac
+}
+
+_mgr_sync_completions() {
+    local cur word cmd1 cmd2 i IFS=$' \t\n'
+    cur="${COMP_WORDS[COMP_CWORD]}"
+
+    # Do not complete for options that expect args
+    local short long o
+    for o in ${__mgr_sync_arg_opts}; do
+        short="${o%%:*}"
+        long="${o#*:}"
+        _is_option "$short" "$long" && return
+    done
+
+    # Parse the command and subcommand
+    for i in $(seq 1 $(($COMP_CWORD-1)) ); do
+        word=${COMP_WORDS[i]}
+        if [[ "$word" != -* ]]; then
+            # Skip the option arguments
+            _is_arg_opt ${COMP_WORDS[i-1]} && continue
+            if [ -z "$cmd1" ]; then
+                cmd1=$word
+            else
+                cmd2=$word
+                break
+            fi
+        fi
+    done
+
+    case "$cur" in
+        --*=) ;;
+        -*)
+            # Complete options
+            _complete_cmd_options $cmd1 ;;
+        *)
+            # Complete commands
+            if [ -z "$cmd2" ]; then
+                case "$cmd1" in
+                    list)
+                        _complete_list $__mgr_sync_add_cmds
+                        ;;
+                    add)
+                        _complete_list $__mgr_sync_add_cmds
+                        ;;
+                    refresh)
+                        ;;
+                    delete)
+                        _complete_list $__mgr_sync_delete_cmds
+                        ;;
+                    sync)
+                        _complete_list $__mgr_sync_sync_cmds
+                        ;;
+                    *)
+                        _complete_list $__mgr_sync_cmds
+                        ;;
+                esac
+            else
+                _complete_cmd_options $cmd1
+            fi
+            ;;
+    esac
+}
+
+complete -o nospace -F _mgr_sync_completions mgr-sync

--- a/susemanager/bash-completion/completions/spacewalk-common-channels.bash
+++ b/susemanager/bash-completion/completions/spacewalk-common-channels.bash
@@ -1,0 +1,55 @@
+__spacewalk_common_channels_options="c:config= u:user= p:password= s:server= k:keys= n:dry-run
+    a:archs= v:verbose l:list d:default-channels h:help"
+
+_spacewalk_common_channels_completions() {
+    local cur IFS=$' \t\n'
+    cur="${COMP_WORDS[COMP_CWORD]}"
+
+    # Replace short options with long versions
+    local short long c i
+    for c in $__spacewalk_common_channels_options; do
+        short="${c%%:*}"
+        long="${c#*:}"
+        if [ "-$short" = "$cur" ]; then
+            _add_suffix $long
+            COMPREPLY[i++]="--$opt"
+            return
+        fi
+    done
+
+    # Complete filenames for config
+    if _is_option c config; then
+        cur="${cur#=}"
+        _complete_files
+        return
+    fi
+
+
+    # Complete architectures
+    if _is_option a archs; then
+        cur="${cur#=}"
+        _complete_list $(spacewalk-common-channels --list | tail -n +2 |
+            sed 's/^[^:]*:\s\+//' | sed 's/, /\n/g' | sort | uniq)
+        return
+    fi
+
+    # Long options
+    case "$cur" in
+    --*=) ;;
+    -*)
+        for o in $__spacewalk_common_channels_options; do
+            o="${o#*:}"
+            if [[ "--$o" = "$cur"* ]]; then
+                _add_suffix $o
+                COMPREPLY[i++]="--$opt"
+            fi
+        done
+        ;;
+    *)
+        # Complete channels
+        _complete_list $(spacewalk-common-channels --list | tail -n +2 | sed 's/:.*$//')
+        ;;
+    esac
+}
+
+complete -o nospace -F _spacewalk_common_channels_completions spacewalk-common-channels

--- a/susemanager/bash-completion/completions/spacewalk-remove-channel.bash
+++ b/susemanager/bash-completion/completions/spacewalk-remove-channel.bash
@@ -1,0 +1,51 @@
+__spacewalk_remove_channel_options="v:verbose l:list c:channel= a:channel-with-children=
+    u:unsubscribe justdb force p:skip-packages skip-kickstart-trees just-kickstart-trees
+    skip-channels username= password= h:help"
+
+_spacewalk_remove_channel_completions() {
+    local cur IFS=$' \t\n'
+    cur="${COMP_WORDS[COMP_CWORD]}"
+
+    # Replace short options with long versions
+    local short long c i
+    for c in $__spacewalk_remove_channel_options; do
+        short="${c%%:*}"
+        long="${c#*:}"
+        if [ "-$short" = "$cur" ]; then
+            _add_suffix $long
+            COMPREPLY[i++]="--$opt"
+            return
+        fi
+    done
+
+
+    # Complete channels
+    if _is_option c channel; then
+        cur="${cur#=}"
+        _complete_list $(spacewalk-remove-channel --list | sed 's/\s+//')
+        return
+    fi
+
+    # Complete base channels
+    if _is_option a channel-with-children; then
+        cur="${cur#=}"
+        _complete_list $(spacewalk-remove-channel --list | grep '^\w')
+        return
+    fi
+
+    # Long options
+    case "$cur" in
+    *=) ;;
+    *)
+        for o in $__spacewalk_remove_channel_options; do
+            o="${o#*:}"
+            if [[ "--$o" = "$cur"* ]]; then
+                _add_suffix $o
+                COMPREPLY[i++]="--$opt"
+            fi
+        done
+        ;;
+    esac
+}
+
+complete -o nospace -F _spacewalk_remove_channel_completions spacewalk-remove-channel

--- a/susemanager/bash-completion/completions/spacewalk-repo-sync.bash
+++ b/susemanager/bash-completion/completions/spacewalk-repo-sync.bash
@@ -1,0 +1,66 @@
+__spacewalk_repo_sync_options="h:help l:list s:show-packages u:url= c:channel=
+    p:parent-channel= d:dry-run :latest g:config= t:type= f:fail n:non-interactive
+    i:include= e:exclude= :email :traceback-mail= :no-errata :no-packages :sync-kickstart
+    :force-all-errata :batch-size= Y:deep-verify v:verbose"
+
+_spacewalk_repo_sync_completions() {
+    local cur IFS=$' \t\n'
+    cur="${COMP_WORDS[COMP_CWORD]}"
+
+    # Replace short options with long versions
+    local short long c i
+    for c in $__spacewalk_repo_sync_options; do
+        short="${c%%:*}"
+        long="${c#*:}"
+        if [ "-$short" = "$cur" ]; then
+            _add_suffix $long
+            COMPREPLY[i++]="--$opt"
+            return
+        fi
+    done
+
+
+    # Complete channels
+    if _is_option c channel; then
+        cur="${cur#=}"
+        _complete_list $(spacewalk-remove-channel --list | sed 's/\s+//')
+        return
+    fi
+
+    # Complete base channels
+    if _is_option p parent-channel; then
+        cur="${cur#=}"
+        _complete_list $(spacewalk-remove-channel --list | grep '^\w')
+        return
+    fi
+
+    # Complete repo types
+    if _is_option t type; then
+        cur="${cur#=}"
+        _complete_list "yum uln deb"
+        return
+    fi
+
+    # Complete filenames for config
+    if _is_option c config; then
+        cur="${cur#=}"
+        _complete_files
+        return
+    fi
+
+    # Long options
+    case "$cur" in
+    *=) ;;
+    *)
+        for o in $__spacewalk_repo_sync_options; do
+            o="${o#*:}"
+            if [[ "--$o" = "$cur"* ]]; then
+                _add_suffix $o
+                COMPREPLY[i++]="--$opt"
+            fi
+        done
+        ;;
+    esac
+}
+
+complete -o nospace -F _spacewalk_repo_sync_completions spacewalk-repo-sync

--- a/susemanager/susemanager.changes.cbbayburt.bash-completion
+++ b/susemanager/susemanager.changes.cbbayburt.bash-completion
@@ -1,0 +1,1 @@
+- Add bash completion for CLI tools

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -162,6 +162,13 @@ BuildRequires:  docbook-utils
 %description tools
 This package contains SUSE Manager tools
 
+%package bash-completion
+Summary:        Bash completion for SUSE Manager CLI tools
+Group:          Productivity/Other
+
+%description bash-completion
+Bash completion for SUSE Manager CLI tools
+
 %prep
 %setup -q
 
@@ -174,6 +181,9 @@ do
     sed -i '1s=^#!/usr/bin/\(python\|env python\)[0-9.]*=#!/usr/bin/python3=' $i;
 done
 %endif
+
+# Bash completion
+%make_build -C bash-completion
 
 %install
 mkdir -p %{buildroot}/%{_prefix}/lib/susemanager/bin/
@@ -229,6 +239,9 @@ rm -f %{buildroot}/%{_prefix}/lib/susemanager/bin/server-migrator.sh
 make -C po install PREFIX=$RPM_BUILD_ROOT
 
 %find_lang susemanager
+
+# Bash completion
+%make_install -C bash-completion
 
 %check
 # we need to build a fake python dir. python did not work with
@@ -329,5 +342,12 @@ sed -i '/You can access .* via https:\/\//d' /tmp/motd 2> /dev/null ||:
 %{reporoot}/repositories/empty-deb/Packages
 %{reporoot}/repositories/empty-deb/Release
 /etc/apache2/conf.d/empty-repo.conf
+
+%files bash-completion
+%{_datadir}/bash-completion/completions/mgr-sync
+%{_datadir}/bash-completion/completions/mgr-create-bootstrap-repo
+%{_datadir}/bash-completion/completions/spacewalk-common-channels
+%{_datadir}/bash-completion/completions/spacewalk-remove-channel
+%{_datadir}/bash-completion/completions/spacewalk-repo-sync
 
 %changelog

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -165,6 +165,9 @@ This package contains SUSE Manager tools
 %package bash-completion
 Summary:        Bash completion for SUSE Manager CLI tools
 Group:          Productivity/Other
+Supplements:    spacewalk-backend
+Supplements:    susemanager
+Supplements:    spacewalk-utils
 
 %description bash-completion
 Bash completion for SUSE Manager CLI tools


### PR DESCRIPTION
Provide bash completion scripts for the following CLI tools:
 - spacewalk-remove-channel
 - spacewalk-common-channels
 - mgr-sync
 - mgr-create-bootstrap-repo
 - spacewalk-repo-sync

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
