### PR TITLE
PoC: Push code coverage from each feature into a Redis DB

### DIFF
--- a/.github/scripts/test_covering_pr.js
+++ b/.github/scripts/test_covering_pr.js
@@ -1,0 +1,30 @@
+const Redis = require('ioredis');
+const fs = require('fs').promises;
+
+const main = async () => {
+    const changedFiles = process.argv.slice(2)
+    const redis = new Redis({
+        host: process.env.REDIS_HOST,
+        port: process.env.REDIS_PORT,
+        username: process.env.REDIS_USER,
+        password: process.env.REDIS_PASS,
+        enableReadyCheck: false
+    });
+    let tests = new Set();
+
+    /**
+     * Loop over all the files changed in the PR and check if it's covered by a test
+     **/
+    for (const filepath of changedFiles) {
+        var classpath = filepath.replace('java/code/src/', '');
+        await redis.smembers(classpath, function(err, test_names) {
+            test_names.forEach(function(test) {
+                tests.add(test);
+            });
+        });
+    }
+
+    console.log('<html><ul><li>%s</ul></html>', Array.from(tests).join('<li>'));
+    process.exit(0);
+}
+main();

--- a/.github/workflows/test-covering-pr.yml
+++ b/.github/workflows/test-covering-pr.yml
@@ -1,0 +1,41 @@
+name: 'Suggested tests to cover this Pull Request'
+
+on:
+  pull_request:
+    paths:
+      - '**.java'
+  pull_request_target:
+    paths:
+      - '**.java'
+
+jobs:
+  tests-covering-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Use Node.js 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm i ioredis
+      - id: files
+        uses: Ana06/get-changed-files@v2.2.0
+        with:
+          filter: '*.java'
+      - id: tests_covering_pr
+        name: Tests covering PR
+        env:
+          REDIS_USER: ${{ secrets.REDIS_USER }}
+          REDIS_PASS: ${{ secrets.REDIS_PASS }}
+          REDIS_HOST: ${{ secrets.REDIS_HOST }}
+          REDIS_PORT: ${{ secrets.REDIS_PORT }}
+        run: echo "result=$(node .github/scripts/test_covering_pr.js ${{ steps.files.outputs.added_modified }})" >> $GITHUB_OUTPUT
+      - name: Write a comment into the Pull Request
+        uses: actions-cool/maintain-one-comment@v3
+        with:
+          body: |
+            #### :mag_right: Suggested tests to cover this Pull Request
+            ${{ steps.tests_covering_pr.outputs.result }}
+          body-include: ':mag_right:'

--- a/testsuite/Gemfile
+++ b/testsuite/Gemfile
@@ -23,6 +23,7 @@ gem 'syntax', "~> 1.2"
 gem 'parallel_tests', "~> 3.12"
 gem 'simplecov', "~> 0.22"
 gem 'rubocop', '0.83.0'
+gem 'redis', '~> 5.0'
 # Pre-requisite:
 # Add repository https://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/<your_distro> and install twopence RPMs
 # or build and install from https://github.com/openSUSE/twopence

--- a/testsuite/features/support/code_coverage.rb
+++ b/testsuite/features/support/code_coverage.rb
@@ -1,0 +1,76 @@
+# Copyright (c) 2016-2023 SUSE LLC.
+# Licensed under the terms of the MIT license.
+require 'redis'
+require 'nokogiri'
+require 'open-uri'
+
+# CodeCoverage handler to produce, parse and report Code Coverage from the Jave Server to our GitHub PRs
+class CodeCoverage
+  include(Nokogiri::XML)
+  ##
+  # Initialize a connection with a Redis database
+  def initialize(redis_host, redis_port, redis_username, redis_password)
+    @database = Redis.new(host: redis_host, port: redis_port, username: redis_username, password: redis_password)
+  end
+
+  ##
+  # Close the connection with the Redis database
+  def close
+    @database.close
+  end
+
+  ##
+  # Parse a JaCoCo XML report, extracting information that will be included in a Set on a Redis database
+  #
+  # Args:
+  #   feature_name: The feature name of the code coverage report we want to parse and push to Redis
+  def push_feature_coverage(feature_name)
+    filename = "/tmp/jacoco-#{feature_name}.xml"
+    begin
+      xml = File.read(filename, mode: 'r')
+      options = Nokogiri::XML::ParseOptions.new(ParseOptions::HUGE | ParseOptions::RECOVER | ParseOptions::NONET)
+      tree = Nokogiri::XML::Document.parse(xml, nil, nil, options)
+      tree.xpath('.//package').each do |package|
+        package_name = package.attr('name')
+        package.xpath('.//sourcefile').each do |sourcefile|
+          sourcefile_name = sourcefile.attr('name')
+          counter_class = sourcefile.xpath(".//counter[@type='CLASS']")
+          next if counter_class.nil? || counter_class.attr('covered').to_s == ''
+
+          next unless Integer(counter_class.attr('covered').to_s).positive?
+
+          begin
+            @database.sadd("#{package_name}/#{sourcefile_name}", feature_name)
+          rescue StandardError => e
+            warn("#{e.backtrace} > #{package_name}/#{sourcefile_name} : #{feature_name}")
+          end
+        end
+      end
+    rescue StandardError => e
+      warn(e.backtrace)
+    ensure
+      File.delete(filename)
+    end
+  end
+
+  ##
+  # Generate a JaCoCo report naming it as the feature name passed by parameter
+  # (https://redis.io/docs/data-types/sets/)
+  #
+  # Args:
+  #   feature_name: The feature name of the code coverage report we want to generate
+  #   html: A boolean to export it as HTML
+  #   xml: A boolean to export it as XML
+  #   source: The path of the class files of the product (Jacoco will provide extra information if we provide it)
+  def jacoco_dump(feature_name, html = false, xml = true, source = false)
+    cli = 'java -jar /tmp/jacococli.jar'
+    html_report = html ? "--html /srv/www/htdocs/pub/jacoco-#{feature_name}" : ''
+    xml_report = xml ? "--xml /srv/www/htdocs/pub/jacoco-#{feature_name}.xml" : ''
+    sourcefiles = source ? '--sourcefiles /tmp/uyuni-master/java/code/src' : ''
+    classfiles = '--classfiles /srv/tomcat/webapps/rhn/WEB-INF/lib'
+    dump_path = "/tmp/jacoco-#{feature_name}.exec"
+    $server.run("#{cli} dump --address localhost --destfile #{dump_path} --port 6300 --reset")
+    $server.run("#{cli} report #{dump_path} #{html_report} #{xml_report} #{sourcefiles} #{classfiles}")
+    file_extract($server, "/srv/www/htdocs/pub/jacoco-#{feature_name}.xml", "/tmp/jacoco-#{feature_name}.xml")
+  end
+end

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -14,12 +14,20 @@ require 'securerandom'
 require 'selenium-webdriver'
 require 'multi_test'
 require 'set'
+require_relative 'code_coverage'
 
 ## code coverage analysis
 # SimpleCov.start
 
 server = ENV['SERVER']
-$debug_mode = true if ENV['DEBUG']
+if ENV['DEBUG']
+  $debug_mode = true
+  STDOUT.puts('DEBUG MODE ENABLED.')
+end
+if ENV['REDIS_HOST']
+  $code_coverage_mode = true
+  STDOUT.puts('CODE COVERAGE MODE ENABLED.')
+end
 
 # Channels triggered by our tests to be synchronized
 $channels_synchronized = Set[]
@@ -89,6 +97,9 @@ STDOUT.puts "Capybara APP Host: #{Capybara.app_host}:#{Capybara.server_port}"
 # enable minitest assertions in steps
 enable_assertions
 
+# Init CodeCoverage Handler
+$code_coverage = CodeCoverage.new(ENV['REDIS_HOST'], ENV['REDIS_PORT'], ENV['REDIS_USERNAME'], ENV['REDIS_PASSWORD']) if $code_coverage_mode
+
 # embed a screenshot after each failed scenario
 After do |scenario|
   current_epoch = Time.new.to_i
@@ -112,6 +123,31 @@ After do |scenario|
     end
   end
   page.instance_variable_set(:@touched, false)
+end
+
+# Process the code coverage for each feature when it ends
+def process_code_coverage
+  return if $feature_path.nil?
+
+  feature_filename = $feature_path.split(%r{(\.feature|\/)})[-2]
+  $code_coverage.jacoco_dump(feature_filename)
+  $code_coverage.push_feature_coverage(feature_filename)
+end
+
+# Dump feature code coverage into a Redis DB
+After do |scenario|
+  next unless $code_coverage_mode
+  next unless $feature_path != scenario.location.file
+
+  process_code_coverage
+  $feature_path = scenario.location.file
+end
+
+# Dump feature code coverage into a Redis DB, for the last feature
+AfterAll do
+  next unless $code_coverage_mode
+
+  process_code_coverage
 end
 
 # get the Cobbler log output when it fails

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -341,7 +341,7 @@ def client_public_ip(host)
       return output.split[1].split('/')[0]
     end
   end
-  raise 'Cannot resolve public ip'
+  raise "Cannot resolve public ip of #{host}"
 end
 
 # Initialize IP address or domain name


### PR DESCRIPTION
## What does this PR change?

This PR add a new functionality to our test framework.
If a flag in the environment variable is enabled, it will produce code coverage in the Java server using Jacoco.

1. It will generate a report once each test feature finish, and flush the cove coverage triggered to have new metrics on next test feature.

2. Also, once a feature finish and we have the code coverage report, we parse the XML report using Nokogiri and we push the results to a Redis database instance that is configurable by environment variables in our controller.

1. Finally, this PR includes a new GitHub Action that will suggest as a comment in all new PRs opened, which are the Cucumber tests that will cover the product changes.

**Note**:
Before merging this PR, I will revert a commit including a change in `java/code/src/com/suse/manager/api/HttpApiResponse.java` that was only commited to test the GitHub action and the comment that you can see bellow this PR.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Documentation might come later

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Internal Code Coverage Jenkins Pipeline:
https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-master-dev-acceptance-tests-code-coverage/

Ports:
- GitHub actions are only supported in Uyuni, so we will only generate code coverage for Uyuni

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
