### PR TITLE
Fix spacecmd output for softwarechannel diffs (bsc#1207352)

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,6 @@
+- Fix spacecmd not showing any output for softwarechannel_diff 
+  and softwarechannel_errata_diff (bsc#1207352)
+
 -------------------------------------------------------------------
 Mon Jan 23 08:24:16 CET 2023 - jgonzalez@suse.com
 

--- a/spacecmd/src/spacecmd/softwarechannel.py
+++ b/spacecmd/src/spacecmd/softwarechannel.py
@@ -2164,8 +2164,8 @@ def do_softwarechannel_diff(self, args):
     # therefore there is no need to use replace dicts
     source_data = self.dump_softwarechannel(source_channel, None)
     target_data = self.dump_softwarechannel(target_channel, None)
-
-    return diff(source_data, target_data, source_channel, target_channel)
+    for line in diff(source_data, target_data, source_channel, target_channel):
+        print(line)
 
 ####################
 
@@ -2227,7 +2227,8 @@ def do_softwarechannel_errata_diff(self, args):
     # therefore there is no need to use replace dicts
     source_data = self.dump_softwarechannel_errata(source_channel)
     target_data = self.dump_softwarechannel_errata(target_channel)
-    return diff(source_data, target_data, source_channel, target_channel)
+    for line in diff(source_data, target_data, source_channel, target_channel):
+        print(line)
 
 ####################
 

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -3,7 +3,7 @@
 Test software channel module.
 """
 
-from mock import MagicMock, patch
+from mock import Mock, MagicMock, patch
 import spacecmd.softwarechannel
 from helpers import shell, assert_expect, assert_list_args_expect
 import pytest
@@ -638,3 +638,65 @@ def test_listlatestpackages_channel_packages_as_data(shell):
     assert shell.client.channel.software.listAllPackages.called
 
     assert out == ['emacs-42.0-9.x86_64', 'emacs-nox-42.0-10.x86_64', 'tiff-1.0-11:3.x86_64']
+
+def test_softwarechannel_diff(shell):
+    """
+    Test that do_softwarechannel_diff function prints correct output
+    :param shell: SpacewalkShell
+    :return: None
+    """
+
+    shell.dump_softwarechannel = Mock(
+        side_effect=[["hwdata-0.314-10.9.1.noarch"], ["koan-2.4.2-6.34.noarch"]]
+    )
+
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint):
+        out = spacecmd.softwarechannel.do_softwarechannel_diff(
+            shell, "source_channel target_channel"
+        )
+
+    assert out is None
+    assert_list_args_expect(
+        mprint.call_args_list,
+        [
+            "--- source_channel\n",
+            "+++ target_channel\n",
+            "@@ -1 +1 @@\n",
+            "-hwdata-0.314-10.9.1.noarch",
+            "+koan-2.4.2-6.34.noarch",
+        ],
+    )
+
+def test_softwarechannel_errata_diff(shell):
+    """
+    Test that do_softwarechannel_errata_diff function prints correct output
+    :param shell: SpacewalkShell
+    :return: None
+    """
+
+    shell.dump_softwarechannel_errata = Mock(
+        side_effect=[
+            ["SUSE-12-2021-607 important: Security update for python-Jinja2"],
+            ["SUSE-12-2021-3660 Recommended update for NetworkManager"],
+        ]
+    )
+
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint):
+        out = spacecmd.softwarechannel.do_softwarechannel_errata_diff(
+            shell, "source_channel target_channel"
+        )
+
+    assert out is None
+    assert_list_args_expect(
+        mprint.call_args_list,
+        [
+            "--- source_channel\n",
+            "+++ target_channel\n",
+            "@@ -1 +1 @@\n",
+            "-SUSE-12-2021-607 important: Security update for python-Jinja2",
+            "+SUSE-12-2021-3660 Recommended update for NetworkManager",
+        ],
+    )
+


### PR DESCRIPTION
## What does this PR change?

spacecmd commands `softwarechannel_diff` and `softwarechannel_errata_diff` were not showing any output. Now they print the result of the diff properly.

## GUI diff

No difference.


- [X] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [X] **DONE**

## Test coverage

- Unit tests were added


- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20279

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
