### PR TITLE
Specify the required cobbler version at a single place: patterns

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,6 +1,8 @@
 - Improve automatic dependency selection for vendor clones
 - Fix taskomatic logging (bsc#1207867)
 - Added APIs to allow frontend to install and remove ptf
+- Do not specify a cobbler version, as that is now centralized at the
+  patterns
 - Fix not being able to delete CLM environment if there are custom child
   channels that where not built by the environment (bsc#1206932)
 - Makes systems column sortable on relevant patch page, to list by most affected systems

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -177,7 +177,7 @@ Requires:       bcel
 Requires:       byte-buddy
 Requires:       c3p0 >= 0.9.1
 Requires:       cglib
-Requires:       cobbler >= 3.3.3
+Requires:       cobbler
 Requires:       concurrent
 Requires:       dwr >= 3
 Requires:       glassfish-jaxb-runtime
@@ -355,7 +355,7 @@ Requires:       bcel
 Requires:       byte-buddy
 Requires:       c3p0 >= 0.9.1
 Requires:       cglib
-Requires:       cobbler >= 3.3.3
+Requires:       cobbler
 Requires:       concurrent
 Requires:       hibernate-commons-annotations
 Requires:       httpcomponents-client

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,4 +1,6 @@
 - add logspec param in rhn.conf to set urlgrabber loglevel
+- Do not specify a cobbler version, as that is now centralized at the
+  patterns
 
 -------------------------------------------------------------------
 Tue Jan 24 13:12:35 CET 2023 - jgonzalez@suse.com

--- a/python/spacewalk/spacewalk-backend.spec
+++ b/python/spacewalk/spacewalk-backend.spec
@@ -253,7 +253,7 @@ Requires:       mod_ssl
 %endif
 Requires:       %{m2crypto}
 Requires:       %{name}-xml-export-libs
-Requires:       cobbler >= 3.3.3
+Requires:       cobbler
 Requires:       python3-requests
 Requires:       python3-rhnlib  >= 2.5.57
 

--- a/spacewalk/package/spacewalk.changes
+++ b/spacewalk/package/spacewalk.changes
@@ -1,3 +1,6 @@
+- Do not specify a cobbler version, as that is now centralized at the
+  patterns
+
 -------------------------------------------------------------------
 Wed Dec 14 14:13:41 CET 2022 - jgonzalez@suse.com
 

--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -84,7 +84,7 @@ Requires:       susemanager-sls
 
 Obsoletes:      spacewalk-monitoring < 2.3
 
-Requires:       cobbler >= 3
+Requires:       cobbler
 Requires:       susemanager-jsp_en
 
 # weakremover used on SUSE to get rid of orphan packages which are

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,6 @@
+- Do not specify a cobbler version, as that is now centralized at the
+  patterns
+
 -------------------------------------------------------------------
 Wed Dec 14 14:07:13 CET 2022 - jgonzalez@suse.com
 

--- a/spacewalk/setup/spacewalk-setup.spec
+++ b/spacewalk/setup/spacewalk-setup.spec
@@ -89,7 +89,7 @@ BuildRequires:  perl-libwww-perl
 %else
 Requires:       %{sbinpath}/restorecon
 %endif
-Requires(post): cobbler >= 3.3.3
+Requires(post): cobbler
 Requires:       perl-Satcon
 Requires:       spacewalk-admin
 Requires:       spacewalk-backend-tools


### PR DESCRIPTION
## What does this PR change?

Specify the required cobbler version at a single place: patterns, so we have a single place to change when we need a new cobbler version, and so we lower the risk of conflicts with PackageHub, as discussed at https://github.com/SUSE/spacewalk/issues/19497 with Marina, and at Slack with Pablo.

**WARNING: To be merged with the SR https://build.opensuse.org/request/show/1064014!**

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Internal change

- [x] **DONE**

## Test coverage
- No tests: Installation and acceptance tests will test it.

- [x] **DONE**

## Links

Partial fix for https://github.com/SUSE/spacewalk/issues/19497 (will require backporting to SUSE Manager 4.3)

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
