### PR TITLE
Avoid using env labels containing dots in modal IDs in CLM (bsc#1207838)

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/mappers/ResponseMappers.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/mappers/ResponseMappers.java
@@ -136,6 +136,7 @@ public class ResponseMappers {
                 .stream()
                 .map(envDB -> {
                     EnvironmentResponse environmentResponse = new EnvironmentResponse();
+                    environmentResponse.setId(envDB.getId());
                     environmentResponse.setLabel(envDB.getLabel());
                     environmentResponse.setName(envDB.getName());
                     environmentResponse.setVersion(envDB.getVersion());

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/response/EnvironmentResponse.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/response/EnvironmentResponse.java
@@ -21,6 +21,7 @@ import java.util.Date;
  */
 public class EnvironmentResponse {
 
+    private long id;
     private String projectLabel;
     private String label;
     private String name;
@@ -29,6 +30,10 @@ public class EnvironmentResponse {
     private String status;
     private Date builtTime;
     private boolean hasProfiles;
+
+    public void setId(long idIn) {
+        id = idIn;
+    }
 
     public void setStatus(String statusIn) {
         this.status = statusIn;

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix CLM environments UI for environment labels containing dots (bsc#1207838)
 - Change Rocky Linux Advisory page URL
 - Mark as failed actions that cannot be scheduled because earliest
   date is too old

--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.tsx
@@ -50,7 +50,7 @@ const EnvironmentView = React.memo((props: Props) => {
         <dt className="col-xs-3">{t("Version")}:</dt>
         <dd className="col-xs-9">
           <BuildVersion
-            id={`${props.environment.version}_${props.environment.label}`}
+            id={`${props.environment.version}_${props.environment.id}`}
             text={getVersionMessageByNumber(props.environment.version, props.historyEntries) || t("not built")}
             collapsed={true}
           />

--- a/web/html/src/manager/content-management/shared/components/panels/promote/promote.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/promote/promote.tsx
@@ -41,7 +41,7 @@ const Promote = (props: Props) => {
     }
   }, [open]);
 
-  const modalNameId = `${props.environmentPromote.label}-cm-promote-env-modal`;
+  const modalNameId = `cm-promote-env-modal-${props.environmentPromote.id}`;
 
   const disabled =
     !hasEditingPermissions ||
@@ -55,7 +55,7 @@ const Promote = (props: Props) => {
       <DownArrow />
       <div className="text-center">
         <ModalButton
-          id={`${props.environmentPromote.label}-promote-modal-link`}
+          id={`promote-modal-link-${props.environmentPromote.id}`}
           className="btn-default"
           text={t("Promote")}
           disabled={disabled}
@@ -80,7 +80,7 @@ const Promote = (props: Props) => {
                 <dt className="col-xs-4">{t("Version")}:</dt>
                 <dd className="col-xs-8">
                   <BuildVersion
-                    id={`${props.environmentPromote.version}_promote_${props.environmentTarget.label}`}
+                    id={`${props.environmentPromote.version}_promote_${props.environmentTarget.id}`}
                     text={
                       getVersionMessageByNumber(props.environmentPromote.version, props.historyEntries) ||
                       t("not built")

--- a/web/html/src/manager/content-management/shared/type/project.type.ts
+++ b/web/html/src/manager/content-management/shared/type/project.type.ts
@@ -21,6 +21,7 @@ export type ProjectSoftwareSourceType = {
 };
 
 export type ProjectEnvironmentType = {
+  id: number;
   projectLabel: string;
   label: string;
   name: string;

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix CLM environments UI for environment labels containing dots (bsc#1207838)
 - Added pages to install and remove ptf
 
 -------------------------------------------------------------------


### PR DESCRIPTION
Dots in `id` attributes in DOM cause modal buttons to fail when targeting respective modals. A dot is a valid character in CLM project environment labels, so this PR avoids using environment labels in modal IDs and uses environment IDs instead.

See: https://bugzilla.suse.com/show_bug.cgi?id=1207838

Port of: https://github.com/SUSE/spacewalk/pull/20375

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
