### PR TITLE
Ignore the .obs-to-maven-cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ java/buildconf/tempjars/*
 java/.checkstyle
 java/.classpath
 java/.externalToolBuilders
+java/.obs-to-maven-cache
 java/.pmd
 java/.project
 java/.settings/*

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ java/buildconf/tempjars/*
 java/.checkstyle
 java/.classpath
 java/.externalToolBuilders
-java/.obs-to-maven-cache
 java/.pmd
 java/.project
 java/.settings/*
@@ -46,6 +45,7 @@ search-server/spacewalk-search/rhn_search_daemon.log
 search-server/spacewalk-search/buildconf/repository/
 *~
 *#*#*
+.obs-to-maven-cache
 .project
 .pydevproject
 .zanata-cache


### PR DESCRIPTION
## What does this PR change?

The cache directory for `obs-to-maven` (usually inside the `java` subfolder) should be ignored by git.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed.

- [X] **DONE**

## Test coverage

- No tests needed.

- [X] **DONE**

## Links

No links.

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
