### PR TITLE
Fix the taskomatic log handling

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/LogUtils.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/LogUtils.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.taskomatic;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.FileAppender;
+import org.apache.logging.log4j.core.config.AppenderRef;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.filter.ThresholdFilter;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+
+/**
+ * Utilities to setup loggers for taskomatic tasks
+ */
+public class LogUtils {
+
+    /**
+     * Setup the logger to output errors in an err file and everything else in an out file
+     *
+     * @param clazz the class to configure the logger for
+     * @param outPath the path for non-error logs
+     * @param errPath the path for error logs
+     * @return the configured logger
+     */
+    public static Logger configureLogger(Class<?> clazz, String outPath, String errPath) {
+
+        String loggerName = clazz.getName();
+        cleanLogging(loggerName);
+
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        final var config = context.getConfiguration();
+        LoggerConfig loggerConfig = config.getLoggerConfig(loggerName);
+
+        PatternLayout layout = PatternLayout.newBuilder()
+                .withPattern("%d [%t] %-5p %c - %m%n")
+                .withConfiguration(config)
+                .build();
+
+        // Carry over the log level changes from the config file to allow getting finer logs than INFO
+        Level level = loggerConfig.getLevel().isLessSpecificThan(Level.INFO) ? loggerConfig.getLevel() : Level.INFO;
+        config.removeLogger(loggerName);
+        Filter outFilter = ThresholdFilter.createFilter(Level.ERROR, Filter.Result.DENY, Filter.Result.ACCEPT);
+        Appender outAppender = FileAppender.newBuilder().withFileName(outPath)
+                .setName(loggerName + "fileAppender_out")
+                .setLayout(layout)
+                .setFilter(outFilter)
+                .build();
+        outAppender.start();
+
+        Filter errFilter = ThresholdFilter.createFilter(Level.ERROR, Filter.Result.ACCEPT, Filter.Result.DENY);
+        Appender errAppender = FileAppender.newBuilder().withFileName(errPath)
+                .setName(loggerName + "fileAppender_err")
+                .setLayout(layout)
+                .setFilter(errFilter)
+                .build();
+        errAppender.start();
+
+        AppenderRef[] refs = new AppenderRef[]{
+                AppenderRef.createAppenderRef(outAppender.getName(), null, null),
+                AppenderRef.createAppenderRef(errAppender.getName(), null, null)
+        };
+        config.addAppender(outAppender);
+        config.addAppender(errAppender);
+        loggerConfig = LoggerConfig.createLogger(false, level, loggerName, "false",
+                refs, null, config, null);
+        loggerConfig.addAppender(outAppender, level, outFilter);
+        loggerConfig.addAppender(errAppender, Level.ERROR, errFilter);
+        config.addLogger(loggerName, loggerConfig);
+
+        context.updateLoggers();
+        return context.getLogger(clazz);
+    }
+
+    /**
+     * Remove the logger appenders
+     *
+     * @param loggerName the name of logger for which to stop and remove the appenders
+     */
+    public static void cleanLogging(String loggerName) {
+        final var config = ((LoggerContext) LogManager.getContext(false)).getConfiguration();
+        LoggerConfig loggerConfig = config.getLoggerConfig(loggerName);
+        if (loggerConfig.getName().equals(loggerName)) {
+            for (var appender : config.getLoggerConfig(loggerName).getAppenders().values()) {
+                appender.stop();
+                config.getLoggerConfig(loggerName).removeAppender(appender.getName());
+                config.getAppenders().remove(appender.getName());
+            }
+        }
+    }
+
+    private LogUtils() {
+    }
+}

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ChannelRepodata.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ChannelRepodata.java
@@ -16,9 +16,6 @@ package com.redhat.rhn.taskomatic.task;
 
 import com.redhat.rhn.taskomatic.task.repomd.ChannelRepodataDriver;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 /**
  *
  *
@@ -26,15 +23,6 @@ import org.apache.logging.log4j.Logger;
 public class ChannelRepodata extends RhnQueueJob<ChannelRepodataDriver> {
 
     public static final String DISPLAY_NAME = "channel_repodata";
-    private static Logger log = null;
-
-    @Override
-    protected Logger getLogger() {
-        if (log == null) {
-            log = LogManager.getLogger(ChannelRepodata.class);
-        }
-        return log;
-    }
 
     @Override
     public String getConfigNamespace() {

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ErrataCacheTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ErrataCacheTask.java
@@ -16,9 +16,6 @@ package com.redhat.rhn.taskomatic.task;
 
 import com.redhat.rhn.taskomatic.task.errata.ErrataCacheDriver;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 
 /**
  * ErrataCacheTask
@@ -26,19 +23,10 @@ import org.apache.logging.log4j.Logger;
 public class ErrataCacheTask extends RhnQueueJob<ErrataCacheDriver> {
 
     public static final String DISPLAY_NAME = "errata_cache";
-    private static Logger log = null;
 
     @Override
     public String getConfigNamespace() {
         return "errata_cache";
-    }
-
-    @Override
-    protected Logger getLogger() {
-        if (log == null) {
-            log = LogManager.getLogger(ErrataCacheTask.class);
-        }
-        return log;
     }
 
     @Override

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ErrataQueue.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ErrataQueue.java
@@ -16,9 +16,6 @@ package com.redhat.rhn.taskomatic.task;
 
 import com.redhat.rhn.taskomatic.task.errata.ErrataQueueDriver;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 /**
  * Manages the pending errata queue
  *
@@ -26,19 +23,10 @@ import org.apache.logging.log4j.Logger;
 public class ErrataQueue extends RhnQueueJob<ErrataQueueDriver> {
 
     public static final String DISPLAY_NAME = "errata_queue";
-    private static Logger log = null;
 
     @Override
     public String getConfigNamespace() {
         return "errata_queue";
-    }
-
-    @Override
-    protected Logger getLogger() {
-        if (log == null) {
-            log = LogManager.getLogger(ErrataQueue.class);
-        }
-        return log;
     }
 
     @Override

--- a/java/code/src/com/redhat/rhn/taskomatic/task/HubReportDbUpdateTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/HubReportDbUpdateTask.java
@@ -14,21 +14,7 @@
  */
 package com.redhat.rhn.taskomatic.task;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-
 public class HubReportDbUpdateTask extends RhnQueueJob<HubReportDbUpdateDriver> {
-
-    private final Logger log = LogManager.getLogger(getClass());
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected Logger getLogger() {
-        return log;
-    }
 
     /**
      * {@inheritDoc}

--- a/java/code/src/com/redhat/rhn/taskomatic/task/RhnQueueJob.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/RhnQueueJob.java
@@ -16,17 +16,14 @@ package com.redhat.rhn.taskomatic.task;
 
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.taskomatic.LogUtils;
 import com.redhat.rhn.taskomatic.domain.TaskoRun;
 import com.redhat.rhn.taskomatic.task.threaded.QueueDriver;
 import com.redhat.rhn.taskomatic.task.threaded.TaskQueue;
 import com.redhat.rhn.taskomatic.task.threaded.TaskQueueFactory;
 
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.config.Configurator;
-import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 
@@ -42,7 +39,10 @@ import org.quartz.JobExecutionException;
 public abstract class RhnQueueJob<T extends QueueDriver<?>> implements RhnJob {
 
     private TaskoRun jobRun = null;
-    protected abstract Logger getLogger();
+    protected Logger log = LogManager.getLogger(getClass().getName());
+    protected Logger getLogger() {
+        return log;
+    }
 
     /**
      * {@inheritDoc}
@@ -53,30 +53,7 @@ public abstract class RhnQueueJob<T extends QueueDriver<?>> implements RhnJob {
     }
 
     private void logToNewFile() {
-
-        var loggerName = this.getClass().getName();
-        final var config = ((LoggerContext) LogManager.getContext(false)).getConfiguration();
-        for (var appender : config.getLoggerConfig(loggerName).getAppenders().values()) {
-            appender.stop();
-            config.getLoggerConfig(loggerName).removeAppender(appender.getName());
-        }
-        Configurator.reconfigure(config);
-
-        var builder = ConfigurationBuilderFactory.newConfigurationBuilder();
-
-        var layoutBuilder = builder
-                .newLayout("PatternLayout")
-                .addAttribute("pattern", DEFAULT_LOGGING_LAYOUT);
-        var appenderName = loggerName + "fileAppender";
-        var appenderBuilder = builder
-                .newAppender(appenderName, "File")
-                .addAttribute("fileName", jobRun.buildStdOutputLogPath())
-                .add(layoutBuilder);
-        builder.add(appenderBuilder);
-
-        var logger = builder.newLogger(loggerName, Level.INFO);
-        builder.add(logger.add(builder.newAppenderRef(appenderName)));
-        Configurator.reconfigure(builder.build());
+        log = LogUtils.configureLogger(getClass(), jobRun.buildStdOutputLogPath(), jobRun.buildStdErrorLogPath());
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/taskomatic/task/SSHPush.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/SSHPush.java
@@ -16,31 +16,16 @@ package com.redhat.rhn.taskomatic.task;
 
 import com.redhat.rhn.taskomatic.task.sshpush.SSHPushDriver;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 /**
  * Call rhn_check on relevant systems via SSH using remote port forwarding.
  */
 public class SSHPush extends RhnQueueJob<SSHPushDriver> {
 
     public static final String QUEUE_NAME = "ssh_push";
-    private static Logger log = null;
 
     @Override
     public String getConfigNamespace() {
         return "sshpush";
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected Logger getLogger() {
-        if (log == null) {
-            log = LogManager.getLogger(SSHPush.class);
-        }
-        return log;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/taskomatic/task/SystemOverviewUpdateQueue.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/SystemOverviewUpdateQueue.java
@@ -16,25 +16,15 @@ package com.redhat.rhn.taskomatic.task;
 
 import com.redhat.rhn.taskomatic.task.systems.SystemsOverviewUpdateDriver;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 /**
  * Manages the pending system overview updates queue
  *
  */
-public class SystemOverviewUpdateQueue extends RhnQueueJob {
-
-    private static final Logger LOG = LogManager.getLogger(SystemOverviewUpdateQueue.class);
+public class SystemOverviewUpdateQueue extends RhnQueueJob<SystemsOverviewUpdateDriver> {
 
     @Override
     public String getConfigNamespace() {
         return "system_overview_update_queue";
-    }
-
-    @Override
-    protected Logger getLogger() {
-        return LOG;
     }
 
     @Override
@@ -43,7 +33,7 @@ public class SystemOverviewUpdateQueue extends RhnQueueJob {
     }
 
     @Override
-    protected Class getDriverClass() {
+    protected Class<SystemsOverviewUpdateDriver> getDriverClass() {
         return SystemsOverviewUpdateDriver.class;
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/RhnJavaJobTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/RhnJavaJobTest.java
@@ -95,8 +95,8 @@ public class RhnJavaJobTest {
         var appenders = config.getAppenders();
         var appenderRefs = config.getAppenderRefs();
 
-        assertEquals(1, config.getAppenderRefs().size());
-        assertEquals(1, config.getAppenders().size());
+        assertEquals(2, config.getAppenderRefs().size());
+        assertEquals(2, config.getAppenders().size());
         assertEquals(
                 appenderRefs.stream().map(AppenderRef::getRef).collect(Collectors.toSet()),
                 appenders.keySet()

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix taskomatic logging (bsc#1207867)
 - Added APIs to allow frontend to install and remove ptf
 - Fix not being able to delete CLM environment if there are custom child
   channels that where not built by the environment (bsc#1206932)


### PR DESCRIPTION
## What does this PR change?

The current code was only configuring one appender, the log file never got anything and there where some race conditions with the files handling.

All the task configurations are applied on the main taskomatic log configuration, so we need to only touch what concerns the current task.

Creating a new logger out of the context with the changed configuration gets the data to the log files. And what's more: the log level can be changed in the /usr/share/rhn/classes/log4j2.xml file for the task, this will be taken into account at the next taskomatic start.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: Log handling changes

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20369 and https://github.com/SUSE/spacewalk/issues/20372
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
