### PR TITLE
Use transactional_update.reboot to reboot SLE Micro in an Action Chain

### DIFF
--- a/susemanager-utils/susemanager-sls/src/modules/mgractionchains.py
+++ b/susemanager-utils/susemanager-sls/src/modules/mgractionchains.py
@@ -170,9 +170,12 @@ def start(actionchain_id):
         inside_transaction = os.environ.get("TRANSACTIONAL_UPDATE")
 
     if transactional_update and not inside_transaction:
-        ret = __salt__['transactional_update.sls'](target_sls, queue=True, activate_transaction=reboot_required)
+        ret = __salt__['transactional_update.sls'](target_sls, queue=True, activate_transaction=False)
     else:
         ret = __salt__['state.sls'](target_sls, queue=True)
+
+    if reboot_required :
+        __salt__['transactional_update.reboot']()
 
     if isinstance(ret, list):
         raise CommandExecutionError(ret)
@@ -244,9 +247,12 @@ def resume():
         inside_transaction = os.environ.get("TRANSACTIONAL_UPDATE")
 
     if transactional_update and not inside_transaction:
-        ret = __salt__['transactional_update.sls'](next_chunk, queue=True, activate_transaction=reboot_required)
+        ret = __salt__['transactional_update.sls'](next_chunk, queue=True, activate_transaction=False)
     else:
         ret = __salt__['state.sls'](next_chunk, queue=True)
+
+    if reboot_required :
+        __salt__['transactional_update.reboot']()
 
     if isinstance(ret, list):
         raise CommandExecutionError(ret)

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix current limitation on Action Chains for SLE Micro
 - Support SLE Micro migration (bsc#1205011)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Now that reboot in SLE Micro works as expected, we can remove the `activate_transaction=true` workaround and run `transactional_update.reboot` outside the main transaction when the action chain contains a reboot command

LIMITATION:
`transactional_update.reboot` does not have the option `at_time` as `system.reboot`: this mean that the reboot is executed immediately, instead of after 3 minutes. This cause some issue on the visualization. Let's take an action chains with:
- package installation
- reboot
- package installation
- reboot

The action chain is executed correctly, but `System History` shows that these execution order (first action in the list is the first executed):
- package installation
- package installation
- reboot
- reboot

This happen because the time between the two reboot is too short.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: already covered

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20277

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
