### PR TITLE
Testsuite: Shortening xccdf result link

### DIFF
--- a/testsuite/features/secondary/min_deblike_openscap_audit.feature
+++ b/testsuite/features/secondary/min_deblike_openscap_audit.feature
@@ -39,7 +39,7 @@ Feature: OpenSCAP audit of Debian-like Salt minion
   Scenario: Check the results of the OpenSCAP scan on the Debian-like minion
     Given I am on the Systems overview page of this "deblike_minion"
     When I follow "Audit" in the content area
-    And I follow "xccdf_org.open-scap_testresult_xccdf_org"
+    And I follow "xccdf_org.open-scap_testresult"
     Then I should see a "Details of XCCDF Scan" text
     And I should see a "Ubuntu" text
     And I should see a "XCCDF Rule Results" text

--- a/testsuite/features/secondary/min_deblike_openscap_audit.feature
+++ b/testsuite/features/secondary/min_deblike_openscap_audit.feature
@@ -39,7 +39,7 @@ Feature: OpenSCAP audit of Debian-like Salt minion
   Scenario: Check the results of the OpenSCAP scan on the Debian-like minion
     Given I am on the Systems overview page of this "deblike_minion"
     When I follow "Audit" in the content area
-    And I follow "xccdf_org.open-scap_testresult_xccdf_org.ssgproject.content_profile_standard"
+    And I follow "xccdf_org.open-scap_testresult_xccdf_org"
     Then I should see a "Details of XCCDF Scan" text
     And I should see a "Ubuntu" text
     And I should see a "XCCDF Rule Results" text

--- a/testsuite/features/secondary/min_rhlike_openscap_audit.feature
+++ b/testsuite/features/secondary/min_rhlike_openscap_audit.feature
@@ -50,7 +50,7 @@ Feature: OpenSCAP audit of Red Hat-like Salt minion
   Scenario: Check the results of the OpenSCAP scan on the Red Hat-like minion
     Given I am on the Systems overview page of this "rhlike_minion"
     When I follow "Audit" in the content area
-    And I follow "xccdf_org.open-scap_testresult_xccdf_org.ssgproject.content_profile_standard"
+    And I follow "xccdf_org.open-scap_testresult"
     Then I should see a "Details of XCCDF Scan" text
     And I should see a "RHEL-8" text
     And I should see a "XCCDF Rule Results" text

--- a/testsuite/features/secondary/min_salt_openscap_audit.feature
+++ b/testsuite/features/secondary/min_salt_openscap_audit.feature
@@ -30,7 +30,7 @@ Feature: OpenSCAP audit of Salt minion
 
   Scenario: Check results of the audit job on the minion
     When I follow "Audit" in the content area
-    And I follow "xccdf_org.open-scap_testresult_xccdf_org.ssgproject.content_profile_standard"
+    And I follow "xccdf_org.open-scap_testresult"
     Then I should see a "Details of XCCDF Scan" text
     And I should see a "profile standard" text
     And I should see a "XCCDF Rule Results" text


### PR DESCRIPTION
## What does this PR change?

The link name for XCCDF results tends to change for some reason and needs to be adjusted in the testsuite - e.g. in https://github.com/SUSE/spacewalk/pull/20200 
To avoid adapting the testsuite every time, we can provide a partial name of the link to the testsuite that is common to the different possible names. 
Since only one result is available at a time, this PR won't create interference between Openscap features.
  
## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links

Fixes #
Tracks # 
4.2 https://github.com/SUSE/spacewalk/pull/20404
4.3 https://github.com/SUSE/spacewalk/pull/20405
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
