### PR TITLE
Additional PTFs fixes

### DIFF
--- a/java/code/src/com/redhat/rhn/common/security/acl/Access.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/Access.java
@@ -564,7 +564,7 @@ public class Access extends BaseHandler {
     }
 
     /**
-     * Checks if a server can support product temporary fixes (ptf).
+     * Checks if a server can support Program Temporary Fixes (PTFs).
      * @param ctx acl context
      * @param params parameters for acl
      * @return true if the server can have ptf

--- a/java/code/src/com/redhat/rhn/domain/server/Server.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Server.java
@@ -2318,7 +2318,7 @@ public class Server extends BaseDomainHelper implements Identifiable {
     }
 
     /**
-     * Return <code>true</code> if OS supports Product Temporary Fixes (PTF)
+     * Return <code>true</code> if OS supports Program Temporary Fixes (PTFs)
      *
      * @return <code>true</code> if OS supports PTF uninstallation
      */

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -582,7 +582,7 @@ public class ServerFactory extends HibernateFactory {
             }
 
             final RpmVersionComparator rpmVersionComparator = new RpmVersionComparator();
-            if ("15".equals(server.getRelease())) {
+            if (server.isSLES15()) {
                 return rpmVersionComparator.compare(zypperEvr.getVersion(), "1.14.59") >= 0;
             }
         }

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -1673,12 +1673,12 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
 
         Server ptfSupportNoUninstall = createTestServer(user);
         ptfSupportNoUninstall.setOs(ServerConstants.SLES);
-        ptfSupportNoUninstall.setRelease("15");
+        ptfSupportNoUninstall.setRelease("15.3");
         PackageTestUtils.installPackagesOnServer(List.of(zypperNoSupport), ptfSupportNoUninstall);
 
         Server ptfFullSupport = createTestServer(user);
         ptfFullSupport.setOs(ServerConstants.SLES);
-        ptfFullSupport.setRelease("15");
+        ptfFullSupport.setRelease("15.3");
         PackageTestUtils.installPackagesOnServer(List.of(zypperWithSupport), ptfFullSupport);
 
         noPtfSupport = TestUtils.reload(noPtfSupport);

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -733,7 +733,7 @@
       <trans-unit id="PTF" xml:space="preserve">
         <source>PTFs</source>
         <context-group name="ctx">
-          <context context-type="sourcefile">Product Temporary Fixes Navigation Tabs</context>
+          <context context-type="sourcefile">Program Temporary Fixes (PTFs) Navigation Tabs</context>
         </context-group>
       </trans-unit>
       <trans-unit id="Package Search" xml:space="preserve">
@@ -7611,10 +7611,10 @@ Follow this url to see the full list of inactive systems:
         <source>Invalid package: {0}</source>
       </trans-unit>
       <trans-unit id="api.package.ptfpackage" xml:space="preserve">
-        <source>Packages part of a Product Temporary Fixes (PTF): {0}</source>
+        <source>Packages part of a Program Temporary Fix (PTF): {0}</source>
       </trans-unit>
       <trans-unit id="api.package.ptfmaster" xml:space="preserve">
-        <source>Product Temporary Fixes packages (PTF): {0}</source>
+        <source>Program Temporary Fixes (PTFs) packages: {0}</source>
       </trans-unit>
       <trans-unit id="api.errata.duplicateerrata" xml:space="preserve">
         <source>Patch already exists with advisory {0}</source>

--- a/web/html/src/manager/content-management/shared/business/filters.enum.test.ts
+++ b/web/html/src/manager/content-management/shared/business/filters.enum.test.ts
@@ -218,7 +218,7 @@ describe("Testing filters enum and descriptions", () => {
     };
 
     expect(getClmFilterDescription(filter)).toEqual(
-      "filter all ptf: deny ptf all product temporary fixes ALL (ptf_all)"
+      "filter all ptf: deny ptf all program temporary fixes ALL (ptf_all)"
     );
   });
 

--- a/web/html/src/manager/content-management/shared/business/filters.enum.ts
+++ b/web/html/src/manager/content-management/shared/business/filters.enum.ts
@@ -128,7 +128,7 @@ const filterMatchers: FilterMatcherEnumType = {
   PTF_ALL: {
     key: "ptf_all",
     text: t("all"),
-    longDescription: t("all product temporary fixes"),
+    longDescription: t("all program temporary fixes"),
   },
 };
 

--- a/web/html/src/manager/minion/ptf/ptf-install.renderer.tsx
+++ b/web/html/src/manager/minion/ptf/ptf-install.renderer.tsx
@@ -24,16 +24,16 @@ export const renderer = (id) =>
       listDataAPI={`/rhn/manager/api/systems/${window.serverId}/details/ptf/available`}
       scheduleActionAPI={`/rhn/manager/api/systems/${window.serverId}/details/ptf/scheduleAction`}
       actionType="packages.update"
-      listTitle={t("Install Product Temporary Fixes")}
+      listTitle={t("Install Program Temporary Fixes (PTFs)")}
       listSummary={t(
-        "The following Product Temporary Fixes (PTF) are available for installation on this system. " +
+        "The following Program Temporary Fixes (PTFs) are available for installation on this system. " +
           "These packages are only meant to address a specific open issue. " +
           "Please follow the instructions from customer support before proceeding with the installation."
       )}
-      listEmptyText={t("No Product Temporary Fixes available.")}
-      listActionLabel={t("Install PTF")}
+      listEmptyText={t("No Program Temporary Fixes (PTFs) available.")}
+      listActionLabel={t("Install PTFs")}
       listColumns={[PTF_COLUMN_SUMMARY, PTF_COLUMN_ARCH]}
-      confirmTitle={t("Confirm Product Temporary Fixes Installation")}
+      confirmTitle={t("Confirm Program Temporary Fixes (PTFs) Installation")}
     />,
     document.getElementById(id)
   );

--- a/web/html/src/manager/minion/ptf/ptf-list-remove.renderer.tsx
+++ b/web/html/src/manager/minion/ptf/ptf-list-remove.renderer.tsx
@@ -24,17 +24,17 @@ export const renderer = (id) =>
       listDataAPI={`/rhn/manager/api/systems/${window.serverId}/details/ptf/installed`}
       scheduleActionAPI={`/rhn/manager/api/systems/${window.serverId}/details/ptf/scheduleAction`}
       actionType="packages.remove"
-      listTitle={t("Remove Product Temporary Fixes")}
+      listTitle={t("Remove Program Temporary Fixes (PTFs)")}
       listSummary={t(
-        "The following Product Temporary Fixes (PTF) are currently installed on this system. " +
+        "The following Program Temporary Fixes (PTFs) are currently installed on this system. " +
           'These PTFs may be scheduled for removal by selecting them and clicking "Remove PTF" below. ' +
           "Please note that removing any non-obsolete PTF will result in the installation of the most recent " +
           "versions of the packages that are part of the PTF."
       )}
-      listEmptyText={t("No Product Temporary Fixes installed.")}
-      listActionLabel={t("Remove PTF")}
+      listEmptyText={t("No Program Temporary Fixes (PTFs) installed.")}
+      listActionLabel={t("Remove PTFs")}
       listColumns={[PTF_COLUMN_SUMMARY, PTF_COLUMN_ARCH, PTF_COLUMN_INSTALL_DATE]}
-      confirmTitle={t("Confirm Product Temporary Fixes Removal")}
+      confirmTitle={t("Confirm Program Temporary Fixes (PTFs) Removal")}
     />,
     document.getElementById(id)
   );

--- a/web/html/src/manager/minion/ptf/ptf-overview.renderer.tsx
+++ b/web/html/src/manager/minion/ptf/ptf-overview.renderer.tsx
@@ -51,7 +51,7 @@ class PtfOverview extends React.Component<Props, State> {
     return (
       <>
         <MessagesContainer />
-        <InnerPanel title={t("Product Temporary Fixes (PTF)")} icon="fa-fire-extinguisher">
+        <InnerPanel title={t("Program Temporary Fixes (PTFs)")} icon="fa-fire-extinguisher">
           {this.state.loading ? (
             <Loading text={t("Loading...")} />
           ) : this.state.allowedActions.length === 0 ? (


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue where the wrong SLES version was used to check if the PTF uninstall feature was available. It also renames all the occurences of "Product Temporary Fixes" to the correct "Program Temporary Fixes (PTFs)" as used in the official documentation  (i.e. https://www.suse.com/support/kb/doc/?id=000018572)

## GUI diff

No UI difference, just naming corrections

- [X] **DONE**

## Documentation

Project lotus documentation WIP

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
