### PR TITLE
Add clear error message for Ace editor

### DIFF
--- a/web/html/src/components/ace-editor.tsx
+++ b/web/html/src/components/ace-editor.tsx
@@ -18,17 +18,24 @@ class AceEditor extends React.Component<Props> {
     const component = this;
 
     const node = ReactDOM.findDOMNode(component.refs.editor);
-    const editor = ace.edit(node);
-    editor.setTheme("ace/theme/xcode");
-    editor.getSession().setMode("ace/mode/" + component.props.mode);
-    editor.setShowPrintMargin(false);
-    editor.setOptions({ minLines: component.props.minLines });
-    editor.setOptions({ maxLines: component.props.maxLines });
-    editor.setReadOnly(component.props.readOnly);
+    try {
+      const editor = ace.edit(node);
+      editor.setTheme("ace/theme/xcode");
+      editor.getSession().setMode("ace/mode/" + component.props.mode);
+      editor.setShowPrintMargin(false);
+      editor.setOptions({ minLines: component.props.minLines });
+      editor.setOptions({ maxLines: component.props.maxLines });
+      editor.setReadOnly(component.props.readOnly);
 
-    editor.getSession().on("change", function () {
-      component.props.onChange?.(editor.getSession().getValue());
-    });
+      editor.getSession().on("change", function () {
+        component.props.onChange?.(editor.getSession().getValue());
+      });
+    } catch (error) {
+      Loggerhead.error(
+        "Failed to initialize AceEditor, please check if `ace-editor/ace.js` and related dependencies have been imported in your Jade/JSP template"
+      );
+      Loggerhead.error(error);
+    }
   }
 
   render() {


### PR DESCRIPTION
## What does this PR change?

Since Ace editor still relies on the global script being imported correctly, add a clearer error message to outline how to debug the issue.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
