### PR TITLE
handle ubuntu advisory ids with USN prefix (bsc#1207883)

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix NumberFormatException when syncing ubuntu errata (bsc#1207883)
 - Fix duplicate keys in suseImageFile and other tables (bsc#1207799)
 - Fix CLM environments UI for environment labels containing dots (bsc#1207838)
 - Change Rocky Linux Advisory page URL


### PR DESCRIPTION
## What does this PR change?

This fixes a NumberFormatException when importing ubuntu errata with a different format.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests: manually verified

- [x] **DONE**

## Links

Fixes #https://github.com/SUSE/spacewalk/issues/20337
Fixes https://github.com/uyuni-project/uyuni/issues/6534

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
