### PR TITLE
Fix UI bugs in susemanager-light and susemanager-dark theme

### DIFF
--- a/web/html/src/branding/css/base/theme.less
+++ b/web/html/src/branding/css/base/theme.less
@@ -263,6 +263,8 @@ header, nav.navbar-pf {
       margin-left: -4px;
       border-left: 1px dashed @gray-dark;
       color: @gray-light;
+      background-color: transparent;
+
       i {
         margin: 0;
       }
@@ -538,6 +540,7 @@ header, nav.navbar-pf {
   color: #666666;
   background-color: #ffffff;
   border-color: #cccccc;
+  margin-left: 8px !important;
 }
 
 .spacewalk-list {
@@ -547,6 +550,8 @@ header, nav.navbar-pf {
       width: auto;
     }
     .spacewalk-list-filter {
+      min-width: 33%;
+
       input.with-bottom-margin {
         margin-bottom: .5em;
       }

--- a/web/html/src/branding/css/susemanager/components/tables.less
+++ b/web/html/src/branding/css/susemanager/components/tables.less
@@ -16,15 +16,21 @@
 
 .table-search-wrapper {
   flex: 1;
-  display: flex;
-  align-items: center;
-  gap: 0.5em;
+
+  .form-group {
+    margin: 0;
+  }
 }
 
 .table-input-search {
-  width: 60%;
   max-width: 500px;
   display: inline-block;
+  margin-bottom: 4px;
+}
+
+.table-search-select-all {
+  margin-top: 4px;
+  margin-left: 4px;
 }
 
 thead tr {

--- a/web/html/src/components/table/SearchField.tsx
+++ b/web/html/src/components/table/SearchField.tsx
@@ -50,21 +50,22 @@ export function SearchField(props: SearchFieldProps) {
       {props.options != null && (
         <Select
           name="filter"
-          className="col-md-2"
           placeholder={t("Select a filter")}
           defaultValue={props.field}
           options={props.options}
           onChange={(name: string | undefined, value: string) => props.onSearchField?.(value)}
         />
       )}
-      <input
-        className="form-control table-input-search"
-        value={props.criteria || ""}
-        placeholder={props.placeholder}
-        type="text"
-        onChange={(e) => props.onSearch?.(e.target.value)}
-        name={props.name}
-      />
+      <div className="form-group">
+        <input
+          className="form-control table-input-search"
+          value={props.criteria || ""}
+          placeholder={props.placeholder}
+          type="text"
+          onChange={(e) => props.onSearch?.(e.target.value)}
+          name={props.name}
+        />
+      </div>
     </Form>
   );
 }

--- a/web/html/src/components/table/SearchPanel.tsx
+++ b/web/html/src/components/table/SearchPanel.tsx
@@ -52,7 +52,7 @@ export function SearchPanel(props: SearchPanelProps) {
           onSearchField: props.onSearchField,
         })
       )}
-      <div className="d-inline-block">
+      <div className="d-inline-block table-search-select-all">
         <span>{t("Items {0} - {1} of {2}", props.fromItem, props.toItem, props.itemCount)}&nbsp;&nbsp;</span>
         {props.selectable && props.selectedCount > 0 && (
           <span>

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Fix UI inconsistencies in susemanager-light and susemanager-dark
+  theme
 - Deprecate jQuery datepicker, integrate React datepicker
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Fix header color bug, make search box layouts flow similar to Uyuni theme.

## GUI diff

Before:

<img width="421" alt="Screenshot 2023-02-08 at 20 47 07" src="https://user-images.githubusercontent.com/3171718/217635946-8c5be658-f6e2-494d-bc8a-c84996f6b029.png">

<img width="651" alt="Screenshot 2023-02-08 at 20 47 16" src="https://user-images.githubusercontent.com/3171718/217635987-35d797ba-fcb2-4f23-98a9-80931a51927a.png">

After:

<img width="427" alt="Screenshot 2023-02-08 at 20 47 11" src="https://user-images.githubusercontent.com/3171718/217636031-d89b497c-d6bc-45b0-93e6-036945704d1b.png">

<img width="633" alt="Screenshot 2023-02-08 at 20 47 21" src="https://user-images.githubusercontent.com/3171718/217636069-4224c7d1-7244-46bc-9ed7-44df0141f0c4.png">

- [x] **DONE**

## Documentation
- No documentation needed: Bugfixes, no feature changes.

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19738

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
