### PR TITLE
Removed wrong quotes

### DIFF
--- a/web/html/src/manager/state/highstate.tsx
+++ b/web/html/src/manager/state/highstate.tsx
@@ -68,7 +68,7 @@ class Highstate extends React.Component<HighstateProps, HighstateState> {
             </span>
           ) : (
             <span>
-              {t("Applying the highstate has been '{0}'.", <ActionLink id={data}>{t("scheduled")}</ActionLink>)}
+              {t("Applying the highstate has been {0}.", <ActionLink id={data}>{t("scheduled")}</ActionLink>)}
             </span>
           )
         );


### PR DESCRIPTION
## What does this PR change?

This PR remove wrong quoting added by mistake by commit https://github.com/uyuni-project/uyuni/commit/5349df95eaff8eda6fedd81ed973a86c72ace70f

## GUI diff

Text message fixed

Before: `Applying the highstate has been 'scheduled'.`
After: `Applying the highstate has been scheduled.`

- [X] **DONE**

## Documentation
- No documentation needed: no functional changes.

- [X] **DONE**

## Test coverage
- No tests: no code changes

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
