### PR TITLE
Fix missing module when bootstraping transactional systems

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/disablelocalrepos.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/disablelocalrepos.sls
@@ -5,6 +5,9 @@
 {% endif %}
 {% do repos_disabled.update({'count': 0}) %}
 
+include:
+  - util.syncstates
+
 {% set repos = salt['pkg.list_repos']() %}
 {% for alias, data in repos.items() %}
 {% if grains['os_family'] == 'Debian' %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix missing module when bootstraping transactional systems (bsc#1207792)
 - Support SLE Micro migration (bsc#1205011)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

The `util.syncstates` is not being included when bootstraping transactional systems and it is causing error when the systems has local repositories to be disabled. This PR adds the missing module to `channels/disablelocalrepos.sls` to fix the problem.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20349

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
