### PR TITLE
Taskomatic memory improvements

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/channel/Channel.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/Channel.hbm.xml
@@ -569,6 +569,28 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     <return alias="p" class="com.redhat.rhn.domain.rhnpackage.Package" />
     </sql-query>
 
+    <sql-query name="Channel.packageByNevra">
+        <![CDATA[SELECT {p.*}
+          FROM rhnPackage {p},
+             rhnChannelPackage CP,
+             rhnPackageName PN,
+             rhnPackageEvr PE,
+             rhnPackageArch PA
+             WHERE CP.channel_id = :channel_id
+               AND CP.package_id = P.id
+               AND P.name_id = PN.id
+               AND P.evr_id = PE.id
+               AND P.package_arch_id = PA.id
+               AND PN.name = :name
+               AND PA.label = :arch
+               AND PE.version = :version
+               AND PE.release = :release
+               AND PE.type = :type
+               AND ((PE.epoch IS NULL AND :epoch IS NULL) OR (:epoch IS NOT NULL AND PE.epoch = :epoch))
+        ]]>
+        <return alias="p" class="com.redhat.rhn.domain.rhnpackage.Package" />
+    </sql-query>
+
     <sql-query name="Channel.packageByFileNameAndRange">
 	    <![CDATA[SELECT {p.*},
                             (CASE WHEN C.id = :channel_id THEN 1 ELSE 0 end) as chanprio

--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
@@ -38,6 +38,8 @@ import org.hibernate.Session;
 import org.hibernate.criterion.MatchMode;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
+import org.hibernate.type.LongType;
+import org.hibernate.type.StringType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1043,6 +1045,35 @@ public class ChannelFactory extends HibernateFactory {
             return null;
         }
         return pkgs.get(0);
+    }
+
+    /**
+     * Lookup packages base on channel, package name, EVR and arch label
+     *
+     * @param channel the channel to match
+     * @param name the package name
+     * @param archLabel the architecture label
+     * @param version the package version
+     * @param release the package release
+     * @param epoch the package epoch (can be null)
+     * @param evrType the EVR type
+     *
+     * @return the list of matching packages
+     */
+    @SuppressWarnings("unchecked")
+    public static List<Package> lookupPackagesByNevra(Channel channel, String name, String archLabel,
+                                                      String version, String release, String epoch,
+                                                      String evrType) {
+        return HibernateFactory.getSession()
+                .getNamedQuery("Channel.packageByNevra")
+                .setParameter("name", name, StringType.INSTANCE)
+                .setParameter("channel_id", channel.getId(), LongType.INSTANCE)
+                .setParameter("arch", archLabel, StringType.INSTANCE)
+                .setParameter("version", version, StringType.INSTANCE)
+                .setParameter("release", release, StringType.INSTANCE)
+                .setParameter("epoch", epoch, StringType.INSTANCE)
+                .setParameter("type", evrType, StringType.INSTANCE)
+                .list();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManager.java
@@ -215,9 +215,9 @@ public class UbuntuErrataManager {
      */
     public static void processUbuntuErrata(Set<Channel> channels, List<Entry> ubuntuErrataInfo) {
 
-        Map<Channel, Set<Package>> ubuntuChannels = channels.stream()
+        Map<Optional<Org>, Set<Channel>> orgDebChannels = channels.stream()
                 .filter(c -> c.isTypeDeb() && !c.isCloned())
-                .collect(Collectors.toMap(c -> c, Channel::getPackages));
+                .collect(Collectors.groupingBy(e -> Optional.ofNullable(e.getOrg()), Collectors.toSet()));
 
         List<String> uniqueCVEs = ubuntuErrataInfo.stream()
                 .flatMap(e -> e.getCves().stream().filter(c -> c.startsWith("CVE-")))
@@ -231,101 +231,86 @@ public class UbuntuErrataManager {
 
         Set<Errata> changedErrata = new HashSet<>();
         TimeUtils.logTime(LOG, "writing " + ubuntuErrataInfo.size() + " erratas to db", () -> ubuntuErrataInfo.stream()
-                .flatMap(entry -> {
+                .flatMap(entry -> orgDebChannels.entrySet().stream().flatMap(orgChannels -> {
+                    Map<Channel, Set<Package>> channelPackages = orgChannels.getValue().stream()
+                        .collect(Collectors.toMap(
+                            c -> c,
+                            c -> entry.getPackages().stream().flatMap(e -> {
+                                PackageEvr packageEvr = PackageEvr.parseDebian(e.getB());
+                                return e.getC().stream()
+                                        .flatMap(arch ->
+                                                ChannelFactory.lookupPackagesByNevra(c,
+                                                        e.getA(),
+                                                        archToPackageArchLabel(arch).orElse(""),
+                                                        packageEvr.getVersion(),
+                                                        packageEvr.getRelease(),
+                                                        packageEvr.getEpoch(),
+                                                        packageEvr.getType()).stream()
+                                        );
+                            }).collect(Collectors.toSet())
+                        ));
 
+                    Errata errata = Optional.ofNullable(ErrataFactory.lookupByAdvisoryAndOrg(
+                            entry.getId(), orgChannels.getKey().orElse(null)
+                    )).orElseGet(() -> {
+                        Errata newErrata = new Errata();
+                        newErrata.setOrg(orgChannels.getKey().orElse(null));
+                        return newErrata;
+                    });
 
-            Map<Channel, Set<Package>> matchingPackagesByChannel =
-                    TimeUtils.logTime(LOG, "matching packages for " + entry.getId(),
-                            () -> ubuntuChannels.entrySet().stream()
-                                    .collect(Collectors.toMap(Map.Entry::getKey,
-                                            c -> c.getValue().stream().filter(p -> entry.getPackages().stream()
-                                                    .anyMatch(e -> {
+                    errata.setAdvisory(entry.getId());
+                    errata.setAdvisoryName(entry.getId());
+                    errata.setAdvisoryStatus(AdvisoryStatus.STABLE);
+                    errata.setAdvisoryType(ErrataFactory.ERRATA_TYPE_SECURITY);
+                    errata.setIssueDate(Date.from(entry.getDate()));
+                    errata.setUpdateDate(Date.from(entry.getDate()));
+                    String[] split = entry.getId().split("-", 3);
+                    if (split.length == 3 && split[0].equals("USN")) {
+                        errata.setAdvisoryRel(Long.parseLong(split[2]));
+                    }
+                    else if (split.length == 2) {
+                        errata.setAdvisoryRel(Long.parseLong(split[1]));
+                    }
+                    else {
+                        LOG.warn("Could not parse advisory id: {}", entry.getId());
+                        return Stream.empty();
+                    }
 
-                                    PackageEvr packageEvr = PackageEvr.parseDebian(e.getB());
-                                    return e.getC().stream()
-                                            .anyMatch(arch -> p.getPackageName().getName().equals(e.getA()) &&
-                                                archToPackageArchLabel(arch)
-                                                        .map(a -> p.getPackageArch().getLabel().equals(a))
-                                                        .orElse(false) &&
-                                                p.getPackageEvr().getVersion().equals(packageEvr.getVersion()) &&
-                                                p.getPackageEvr().getRelease().equals(packageEvr.getRelease()) &&
-                                                Optional.ofNullable(p.getPackageEvr().getEpoch())
-                                                        .equals(Optional.ofNullable(packageEvr.getEpoch())) &&
-                                                p.getPackageEvr().getPackageType()
-                                                        .equals(packageEvr.getPackageType()));
-
-                                })).collect(Collectors.toSet()))));
-
-            Map<Optional<Org>, Map<Channel, Set<Package>>> collect = matchingPackagesByChannel.entrySet().stream()
-                    .collect(Collectors.groupingBy(e -> Optional.ofNullable(e.getKey().getOrg()),
-                            Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-
-            return collect.entrySet().stream().flatMap(e -> {
-                Optional<Org> org = e.getKey();
-                Errata errata = Optional.ofNullable(ErrataFactory.lookupByAdvisoryAndOrg(
-                            entry.getId(), org.orElse(null)
-                        )).orElseGet(() -> {
-                            Errata newErrata = new Errata();
-                            newErrata.setOrg(org.orElse(null));
-                            return newErrata;
-                        });
-
-                errata.setAdvisory(entry.getId());
-                errata.setAdvisoryName(entry.getId());
-                errata.setAdvisoryStatus(AdvisoryStatus.STABLE);
-                errata.setAdvisoryType(ErrataFactory.ERRATA_TYPE_SECURITY);
-                errata.setIssueDate(Date.from(entry.getDate()));
-                errata.setUpdateDate(Date.from(entry.getDate()));
-
-
-                String[] split = entry.getId().split("-", 3);
-                if (split.length == 3 && split[0].equals("USN")) {
-                    errata.setAdvisoryRel(Long.parseLong(split[2]));
-                }
-                else if (split.length == 2) {
                     errata.setAdvisoryRel(Long.parseLong(split[1]));
-                }
-                else {
-                    LOG.warn("Could not parse advisory id: {}", entry.getId());
-                    return Stream.empty();
-                }
+                    errata.setProduct("Ubuntu");
+                    errata.setSolution("-");
+                    errata.setSynopsis(entry.getIsummary());
+                    Set<Cve> cves = entry.getCves().stream()
+                            .filter(c -> c.startsWith("CVE-"))
+                            .map(cveByName::get)
+                            .collect(Collectors.toSet());
+                    errata.setCves(cves);
+                    errata.setDescription(entry.getDescription());
 
-                errata.setProduct("Ubuntu");
-                errata.setSolution("-");
-                errata.setSynopsis(entry.getIsummary());
-                Set<Cve> cves = entry.getCves().stream()
-                        .filter(c -> c.startsWith("CVE-"))
-                        .map(cveByName::get)
-                        .collect(Collectors.toSet());
-                errata.setCves(cves);
-                errata.setDescription(entry.getDescription());
+                    Set<Package> packages = channelPackages.values().stream()
+                            .flatMap(p -> p.stream())
+                            .collect(Collectors.toSet());
+                    if (errata.getPackages() == null) {
+                        errata.setPackages(packages);
+                        changedErrata.add(errata);
+                    }
+                    else if (errata.getPackages().addAll(packages)) {
+                        changedErrata.add(errata);
+                    }
 
-                Set<Package> packages = e.getValue().entrySet().stream()
-                        .flatMap(x -> x.getValue().stream())
-                        .collect(Collectors.toSet());
-                if (errata.getPackages() == null) {
-                    errata.setPackages(packages);
-                    changedErrata.add(errata);
-                }
-                else if (errata.getPackages().addAll(packages)) {
-                    changedErrata.add(errata);
-                }
+                    Set<Channel> matchingChannels = channelPackages.keySet().stream()
+                            .filter(c -> c != null)
+                            .collect(Collectors.toSet());
 
-                Set<Channel> matchingChannels = e.getValue().entrySet().stream()
-                        .filter(c -> !c.getValue().isEmpty())
-                        .map(Map.Entry::getKey)
-                        .collect(Collectors.toSet());
+                    if (errata.getChannels().addAll(matchingChannels)) {
+                        changedErrata.add(errata);
+                    }
 
-                if (errata.getChannels().addAll(matchingChannels)) {
-                    changedErrata.add(errata);
-                }
-
-                if (errata.getId() == null) {
-                    changedErrata.add(errata);
-                }
-                return Stream.of(errata);
-            });
-        }).forEach(ErrataFactory::save));
+                    if (errata.getId() == null) {
+                        changedErrata.add(errata);
+                    }
+                    return Stream.of(errata);
+                })).forEach(ErrataFactory::save));
 
         // add changed errata to notification queue
         Map<Long, List<Long>> errataToChannels = changedErrata.stream().collect(

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Reduce taskomatic memory consumption while processing Ubuntu Erratas
 - send virtualization information to SCC
 - Do not execute immediately Package Refresh action for the SSH minion (bsc#1208325)
 - Add support to add optional channels via webUI


### PR DESCRIPTION
## What does this PR change?

Refactor the `UbuntuErrataManager` to consume less memory.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: Would require performance tests
- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19718

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
