### PR TITLE
Testsuite: Restore SCC credentials step

### DIFF
--- a/testsuite/features/step_definitions/setup_steps.rb
+++ b/testsuite/features/step_definitions/setup_steps.rb
@@ -26,10 +26,10 @@ When(/^I enter the SCC credentials$/) do
   )
 end
 
-Then(/^the SCC credentials should be valid$/) do
+When(/^I wait until the SCC credentials are valid$/) do
   scc_username, scc_password = ENV['SCC_CREDENTIALS'].split('|')
   within(:xpath, "//h3[contains(text(), '#{scc_username}')]/../..") do
-    raise 'Success icon not found' unless find('i.text-success', wait: DEFAULT_TIMEOUT)
+    raise 'Success icon not found' unless find('i.text-success', wait: 30)
   end
 end
 


### PR DESCRIPTION
## What does this PR change?
This PR restores a step whose definition was lost in another PR.
## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links
Fixes #
Tracks # 
4.3 https://github.com/SUSE/spacewalk/pull/20426
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
