### PR TITLE
Add theme hooks to SPA navigation

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/login/templates/login.jade
+++ b/java/code/src/com/suse/manager/webui/controllers/login/templates/login.jade
@@ -13,7 +13,8 @@ html(lang=window.preferredLocale.replace("_", "-"))
         // import custom fonts/icons styles
         link(rel='stylesheet', href='/fonts/font-spacewalk/css/spacewalk-font.css?cb=#{webBuildtimestamp}')
         // import styles
-        link(rel='stylesheet', href='/css/#{webTheme}.css?cb=#{webBuildtimestamp}')
+        link(rel='stylesheet', href='/css/#{webTheme}.css?cb=#{webBuildtimestamp}', id='web-theme')
+        link(rel='stylesheet', href='/css/updated-#{webTheme}.css?cb=#{webBuildtimestamp}', id='updated-web-theme', disabled="disabled")
         script(src='/javascript/jquery.js?cb=#{webBuildtimestamp}')
         script(src='/javascript/login.js?cb=#{webBuildtimestamp}')
         script(src='/javascript/bootstrap.js?cb=#{webBuildtimestamp}')

--- a/java/code/webapp/WEB-INF/decorators/layout_error.jsp
+++ b/java/code/webapp/WEB-INF/decorators/layout_error.jsp
@@ -32,7 +32,8 @@
 
     <c:set var="webTheme" value="${ConfigDefaults.get().getDefaultWebTheme()}"/>
     <!-- import styles -->
-    <link rel="stylesheet" href="/css/${webTheme}.css?cb=${cb_version}" />
+    <link rel="stylesheet" href="/css/${webTheme}.css?cb=${cb_version}" id="web-theme" />
+    <link rel="stylesheet" href="/css/updated-${webTheme}.css?cb=${cb_version}" id="updated-web-theme" disabled="disabled" />
 
     <!-- expose user preferred language to the application -->
     <c:set var="currentLocale" value="${ConfigDefaults.get().getDefaultLocale()}"/>

--- a/web/html/javascript/spacewalk-essentials.js
+++ b/web/html/javascript/spacewalk-essentials.js
@@ -68,9 +68,7 @@ function scrollTopBehavior() {
 // to set HTML tag dimensions
 function alignContentDimensions() {
   adaptFluidColLayout();
-  adjustDistanceForFixedHeader();
   sstStyle();
-  columnHeight();
 }
 
 // empty function by default hooked on window.scroll event
@@ -161,31 +159,9 @@ function sstStyle() {
   sst.width(sst.parent().width() - sst.css('padding-left') - sst.css('padding-right'));
 }
 
-// Header is fixed, the main content column needs
-// padding-top equals the header height to be fully visible
-function adjustDistanceForFixedHeader() {
-  // subtract 1px in case the outerHeight comes to us already upper rounded
-  jQuery('body').css('padding-top', jQuery('header').outerHeight());
-}
-
-// Make columns 100% in height
-function columnHeight() {
-  const aside = jQuery('.spacewalk-main-column-layout aside');
-  const navToolBox = jQuery('.spacewalk-main-column-layout aside .nav-tool-box');
-  const headerHeight = jQuery('header').outerHeight();
-  const footerHeight = jQuery('footer').outerHeight();
-  const winHeight = jQuery(window).height();
-  // // Column height should equal the window height minus the header and footer height
-  aside.css('height', winHeight - headerHeight);
-  // aside.css('padding-bottom', footerHeight);
-  const nav = jQuery('.spacewalk-main-column-layout aside #nav nav ul.level1');
-  nav.css('height', aside.outerHeight() - navToolBox.outerHeight() - footerHeight);
-};
-
 jQuery(document).on('click', '.navbar-toggle', function() {
   jQuery('aside').toggleClass('in');
   jQuery('aside').toggleClass('collapse');
-  columnHeight();
 });
 
 // returns an object that can be passed to ajax renderer as a callback
@@ -198,7 +174,6 @@ function makeRendererHandler(divId, debug) {
     }
     jQuery('#' + divId).html(text);
     jQuery('#' + divId).fadeIn();
-    columnHeight();
   });
 }
 

--- a/web/html/src/branding/css/base/theme.less
+++ b/web/html/src/branding/css/base/theme.less
@@ -2,26 +2,32 @@
  * This file is the old core theme file, over time we can hopefully clean this up and separate the logic accordingly
  */
 
+html,
 body {
-  background: @body-background;
-  width: auto;
-  -webkit-font-smoothing: antialiased;
-  font-family: @lato;
-}
-html, body {
-  height: auto;
+  height: 100%;
+  min-height: 100%;
+  min-width: fit-content;
+  margin: 0;
+  max-height: 100%;
+  overflow: hidden;
 }
 
+body {
+  display: flex;
+  flex-direction: column;
+  background: @body-background;
+  font-family: @lato;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+ 
 a {
   color: @link-color;
   cursor: pointer;
 }
 
 header {
-  position: fixed;
-  top: 0;
   height:auto;
-  z-index: 1000;
   width: 100%;
   border: none;
   border-radius: 0;
@@ -43,6 +49,34 @@ header {
 
   img {
     float: left;
+  }
+}
+
+.spacewalk-main-column-layout {
+  display: flex;
+  flex: 1 1 auto;
+  overflow: hidden;
+
+  aside {
+    overflow: auto !important;
+    float: none !important;
+    position: relative !important;
+
+    footer {
+      position: -webkit-sticky;
+      position: sticky;
+      bottom: 0;
+    }
+  }
+
+  section {
+    width: 100% !important;
+    float: none !important;
+  }
+
+  #page-body {
+    flex: 1 1 auto;
+    overflow: auto;
   }
 }
 
@@ -155,18 +189,19 @@ section {
 }
 
 .navbar-collapse {
-  max-height: none;
+  display: flex;
+  flex-direction: column;
+
+  #nav {
+    flex: 1 0 auto;
+  }
 
   &.in {
-    display: block !important;
+    display: flex !important;
   }
 
   &.collapse {
     display: none !important;
-
-    & + div section {
-      width: 100%;
-    }
   }
 }
 

--- a/web/html/src/branding/css/base/theme.less
+++ b/web/html/src/branding/css/base/theme.less
@@ -195,7 +195,21 @@ section {
   flex-direction: column;
 
   #nav {
-    flex: 1 0 auto;
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    overflow: hidden;
+
+    nav {
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+
+      > ul {
+        flex: 1 1 auto;
+        margin: 0 !important;
+      }
+    }
   }
 
   &.in {

--- a/web/html/src/branding/css/base/theme.less
+++ b/web/html/src/branding/css/base/theme.less
@@ -139,6 +139,8 @@ section {
   margin-left: 0;
    aside {
     .make-xs-column(2);
+    min-width: 16.66667%;
+    max-width: 16.66667%;
     background: @aside;
     border-right: 1px solid @aside-border;
     /* erasing the predefined paddings in the columns */

--- a/web/html/src/branding/css/susemanager/components/header.less
+++ b/web/html/src/branding/css/susemanager/components/header.less
@@ -1,0 +1,36 @@
+.header-content {
+  display: flex;
+  align-items: center;
+  padding: 7px 10px !important;
+}
+
+.navbar-header {
+  margin-right: auto !important;
+}
+
+.navbar-utility {
+  order: 1;
+  display: flex !important;
+  align-items: center;
+
+  &:before,
+  &:after {
+    content: none !important;
+  }
+}
+
+.navbar-primary {
+  display: flex !important;
+  align-items: center;
+  gap: 4px;
+
+  &:before,
+  &:after {
+    content: none !important;
+  }
+}
+
+#ssm-box {
+  margin-top: 2px;
+  margin-bottom: -2px;
+}

--- a/web/html/src/branding/css/susemanager/susemanager-theme.less
+++ b/web/html/src/branding/css/susemanager/susemanager-theme.less
@@ -25,6 +25,7 @@
 @import url(./components/toolbar.less);
 @import url(./components/legend-box.less);
 @import url(./components/date-time-picker.less);
+@import url(./components/header.less);
 
 // Responsive overrides
 @import url(../base/responsive-rules.less);

--- a/web/html/src/branding/css/updated/layout.scss
+++ b/web/html/src/branding/css/updated/layout.scss
@@ -1,0 +1,38 @@
+html,
+body {
+  height: 100%;
+  min-height: 100%;
+  min-width: fit-content;
+  margin: 0;
+  max-height: 100%;
+  overflow: hidden;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.spacewalk-main-column-layout {
+  display: flex;
+  flex: 1 1 auto;
+  overflow: hidden;
+
+  aside {
+    overflow: auto;
+    position: relative;
+
+    footer {
+      position: -webkit-sticky;
+      position: sticky;
+      bottom: 0;
+    }
+  }
+
+  #page-body {
+    flex: 1 1 auto;
+    overflow: auto;
+  }
+}

--- a/web/html/src/branding/css/uyuni.less
+++ b/web/html/src/branding/css/uyuni.less
@@ -24,6 +24,7 @@
 @import url(uyuni/buttons.less);
 @import url(uyuni/toastr.less);
 @import url(susemanager/components/date-time-picker.less);
+@import url(uyuni/header.less);
 
 // LEAVE THIS LINE AT THE END ALWAYS TO WARRANTY THE RESPONSIVE RULES REWRITE THE EXISTING STYLES
 @import url(base/responsive-rules.less);

--- a/web/html/src/branding/css/uyuni/header.less
+++ b/web/html/src/branding/css/uyuni/header.less
@@ -1,0 +1,36 @@
+.header-content {
+  display: flex;
+  align-items: center;
+  padding: 0 !important;
+}
+
+.navbar-header {
+  margin-right: auto !important;
+}
+
+.navbar-utility {
+  order: 1;
+  display: flex !important;
+  align-items: center;
+
+  &:before,
+  &:after {
+    content: none !important;
+  }
+}
+
+.navbar-primary {
+  display: flex !important;
+  align-items: center;
+  gap: 4px;
+
+  &:before,
+  &:after {
+    content: none !important;
+  }
+}
+
+#ssm-box {
+  margin-top: 1px;
+  margin-bottom: -1px;
+}

--- a/web/html/src/branding/css/uyuni/legacy-theme.less
+++ b/web/html/src/branding/css/uyuni/legacy-theme.less
@@ -18,9 +18,6 @@ input.form-control::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */
 }
 
 header {
-  position: fixed;
-  top: 0;
-  height:auto;
   z-index: 1000;
   width: 100%;
   border: none;

--- a/web/html/src/branding/css/uyuni/legacy-theme.less
+++ b/web/html/src/branding/css/uyuni/legacy-theme.less
@@ -175,13 +175,10 @@ section {
 }
 
 .navbar-collapse.in {
-  display: block !important;
+  display: flex !important;
 }
 .navbar-collapse.collapse {
   display: none !important;
-}
-.navbar-collapse.collapse + div section {
-  width: 100%;
 }
 
 header, nav.navbar-pf {

--- a/web/html/src/branding/css/uyuni/legacy-theme.less
+++ b/web/html/src/branding/css/uyuni/legacy-theme.less
@@ -125,6 +125,8 @@ section {
   margin-left: 0;
    aside {
     .make-xs-column(2);
+    min-width: 16.66667%;
+    max-width: 16.66667%;
     background: @aside;
     border-right: 1px solid @aside-border;
     /* erasing the predefined paddings in the columns */

--- a/web/html/src/branding/css/uyuni/theme.less
+++ b/web/html/src/branding/css/uyuni/theme.less
@@ -1,7 +1,50 @@
 /* Main HTML5 tags defined for the theme */
-html, body {
-  height: 100%
+html,
+body {
+  height: 100% !important;
+  min-height: 100%;
+  min-width: fit-content;
+  margin: 0;
+  max-height: 100%;
+  overflow: hidden !important;
 }
+
+body {
+  display: flex;
+  flex-direction: column;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.spacewalk-main-column-layout {
+  display: flex;
+  flex: 1 1 auto;
+  overflow: hidden;
+
+  aside {
+    overflow: auto !important;
+    float: none !important;
+    position: relative !important;
+
+    footer {
+      position: -webkit-sticky;
+      position: sticky;
+      bottom: 0;
+    }
+  }
+
+  section {
+    width: 100% !important;
+    float: none !important;
+  }
+
+  #page-body {
+    flex: 1 1 auto;
+    overflow: auto;
+  }
+}
+
+
 footer {
   padding: 1.2em 0;
   background: #030303;
@@ -60,7 +103,7 @@ p {
 
 .spacewalk-main-column-layout {
   .make-row(0);
-  min-height: 100%;
+
   aside {
     .make-sm-column(2);
   }

--- a/web/html/src/branding/css/uyuni/theme.less
+++ b/web/html/src/branding/css/uyuni/theme.less
@@ -25,6 +25,11 @@ body {
     overflow: auto !important;
     float: none !important;
     position: relative !important;
+    flex-direction: column;
+
+    #nav {
+      flex: 1 0 auto;
+    }
 
     footer {
       position: -webkit-sticky;

--- a/web/html/src/branding/css/uyuni/theme.less
+++ b/web/html/src/branding/css/uyuni/theme.less
@@ -28,7 +28,21 @@ body {
     flex-direction: column;
 
     #nav {
-      flex: 1 0 auto;
+      display: flex;
+      flex-direction: column;
+      flex: 1 1 auto;
+      overflow: hidden;
+  
+      nav {
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+  
+        > ul {
+          flex: 1 1 auto;
+          margin: 0 !important;
+        }
+      }
     }
 
     footer {

--- a/web/html/src/core/spa/spa-engine.tsx
+++ b/web/html/src/core/spa/spa-engine.tsx
@@ -7,7 +7,9 @@ import App, { HtmlScreen } from "senna";
 
 import SpaRenderer from "core/spa/spa-renderer";
 
-import { showErrorToastr } from "components/toastr/toastr";
+import { showErrorToastr } from "components/toastr";
+
+import { onEndNavigate } from "./theme-loader";
 
 function isLoginPage(pathName) {
   const allLoginPossiblePaths = ["/", "/rhn/manager/login"];
@@ -18,7 +20,7 @@ window.pageRenderers = window.pageRenderers || {};
 window.pageRenderers.spaengine = window.pageRenderers.spaengine || {};
 
 // Navigation hook for standalone renderers to detect navigation
-const onSpaEndNavigationCallbacks: Function[] = [];
+const onSpaEndNavigationCallbacks: Function[] = [onEndNavigate];
 window.pageRenderers.spaengine.onSpaEndNavigation = function onSpaEndNavigation(callback: Function) {
   if (onSpaEndNavigationCallbacks.indexOf(callback) === -1) {
     onSpaEndNavigationCallbacks.push(callback);
@@ -120,10 +122,10 @@ window.pageRenderers.spaengine.init = function init(timeout?: number) {
   }
 };
 
-window.pageRenderers.spaengine.navigate = function navigate(url) {
+window.pageRenderers.spaengine.navigate = function navigate(url: string) {
   if (window.pageRenderers?.spaengine?.appInstance) {
     window.pageRenderers.spaengine.appInstance.navigate(url);
   } else {
-    window.location = url;
+    window.location.href = url;
   }
 };

--- a/web/html/src/core/spa/theme-loader.ts
+++ b/web/html/src/core/spa/theme-loader.ts
@@ -1,8 +1,8 @@
-// TODO: Get this dynamically after https://github.com/SUSE/spacewalk/issues/18942 is implemented
 /**
  * A list of updated page pathnames, e.g. `"/rhn/manager/foo/bar"`
+ * NB! This must be in sync with java/code/src/com/suse/manager/webui/utils/ViewHelper.java
  */
-const UPDATED_PAGES: string[] = [];
+const BOOTSTRAP_READY_PAGES: string[] = [];
 
 export const onEndNavigate = () => {
   const pathname = window.location.pathname;
@@ -13,7 +13,7 @@ export const onEndNavigate = () => {
     return;
   }
 
-  if (UPDATED_PAGES.includes(pathname)) {
+  if (BOOTSTRAP_READY_PAGES.includes(pathname)) {
     themeLink.setAttribute("disabled", "disabled");
     updatedThemeLink.removeAttribute("disabled");
   } else {

--- a/web/html/src/core/spa/theme-loader.ts
+++ b/web/html/src/core/spa/theme-loader.ts
@@ -1,0 +1,23 @@
+// TODO: Get this dynamically after https://github.com/SUSE/spacewalk/issues/18942 is implemented
+/**
+ * A list of updated page pathnames, e.g. `"/rhn/manager/foo/bar"`
+ */
+const UPDATED_PAGES: string[] = [];
+
+export const onEndNavigate = () => {
+  const pathname = window.location.pathname;
+  const themeLink = document.getElementById("web-theme");
+  const updatedThemeLink = document.getElementById("updated-web-theme");
+  if (!themeLink || !updatedThemeLink) {
+    Loggerhead.error(`Unable to identify web theme at ${pathname}`);
+    return;
+  }
+
+  if (UPDATED_PAGES.includes(pathname)) {
+    themeLink.setAttribute("disabled", "disabled");
+    updatedThemeLink.removeAttribute("disabled");
+  } else {
+    themeLink.removeAttribute("disabled");
+    updatedThemeLink.setAttribute("disabled", "disabled");
+  }
+};


### PR DESCRIPTION
## What does this PR change?

Add SPA navigation hooks to toggle between the current and updated theme. Deprecate numerous jQuery layout handlers that were causing problems when switching between themes.

## GUI diff

Only minor visual alignment changes: the scrollbar wrapper has changed on the main area, the header icons are now more consistently aligned, the header is more uniform between the two themes.

- [x] **DONE**

## Documentation

- Documentation issue already exists for the theme update.

- [x] **DONE**

## Test coverage

- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18943
Fixes https://github.com/SUSE/spacewalk/issues/18944

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
