### PR TITLE
Correct name for Rocky 8 custom channel from CLM

### DIFF
--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -248,7 +248,7 @@ When(/^I create an activation key including custom channels for "([^"]*)" via AP
   client.sub! 'terminal', 'minion'
   client.sub! 'monitoring_server', 'sle15sp4_minion'
   custom_channel = if client.include? 'rocky8'
-                     'no-appstream-8-result-custom_channel_rocky8_minion'
+                     'no-appstream-result-custom_channel_rocky8_minion'
                    elsif client.include? 'rocky9'
                      'no-appstream-9-result-custom_channel_rocky9_minion'
                    elsif client.include? 'alma9'


### PR DESCRIPTION
## What does this PR change?

Fix name of Rocky 8 custom channel from CLM.


## Links

Ports:
* 4.2: https://github.com/SUSE/spacewalk/pull/20479
* 4.3: https://github.com/SUSE/spacewalk/pull/20480


## Changelogs

- [x] No changelog needed
