### PR TITLE
Name of CLM results differs according to branch

### DIFF
--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -248,7 +248,7 @@ When(/^I create an activation key including custom channels for "([^"]*)" via AP
   client.sub! 'terminal', 'minion'
   client.sub! 'monitoring_server', 'sle15sp4_minion'
   custom_channel = if client.include? 'rocky8'
-                     'no-appstream-result-custom_channel_rocky8_minion'
+                     'no-appstream-8-result-custom_channel_rocky8_minion'
                    elsif client.include? 'rocky9'
                      'no-appstream-9-result-custom_channel_rocky9_minion'
                    elsif client.include? 'alma9'


### PR DESCRIPTION
## What does this PR change?

Revert in branches uyuni and 4.3 of previous PR.
Adjustment in branch 4.2.


## Links

Ports:
* 4.3: https://github.com/SUSE/spacewalk/pull/20481
* 4.2: https://github.com/SUSE/spacewalk/pull/20482


## Changelogs

- [x] No changelog needed
