### PR TITLE
Testsuite: Change the way buttons are found in content lifecycle feature

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -554,7 +554,7 @@ end
 When(/^I click promote from QA to Production$/) do
   begin
     promote_second = find_all(:xpath, "//button[contains(., 'Promote')]", minimum: 2)[1]
-    promote_first.click
+    promote_second.click
   rescue Capybara::ElementNotFound => e
     raise "Click on promote from QA failed: #{e}"
   end

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -543,11 +543,13 @@ When(/^I click the environment build button$/) do
 end
 
 When(/^I click promote from Development to QA$/) do
-  raise 'Click on promote from Development failed' unless find_button('dev_label-promote-modal-link', disabled: false, wait: DEFAULT_TIMEOUT).click
+  promote_first = find_all(:xpath, "//button[contains(., 'Promote')]")[0]
+  raise 'Click on promote from Development failed' unless promote_first.click
 end
 
 When(/^I click promote from QA to Production$/) do
-  raise 'Click on promote from QA failed' unless find_button('qa_label-promote-modal-link', disabled: false, wait: DEFAULT_TIMEOUT).click
+  promote_second = find_all(:xpath, "//button[contains(., 'Promote')]")[1]
+  raise 'Click on promote from QA failed' unless promote_second.click
 end
 
 Then(/^I should see a "([^"]*)" text in the environment "([^"]*)"$/) do |text, env|

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -543,13 +543,21 @@ When(/^I click the environment build button$/) do
 end
 
 When(/^I click promote from Development to QA$/) do
-  promote_first = find_all(:xpath, "//button[contains(., 'Promote')]")[0]
-  raise 'Click on promote from Development failed' unless promote_first.click
+  begin
+    promote_first = first(:xpath, "//button[contains(., 'Promote')]")
+    promote_first.click
+  rescue Capybara::ElementNotFound => e
+    raise "Click on promote from Development failed: #{e}"
+  end
 end
 
 When(/^I click promote from QA to Production$/) do
-  promote_second = find_all(:xpath, "//button[contains(., 'Promote')]")[1]
-  raise 'Click on promote from QA failed' unless promote_second.click
+  begin
+    promote_second = find_all(:xpath, "//button[contains(., 'Promote')]", minimum: 2)[1]
+    promote_first.click
+  rescue Capybara::ElementNotFound => e
+    raise "Click on promote from QA failed: #{e}"
+  end
 end
 
 Then(/^I should see a "([^"]*)" text in the environment "([^"]*)"$/) do |text, env|


### PR DESCRIPTION
## What does this PR change?
The id of `Promote` buttons on the Conten Lifceycle Project page have been changed to use the environment ID instead of their labels. Since the ids are not necessarily pre-determined, we can search and click on the buttons in their order of appearance instead.
Needed after https://github.com/SUSE/spacewalk/pull/20376
## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links
Fixes # https://github.com/SUSE/spacewalk/issues/20501
Tracks # 
4.2 https://github.com/SUSE/spacewalk/pull/20505
4.3 https://github.com/SUSE/spacewalk/pull/20506
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
