### PR TITLE
Allow for flexible Pgsql14 installation

### DIFF
--- a/spacewalk/admin/spacewalk-service
+++ b/spacewalk/admin/spacewalk-service
@@ -70,7 +70,7 @@ start() {
     echo "  Checking DB schema and running DB schema upgrade if needed. This may take a while."
     echo "  Call the following command to see progress: journalctl -f -u uyuni-check-database.service"
     if grep -E -m1 "^db_host[[:space:]]*=[[:space:]]*localhost" /etc/rhn/rhn.conf >/dev/null && \
-       grep "md5" /var/lib/pgsql/data/pg_hba.conf >/dev/null; then
+       grep "md5" `sudo -Hiu postgres env | grep PGDATA | cut -f2- -d=`/pg_hba.conf >/dev/null; then
          echo
          echo "INFO: Migrating password encryption mechanism to scram-sha-256"
     fi

--- a/spacewalk/admin/spacewalk-service
+++ b/spacewalk/admin/spacewalk-service
@@ -70,7 +70,7 @@ start() {
     echo "  Checking DB schema and running DB schema upgrade if needed. This may take a while."
     echo "  Call the following command to see progress: journalctl -f -u uyuni-check-database.service"
     if grep -E -m1 "^db_host[[:space:]]*=[[:space:]]*localhost" /etc/rhn/rhn.conf >/dev/null && \
-       grep "md5" `sudo -Hiu postgres env | grep PGDATA | cut -f2- -d=`/pg_hba.conf >/dev/null; then
+       grep "md5" `runuser -l postgres -c env | grep PGDATA | cut -f2- -d=`/pg_hba.conf >/dev/null; then
          echo
          echo "INFO: Migrating password encryption mechanism to scram-sha-256"
     fi

--- a/spacewalk/admin/spacewalk-startup-helper
+++ b/spacewalk/admin/spacewalk-startup-helper
@@ -74,7 +74,7 @@ parse_rhn_property() {
 
 
 db_migrate_md5_to_scram() {
-    PGDATAVAR=$(sudo -Hiu postgres env | grep PGDATA | cut -f2- -d=)
+    PGDATAVAR=$(runuser -l postgres -c env | grep PGDATA | cut -f2- -d=)
     if ! grep "md5" ${PGDATAVAR}/pg_hba.conf >/dev/null; then
         return
     fi

--- a/spacewalk/admin/spacewalk-startup-helper
+++ b/spacewalk/admin/spacewalk-startup-helper
@@ -74,13 +74,14 @@ parse_rhn_property() {
 
 
 db_migrate_md5_to_scram() {
-    if ! grep "md5" /var/lib/pgsql/data/pg_hba.conf >/dev/null; then
+    PGDATAVAR=$(sudo -Hiu postgres env | grep PGDATA | cut -f2- -d=)
+    if ! grep "md5" ${PGDATAVAR}/pg_hba.conf >/dev/null; then
         return
     fi
     logger -p user.notice "Migrate database password encryption from md5 to scram-sha256"
-    if ! grep -E "^password_encryption[[:space:]]*=[[:space:]]*scram-sha-256" /var/lib/pgsql/data/postgresql.conf >/dev/null; then
+    if ! grep -E "^password_encryption[[:space:]]*=[[:space:]]*scram-sha-256" ${PGDATAVAR}/postgresql.conf >/dev/null; then
         logger -p user.notice "Set database password encryption default to scram-sha256"
-        echo "password_encryption = scram-sha-256" >> /var/lib/pgsql/data/postgresql.conf
+        echo "password_encryption = scram-sha-256" >> ${PGDATAVAR}/postgresql.conf
         systemctl reload postgresql
     fi
     parse_rhn_property "db_name" DBNAME
@@ -91,7 +92,7 @@ db_migrate_md5_to_scram() {
     runuser - postgres -c "echo \"ALTER USER $DBUSER WITH PASSWORD '$DBPASSWD';\" | psql"
 
     logger -p user.notice "Change encryption in pg_hba.conf to scram-sha-256"
-    sed -i 's|md5|scram-sha-256|g' /var/lib/pgsql/data/pg_hba.conf
+    sed -i 's|md5|scram-sha-256|g' ${PGDATAVAR}/pg_hba.conf
 }
 
 check_database() {

--- a/spacewalk/package/spacewalk.changes
+++ b/spacewalk/package/spacewalk.changes
@@ -1,3 +1,5 @@
+- Link /usr/bin/initdb for Enterprise Linux.
+
 -------------------------------------------------------------------
 Tue Feb 21 14:04:30 CET 2023 - jgonzalez@suse.com
 

--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -163,6 +163,10 @@ for i in ${RDBMS} ; do
 db-backend = $i
 EOF
 done
+install -d $RPM_BUILD_ROOT/%{_bindir}
+%if 0%{?rhel}
+ln -s /usr/pgsql-14/bin/initdb $RPM_BUILD_ROOT/%{_bindir}/initdb
+%endif
 
 %files common
 %{_sysconfdir}/*-release
@@ -176,5 +180,8 @@ done
 
 %files postgresql
 %{_datadir}/spacewalk/setup/defaults.d/postgresql-backend.conf
+%if 0%{?rhel}
+%{_bindir}/initdb
+%endif
 
 %changelog

--- a/spacewalk/setup/lib/Spacewalk/Setup.pm
+++ b/spacewalk/setup/lib/Spacewalk/Setup.pm
@@ -940,7 +940,7 @@ sub postgresql_reportdb_setup {
 }
 
 sub postgresql_start {
-    my $pgservice=`systemctl list-unit-files | grep postgresql | cut -f1 -d.`;
+    my $pgservice=`systemctl list-unit-files | grep postgresql | cut -f1 -d. | tr -d '\n'`;
     system("service $pgservice status >&/dev/null");
     system("service $pgservice start >&/dev/null") if ($? >> 8);
     return ($? >> 8);

--- a/spacewalk/setup/lib/Spacewalk/Setup.pm
+++ b/spacewalk/setup/lib/Spacewalk/Setup.pm
@@ -967,7 +967,7 @@ EOQ
         exit 24;
     }
 
-    my $pgdata=`sudo -Hiu postgres env | grep PGDATA | cut -f2- -d=`;
+    my $pgdata=`runuser -l postgres -c env | grep PGDATA | cut -f2- -d=`;
 
     if (-d "$pgdata/base" and
         ! system(qq{/usr/bin/spacewalk-setup-postgresql check --db $answers->{'db-name'}})) {

--- a/spacewalk/setup/lib/Spacewalk/Setup.pm
+++ b/spacewalk/setup/lib/Spacewalk/Setup.pm
@@ -940,8 +940,9 @@ sub postgresql_reportdb_setup {
 }
 
 sub postgresql_start {
-    system('service postgresql status >&/dev/null');
-    system('service postgresql start >&/dev/null') if ($? >> 8);
+    my $pgservice=`systemctl list-unit-files | grep postgresql | cut -f1 -d.`;
+    system("service $pgservice status >&/dev/null");
+    system("service $pgservice start >&/dev/null") if ($? >> 8);
     return ($? >> 8);
 }
 

--- a/spacewalk/setup/lib/Spacewalk/Setup.pm
+++ b/spacewalk/setup/lib/Spacewalk/Setup.pm
@@ -966,7 +966,9 @@ EOQ
         exit 24;
     }
 
-    if (-d "/var/lib/pgsql/data/base" and
+    my $pgdata=`sudo -Hiu postgres env | grep PGDATA | cut -f2- -d=`;
+
+    if (-d "$pgdata/base" and
         ! system(qq{/usr/bin/spacewalk-setup-postgresql check --db $answers->{'db-name'}})) {
         my $shared_dir = SHARED_DIR;
         print loc(<<EOQ);
@@ -981,7 +983,7 @@ EOQ
 
     if (not $opts->{"skip-db-diskspace-check"}) {
         system_or_exit(['python3', SHARED_DIR .
-            '/embedded_diskspace_check.py', '/var/lib/pgsql/data', '12288'], 14,
+            '/embedded_diskspace_check.py', '$pgdata', '12288'], 14,
             'There is not enough space available for the embedded database.');
     }
     else {

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,5 @@
+- Automatically detect PostgreSQL service and data folder name.
+
 -------------------------------------------------------------------
 Wed Apr 19 13:00:08 CEST 2023 - marina.latini@suse.com
 

--- a/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb
+++ b/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb
@@ -93,7 +93,7 @@ def_regexes() {
 def_regexes
 unset -f def_regexes
 
-PG_DATA=/var/lib/pgsql/data
+PG_DATA=$(sudo -Hiu postgres env | grep PGDATA | cut -f2- -d=)
 PG_HBA="$PG_DATA/pg_hba.conf"
 PG_IDENT="$PG_DATA/pg_ident.conf"
 POSTGRESQL="$PG_DATA/postgresql.conf"

--- a/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb
+++ b/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb
@@ -474,7 +474,7 @@ pg_hba_remove() {
 }
 
 postgresql_service() {
-    POSTGRESQL=$(systemctl list-unit-files | grep postgresql | cut -f1 -d.)
+    POSTGRESQL=$(systemctl list-unit-files | grep postgresql | cut -f1 -d. | tr -d '\n')
     case $1 in
         initdb)
             if isSUSE ; then

--- a/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb
+++ b/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb
@@ -93,7 +93,7 @@ def_regexes() {
 def_regexes
 unset -f def_regexes
 
-PG_DATA=$(sudo -Hiu postgres env | grep PGDATA | cut -f2- -d=)
+PG_DATA=$(runuser -l postgres -c env | grep PGDATA | cut -f2- -d=)
 PG_HBA="$PG_DATA/pg_hba.conf"
 PG_IDENT="$PG_DATA/pg_ident.conf"
 POSTGRESQL="$PG_DATA/postgresql.conf"

--- a/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb
+++ b/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb
@@ -474,7 +474,7 @@ pg_hba_remove() {
 }
 
 postgresql_service() {
-    POSTGRESQL=$(systemctl list-unit-files | grep postgresql | cut -f1 -d. | tr -d '\n')
+    POSTGRESQL_SERVICE=$(systemctl list-unit-files | grep postgresql | cut -f1 -d. | tr -d '\n')
     case $1 in
         initdb)
             if isSUSE ; then
@@ -485,19 +485,19 @@ postgresql_service() {
                     systemctl start postgresql
                 fi
 	    else
-                ${POSTGRESQL}-setup initdb
+                ${POSTGRESQL_SERVICE}-setup initdb
 	    fi
 	    ;;
         status)
             if $LOCAL ; then
                 pgrep -x postgresql >/dev/null && return 1 || return 0
             else
-                systemctl $1 ${POSTGRESQL}
+                systemctl $1 ${POSTGRESQL_SERVICE}
             fi
             ;;
         enable)
             if ! $LOCAL ; then
-                systemctl $1 ${POSTGRESQL}
+                systemctl $1 ${POSTGRESQL_SERVICE}
             fi
             ;;
         *)
@@ -505,7 +505,7 @@ postgresql_service() {
                 echo ">> $1"
                 $RUNUSER - postgres -c "/usr/share/postgresql/postgresql-script $1"
             else
-                systemctl $1 ${POSTGRESQL}
+                systemctl $1 ${POSTGRESQL_SERVICE}
             fi
             ;;
     esac

--- a/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb
+++ b/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb
@@ -474,6 +474,7 @@ pg_hba_remove() {
 }
 
 postgresql_service() {
+    POSTGRESQL=$(systemctl list-unit-files | grep postgresql | cut -f1 -d.)
     case $1 in
         initdb)
             if isSUSE ; then
@@ -484,19 +485,19 @@ postgresql_service() {
                     systemctl start postgresql
                 fi
 	    else
-                postgresql-setup initdb
+                ${POSTGRESQL}-setup initdb
 	    fi
 	    ;;
         status)
             if $LOCAL ; then
                 pgrep -x postgresql >/dev/null && return 1 || return 0
             else
-                systemctl $1 postgresql
+                systemctl $1 ${POSTGRESQL}
             fi
             ;;
         enable)
             if ! $LOCAL ; then
-                systemctl $1 postgresql
+                systemctl $1 ${POSTGRESQL}
             fi
             ;;
         *)
@@ -504,7 +505,7 @@ postgresql_service() {
                 echo ">> $1"
                 $RUNUSER - postgres -c "/usr/share/postgresql/postgresql-script $1"
             else
-                systemctl $1 postgresql
+                systemctl $1 ${POSTGRESQL}
             fi
             ;;
     esac

--- a/spacewalk/uyuni-setup-reportdb/bin/uyuni-sort-pg_hba
+++ b/spacewalk/uyuni-setup-reportdb/bin/uyuni-sort-pg_hba
@@ -4,7 +4,10 @@ import sys
 import os
 import time
 
-pg_hba_conf = '/var/lib/pgsql/data/pg_hba.conf'
+stream = os.popen('sudo -Hiu postgres env | grep PGDATA | cut -f2- -d=')
+pgdata = stream.read().strip()
+
+pg_hba_conf = pgdata + '/pg_hba.conf'
 pg_hba_bak = pg_hba_conf + '-' + '-'.join([str(el).zfill(2) for el in list(time.localtime())][:6])
 
 dbconf = {}

--- a/spacewalk/uyuni-setup-reportdb/bin/uyuni-sort-pg_hba
+++ b/spacewalk/uyuni-setup-reportdb/bin/uyuni-sort-pg_hba
@@ -4,7 +4,7 @@ import sys
 import os
 import time
 
-stream = os.popen('sudo -Hiu postgres env | grep PGDATA | cut -f2- -d=')
+stream = os.popen('runuser -l postgres -c env | grep PGDATA | cut -f2- -d=')
 pgdata = stream.read().strip()
 
 pg_hba_conf = pgdata + '/pg_hba.conf'

--- a/spacewalk/uyuni-setup-reportdb/uyuni-setup-reportdb.changes
+++ b/spacewalk/uyuni-setup-reportdb/uyuni-setup-reportdb.changes
@@ -1,3 +1,5 @@
+- Automatically detect PostgreSQL service and data folder name.
+
 -------------------------------------------------------------------
 Tue Feb 21 12:33:30 CET 2023 - jgonzalez@suse.com
 

--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -226,8 +226,9 @@ exists_user() {
 
 setup_db_postgres() {
     if [ $EXTERNALDB = 0 ]; then
+        POSTGRESQLSERVICE=$(systemctl list-unit-files | grep postgresql | cut -f1 -d.)
         DATADIR=$(sudo -Hiu postgres env | grep PGDATA | cut -f2- -d=)
-        systemctl --quiet enable postgresql 2>&1
+        systemctl --quiet enable ${POSTGRESQLSERVICE} 2>&1
         if [[ "echo $(source /etc/os-release && echo ${ID_LIKE})" != *"suse"* ]]; then
             # Create the PostgreSQL data folder, should it not exist.
             if [ ! -f $DATADIR/PG_VERSION ]; then
@@ -265,11 +266,11 @@ setup_db_postgres() {
                 fi
             fi
         fi
-        systemctl start postgresql
+        systemctl start ${POSTGRESQLSERVICE}
         if ! exists_db $MANAGER_DB_NAME; then
             # required for postgresql <= 13 before creating the user
             echo "password_encryption = 'scram-sha-256'" >> ${DATADIR}/postgresql.conf
-            systemctl restart postgresql
+            systemctl restart ${POSTGRESQLSERVICE}
             su - postgres -c "createdb -E UTF8 $MANAGER_DB_NAME ; echo \"CREATE ROLE $MANAGER_USER PASSWORD '$MANAGER_PASS' SUPERUSER NOCREATEDB NOCREATEROLE INHERIT LOGIN;\" | psql"
 
             echo "local $MANAGER_DB_NAME postgres peer
@@ -282,7 +283,7 @@ setup_db_postgres() {
             mv /tmp/pg_hba.conf ${DATADIR}/pg_hba.conf
             chmod 600 ${DATADIR}/pg_hba.conf
             chown postgres:postgres ${DATADIR}/pg_hba.conf
-            systemctl restart postgresql
+            systemctl restart ${POSTGRESQLSERVICE}
         else
             echo "Database exists. Preparing for resetup. All data will be removed."
         fi
@@ -679,18 +680,20 @@ check_remote_type() {
 
 postgres_fast() {
     DATADIR=$(sudo -Hiu postgres env | grep PGDATA | cut -f2- -d=)
+    POSTGRESQLSERVICE=$(systemctl list-unit-files | grep postgresql | cut -f1 -d.)
     cp -a ${DATADIR}/postgresql.conf ${DATADIR}/postgresql.conf.migrate
     echo "fsync = off" >> ${DATADIR}/postgresql.conf
     echo "full_page_writes = off" >> ${DATADIR}/postgresql.conf
     echo "checkpoint_completion_target = 0.9" >> ${DATADIR}/postgresql.conf
-    systemctl restart postgresql
+    systemctl restart ${POSTGRESQLSERVICE}
 }
 
 postgres_safe() {
     DATADIR=$(sudo -Hiu postgres env | grep PGDATA | cut -f2- -d=)
+    POSTGRESQLSERVICE=$(systemctl list-unit-files | grep postgresql | cut -f1 -d.)
     if [ -f ${DATADIR}/postgresql.conf.migrate ]; then
         mv ${DATADIR}/postgresql.conf.migrate ${DATADIR}/postgresql.conf
-        systemctl restart postgresql
+        systemctl restart ${POSTGRESQLSERVICE}
     fi
 }
 

--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -227,7 +227,7 @@ exists_user() {
 setup_db_postgres() {
     if [ $EXTERNALDB = 0 ]; then
         POSTGRESQLSERVICE=$(systemctl list-unit-files | grep postgresql | cut -f1 -d. | tr -d '\n')
-        DATADIR=$(sudo -Hiu postgres env | grep PGDATA | cut -f2- -d=)
+        DATADIR=$(runuser -l postgres -c env | grep PGDATA | cut -f2- -d=)
         systemctl --quiet enable ${POSTGRESQLSERVICE} 2>&1
         if [[ "echo $(source /etc/os-release && echo ${ID_LIKE})" != *"suse"* ]]; then
             # Create the PostgreSQL data folder, should it not exist.
@@ -679,7 +679,7 @@ check_remote_type() {
 }
 
 postgres_fast() {
-    DATADIR=$(sudo -Hiu postgres env | grep PGDATA | cut -f2- -d=)
+    DATADIR=$(runuser -l postgres -c env | grep PGDATA | cut -f2- -d=)
     POSTGRESQLSERVICE=$(systemctl list-unit-files | grep postgresql | cut -f1 -d. | tr -d '\n')
     cp -a ${DATADIR}/postgresql.conf ${DATADIR}/postgresql.conf.migrate
     echo "fsync = off" >> ${DATADIR}/postgresql.conf
@@ -689,7 +689,7 @@ postgres_fast() {
 }
 
 postgres_safe() {
-    DATADIR=$(sudo -Hiu postgres env | grep PGDATA | cut -f2- -d=)
+    DATADIR=$(runuser -l postgres -c env | grep PGDATA | cut -f2- -d=)
     POSTGRESQLSERVICE=$(systemctl list-unit-files | grep postgresql | cut -f1 -d. | tr -d '\n')
     if [ -f ${DATADIR}/postgresql.conf.migrate ]; then
         mv ${DATADIR}/postgresql.conf.migrate ${DATADIR}/postgresql.conf

--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -226,7 +226,7 @@ exists_user() {
 
 setup_db_postgres() {
     if [ $EXTERNALDB = 0 ]; then
-        POSTGRESQLSERVICE=$(systemctl list-unit-files | grep postgresql | cut -f1 -d.)
+        POSTGRESQLSERVICE=$(systemctl list-unit-files | grep postgresql | cut -f1 -d. | tr -d '\n')
         DATADIR=$(sudo -Hiu postgres env | grep PGDATA | cut -f2- -d=)
         systemctl --quiet enable ${POSTGRESQLSERVICE} 2>&1
         if [[ "echo $(source /etc/os-release && echo ${ID_LIKE})" != *"suse"* ]]; then
@@ -680,7 +680,7 @@ check_remote_type() {
 
 postgres_fast() {
     DATADIR=$(sudo -Hiu postgres env | grep PGDATA | cut -f2- -d=)
-    POSTGRESQLSERVICE=$(systemctl list-unit-files | grep postgresql | cut -f1 -d.)
+    POSTGRESQLSERVICE=$(systemctl list-unit-files | grep postgresql | cut -f1 -d. | tr -d '\n')
     cp -a ${DATADIR}/postgresql.conf ${DATADIR}/postgresql.conf.migrate
     echo "fsync = off" >> ${DATADIR}/postgresql.conf
     echo "full_page_writes = off" >> ${DATADIR}/postgresql.conf
@@ -690,7 +690,7 @@ postgres_fast() {
 
 postgres_safe() {
     DATADIR=$(sudo -Hiu postgres env | grep PGDATA | cut -f2- -d=)
-    POSTGRESQLSERVICE=$(systemctl list-unit-files | grep postgresql | cut -f1 -d.)
+    POSTGRESQLSERVICE=$(systemctl list-unit-files | grep postgresql | cut -f1 -d. | tr -d '\n')
     if [ -f ${DATADIR}/postgresql.conf.migrate ]; then
         mv ${DATADIR}/postgresql.conf.migrate ${DATADIR}/postgresql.conf
         systemctl restart ${POSTGRESQLSERVICE}

--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -226,7 +226,7 @@ exists_user() {
 
 setup_db_postgres() {
     if [ $EXTERNALDB = 0 ]; then
-        DATADIR="/var/lib/pgsql/data" 
+        DATADIR=$(sudo -Hiu postgres env | grep PGDATA | cut -f2- -d=)
         systemctl --quiet enable postgresql 2>&1
         if [[ "echo $(source /etc/os-release && echo ${ID_LIKE})" != *"suse"* ]]; then
             # Create the PostgreSQL data folder, should it not exist.
@@ -268,7 +268,7 @@ setup_db_postgres() {
         systemctl start postgresql
         if ! exists_db $MANAGER_DB_NAME; then
             # required for postgresql <= 13 before creating the user
-            echo "password_encryption = 'scram-sha-256'" >> /var/lib/pgsql/data/postgresql.conf
+            echo "password_encryption = 'scram-sha-256'" >> ${DATADIR}/postgresql.conf
             systemctl restart postgresql
             su - postgres -c "createdb -E UTF8 $MANAGER_DB_NAME ; echo \"CREATE ROLE $MANAGER_USER PASSWORD '$MANAGER_PASS' SUPERUSER NOCREATEDB NOCREATEROLE INHERIT LOGIN;\" | psql"
 
@@ -277,11 +277,11 @@ setup_db_postgres() {
     host $MANAGER_DB_NAME $MANAGER_USER 127.0.0.1/32 scram-sha-256
     host $MANAGER_DB_NAME $MANAGER_USER ::1/128 scram-sha-256
     " > /tmp/pg_hba.conf
-            cat /var/lib/pgsql/data/pg_hba.conf >> /tmp/pg_hba.conf
-            mv /var/lib/pgsql/data/pg_hba.conf /var/lib/pgsql/data/pg_hba.conf.bak
-            mv /tmp/pg_hba.conf /var/lib/pgsql/data/pg_hba.conf
-            chmod 600 /var/lib/pgsql/data/pg_hba.conf
-            chown postgres:postgres /var/lib/pgsql/data/pg_hba.conf
+            cat ${DATADIR}/pg_hba.conf >> /tmp/pg_hba.conf
+            mv ${DATADIR}/pg_hba.conf ${DATADIR}/pg_hba.conf.bak
+            mv /tmp/pg_hba.conf ${DATADIR}/pg_hba.conf
+            chmod 600 ${DATADIR}/pg_hba.conf
+            chown postgres:postgres ${DATADIR}/pg_hba.conf
             systemctl restart postgresql
         else
             echo "Database exists. Preparing for resetup. All data will be removed."
@@ -678,16 +678,18 @@ check_remote_type() {
 }
 
 postgres_fast() {
-    cp -a /var/lib/pgsql/data/postgresql.conf /var/lib/pgsql/data/postgresql.conf.migrate
-    echo "fsync = off" >> /var/lib/pgsql/data/postgresql.conf
-    echo "full_page_writes = off" >> /var/lib/pgsql/data/postgresql.conf
-    echo "checkpoint_completion_target = 0.9" >> /var/lib/pgsql/data/postgresql.conf
+    DATADIR=$(sudo -Hiu postgres env | grep PGDATA | cut -f2- -d=)
+    cp -a ${DATADIR}/postgresql.conf ${DATADIR}/postgresql.conf.migrate
+    echo "fsync = off" >> ${DATADIR}/postgresql.conf
+    echo "full_page_writes = off" >> ${DATADIR}/postgresql.conf
+    echo "checkpoint_completion_target = 0.9" >> ${DATADIR}/postgresql.conf
     systemctl restart postgresql
 }
 
 postgres_safe() {
-    if [ -f /var/lib/pgsql/data/postgresql.conf.migrate ]; then
-        mv /var/lib/pgsql/data/postgresql.conf.migrate /var/lib/pgsql/data/postgresql.conf
+    DATADIR=$(sudo -Hiu postgres env | grep PGDATA | cut -f2- -d=)
+    if [ -f ${DATADIR}/postgresql.conf.migrate ]; then
+        mv ${DATADIR}/postgresql.conf.migrate ${DATADIR}/postgresql.conf
         systemctl restart postgresql
     fi
 }

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Automatically detect PostgreSQL service and data folder name.
 - Adjust product name in setup script output (bsc#1195380)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

The installation structure of PGSQL14 from the official PostgreSQL repository is different. This repository is being used for the Enterprise Linux implementation.

This change tries to detect the service and data folder names.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered
Manually tested installation on Leap 15.4

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
