### PR TITLE
Add openSUSE Leap 15.5 support

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1214,6 +1214,14 @@ DATA = {
         'BASECHANNEL' : 'opensuse_leap15_4-aarch64', 'PKGLIST' :  PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensuse/15/4/bootstrap/'
     },
+    'openSUSE-Leap-15.5-x86_64-uyuni' : {
+        'BASECHANNEL' : 'opensuse_leap15_5-x86_64', 'PKGLIST' :  PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensuse/15/5/bootstrap/'
+    },
+    'openSUSE-Leap-15.5-aarch64-uyuni' : {
+        'BASECHANNEL' : 'opensuse_leap15_5-aarch64', 'PKGLIST' :  PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensuse/15/5/bootstrap/'
+    },
     'openSUSE-Leap-Micro-5.3-x86_64-uyuni' : {
         'BASECHANNEL' : 'opensuse_micro5_3-x86_64', 'PKGLIST' :  PKGLISTMICRO_BUNDLE_ONLY,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensusemicro/5/3/bootstrap/'

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -2,6 +2,7 @@
 - Bootstrap repository definitions for openSUSE Leap Micro 5.3 and
   openSUSE MicroOS for Uyuni
 - Add SLES15SP5 to bootstrap repo definitions
+- Add openSUSE Leap 15.5 uyuni bootstrap repositories
 
 -------------------------------------------------------------------
 Mon Jan 23 08:31:18 CET 2023 - jgonzalez@suse.com

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1184,6 +1184,78 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
 
+[opensuse_leap15_5]
+checksum = sha256
+archs    = x86_64, aarch64
+name     = openSUSE Leap 15.5 (%(arch)s)
+gpgkey_url = http://download.opensuse.org/distribution/leap/15.5/repo/oss/repodata/repomd.xml.key
+gpgkey_id = 3DBDC284
+gpgkey_fingerprint = 22C0 7BA5 3417 8CD0 2EFE  22AA B88B 2FD4 3DBD C284
+repo_url = http://download.opensuse.org/distribution/leap/15.5/repo/oss/
+dist_map_release = 15.5
+
+[opensuse_leap15_5-non-oss]
+label    = %(base_channel)s-non-oss
+name     = openSUSE 15.5 non oss (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_leap15_5-%(arch)s
+repo_url = http://download.opensuse.org/distribution/leap/15.5/repo/non-oss/
+
+[opensuse_leap15_5-updates]
+label    = %(base_channel)s-updates
+name     = openSUSE Leap 15.5 Updates (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_leap15_5-%(arch)s
+repo_url = http://download.opensuse.org/update/leap/15.5/oss/
+
+[opensuse_leap15_5-non-oss-updates]
+label    = %(base_channel)s-non-oss-updates
+name     = openSUSE Leap 15.5 non oss Updates (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_leap15_5-%(arch)s
+repo_url = http://download.opensuse.org/update/leap/15.5/non-oss/
+
+[opensuse_leap15_5-sle-updates]
+label    = %(base_channel)s-sle-updates
+name     = Update repository with updates from SUSE Linux Enterprise 15 (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_leap15_5-%(arch)s
+repo_url = http://download.opensuse.org/update/leap/15.5/sle/
+
+[opensuse_leap15_5-backports-updates]
+label    = %(base_channel)s-backports-updates
+name     = Update repository of openSUSE Backports (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_leap15_5-%(arch)s
+repo_url = http://download.opensuse.org/update/leap/15.5/backports/
+
+# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap 15.X releases
+[opensuse_leap15_5-uyuni-client]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = x86_64, aarch64
+base_channels = opensuse_leap15_5-%(arch)s
+checksum = sha256
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+
+# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap 15.X releases
+[opensuse_leap15_5-uyuni-client-devel]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = x86_64, aarch64
+base_channels = opensuse_leap15_5-%(arch)s
+checksum = sha256
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+
 [opensuse_micro5_3]
 checksum = sha256
 archs    = x86_64, aarch64
@@ -2112,6 +2184,16 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 name     = Uyuni Server Stable for %(base_channel_name)s
 archs    = x86_64, aarch64
 base_channels = opensuse_leap15_4-%(arch)s
+checksum = sha256
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/
+
+[uyuni-server-stable-leap-155]
+name     = Uyuni Server Stable for %(base_channel_name)s
+archs    = x86_64, aarch64
+base_channels = opensuse_leap15_5-%(arch)s
 checksum = sha256
 gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,5 +1,6 @@
 - Add openSUSE Leap Micro 5.3 and openSUSE MicroOS repositories 
 - Add SLES 15 SP5 client tools repositories to spacewalk-common-channels
+- Add openSUSE Leap 15.5 repositories to spacewalk-common-channels
 
 -------------------------------------------------------------------
 Mon Jan 23 08:24:57 CET 2023 - jgonzalez@suse.com


### PR DESCRIPTION
## What does this PR change?

Add openSUSE Leap 15.5 as a supported client to Uyuni

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- Documentation issue was created: https://github.com/uyuni-project/uyuni-docs/issues/2028

- [X] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [X] **DONE**

## Links

No links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
