### PR TITLE
Retry loading of pillars from DB on connection error

### DIFF
--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.nadvornik.pillar-fix
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.nadvornik.pillar-fix
@@ -1,0 +1,1 @@
+- Retry loading of pillars from DB on connection error

--- a/susemanager-utils/susemanager-sls/test/test_pillar_suma_minion.py
+++ b/susemanager-utils/susemanager-sls/test/test_pillar_suma_minion.py
@@ -34,6 +34,9 @@ TEST_FORMULA_ORDER = [
     "bind"
 ]
 
+def cursor_callback(cursor):
+    assert cursor is not None
+
 @pytest.fixture(autouse=True)
 def data_paths():
     '''
@@ -92,8 +95,7 @@ def test_reading_postgres_opts_in__get_cursor():
     with patch.object(suma_minion, "__opts__", test_opts), patch(
         "suma_minion.psycopg2.connect", pg_connect_mock
     ), patch.dict(suma_minion.__context__, {}):
-        with suma_minion._get_cursor() as cursor:
-            assert cursor is not None
+        suma_minion._get_cursor(cursor_callback)
         assert pg_connect_mock.call_args_list[0][1] == {
             "host": "test_host",
             "user": "test_user",
@@ -107,9 +109,7 @@ def test_reading_postgres_opts_in__get_cursor():
     with patch.object(suma_minion, "__opts__", {"__master_opts__": test_opts}), patch(
         "suma_minion.psycopg2.connect", pg_connect_mock
     ), patch.dict(suma_minion.__context__, {}):
-        assert cursor is not None
-        with suma_minion._get_cursor() as cursor:
-            assert cursor is not None
+        suma_minion._get_cursor(cursor_callback)
         assert pg_connect_mock.call_args_list[0][1] == {
             "host": "test_host",
             "user": "test_user",
@@ -137,8 +137,7 @@ def test_using_context_in__get_cursor():
         "suma_minion.psycopg2.connect", pg_connect_mock
     ), patch.dict(suma_minion.__context__, {}):
         # Check if it creates new connection if it's not in the context
-        with suma_minion._get_cursor() as cursor:
-            assert cursor is not None
+        suma_minion._get_cursor(cursor_callback)
         assert pg_connect_mock.call_args_list[0][1] == {
             "host": "test_host",
             "user": "test_user",
@@ -150,8 +149,7 @@ def test_using_context_in__get_cursor():
         pg_connect_mock.reset_mock()
 
         # Check if it reuses the connection from the context
-        with suma_minion._get_cursor() as cursor:
-            assert cursor is not None
+        suma_minion._get_cursor(cursor_callback)
 
         pg_connect_mock.assert_not_called()
 
@@ -168,16 +166,14 @@ def test_using_context_in__get_cursor():
         suma_minion.__context__, {"suma_minion_cnx": pg_cnx_mock}
     ):
         # Check if it reuses the connection from the context
-        with suma_minion._get_cursor() as cursor:
-            assert cursor is not None
+        suma_minion._get_cursor(cursor_callback)
 
         pg_cnx_mock.cursor.assert_called_once()
 
         pg_connect_mock.assert_not_called()
 
         # Check if it tries to recoonect if the connection in the context is not alive
-        with suma_minion._get_cursor() as cursor:
-            assert cursor is not None
+        suma_minion._get_cursor(cursor_callback)
 
         assert pg_connect_mock.call_args_list[0][1] == {
             "host": "test_host",


### PR DESCRIPTION
## What does this PR change?

After postgres restart, suma_minion.py module gets empty pillars, because the connection is closed.
This PR detects this situation and tries again.

This was detected by this test: https://github.com/uyuni-project/uyuni/pull/6539

The problem was introduced in PR https://github.com/uyuni-project/uyuni/pull/6033

## GUI diff

No difference.


## Documentation
- No documentation needed: bugfix

## Test coverage
- Cucumber tests WIP: https://github.com/uyuni-project/uyuni/pull/6539

- [ ] **DONE**

## Links

Partial fix for https://github.com/SUSE/spacewalk/issues/20143

Testcase PR: https://github.com/uyuni-project/uyuni/pull/6539


## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
