### PR TITLE
Add openEuler 22.03 support

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -441,6 +441,9 @@ if [ "$INSTALLER" == yum ]; then
         elif [ -f /etc/redhat-release ]; then
             grep -v '^#' /etc/redhat-release | grep -q '\(Red Hat\)' && BASE="res"
             VERSION=`grep -v '^#' /etc/redhat-release | grep -Po '(?<=release )\d+'`
+	elif [ -f /etc/openEuler-release ]; then
+            grep -v '^#' /etc/openEuler-release | grep -q '\(openEuler\)' && BASE="openEuler"
+            VERSION=`grep -v '^#' /etc/openEuler-release | grep -Po '(?<=release )(\d+\.)+\d+'`
         elif [ -f /etc/os-release ]; then
             BASE=$(source /etc/os-release; echo $ID)
             VERSION=$(source /etc/os-release; echo $VERSION_ID)
@@ -474,6 +477,7 @@ if [ "$INSTALLER" == yum ]; then
       [ "$Y_CLIENT_CODE_BASE" == rockylinux ] || \
       [ "$Y_CLIENT_CODE_BASE" == oracle ] || \
       [ "$Y_CLIENT_CODE_BASE" == alibaba ] || \
+      [ "$Y_CLIENT_CODE_BASE" == openEuler ] || \
       [ "$Y_CLIENT_CODE_BASE" == centos ] ; then
         $FETCH $CLIENT_REPO_URL/repodata/repomd.xml &> /dev/null
         if [ $? -ne 0 ]; then

--- a/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
+++ b/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
@@ -95,6 +95,9 @@ function getY_CLIENT_CODE_BASE() {
     if [ -L /usr/share/doc/sles_es-release ]; then
         BASE="res"
         VERSION=6
+    elif [ -f /etc/openEuler-release ]; then
+        grep -v '^#' /etc/openEuler-release | grep -q '\(openEuler\)' && BASE="openEuler"
+	VERSION=`grep -v '^#' /etc/openEuler-release | grep -Po '(?<=release )(\d+\.)+\d+'`
     elif [ -f /etc/almalinux-release ]; then
         grep -v '^#' /etc/almalinux-release | grep -q '\(AlmaLinux\)' && BASE="almalinux"
         VERSION=`grep -v '^#' /etc/almalinux-release | grep -Po '(?<=release )\d+'`

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -90,9 +90,15 @@ no_ssh_push_key_authorized:
   #end of expections
 {%- endif %}
 
+# openEuler Family. This OS is based in RedHat, but declares a separate family
+{%- if grains['os_family'] == 'openEuler' %}
+  {% set os_base = grains['os'] %}
+  {% set osrelease = grains['osrelease'] %}
+{%- endif %}
+
 {% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/' ~ os_base ~ '/' ~ osrelease ~ '/bootstrap/' %}
 
-{%- if grains['os_family'] == 'RedHat' or  grains['os_family'] == 'Suse'%}
+{%- if grains['os_family'] == 'RedHat' or grains['os_family'] == 'openEuler' or grains['os_family'] == 'Suse'%}
   {% set bootstrap_repo_request = salt['http.query'](bootstrap_repo_url + 'repodata/repomd.xml', status=True, verify_ssl=False) %}
   {%- if 'status' not in bootstrap_repo_request %}
     {{ raise('Missing request status: {}'.format(bootstrap_repo_request)) }}
@@ -120,7 +126,7 @@ bootstrap_repo:
   file.managed:
 {%- if grains['os_family'] == 'Suse' %}
     - name: /etc/zypp/repos.d/susemanager:bootstrap.repo
-{%- elif grains['os_family'] == 'RedHat' %}
+{%- elif grains['os_family'] == 'RedHat' or grains['os_family'] == 'openEuler' %}
     - name: /etc/yum.repos.d/susemanager:bootstrap.repo
 {%- elif grains['os_family'] == 'Debian' %}
     - name: /etc/apt/sources.list.d/susemanager_bootstrap.list
@@ -230,6 +236,20 @@ salt-install-contextvars:
 
 {%- if not transactional %}
 {% include 'bootstrap/remove_traditional_stack.sls' %}
+
+mgr_update_basic_pkgs:
+  pkg.latest:
+    - pkgs:
+      - openssl
+{%- if grains['os_family'] == 'Suse' and grains['osrelease'] in ['11.3', '11.4'] and grains['cpuarch'] in ['i586', 'x86_64'] %}
+      - pmtools
+{%- elif grains['cpuarch'] in ['aarch64', 'x86_64'] %}
+      - dmidecode
+{%- endif %}
+{%- if grains['os_family'] == 'Suse' %}
+      - zypper
+{%- elif grains['os_family'] == 'RedHat' or grains['os_family'] == 'openEuler' %}
+      - yum
 {%- endif %}
 
 # Manage minion key files in case they are provided in the pillar

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/remove_traditional_stack.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/remove_traditional_stack.sls
@@ -36,7 +36,7 @@ remove_traditional_stack_all:
       - rhnmd
 {%- if grains['os_family'] == 'Suse' %}
       - zypp-plugin-spacewalk
-{%- elif grains['os_family'] == 'RedHat' %}
+{%- elif grains['os_family'] == 'RedHat' or grains['os_family'] == 'openEuler' %}
       - yum-rhn-plugin
       - rhnsd
       - rhn-check
@@ -77,7 +77,7 @@ remove_spacewalk_sources:
 
 # Remove suseRegisterInfo in a separate yum transaction to avoid being called by
 # the yum plugin.
-{%- if grains['os_family'] == 'RedHat' %}
+{%- if grains['os_family'] == 'RedHat' or grains['os_family'] == 'openEuler' %}
 remove_suse_register_info_rh:
   pkg.removed:
     - name: suseRegisterInfo

--- a/susemanager-utils/susemanager-sls/salt/certs/openeuler.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/openeuler.sls
@@ -1,0 +1,1 @@
+redhat.sls

--- a/susemanager-utils/susemanager-sls/salt/channels/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/init.sls
@@ -9,7 +9,7 @@ include:
 {%- endif %}
 {% include 'channels/disablelocalrepos.sls' %}
 
-{%- if grains['os_family'] == 'RedHat' %}
+{%- if grains['os_family'] == 'RedHat' or grains['os_family'] == 'openEuler' %}
 
 {%- set yum_version = salt['pkg.version']("yum") %}
 {%- set is_yum = yum_version and salt['pkg.version_cmp'](yum_version, "4") < 0 %}
@@ -79,7 +79,7 @@ mgrchannels_repo:
   file.managed:
 {%- if grains['os_family'] == 'Suse' %}
     - name: "/etc/zypp/repos.d/susemanager:channels.repo"
-{%- elif grains['os_family'] == 'RedHat' %}
+{%- elif grains['os_family'] == 'RedHat' or grains['os_family'] == 'openEuler' %}
     - name: "/etc/yum.repos.d/susemanager:channels.repo"
 {%- elif grains['os_family'] == 'Debian' %}
     - name: "/etc/apt/sources.list.d/susemanager:channels.list"
@@ -92,7 +92,7 @@ mgrchannels_repo:
     - mode: 644
     - require:
        - file: mgr_ca_cert
-{%- if grains['os_family'] == 'RedHat' %}
+{%- if grains['os_family'] == 'RedHat' or grains['os_family'] == 'openEuler' %}
 {%- if is_dnf %}
        - file: mgrchannels_susemanagerplugin_dnf
        - file: mgrchannels_susemanagerplugin_conf_dnf
@@ -118,7 +118,7 @@ aptauth_conf:
     - mode: 600
 {%- endif %}
 
-{%- if grains['os_family'] == 'RedHat' %}
+{%- if grains['os_family'] == 'RedHat' or grains['os_family'] == 'openEuler' %}
 {%- if is_dnf %}
 mgrchannels_dnf_clean_all:
   cmd.run:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -2,6 +2,7 @@
 - Fix current limitation on Action Chains for SLE Micro
 - Support SLE Micro migration (bsc#1205011)
 - Add data for openSUSE Leap Micro 5.3 and openSUSE MicroOS bootstrapping
+- Add openEuler 22.03 support 
 
 -------------------------------------------------------------------
 Thu Jan 26 12:27:21 CET 2023 - jgonzalez@suse.com

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -232,6 +232,10 @@ RES9 = [
     "venv-salt-minion", 
 ]
 
+OPENEULER2203 = [
+        "venv-salt-minion",
+]
+
 AMAZONLINUX2 = [
     "dwz",
     "groff-base",
@@ -1552,5 +1556,13 @@ DATA = {
          'BASECHANNEL' : 'astralinux-orel-pool-amd64', 'PKGLIST' : PKGLISTASTRALINUXOREL,
          'DEST' : DOCUMENT_ROOT + '/pub/repositories/astra/orel/bootstrap/',
          'TYPE' : 'deb'
+     },
+     'openeuler22.03-x86_64-uyuni': {
+         'BASECHANNEL' : 'openeuler2203-x86_64', 'PKGLIST' : OPENEULER2203,
+         'DEST' : DOCUMENT_ROOT + '/pub/repositories/openEuler/22.03/bootstrap/'
+     },
+     'openeuler22.03-aarch64-uyuni': {
+         'BASECHANNEL' : 'openeuler2203-aarch64', 'PKGLIST' : OPENEULER2203,
+         'DEST' : DOCUMENT_ROOT + '/pub/repositories/openEuler/22.03/bootstrap/'
      }
 }

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -2,6 +2,7 @@
 - Bootstrap repository definitions for openSUSE Leap Micro 5.3 and
   openSUSE MicroOS for Uyuni
 - Add SLES15SP5 to bootstrap repo definitions
+- Add bootstrap repository definitions for openEuler 22.03
 
 -------------------------------------------------------------------
 Mon Jan 23 08:31:18 CET 2023 - jgonzalez@suse.com

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -3902,3 +3902,59 @@ gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL8-Uyuni-Client-Tools/EL_8/
+
+[openeuler2203]
+archs	= x86_64, aarch64
+name	= openEuler 22.03 %(arch)s
+gpgkey_url = https://repo.openeuler.org/openEuler-22.03-LTS/OS/x86_64/RPM-GPG-KEY-openEuler
+gpgkey_id = AC26B6D3
+gpgkey_fingerprint = 12EA 74AC 9DF4 8D46 C69C  A0BE D557 065E B25E 7F66
+repo_url = https://repo.openeuler.org/openEuler-22.03-LTS/OS/%(arch)s
+
+[openeuler2203-update]
+archs	= x86_64, aarch64
+name	= openEuler 22.03 Update %(arch)s
+label	= openeuler2203-update-%(arch)s
+base_channels = openeuler2203-%(arch)s
+gpgkey_url = https://repo.openeuler.org/openEuler-22.03-LTS/OS/x86_64/RPM-GPG-KEY-openEuler
+gpgkey_id = AC26B6D3
+gpgkey_fingerprint = 12EA 74AC 9DF4 8D46 C69C  A0BE D557 065E B25E 7F66
+repo_url = https://repo.openeuler.org/openEuler-22.03-LTS/update/%(arch)s
+
+[openeuler2203-everything]
+archs	= x86_64, aarch64
+name	= openEuler 22.03 Everything %(arch)s
+label	= openeuler2203-everything-%(arch)s
+base_channels = openeuler2203-%(arch)s
+gpgkey_url = https://repo.openeuler.org/openEuler-22.03-LTS/everything/x86_64/RPM-GPG-KEY-openEuler
+gpgkey_id = AC26B6D3
+gpgkey_fingerprint = 12EA 74AC 9DF4 8D46 C69C  A0BE D557 065E B25E 7F66
+repo_url = https://repo.openeuler.org/openEuler-22.03-LTS/everything/%(arch)s
+
+[openeuler2203-epol]
+archs	= x86_64, aarch64
+name	= openEuler 22.03 EPOL %(arch)s
+label	= openeuler2203-epol-%(arch)s
+base_channels = openeuler2203-%(arch)s
+gpgkey_url = https://repo.openeuler.org/openEuler-22.03-LTS/OS/x86_64/RPM-GPG-KEY-openEuler
+gpgkey_id = AC26B6D3
+gpgkey_fingerprint = 12EA 74AC 9DF4 8D46 C69C  A0BE D557 065E B25E 7F66
+repo_url = https://repo.openeuler.org/openEuler-22.03-LTS/EPOL/main/%(arch)s
+
+[openeuler2203-uyuni-client]
+archs	= x86_64, aarch64
+name	= Uyuni client tools for %(base_channel_name)s
+base_channels = openeuler2203-%(arch)s
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/
+
+[openeuler2203-uyuni-client-devel]
+archs	= x86_64, aarch64
+name	= Uyuni client tools for %(base_channel_name)s (Development)
+base_channels = openeuler2203-%(arch)s
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL8-Uyuni-Client-Tools/EL_8/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL8-Uyuni-Client-Tools/EL_8/

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,5 +1,6 @@
 - Add openSUSE Leap Micro 5.3 and openSUSE MicroOS repositories 
 - Add SLES 15 SP5 client tools repositories to spacewalk-common-channels
+- Add openEuler 22.03 repositories
 
 -------------------------------------------------------------------
 Mon Jan 23 08:24:57 CET 2023 - jgonzalez@suse.com


### PR DESCRIPTION
# WARNING
Salt bundle did not work out of the box and some adjustments were needed. @vzhestkov took care of that, so please check with him and **do not merge** until his changes are ready for the bundle.

The following rpm as a PoC was used, and is the one that hopefully will be merged soon: https://download.opensuse.org/repositories/home:/vzhestkov:/saltstack:/bundle:/next/AlmaLinux_8/

## What does this PR change?

**Add Openeuler 22.03**

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Documentation issue was created: Yes, see https://github.com/uyuni-project/uyuni-docs/pull/1636

- [X] **DONE**

## Test coverage
- Cucumber tests to be added later

- [ ] **DONE**

## Links

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"