### PR TITLE
Fix missing module when bootstraping transactional systems

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -230,6 +230,9 @@ salt-install-contextvars:
 
 {%- if not transactional %}
 {% include 'bootstrap/remove_traditional_stack.sls' %}
+{% else %}
+include:
+  - util.syncstates
 {%- endif %}
 
 # Manage minion key files in case they are provided in the pillar

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix missing module when bootstraping transactional systems (bsc#1207792)
 - Install the reboot info beacon using a conf file instead of using pillars
 - add CPU sockets, threads and total number to standard CPU grains
 - Fix mgrnet custom module to be compatible with old Python 2.6 (bsc#1206979) (bsc#1206981)


### PR DESCRIPTION
## What does this PR change?

The util.syncstates is not being included when bootstraping transactional systems and it is causing error when the systems has local repositories to be disabled. This PR adds the missing module to fix the problem.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20349

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
