### PR TITLE
Filter modular packages using release strings (bsc#1207814)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
@@ -366,8 +366,10 @@ public class AccessTest extends BaseTestCaseWithUser {
 
         assertFalse(acl.evalAcl(context, "is_modular_channel()"));
 
-        Modules mod = new Modules("filename", new Date());
-        chan.addModules(mod);
+        Modules mod = new Modules();
+        mod.setRelativeFilename("filename");
+        chan.setModules(mod);
+        mod.setChannel(chan);
 
         assertTrue(acl.evalAcl(context, "is_modular_channel()"));
 

--- a/java/code/src/com/redhat/rhn/domain/channel/Channel.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/Channel.hbm.xml
@@ -75,10 +75,8 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <one-to-one name="comps" property-ref="channel"
             class="com.redhat.rhn.domain.channel.Comps" cascade="all" lazy="proxy"/>
 
-        <set name="modules" cascade="all-delete-orphan" lazy="true" inverse="true" where="comps_type_id = 2">
-            <key column="channel_id" not-null="true"/>
-            <one-to-many class="com.redhat.rhn.domain.channel.Modules"/>
-        </set>
+        <one-to-one name="modules" property-ref="channel"
+            class="com.redhat.rhn.domain.channel.Modules" cascade="all" lazy="proxy"/>
 
         <one-to-one name="mediaProducts" property-ref="channel"
             class="com.redhat.rhn.domain.channel.MediaProducts" cascade="all" lazy="proxy"/>

--- a/java/code/src/com/redhat/rhn/domain/channel/Channel.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/Channel.java
@@ -26,7 +26,6 @@ import com.redhat.rhn.manager.channel.ChannelManager;
 import com.redhat.rhn.manager.system.IncompatibleArchException;
 import com.redhat.rhn.manager.system.SystemManager;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -35,7 +34,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -80,7 +78,7 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
     private ChannelProduct product;
     private ProductName productName;
     private Comps comps;
-    private Set<Modules> modules;
+    private Modules modules;
     private MediaProducts mediaProducts;
     private String summary;
     private Set<Errata> erratas = new HashSet<>();
@@ -223,29 +221,8 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
     /**
      * @param modulesIn The Modules to set.
      */
-    public void setModules(Set<Modules> modulesIn) {
+    public void setModules(Modules modulesIn) {
         this.modules = modulesIn;
-    }
-
-    /**
-     * Add a module metadata file to the channel
-     * @param modulesIn the module metadata entity to add
-     */
-    public void addModules(Modules modulesIn) {
-        if (this.modules == null) {
-            this.modules = new HashSet<>();
-        }
-        modulesIn.setChannel(this);
-        this.modules.add(modulesIn);
-    }
-
-    /**
-     * Remove an existing module metadata file from the channel
-     * @param modulesIn the module metadata entity to remove
-     */
-    public void removeModules(Modules modulesIn) {
-        this.modules.remove(modulesIn);
-        modulesIn.setChannel(null);
     }
 
     /**
@@ -258,27 +235,14 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
     }
 
     /**
-     * Gets the synced module metadata files belonging to the channel
-     * <p>
-     * See {@link Channel#getLatestModules()} to get the latest metadata file currently in use.
-     *
      * @return Returns the Modules.
      */
-    public Set<Modules> getModules() {
+    public Modules getModules() {
         return modules;
     }
 
-    /**
-     * Gets the latest module metadata file in use
-     *
-     * @return the module metadata (modules.yaml) file
-     */
-    public Modules getLatestModules() {
-        return modules.stream().max(Comparator.comparing(Modules::getLastModified)).orElse(null);
-    }
-
     public boolean isModular() {
-        return CollectionUtils.isNotEmpty(modules);
+        return modules != null;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
@@ -1308,13 +1308,19 @@ public class ChannelFactory extends HibernateFactory {
      * @param to  the target Channel
      */
     public static void cloneModulesMetadata(Channel from, Channel to) {
-        if (to.isModular()) {
-            to.getModules().clear();
-            getSession().flush();
+        if (!from.isModular()) {
+            if (to.isModular()) {
+                HibernateFactory.getSession().delete(to.getModules());
+                to.setModules(null);
+            }
         }
-        if (from.isModular()) {
-            from.getModules().forEach(fromModule ->
-                    to.addModules(new Modules(fromModule.getRelativeFilename(), fromModule.getLastModified())));
+        else {
+            if (!to.isModular()) {
+                Modules modules = new Modules();
+                modules.setChannel(to);
+                to.setModules(modules);
+            }
+            to.getModules().setRelativeFilename(from.getModules().getRelativeFilename());
         }
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/channel/Modules.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/Modules.java
@@ -14,25 +14,10 @@
  */
 package com.redhat.rhn.domain.channel;
 
-import java.util.Date;
-
 /**
  *
  *
  */
 public class Modules extends RepoMetadata {
-    /**
-     * Create a new empty {@link Modules} instance
-     */
-    public Modules() { }
 
-    /**
-     * Create a new {@link Modules} instance
-     * @param relativeFilename the relative filename of the module metadata file
-     * @param lastModified the 'last modified date' of the module metadata file
-     */
-    public Modules(String relativeFilename, Date lastModified) {
-        this.setRelativeFilename(relativeFilename);
-        this.setLastModified(lastModified);
-    }
 }

--- a/java/code/src/com/redhat/rhn/domain/channel/RepoMetadata.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/RepoMetadata.hbm.xml
@@ -17,7 +17,6 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         </id>
         <discriminator column="comps_type_id" type="java.lang.Integer"/>
         <property name="relativeFilename" type="string" column="relative_filename" not-null="true"/>
-        <property name="lastModified" type="timestamp" column="last_modified" not-null="true" />
 
         <many-to-one name="channel"
                      class="com.redhat.rhn.domain.channel.Channel"

--- a/java/code/src/com/redhat/rhn/domain/channel/RepoMetadata.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/RepoMetadata.java
@@ -16,8 +16,6 @@ package com.redhat.rhn.domain.channel;
 
 import com.redhat.rhn.domain.BaseDomainHelper;
 
-import java.util.Date;
-
 /**
  *
  *
@@ -27,7 +25,6 @@ public class RepoMetadata extends BaseDomainHelper {
     private Long id;
     private String relativeFilename;
     private Channel channel;
-    private Date lastModified;
 
     /**
      *
@@ -75,21 +72,5 @@ public class RepoMetadata extends BaseDomainHelper {
      */
     public Channel getChannel() {
         return channel;
-    }
-
-    /**
-     * Gets the last modified date of the underlying comps file
-     * @return the last modified date of the comps file
-     */
-    public Date getLastModified() {
-        return lastModified;
-    }
-
-    /**
-     * Sets the last modified date of the underlying comps file
-     * @param lastModifiedIn the last modified date
-     */
-    public void setLastModified(Date lastModifiedIn) {
-        lastModified = lastModifiedIn;
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/channel/test/ChannelFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/test/ChannelFactoryTest.java
@@ -29,7 +29,6 @@ import com.redhat.rhn.domain.channel.ChannelFamilyFactory;
 import com.redhat.rhn.domain.channel.ClonedChannel;
 import com.redhat.rhn.domain.channel.ContentSource;
 import com.redhat.rhn.domain.channel.ContentSourceType;
-import com.redhat.rhn.domain.channel.Modules;
 import com.redhat.rhn.domain.channel.ProductName;
 import com.redhat.rhn.domain.common.ChecksumType;
 import com.redhat.rhn.domain.kickstart.KickstartInstallType;
@@ -50,8 +49,6 @@ import com.redhat.rhn.testing.UserTestUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 
-import java.time.Duration;
-import java.time.Instant;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -590,29 +587,5 @@ public class ChannelFactoryTest extends RhnBaseTestCase {
         assertEquals("b_parent1", channels.get(1).getLabel());
         assertEquals("a_child1", channels.get(2).getLabel());
         assertEquals("b_parent3", channels.get(3).getLabel());
-    }
-
-    @Test
-    public void testCloneModulesMetadata() throws Exception {
-        User user = UserTestUtils.findNewUser("testUser", "testOrg" + this.getClass().getSimpleName());
-        Instant nowDate = Instant.now();
-        Channel orig = ChannelTestUtils.createTestChannel(user);
-        Modules modules = new Modules("modules1.yaml", Date.from(nowDate.minus(Duration.ofHours(1))));
-        modules.setChannel(orig);
-        orig.addModules(modules);
-        assertTrue(orig.isModular());
-
-        Channel clone = ChannelTestUtils.createTestChannel(user);
-        modules = new Modules("modules2.yaml", Date.from(nowDate));
-        modules.setChannel(clone);
-        clone.addModules(modules);
-        assertTrue(clone.isModular());
-
-        ChannelFactory.cloneModulesMetadata(orig, clone);
-
-        assertTrue(clone.isModular());
-        assertEquals(1, clone.getModules().size());
-        assertEquals("modules1.yaml", clone.getLatestModules().getRelativeFilename());
-        assertEquals(orig.getLatestModules().getLastModified(), clone.getLatestModules().getLastModified());
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/channel/test/ChannelTest.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/test/ChannelTest.java
@@ -253,9 +253,11 @@ public class ChannelTest extends BaseTestCaseWithUser {
     @Test
     public void testIsModular() throws Exception {
         Channel c = ChannelFactoryTest.createTestChannel(user);
+        assertNull(c.getModules());
         assertFalse(c.isModular());
 
         c.addModules(new Modules("filename", new Date()));
+        assertNotNull(c.getModules());
         assertTrue(c.isModular());
     }
 

--- a/java/code/src/com/redhat/rhn/domain/channel/test/ChannelTest.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/test/ChannelTest.java
@@ -46,7 +46,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
 
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -256,7 +255,7 @@ public class ChannelTest extends BaseTestCaseWithUser {
         assertNull(c.getModules());
         assertFalse(c.isModular());
 
-        c.addModules(new Modules("filename", new Date()));
+        c.setModules(new Modules());
         assertNotNull(c.getModules());
         assertTrue(c.isModular());
     }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
@@ -232,7 +232,7 @@ public abstract class ContentFilter<T> extends BaseDomainHelper implements Predi
     }
 
     /**
-     * Sets the criteria.
+     * Sets the criteria, validating it against allowed matcher-field combinations
      *
      * @param criteriaIn - the criteria
      * @throws IllegalArgumentException when the matcher-field combination is not allowed

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ModularPackageFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ModularPackageFilter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.domain.contentmgmt;
+
+import com.redhat.rhn.domain.rhnpackage.Package;
+
+/**
+ * Modular package filter that filters out every modular package in a project.
+ * <p>This is an internal filter that cannot be created or manipulated by the user.</p>
+ */
+public class ModularPackageFilter extends PackageFilter {
+    /**
+     * Initialize a new filter instance
+     */
+    public ModularPackageFilter() {
+        super.setRule(Rule.DENY);
+    }
+
+    @Override
+    public boolean test(Package pack) {
+        return pack.getPackageEvr().getRelease().contains(".module");
+    }
+
+    @Override
+    public void setCriteria(FilterCriteria criteriaIn) {
+        throw new UnsupportedOperationException("Criteria cannot be set for the modular package filter.");
+    }
+
+    @Override
+    public void setRule(Rule ruleIn) {
+        throw new UnsupportedOperationException("Rule cannot be set for the modular package filter.");
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ModulemdApi.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ModulemdApi.java
@@ -57,13 +57,14 @@ public class ModulemdApi {
     }
 
     /**
-     * Get all modular packages from a single metadata file
+     * Get all modular packages in the specified source channels
      *
-     * @param modules the module metadata (modules.yaml) instance
+     * @param sources the modular source channels
      * @return a list of modular packages in NEVRA format
      */
-    public List<String> getAllPackages(Modules modules) throws ModulemdApiException {
-        ModulemdApiResponse res = callSync(ModulemdApiRequest.listPackagesRequest(List.of(getMetadataPath(modules))));
+    public List<String> getAllPackages(List<Channel> sources) throws ModulemdApiException {
+        List<String> metadataPaths = getMetadataPaths(sources);
+        ModulemdApiResponse res = callSync(ModulemdApiRequest.listPackagesRequest(metadataPaths));
         return res.getListPackages().getPackages();
     }
 
@@ -113,17 +114,8 @@ public class ModulemdApi {
         if (!channel.isModular()) {
             throw new RepositoryNotModularException();
         }
-        return getMetadataPath(channel.getLatestModules());
-    }
-
-    /**
-     * Get 'modules.yaml' file path for the specified source on the server
-     *
-     * @param modules the module metadata instance
-     * @return the 'modules.yaml' path
-     */
-    private static String getMetadataPath(Modules modules) {
-        return new File(MOUNT_POINT_PATH, modules.getRelativeFilename()).getAbsolutePath();
+        Modules metadata = channel.getModules();
+        return new File(MOUNT_POINT_PATH, metadata.getRelativeFilename()).getAbsolutePath();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
@@ -614,7 +614,7 @@ public class DownloadFile extends DownloadAction {
                     }
                     else if (path.endsWith("/modules.yaml")) {
                         diskPath = Config.get().getString(ConfigDefaults.MOUNT_POINT) +
-                            "/" + tree.getChannel().getLatestModules().getRelativeFilename();
+                            "/" + tree.getChannel().getModules().getRelativeFilename();
                     }
                     else {
                         String[] split = StringUtils.split(path, '/');
@@ -648,7 +648,7 @@ public class DownloadFile extends DownloadAction {
             }
             else if (path.endsWith("/modules.yaml")) {
                 diskPath = Config.get().getString(ConfigDefaults.MOUNT_POINT) +
-                    "/" + child.getLatestModules().getRelativeFilename();
+                    "/" + child.getModules().getRelativeFilename();
             }
             else {
                 String[] split = StringUtils.split(path, '/');

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -3665,7 +3665,7 @@ public class SystemHandler extends BaseHandler {
             for (Long sid : serverIds) {
                 Server server = SystemManager.lookupByIdAndUser(sid, loggedInUser);
                 for (Channel channel : server.getChannels()) {
-                    if (channel.isModular()) {
+                    if (channel.getModules() != null) {
                         throw new ModulesNotAllowedException();
                     }
                 }
@@ -3974,7 +3974,7 @@ public class SystemHandler extends BaseHandler {
             for (Integer sid : sids) {
                 Server server = SystemManager.lookupByIdAndUser(sid.longValue(), loggedInUser);
                 for (Channel channel : server.getChannels()) {
-                    if (channel.isModular()) {
+                    if (channel.getModules() != null) {
                         hasModules = true;
                         break;
                     }

--- a/java/code/src/com/redhat/rhn/manager/channel/CloneChannelCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/CloneChannelCommand.java
@@ -118,9 +118,14 @@ public class CloneChannelCommand extends CreateChannelCommand {
         ChannelFactory.save(c);
         c = HibernateFactory.reload(c);
 
-        // Comps files are cloned by the DB trigger 'rhn_channel_cloned_comps_trig'
-        if (stripModularMetadata && c.isModular()) {
-            c.getModules().clear();
+        if (stripModularMetadata) {
+            if (c.getModules() != null) {
+                HibernateFactory.getSession().delete(c.getModules());
+            }
+            c.setModules(null);
+        }
+        else {
+            c.cloneModulesFrom(original);
         }
 
         // This ends up being a mode query call so need to save first to get channel id

--- a/java/code/src/com/redhat/rhn/manager/channel/test/CloneChannelCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/CloneChannelCommandTest.java
@@ -17,7 +17,6 @@ package com.redhat.rhn.manager.channel.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -29,9 +28,6 @@ import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ChannelTestUtils;
 
 import org.junit.jupiter.api.Test;
-
-import java.util.Date;
-import java.util.Set;
 
 public class CloneChannelCommandTest extends BaseTestCaseWithUser {
 
@@ -78,28 +74,20 @@ public class CloneChannelCommandTest extends BaseTestCaseWithUser {
     @Test
     public void testCloneModularSource() throws Exception {
         Channel original = createBaseChannel();
-        Modules modules = new Modules("blablafilename1", new Date());
-        original.addModules(modules);
-
-        modules = new Modules("blablafilename2", new Date());
-        original.addModules(modules);
-
+        Modules modules = new Modules();
+        modules.setChannel(original);
+        modules.setRelativeFilename("blablafilename");
+        original.setModules(modules);
         assertTrue(original.isModular());
 
         CloneChannelCommand ccc = new CloneChannelCommand(CloneChannelCommand.CloneBehavior.ORIGINAL_STATE, original);
         ccc.setUser(user);
         Channel clone = ccc.create();
-        Set<Modules> originalModules = original.getModules();
-        Set<Modules> cloneModules = clone.getModules();
-
-        assertEquals(2, cloneModules.size());
-        cloneModules.forEach(m -> {
-            Modules orig = originalModules.stream()
-                    .filter(o -> m.getRelativeFilename().equals(o.getRelativeFilename())).findFirst().get();
-            assertEquals(orig.getLastModified(), m.getLastModified());
-            assertEquals(clone, m.getChannel());
-            assertNotEquals(orig.getId(), m.getId());
-        });
+        Modules originalModules = original.getModules();
+        Modules cloneModules = clone.getModules();
+        assertEquals(originalModules.getRelativeFilename(), cloneModules.getRelativeFilename());
+        assertEquals(clone, cloneModules.getChannel());
+        assertFalse(originalModules.getId().equals(cloneModules.getId()));
     }
 
     /**
@@ -108,8 +96,10 @@ public class CloneChannelCommandTest extends BaseTestCaseWithUser {
     @Test
     public void testStripModularMetadata() throws Exception {
         Channel original = createBaseChannel();
-        Modules modules = new Modules("blablafilename", new Date());
-        original.addModules(modules);
+        Modules modules = new Modules();
+        modules.setChannel(original);
+        modules.setRelativeFilename("blablafilename");
+        original.setModules(modules);
         assertTrue(original.isModular());
 
         CloneChannelCommand ccc = new CloneChannelCommand(CloneChannelCommand.CloneBehavior.ORIGINAL_STATE, original);

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -769,8 +769,9 @@ public class ContentManager {
     }
 
     private static void stripModuleMetadata(Channel channel) {
-        if (channel != null && channel.isModular()) {
-            channel.getModules().clear();
+        if (channel != null && channel.getModules() != null) {
+            HibernateFactory.getSession().delete(channel.getModules());
+            channel.setModules(null);
         }
     }
 

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/DependencyResolver.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/DependencyResolver.java
@@ -18,7 +18,6 @@ package com.redhat.rhn.manager.contentmgmt;
 import static java.util.stream.Collectors.toList;
 
 import com.redhat.rhn.domain.channel.Channel;
-import com.redhat.rhn.domain.channel.Modules;
 import com.redhat.rhn.domain.contentmgmt.ContentFilter;
 import com.redhat.rhn.domain.contentmgmt.ContentProject;
 import com.redhat.rhn.domain.contentmgmt.FilterCriteria;
@@ -34,11 +33,9 @@ import com.redhat.rhn.domain.contentmgmt.modulemd.ModulemdApiException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -147,24 +144,14 @@ public class DependencyResolver {
         List<Module> resolvedModules = modPkgList.getSelected().stream().map(Module::new).collect(Collectors.toList());
 
         // 1. Modular packages to be denied
-        // Collect every synced module metadata file in every source, including outdated ones
-        Set<Modules> allMetadata = sources.stream()
-                .flatMap(s -> s.getModules().stream())
-                .collect(Collectors.toSet());
-
-        // Set to collect all the modular package NEVRAs
-        Set<String> pkgNevras = new HashSet<>();
         Stream<PackageFilter> pkgDenyFilters;
         try {
-            for (Modules metadata : allMetadata) {
-                pkgNevras.addAll(modulemdApi.getAllPackages(metadata));
-            }
+            pkgDenyFilters = modulemdApi.getAllPackages(sources).stream()
+                    .map(nevra -> initFilterFromPackageNevra(nevra, ContentFilter.Rule.DENY));
         }
         catch (ModulemdApiException e) {
             throw new DependencyResolutionException("Failed to resolve modular dependencies.", e);
         }
-        // Generate a DENY filter for each modular package
-        pkgDenyFilters = pkgNevras.stream().map(nevra -> initFilterFromPackageNevra(nevra, ContentFilter.Rule.DENY));
 
         // 2. Non-modular packages to be denied by name
         Stream<PackageFilter> providedRpmApiFilters = modPkgList.getRpmApis().stream()

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
@@ -76,7 +76,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -991,8 +990,7 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         // Assert that the target channel is also modular
         Channel targetChannel = env.getTargets().get(0).asSoftwareTarget().get().getChannel();
         assertTrue(targetChannel.isModular());
-        assertEquals(channel.getLatestModules().getRelativeFilename(),
-                targetChannel.getLatestModules().getRelativeFilename());
+        assertEquals(channel.getModules().getRelativeFilename(), targetChannel.getModules().getRelativeFilename());
         assertEquals(channel.getPackageCount(), targetChannel.getPackageCount());
     }
 
@@ -1734,8 +1732,10 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
 
         // we already have a modular target cloned from the past
         var alreadyExistingTgt = createChannelInEnvironment(env, of(channel.getLabel()));
-        Modules modules = new Modules("srcfilename", new Date());
-        alreadyExistingTgt.addModules(modules);
+        Modules modules = new Modules();
+        modules.setRelativeFilename("srcfilename");
+        modules.setChannel(alreadyExistingTgt);
+        alreadyExistingTgt.setModules(modules);
         env.addTarget(new SoftwareEnvironmentTarget(env, alreadyExistingTgt));
 
         contentManager.buildProject("cplabel", empty(), false, user);
@@ -1764,8 +1764,10 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         contentManager.attachSource("cplabel", SW_CHANNEL, channel.getLabel(), empty(), user);
 
         var alreadyExistingTgt = createChannelInEnvironment(env, of(channel.getLabel()));
-        Modules modules = new Modules("srcfilename", new Date());
-        alreadyExistingTgt.addModules(modules);
+        Modules modules = new Modules();
+        modules.setRelativeFilename("srcfilename");
+        modules.setChannel(alreadyExistingTgt);
+        alreadyExistingTgt.setModules(modules);
         env.addTarget(new SoftwareEnvironmentTarget(env, alreadyExistingTgt));
 
         // both source and current target have modular metadata...
@@ -1792,15 +1794,18 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         assertFalse(env.getTargets().get(0).asSoftwareTarget().get().getChannel().isModular());
 
         // verify that a modular source results in a modular target
-        Modules modules = new Modules("srcfilename", new Date());
-        channel.addModules(modules);
+        Modules modules = new Modules();
+        modules.setRelativeFilename("srcfilename");
+        modules.setChannel(channel);
+        channel.setModules(modules);
         contentManager.buildProject("cplabel", empty(), false, user);
         var tgtChannel = env.getTargets().get(0).asSoftwareTarget().get().getChannel();
         assertTrue(tgtChannel.isModular());
-        assertEquals("srcfilename",  tgtChannel.getLatestModules().getRelativeFilename());
+        assertEquals("srcfilename",  tgtChannel.getModules().getRelativeFilename());
 
         // verify that a non-modular source strips the modular data
-        channel.getModules().clear();
+        HibernateFactory.getSession().delete(channel.getModules());
+        channel.setModules(null);
         contentManager.buildProject("cplabel", empty(), false, user);
         assertFalse(env.getTargets().get(0).asSoftwareTarget().get().getChannel().isModular());
     }
@@ -1825,11 +1830,11 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         contentManager.buildProject("cplabel", empty(), false, user);
         contentManager.promoteProject("cplabel", "fst", false, user);
 
-        String relativeFilename = channel.getLatestModules().getRelativeFilename();
+        String relativeFilename = channel.getModules().getRelativeFilename();
         Channel fstTgt = fst.getTargets().get(0).asSoftwareTarget().get().getChannel();
         Channel sndTgt = snd.getTargets().get(0).asSoftwareTarget().get().getChannel();
-        assertEquals(relativeFilename, fstTgt.getLatestModules().getRelativeFilename());
-        assertEquals(relativeFilename, sndTgt.getLatestModules().getRelativeFilename());
+        assertEquals(relativeFilename, fstTgt.getModules().getRelativeFilename());
+        assertEquals(relativeFilename, sndTgt.getModules().getRelativeFilename());
     }
 
     private void assertBuildFails(String projectLabel) {

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/DependencyResolverTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/DependencyResolverTest.java
@@ -194,7 +194,7 @@ public class DependencyResolverTest extends BaseTestCaseWithUser {
 
         // DENY filters for all modular packages
         // Deny-all rule for all modular packages (are overridden by ALLOW filters for the selected modules)
-        api.getAllPackages(modularChannel.getLatestModules())
+        api.getAllPackages(singletonList(modularChannel))
                 .forEach(p -> assertTrue(filters.stream().anyMatch(f -> isDenyNevraEquals(f, p))));
     }
 

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/DependencyResolverTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/DependencyResolverTest.java
@@ -34,6 +34,7 @@ import com.redhat.rhn.domain.contentmgmt.ContentFilter;
 import com.redhat.rhn.domain.contentmgmt.ContentProject;
 import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
 import com.redhat.rhn.domain.contentmgmt.FilterCriteria;
+import com.redhat.rhn.domain.contentmgmt.ModularPackageFilter;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ConflictingStreamsException;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ModularityDisabledException;
 import com.redhat.rhn.domain.contentmgmt.modulemd.Module;
@@ -154,7 +155,7 @@ public class DependencyResolverTest extends BaseTestCaseWithUser {
      * Expected result from the sample data in MockModulemdApi:
      * 5 ALLOW nevra filters for modular packages of the selected modules (postgresql:10, perl:5.24)
      * 3 DENY name filters for postgresql:10 provided apis (postgresql, postgresql-server, perl)
-     * 7 DENY nevra filters for all modular packages
+     * 1 DENY filter for all modular packages
      *
      * @see DependencyResolver#resolveModularDependencies
      */
@@ -173,7 +174,7 @@ public class DependencyResolverTest extends BaseTestCaseWithUser {
 
         // The original module filters must be absent
         List<ContentFilter> filters = result.getFilters();
-        assertEquals(15, filters.size());
+        assertEquals(9, filters.size());
         assertTrue(filters.stream().noneMatch(filter1::equals));
         assertTrue(filters.stream().noneMatch(filter2::equals));
 
@@ -192,10 +193,9 @@ public class DependencyResolverTest extends BaseTestCaseWithUser {
         // For the enabled module, all other packages with the same name should be filtered out from different sources
         moduleData.getRpmApis().forEach(a -> assertTrue(filters.stream().anyMatch(f -> isDenyNameMatches(f, a))));
 
-        // DENY filters for all modular packages
+        // DENY filter for all modular packages
         // Deny-all rule for all modular packages (are overridden by ALLOW filters for the selected modules)
-        api.getAllPackages(singletonList(modularChannel))
-                .forEach(p -> assertTrue(filters.stream().anyMatch(f -> isDenyNevraEquals(f, p))));
+        assertTrue(filters.stream().anyMatch(f -> f instanceof ModularPackageFilter));
     }
 
     /**
@@ -210,12 +210,12 @@ public class DependencyResolverTest extends BaseTestCaseWithUser {
 
         List<ContentFilter> result = resolver.resolveFilters(singletonList(filter)).getFilters();
 
-        assertEquals(10, result.size());
+        assertEquals(4, result.size());
         // There should be one and only one "perl" api filter
         assertEquals(1, result.stream().filter(f -> isDenyNameMatches(f, "perl")).count());
         // There should be "allow" filters for both versions
-        assertTrue(result.stream().anyMatch(f -> isAllowNevraEquals(f, "perl-0:5.24.0-xxx.x86_64")));
-        assertTrue(result.stream().anyMatch(f -> isAllowNevraEquals(f, "perl-0:5.24.1-yyy.x86_64")));
+        assertTrue(result.stream().anyMatch(f -> isAllowNevraEquals(f, "perl-0:5.24.0-1.module_xxx.x86_64")));
+        assertTrue(result.stream().anyMatch(f -> isAllowNevraEquals(f, "perl-0:5.24.1-1.module_yyy.x86_64")));
     }
 
     /**
@@ -242,7 +242,7 @@ public class DependencyResolverTest extends BaseTestCaseWithUser {
     @Test
     public void testModuleFiltersForeignPackagesSelected() throws Exception {
         FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "module_stream", "perl:5.26");
-        ContentFilter filter = contentManager.createFilter("perl-5.24-filter", ALLOW, MODULE, criteria, user);
+        ContentFilter filter = contentManager.createFilter("perl-5.26-filter", ALLOW, MODULE, criteria, user);
 
         List<ContentFilter> result = resolver.resolveFilters(singletonList(filter)).getFilters();
         assertNotEmpty(result);
@@ -327,6 +327,10 @@ public class DependencyResolverTest extends BaseTestCaseWithUser {
 
     private boolean isFilterOfType(ContentFilter f, ContentFilter.Rule rule, FilterCriteria.Matcher matcher,
             String field, String value) {
+        if (f.getCriteria() == null) {
+            return false;
+        }
+
         return rule.equals(f.getRule()) && matcher.equals(f.getCriteria().getMatcher()) && field
                 .equals(f.getCriteria().getField()) && value.equals(f.getCriteria().getValue());
     }

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/MockModulemdApi.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/MockModulemdApi.java
@@ -44,7 +44,6 @@ import com.redhat.rhn.testing.TestUtils;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -126,8 +125,10 @@ public class MockModulemdApi extends ModulemdApi {
     public static Channel createModularTestChannel(User user) throws Exception {
         Channel channel = TestUtils.reload(ChannelFactoryTest.createTestChannel(user, "channel-x86_64"));
         channel.setChecksumType(ChannelFactory.findChecksumTypeByLabel("sha1"));
-        Modules modulemd = new Modules("/path/to/modulemd.yaml", new Date());
-        channel.addModules(modulemd);
+        Modules modulemd = new Modules();
+        modulemd.setChannel(channel);
+        modulemd.setRelativeFilename("/path/to/modulemd.yaml");
+        channel.setModules(modulemd);
 
         List<String> nevras = doGetAllPackages();
         // perl 5.26 is a special package which is included in the module definition even though it's not served as a
@@ -236,7 +237,7 @@ public class MockModulemdApi extends ModulemdApi {
         if (!channel.isModular()) {
             throw new RepositoryNotModularException();
         }
-        Modules metadata = channel.getLatestModules();
+        Modules metadata = channel.getModules();
         return new File(MOUNT_POINT_PATH, metadata.getRelativeFilename()).getAbsolutePath();
     }
 

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/MockModulemdApi.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/MockModulemdApi.java
@@ -72,7 +72,10 @@ public class MockModulemdApi extends ModulemdApi {
     }
 
     @Override
-    public List<String> getAllPackages(Modules modules) {
+    public List<String> getAllPackages(List<Channel> sources) {
+        // Dummy call to trigger RepositoryNotModular exception:
+        getMetadataPaths(sources);
+
         // Mock list
         try {
             return doGetAllPackages();

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/MockModulemdApi.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/MockModulemdApi.java
@@ -208,8 +208,8 @@ public class MockModulemdApi extends ModulemdApi {
                 // Return multiple versions of the package. The different versions are represented as separate module
                 // entries in the metadata and they are merged in to a package list with multiple versions.
                 pkgList.addAll(asList(
-                        "perl-0:5.24.0-xxx.x86_64",
-                        "perl-0:5.24.1-yyy.x86_64"
+                        "perl-0:5.24.0-1.module_xxx.x86_64",
+                        "perl-0:5.24.1-1.module_yyy.x86_64"
                 ));
             }
             else {

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriter.java
@@ -490,7 +490,7 @@ public class RpmRepositoryWriter extends RepositoryWriter {
                 method = channel.getClass().getMethod("getComps");
             }
             else if (metadataType.equals(MODULES)) {
-                method = channel.getClass().getMethod("getLatestModules");
+                method = channel.getClass().getMethod("getModules");
             }
         }
         catch (NoSuchMethodException e) {

--- a/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
@@ -328,10 +328,10 @@ public class DownloadController {
      * @return modules file to be used for this channel
      */
     private static File getModulesFile(Channel channel) {
-        Modules modules = channel.getLatestModules();
+        Modules modules = channel.getModules();
 
         if (modules == null && channel.isCloned()) {
-            modules = channel.getOriginal().getLatestModules();
+            modules = channel.getOriginal().getModules();
         }
         if (modules != null) {
             return new File(MOUNT_POINT_PATH, modules.getRelativeFilename()).getAbsoluteFile();

--- a/java/code/src/com/suse/manager/webui/controllers/test/DownloadControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/DownloadControllerTest.java
@@ -67,14 +67,10 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.attribute.FileTime;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -336,7 +332,6 @@ public class DownloadControllerTest extends BaseTestCaseWithUser {
             Comps comps = new Comps();
             comps.setChannel(channel);
             comps.setRelativeFilename(compsRelativeDirPath + "/" + compsFile.getName());
-            comps.setLastModified(new Date());
             channel.setComps(comps);
 
             try {
@@ -666,7 +661,6 @@ public class DownloadControllerTest extends BaseTestCaseWithUser {
             Comps comps = new Comps();
             comps.setChannel(channel);
             comps.setRelativeFilename(compsRelativeDirPath + "/" + compsFile.getName());
-            comps.setLastModified(new Date());
             channel.setComps(comps);
 
             try {
@@ -705,35 +699,28 @@ public class DownloadControllerTest extends BaseTestCaseWithUser {
                 Collections.emptyMap(),
                 channel.getLabel(), "modules.yaml");
 
-        Path modulesRelativeDir = Path.of("rhn", "modules", channel.getName());
-        Path modulesDir = Path.of(Config.get().getString(ConfigDefaults.MOUNT_POINT)).resolve(modulesRelativeDir);
+        String modulesRelativeDirPath = "rhn/modules/" + channel.getName();
+        String modulesDirPath = Config.get().getString(ConfigDefaults.MOUNT_POINT) + "/" + modulesRelativeDirPath;
+        String modulesName = modulesRelativeDirPath + "123hash123-modules";
+        File modulesDir = new File(modulesDirPath);
         try {
-            Files.createDirectories(modulesDir);
-            Path modulesFile = Files.createTempFile(modulesDir, "n3wha5h", "-modules.yaml");
-            Files.write(modulesFile, TestUtils.randomString().getBytes());
+            assertTrue(modulesDir.mkdirs());
+            File modulesFile = File.createTempFile(modulesDirPath + "/" + modulesName, ".yaml", modulesDir);
+            Files.write(modulesFile.getAbsoluteFile().toPath(),
+                    TestUtils.randomString().getBytes());
 
             // create modules object
-            Modules modulesLatest = new Modules(modulesRelativeDir.resolve(modulesFile.getFileName()).toString(),
-                    Date.from(Files.getLastModifiedTime(modulesFile).toInstant()));
-            channel.addModules(modulesLatest);
-
-            // Create a second, older modules.yaml file
-            Path modulesFileOlder = Files.createTempFile(modulesDir, "01dha5h", "-modules.yaml");
-            Files.write(modulesFileOlder, TestUtils.randomString().getBytes());
-            // Set file time to 1 second earlier than the other one
-            Files.setLastModifiedTime(modulesFileOlder,
-                    FileTime.from(Files.getLastModifiedTime(modulesFile).toInstant().minus(Duration.ofSeconds(1))));
-
-            Modules modulesOlder = new Modules(modulesRelativeDir.resolve(modulesFileOlder.getFileName()).toString(),
-                    Date.from(Files.getLastModifiedTime(modulesFileOlder).toInstant()));
-            channel.addModules(modulesOlder);
+            Modules modules = new Modules();
+            modules.setChannel(channel);
+            modules.setRelativeFilename(modulesRelativeDirPath + "/" + modulesFile.getName());
+            channel.setModules(modules);
 
             try {
                 assertNotNull(DownloadController.downloadMetadata(request, response));
 
-                assertEquals(modulesFile.toAbsolutePath().toString(), response.raw().getHeader("X-Sendfile"));
+                assertEquals(modulesFile.getAbsolutePath(), response.raw().getHeader("X-Sendfile"));
                 assertEquals("application/octet-stream", response.raw().getHeader("Content-Type"));
-                assertEquals("attachment; filename=" + modulesFile.getFileName().toString(),
+                assertEquals("attachment; filename=" + modulesFile.getName(),
                         response.raw().getHeader("Content-Disposition"));
             }
             catch (spark.HaltException e) {
@@ -741,7 +728,7 @@ public class DownloadControllerTest extends BaseTestCaseWithUser {
             }
         }
         finally {
-            FileUtils.deleteDirectory(modulesDir.toFile());
+            FileUtils.deleteDirectory(modulesDir);
         }
     }
 
@@ -778,7 +765,6 @@ public class DownloadControllerTest extends BaseTestCaseWithUser {
             MediaProducts prd = new MediaProducts();
             prd.setChannel(channel);
             prd.setRelativeFilename(productsRelativeDirPath + "/" + productsFile.getName());
-            prd.setLastModified(new Date());
             channel.setMediaProducts(prd);
 
             try {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Filter CLM modular packages using release strings (bsc#1207814)
 - Fix systems subscribed to channel CSV download (bsc#1201063)
 - Save scheduler user when creating Patch actions manually (bsc#1208321)
 - Fix cobbler system entries for retail terminals (bsc#1208661)

--- a/python/spacewalk/satellite_tools/reposync.py
+++ b/python/spacewalk/satellite_tools/reposync.py
@@ -859,11 +859,7 @@ class RepoSync(object):
         src.close()
         if old_checksum and old_checksum != getFileChecksum('sha256', abspath):
             self.regen = True
-
-        if comps_type == 'modules':
-            log(0, "*** NOTE: Importing {1} file for the channel '{0}'.".format(self.channel['label'], comps_type))
-        else:
-            log(0, "*** NOTE: Importing {1} file for the channel '{0}'. Previous {1} will be discarded.".format(self.channel['label'], comps_type))
+        log(0, "*** NOTE: Importing {1} file for the channel '{0}'. Previous {1} will be discarded.".format(self.channel['label'], comps_type))
 
         repoDataKey = 'group' if comps_type == 'comps' else comps_type
         file_timestamp = os.path.getmtime(filename)
@@ -875,30 +871,26 @@ class RepoSync(object):
             return abspath
 
         # update or insert
-        hu = rhnSQL.prepare("""
-            update rhnChannelComps
-            set relative_filename = :relpath,
-                modified = current_timestamp,
-                last_modified = :last_modified
-            where channel_id = :cid
-                and comps_type_id = (select id from rhnCompsType where label = :ctype)
-                and relative_filename = :relpath""")
+        hu = rhnSQL.prepare("""update rhnChannelComps
+                                  set relative_filename = :relpath,
+                                      modified = current_timestamp,
+                                      last_modified = :last_modified
+                                where channel_id = :cid
+                                  and comps_type_id = (select id from rhnCompsType where label = :ctype)""")
         hu.execute(cid=self.channel['id'], relpath=relativepath, ctype=comps_type,
                    last_modified=last_modified)
 
-        hi = rhnSQL.prepare("""
-            insert into rhnChannelComps(id, channel_id, relative_filename, last_modified, comps_type_id)
-            (select sequence_nextval('rhn_channelcomps_id_seq'),
-                    :cid,
-                    :relpath,
-                    :last_modified,
-                    (select id from rhnCompsType where label = :ctype)
-                from dual
-                where not exists
-                    (select 1 from rhnChannelComps
-                        where channel_id = :cid
-                            and comps_type_id = (select id from rhnCompsType where label = :ctype)
-                            and relative_filename = :relpath))""")
+        hi = rhnSQL.prepare("""insert into rhnChannelComps
+                              (id, channel_id, relative_filename, last_modified, comps_type_id)
+                              (select sequence_nextval('rhn_channelcomps_id_seq'),
+                                      :cid,
+                                      :relpath,
+                                      :last_modified,
+                              (select id from rhnCompsType where label = :ctype)
+                                 from dual
+                                where not exists (select 1 from rhnChannelComps
+                                    where channel_id = :cid
+                                    and comps_type_id = (select id from rhnCompsType where label = :ctype)))""")
         hi.execute(cid=self.channel['id'], relpath=relativepath, ctype=comps_type,
                    last_modified=last_modified)
         return abspath

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Filter CLM modular packages using release strings (bsc#1207814)
 - fix repo sync for cloud payg connected repositories (bsc#1208772)
 - Fix issues with kickstart syncing on mirrorlist repositories
 - Do not sync .mirrorlist and other non needed files

--- a/schema/spacewalk/common/tables/rhnChannelComps.sql
+++ b/schema/spacewalk/common/tables/rhnChannelComps.sql
@@ -31,14 +31,12 @@ CREATE TABLE rhnChannelComps
                            DEFAULT (current_timestamp) NOT NULL,
     comps_type_id      NUMERIC NOT NULL
                           CONSTRAINT rhn_channelcomps_comps_type_fk
-                               REFERENCES rhnCompsType(id),
-    CONSTRAINT rhn_channelcomps_cid_ctype_filename_uq
-        UNIQUE(channel_id, comps_type_id, relative_filename)
+                               REFERENCES rhnCompsType(id)
 )
 
 ;
 
-CREATE INDEX rhn_channelcomps_cid_ctype_idx
+CREATE UNIQUE INDEX rhn_channelcomps_cid_ctype_uq
     ON rhnChannelComps (channel_id, comps_type_id)
     ;
 

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Filter CLM modular packages using release strings (bsc#1207814)
 - merge multiple older schema upgrade directories together
 
 -------------------------------------------------------------------

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.5-to-susemanager-schema-4.4.6/001-rhnChannelComps-revert_drop_uidx.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.5-to-susemanager-schema-4.4.6/001-rhnChannelComps-revert_drop_uidx.sql
@@ -1,0 +1,18 @@
+-- Drop the indexes
+DROP INDEX IF EXISTS rhn_channelcomps_cid_ctype_uq;
+DROP INDEX IF EXISTS rhn_channelcomps_cid_ctype_idx;
+ALTER TABLE rhnChannelComps DROP CONSTRAINT IF EXISTS rhn_channelcomps_cid_ctype_filename_uq;
+
+-- Delete outdated (archived) comps entries,
+-- keeping only the latest for each type, per channel
+DELETE FROM rhnChannelComps c
+WHERE EXISTS (
+    SELECT 1
+    FROM rhnChannelComps
+    WHERE id != c.id
+        AND channel_id = c.channel_id
+        AND last_modified >= c.last_modified
+        AND comps_type_id = c.comps_type_id
+);
+
+CREATE UNIQUE INDEX rhn_channelcomps_cid_ctype_uq ON rhnChannelComps(channel_id, comps_type_id);


### PR DESCRIPTION
### Background

I recently discovered that a corrupt module metadata file was served by the vendor a few months ago. This file has been replaced the next day. But Uyuni keeps all mirrored metadata and calculates modular filtering using data from all of them. Because of this, CLM AppStream filtering has stopped working ever since for all instances that mirrored this invalid file. Simply discarding the corrupt file is not feasible either, because that means some packages that are unique in that file would leak into the target repositories.

### Solution

This patch introduces a much simpler way of filtering out modular packages by relying on a keyword (`module`) in their release strings. With this improvement, archiving older metadata files is not necessary anymore.

```
postgresql-server-0:10.6-1.module_el8.0.0+15+f57f353b.x86_64
```

The keyword `module` in the release string has been there since the initial release of modularity, and it's been long enough to say it's reliable across all distributions.

### Implementation

The PR first **carefully** reverts the older implementation of archiving and processing older module metadata files (#5786, #6440). On top of it, it introduces a new single filter that filters out every modular package by matching the keyword `.module_` in the release string. This filter is internally added by the `DependencyResolver`, and cannot be seen, created, or manipulated by the user.

As a bonus, the new filter is used only once, instead of one per package in the older implementation, which brings a significant performance boost.

## Documentation
- No documentation needed: Only internal and user-invisible changes

## Test coverage
- Unit tests were added

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20447

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
