### PR TITLE
get uptime with package profile update

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -491,6 +491,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
     public void testPackagesProfileUpdateLivePatching() throws Exception {
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
         minion.setMinionId("minionsles12-suma3pg.vagrant.local");
+        minion.setLastBoot(0L);
 
         Action action = ActionFactoryTest.createAction(
                 user, ActionFactory.TYPE_PACKAGES_REFRESH_LIST);
@@ -508,6 +509,9 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         // Verify no live patching version is returned
         assertNull(minion.getKernelLiveVersion());
 
+        // Verify no Uptime is set
+        assertEquals(0L, minion.getLastBoot());
+
         //Switch to live patching
         message = new JobReturnEventMessage(JobReturnEvent
                 .parse(getJobReturnEvent("packages.profileupdate.livepatching.json",
@@ -518,6 +522,10 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         // Verify live patching version
         assertEquals("livepatch_2_2_1", minion.getKernelLiveVersion());
 
+        // Verify Uptime is set
+        Date bootTime = new Date(System.currentTimeMillis() - (600 * 1000));
+        assertTrue(minion.getLastBoot() == (bootTime.getTime() / 1000));
+
         //Switch back from live patching
         message = new JobReturnEventMessage(JobReturnEvent
                 .parse(getJobReturnEvent("packages.profileupdate.json",
@@ -527,6 +535,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         // Verify no live patching version is returned again
         assertNull(minion.getKernelLiveVersion());
+
     }
 
     /**

--- a/java/code/src/com/suse/manager/reactor/messaging/test/packages.profileupdate.livepatching.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/packages.profileupdate.livepatching.json
@@ -254,6 +254,24 @@
         "result": true,
         "start_time": "11:16:23.084040"
       },
+      "mgrcompat_|-status_uptime_|-status.uptime_|-module_run": {
+        "__run_num__": 4,
+        "changes": {
+          "ret": {
+            "seconds": 600.0,
+            "since_iso": "2023-02-14T00:14:34.453950",
+            "since_t": 1676330074.0,
+            "days": 0.0,
+            "time": "13:11",
+            "users": 1.0
+          }
+        },
+        "comment": "Module function status.uptime executed",
+        "duration": 0.420,
+        "name": "status.uptime",
+        "result": true,
+        "start_time": "13:58:37.216400"
+      },
       "mgrcompat_|-kernel_live_version_|-sumautil.get_kernel_live_version_|-module_run": {
         "__run_num__": 5,
         "changes": {

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -1435,6 +1435,12 @@ public class SaltUtils {
             }
         }
 
+        // Update last boot time
+        handleUptimeUpdate(server, result.getUpTime()
+                .map(ut -> (Number)ut.getChanges().getRet().get("seconds"))
+                .map(n -> n.longValue())
+                .orElse(null));
+
         // Update live patching version
         server.setKernelLiveVersion(result.getKernelLiveVersionInfo()
                 .map(klv -> klv.getChanges().getRet()).filter(Objects::nonNull)
@@ -1942,6 +1948,9 @@ public class SaltUtils {
      * @param uptimeSeconds uptime time in seconds
      */
     public static void handleUptimeUpdate(MinionServer minion, Long uptimeSeconds) {
+        if (uptimeSeconds == null) {
+            return;
+        }
         Date bootTime = new Date(
                 System.currentTimeMillis() - (uptimeSeconds * 1000));
         LOG.debug("Set last boot for {} to {}", minion.getMinionId(), bootTime);

--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/PkgProfileUpdateSlsResult.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/PkgProfileUpdateSlsResult.java
@@ -53,8 +53,10 @@ public class PkgProfileUpdateSlsResult {
     public static final String PKG_PROFILE_WHATPROVIDES_SLL_RELEASE =
             "cmd_|-sllpkgquery_|-rpm -q --whatprovides 'sll-release'_|-run";
 
-    @SerializedName("mgrcompat_|-kernel_live_version_|-sumautil.get_kernel_live_version_|" +
-            "-module_run")
+    @SerializedName("mgrcompat_|-status_uptime_|-status.uptime_|-module_run")
+    private Optional<StateApplyResult<Ret<Map<String, Object>>>> upTime = Optional.empty();
+
+    @SerializedName("mgrcompat_|-kernel_live_version_|-sumautil.get_kernel_live_version_|-module_run")
     private Optional<StateApplyResult<Ret<KernelLiveVersionInfo>>> kernelLiveVersionInfo = Optional.empty();
 
     @SerializedName("mgrcompat_|-grains_update_|-grains.items_|-module_run")
@@ -92,6 +94,14 @@ public class PkgProfileUpdateSlsResult {
 
     @SerializedName(PKG_PROFILE_WHATPROVIDES_SLL_RELEASE)
     private StateApplyResult<CmdResult> whatProvidesSLLReleasePkg;
+
+    /**
+     * Gets the system uptime
+     * @return the system uptime
+     */
+    public Optional<StateApplyResult<Ret<Map<String, Object>>>> getUpTime() {
+        return upTime;
+    }
 
     /**
      * Gets live patching info.

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- set uptime at package profile update
 - Install the reboot info beacon using a conf file instead of using pillars
 - Handle taskomatic failures during action creation
 - Reduce taskomatic memory consumption while processing Ubuntu Erratas

--- a/susemanager-utils/susemanager-sls/salt/packages/profileupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/profileupdate.sls
@@ -39,6 +39,11 @@ grains_update:
 {%- endif %}
 
 {% if not pillar.get('imagename') %}
+
+status_uptime:
+  mgrcompat.module_run:
+    - name: status.uptime
+
 kernel_live_version:
   mgrcompat.module_run:
     - name: sumautil.get_kernel_live_version

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- get uptime with package profile update
 - Fix missing module when bootstraping transactional systems (bsc#1207792)
 - Install the reboot info beacon using a conf file instead of using pillars
 - add CPU sockets, threads and total number to standard CPU grains


### PR DESCRIPTION
## What does this PR change?

A Package Profile Update should also report and handle the uptime of the system.
In case the salt start event gets lost, it is currently not possible to update this value with an action.
As the kernel live version and grains are also handled in pkgprofile update, it makes sense to send and update the uptime as well.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were updated

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/20537

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
