### PR TITLE
report subscription warnings via notification only on mondays

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
@@ -41,7 +41,10 @@ import org.apache.logging.log4j.Logger;
 import org.quartz.JobExecutionContext;
 
 import java.io.IOException;
+import java.time.DayOfWeek;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -123,6 +126,10 @@ public class DailySummary extends RhnJavaJob {
     }
 
     private void  processSubscriptionWarningNotification() {
+        if (Instant.now().atZone(ZoneId.systemDefault()).getDayOfWeek() != DayOfWeek.MONDAY) {
+            // we want to show this notification only on Mondays
+            return;
+        }
         SubscriptionWarning sw = new SubscriptionWarning();
         if (sw.expiresSoon()) {
             NotificationMessage notificationMessage =

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- send subscription warning notifications only on monday
 - set uptime at package profile update
 - Install the reboot info beacon using a conf file instead of using pillars
 - Handle taskomatic failures during action creation


### PR DESCRIPTION
## What does this PR change?

This might get send as email and could be very annoying as there is no chance to prevent it

## Links

Port of https://github.com/SUSE/spacewalk/pull/20538

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
