### PR TITLE
Hide the install option for RHEL9 kickstart installs

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartOptionsCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartOptionsCommand.java
@@ -73,6 +73,10 @@ public class KickstartOptionsCommand  extends BaseKickstartCommand {
             log.debug("avail commandname: {}", cn.getName());
 
             String name = cn.getName();
+            if (getKickstartData().getInstallType().isRhel9OrGreater() && name.equals("install")) {
+                log.debug("install is not supported on RHEL 9 or greater, don't show it");
+                continue;
+            }
             boolean added = false;
             for (KickstartCommand c : options) {
                 if (c.getCommandName().getName().equals(name)) {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Hide install option for RHEL9+ kickstarts
 - Make API method systemgroup.listSystemsMinimal read-only (bsc#1208550)
 - Allow single-value lists in query strings in HTTP API (bsc#1207297)
 - Do not include channels from different orgs when listing mandatory channels (bsc#1204270)


### PR DESCRIPTION
## What does this PR change?

RHEL9 doesn't support the kickstart `install` option. Hide it from the details UI.

## GUI diff

Option hidden.

- [X] **DONE**

## Documentation
- No documentation needed: Kickstarts are not documented
- [X] **DONE**

## Test coverage
- No tests: Kickstarts are not auto tested
- [X] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/5513

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
