### PR TITLE
Do not include channels from different orgs when listing mandatory channels

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/product/SUSEProductFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/product/SUSEProductFactory.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -299,7 +300,8 @@ public class SUSEProductFactory extends HibernateFactory {
                                 .flatMap(c -> {
                                     return c.allClonedChannels().filter(clone -> {
                                         List<String> cloneParts = List.of(clone.getLabel().split("-"));
-                                        return cloneParts.containsAll(uniqueParts);
+                                        return cloneParts.containsAll(uniqueParts) &&
+                                                Objects.equals(clone.getOrg(), channel.getOrg());
                                     });
                                 })
                                 .map(c -> (Channel) c);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Do not include channels from different orgs when listing mandatory channels (bsc#1204270)
+
 -------------------------------------------------------------------
 Tue Feb 28 11:55:21 CET 2023 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

When listing mandatory channels for a given cloned channel, the code starts from the original channel and includes in the list all the channels cloned from it, including CLM channels from other organizations. If the user hasn't permission to access some mandatory channel from other org included in the list, CLM breaks down. This PR includes an additional condition to avoid including channels from other orgs into the list of mandatory channels.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19250

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
