### PR TITLE
QE: Enable buildhost options in Activation Key for buildhost minion

### DIFF
--- a/testsuite/features/build_validation/retail/sle12sp5_buildhost_build_kiwi_image.feature
+++ b/testsuite/features/build_validation/retail/sle12sp5_buildhost_build_kiwi_image.feature
@@ -22,14 +22,6 @@ Feature: Prepare buildhost and build OS image for SLES 12 SP5
     And I accept "sle12sp5_buildhost" key in the Salt master
     And I wait until onboarding is completed for "sle12sp5_buildhost"
 
-  Scenario: Turn the SLES 12 SP5 build host into an OS image build host
-    Given I am on the Systems overview page of this "sle12sp5_buildhost"
-    When I follow "Details" in the content area
-    And I follow "Properties" in the content area
-    And I check "osimage_build_host"
-    And I click on "Update Properties"
-    Then I should see a "OS Image Build Host type has been applied." text
-
   Scenario: Apply the highstate to the SLES 12 SP5 build host
     Given I am on the Systems overview page of this "sle12sp5_buildhost"
     When I wait until no Salt job is running on "sle12sp5_buildhost"

--- a/testsuite/features/build_validation/retail/sle15sp4_buildhost_build_kiwi_image.feature
+++ b/testsuite/features/build_validation/retail/sle15sp4_buildhost_build_kiwi_image.feature
@@ -22,14 +22,6 @@ Feature: Prepare buildhost and build OS image for SLES 15 SP4
     And I accept "sle15sp4_buildhost" key in the Salt master
     And I wait until onboarding is completed for "sle15sp4_buildhost"
 
-  Scenario: Turn the SLES 15 SP4 build host into an OS image build host
-    Given I am on the Systems overview page of this "sle15sp4_buildhost"
-    When I follow "Details" in the content area
-    And I follow "Properties" in the content area
-    And I check "osimage_build_host"
-    And I click on "Update Properties"
-    Then I should see a "OS Image Build Host type has been applied." text
-
   Scenario: Apply the highstate to the SLES 15 SP4 build host
     Given I am on the Systems overview page of this "sle15sp4_buildhost"
     When I wait until no Salt job is running on "sle15sp4_buildhost"

--- a/testsuite/features/init_clients/buildhost_bootstrap.feature
+++ b/testsuite/features/init_clients/buildhost_bootstrap.feature
@@ -7,7 +7,7 @@ Feature: Bootstrap a Salt build host via the GUI
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  Scenario: Update the SLESS activation key
+  Scenario: Update the SLES activation key
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE Test Key x86_64" in the content area
     And I check "container_build_host"

--- a/testsuite/features/init_clients/buildhost_bootstrap.feature
+++ b/testsuite/features/init_clients/buildhost_bootstrap.feature
@@ -7,6 +7,13 @@ Feature: Bootstrap a Salt build host via the GUI
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
+  Scenario: Update the SLESS activation key
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "SUSE Test Key x86_64" in the content area
+    And I check "container_build_host"
+    And I check "osimage_build_host"
+    And I click on "Update Activation Key"
+
   Scenario: Bootstrap a SLES build host
     When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
@@ -44,38 +51,7 @@ Feature: Bootstrap a Salt build host via the GUI
   Scenario: Detect latest Salt changes on the SLES build host
     When I query latest Salt changes on "build_host"
 
-  Scenario: Turn the SLES build host into a container build host
-    Given I am on the Systems overview page of this "build_host"
-    When I follow "Details" in the content area
-    And I follow "Properties" in the content area
-    And I check "container_build_host"
-    And I click on "Update Properties"
-    Then I should see a "Container Build Host type has been applied." text
-    And I should see a "Note: This action will not result in state application" text
-    And I should see a "To apply the state, either use the states page or run state.highstate from the command line." text
-    And I should see a "System properties changed" text
-
-  Scenario: Turn the SLES build host into an OS image build host
-    Given I am on the Systems overview page of this "build_host"
-    When I follow "Details" in the content area
-    And I follow "Properties" in the content area
-    And I check "osimage_build_host"
-    And I click on "Update Properties"
-    Then I should see a "OS Image Build Host type has been applied." text
-    And I should see a "Note: This action will not result in state application" text
-    And I should see a "To apply the state, either use the states page or run state.highstate from the command line." text
-    And I should see a "System properties changed" text
-
-  Scenario: Apply the highstate to the build host
-    Given I am on the Systems overview page of this "build_host"
-    When I wait until no Salt job is running on "build_host"
-    And I apply highstate on "build_host"
-    And I wait until "docker" service is active on "build_host"
-    # WORKAROUND for https://github.com/SUSE/spacewalk/issues/20318
-    And I install the needed packages for highstate in build host
-    And I wait until file "/var/lib/Kiwi/repo/rhn-org-trusted-ssl-cert-osimage-1.0-1.noarch.rpm" exists on "build_host"
-
-  Scenario: Check that the build host is now a build host
+  Scenario: Check that the build host is a build host
     Given I am on the Systems overview page of this "build_host"
     Then I should see a "[Container Build Host]" text
     Then I should see a "[OS Image Build Host]" text
@@ -83,3 +59,10 @@ Feature: Bootstrap a Salt build host via the GUI
   Scenario: Check events history for failures on SLES build host
     Given I am on the Systems overview page of this "build_host"
     Then I check for failed events on history event page
+
+  Scenario: Cleanup: Restore the SLES activation key to its original state
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "SUSE Test Key x86_64" in the content area
+    And I uncheck "container_build_host"
+    And I uncheck "osimage_build_host"
+    And I click on "Update Activation Key"

--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -233,6 +233,9 @@ When(/^I create an activation key including custom channels for "([^"]*)" via AP
 
   is_ssh_minion = client.include? 'ssh_minion'
   $api_test.activationkey.set_details(key, description, base_channel, 100, is_ssh_minion ? 'ssh-push' : 'default')
+  entitlements = ''
+  entitlements = ['container_build_host', 'osimage_build_host'] if client.include? 'buildhost'
+  $api_test.activationkey.set_entitlement(key, entitlements) unless entitlements.empty?
 
   # Get the list of child channels for this base channel
   child_channels = $api_test.channel.software.list_child_channels(base_channel)

--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -233,8 +233,7 @@ When(/^I create an activation key including custom channels for "([^"]*)" via AP
 
   is_ssh_minion = client.include? 'ssh_minion'
   $api_test.activationkey.set_details(key, description, base_channel, 100, is_ssh_minion ? 'ssh-push' : 'default')
-  entitlements = ''
-  entitlements = ['osimage_build_host'] if client.include? 'buildhost'
+  entitlements = (client.include? 'buildhost') ? ['osimage_build_host'] : ''
   $api_test.activationkey.set_entitlement(key, entitlements) unless entitlements.empty?
 
   # Get the list of child channels for this base channel

--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -233,7 +233,7 @@ When(/^I create an activation key including custom channels for "([^"]*)" via AP
 
   is_ssh_minion = client.include? 'ssh_minion'
   $api_test.activationkey.set_details(key, description, base_channel, 100, is_ssh_minion ? 'ssh-push' : 'default')
-  entitlements = (client.include? 'buildhost') ? ['osimage_build_host'] : ''
+  entitlements = client.include?('buildhost') ? ['osimage_build_host'] : ''
   $api_test.activationkey.set_entitlement(key, entitlements) unless entitlements.empty?
 
   # Get the list of child channels for this base channel

--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -234,7 +234,7 @@ When(/^I create an activation key including custom channels for "([^"]*)" via AP
   is_ssh_minion = client.include? 'ssh_minion'
   $api_test.activationkey.set_details(key, description, base_channel, 100, is_ssh_minion ? 'ssh-push' : 'default')
   entitlements = ''
-  entitlements = ['container_build_host', 'osimage_build_host'] if client.include? 'buildhost'
+  entitlements = ['osimage_build_host'] if client.include? 'buildhost'
   $api_test.activationkey.set_entitlement(key, entitlements) unless entitlements.empty?
 
   # Get the list of child channels for this base channel

--- a/testsuite/features/support/namespaces/activationkey.rb
+++ b/testsuite/features/support/namespaces/activationkey.rb
@@ -125,4 +125,20 @@ class NamespaceActivationkey
     }
     @test.call('activationkey.setDetails', sessionKey: @test.token, key: id, details: details).to_i == 1
   end
+
+  ##
+  # Sets the entitlements of an activation key.
+  #
+  # Args:
+  #   id: The ID of the activation key.
+  #   entitlements: Array of entitlements to enable on this AK.
+  #                   Valid values are:
+  #                   - container_build_host
+  #                   - monitoring_entitled
+  #                   - osimage_build_host
+  #                   - virtualization_host
+  #                   - ansible_control_node
+  def set_entitlement(id, entitlements)
+    @test.call('activationkey.addEntitlements', sessionKey: @test.token, key: id, entitlements: entitlements)
+  end
 end


### PR DESCRIPTION
## What does this PR change?
Instead of transforming a bootstrapped minion into a buildhost, we change the SLE activation key before bootstrapping to have the minion bootstrapped as a buildhost directly.
## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were added
- [x] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/13736
Tracks #
4.2 https://github.com/SUSE/spacewalk/pull/20618
4.3 https://github.com/SUSE/spacewalk/pull/20619
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
