### PR TITLE
Add python3 XML-RPC datetime example

### DIFF
--- a/java/buildconf/apidoc/asciidoc/scripts.txt
+++ b/java/buildconf/apidoc/asciidoc/scripts.txt
@@ -262,6 +262,28 @@ print(client.user.list_users(key))
 client.auth.logout(key)
 ----
 
+The following code shows how to use date-time parameters. This code will schedule immediate installation of package rhnlib-2.5.22.9.el6.noarch to system with id 1000000001.
+
+[source,python]
+----
+#!/usr/bin/env python3
+from datetime import datetime
+from xmlrpc.client import ServerProxy
+
+MANAGER_URL = "http://manager.example.com/rpc/api"
+MANAGER_LOGIN = "username"
+MANAGER_PASSWORD = "password"
+
+client = ServerProxy(MANAGER_URL)
+
+key = client.auth.login(MANAGER_LOGIN, MANAGER_PASSWORD)
+package_list = client.packages.findByNvrea(key, 'rhnlib', '2.5.22', '9.el6', '', 'noarch')
+earliest_occurrence = datetime.today()
+client.system.schedulePackageInstall(key, 1000000001, [package_list[0]['id']], earliest_occurrence)
+
+client.auth.logout(key)
+----
+
 
 === Ruby Example
 

--- a/java/buildconf/apidoc/docbook/scripts.txt
+++ b/java/buildconf/apidoc/docbook/scripts.txt
@@ -239,6 +239,23 @@ key = client.auth.login(MANAGER_LOGIN, MANAGER_PASSWORD)
 print(client.user.list_users(key))
 
 client.auth.logout(key)</programlisting>
+    <para>The following code shows how to use date-time parameters. This code will schedule immediate installation of package rhnlib-2.5.22.9.el6.noarch to system with id 1000000001.</para>
+    <programlisting>#!/usr/bin/env python3
+from datetime import datetime
+from xmlrpc.client import ServerProxy
+
+MANAGER_URL = "http://manager.example.com/rpc/api"
+MANAGER_LOGIN = "username"
+MANAGER_PASSWORD = "password"
+
+client = ServerProxy(MANAGER_URL)
+
+key = client.auth.login(MANAGER_LOGIN, MANAGER_PASSWORD)
+package_list = client.packages.findByNvrea(key, 'rhnlib', '2.5.22', '9.el6', '', 'noarch')
+earliest_occurrence = datetime.today()
+client.system.schedulePackageInstall(key, 1000000001, [package_list[0]['id']], earliest_occurrence)
+
+client.auth.logout(key)</programlisting>
 </example>
 
 <example>

--- a/java/buildconf/apidoc/html/scripts.txt
+++ b/java/buildconf/apidoc/html/scripts.txt
@@ -255,6 +255,30 @@ print(client.user.list_users(key))
 
 client.auth.logout(key)
 </pre>
+<p/>
+The following code shows how to use date-time parameters. This code will schedule
+immediate installation of package <code>rhnlib-2.5.22.9.el6.noarch</code> to system with
+ID <code>1000000001</code>.
+<p/>
+
+<pre>
+#!/usr/bin/env python3
+from datetime import datetime
+from xmlrpc.client import ServerProxy
+
+MANAGER_URL = "http://manager.example.com/rpc/api"
+MANAGER_LOGIN = "username"
+MANAGER_PASSWORD = "password"
+
+client = ServerProxy(MANAGER_URL)
+
+key = client.auth.login(MANAGER_LOGIN, MANAGER_PASSWORD)
+package_list = client.packages.findByNvrea(key, 'rhnlib', '2.5.22', '9.el6', '', 'noarch')
+earliest_occurrence = datetime.today()
+client.system.schedulePackageInstall(key, 1000000001, [package_list[0]['id']], earliest_occurrence)
+
+client.auth.logout(key)
+</pre>
 <hr/>
 <p/>
 <h3>Ruby example:</h3>

--- a/java/buildconf/apidoc/jsp/scripts.txt
+++ b/java/buildconf/apidoc/jsp/scripts.txt
@@ -260,6 +260,30 @@ print(client.user.list_users(key))
 
 client.auth.logout(key)
 </pre>
+<p/>
+The following code shows how to use date-time parameters. This code will schedule
+immediate installation of package <code>rhnlib-2.5.22.9.el6.noarch</code> to system with
+ID <code>1000000001</code>.
+<p/>
+
+<pre>
+#!/usr/bin/env python3
+from datetime import datetime
+from xmlrpc.client import ServerProxy
+
+MANAGER_URL = "http://manager.example.com/rpc/api"
+MANAGER_LOGIN = "username"
+MANAGER_PASSWORD = "password"
+
+client = ServerProxy(MANAGER_URL)
+
+key = client.auth.login(MANAGER_LOGIN, MANAGER_PASSWORD)
+package_list = client.packages.findByNvrea(key, 'rhnlib', '2.5.22', '9.el6', '', 'noarch')
+earliest_occurrence = datetime.today()
+client.system.schedulePackageInstall(key, 1000000001, [package_list[0]['id']], earliest_occurrence)
+
+client.auth.logout(key)
+</pre>
 <hr/>
 <p/>
 <h3>Ruby example:</h3>

--- a/java/buildconf/apidoc/singlepage/scripts.txt
+++ b/java/buildconf/apidoc/singlepage/scripts.txt
@@ -255,6 +255,30 @@ print(client.user.list_users(key))
 
 client.auth.logout(key)
 </pre>
+<p/>
+The following code shows how to use date-time parameters. This code will schedule
+immediate installation of package <code>rhnlib-2.5.22.9.el6.noarch</code> to system with
+ID <code>1000000001</code>.
+<p/>
+
+<pre>
+#!/usr/bin/env python3
+from datetime import datetime
+from xmlrpc.client import ServerProxy
+
+MANAGER_URL = "http://manager.example.com/rpc/api"
+MANAGER_LOGIN = "username"
+MANAGER_PASSWORD = "password"
+
+client = ServerProxy(MANAGER_URL)
+
+key = client.auth.login(MANAGER_LOGIN, MANAGER_PASSWORD)
+package_list = client.packages.findByNvrea(key, 'rhnlib', '2.5.22', '9.el6', '', 'noarch')
+earliest_occurrence = datetime.today()
+client.system.schedulePackageInstall(key, 1000000001, [package_list[0]['id']], earliest_occurrence)
+
+client.auth.logout(key)
+</pre>
 <hr/>
 <p/>
 <h3>Ruby example:</h3>


### PR DESCRIPTION
## What does this PR change?

Python2 XML-RPC API call example shows how to use datetime parameters.
This PR adds similar example to python3  section.
https://bugzilla.suse.com/show_bug.cgi?id=1205981 shows, that this example is needed.

## Links

https://github.com/SUSE/spacewalk/issues/19814
https://bugzilla.suse.com/show_bug.cgi?id=1205981

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
