### PR TITLE
QE: fix the reboot through webUI steps

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -713,14 +713,16 @@ When(/^I reboot the "([^"]*)" minion through SSH$/) do |host|
 end
 
 When(/^I reboot the "([^"]*)" minion through the web UI$/) do |host|
-  step %(Given I am on the Systems overview page of this "#{host}")
-  step %(When I follow first "Schedule System Reboot")
-  step %(Then I should see a "System Reboot Confirmation" text")
-  step %(And I should see a "Reboot system" button")
-  step %(When I click on "Reboot system")
-  step %(Then I should see a "Reboot scheduled for system" text")
-  step %(And I wait at most 600 seconds until event "System reboot scheduled by admin" is completed")
-  step %(Then I should see a "This action's status is: Completed" text")
+  steps %(
+    Given I am on the Systems overview page of this "#{host}"
+    When I follow first "Schedule System Reboot"
+    Then I should see a "System Reboot Confirmation" text
+    And I should see a "Reboot system" button
+    When I click on "Reboot system"
+    Then I should see a "Reboot scheduled for system" text
+    And I wait at most 600 seconds until event "System reboot scheduled by admin" is completed
+    Then I should see a "This action's status is: Completed" text
+         )
 end
 
 When(/^I change the server's short hostname from hosts and hostname files$/) do


### PR DESCRIPTION
# What does this PR change?

This will fix the reboot through webUI step in Ruby. Fixup of https://github.com/uyuni-project/uyuni/pull/5723

Tested on the 4.3 BV e.g. for Debian 11:
```bash
  Scenario: Reboot the debian11_minion and wait until reboot is completed # features/build_validation/smoke_tests/debian11_minion_smoke_tests.feature:156
      This scenario ran at: 2023-02-22 11:52:03 +0100
    And I reboot the "debian11_minion" minion through the web UI          # features/step_definitions/common_steps.rb:549
      2023-02-22 11:54:59 +0100 Still waiting for action to complete...        
      This scenario took: 222 seconds 
2 scenarios (2 passed)
2 steps (2 passed)
3m46.725s
```


## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links

Manager 4.3: https://github.com/SUSE/spacewalk/pull/20561

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
