### PR TITLE
Fix some problems with reposync kickstart files syncing

### DIFF
--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -85,6 +85,9 @@ RPM_PUBKEY_VERSION_RELEASE_RE = re.compile(r'^gpg-pubkey-([0-9a-fA-F]+)-([0-9a-f
 APACHE_USER = 'wwwrun'
 APACHE_GROUP = 'www'
 
+# possible urlgrabber errno
+NO_MORE_MIRRORS_TO_TRY = 256
+
 class ZyppoSync:
     """
     This class prepares a environment for running Zypper inside a dedicated reposync root
@@ -1095,7 +1098,7 @@ type=rpm-md
             mirror_group.urlgrab(url, media_products_path, **urlgrabber_opts)
         except URLGrabError as exc:
             repl_url = suseLibURL(url).getURL(stripPw=True)
-            if not hasattr(exc, "code") and exc.errno != 256:
+            if not hasattr(exc, "code") and exc.errno != NO_MORE_MIRRORS_TO_TRY:
                 msg = "ERROR: Media product file download failed: %s - %s" % (
                     url,
                     exc.strerror,

--- a/python/spacewalk/satellite_tools/reposync.py
+++ b/python/spacewalk/satellite_tools/reposync.py
@@ -146,7 +146,7 @@ class KSDirHtmlParser(KSDirParser):
 
         for s in (m.group(1) for m in re.finditer(r'(?i)<a href="(.+?)"', dir_html.decode())):
             if not (re.match(r'/', s) or re.search(r'\?', s) or re.search(r'\.\.', s) or re.match(r'[a-zA-Z]+:', s) or
-                    re.search(r'\.rpm$', s)):
+                    s.endswith('.rpm') or s.endswith('.mirrorlist') or s == '#'):
                 if re.search(r'/$', s):
                     file_type = 'DIR'
                 else:

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Fix issues with kickstart syncing on mirrorlist repositories
+- Do not sync .mirrorlist and other non needed files
 - reposync: catch local file not found urlgrabber error properly (bsc#1208288)
 - OS specific httpd user for logrotate config.
 

--- a/python/test/unit/spacewalk/satellite_tools/test_yum_src.py
+++ b/python/test/unit/spacewalk/satellite_tools/test_yum_src.py
@@ -29,7 +29,7 @@ except ImportError:
     from StringIO import StringIO
 from collections import namedtuple
 
-from mock import Mock, MagicMock, patch
+from mock import Mock, MagicMock, patch, mock_open
 
 from spacewalk.satellite_tools.repo_plugins import yum_src, ContentPackage
 from spacewalk.satellite_tools.repo_plugins.yum_src import UpdateNotice
@@ -171,10 +171,12 @@ class YumSrcTest(unittest.TestCase):
         CFG.PREPENDED_DIR = ''
         CFG.http_proxy = False
 
-        grabber_spy = Mock()
+        urlgrabber_spy = Mock()
+        urlgrabber_spy.urlread = Mock()
+        mirror_group_mock = Mock(return_value=urlgrabber_spy)
 
         with patch(
-            "spacewalk.satellite_tools.repo_plugins.yum_src.urlgrabber.urlread", grabber_spy
+            "spacewalk.satellite_tools.repo_plugins.yum_src.MirrorGroup", mirror_group_mock
         ), patch("uyuni.common.context_managers.CFG", CFG), patch(
             "spacewalk.satellite_tools.repo_plugins.yum_src.os.path.isfile",
             Mock(return_value=False),
@@ -182,8 +184,60 @@ class YumSrcTest(unittest.TestCase):
             cs = yum_src.ContentSource("http://example.com/foo/", "test_repo", org="")
             cs.get_file("bar")
 
-            self.assertEqual(grabber_spy.call_args[1]["timeout"],  42)
-            self.assertEqual(grabber_spy.call_args[1]["minrate"],  42)
+            self.assertEqual(urlgrabber_spy.urlread.call_args[1]["timeout"],  42)
+            self.assertEqual(urlgrabber_spy.urlread.call_args[1]["minrate"],  42)
+
+    @patch("uyuni.common.context_managers.initCFG", Mock())
+    @patch("spacewalk.satellite_tools.repo_plugins.yum_src.os.unlink", Mock())
+    @patch("urlgrabber.grabber.PyCurlFileObject", Mock())
+    @patch("spacewalk.common.rhnLog", Mock())
+    @patch("spacewalk.satellite_tools.repo_plugins.yum_src.fileutils.makedirs", Mock())
+    @patch("spacewalk.satellite_tools.repo_plugins.yum_src.etree.parse", MagicMock(side_effect=Exception))
+    def test_get_file_with_mirrorlist_repo(self):
+        cs = self._make_dummy_cs()
+        cs.url = "http://example.com/url_with_mirrorlist/"
+
+        urlgrabber_spy = Mock()
+        urlgrabber_spy.urlread = Mock()
+        mirror_group_mock = Mock(return_value=urlgrabber_spy)
+        subprocess_mock = Mock()
+        subprocess_mock.returncode = 0
+        subprocess_mock.stderr = False
+
+        MIRROR_LIST = [
+            "http://example/base/arch1/os/",
+            "http://example/",
+            "http://example.com/",
+            "https://example.org/repo/path/?token",
+        ]
+
+        with patch(
+            "spacewalk.satellite_tools.repo_plugins.yum_src.MirrorGroup",
+            mirror_group_mock
+        ), patch(
+            "spacewalk.satellite_tools.repo_plugins.yum_src.os.path.isfile",
+            Mock(return_value=False),
+        ), patch(
+            "spacewalk.satellite_tools.repo_plugins.yum_src.ZyppoSync._init_root",
+            MagicMock()
+        ), patch(
+            "spacewalk.satellite_tools.repo_plugins.yum_src.ContentSource._get_mirror_list",
+            MagicMock(return_value=MIRROR_LIST)
+        ), patch.object(
+            yum_src.ZyppoSync, "_ZyppoSync__synchronize_gpg_keys",
+            MagicMock()
+        ), patch(
+            "builtins.open", mock_open()
+        ), patch(
+            "spacewalk.satellite_tools.repo_plugins.yum_src.subprocess.run",
+            MagicMock(return_value=subprocess_mock)
+        ):
+               repo = yum_src.ZypperRepo(tempfile.mkdtemp(), "http://example.com/url_with_mirrorlist/", "1")
+               cs.repo = repo
+               cs.setup_repo(repo)
+               cs.get_file("foobar")
+               self.assertEqual(urlgrabber_spy.urlread.call_args[0][0], "foobar")
+               self.assertEqual(urlgrabber_spy.urlread.call_args.kwargs['urls'], MIRROR_LIST)
 
     @patch("spacewalk.satellite_tools.repo_plugins.yum_src.ZYPP_RAW_CACHE_PATH", "./")
     def test_get_comps_and_modules(self):


### PR DESCRIPTION
## What does this PR change?

This PR fixes some problems detected on "reposync" during kickstart files syncing:

- Fix issues with syncing from repository using mirrorlist
- Do not sync unnecessary and flaky files from "download.opensuse.org", i.a. Leap 15.4 repos, where it downloads tons of `.mirrorlist` and `#` files that are wrongly parsed from the HTML.

## GUI diff

Before:

```console
# /usr/bin/spacewalk-repo-sync --channel almalinux8-x86_64 --type yum --non-interactive --sync-kickstart
...
08:46:04 
08:46:04   Importing kickstarts.
08:46:04 Trying treeinfo
08:46:04 Trying .treeinfo
08:46:04     Kickstartable tree not detected (no valid treeinfo file)
08:46:04 Sync completed.
08:46:04 Total time: 0:00:07
```

After:

```console
# /usr/bin/spacewalk-repo-sync --channel almalinux8-x86_64 --type yum --non-interactive --sync-kickstart
...
14:37:00 +02:00 
14:37:00 +02:00   Importing kickstarts.
14:37:00 +02:00     Added new kickstartable tree External_-_AlmaLinux_8_x86_64. Downloading content...
14:37:00 +02:00     Gathering all files in kickstart repository...
14:37:03 +02:00     Downloading 38 kickstart files.
14:39:22 +02:00 97.37 %
14:39:40 +02:00 Download finished.
14:40:54 +02:00 Sync completed.
```

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
- No tests: **no tests for kickstart syncing**
- 
- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/4747
Tracks https://github.com/SUSE/spacewalk/issues/18262

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
