### PR TITLE
QE: Wait 5 seconds when checking if a checkbox is marked

### DIFF
--- a/testsuite/features/init_clients/allcli_update_activationkeys.feature
+++ b/testsuite/features/init_clients/allcli_update_activationkeys.feature
@@ -55,14 +55,14 @@ Feature: Update activation keys
     And I check "Fake-RPM-SLES-Channel"
 
   Scenario: Check that sub-channels are automatically selected
-    Then I should see "SLE-Module-Basesystem15-SP4-Pool for x86_64" as checked
-    And I should see "SLE-Module-Basesystem15-SP4-Updates for x86_64" as checked
-    And I should see "SLE-Module-Server-Applications15-SP4-Pool for x86_64" as checked
-    And I should see "SLE-Module-Server-Applications15-SP4-Updates for x86_64" as checked
-    And I should see "SLE-Module-DevTools15-SP4-Updates for x86_64" as checked
-    And I should see "SLE-Module-Desktop-Applications15-SP4-Pool for x86_64" as checked
-    And I should see "SLE-Module-Desktop-Applications15-SP4-Updates for x86_64" as checked
-    And I should see "SLE-Module-Containers15-SP4-Updates for x86_64" as checked
+    When I wait until "SLE-Module-Basesystem15-SP4-Pool for x86_64" has been checked
+    And I wait until "SLE-Module-Basesystem15-SP4-Updates for x86_64" has been checked
+    And I wait until "SLE-Module-Server-Applications15-SP4-Pool for x86_64" has been checked
+    And I wait until "SLE-Module-Server-Applications15-SP4-Updates for x86_64" has been checked
+    And I wait until "SLE-Module-DevTools15-SP4-Updates for x86_64" has been checked
+    And I wait until "SLE-Module-Desktop-Applications15-SP4-Pool for x86_64" has been checked
+    And I wait until "SLE-Module-Desktop-Applications15-SP4-Updates for x86_64" has been checked
+    And I wait until "SLE-Module-Containers15-SP4-Updates for x86_64" has been checked
     When I click on "Update Activation Key"
     Then I should see a "Activation key SUSE Test Key x86_64 has been modified" text
 

--- a/testsuite/features/step_definitions/setup_steps.rb
+++ b/testsuite/features/step_definitions/setup_steps.rb
@@ -420,6 +420,16 @@ When(/^I wait until radio button "([^"]*)" is checked, refreshing the page$/) do
   end
 end
 
+When(/^I wait until "([^"]*)" has been checked$/) do |text|
+  unless has_checked_field?(text)
+    repeat_until_timeout(message: "Couldn't find checked #{text}", timeout: 5) do
+      break if has_checked_field?(text)
+
+      sleep(1)
+    end
+  end
+end
+
 Then(/^I check the first notification message$/) do
   if count_table_items == '0'
     log "There are no notification messages, nothing to do then"


### PR DESCRIPTION
## What does this PR change?

This fixs Uyuni CI flaky test, when we expect an auto-selection from SUSE Manager of some channels, but this is not immediate.
Wait 5 seconds when checking if a checkbox is marked

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were refactored

- [x] **DONE**

## Links

Ports:
- Manager-4.2
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
