### PR TITLE
Fix cobbler system entries for retail terminals - bsc#1208661

### DIFF
--- a/java/code/src/com/suse/manager/saltboot/test/PXEEventTest.java
+++ b/java/code/src/com/suse/manager/saltboot/test/PXEEventTest.java
@@ -26,8 +26,6 @@ import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.suse.manager.saltboot.PXEEvent;
 import com.suse.salt.netapi.datatypes.Event;
 
-import com.google.gson.JsonObject;
-
 import org.jmock.Expectations;
 import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,31 +47,31 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
     private Map<String, Object> createTestData(String minionId, String saltbootGroup, String root, String saltDevice,
                                   String bootImage, String kernelOptions, boolean includeMACs) {
         Map<String, Object> data = new HashMap<>();
-        JsonObject jsonData = new JsonObject();
+        Map<String, Object> innerData = new HashMap<>();
         if (!saltbootGroup.isEmpty()) {
-            jsonData.addProperty("minion_id_prefix", saltbootGroup);
+            innerData.put("minion_id_prefix", saltbootGroup);
         }
         if (!root.isEmpty()) {
-            jsonData.addProperty("root", root);
+            innerData.put("root", root);
         }
         if (!saltDevice.isEmpty()) {
-            jsonData.addProperty("salt_device", saltDevice);
+            innerData.put("salt_device", saltDevice);
         }
         if (!bootImage.isEmpty()) {
-            jsonData.addProperty("boot_image", bootImage);
+            innerData.put("boot_image", bootImage);
         }
         if (!kernelOptions.isEmpty()) {
-            jsonData.addProperty("terminal_kernel_parameters", kernelOptions);
+            innerData.put("terminal_kernel_parameters", kernelOptions);
         }
         if (includeMACs) {
-            JsonObject hwAddrs = new JsonObject();
-            hwAddrs.addProperty("eth1", "00:11:22:33:44:55");
-            hwAddrs.addProperty("lo", "00:00:00:00:00:00");
-            jsonData.add("hwaddr_interfaces", hwAddrs);
+            Map<String, Object> hwAddrs = new HashMap<>();
+            hwAddrs.put("eth1", "00:11:22:33:44:55");
+            hwAddrs.put("lo", "00:00:00:00:00:00");
+            innerData.put("hwaddr_interfaces", hwAddrs);
         }
 
         data.put("id", minionId);
-        data.put("data", jsonData);
+        data.put("data", innerData);
 
         return data;
     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix cobbler system entries for retail terminals (bsc#1208661)
 - Add missing text for user preferenaces page
 - Hide install option for RHEL9+ kickstarts
 - Make API method systemgroup.listSystemsMinimal read-only (bsc#1208550)


### PR DESCRIPTION
## What does this PR change?

Pxe event parsing was broken.
This PR fixes it, updates unit tests and adds logging.

## GUI diff

No difference.

## Documentation
- No documentation needed: fix

## Test coverage
- Unit tests fixed

- [x] **DONE**

## Links

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1208661

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
