### PR TITLE
Fix "configure-tftpsync.sh" to not remove "webdir_whitelist" list values from Cobbler settings (bsc#1207063)

### DIFF
--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -72,6 +72,12 @@ Feature: PXE boot a terminal with Cobbler
     And I follow "Autoinstallation File"
     Then I should see a "SLE-15-SP4-TFTP" text
 
+  Scenario: Migration of cobbler settings
+    Given cobbler is running
+    And cobbler settings are successfully migrated
+    When I restart cobbler on the server
+    Then service "cobblerd" is active on "server"
+
   Scenario: Set up tftp installation
     When I configure tftp on the "server"
     And I start tftp on the proxy

--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -73,7 +73,7 @@ Feature: PXE boot a terminal with Cobbler
     Then I should see a "SLE-15-SP4-TFTP" text
 
   Scenario: Migration of cobbler settings
-    Given cobbler is running
+    Given cobblerd is running
     And cobbler settings are successfully migrated
     When I restart cobbler on the server
     Then service "cobblerd" is active on "server"

--- a/testsuite/features/step_definitions/cobbler_steps.rb
+++ b/testsuite/features/step_definitions/cobbler_steps.rb
@@ -190,6 +190,12 @@ When(/^I cleanup xorriso temp files$/) do
   $server.run('rm /var/cache/cobbler/xorriso_*', check_errors: false)
 end
 
+# cobbler settings
+Given(/^cobbler settings are successfully migrated$/) do
+  out, code = $server.run("cobbler-settings migrate -t /etc/cobbler/settings.yaml")
+  raise "error when running cobbler-settings to migrate current settings.\nLogs:\n#{out}" if code.nonzero?
+end
+
 # cobbler parameters
 Then(/^I add the Cobbler parameter "([^"]*)" with value "([^"]*)" to item "(distro|profile|system)" with name "([^"]*)"$/) do |param, value, item, name|
   result, code = $server.run("cobbler #{item} edit --name=#{name} --#{param}=#{value}", verbose: true)

--- a/testsuite/features/step_definitions/cobbler_steps.rb
+++ b/testsuite/features/step_definitions/cobbler_steps.rb
@@ -192,7 +192,7 @@ end
 
 # cobbler settings
 Given(/^cobbler settings are successfully migrated$/) do
-  out, code = $server.run("cobbler-settings migrate -t /etc/cobbler/settings.yaml")
+  out, code = $server.run('cobbler-settings migrate -t /etc/cobbler/settings.yaml')
   raise "error when running cobbler-settings to migrate current settings.\nLogs:\n#{out}" if code.nonzero?
 end
 

--- a/tftpsync/susemanager-tftpsync/configure-tftpsync.sh
+++ b/tftpsync/susemanager-tftpsync/configure-tftpsync.sh
@@ -42,7 +42,7 @@ done
 
 cp /etc/cobbler/settings.yaml /etc/cobbler/settings.yaml.bak
 # remove proxies section from conf
-cat /etc/cobbler/settings.yaml.bak | awk '{if(/^proxies:/) x=1; else if (x == 1 && /^[[:space:]]*-/) x=1; else print }' > /etc/cobbler/settings.yaml
+cat /etc/cobbler/settings.yaml.bak | awk '{if(/^proxies:/) x=1; else if (x == 1 && /^[[:space:]]*-/) x=1; else if (x == 1 && ! /^[[:space:]]*-/) {x=0; print;} else print }' > /etc/cobbler/settings.yaml
 
 # create new proxies section
 echo "proxies:" >> /etc/cobbler/settings.yaml

--- a/tftpsync/susemanager-tftpsync/susemanager-tftpsync.changes
+++ b/tftpsync/susemanager-tftpsync/susemanager-tftpsync.changes
@@ -1,3 +1,5 @@
+- Fix removal of proxies section in cobbler settings (bsc#1207063)
+
 -------------------------------------------------------------------
 Mon Jan 23 08:26:55 CET 2023 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes a problem in the logic to remove the `proxies` section from Cobbler settings, at the time of running `configure-tftpsync.sh` script.

Before this PR, the logic to remove the `proxies` logic was buggy and it could go beyond expections, so ending up removing any other possible list item after the `proxies` section. In particular, we see this happening and removing items for `webdir_whitelist` and making Cobbler settings invalid.

This issue seems only visible in long running server, where Cobbler settings migration was executed at some point (making `proxies` section not being the latest one defined on the Cobbler settings file).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/20132

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
