### PR TITLE
speedup ubuntu errata processing

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageFactory.java
@@ -21,6 +21,7 @@ import com.redhat.rhn.common.db.datasource.ModeFactory;
 import com.redhat.rhn.common.db.datasource.Row;
 import com.redhat.rhn.common.db.datasource.SelectMode;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.server.InstalledPackage;
 import com.redhat.rhn.domain.server.Server;
@@ -258,6 +259,21 @@ public class PackageFactory extends HibernateFactory {
         return session.getNamedQuery("Package.findByPackageName").setParameter("packageName",
                 pn).list();
 
+    }
+
+    /**
+     * List package names of a channel
+     * @param channel the channel
+     * @return list of package names in the given channel
+     */
+    public static Set<String> listPackageNamesInChannel(Channel channel) {
+        return Set.copyOf(getSession().createQuery(
+                "select p.packageName.name " +
+                   " from com.redhat.rhn.domain.rhnpackage.Package as p " +
+                   " join p.channels c " +
+                   "where c.id = :cid", String.class)
+                .setParameter("cid", channel.getId())
+                .list());
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManager.java
@@ -194,11 +194,16 @@ public class UbuntuErrataManager {
      * @throws IOException in case of download issues
      */
     public static void sync(Set<Long> channelIds) throws IOException {
-        LOG.debug("sync started - get and parse errata");
-        List<Entry> ubuntuErrataInfo = parseUbuntuErrata(getUbuntuErrataInfo());
-        LOG.debug("get and parse errata finished - process Ubuntu Errata By Id");
-        processUbuntuErrataByIds(channelIds, ubuntuErrataInfo);
-        LOG.debug("process Ubuntu Errata By Id finished");
+        LOG.debug("sync Ubuntu Errata started");
+        Set<Channel> channels = channelIds.stream().map(ChannelFactory::lookupById).collect(Collectors.toSet());
+        if (channels.stream()
+                .filter(c -> c.isTypeDeb() && !c.isCloned())
+                .findFirst().isPresent()) {
+            List<Entry> ubuntuErrataInfo = parseUbuntuErrata(getUbuntuErrataInfo());
+            LOG.debug("get and parse errata finished - process Ubuntu Errata By Id");
+            processUbuntuErrata(channels, ubuntuErrataInfo);
+        }
+        LOG.debug("sync Ubuntu Errata finished");
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- speedup ubuntu errata processing (bsc#1208614)
+
 -------------------------------------------------------------------
 Tue Feb 21 14:12:10 CET 2023 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Currently Ubuntu Errata Parsing break the testsuite as it takes ~30-60 minutes to run for a fake channel with 8 packages where no of the errata match.

The problem is, that all errata are added to the DB, also when we have no packages for the update.

1. if no packages are found, skip the errata
2. try to create a full package only when at least the package name appears in the channel.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests TBD

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
