### PR TITLE
OS specific httpd user for logrotate config

### DIFF
--- a/python/spacewalk/logrotate/spacewalk-backend-app
+++ b/python/spacewalk/logrotate/spacewalk-backend-app
@@ -8,5 +8,5 @@
     notifempty
     missingok
     size 10M
-    su wwwrun www
+    su @HTTPD_USER@ @HTTPD_GROUP@
 }

--- a/python/spacewalk/logrotate/spacewalk-backend-applet
+++ b/python/spacewalk/logrotate/spacewalk-backend-applet
@@ -8,5 +8,5 @@
     notifempty
     missingok
     size 10M
-    su wwwrun www
+    su @HTTPD_USER@ @HTTPD_GROUP@
 }

--- a/python/spacewalk/logrotate/spacewalk-backend-cdn
+++ b/python/spacewalk/logrotate/spacewalk-backend-cdn
@@ -8,7 +8,7 @@
     notifempty
     missingok
     size 10M
-#LOGROTATE-3.8#    su root apache
+#LOGROTATE-3.8#    su root @HTTPD_GROUP@
 }
 
 /var/log/rhn/cdnsync/*.log {

--- a/python/spacewalk/logrotate/spacewalk-backend-config-files
+++ b/python/spacewalk/logrotate/spacewalk-backend-config-files
@@ -7,5 +7,5 @@
     notifempty
     missingok
     size 10M
-    su wwwrun www
+    su @HTTPD_USER@ @HTTPD_GROUP@
 }

--- a/python/spacewalk/logrotate/spacewalk-backend-config-files-tool
+++ b/python/spacewalk/logrotate/spacewalk-backend-config-files-tool
@@ -8,5 +8,5 @@
     notifempty
     missingok
     size 10M
-    su wwwrun www
+    su @HTTPD_USER@ @HTTPD_GROUP@
 }

--- a/python/spacewalk/logrotate/spacewalk-backend-iss
+++ b/python/spacewalk/logrotate/spacewalk-backend-iss
@@ -8,5 +8,5 @@
     notifempty
     missingok
     size 10M
-    su wwwrun www
+    su @HTTPD_USER@ @HTTPD_GROUP@
 }

--- a/python/spacewalk/logrotate/spacewalk-backend-iss-export
+++ b/python/spacewalk/logrotate/spacewalk-backend-iss-export
@@ -8,5 +8,5 @@
     notifempty
     missingok
     size 10M
-    su wwwrun www
+    su @HTTPD_USER@ @HTTPD_GROUP@
 }

--- a/python/spacewalk/logrotate/spacewalk-backend-package-push-server
+++ b/python/spacewalk/logrotate/spacewalk-backend-package-push-server
@@ -8,5 +8,5 @@
     notifempty
     missingok
     size 10M
-    su wwwrun www
+    su @HTTPD_USER@ @HTTPD_GROUP@
 }

--- a/python/spacewalk/logrotate/spacewalk-backend-server
+++ b/python/spacewalk/logrotate/spacewalk-backend-server
@@ -8,5 +8,5 @@
     notifempty
     missingok
     size 10M
-    su wwwrun www
+    su @HTTPD_USER@ @HTTPD_GROUP@
 }

--- a/python/spacewalk/logrotate/spacewalk-backend-tools
+++ b/python/spacewalk/logrotate/spacewalk-backend-tools
@@ -8,7 +8,7 @@
     notifempty
     missingok
     size 10M
-#LOGROTATE-3.8#    su root apache
+#LOGROTATE-3.8#    su root @HTTPD_GROUP@
 }
 
 /var/log/rhn/rhn_server_satellite.log {
@@ -18,7 +18,7 @@
     notifempty
     missingok
     size 10M
-    su wwwrun www
+    su @HTTPD_USER@ @HTTPD_GROUP@
 }
 
 /var/log/rhn/reposync.log {
@@ -28,7 +28,7 @@
     notifempty
     missingok
     size 10M
-#LOGROTATE-3.8#    su root apache
+#LOGROTATE-3.8#    su root @HTTPD_GROUP@
 }
 
 /var/log/rhn/reposync/*.log {

--- a/python/spacewalk/logrotate/spacewalk-backend-xmlrpc
+++ b/python/spacewalk/logrotate/spacewalk-backend-xmlrpc
@@ -8,5 +8,5 @@
     notifempty
     missingok
     size 10M
-    su wwwrun www
+    su @HTTPD_USER@ @HTTPD_GROUP@
 }

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- OS specific httpd user for logrotate config.
+
 -------------------------------------------------------------------
 Tue Feb 21 14:05:08 CET 2023 - jgonzalez@suse.com
 

--- a/python/spacewalk/spacewalk-backend.spec
+++ b/python/spacewalk/spacewalk-backend.spec
@@ -333,12 +333,11 @@ sed -i 's|#DOCUMENTROOT#|%{documentroot}|' $RPM_BUILD_ROOT%{rhnconfigdefaults}/r
 sed -i 's|#HTTPD_CONFIG_DIR#|%{apacheconfd}|' $RPM_BUILD_ROOT%{rhnconfigdefaults}/rhn.conf
 sed -i 's|#REPORT_DB_SSLROOTCERT#|%{sslrootcert}RHN-ORG-TRUSTED-SSL-CERT|' $RPM_BUILD_ROOT%{rhnconfigdefaults}/rhn.conf
 
-%if 0%{?fedora} || 0%{?rhel} > 6
 sed -i 's/#LOGROTATE-3.8#//' $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/spacewalk-backend-*
-%endif
-%if 0%{?suse_version}
-sed -i 's/#LOGROTATE-3.8#.*/    su root www/' $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/spacewalk-backend-*
+sed -i 's/@HTTPD_GROUP@/%{apache_group}/' $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/spacewalk-backend-*
+sed -i 's/@HTTPD_USER@/%{apache_user}/' $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/spacewalk-backend-*
 
+%if 0%{?suse_version}
 %py3_compile -O %{buildroot}/%{python3rhnroot}
 %fdupes %{buildroot}/%{python3rhnroot}
 %endif


### PR DESCRIPTION
## What does this PR change?

OS specific httpd user for logrotate config.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
