### PR TITLE
Add openssf best practices badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/6593/badge)](https://bestpractices.coreinfrastructure.org/projects/6593)
+
 Uyuni
 =====
 


### PR DESCRIPTION
## What does this PR change?

This patch is simply adding the openssf badge to the project README file, referencing this page: https://bestpractices.coreinfrastructure.org/en/projects/6593.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed.

- [X] **DONE**

## Test coverage

- No tests needed.

- [X] **DONE**

## Links

No links.

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository.

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
