### PR TITLE
Tweak GitHub action for tests covering pr

### DIFF
--- a/.github/workflows/test-covering-pr.yml
+++ b/.github/workflows/test-covering-pr.yml
@@ -1,9 +1,6 @@
 name: 'Suggested tests to cover this Pull Request'
 
 on:
-  pull_request:
-    paths:
-      - '**.java'
   pull_request_target:
     paths:
       - '**.java'


### PR DESCRIPTION
## What does this PR change?

Tweak the GitHub action test-covering-pr as apparently it only need one target, and must be the one that have access to write comments from a fork.

Note: That was already warned by @renner I could not see any issue when I was working in the PR, as I was not in a fork.
It seems `pull_request_target` will work for both scenarios.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

No ports.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
