### PR TITLE
Fix handling of http 404 (bsc#1208624)

### DIFF
--- a/containers/proxy-tftpd-image/proxy-tftpd-image.changes
+++ b/containers/proxy-tftpd-image/proxy-tftpd-image.changes
@@ -1,3 +1,5 @@
+- Fix handling of http 404 (bsc#1208624)
+
 -------------------------------------------------------------------
 Tue Feb 21 13:16:11 UTC 2023 - Julio González Gil <jgonzalez@suse.com>
 

--- a/containers/proxy-tftpd-image/tftp_wrapper.py
+++ b/containers/proxy-tftpd-image/tftp_wrapper.py
@@ -33,6 +33,9 @@ class HttpResponseData(ResponseData):
     def __init__(self, url, capath):
         # request file by url and store it
         self._request = requests.get(url, stream=True, verify=capath)
+        if self._request.status_code == 404:
+            raise FileNotFoundError()
+        self._request.raise_for_status()
         self._stream = self._request.iter_content(chunk_size=1024)
         self._content = b''
     def read(self, requested):
@@ -82,7 +85,7 @@ class TFTPHandler(BaseHandler):
         elif path.startswith("pxelinux.cfg/"):
             # ignore other pxelinux.cfg files
             logging.debug(f"Got request for {path}, ignoring")
-            return StringResponseData("")
+            raise FileNotFoundError()
         # The rest get from http
         logging.debug(f"Got request for {path}, forwarding to HTTP")
         return HttpResponseData(f"https://{target}/tftp/{path}", capath)


### PR DESCRIPTION
## What does this PR change?

TFTP server on containerized proxy did not differentiate between missing file and empty file.
Grub tries multiple menu files and uses the first existing. With this bug it ended up with empty menu. 

## GUI diff

No difference.


## Documentation
- No documentation needed: bugfix

## Test coverage
- No tests

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1208624


## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
