### PR TITLE
Enable selective loading of stylesheets for Bootstrap upgrade

### DIFF
--- a/java/code/src/com/suse/manager/webui/utils/ViewHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/ViewHelper.java
@@ -52,6 +52,12 @@ public enum ViewHelper {
 
     private static final RenderUtils RENDER_UTILS = GlobalInstanceHolder.RENDER_UTILS;
 
+    /**
+     * List of pages that are updated to newer Bootstrap.
+     * @see ViewHelper#isBootstrapReady
+     */
+    private static final List<String> BOOTSTRAP_READY_PAGES = List.of();
+
     ViewHelper() { }
 
     /**
@@ -270,5 +276,17 @@ public enum ViewHelper {
      */
     public boolean hasSshPushContactMethod(Server server) {
         return ContactMethodUtil.isSSHPushContactMethod(server.getContactMethod());
+    }
+
+    /**
+     * Checks if the requested page is updated to newer Bootstrap.
+     * @param uri the page URI
+     * @return true if the URI is in the list of updated pages
+     * @deprecated this is a temporary hook that makes partial Bootstrap migration possible. Will be removed when the
+     * migration is finished.
+     */
+    @Deprecated
+    public boolean isBootstrapReady(String uri) {
+        return BOOTSTRAP_READY_PAGES.contains(uri);
     }
 }

--- a/java/code/webapp/WEB-INF/decorators/layout_head.jsp
+++ b/java/code/webapp/WEB-INF/decorators/layout_head.jsp
@@ -34,7 +34,16 @@
 
     <!-- import styles -->
     <c:set var="webTheme" value="${GlobalInstanceHolder.USER_PREFERENCE_UTILS.getCurrentWebTheme(pageContext)}"/>
-    <link rel="stylesheet" href="/css/${webTheme}.css?cb=${cb_version}" />
+    <c:choose>
+      <c:when test="${GlobalInstanceHolder.VIEW_HELPER.isBootstrapReady(pageContext.request.requestURI)}">
+        <link rel="stylesheet" href="/css/${webTheme}.css?cb=${cb_version}" id="web-theme" disabled="disabled"/>
+        <link rel="stylesheet" href="/css/updated-${webTheme}.css?cb=${cb_version}" id="updated-web-theme"/>
+      </c:when>
+      <c:otherwise>
+        <link rel="stylesheet" href="/css/${webTheme}.css?cb=${cb_version}" id="web-theme"/>
+        <link rel="stylesheet" href="/css/updated-${webTheme}.css?cb=${cb_version}" id="updated-web-theme" disabled="disabled"/>
+      </c:otherwise>
+    </c:choose>
 
     <!-- expose user preferred language to the application -->
     <c:set var="currentLocale" value="${GlobalInstanceHolder.USER_PREFERENCE_UTILS.getCurrentLocale(pageContext)}"/>


### PR DESCRIPTION
Adds base for selective stylesheet loading that enables us to upgrade Bootstrap page by page.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: not a real feature

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18942

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
