### PR TITLE
Teststuite: Wait for expected channels to be checked before checking other channels

### DIFF
--- a/testsuite/features/init_clients/allcli_update_activationkeys.feature
+++ b/testsuite/features/init_clients/allcli_update_activationkeys.feature
@@ -50,19 +50,17 @@ Feature: Update activation keys
     And I wait until I do not see "Loading..." text
     And I select "SLE-Product-SLES15-SP4-Pool for x86_64" from "selectedBaseChannel"
     And I include the recommended child channels
-    And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"
-    And I check "SLE-Module-Containers15-SP4-Pool for x86_64"
-    And I check "Fake-RPM-SLES-Channel"
-
-  Scenario: Check that sub-channels are automatically selected
-    When I wait until "SLE-Module-Basesystem15-SP4-Pool for x86_64" has been checked
+    And I wait until "SLE-Module-Basesystem15-SP4-Pool for x86_64" has been checked
     And I wait until "SLE-Module-Basesystem15-SP4-Updates for x86_64" has been checked
     And I wait until "SLE-Module-Server-Applications15-SP4-Pool for x86_64" has been checked
     And I wait until "SLE-Module-Server-Applications15-SP4-Updates for x86_64" has been checked
+    And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"
     And I wait until "SLE-Module-DevTools15-SP4-Updates for x86_64" has been checked
     And I wait until "SLE-Module-Desktop-Applications15-SP4-Pool for x86_64" has been checked
     And I wait until "SLE-Module-Desktop-Applications15-SP4-Updates for x86_64" has been checked
+    And I check "SLE-Module-Containers15-SP4-Pool for x86_64"
     And I wait until "SLE-Module-Containers15-SP4-Updates for x86_64" has been checked
+    And I check "Fake-RPM-SLES-Channel"
     When I click on "Update Activation Key"
     Then I should see a "Activation key SUSE Test Key x86_64 has been modified" text
 


### PR DESCRIPTION
## What does this PR change?
When updating the activation key with child channels, wait for channels that should be automatically selected to appear as checked before checking other channels.

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Fixes #
Tracks # 
4.2 https://github.com/SUSE/spacewalk/pull/20662
4.3 https://github.com/SUSE/spacewalk/pull/20661
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
