### PR TITLE
Allow default component for context manager

### DIFF
--- a/python/uyuni/common/context_managers.py
+++ b/python/uyuni/common/context_managers.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 from spacewalk.common.rhnConfig import CFG, initCFG
 
 @contextmanager
-def cfg_component(component, root=None, filename=None):
+def cfg_component(component=None, root=None, filename=None):
     """Context manager for rhnConfig.
 
     :param comp: The configuration component to use in this context

--- a/python/uyuni/uyuni-common-libs.changes
+++ b/python/uyuni/uyuni-common-libs.changes
@@ -1,3 +1,5 @@
+- Allow default component for context manager.
+
 -------------------------------------------------------------------
 Wed Dec 14 14:13:10 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Allow default component for context manager in case no component is declared when using the context manager.


## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
