### PR TITLE
Add server monitoring support

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -116,7 +116,6 @@ namespace :utils do
   task :generate_create_bootstrap_repositories_features do
     clients = Rake::FileList['features/build_validation/init_clients/*.feature']
     clients.reject! { |client| client.include? 'ssh'}
-    clients.reject! { |client| client.include? 'monitoring_server' }
     clients.reject! { |client| (client.include? 'buildhost') || (client.include? 'terminal') }
     clients.each do |client|
       Rake::Task['utils:generate_feature'].invoke('features/build_validation/create_bootstrap_repositories/create_bootstrap_repository.template',


### PR DESCRIPTION
## What does this PR change?

Create repository bootstrap during BV for monitoring server.


## Test coverage

- [x] **DONE**

## Links


- [ ] **DONE**

## Changelogs

- [x] No changelog needed



## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
