### PR TITLE
fix db connection check tool

### DIFF
--- a/susemanager-utils/supportutils-plugin-susemanager/supportutils-plugin-susemanager.changes
+++ b/susemanager-utils/supportutils-plugin-susemanager/supportutils-plugin-susemanager.changes
@@ -1,3 +1,5 @@
+- fix db connection check tool (bsc#1208586)
+
 -------------------------------------------------------------------
 Mon Jan 23 08:29:01 CET 2023 - jgonzalez@suse.com
 

--- a/susemanager-utils/supportutils-plugin-susemanager/susemanager-connection-check.pl
+++ b/susemanager-utils/supportutils-plugin-susemanager/susemanager-connection-check.pl
@@ -95,10 +95,11 @@ if ($javamax == 0)
     };
 }
 
-# java web ui, taskomatic and search uses c3p0 pooling
+# java web ui, taskomatic uses c3p0 pooling
+# search used a fixed number of connections (10)
 # + every apache process can eat a connection
 # + buffer for local connections
-my $mindb = (3*$javamax) + $apachemax + 60;
+my $mindb = (2*$javamax) + $apachemax + 10 + 60;
 my $dblimit = 0;
 
 $dblimit = run_query(<<EOF);


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/20690

Fix connection check tool as the calculation was not correct.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

Documentation PR was created: uyuni-project/uyuni-docs#2111

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/20691

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
