### PR TITLE
Fix systems subscribed to channel CSV download

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -226,7 +226,7 @@ SELECT COUNT(S.id) AS count
   </query>
 </mode>
 
-<mode name="systems_subscribed_to_channel">
+<mode name="systems_subscribed_to_channel" class="com.redhat.rhn.frontend.dto.SystemOverview">
   <query params="org_id, cid, user_id">
 SELECT
        S.id as id,

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix systems subscribed to channel CSV download (bsc#1201063)
 - Save scheduler user when creating Patch actions manually (bsc#1208321)
 - Fix cobbler system entries for retail terminals (bsc#1208661)
 - Add missing text for user preferenaces page


### PR DESCRIPTION
## What does this PR change?

It adds `class` attribute to `systems_subscribed_to_channel` mode to avoid a `java.lang.ClassCastException` when downloading CSV. If the class is null, there is a [conversion to `com.redhat.rhn.common.db.datasource.Row` when processing the result set of a `CachedStatement`](https://github.com/uyuni-project/uyuni/blob/master/java/code/src/com/redhat/rhn/common/db/datasource/CachedStatement.java#L664).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18285

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
