### PR TITLE
Add specific run set for Create clm filter for RH-like minion feature

### DIFF
--- a/testsuite/features/build_validation/add_custom_repositories/add_ubuntu_repositories.feature
+++ b/testsuite/features/build_validation/add_custom_repositories/add_ubuntu_repositories.feature
@@ -1,6 +1,7 @@
 # Copyright 2021-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@ubuntu1804_minion
 Feature: Add Ubuntu common channels and schedule their synchronization
   In order to use external repositories for Ubuntu that are not in SCC
   As an authorized user

--- a/testsuite/run_sets/build_validation_add_common_channels.yml
+++ b/testsuite/run_sets/build_validation_add_common_channels.yml
@@ -3,7 +3,6 @@
 ## Add common channels and special repositories BEGIN ###
 
 - features/build_validation/add_custom_repositories/add_ubuntu_repositories.feature
-- features/build_validation/add_custom_repositories/srv_prepare_clm_filters.feature
 - features/build_validation/add_custom_repositories/add_alma9_repositories.feature
 - features/build_validation/add_custom_repositories/add_centos7_repositories.feature
 - features/build_validation/add_custom_repositories/add_liberty9_repositories.feature

--- a/testsuite/run_sets/build_validation_prepare_clm_filters.yml
+++ b/testsuite/run_sets/build_validation_prepare_clm_filters.yml
@@ -1,0 +1,7 @@
+# This file describes the order of features in a Build Validation test suite run.
+
+## Add clm for rhel BEGIN ###
+
+- features/build_validation/add_custom_repositories/srv_prepare_clm_filters.feature
+
+## Add clm for rhel END ###


### PR DESCRIPTION
## What does this PR change?

Create a specific run set for the feature `Create the CLM filters for RH-like minions` to support parallel BV.

## GUI diff

No difference.


## Documentation

## GUI diff

No difference.


## Documentation


- [x] **DONE**

## Test coverage

- No tests: already covered


- [x] **DONE**

## Links

CI PR : https://github.com/SUSE/susemanager-ci/pull/794/commits/36fc1155e2ad9574bafaa8af55fa21644881019d

- [x] **DONE**

## Changelogs


- [x] No changelog needed



## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
