### PR TITLE
Fix SLE Micro init clients in BV

### DIFF
--- a/testsuite/features/build_validation/init_clients/slemicro52_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro52_minion.feature
@@ -21,13 +21,13 @@ Feature: Bootstrap a SLE Micro 5.2 Salt minion
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
-    And I wait until onboarding is completed for "slemicro52_minion"
 
   Scenario: Reboot the SLE Micro 5.2 minion and wait until reboot is completed
     When I reboot the "slemicro52_minion" minion through SSH
 
   Scenario: Check the new bootstrapped SLE Micro 5.2 minion in System Overview page
-    When I follow the left menu "Salt > Keys"
+    When I wait until onboarding is completed for "slemicro52_minion"
+    And I follow the left menu "Salt > Keys"
     Then I should see a "accepted" text
     And the Salt master can reach "slemicro52_minion"
 

--- a/testsuite/features/build_validation/init_clients/slemicro53_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro53_minion.feature
@@ -21,13 +21,13 @@ Feature: Bootstrap a SLE Micro 5.3 Salt minion
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
-    And I wait until onboarding is completed for "slemicro53_minion"
 
   Scenario: Reboot the SLE Micro 5.3 minion and wait until reboot is completed
     When I reboot the "slemicro53_minion" minion through SSH
 
   Scenario: Check the new bootstrapped SLE Micro 5.3 minion in System Overview page
-    When I follow the left menu "Salt > Keys"
+    When I wait until onboarding is completed for "slemicro53_minion"
+    And I follow the left menu "Salt > Keys"
     Then I should see a "accepted" text
     And the Salt master can reach "slemicro53_minion"
 


### PR DESCRIPTION
## What does this PR change?

The reboot of SLE Micro has to be the first thing after being onboarded, otherwise we cannot check events. The step
`I wait until onboarding is completed for ...` contains of several sub steps that can only be successful executed after SLE Micro gets rebooted.
The SSH minions behave differently and need no adaption.

## GUI diff

No difference.


- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links

Manager 4.3: 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
