### PR TITLE
support multiple gpgkey urls for a channel

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -1767,8 +1767,9 @@ public class ContentSyncManager {
                             prodRepoLink.setRepository(repo);
                             prodRepoLink.setRootProduct(root);
                             if (!entry.getGpgInfo().isEmpty()) {
-                                // we use only the 1st entry
-                                prodRepoLink.setGpgKeyUrl(entry.getGpgInfo().get(0).getUrl());
+                                prodRepoLink.setGpgKeyUrl(entry.getGpgInfo()
+                                        .stream().map(i -> i.getUrl()).collect(Collectors.joining(" ")));
+                                // we use only the 1st entry for id and fingerprint
                                 prodRepoLink.setGpgKeyId(entry.getGpgInfo().get(0).getKeyId());
                                 prodRepoLink.setGpgKeyFingerprint(entry.getGpgInfo().get(0).getFingerprint());
                             }
@@ -1810,8 +1811,9 @@ public class ContentSyncManager {
                             prodRepoLink.setMandatory(entry.isMandatory());
                             prodRepoLink.getRepository().setSigned(entry.isSigned());
                             if (!entry.getGpgInfo().isEmpty()) {
-                                // we use only the 1st entry
-                                prodRepoLink.setGpgKeyUrl(entry.getGpgInfo().get(0).getUrl());
+                                prodRepoLink.setGpgKeyUrl(entry.getGpgInfo()
+                                        .stream().map(i -> i.getUrl()).collect(Collectors.joining(" ")));
+                                // we use only the 1st entry for id and fingerprint
                                 prodRepoLink.setGpgKeyId(entry.getGpgInfo().get(0).getKeyId());
                                 prodRepoLink.setGpgKeyFingerprint(entry.getGpgInfo().get(0).getFingerprint());
                             }

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -48,8 +48,11 @@ import com.redhat.rhn.domain.scc.SCCRepositoryBasicAuth;
 import com.redhat.rhn.domain.scc.SCCRepositoryNoAuth;
 import com.redhat.rhn.domain.scc.SCCRepositoryTokenAuth;
 import com.redhat.rhn.domain.scc.SCCSubscription;
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.manager.channel.ChannelManager;
 
+import com.suse.manager.webui.services.pillar.MinionGeneralPillarGenerator;
 import com.suse.mgrsync.MgrSyncStatus;
 import com.suse.salt.netapi.parser.JsonParser;
 import com.suse.scc.client.SCCClient;
@@ -2116,39 +2119,53 @@ public class ContentSyncManager {
         }
         String label = dbChannel.getLabel();
         List<SUSEProductSCCRepository> suseProductSCCRepositories = SUSEProductFactory.lookupPSRByChannelLabel(label);
+        boolean regenPillar = false;
 
-        Opt.consume(suseProductSCCRepositories.stream().findFirst(),
-                () -> {
-                    log.warn("Expired Vendor Channel with label '{}' found. To remove it please run: ", label);
-                    log.warn("spacewalk-remove-channel -c {}", label);
-                },
-                productrepo -> {
-                    SUSEProduct product = productrepo.getProduct();
+        Optional<SUSEProductSCCRepository> prdrepoOpt = suseProductSCCRepositories.stream().findFirst();
+        if (prdrepoOpt.isEmpty()) {
+            log.warn("Expired Vendor Channel with label '{}' found. To remove it please run: ", label);
+            log.warn("spacewalk-remove-channel -c {}", label);
+        }
+        else {
+            SUSEProductSCCRepository productrepo = prdrepoOpt.get();
+            SUSEProduct product = productrepo.getProduct();
 
-                    // update only the fields which are save to be updated
-                    dbChannel.setChannelFamily(product.getChannelFamily());
-                    dbChannel.setName(productrepo.getChannelName());
-                    dbChannel.setSummary(product.getFriendlyName());
-                    dbChannel.setDescription(
-                            Optional.ofNullable(product.getDescription())
-                                    .orElse(product.getFriendlyName()));
-                    dbChannel.setProduct(MgrSyncUtils.findOrCreateChannelProduct(product));
-                    dbChannel.setProductName(MgrSyncUtils.findOrCreateProductName(product.getName()));
-                    dbChannel.setUpdateTag(productrepo.getUpdateTag());
-                    dbChannel.setInstallerUpdates(productrepo.getRepository().isInstallerUpdates());
-                    dbChannel.setGPGKeyUrl(productrepo.getGpgKeyUrl());
-                    dbChannel.setGPGKeyId(productrepo.getGpgKeyId());
-                    dbChannel.setGPGKeyFp(productrepo.getGpgKeyFingerprint());
-                    ChannelFactory.save(dbChannel);
+            // update only the fields which are save to be updated
+            dbChannel.setChannelFamily(product.getChannelFamily());
+            dbChannel.setName(productrepo.getChannelName());
+            dbChannel.setSummary(product.getFriendlyName());
+            dbChannel.setDescription(
+                    Optional.ofNullable(product.getDescription())
+                            .orElse(product.getFriendlyName()));
+            dbChannel.setProduct(MgrSyncUtils.findOrCreateChannelProduct(product));
+            dbChannel.setProductName(MgrSyncUtils.findOrCreateProductName(product.getName()));
+            dbChannel.setUpdateTag(productrepo.getUpdateTag());
+            dbChannel.setInstallerUpdates(productrepo.getRepository().isInstallerUpdates());
+            if (!Objects.equals(dbChannel.getGPGKeyUrl(), productrepo.getGpgKeyUrl())) {
+                dbChannel.setGPGKeyUrl(productrepo.getGpgKeyUrl());
+                regenPillar = true;
+            }
+            dbChannel.setGPGKeyId(productrepo.getGpgKeyId());
+            dbChannel.setGPGKeyFp(productrepo.getGpgKeyFingerprint());
+            ChannelFactory.save(dbChannel);
 
-                    // update Mandatory Flag
-                    dbChannel.getSuseProductChannels().forEach(pc -> suseProductSCCRepositories.forEach(pr -> {
-                        if (pr.getProduct().equals(pc.getProduct()) && pr.isMandatory() != pc.isMandatory()) {
-                            pc.setMandatory(pr.isMandatory());
-                            SUSEProductFactory.save(pc);
-                        }
-                    }));
-                });
+            // update Mandatory Flag
+            for (SUSEProductChannel pc : dbChannel.getSuseProductChannels()) {
+                for (SUSEProductSCCRepository pr : suseProductSCCRepositories) {
+                    if (pr.getProduct().equals(pc.getProduct()) && pr.isMandatory() != pc.isMandatory()) {
+                        pc.setMandatory(pr.isMandatory());
+                        regenPillar = true;
+                        SUSEProductFactory.save(pc);
+                    }
+                }
+            }
+        }
+        if (regenPillar) {
+            for (MinionServer minion : ServerFactory.listMinionsByChannel(dbChannel.getId())) {
+                MinionGeneralPillarGenerator gen = new MinionGeneralPillarGenerator();
+                gen.generatePillarData(minion);
+            }
+        }
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -1690,12 +1690,9 @@ public class ContentSyncManager {
                             Opt.or(
                                     Optional.ofNullable(dbProductsById.get(productJson.getId())),
                                     Optional.ofNullable(SUSEProductFactory.findSUSEProduct(
-                                            productJson.getIdentifier(),
-                                            productJson.getVersion(),
-                                            productJson.getReleaseType(),
-                                            productJson.getArch(),
-                                            false
-                                    ))),
+                                            productJson.getIdentifier(), productJson.getVersion(),
+                                            productJson.getReleaseType(), productJson.getArch(), false))
+                            ),
                             () -> {
                                 SUSEProduct prod = createNewProduct(productJson, channelFamilyMap, packageArchMap);
                                 dbProductsById.put(prod.getProductId(), prod);

--- a/java/code/src/com/redhat/rhn/manager/content/test/data1/product_tree.json
+++ b/java/code/src/com/redhat/rhn/manager/content/test/data1/product_tree.json
@@ -10227,7 +10227,19 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Pool for x86_64"
+        "channel_name": "SLE-Module-Legacy12-Pool for x86_64",
+        "gpg_info": [
+            {
+                "url": "file:///usr/lib/rpm/gnupg/keys/gpg-pubkey-39db7c82-5f68629b.asc",
+                "keyId": "39DB7C82",
+                "fingerprint": "FEAB502539D846DB2C0961CA70AF9E8139DB7C82"
+            },
+            {
+                "url": "file:///etc/pki/rpm-gpg/suse-addon-97a636db0bad8ecc.key",
+                "keyId": "97A636DB0BAD8ECC",
+                "fingerprint": "CCB57F6E2FA5D41B256E02B897A636DB0BAD8ECC"
+            }
+        ]
     },
     {
         "channel_label": "sle-module-legacy12-debuginfo-pool-x86_64",

--- a/java/code/src/com/redhat/rhn/manager/content/test/smallBase/product_tree.json
+++ b/java/code/src/com/redhat/rhn/manager/content/test/smallBase/product_tree.json
@@ -10662,7 +10662,14 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Pool for x86_64"
+        "channel_name": "SLE-Module-Legacy12-Pool for x86_64",
+        "gpg_info": [
+            {
+                "url": "file:///usr/lib/rpm/gnupg/keys/gpg-pubkey-39db7c82-5f68629b.asc",
+                "keyId": "39DB7C82",
+                "fingerprint": "FEAB502539D846DB2C0961CA70AF9E8139DB7C82"
+            }
+        ]
     },
     {
         "channel_label": "sle-module-legacy12-debuginfo-pool-x86_64",

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- support multiple gpgkey urls for a channel (bsc#1208540)
 - Refactor Java notification synchronize to avoid dead locks (bsc#1209369)
 - Filter CLM modular packages using release strings (bsc#1207814)
 - Fix systems subscribed to channel CSV download (bsc#1201063)

--- a/susemanager-utils/susemanager-sls/salt/channels/gpg-keys.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/gpg-keys.sls
@@ -30,6 +30,13 @@ mgr_deploy_tools_uyuni_key:
     - makedirs: True
     - mode: 644
 
+mgr_deploy_suse_addon_key:
+  file.managed:
+    - name: /etc/pki/rpm-gpg/suse-addon-97a636db0bad8ecc.key
+    - source: salt://gpg/build-addon-97A636DB0BAD8ECC.key
+    - makedirs: True
+    - mode: 644
+
 {%- if grains['os_family'] == 'RedHat' %}
 {# deploy all keys to the clients. If they get imported dependes on the used channels #}
 
@@ -81,8 +88,13 @@ mgr_deploy_{{ keyname }}:
 
 {%- set gpg_urls = [] %}
 {%- for chan, args in pillar.get(pillar.get('_mgr_channels_items_name', 'channels'), {}).items() %}
-{%- if args['gpgkeyurl'] is defined and args['gpgkeyurl'] not in gpg_urls %}
-{{ gpg_urls.append(args['gpgkeyurl']) | default("", True) }}
+{%- if args['gpgkeyurl'] is defined %}
+{%- set keys = args['gpgkeyurl'].split(' ') %}
+{%- for gpgkey in keys %}
+{%- if gpgkey not in gpg_urls %}
+{{ gpg_urls.append(gpgkey) | default("", True) }}
+{%- endif %}
+{%- endfor %}
 {%- endif %}
 {%- endfor %}
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- support multiple gpgkey urls for a channel (bsc#1208540)
+- make SUSE Addon GPG key available on all instance (bsc#1208540)
 - Improve error handling in mgr_events.py (bsc#1208687)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

There is a need to define multiple GPG key URLs for a channel.
With this PR it is possible to define a space separated list in the field and the backend takes all of them into account.
Additionally the suse addon gpg key is deployed on all system to be available if needed.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- https://github.com/uyuni-project/uyuni-docs/pull/2120

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/20722

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
