### PR TITLE
spacecmd: show packages before removing them (bsc#1207830)

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,5 @@
+- Show targetted packages before actually removing them (bsc#1207830)
+
 -------------------------------------------------------------------
 Tue Feb 21 12:29:28 CET 2023 - jgonzalez@suse.com
 

--- a/spacecmd/src/spacecmd/package.py
+++ b/spacecmd/src/spacecmd/package.py
@@ -203,13 +203,13 @@ def do_package_remove(self, args):
         print(_("No packages found to remove"))
         return 1
 
-    if not self.user_confirm(_('Remove these packages [y/N]:')):
-        print(_("No packages has been removed"))
-        return 1
-
     print(_('Packages'))
     print('--------')
     print('\n'.join(sorted(to_remove)))
+
+    if not self.user_confirm(_('Remove these packages [y/N]:')):
+        print(_("No packages has been removed"))
+        return 1
 
     for package in to_remove:
         for package_id in self.get_package_id(package):
@@ -261,13 +261,13 @@ def do_package_removeorphans(self, args):
         logging.warning(_N('No orphaned packages'))
         return 1
 
-    if not self.user_confirm(_('Remove these packages [y/N]:')):
-        print(_("No packages were removed"))
-        return 1
-
     print(_('Packages'))
     print('--------')
     print('\n'.join(sorted(build_package_names(packages))))
+
+    if not self.user_confirm(_('Remove these packages [y/N]:')):
+        print(_("No packages were removed"))
+        return 1
 
     for package in packages:
         try:

--- a/spacecmd/tests/test_package.py
+++ b/spacecmd/tests/test_package.py
@@ -562,7 +562,7 @@ class TestSCPackage:
         assert shell.get_package_names.called
         assert mprint.called
 
-        assert_expect(mprint.call_args_list, "No packages has been removed")
+        assert mprint.call_args_list[-1][0][0] == "No packages has been removed"
 
     def test_package_remove_specific_pkg_accepted(self, shell):
         """
@@ -579,6 +579,9 @@ class TestSCPackage:
         shell.user_confirm = MagicMock(return_value=True)
         mprint = MagicMock()
         logger = MagicMock()
+        mocks_order = MagicMock()
+        mocks_order.mprint, mocks_order.removePackage = mprint, shell.client.packages.removePackage
+
         with patch("spacecmd.package.print", mprint) as prn, \
             patch("spacecmd.package.logging", logger) as lgr:
             spacecmd.package.do_package_remove(shell, "vim* gvim pico")
@@ -602,6 +605,10 @@ class TestSCPackage:
             assert_expect([call], next(iter(exp)))
             exp.pop(0)
         assert not exp
+
+        # mprint is called first and removePackage the last
+        assert mocks_order.mock_calls[0][0] == 'mprint'
+        assert mocks_order.mock_calls[-1][0] == 'removePackage'
 
     def test_package_listorphans_noarg(self, shell):
         """
@@ -664,7 +671,7 @@ class TestSCPackage:
         assert out is 1
         assert shell.client.channel.software.listPackagesWithoutChannel.called
 
-        assert_expect(mprint.call_args_list, "No packages were removed")
+        assert mprint.call_args_list[-1][0][0] == "No packages were removed"
 
     def test_package_removeorphans_confirm(self, shell):
         """


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue in `spacecmd` that makes the targetted packages summary to be displayed in the console AFTER the user confirmation, instead of before to double check the action is going to perform what the user is expecting.

- Before this PR, the summary of packages is wrongly displayed AFTER the user confirmation:

```console
spacecmd {SSM:0}> package_remove zypper-log-*
 
Remove these packages [y/N]: n
Packages
--------
zypper-log-1.14.52-150400.1.9.noarch
zypper-log-1.14.53-150400.3.3.1.noarch
zypper-log-1.14.55-150400.3.6.1.noarch
zypper-log-1.14.57-150400.3.9.1.noarch

No packages has been removed
```

- After this PR, the summary is displayed BEFORE the user confirmation:

```console
spacecmd {SSM:0}> package_remove zypper-log-*
Packages
--------
zypper-log-1.14.52-150400.1.9.noarch
zypper-log-1.14.53-150400.3.3.1.noarch
zypper-log-1.14.55-150400.3.6.1.noarch
zypper-log-1.14.57-150400.3.9.1.noarch

Remove these packages [y/N]: n
No packages has been removed
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/20366

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
