### PR TITLE
QE: Refactor smoke test template for SLE Micro

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -46,10 +46,7 @@ Feature: Smoke tests for <client>
     And I click on "Confirm"
     Then I should see a "1 patch update has been scheduled for" text
     And I wait until event "Patch Update:" is completed
-
-@slemicro
-  Scenario: Reboot the <client> and wait until reboot is completed
-    And I reboot the "<client>" minion through the web UI
+    And I reboot the "<client>" if it is a SLE Micro
 
   Scenario: Install a package on the <client>
     When I follow "Software" in the content area
@@ -61,10 +58,7 @@ Feature: Smoke tests for <client>
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text
     And I wait until event "Package Install/Upgrade scheduled by admin" is completed
-
-@slemicro
-  Scenario: Reboot the <client> and wait until reboot is completed
-    And I reboot the "<client>" minion through the web UI
+    And I reboot the "<client>" if it is a SLE Micro
 
   Scenario: Remove package from <client>
     When I follow "Software" in the content area
@@ -76,10 +70,7 @@ Feature: Smoke tests for <client>
     And I click on "Confirm"
     Then I should see a "1 package removal has been scheduled" text
     And I wait until event "Package Removal scheduled by admin" is completed
-
-@slemicro
-  Scenario: Reboot the <client> and wait until reboot is completed
-    And I reboot the "<client>" minion through the web UI
+    And I reboot the "<client>" if it is a SLE Micro
 
   Scenario: Run a remote command on <client> minion
     When I follow the left menu "Salt > Remote Commands"
@@ -115,10 +106,7 @@ Feature: Smoke tests for <client>
     And I click on "Continue"
     And I click on "Update Channel Rankings"
     Then I should see a "Channel Subscriptions successfully changed for" text
-
-@slemicro
-  Scenario: Reboot the <client> and wait until reboot is completed
-    And I reboot the "<client>" minion through the web UI
+    And I reboot the "<client>" if it is a SLE Micro
 
   Scenario: Deploy the configuration file to <client>
     And I follow the left menu "Configuration > Channels"
@@ -132,13 +120,19 @@ Feature: Smoke tests for <client>
     When I click on "Deploy Files to Selected Systems"
     Then I should see a "1 revision-deploy is being scheduled." text
     And I should see a "0 revision-deploys overridden." text
-
-  Scenario: Reboot the <client> and wait until reboot is completed
-    And I reboot the "<client>" minion through the web UI
-
-  Scenario: Check the configuration file afterwards
+    And I reboot the "<client>" if it is a SLE Micro
     And I wait until file "/etc/s-mgr/config" exists on "<client>"
     Then file "/etc/s-mgr/config" should contain "COLOR=white" on "<client>"
+
+  Scenario: Reboot the <client> and wait until reboot is completed
+    Given I am on the Systems overview page of this "<client>"
+    When I follow first "Schedule System Reboot"
+    Then I should see a "System Reboot Confirmation" text
+    And I should see a "Reboot system" button
+    When I click on "Reboot system"
+    Then I should see a "Reboot scheduled for system" text
+    And I wait at most 600 seconds until event "System reboot scheduled by admin" is completed
+    Then I should see a "This action's status is: Completed" text
 
   Scenario: Install spacecmd from the client tools on the <client>
     When I follow "Software" in the content area
@@ -150,10 +144,7 @@ Feature: Smoke tests for <client>
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text
     And I wait until event "Package Install/Upgrade scheduled by admin" is completed
-
-@slemicro
-  Scenario: Reboot the <client> and wait until reboot is completed
-    And I reboot the "<client>" minion through the web UI
+    And I reboot the "<client>" if it is a SLE Micro
 
   Scenario: Test Prometheus exporter formula on the <client>
     Given I am on the Systems overview page of this "<client>"
@@ -182,10 +173,7 @@ Feature: Smoke tests for <client>
     And I visit "Prometheus apache exporter" endpoint of this "<client>"
     And I wait until "postgres" exporter service is active on "<client>"
     And I visit "Prometheus postgres exporter" endpoint of this "<client>"
-
-@slemicro
-  Scenario: Reboot the <client> and wait until reboot is completed
-    And I reboot the "<client>" minion through the web UI
+    And I reboot the "<client>" if it is a SLE Micro
 
   Scenario: Test <client> on Grafana
     When I visit the grafana dashboards of this "monitoring_server"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1738,6 +1738,12 @@ When(/^I reboot the "([^"]*)" minion through the web UI$/) do |host|
   )
 end
 
+When(/^I reboot the "([^"]*)" if it is a SLE Micro$/) do |host|
+  if slemicro_host?(host)
+    step %(I reboot the "#{host}" minion through SSH)
+  end
+end
+
 When(/^I change the server's short hostname from hosts and hostname files$/) do
   old_hostname = $server.hostname
   new_hostname = old_hostname + '2'


### PR DESCRIPTION
## What does this PR change?

This will refactor the necessary reboot steps for SLE Micro in our build validation smoke test template file. Thank you @Bischoff for doing this together with me.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links

- Manager 4.3: 
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

