### PR TITLE
fix not showing details

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Display activation key details after executing the corresponding command (bsc#1208719)
 - Show targetted packages before actually removing them (bsc#1207830)
 
 -------------------------------------------------------------------

--- a/spacecmd/src/spacecmd/activationkey.py
+++ b/spacecmd/src/spacecmd/activationkey.py
@@ -1000,6 +1000,9 @@ def do_activationkey_details(self, args):
                 name += '.%s' % package.get('arch')
 
             result.append(name)
+    for entry in result:
+        print(_N(entry))
+
     return result
 
 ####################

--- a/spacecmd/tests/test_activationkey.py
+++ b/spacecmd/tests/test_activationkey.py
@@ -897,7 +897,7 @@ class TestSCActivationKeyMethods:
         mprint = MagicMock()
         with patch("spacecmd.activationkey.print", mprint) as mpr:        
             out = spacecmd.activationkey.do_activationkey_details(shell, "somekey")
-        assert not mprint.called
+        assert mprint.called
 
         expectation = ['Key:                    somekey',
                        'Description:            Key description', 'Universal Default:      yes',


### PR DESCRIPTION
## What does this PR change?

Fix the `spacecmd activationkey_details <key>` command showing the key details only in the debug mode with the `-d` flag set. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20615

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_pgsql"
- [x] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
