### PR TITLE
QE: Add monitoring ports to firewall for oracle minions

### DIFF
--- a/testsuite/.rubocop_todo.yml
+++ b/testsuite/.rubocop_todo.yml
@@ -401,6 +401,11 @@ Style/DocumentationMethod:
     - 'features/support/namespaces/system.rb'
     - 'features/support/twopence_init.rb'
 
+# Offense count: 1
+Style/For:
+  Exclude:
+    - 'features/step_definitions/command_steps.rb'
+
 # Offense count: 40
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/testsuite/features/build_validation/init_clients/oracle9_minion.feature
+++ b/testsuite/features/build_validation/init_clients/oracle9_minion.feature
@@ -38,6 +38,10 @@ Feature: Bootstrap a Oracle 9 Salt minion
     And I follow "Proxy" in the content area
     Then I should see "oracle9_minion" hostname
 
+@monitoring_server
+  Scenario: Prepare Oracle 9 Salt minion firewall for monitoring
+    When I enable firewall ports for monitoring on this "oracle9_minion"
+
   Scenario: Check events history for failures on Oracle 9 Salt minion
     Given I am on the Systems overview page of this "oracle9_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/build_validation/init_clients/oracle9_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/oracle9_ssh_minion.feature
@@ -39,6 +39,10 @@ Feature: Bootstrap a Oracle 9 Salt SSH minion
     And I follow "Proxy" in the content area
     Then I should see "oracle9_ssh_minion" hostname
 
+@monitoring_server
+  Scenario: Prepare Oracle 9 Salt SSH minion firewall for monitoring
+    When I enable firewall ports for monitoring on this "oracle9_ssh_minion"
+
   Scenario: Check events history for failures on Oracle 9 Salt SSH minion
     Given I am on the Systems overview page of this "oracle9_ssh_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1789,3 +1789,16 @@ When(/^I clean up the server's hosts file$/) do
   command = "sed -i '$d' /etc/hosts && sed -i '$d' /etc/hosts"
   $server.run(command)
 end
+
+When(/^I enable firewall ports for monitoring on this "([^"]*)"$/) do |host|
+  add_ports = ''
+  for port in [9100, 9117, 9187] do
+    add_ports += "firewall-cmd --add-port=#{port}/tcp --permanent && "
+  end
+  cmd = "#{add_ports.rstrip!} firewall-cmd --reload"
+  node = get_target(host)
+  node.run(cmd)
+  output, _code = node.run('firewall-cmd --list-ports')
+  raise StandardError, "Couldn't successfully enable all ports needed for monitoring. Opened ports: #{output}" unless
+    output.include? '9100/tcp 9117/tcp 9187/tcp'
+end


### PR DESCRIPTION
## What does this PR change?
Adds the ports needed for monitoring to the Oracle minions' firewall permissions.

## Links
- 4.3 https://github.com/SUSE/spacewalk/pull/20731

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
