### PR TITLE
send http headers with additional auth data on the mirrorlist request

### DIFF
--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -539,7 +539,7 @@ class ContentSource:
         cert = (self.sslclientcert, self.sslclientkey)
         verify = self.sslcacert
         try:
-            webpage = requests.get(url, proxies=proxies, cert=cert, verify=verify)
+            webpage = requests.get(url, proxies=proxies, cert=cert, verify=verify, headers=self.http_headers)
             # We want to check the page content-type usually, but
             # we have to wrap the next bit in a try-block for if the resource is
             # cached and returns a 304; cached page returns no content type

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- fix repo sync for cloud payg connected repositories (bsc#1208772)
 - Fix issues with kickstart syncing on mirrorlist repositories
 - Do not sync .mirrorlist and other non needed files
 - reposync: catch local file not found urlgrabber error properly (bsc#1208288)


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/20721

The cloud infrastructure seems to forbid requests for a while when the authentication failed.
(maybe a DOS prevention?)
The wrong request to detect a mirror list caused failing download of metadata even with correct credentials.

This PR send now the required headers to authenticate successful against the cloud infrastructure.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
