### PR TITLE
Testsuite: Correct name of called feature

### DIFF
--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -60,5 +60,5 @@
 - features/secondary/srv_cobbler_sync.feature
 - features/secondary/srv_cobbler_distro.feature
 - features/secondary/srv_cobbler_buildiso.feature
-- features/secondary/srv_cobbler_profile_ise.feature
+- features/secondary/srv_cobbler_profile.feature
 ## Secondary features END ##


### PR DESCRIPTION
## What does this PR change?
A spelling error causes the CI to skip the features in `secondary.yml` to be skipped.
This PR fixes it
Related to https://github.com/uyuni-project/uyuni/pull/6628

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Fixes #
Tracks # 
4.3 https://github.com/SUSE/spacewalk/pull/20757

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
