### PR TITLE
CLM feature: Remove separation between SUMA and Uyuni

### DIFF
--- a/testsuite/features/secondary/srv_content_lifecycle.feature
+++ b/testsuite/features/secondary/srv_content_lifecycle.feature
@@ -40,21 +40,11 @@ Feature: Content lifecycle
     And I wait until I see "SLE-Product-SLES15-SP4-Pool for x86_64" text
     Then I should see a "Version 1: (draft - not built) - Check the changes below" text
 
-@uyuni
-  Scenario: Verify added sources for Uyuni
+  Scenario: Verify added sources
     When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
     Then I should see a "SLE-Product-SLES15-SP4-Updates for x86_64" text
     And I should see a "Build (2)" text
-
-@susemanager
-  Scenario: Verify added sources for SUSE Manager
-    When I follow the left menu "Content Lifecycle > Projects"
-    And I follow "clp_name"
-    Then I should see a "SLE-Manager-Tools15-Updates for x86_64 SP4" text
-    And I should see a "SLE-Product-SLES15-SP4-Updates for x86_64" text
-    And I should see a "SLE-Manager-Tools15-Pool for x86_64 SP4" text
-    And I should see a "Build (4)" text
 
   Scenario: Add environments to the project
     When I follow the left menu "Content Lifecycle > Projects"
@@ -83,24 +73,11 @@ Feature: Content lifecycle
     Then I wait until I see "qa_name" text
     And I should see a "qa_desc" text
 
-@uyuni
-  Scenario: Build the sources in the project for Uyuni
+  Scenario: Build the sources in the project
     When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
     Then I should see a "not built" text in the environment "qa_name"
     When I click on "Build (2)"
-    Then I should see a "Version 1 history" text
-    When I enter "test version message 1" as "message"
-    And I click the environment build button
-    And I wait until I see "Version 1: test version message 1" text in the environment "dev_name"
-    And I wait at most 600 seconds until I see "Built" text in the environment "dev_name"
-
-@susemanager
-  Scenario: Build the sources in the project for SUSE Manager
-    When I follow the left menu "Content Lifecycle > Projects"
-    And I follow "clp_name"
-    Then I should see a "not built" text in the environment "qa_name"
-    When I click on "Build (4)"
     Then I should see a "Version 1 history" text
     When I enter "test version message 1" as "message"
     And I click the environment build button
@@ -159,8 +136,7 @@ Feature: Content lifecycle
     And I click on "Delete" in "Delete Project" modal
     Then I should not see a "clp_name" text
 
-@uyuni
-  Scenario: Cleanup: remove the created channels for Uyuni
+  Scenario: Cleanup: remove the created channels
     When I delete these channels with spacewalk-remove-channel:
       |clp_label-prod_label-fake_base_channel|
       |clp_label-prod_label-sle-product-sles15-sp4-updates-x86_64|
@@ -173,26 +149,4 @@ Feature: Content lifecycle
       |clp_label-qa_label-sle-product-sles15-sp4-pool-x86_64|
       |clp_label-dev_label-sle-product-sles15-sp4-pool-x86_64|
     And I list channels with spacewalk-remove-channel
-    Then I shouldn't get "clp_label"
-
-@susemanager
-  Scenario: Cleanup: remove the created channels for SUSE Manager
-    When I delete these channels with spacewalk-remove-channel:
-      |clp_label-prod_label-fake_base_channel|
-      |clp_label-prod_label-sles12-sp5-updates-x86_64|
-      |clp_label-prod_label-sle-manager-tools12-pool-x86_64-sp5|
-      |clp_label-prod_label-sle-manager-tools12-updates-x86_64-sp5|
-      |clp_label-qa_label-fake_base_channel|
-      |clp_label-qa_label-sles12-sp5-updates-x86_64|
-      |clp_label-qa_label-sle-manager-tools12-pool-x86_64-sp5|
-      |clp_label-qa_label-sle-manager-tools12-updates-x86_64-sp5|
-      |clp_label-dev_label-fake_base_channel|
-      |clp_label-dev_label-sles12-sp5-updates-x86_64|
-      |clp_label-dev_label-sle-manager-tools12-pool-x86_64-sp5|
-      |clp_label-dev_label-sle-manager-tools12-updates-x86_64-sp5|
-    And I delete these channels with spacewalk-remove-channel:
-      |clp_label-prod_label-sles12-sp5-pool-x86_64|
-      |clp_label-qa_label-sles12-sp5-pool-x86_64|
-      |clp_label-dev_label-sles12-sp5-pool-x86_64|
-    When I list channels with spacewalk-remove-channel
     Then I shouldn't get "clp_label"


### PR DESCRIPTION
## What does this PR change?

With the removal of the recommended child channels in the Content Lifecycle project feature (which did not have any impact on the feature) the code for Uyuni and SUMA are now identical.
This PR removes the present redundancy from this feature.
N.B. the differences between products on Uyuni branch are from an un-ported PR (https://github.com/SUSE/spacewalk/pull/20749)
## GUI diff

No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Fixes #
Tracks # 
4.2 https://github.com/SUSE/spacewalk/pull/20762
4.3 https://github.com/SUSE/spacewalk/pull/20761
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
