### PR TITLE
use template for reportdb configuration (bsc#1206783)

### DIFF
--- a/spacewalk/admin/rhn-config-satellite.pl
+++ b/spacewalk/admin/rhn-config-satellite.pl
@@ -128,7 +128,7 @@ B<rhn-config-satellite.pl> --target=<target_file> --option=<key,value> [ --optio
 
 =head1 DESCRIPTION
 
-This script will make sure that in F<target_file> are present configuration variables in format C<key=value>. If such key already exist there, it is removed and new variables are put at the end of the F<target_file>. Original file is preserved as F<target_file.DATE>
+This script will make sure that in F<target_file> are present configuration variables in format C<key=value>. If such key already exist there, it is removed and new variables are put at the end of the F<target_file>. Original file is preserved as F<target_file.CURRENT_TIME>
 
 This script is used internally by B<spacewalk-setup>(1)
 =head1 OPTIONS

--- a/spacewalk/admin/rhn-config-satellite.pl
+++ b/spacewalk/admin/rhn-config-satellite.pl
@@ -17,6 +17,9 @@
 
 use strict;
 use warnings;
+use Time::Piece;
+use Time::HiRes;
+
 
 use Getopt::Long;
 use English;
@@ -49,12 +52,11 @@ if (! grep { $_ eq $target} @allowed_target_files) {
   die("Cannot modify a file that is not a spacewalk config file: " . $target);
 }
 
-if (-e $target . ".orig") {
-  unlink($target . ".orig") or die "Could not remove $target to ${target}.orig prior to new backup: $OS_ERROR";
-}
+my ($seconds,$microseconds) = Time::HiRes::gettimeofday;
+my $current_time = sprintf '%s.%06d', gmtime($seconds)->strftime('%Y-%m-%d_%H:%M:%S'), $microseconds;
 
 if (-e $target) {
-  link($target, $target . ".orig") or die "Could not rename $target to ${target}.orig: $OS_ERROR";
+  link($target, $target . "." . $current_time) or die "Could not rename $target to ${target}.${current_time}: $OS_ERROR";
   open(TARGET, "< $target") or die "Could not open $target: $OS_ERROR";
 }
 
@@ -126,7 +128,7 @@ B<rhn-config-satellite.pl> --target=<target_file> --option=<key,value> [ --optio
 
 =head1 DESCRIPTION
 
-This script will make sure that in F<target_file> are present configuration variables in format C<key=value>. If such key already exist there, it is removed and new variables are put at the end of the F<target_file>. Original file is preserved as F<target_file.orig>
+This script will make sure that in F<target_file> are present configuration variables in format C<key=value>. If such key already exist there, it is removed and new variables are put at the end of the F<target_file>. Original file is preserved as F<target_file.DATE>
 
 This script is used internally by B<spacewalk-setup>(1)
 =head1 OPTIONS

--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,5 @@
+- change backup file extension from .orig to .date
+
 -------------------------------------------------------------------
 Tue Feb 21 12:39:12 CET 2023 - jgonzalez@suse.com
 

--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,4 +1,4 @@
-- change backup file extension from .orig to .date
+- change backup file extension from .orig to .current_time
 
 -------------------------------------------------------------------
 Tue Feb 21 12:39:12 CET 2023 - jgonzalez@suse.com

--- a/spacewalk/setup/bin/spacewalk-setup
+++ b/spacewalk/setup/bin/spacewalk-setup
@@ -145,10 +145,9 @@ setup_ssl_certs(\%opts, \%answers);
 
 if(not $opts{"skip-reportdb-setup"}) {
     Spacewalk::Setup::postgresql_reportdb_setup(\%opts, \%answers);
+    print Spacewalk::Setup::loc("* Report DB Configured. \n");
 }
 
-print Spacewalk::Setup::loc("* Deploying configuration files.\n");
-populate_final_configs(\%opts, \%answers);
 
 if(not $opts{"skip-db-population"}) {
     print Spacewalk::Setup::loc("* Update configuration in database.\n");
@@ -157,6 +156,9 @@ if(not $opts{"skip-db-population"}) {
 
 print Spacewalk::Setup::loc("* Setting up Cobbler..\n");
 setup_cobbler(\%opts, \%answers);
+
+print Spacewalk::Setup::loc("* Deploying configuration files.\n");
+populate_final_configs(\%opts, \%answers);
 
 if ($opts{'upgrade'}) {
   Spacewalk::Setup::postgresql_start() if (Spacewalk::Setup::is_embedded_db(\%opts));
@@ -843,8 +845,8 @@ sub populate_initial_configs {
      db_port => $answers->{'db-port'},
      db_ssl_enabled => $answers->{'db-ssl-enabled'},
      externaldb => $answers->{'externaldb'},
-     external_db_admin_user => $answers->{'externaldb-admin-user'},
-     external_db_admin_password => $answers->{'externaldb-admin-password'},
+     externaldb_admin_user => $answers->{'externaldb-admin-user'},
+     externaldb_admin_password => $answers->{'externaldb-admin-password'},
      db_sslrootcert => $answers->{'db-ca-cert'},
      hibernate_dialect => $answers->{'hibernate.dialect'},
      hibernate_driver => $answers->{'hibernate.connection.driver_class'},

--- a/spacewalk/setup/lib/Spacewalk/Setup.pm
+++ b/spacewalk/setup/lib/Spacewalk/Setup.pm
@@ -123,8 +123,8 @@ use constant SCC_CREDENTIAL_FILE =>
 my $DEBUG;
 $DEBUG = 0;
 
-my $SILENT;
-$SILENT = 0;
+my $DRY_RUN;
+$DRY_RUN = 0;
 
 sub parse_options {
   my @valid_opts = (
@@ -285,7 +285,7 @@ sub system_debug {
   if ($DEBUG) {
     print "Command: '" . join(' ', @args) . "'\n";
   }
-  if ($SILENT) {
+  if ($DRY_RUN) {
     return 0;
   }
   else {
@@ -533,7 +533,7 @@ EOQ
         $drop_sth->execute();
     }
 
-    if ($SILENT) {
+    if ($DRY_RUN) {
         $dbh->rollback();
     }
     else {

--- a/spacewalk/setup/lib/Spacewalk/Setup.pm
+++ b/spacewalk/setup/lib/Spacewalk/Setup.pm
@@ -929,6 +929,7 @@ sub postgresql_reportdb_setup {
     
     if (-e Spacewalk::Setup::DEFAULT_RHN_CONF_LOCATION) {
         my %dbOptions = ();
+        ### uyuni-setup-reportdb writes param in rhn.conf. We need to read them and persists them in satellite-local-rules.conf
         read_config(Spacewalk::Setup::DEFAULT_RHN_CONF_LOCATION, \%dbOptions);
         ### here we need _ instead of - cause we read them from rhn.conf
         write_rhn_conf(\%dbOptions, 'report_db_backend', 'report_db_host', 'report_db_port', 'report_db_name', 'report_db_user', 'report_db_password', 'report_db_ssl_enabled');

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,5 @@
+- use template for reportdb configuration (bsc#1206783)
+
 -------------------------------------------------------------------
 Tue Feb 21 12:29:07 CET 2023 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

- fix `externaldb*` and `reportdb` param in `spacewalk-setup`: they didn't match with template in `spacewalk/config/var/lib/rhn/rhn-satellite-prep/etc/rhn/rhn.conf`
- `Setup.pm`: the DEBUG variable was also a dry-run mode, create a new variable to separate them
- `Setup.pm`: align `/etc/rhn/rhn.conf` with `/var/lib/rhn/rhn-satellite-prep/satellite-local-rules.conf`
- `rhn-config-satellite.pl` (called by `spacewalk-setup`) generates a backup file (with extensions `.orig`) everytime is called. Since it's called several time, the `.orig` file is pretty useless. I change it to save the backup file with `.CURRENT_TIME` extension

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20035

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
