### PR TITLE
QE: Add ports to firewall for monitoring on liberty linux

### DIFF
--- a/testsuite/features/build_validation/init_clients/liberty9_minion.feature
+++ b/testsuite/features/build_validation/init_clients/liberty9_minion.feature
@@ -38,6 +38,10 @@ Feature: Bootstrap a Liberty Linux 9 Salt minion
     And I follow "Proxy" in the content area
     Then I should see "liberty9_minion" hostname
 
+@monitoring_server
+  Scenario: Prepare Liberty Linux 9 Salt minion firewall for monitoring
+    When I enable firewall ports for monitoring on this "liberty9_minion"
+
   Scenario: Check events history for failures on Liberty Linux 9 Salt minion
     Given I am on the Systems overview page of this "liberty9_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/build_validation/init_clients/liberty9_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/liberty9_ssh_minion.feature
@@ -39,6 +39,10 @@ Feature: Bootstrap a Liberty Linux 9 Salt SSH minion
     And I follow "Proxy" in the content area
     Then I should see "liberty9_ssh_minion" hostname
 
+@monitoring_server
+  Scenario: Prepare Liberty Linux 9 Salt SSH minion firewall for monitoring
+    When I enable firewall ports for monitoring on this "liberty9_ssh_minion"
+
   Scenario: Check events history for failures on Liberty Linux 9 Salt SSH minion
     Given I am on the Systems overview page of this "liberty9_ssh_minion"
     Then I check for failed events on history event page


### PR DESCRIPTION
## What does this PR change?
Adds the ports needed for monitoring to the Liberty Linux minions' firewall permissions.

## Links
- 4.3 https://github.com/SUSE/spacewalk/pull/20766

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
