### PR TITLE
Fix rendering of notifications page with subscription warnings (bsc#1209259)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/notification/types/SubscriptionWarning.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/SubscriptionWarning.java
@@ -52,17 +52,11 @@ public class SubscriptionWarning implements NotificationData {
 
     @Override
     public String getSummary() {
-         if (expiresSoon()) {
-             return LOCALIZATION_SERVICE.getMessage("notification.subscriptionwarning.summary");
-         }
-        return null;
+         return LOCALIZATION_SERVICE.getMessage("notification.subscriptionwarning.summary");
     }
 
     @Override
     public String getDetails() {
-        if (expiresSoon()) {
-            return LOCALIZATION_SERVICE.getMessage("notification.subscriptionwarning.detail");
-        }
-        return null;
+        return LOCALIZATION_SERVICE.getMessage("notification.subscriptionwarning.detail");
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/notification/types/test/SubscriptionWarningTest.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/test/SubscriptionWarningTest.java
@@ -16,7 +16,6 @@
 package com.redhat.rhn.domain.notification.types.test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.redhat.rhn.domain.notification.types.SubscriptionWarning;
 import com.redhat.rhn.testing.RhnBaseTestCase;
@@ -30,18 +29,6 @@ class SubscriptionWarningTest extends RhnBaseTestCase {
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
-    }
-
-    @Test
-    public void testGetNullStrings() {
-        SubscriptionWarning sw = new SubscriptionWarning() {
-            @Override
-            public boolean expiresSoon() {
-                return false;
-            }
-        };
-        assertNull(sw.getSummary());
-        assertNull(sw.getDetails());
     }
 
     @Test

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Fix rendering of notifications list with subscription warnings (bsc#1209259)
+
 -------------------------------------------------------------------
 Tue Feb 28 11:55:21 CET 2023 - jgonzalez@suse.com
 


### PR DESCRIPTION
Prevents null values in the `summary` and `details` fields of subscription warning notifications that cause the notifications page to crash.

Port of: https://github.com/SUSE/spacewalk/pull/20772

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
