### PR TITLE
Refactor Java notification synchronize to avoid dead locks (bsc#1209369)

### DIFF
--- a/java/code/src/com/suse/manager/webui/websocket/Notification.java
+++ b/java/code/src/com/suse/manager/webui/websocket/Notification.java
@@ -32,11 +32,13 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.EOFException;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -69,8 +71,8 @@ public class Notification {
 
     private static final Object LOCK = new Object();
     private static final Gson GSON = new GsonBuilder().create();
-    private static Map<Session, Set<String>> wsSessions = new HashMap<>();
-    private static Set<Session> brokenSessions = new HashSet<>();
+    private static Map<Session, Set<String>> wsSessions = new ConcurrentHashMap();
+    private static Set<Session> brokenSessions = ConcurrentHashMap.newKeySet();
     private static final WebsocketHeartbeatService HEARTBEAT_SERVICE = GlobalInstanceHolder.WEBSOCKET_SESSION_MANAGER;
 
     /**
@@ -186,8 +188,6 @@ public class Notification {
 
     /**
      * A static method to notify all {@link Session}s attached to WebSocket from the outside
-     * Must be synchronized. Sending messages concurrently from separate threads
-     * will result in IllegalStateException.
      *
      * @param property which property to spread to all sessions
      */
@@ -195,16 +195,14 @@ public class Notification {
         // Check for closed sessions before notifying them
         clearBrokenSessions();
 
-        synchronized (LOCK) {
-            // if there are unread messages, notify it to all attached WebSocket sessions
-            wsSessions.forEach((session, watched) -> {
-                if (watched.contains(property)) {
-                    Optional.ofNullable(session.getUserProperties().get(WEB_USER_ID))
-                            .map(webUserID -> UserFactory.lookupById((Long) webUserID))
-                            .ifPresent(user -> sendData(session, user, Set.of(property)));
-                }
-            });
-        }
+        // if there are unread messages, notify it to all attached WebSocket sessions
+        wsSessions.forEach((session, watched) -> {
+            if (watched.contains(property)) {
+                Optional.ofNullable(session.getUserProperties().get(WEB_USER_ID))
+                        .map(webUserID -> UserFactory.lookupById((Long) webUserID))
+                        .ifPresent(user -> sendData(session, user, Set.of(property)));
+            }
+        });
     }
 
     private static void sendData(Session session, User user, Set<String> properties) {
@@ -242,10 +240,14 @@ public class Notification {
                 }
             });
 
+            // this is a temporary list to cope with the scenario
+            // when new "brokenSessions" where added while we were cleaning them
+            List<Session> brokenSessionRemove = new LinkedList<>();
             // remove any invalid/broken session from the valid set
             // try to close it if it is still open
             brokenSessions.forEach(session -> {
                 wsSessions.remove(session);
+                brokenSessionRemove.add(session);
                 if (session.isOpen()) {
                     try {
                         session.close();
@@ -255,7 +257,7 @@ public class Notification {
                     }
                 }
             });
-            brokenSessions.clear();
+            brokenSessions.removeAll(brokenSessionRemove);
         }
     }
 
@@ -265,9 +267,7 @@ public class Notification {
      */
     private static void handshakeSession(Session session) {
         HEARTBEAT_SERVICE.register(session);
-        synchronized (LOCK) {
-            wsSessions.put(session, new HashSet<>());
-        }
+        wsSessions.put(session, new HashSet<>());
     }
 
     /**
@@ -276,9 +276,7 @@ public class Notification {
      */
     private static void handbreakSession(Session session) {
         HEARTBEAT_SERVICE.unregister(session);
-        synchronized (LOCK) {
-            brokenSessions.add(session);
-        }
+        brokenSessions.add(session);
     }
 
     private static ScheduledExecutorService scheduledExecutorService;
@@ -286,7 +284,6 @@ public class Notification {
         scheduledExecutorService = Executors.newScheduledThreadPool(1);
         scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
-                clearBrokenSessions();
                 spreadUpdate(USER_NOTIFICATIONS);
             }
             catch (Exception e) {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Refactor Java notification synchronize to avoid dead locks (bsc#1209369)
 - Filter CLM modular packages using release strings (bsc#1207814)
 - Fix systems subscribed to channel CSV download (bsc#1201063)
 - Save scheduler user when creating Patch actions manually (bsc#1208321)
@@ -7,6 +8,7 @@
 - Make API method systemgroup.listSystemsMinimal read-only (bsc#1208550)
 - Allow single-value lists in query strings in HTTP API (bsc#1207297)
 - Do not include channels from different orgs when listing mandatory channels (bsc#1204270)
+
 
 -------------------------------------------------------------------
 Wed Mar 15 15:58:47 CET 2023 - jgonzalez@suse.com


### PR DESCRIPTION
## What does this PR change?

Notification manager had several lock mechanisms to control concurrent access to websocket sessions.

They had a circular dependency between the Object lock and getting a database connection. This code change aims to remove this circular dependency and reduce the number of locks that can block execution.

## GUI diff

No difference. Just internal processing only, related to thread management.

- [x] **DONE**

## Documentation
- No documentation needed: Just internal processing only, related to thread management.

- [x] **DONE**

## Test coverage
- No tests: This problem emerged in the BV test environment. Developing tests for this case is impossible since it depends on thread execution order, which we cannot control.

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20790
Tracks https://github.com/SUSE/spacewalk/pull/20800

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
