### PR TITLE
Change bootstraping message to indicate that reboot is necessary for transactional systems

### DIFF
--- a/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
+++ b/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
@@ -335,7 +335,7 @@ class BootstrapMinions extends React.Component<Props, State> {
           <a className="js-spa" href="/rhn/manager/systems/list/all">
             {t("systems")}
           </a>{" "}
-          {t("shortly")}.
+          {t("shortly. If it is a transactional system, please reboot it to finish registration")}.
         </p>
       );
     } else if (this.state.errors.length > 0) {


### PR DESCRIPTION
## What does this PR change?

As in this moment we don't know if the system is transactional or not, the best we can do is to warn the user to reboot if it is the case.

## GUI diff

Before:
![image](https://user-images.githubusercontent.com/17532261/225872824-21d81a58-71b2-4c3a-9aa1-8827f13288df.png)


After:

![image](https://user-images.githubusercontent.com/17532261/225871979-e89aac60-6d2e-494b-9fb1-ae58da4a15cb.png)

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20275

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
