### PR TITLE
Improve error handling in mgr_events.py (bsc#1208687)

### DIFF
--- a/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
+++ b/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
@@ -145,6 +145,11 @@ class Responder:
                 self.attempt_commit()
             except Exception as err:
                 log.error("%s: %s", __name__, err)
+                try:
+                    self.connection.commit()
+                except Exception as err2:
+                    log.error("%s: Error commiting: %s", __name__, err2)
+                    self.connection.close()
             finally:
                 log.debug("%s: %s", __name__, self.cursor.query)
         else:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Improve error handling in mgr_events.py (bsc#1208687)
+
 -------------------------------------------------------------------
 Tue Feb 21 14:10:36 CET 2023 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

After postgres error, the code never called commit or rollback, so all the following updates ended with postgres message 'current transaction is aborted, commands ignored until end of transaction block'

Details are here:
https://bugzilla.suse.com/show_bug.cgi?id=1208687#c17

## GUI diff

No difference.

## Documentation
- No documentation needed: bugfix

## Test coverage
- No tests: we don't test all possible error conditions

## Links

Partial fix for https://bugzilla.suse.com/show_bug.cgi?id=1208687
https://github.com/SUSE/spacewalk/issues/20649

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
