### PR TITLE
Adds a adjustable option for c3p0 maxPoolSize in search

### DIFF
--- a/search-server/spacewalk-search/spacewalk-search.changes
+++ b/search-server/spacewalk-search/spacewalk-search.changes
@@ -1,3 +1,5 @@
+- Add maxPoolSize option  to search
+
 -------------------------------------------------------------------
 Mon Jan 23 08:32:37 CET 2023 - jgonzalez@suse.com
 

--- a/search-server/spacewalk-search/src/config/com/redhat/satellite/search/db/config.xml
+++ b/search-server/spacewalk-search/src/config/com/redhat/satellite/search/db/config.xml
@@ -21,6 +21,7 @@
                                                 <property name="maxIdleTimeExcessConnections" value="${search.connection.max_idle_time_excess_connections}"/>
                                                 <property name="user" value="${db_user}"/>
                                                 <property name="password" value="${db_password}"/>
+                                                <property name="maxPoolSize" value="${search.connection.maxPoolSize}"/>
                                         </dataSource>
                                 </environment>
                 </environments>

--- a/search-server/spacewalk-search/src/config/search/rhn_search.conf
+++ b/search-server/spacewalk-search/src/config/search/rhn_search.conf
@@ -14,5 +14,5 @@ search.max_ngram = 5
 search.doc.limit_results = false
 search.schedule.interval = 300000
 search.log.explain.results = false
-
+search.connection.maxPoolSize = 10
 


### PR DESCRIPTION
## What does this PR change?
Port of https://github.com/SUSE/spacewalk/pull/20628
Adds a adjustable option for c3p0 pool size in search
#16057 

## GUI diff

No difference.


- [ ] **DONE**

## Documentation
- No documentation needed:  no docs for these

- [ ] **DONE**

## Test coverage
- No tests: 

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
