### PR TITLE
Testsuite: Add cleanup with regular bootstrap procedure

### DIFF
--- a/testsuite/features/secondary/min_bootstrap_api.feature
+++ b/testsuite/features/secondary/min_bootstrap_api.feature
@@ -67,7 +67,7 @@ Feature: Register a Salt minion via API
   Scenario: Bootstrap a salt-ssh system with activation key and default contact method
     When I call system.bootstrap() on a Salt minion with saltSSH = true, but with activation key with default contact method, I should get an API fault
 
-  Scenario: Cleanup: delete SLES minion after after bootstrap script tests
+  Scenario: Cleanup: delete SLES minion after bootstrap script tests
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Delete System"
     Then I should see a "Confirm System Profile Deletion" text

--- a/testsuite/features/secondary/min_bootstrap_api.feature
+++ b/testsuite/features/secondary/min_bootstrap_api.feature
@@ -66,3 +66,24 @@ Feature: Register a Salt minion via API
 
   Scenario: Bootstrap a salt-ssh system with activation key and default contact method
     When I call system.bootstrap() on a Salt minion with saltSSH = true, but with activation key with default contact method, I should get an API fault
+
+  Scenario: Cleanup: delete SLES minion after after bootstrap script tests
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Delete System"
+    Then I should see a "Confirm System Profile Deletion" text
+    When I click on "Delete Profile"
+    And I wait until I see "has been deleted" text
+    Then "sle_minion" should not be registered
+
+  Scenario: Cleanup: bootstrap a SLES minion after bootstrap script tests
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I enter the hostname of "sle_minion" as "hostname"
+    And I enter "22" as "port"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I select "1-SUSE-KEY-x86_64" from "activationKeys"
+    And I select the hostname of "proxy" from "proxies" if present
+    And I click on "Bootstrap"
+    And I wait until I see "Successfully bootstrapped host!" text
+    And I wait until onboarding is completed for "sle_minion"

--- a/testsuite/features/secondary/min_bootstrap_script.feature
+++ b/testsuite/features/secondary/min_bootstrap_script.feature
@@ -83,3 +83,24 @@ Feature: Register a Salt minion via Bootstrap-script
   Scenario: Cleanup: remove package from script-bootstrapped SLES minion
    When I remove package "orion-dummy-1.1-1.1" from this "sle_minion"
    Then "orion-dummy-1.1-1.1" should not be installed on "sle_minion"
+
+  Scenario: Cleanup: delete SLES minion after after bootstrap script tests
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Delete System"
+    Then I should see a "Confirm System Profile Deletion" text
+    When I click on "Delete Profile"
+    And I wait until I see "has been deleted" text
+    Then "sle_minion" should not be registered
+
+  Scenario: Cleanup: bootstrap a SLES minion after bootstrap script tests
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I enter the hostname of "sle_minion" as "hostname"
+    And I enter "22" as "port"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I select "1-SUSE-KEY-x86_64" from "activationKeys"
+    And I select the hostname of "proxy" from "proxies" if present
+    And I click on "Bootstrap"
+    And I wait until I see "Successfully bootstrapped host!" text
+    And I wait until onboarding is completed for "sle_minion"

--- a/testsuite/features/secondary/min_bootstrap_script.feature
+++ b/testsuite/features/secondary/min_bootstrap_script.feature
@@ -84,7 +84,7 @@ Feature: Register a Salt minion via Bootstrap-script
    When I remove package "orion-dummy-1.1-1.1" from this "sle_minion"
    Then "orion-dummy-1.1-1.1" should not be installed on "sle_minion"
 
-  Scenario: Cleanup: delete SLES minion after after bootstrap script tests
+  Scenario: Cleanup: delete SLES minion after bootstrap script tests
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Delete System"
     Then I should see a "Confirm System Profile Deletion" text

--- a/testsuite/features/secondary/min_bootstrap_ssh_key.feature
+++ b/testsuite/features/secondary/min_bootstrap_ssh_key.feature
@@ -65,7 +65,7 @@ Feature: Bootstrap a Salt minion via the GUI using SSH key
   Scenario: Cleanup: restore authorized keys
     When I restore the SSH authorized_keys file of host "sle_minion"
 
-  Scenario: Cleanup: delete SLES minion after after SSH key tests
+  Scenario: Cleanup: delete SLES minion after SSH key tests
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Delete System"
     Then I should see a "Confirm System Profile Deletion" text

--- a/testsuite/features/secondary/min_bootstrap_ssh_key.feature
+++ b/testsuite/features/secondary/min_bootstrap_ssh_key.feature
@@ -64,3 +64,24 @@ Feature: Bootstrap a Salt minion via the GUI using SSH key
 
   Scenario: Cleanup: restore authorized keys
     When I restore the SSH authorized_keys file of host "sle_minion"
+
+  Scenario: Cleanup: delete SLES minion after after SSH key tests
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Delete System"
+    Then I should see a "Confirm System Profile Deletion" text
+    When I click on "Delete Profile"
+    And I wait until I see "has been deleted" text
+    Then "sle_minion" should not be registered
+
+  Scenario: Cleanup: bootstrap a SLES minion after SSH key tests
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I enter the hostname of "sle_minion" as "hostname"
+    And I enter "22" as "port"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I select "1-SUSE-KEY-x86_64" from "activationKeys"
+    And I select the hostname of "proxy" from "proxies" if present
+    And I click on "Bootstrap"
+    And I wait until I see "Successfully bootstrapped host!" text
+    And I wait until onboarding is completed for "sle_minion"


### PR DESCRIPTION
## What does this PR change?
In the different bootstrap scenarios we run, there is no cleanup process in case the bootstrap process fails, causing failures in the following features if it fails.
This PR adds some cleanup processes to several features based on  cleanup in https://github.com/uyuni-project/uyuni/blob/master/testsuite/features/secondary/min_bootstrap_reactivation.feature

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Fixes #
Tracks # 
4.2
4.3
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
