### PR TITLE
QE: Include 4.2 in the list of products that use salt-bundle

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -70,7 +70,7 @@ end
 
 def use_salt_bundle
   # Use venv-salt-minion in Uyuni, or SUMA Head and 4.3
-  $product == 'Uyuni' || %w[head 4.3].include?($product_version)
+  $product == 'Uyuni' || %w[head 4.3 4.2].include?($product_version)
 end
 
 # create salt pillar file in the default pillar_roots location

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -69,7 +69,7 @@ def product_version
 end
 
 def use_salt_bundle
-  # Use venv-salt-minion in Uyuni, or SUMA Head and 4.3
+  # Use venv-salt-minion in Uyuni, or SUMA Head, 4.2 and 4.3
   $product == 'Uyuni' || %w[head 4.3 4.2].include?($product_version)
 end
 


### PR DESCRIPTION
## What does this PR change?

4.2 now uses the salt-bundle in most of its operations. This causes issues on certain features that are salt dependent (e.g [bootstrapping with a script with or without salt-bundle](https://github.com/SUSE/spacewalk/blob/Manager-4.3/testsuite/features/step_definitions/file_management_steps.rb#L50))

This PR adds 4.2 to the list of products to enable salt-bundle use.
## GUI diff

No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Fixes #
Tracks # 
4.3
4.2
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
