### PR TITLE
Prevent HTTP API restricted args from being logged

### DIFF
--- a/java/code/src/com/suse/manager/api/LoggingInvocationProcessor.java
+++ b/java/code/src/com/suse/manager/api/LoggingInvocationProcessor.java
@@ -140,6 +140,9 @@ public abstract class LoggingInvocationProcessor {
      * @return - whether the value should be hidden from logging based on argName
      */
     protected static boolean preventValueLogging(String handler, String method, String argName) {
+        if (argName.toLowerCase().contains("password")) {
+            return true;
+        }
         String handlerAndMethod = handler + "." + method;
         return RESTRICTED_ARGS.containsKey(handlerAndMethod) &&
                 RESTRICTED_ARGS.get(handlerAndMethod).containsValue(argName);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Prevent HTTP API restricted args from being logged (bsc#1208119)
+
 -------------------------------------------------------------------
 Wed Mar 15 15:58:47 CET 2023 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

When logging HTTP API parameters, we typically use a black list to hide restricted parameters, but this is a common source of security issues. To solve this, this patch restricts any parameter whose name contains "password" in its name.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/20444

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
