### PR TITLE
change jar versions in ivy configuration file

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -41,8 +41,8 @@
         <dependency org="suse" name="hibernate-types-52" rev="2.16.2" />
         <dependency org="suse" name="httpasyncclient" rev="4.1.4" />
         <dependency org="suse" name="httpclient" rev="4.5.6" />
-        <dependency org="suse" name="httpcore" rev="4.4.10" />
-        <dependency org="suse" name="httpcore-nio" rev="4.4.10" />
+        <dependency org="suse" name="httpcore" rev="4.4.13" />
+        <dependency org="suse" name="httpcore-nio" rev="4.4.13" />
         <dependency org="suse" name="ical4j" rev="3.0.18" />
         <dependency org="suse" name="jackson-annotations" rev="2.13.0" />
         <dependency org="suse" name="jackson-core" rev="2.13.0" />
@@ -57,8 +57,8 @@
         <dependency org="suse" name="jdom" rev="1.1.3" />
         <dependency org="suse" name="joda-time" rev="2.10.1" />
         <dependency org="suse" name="jose4j" rev="0.5.1" />
-        <dependency org="suse" name="log4j-api" rev="2.17.1" />
-        <dependency org="suse" name="log4j-core" rev="2.17.1" />
+        <dependency org="suse" name="log4j-api" rev="2.17.2" />
+        <dependency org="suse" name="log4j-core" rev="2.17.2" />
         <dependency org="suse" name="jsch" rev="0.1.55" />
         <dependency org="suse" name="jctools-core" rev="2.1.2" />
         <dependency org="suse" name="mchange-commons-java" rev="0.2.20" />
@@ -85,8 +85,8 @@
         <dependency org="suse" name="simple-xml" rev="2.6.2" />
         <dependency org="suse" name="sitemesh" rev="2.1" />
         <dependency org="suse" name="slf4j-api" rev="1.7.30" />
-        <dependency org="suse" name="log4j-slf4j-impl" rev="2.17.1" />
-        <dependency org="suse" name="snakeyaml" rev="1.31" />
+        <dependency org="suse" name="log4j-slf4j-impl" rev="2.17.2" />
+        <dependency org="suse" name="snakeyaml" rev="1.33" />
         <dependency org="suse" name="spark-core" rev="2.9.3" />
         <dependency org="suse" name="spark-template-jade" rev="2.7.1" />
         <dependency org="suse" name="spy" rev="0.8.7" />
@@ -112,16 +112,16 @@
         <dependency org="suse" name="stax-ex" rev="1.8" />
 
         <!-- Tomcat jars -->
-        <dependency org="suse" name="jasper" rev="9.0.36" />
-        <dependency org="suse" name="jasper-el" rev="9.0.36" />
-        <dependency org="suse" name="tomcat-el-3.0-api" rev="9.0.36" />
-        <dependency org="suse" name="tomcat-jsp-2.3-api" rev="9.0.36" />
-        <dependency org="suse" name="tomcat-juli" rev="9.0.36" />
-        <dependency org="suse" name="tomcat-servlet-4.0-api" rev="9.0.36" />
+        <dependency org="suse" name="jasper" rev="9.0.43" />
+        <dependency org="suse" name="jasper-el" rev="9.0.43" />
+        <dependency org="suse" name="tomcat-el-3.0-api" rev="9.0.43" />
+        <dependency org="suse" name="tomcat-jsp-2.3-api" rev="9.0.43" />
+        <dependency org="suse" name="tomcat-juli" rev="9.0.43" />
+        <dependency org="suse" name="tomcat-servlet-4.0-api" rev="9.0.43" />
 
         <!-- Compilation and testing -->
         <dependency org="suse" name="velocity-engine-core" rev="2.3"/>
-        <dependency org="suse" name="jetty-util" rev="9.4.43" />
+        <dependency org="suse" name="jetty-util" rev="9.4.48" />
         <dependency org="checkstyle" name="checkstyle" rev="8.30" transitive="false">
           <artifact name="all" type="jar" url="https://github.com/checkstyle/checkstyle/releases/download/checkstyle-8.30/checkstyle-8.30-all.jar"/>
         </dependency>

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -123,10 +123,10 @@ artifacts:
   - artifact: httpcore
     package: httpcomponents-core
     jar: httpcore.jar
-    repository: Leap
+    repository: Leap_sle
   - artifact: httpcore-nio
     package: httpcomponents-core
-    repository: Leap
+    repository: Leap_sle
   - artifact: jade4j
     repository: Uyuni_Other
   - artifact: jakarta-persistence-api
@@ -156,15 +156,15 @@ artifacts:
   - artifact: log4j-core
     jar: log4j-core.jar
     package: log4j
-    repository: Leap
+    repository: Leap_sle
   - artifact: log4j-api
     jar: log4j-api.jar
     package: log4j
-    repository: Leap
+    repository: Leap_sle
   - artifact: log4j-slf4j-impl
     jar: log4j-slf4j-impl.jar
     package: log4j-slf4j
-    repository: Leap
+    repository: Leap_sle
   - artifact: jsch
     repository: Leap
   - artifact: mchange-commons-java
@@ -301,22 +301,22 @@ artifacts:
   - artifact: jasper
     package: tomcat-lib
     jar: jasper\.jar
-    repository: Leap
+    repository: Leap_sle
   - artifact: jasper-el
     package: tomcat-lib
-    repository: Leap
+    repository: Leap_sle
   - artifact: tomcat-el-3.0-api
     package: tomcat-el-3_0-api
-    repository: Leap
+    repository: Leap_sle
   - artifact: tomcat-jsp-2.3-api
     package: tomcat-jsp-2_3-api
-    repository: Leap
+    repository: Leap_sle
   - artifact: tomcat-juli
     package: tomcat-lib
-    repository: Leap
+    repository: Leap_sle
   - artifact: tomcat-servlet-4.0-api
     package: tomcat-servlet-4_0-api
-    repository: Leap
+    repository: Leap_sle
 
   - artifact: hamcrest-core
     repository: Leap
@@ -329,7 +329,7 @@ artifacts:
   - artifact: ical4j
     repository: Uyuni_Other
   - artifact: jetty-util
-    repository: Leap
+    repository: Leap_sle
   - artifact: glassfish-jaxb-api
     repository: Uyuni_Other
   - artifact: jaxb-runtime

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- change jar versions in ivy configuration file
 - Refactor Software / Manage / Packages to use SQL paging (bsc#1206725)
 - support multiple gpgkey urls for a channel (bsc#1208540)
 - Refactor Java notification synchronize to avoid dead locks (bsc#1209369)


### PR DESCRIPTION
## What does this PR change?

ivy update - The big java update was now also released to Leap.
Some packages changed the repo, so we need to update obs-to-maven config as well.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/20806

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
