### PR TITLE
Enable "netapi" clients in Salt master configuration (required for Salt 3006)

### DIFF
--- a/spacewalk/setup/salt/susemanager.conf
+++ b/spacewalk/setup/salt/susemanager.conf
@@ -18,6 +18,17 @@ external_auth:
       - '@runner'
       - '@jobs'
 
+# Enable netapi clients
+netapi_enable_clients:
+  - local
+  - local_async
+  - local_batch
+  - runner
+  - runner_async
+  - ssh
+  - wheel
+  - wheel_async
+
 # Configure different file roots. Custom salt states should only be placed in /srv/salt.
 # Users should not touch other directories listed here.
 file_roots:

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,5 @@
+- Enable netapi clients in master configuration (required for Salt 3006)
+
 -------------------------------------------------------------------
 Tue Feb 21 12:29:07 CET 2023 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

In preparations for upcoming Salt 3006.0 release, this PR expliciately enables Salt "netapi" required clients, as starting with Salt 3006, all clients are disabled by default.

NOTE: These new settings should not interfere in case "salt-master" is not yet 3006 version.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/19924

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
