### PR TITLE
Update report outdated system query to de-duplicate errata id's

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/SystemReport_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/SystemReport_queries.xml
@@ -181,7 +181,7 @@
     <query params="offset, limit">
           SELECT rhnserverneededcache.server_id AS system_id
                     , count(distinct rhnpackage.name_id) AS packages_out_of_date
-                    , count(rhnserverneededcache.errata_id) AS errata_out_of_date
+                    , count(distinct rhnserverneededcache.errata_id) AS errata_out_of_date
             FROM rhnpackage, rhnserverneededcache
            WHERE rhnserverneededcache.package_id = rhnpackage.id
         GROUP BY rhnserverneededcache.server_id

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Update report outdated system query to de-duplicate errata id's
 - change jar versions in ivy configuration file
 - Refactor Software / Manage / Packages to use SQL paging (bsc#1206725)
 - support multiple gpgkey urls for a channel (bsc#1208540)


### PR DESCRIPTION
## What does this PR change?

Report task that populates the table `SystemOutdated` was counting duplicated errata ID's. This lead to a number of outdated packages that were different from the one shown in the webUI.

## GUI diff

No difference. This is a change in the values in the report database.


- [ ] **DONE**

## Documentation
- No documentation needed: Internal change to the data saved in the database

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
