### PR TITLE
Fix deleting custom info pillar (bsc#1209253)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -1194,6 +1194,8 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
 
         int setResult = handler.setCustomValues(admin, server.getId().intValue(), valuesToSet);
 
+        server = reload(server);
+
         //make sure the val was updated
         val = server.getCustomDataValue(testKey);
         assertEquals(val2, val.getValue());
@@ -1247,6 +1249,9 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
                 valuesToDelete);
 
         assertEquals(1, setResult);
+
+        server = reload(server);
+
         val = server.getCustomDataValue(testKey);
         assertNull(val);
 
@@ -1256,6 +1261,14 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
                 PILLAR_DATA_FILE_EXT);
 
         assertFalse(Files.exists(filePath));
+
+        try {
+            pillar = readCustomInfoPillar(server);
+            fail("Custom info pillar was not deleted.");
+        }
+        catch (java.util.NoSuchElementException e) {
+            //success
+        }
     }
 
     @Test

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionCustomInfoPillarGenerator.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionCustomInfoPillarGenerator.java
@@ -18,6 +18,7 @@ package com.suse.manager.webui.services.pillar;
 import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_EXT;
 import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_PREFIX;
 
+import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.server.CustomDataValue;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.Pillar;
@@ -43,7 +44,10 @@ public class MinionCustomInfoPillarGenerator implements MinionPillarGenerator {
     @Override
     public Optional<Pillar> generatePillarData(MinionServer minion) {
         if (minion.getCustomDataValues().isEmpty()) {
-            minion.getPillarByCategory(CATEGORY).ifPresent(pillar -> minion.getPillars().remove(pillar));
+            minion.getPillarByCategory(CATEGORY).ifPresent(pillar -> {
+                minion.getPillars().remove(pillar);
+                HibernateFactory.getSession().remove(pillar);
+            });
             return Optional.empty();
         }
         Pillar pillar = minion.getPillarByCategory(CATEGORY).orElseGet(() -> {

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarFileManager.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarFileManager.java
@@ -16,6 +16,7 @@ package com.suse.manager.webui.services.pillar;
 
 import static com.suse.manager.webui.services.SaltConstants.SUMA_PILLAR_DATA_PATH;
 
+import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.server.MinionServer;
 
 import org.apache.logging.log4j.LogManager;
@@ -66,7 +67,10 @@ public class MinionPillarFileManager {
     public void removePillar(MinionServer minion) {
         removePillarFile(minion.getMinionId());
         minion.getPillarByCategory(this.minionPillarGenerator.getCategory())
-                .ifPresent(pillar -> minion.getPillars().remove(pillar));
+                .ifPresent(pillar -> {
+                    minion.getPillars().remove(pillar);
+                    HibernateFactory.getSession().remove(pillar);
+                });
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix deleting custom info pillar (bsc#1209253)
 - Update report outdated system query to de-duplicate errata id's
 - change jar versions in ivy configuration file
 - Refactor Software / Manage / Packages to use SQL paging (bsc#1206725)


### PR DESCRIPTION
## What does this PR change?

After removing all custom info entries, the pillar was not removed from the database.
This PR fixes it and also fixes the unit test to detect such bugs next time.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix
- [x] **DONE**

## Test coverage
- Unit tests were fixed

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20829
https://bugzilla.suse.com/show_bug.cgi?id=1209253

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
