### PR TITLE
Skip Grafana testing if Monitoring server is not present / installed

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -177,6 +177,7 @@ Feature: Smoke tests for <client>
     And I visit "Prometheus postgres exporter" endpoint of this "<client>"
     And I reboot the "<client>" if it is a SLE Micro
 
+@monitoring_server
   Scenario: Test <client> on Grafana
     When I visit the grafana dashboards of this "monitoring_server"
     And I wait until I do not see "Loading Grafana" text


### PR DESCRIPTION
## What does this PR change?

Skip Grafana testing if Monitoring server is not present / installed

## GUI diff
No difference.


- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links


- [x] **DONE**

## Changelogs


If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed



## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
