### PR TITLE
Fix update of sql function create_new_org

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Fix update of sql function create_new_org
 - Filter CLM modular packages using release strings (bsc#1207814)
 - merge multiple older schema upgrade directories together
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.5-to-susemanager-schema-4.4.6/002-update-function-create_new_org.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.5-to-susemanager-schema-4.4.6/002-update-function-create_new_org.sql
@@ -1,0 +1,231 @@
+
+create or replace function create_new_org
+(
+        name_in      in varchar,
+        password_in  in varchar
+        --org_id_out   out number
+) returns numeric
+as
+$$
+declare
+        ug_type                 numeric;
+        group_val               numeric;
+        new_org_id              numeric;
+        org_id_out		numeric;
+begin
+
+        select nextval('web_customer_id_seq') into new_org_id from dual;
+
+        insert into web_customer (
+                id, name
+        ) values (
+                new_org_id, name_in
+        );
+
+        select nextval('rhn_user_group_id_seq') into group_val from dual;
+
+        select  id
+        into    ug_type
+        from    rhnUserGroupType
+        where   label = 'org_admin';
+
+        insert into rhnUserGroup (
+                id, name,
+                description,
+                max_members, group_type, org_id
+        ) values (
+                group_val, 'Organization Administrators',
+                'Organization Administrators for Org ' || name_in,
+                NULL, ug_type, new_org_id
+        );
+
+        select nextval('rhn_user_group_id_seq') into group_val from dual;
+
+        select  id
+        into    ug_type
+        from    rhnUserGroupType
+        where   label = 'system_group_admin';
+
+        insert into rhnUserGroup (
+                id, name,
+                description,
+                max_members, group_type, org_id
+        ) values (
+                group_val, 'System Group Administrators',
+                'System Group Administrators for Org ' || name_in,
+                NULL, ug_type, new_org_id
+        );
+
+
+        select nextval('rhn_user_group_id_seq') into group_val from dual;
+
+        select  id
+        into    ug_type
+        from    rhnUserGroupType
+        where   label = 'activation_key_admin';
+
+        insert into rhnUserGroup (
+                id, name,
+                description,
+                max_members, group_type, org_id
+        ) values (
+                group_val, 'Activation Key Administrators',
+                'Activation Key Administrators for Org ' || name_in,
+                NULL, ug_type, new_org_id
+        );
+
+        select nextval('rhn_user_group_id_seq') into group_val from dual;
+
+        select  id
+        into    ug_type
+        from    rhnUserGroupType
+        where   label = 'channel_admin';
+
+        insert into rhnUserGroup (
+                id, name,
+                description,
+                max_members, group_type, org_id
+        ) values (
+                group_val, 'Channel Administrators',
+                'Channel Administrators for Org ' || name_in,
+                NULL, ug_type, new_org_id
+        );
+
+	if new_org_id = 1 then
+            select nextval('rhn_user_group_id_seq') into group_val from dual;
+
+            select  id
+            into    ug_type
+            from    rhnUserGroupType
+            where   label = 'satellite_admin';
+
+            insert into rhnUserGroup (
+                    id, name,
+                    description,
+                    max_members, group_type, org_id
+            ) values (
+                    group_val, 'SUSE Manager Administrators',
+                    'SUSE Manager Administrators for Org ' || name_in,
+                    NULL, ug_type, new_org_id
+            );
+        end if;
+
+        select nextval('rhn_user_group_id_seq') into group_val from dual;
+
+        select  id
+        into    ug_type
+        from    rhnUserGroupType
+        where   label = 'config_admin';
+
+        insert into rhnUserGroup (
+                id, name,
+                description,
+                max_members, group_type, org_id
+        ) values (
+                group_val, 'Configuration Administrators',
+                'Configuration Administrators for Org ' || name_in,
+                NULL, ug_type, new_org_id
+        );
+
+        select nextval('rhn_user_group_id_seq') into group_val from dual;
+
+        select  id
+        into    ug_type
+        from    rhnUserGroupType
+        where   label = 'image_admin';
+
+        insert into rhnUserGroup (
+                id, name,
+                description,
+                max_members, group_type, org_id
+        ) values (
+                group_val, 'Image Administrators',
+                'Image Administrators for Org ' || name_in,
+                NULL, ug_type, new_org_id
+        );
+
+        select nextval('rhn_user_group_id_seq') into group_val from dual;
+
+        -- there aren't any users yet, so we don't need to update
+        -- rhnUserServerPerms
+
+        insert into rhnServerGroup
+                ( id, name, description, group_type, org_id )
+                select nextval('rhn_server_group_id_seq'), sgt.name, sgt.name,
+                        sgt.id, new_org_id
+                from rhnServerGroupType sgt
+                where sgt.label = 'bootstrap_entitled';
+
+        insert into rhnServerGroup
+                ( id, name, description, group_type, org_id )
+                select nextval('rhn_server_group_id_seq'), sgt.name, sgt.name,
+                        sgt.id, new_org_id
+                from rhnServerGroupType sgt
+                where sgt.label = 'enterprise_entitled';
+
+        insert into rhnServerGroup
+                ( id, name, description, group_type, org_id )
+                select nextval('rhn_server_group_id_seq'), sgt.name, sgt.name,
+                        sgt.id, new_org_id
+                from rhnServerGroupType sgt
+                where sgt.label = 'salt_entitled';
+
+        insert into rhnServerGroup
+                ( id, name, description, group_type, org_id )
+                select nextval('rhn_server_group_id_seq'), sgt.name, sgt.name,
+                        sgt.id, new_org_id
+                from rhnServerGroupType sgt
+                where sgt.label = 'foreign_entitled';
+
+        insert into rhnServerGroup
+                ( id, name, description, group_type, org_id )
+                select nextval('rhn_server_group_id_seq'), sgt.name, sgt.name,
+                        sgt.id, new_org_id
+                from rhnServerGroupType sgt
+                where sgt.label = 'virtualization_host';
+
+        insert into rhnServerGroup
+                ( id, name, description, group_type, org_id )
+                select nextval('rhn_server_group_id_seq'), sgt.name, sgt.name,
+                        sgt.id, new_org_id
+                from rhnServerGroupType sgt
+                where sgt.label = 'container_build_host';
+
+        insert into rhnServerGroup
+                ( id, name, description, group_type, org_id )
+                select nextval('rhn_server_group_id_seq'), sgt.name, sgt.name,
+                        sgt.id, new_org_id
+                from rhnServerGroupType sgt
+                where sgt.label = 'osimage_build_host';
+
+        insert into rhnServerGroup
+                ( id, name, description, group_type, org_id )
+                select nextval('rhn_server_group_id_seq'), sgt.name, sgt.name,
+                        sgt.id, new_org_id
+                from rhnServerGroupType sgt
+                where sgt.label = 'monitoring_entitled';
+
+        insert into rhnServerGroup
+                ( id, name, description, group_type, org_id )
+                select nextval('rhn_server_group_id_seq'), sgt.name, sgt.name,
+                        sgt.id, new_org_id
+                from rhnServerGroupType sgt
+                where sgt.label = 'ansible_control_node';
+
+        insert into suseImageStore (id, label, uri, store_type_id, org_id)
+        values (
+            nextval('suse_imgstore_id_seq'),
+            'SUSE Manager OS Image Store',
+            new_org_id || '/',
+            (SELECT id FROM suseImageStoreType WHERE label = 'os_image'),
+            new_org_id
+        );
+
+        org_id_out := new_org_id;
+
+	-- Returning the value of OUT parameter
+        return org_id_out;
+
+end;
+$$
+language plpgsql;


### PR DESCRIPTION
## What does this PR change?

SQL function create_new_org was updated but no update script was created. 
New installations would not have a problem but long-running servers are not able to create new organizations.

This PR adds the update script to change the create_new_org sql function.

## GUI diff

No difference. Sql change only.

- [x] **DONE**

## Documentation
- No documentation needed: SQL change only

- [x] **DONE**

## Test coverage
- No tests: sql change only

- [x] **DONE**

## Links

Fixes # https://github.com/uyuni-project/uyuni/issues/6770
Tracks:
- Manager 4.3: https://github.com/SUSE/spacewalk/pull/20896
- Manager 4.2:  https://github.com/SUSE/spacewalk/pull/20898

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
