### PR TITLE
Bump datepicker z-index

### DIFF
--- a/web/html/src/branding/css/susemanager/components/date-time-picker.less
+++ b/web/html/src/branding/css/susemanager/components/date-time-picker.less
@@ -1,6 +1,6 @@
 /* This element already has `position: absolute` */
 .react-datepicker-popper {
-  z-index: 1010 !important;
+  z-index: 1050 !important;
 }
 
 .react-datepicker {

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix datetime picker appearing behind modal edge
 - Refactor Software / Manage / Packages to use SQL paging (bsc#1206725)
 - Fix UI inconsistencies in susemanager-light and susemanager-dark
   theme


### PR DESCRIPTION
## What does this PR change?

Fix the datetime picker dropdowns appearing behind modals.

## GUI diff

Before:

<img width="935" alt="Screenshot 2023-03-27 at 15 44 54" src="https://user-images.githubusercontent.com/3171718/227957443-01991af8-d08b-4731-b4cb-43b5ac3866d7.png">

After:

<img width="937" alt="Screenshot 2023-03-27 at 15 44 34" src="https://user-images.githubusercontent.com/3171718/227957490-6ad9d209-3e49-4fe0-98a0-00f3d96b96b9.png">

- [x] **DONE**

## Documentation
- No documentation needed: bugfix.

- [x] **DONE**

## Test coverage
- No tests: UI bugfix.

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
