### PR TITLE
QE: Update used channel for distro creation through API

### DIFF
--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -596,13 +596,13 @@ When(/^I create and modify the kickstart system "([^"]*)" with hostname "([^"]*)
 end
 
 When(/^I create a kickstart tree via the API$/) do
-  $api_test.kickstart.tree.create_distro('fedora_kickstart_distro_api', '/var/autoinstall/Fedora_12_i386/', 'rhel8-pool-x86_64', 'fedora18')
+  $api_test.kickstart.tree.create_distro('fedora_kickstart_distro_api', '/var/autoinstall/Fedora_12_i386/', 'fake-rh-like-channel', 'fedora18')
 end
 
 When(/^I create a kickstart tree with kernel options via the API$/) do
-  $api_test.kickstart.tree.create_distro_w_kernel_options('fedora_kickstart_distro_kernel_api', '/var/autoinstall/Fedora_12_i386/', 'rhel8-pool-x86_64', 'fedora18', 'self_update=0', 'self_update=1')
+  $api_test.kickstart.tree.create_distro_w_kernel_options('fedora_kickstart_distro_kernel_api', '/var/autoinstall/Fedora_12_i386/', 'fake-rh-like-channel', 'fedora18', 'self_update=0', 'self_update=1')
 end
 
 When(/^I update a kickstart tree via the API$/) do
-  $api_test.kickstart.tree.update_distro('fedora_kickstart_distro_api', '/var/autoinstall/Fedora_12_i386/', 'rhel8-pool-x86_64', 'generic_rpm', 'self_update=0', 'self_update=1')
+  $api_test.kickstart.tree.update_distro('fedora_kickstart_distro_api', '/var/autoinstall/Fedora_12_i386/', 'fake-rh-like-channel', 'generic_rpm', 'self_update=0', 'self_update=1')
 end


### PR DESCRIPTION
## What does this PR change?
Changes used channel for the distro creation, as RHEL 8 is no longer synched by default.

## Links

4.3 https://github.com/SUSE/spacewalk/pull/20908
Fixes https://github.com/SUSE/spacewalk/issues/20899

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
