### PR TITLE
CI: Acceptance tests at PR: add welcome message

### DIFF
--- a/.github/workflows/test_all_in_one.yml
+++ b/.github/workflows/test_all_in_one.yml
@@ -11,6 +11,8 @@ jobs:
     # run this action in your Pull Requests
     if: github.actor == 'jordimassaguerpla'
     steps:
+      - name: welcome_message
+        run: echo "Running acceptance tests. More info at https://github.com/uyuni-project/uyuni/wiki/Running-Acceptance-Tests-at-PR"
       - uses: actions/checkout@v3
       - name: Cache-jar-files
         uses: actions/cache@v3


### PR DESCRIPTION
## What does this PR change?

Adds a welcome message when running the acceptance tests with a link to the wiki.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- See https://github.com/uyuni-project/uyuni/wiki/Running-Acceptance-Tests-at-PR

- [ ] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/20680

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
