### PR TITLE
Stop core run set if any feature fail

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -28,14 +28,12 @@ namespace :cucumber do
       include_tags =  tags.nil? ? [] : ['--tags', tags]
       cucumber_opts = %W[#{include_profiles} #{html_results} #{json_results} #{junit_results}] +
         %w[-f pretty -r features] + include_tags
+      # Immediately fail core if any feature is failing
+      if filename.to_s.include?('core')
+        cucumber_opts << '--fail-fast'
+      end
       features = YAML.safe_load(File.read(entry))
       t.cucumber_opts = cucumber_opts + features unless features.nil?
-      # When running core, will stop if any feature is failing
-      if filename.to_s.include?('core')
-        t.fail_fast = true # Enable fail_fast to stop execution on first failure.
-      else
-        t.fail_fast = false
-      end
     end
   end
 end

--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -30,6 +30,12 @@ namespace :cucumber do
         %w[-f pretty -r features] + include_tags
       features = YAML.safe_load(File.read(entry))
       t.cucumber_opts = cucumber_opts + features unless features.nil?
+      # When running core, will stop if any feature is failing
+      if filename.to_s.include?('core')
+        t.fail_fast = true # Enable fail_fast to stop execution on first failure.
+      else
+        t.fail_fast = false
+      end
     end
   end
 end


### PR DESCRIPTION
## What does this PR change?
Add fail-fast option to cucumber to immediately fail core run set if any feature is failing.


## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- No tests: already covered

- [x] **DONE**

## Links

Issue : https://github.com/SUSE/spacewalk/issues/20855

- [x] **DONE**

## Changelogs

- [x] No changelog needed


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
