### PR TITLE
Make python3-ordered-set optional for the bootstrap repo

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -228,7 +228,7 @@ PKGLIST15_SALT_NO_BUNDLE = [
     "python3-MarkupSafe",
     "python3-M2Crypto",
     "python3-msgpack",
-    "python3-ordered-set",
+    "python3-ordered-set*",
     "python3-packaging",
     "python3-psutil",
     "python3-py",

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- Make python3-ordered-set optional for the SLE15 bootstrap repo as it is
+  not required or present in SLE15SP3 or older
 - Add bootstrap repository definitions for openSUSE Leap 15.5
 - Add bootstrap repository definitions for openEuler 22.03
 - Tune the dabase after copying the old configuration (bsc#1208611)


### PR DESCRIPTION
## What does this PR change?

python3-ordered-set is only required in SP4 and higher by python3-setuptools.
In SP3 and earlier, this dependency does not exists.
Mark this package as optional.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/6663

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
