### PR TITLE
Fix tftpsync `pxe_cache.json` race

### DIFF
--- a/tftpsync/susemanager-tftpsync/susemanager-tftpsync.changes
+++ b/tftpsync/susemanager-tftpsync/susemanager-tftpsync.changes
@@ -1,3 +1,6 @@
+- Fix server-side cache that's used for only pushing files to
+  proxies that need to be pushed, as well as propagating deletions
+  (bsc#1209215)
 - Fix removal of proxies section in cobbler settings (bsc#1207063)
 
 -------------------------------------------------------------------

--- a/tftpsync/susemanager-tftpsync/sync_post_tftpd_proxies.py
+++ b/tftpsync/susemanager-tftpsync/sync_post_tftpd_proxies.py
@@ -24,7 +24,7 @@ from cobbler import utils
 import time
 import cobbler.MultipartPostHandler as MultipartPostHandler
 import json
-from concurrent.futures import ThreadPoolExecutor
+from concurrent import futures
 import threading
 
 try:
@@ -61,17 +61,25 @@ def run(api, args):
     tftpbootdir = "/srv/tftpboot"
     find_delete_from_proxies(tftpbootdir, settings)
 
-    pool = ThreadPoolExecutor()
+    push_futures = []
+    with futures.ThreadPoolExecutor() as executor:
+        for dirname, _dirnames, filenames in os.walk(tftpbootdir):
+            for fname in filenames:
+                path = os.path.join(dirname, fname)
+                if '.link_cache' in path:
+                    continue
+                push_futures.append(executor.submit(check_push, path, tftpbootdir, settings))
 
-    for root, dirs, files in os.walk(tftpbootdir):
-        for fname in files:
-            path = os.path.join(root, fname)
-            if '.link_cache' in path:
-                continue
-            pool.submit(check_push, path, tftpbootdir, settings)
+        _update_pxe_cache([f.result() for f in futures.as_completed(push_futures)])
 
-    pool.shutdown()
     return 0
+
+def _update_pxe_cache(thread_results):
+    cache = {}
+    for res in thread_results:
+        cache.update(res)
+    with open("/var/lib/cobbler/pxe_cache.json", "w") as pxe_cache:
+        json.dump(cache, pxe_cache)
 
 
 def sync_to_proxies(filename, tftpbootdir, format, settings):
@@ -215,11 +223,10 @@ def check_push(fn, tftpbootdir, settings, lcache='/var/lib/cobbler'):
             format = 'grub'
         if sync_to_proxies(fn, tftpbootdir, format, settings):
             db[fn] = (mtime, key)
-            json.dump(db, open(dbfile, 'w'))
             logger.info("Push successful")
         else:
             logger.info("Push failed")
-
+    return db
 
 class ProxySync(threading.Thread):
     Result = True

--- a/tftpsync/susemanager-tftpsync/sync_post_tftpd_proxies.py
+++ b/tftpsync/susemanager-tftpsync/sync_post_tftpd_proxies.py
@@ -46,19 +46,19 @@ def register():
 
 
 def run(api, args):
+    del args # unused, required API
     logger.info("sync_post_tftp_proxies started - this can take a while (to see the progress check the cobbler logs)")
     settings = api.settings()
 
+
     # test if proxies are configured:
     try:
-        p = settings.proxies
-    except:
+        _ = settings.proxies
+    except AttributeError:
         # not configured - so we return
         return 0
 
     tftpbootdir = "/srv/tftpboot"
-    syncstart = os.stat(tftpbootdir).st_mtime
-
     find_delete_from_proxies(tftpbootdir, settings)
 
     pool = ThreadPoolExecutor()


### PR DESCRIPTION
## What does this PR change?

Fix a race condition where multiple threads were writing to the same file, overriding each others changes. This recording shows the problem without the fix

[![asciicast](https://asciinema.org/a/571221.svg?t=30&speed=1.5)](https://asciinema.org/a/571221?t=30&speed=1.5)

At the end, there are < 20 files referenced in `pxe_cache.json`. After the fix, the same file contains more than 200 entries, i.e. less files are pushed to proxies (fewer cache misses) and file deletions are propagated correctly.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: backend bugfix

- [x] **DONE**

## Test coverage
- No tests: We'll add a cucumber test in a follow up PR

- [ ] **DONE**

## Links

Bug tracker: https://github.com/SUSE/spacewalk/issues/20771

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
