### PR TITLE
QE: Fix cobbler log step not finding file

### DIFF
--- a/testsuite/features/step_definitions/cobbler_steps.rb
+++ b/testsuite/features/step_definitions/cobbler_steps.rb
@@ -289,7 +289,7 @@ Then(/^the local logs for Cobbler should not contain errors$/) do
 
   file_data = File.read(local_file).gsub!("\n", ',').chop
   file_data = "[#{file_data}]"
-  data_hash = JSON.parse(file)
+  data_hash = JSON.parse(file_data)
   output = data_hash.select { |_key, hash| hash['levelname'] == 'ERROR' }
   $server.run("cp #{cobbler_log_file} #{cobbler_log_file}$(date +\"%Y_%m_%d_%I_%M_%p\")") unless output.empty?
   raise "Errors in Cobbler logs:\n #{output}" unless output.empty?


### PR DESCRIPTION
## What does this PR change?
Fix the step looking into cobbler log file by using the right variable name.

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20940
- 4.3 https://github.com/SUSE/spacewalk/pull/20941

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
