### PR TITLE
Add product in proxy repos for maintenance json script

### DIFF
--- a/testsuite/ext-tools/maintenance_json_generator.py
+++ b/testsuite/ext-tools/maintenance_json_generator.py
@@ -25,10 +25,12 @@ defaultdict = {
                         "/SUSE_Updates_SLE-Product-SLES_15-SP2-LTSS_x86_64/"],
     "sle15sp3_client": ["/SUSE_Updates_SLE-Manager-Tools_15_x86_64/",
                         "/SUSE_Updates_SLE-Module-Basesystem_15-SP3_x86_64/",
-                        "/SUSE_Updates_SLE-Module-Server-Applications_15-SP3_x86_64/"],
+                        "/SUSE_Updates_SLE-Module-Server-Applications_15-SP3_x86_64/",
+                        "/SUSE_Updates_SLE-Product-SLES_15-SP3-LTSS_x86_64/"],
     "sle15sp3_minion": ["/SUSE_Updates_SLE-Manager-Tools_15_x86_64/",
                         "/SUSE_Updates_SLE-Module-Basesystem_15-SP3_x86_64/",
-                        "/SUSE_Updates_SLE-Module-Server-Applications_15-SP3_x86_64/"],
+                        "/SUSE_Updates_SLE-Module-Server-Applications_15-SP3_x86_64/",
+                        "/SUSE_Updates_SLE-Product-SLES_15-SP3-LTSS_x86_64/"],
     "sle15sp4_client": ["/SUSE_Updates_SLE-Manager-Tools_15_x86_64/",
                         "/SUSE_Updates_SLE-Module-Basesystem_15-SP4_x86_64/",
                         "/SUSE_Updates_SLE-Module-Server-Applications_15-SP4_x86_64/"],
@@ -58,10 +60,11 @@ defaultdict = {
 # Dictionary for SUMA 4.2 Server and Proxy, which is then added together with the common dictionary for client tools
 nodesdict42 = {
     "server": ["/SUSE_Updates_SLE-Module-SUSE-Manager-Server_4.2_x86_64/",
-               "SUSE_Updates_SLE-Product-SUSE-Manager-Server_4.2_x86_64/",
+               "/SUSE_Updates_SLE-Product-SUSE-Manager-Server_4.2_x86_64/",
                "/SUSE_Updates_SLE-Module-Basesystem_15-SP3_x86_64/",
                "/SUSE_Updates_SLE-Module-Server-Applications_15-SP3_x86_64/"],
     "proxy": ["/SUSE_Updates_SLE-Module-SUSE-Manager-Proxy_4.2_x86_64/",
+              "/SUSE_Updates_SLE-Product-SUSE-Manager-Proxy_4.2_x86_64",
               "/SUSE_Updates_SLE-Module-Basesystem_15-SP3_x86_64/",
               "/SUSE_Updates_SLE-Module-Server-Applications_15-SP3_x86_64/"]
 }
@@ -70,11 +73,11 @@ nodesdict42.update(defaultdict)
 # Dictionary for SUMA 4.3 Server and Proxy, which is then added together with the common dictionary for client tools
 nodesdict43 = {
     "server": ["/SUSE_Updates_SLE-Module-SUSE-Manager-Server_4.3_x86_64/",
-               "SUSE_Updates_SLE-Product-SUSE-Manager-Server_4.3_x86_64/",
+               "/SUSE_Updates_SLE-Product-SUSE-Manager-Server_4.3_x86_64/",
                "/SUSE_Updates_SLE-Module-Basesystem_15-SP4_x86_64/",
                "/SUSE_Updates_SLE-Module-Server-Applications_15-SP4_x86_64/"],
     "proxy": ["/SUSE_Updates_SLE-Module-SUSE-Manager-Proxy_4.3_x86_64/",
-              "SUSE_Updates_SLE-Product-SUSE-Manager-Proxy_4.3_x86_64",
+              "/SUSE_Updates_SLE-Product-SUSE-Manager-Proxy_4.3_x86_64",
               "/SUSE_Updates_SLE-Module-Basesystem_15-SP4_x86_64/",
               "/SUSE_Updates_SLE-Module-Server-Applications_15-SP4_x86_64/"]
 }
@@ -171,7 +174,7 @@ def find_valid_repos(mi_ids, version):
         with open('custom_repositories.json', 'w', encoding='utf-8') as f:
             json.dump(finaldict, f, indent=2)
     else:
-        print("Dictionary is emtpy, something went wrong")
+        print("Dictionary is empty, something went wrong")
         sys.exit(1)
 
 


### PR DESCRIPTION
## What does this PR change?
Add product in proxy repos for maintenance json script because we need it for new packages that maintenance is pushing for 4.2 which is in maintenance but is not LTSS

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes no issue
Tracks no other PR is needed this script is only in uyuni master

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
