### PR TITLE
Load only rhn.jar in Jacoco

### DIFF
--- a/testsuite/features/support/code_coverage.rb
+++ b/testsuite/features/support/code_coverage.rb
@@ -67,7 +67,7 @@ class CodeCoverage
     html_report = html ? "--html /srv/www/htdocs/pub/jacoco-#{feature_name}" : ''
     xml_report = xml ? "--xml /srv/www/htdocs/pub/jacoco-#{feature_name}.xml" : ''
     sourcefiles = source ? '--sourcefiles /tmp/uyuni-master/java/code/src' : ''
-    classfiles = '--classfiles /srv/tomcat/webapps/rhn/WEB-INF/lib'
+    classfiles = '--classfiles /srv/tomcat/webapps/rhn/WEB-INF/lib/rhn.jar'
     dump_path = "/tmp/jacoco-#{feature_name}.exec"
     $server.run("#{cli} dump --address localhost --destfile #{dump_path} --port 6300 --reset")
     $server.run("#{cli} report #{dump_path} #{html_report} #{xml_report} #{sourcefiles} #{classfiles}")


### PR DESCRIPTION
## What does this PR change?

Instead of loading all the Java classpath, we will only consider loading rhn.jar.
That's to avoid a recent issue with log4j that we want to get rid of asap.

```
12:41:16  FAIL: java -jar /tmp/jacococli.jar report /tmp/jacoco-allcli_sanity.exec  --xml /srv/www/htdocs/pub/jacoco-allcli_sanity.xml  --classfiles /srv/tomcat/webapps/rhn/WEB-INF/lib returned status code = 1.
12:41:16  Output:
12:41:16  [INFO] Loading execution data file /tmp/jacoco-allcli_sanity.exec.
12:41:16  Exception in thread "main" java.io.IOException: Error while analyzing /srv/tomcat/webapps/rhn/WEB-INF/lib/log4j_log4j-api.jar@org/apache/logging/log4j/util/Base64Util.class.
12:41:16  at org.jacoco.cli.internal.core.analysis.Analyzer.analyzerError(Analyzer.java:162)
12:41:16  at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeClass(Analyzer.java:134)
12:41:16  at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeClass(Analyzer.java:157)
12:41:16  at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeAll(Analyzer.java:193)
12:41:16  at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeZip(Analyzer.java:265)
12:41:16  at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeAll(Analyzer.java:196)
12:41:16  at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeAll(Analyzer.java:226)
12:41:16  at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeAll(Analyzer.java:221)
12:41:16  at org.jacoco.cli.internal.commands.Report.analyze(Report.java:110)
12:41:16  at org.jacoco.cli.internal.commands.Report.execute(Report.java:84)
12:41:16  at org.jacoco.cli.internal.Main.execute(Main.java:90)
12:41:16  at org.jacoco.cli.internal.Main.main(Main.java:105)
12:41:16  Caused by: java.lang.IllegalStateException: Can't add different class with same name: org/apache/logging/log4j/util/Base64Util
12:41:16  at org.jacoco.cli.internal.core.analysis.CoverageBuilder.visitCoverage(CoverageBuilder.java:106)
12:41:16  at org.jacoco.cli.internal.core.analysis.Analyzer$1.visitEnd(Analyzer.java:99)
12:41:16  at org.jacoco.cli.internal.asm.ClassVisitor.visitEnd(ClassVisitor.java:377)
12:41:16  at org.jacoco.cli.internal.core.internal.flow.ClassProbesAdapter.visitEnd(ClassProbesAdapter.java:100)
12:41:16  at org.jacoco.cli.internal.asm.ClassReader.accept(ClassReader.java:725)
12:41:16  at org.jacoco.cli.internal.asm.ClassReader.accept(ClassReader.java:401)
12:41:16  at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeClass(Analyzer.java:116)
12:41:16  at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeClass(Analyzer.java:132)
12:41:16  ... 10 more
12:41:16  (RuntimeError)
``` 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

No ports

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
