### PR TITLE
Add RHEL channels to spacewalk-common-channels

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1768,6 +1768,94 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
 
+[rhel7-pool-uyuni]
+archs    = x86_64, aarch64
+name     = RedHat Enterprise Linux 7 (%(arch)s)
+checksum = sha256
+repo_type = yum
+gpgkey_url =
+gpgkey_id =
+gpgkey_fingerprint =
+repo_url = http://localhost/pub/repositories/empty/?uniquekey=7
+
+[rhel7-uyuni-client]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = %(_x86_archs)s, aarch64
+base_channels = rhel7-pool-uyuni-%(arch)s
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/
+
+[rhel7-uyuni-client-devel]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = %(_x86_archs)s, aarch64
+base_channels = rhel7-pool-uyuni-%(arch)s
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS7-Uyuni-Client-Tools/CentOS_7/
+
+[rhel8-pool-uyuni]
+archs    = x86_64, aarch64
+name     = RedHat Enterprise Linux 8 (%(arch)s)
+checksum = sha256
+repo_type = yum
+gpgkey_url =
+gpgkey_id =
+gpgkey_fingerprint =
+repo_url = http://localhost/pub/repositories/empty/?uniquekey=8
+
+[rhel8-uyuni-client]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = %(_x86_archs)s, aarch64
+checksum = sha256
+base_channels = rhel8-pool-uyuni-%(arch)s
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/
+
+[rhel8-uyuni-client-devel]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = %(_x86_archs)s, aarch64
+checksum = sha256
+base_channels = rhel8-pool-uyuni-%(arch)s
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL8-Uyuni-Client-Tools/EL_8/
+
+[rhel9-pool-uyuni]
+archs    = x86_64, aarch64, ppc64le, s390x
+name     = RedHat Enterprise Linux 9 (%(arch)s)
+checksum = sha256
+repo_type = yum
+gpgkey_url =
+gpgkey_id =
+gpgkey_fingerprint =
+repo_url = http://localhost/pub/repositories/empty/?uniquekey=9
+
+[rhel9-uyuni-client]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = %(_x86_archs)s, aarch64, ppc64le, s390x
+checksum = sha256
+base_channels = rhel9-pool-uyuni-%(arch)s
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL9-Uyuni-Client-Tools/EL_9/
+
+[rhel9-uyuni-client-devel]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = %(_x86_archs)s, aarch64, ppc64le, s390x
+checksum = sha256
+base_channels = rhel9-pool-uyuni-%(arch)s
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL9-Uyuni-Client-Tools/EL_9/
+
 [oraclelinux9]
 archs    = x86_64, aarch64
 name     = Oracle Linux 9 (%(arch)s)

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+* Add RHEL 7, 8, 9 pool and tools channels
 - Add openSUSE Leap Micro 5.4 repositories
 - Add SLE Micro 5.4 Uyuni Client Tools repositories
 - spacewalk-hostname-rename remains stuck at refreshing pillars (bsc#1207550)


### PR DESCRIPTION
## What does this PR change?

This PR adds the RHEL 7, 8 and 9 pool and tools channels to the spacewalk-common-channels.
We talked on Matrix/Gitter 2 months ago about that.
And this is the part which has to be changed for the application itself, the rest of changes will happen in the documentation.

## Documentation
- ~~No documentation needed: **add explanation. This can't be used if there is a GUI diff**~~
- ~~No documentation needed: only internal and user invisible changes~~
- ~~Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for ~~community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).~~
- ~~API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.~~
- [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pull/2157)

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
