### PR TITLE
Rename wait reposync result file with NODE name 

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -17,8 +17,10 @@ namespace :cucumber do
     Cucumber::Rake::Task.new(File.basename(entry, '.yml').to_sym) do |t|
       filename = File.basename(entry, '.yml').to_sym
       timestamp = Time.now.strftime('%Y%m%d%H%M%S')
-      json_results = "-f json -o results/output_#{timestamp}-#{filename}.json"
-      html_results = "-f html -o results/output_#{timestamp}-#{filename}.html"
+      node_name = ENV['NODE']
+      node_result_extension = node_name.nil? ? '' : "_#{node_name}"
+      json_results = "-f json -o results/output#{node_result_extension}_#{timestamp}-#{filename}.json"
+      html_results = "-f html -o results/output#{node_result_extension}_#{timestamp}-#{filename}.html"
       profiles = ENV['PROFILE']
       # Our profiles include a --tags keyword in all of them, if we have multiple profiles in the list
       # it will act as an intersection of tags, not as an union of them.


### PR DESCRIPTION
## What does this PR change?

output_****-build_validation_wait_for_custom_reposync.json are sometime malformated because two or more nodes will export there results in the same file. 
wait for custom reposync feature don't have a unique name and will be call each time we add non_mu or MU channels.
Because we are now running this steps in parallel, the timestamp can be the same.
To make this result file unique, I'm adding the node name. To do so, I need to export the node name on pipeline side and get this node name on testsuite side

## GUI diff



- [x] **DONE**

## Documentation

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links
CI : https://github.com/SUSE/susemanager-ci/pull/814
SM42 : https://github.com/SUSE/spacewalk/pull/20979
SM43 : https://github.com/SUSE/spacewalk/pull/20978

- [x] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
