### PR TITLE
Project lotus updates

### DIFF
--- a/java/code/src/com/redhat/rhn/common/security/acl/Access.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/Access.java
@@ -22,6 +22,7 @@ import com.redhat.rhn.common.db.datasource.SelectMode;
 import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
+import com.redhat.rhn.domain.channel.ClonedChannel;
 import com.redhat.rhn.domain.channel.ContentSource;
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.errata.ErrataFactory;
@@ -581,6 +582,7 @@ public class Access extends BaseHandler {
         // Evaluate if any of the subscript channel refers to a PTF repository
         return server.getChannels()
                      .stream()
+                     .map(channel -> channel instanceof ClonedChannel ? channel.getOriginal() : channel)
                      .flatMap(c -> c.getSources().stream())
                      .map(ContentSource::getSourceUrl)
                      .anyMatch(url -> url.contains("/PTF/"));

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -585,6 +585,9 @@ public class ServerFactory extends HibernateFactory {
             if (server.isSLES15()) {
                 return rpmVersionComparator.compare(zypperEvr.getVersion(), "1.14.59") >= 0;
             }
+            else if (server.isSLES12()) {
+                return rpmVersionComparator.compare(zypperEvr.getVersion(), "1.13.63") >= 0;
+            }
         }
 
         return false;

--- a/java/code/src/com/suse/manager/webui/controllers/MinionsAPI.java
+++ b/java/code/src/com/suse/manager/webui/controllers/MinionsAPI.java
@@ -449,8 +449,7 @@ public class MinionsAPI {
 
         // When getting ids for the select all we just get all systems ID matching the filter, no paging
         if ("id".equals(pageHelper.getFunction())) {
-            pc.setStart(1);
-            pc.setPageSize(0); // Setting to zero means getting them all
+            return null; // null page control getting them all
         }
 
         return pc;

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- added SLES 12 support for ptf removal
 - fixed issue with checking ptf repositories on cloned channels
 - remove spacewalk-koan and mgr-virtualization usage
 - disable gpgckeck when building docker containers as we

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fixed select all for ptf packages list
 - added SLES 12 support for ptf removal
 - fixed issue with checking ptf repositories on cloned channels
 - remove spacewalk-koan and mgr-virtualization usage

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fixed issue with checking ptf repositories on cloned channels
 - remove spacewalk-koan and mgr-virtualization usage
 - disable gpgckeck when building docker containers as we
   work with trusted content and the repos are served via SSL


### PR DESCRIPTION
## What does this PR change?

This PR addresses the following issues related to project lotus:

- fixes the selection issue when clicking on the "select all" link in the ptf list pages.
- adds support for PTF removal on SLES 12 when the proper zypper version is installed
- fixes an issue with the check of PTF repositories on a system subscribed to cloned channels

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20994

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
