### PR TITLE
python/spacewalk/satellite_tools/spacewalk-data-fsck: Fix srpm check

### DIFF
--- a/python/spacewalk/satellite_tools/spacewalk-data-fsck
+++ b/python/spacewalk/satellite_tools/spacewalk-data-fsck
@@ -59,10 +59,18 @@ def db_init():
 
 
 def src_package_query():
-    query = """select p.id
-                 from rhnPackage p
+    query = """select p.source_rpm_id
+                 from rhnPackageSource p
                 where p.path like :filename"""
     return query
+
+
+def package_find_by_src_id():
+    query = """select id
+                 from rhnPackage p
+                 where source_rpm_id = :id"""
+    return query
+
 
 def package_query(options, bind_path=False):
     query = """select %s
@@ -353,8 +361,15 @@ def is_orphaned_srpm(path, file):
     if is_srpm(file):
         query = src_package_query()
         h = rhnSQL.prepare(query)
-        wildcard_filename = "%/" + file.replace('src','%')
+        wildcard_filename = "%/" + os.path.basename(file)
         h.execute(filename=wildcard_filename)
+        row = h.fetchone_dict()
+        if not row:
+            log(0, f"SRPM not in DB: {path}")
+            return True
+        query = package_find_by_src_id()
+        h = rhnSQL.prepare(query)
+        h.execute(id=row['source_rpm_id'])
         row = h.fetchone_dict()
         if not row:
             log(0, "SRPM without matching RPM in db: %s" % (path))

--- a/python/spacewalk/spacewalk-backend.changes.apatard.spacewalk-data-fsck-srpm
+++ b/python/spacewalk/spacewalk-backend.changes.apatard.spacewalk-data-fsck-srpm
@@ -1,0 +1,1 @@
+- Fix spacewalk-data-fsck src.rpm handling


### PR DESCRIPTION
The function is_orphaned_srpm() is used to check if a src.rpm has a corresponding binary package in the database. It is looking for a binary package having the same name as the src.rpm. For instance a package foo*.src.rpm should produce something like foo*.noarch.rpm. Unfortunately, it's a false idea. For instance, python packages are coming from python-foo*.src.rpm and the resulting package is python3-foo*.noarch.rpm.

To solve the issue:
1 - Try to find the src.rpm in rhnPackageSource table. If not found, the
    file can be deleted
2 - If found, look for packages having the source_rpm_id matching the
    source package.