### PR TITLE
Refactor unit test to remove unneeded commits

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/test/AdvDataSourceTest.java
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/test/AdvDataSourceTest.java
@@ -154,9 +154,7 @@ public class AdvDataSourceTest extends RhnBaseTestCase {
     @Test
     public void testInsert() {
         insert("insert_test", 3);
-        // Close our Session so we test to make sure it
-        // actually inserted.
-        commitAndCloseSession();
+        clearSession();
         lookup("insert_test", 3, 1);
     }
 
@@ -170,7 +168,7 @@ public class AdvDataSourceTest extends RhnBaseTestCase {
         assertEquals(1, m.executeUpdate(params));
         // Close our Session so we test to make sure it
         // actually deleted.
-        commitAndCloseSession();
+        clearSession();
         lookup("Blarg", 1, 0);
     }
 
@@ -186,7 +184,7 @@ public class AdvDataSourceTest extends RhnBaseTestCase {
         assertEquals(1, res);
         // Close our Session so we test to make sure it
         // actually updated.
-        commitAndCloseSession();
+        clearSession();
         lookup("after_update", 4, 1);
     }
 

--- a/java/code/src/com/redhat/rhn/domain/config/test/ConfigurationFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/config/test/ConfigurationFactoryTest.java
@@ -126,8 +126,6 @@ public class ConfigurationFactoryTest extends BaseTestCaseWithUser {
         //Create a content and info to put into this revision
         ConfigContent content = ConfigTestUtils.createConfigContent(234L, true);
         ConfigInfo info = ConfigTestUtils.createConfigInfo("root", "root", 777L);
-        commitAndCloseSession();
-        commitHappened();
 
         //Create a config revision
         ConfigRevision revision =

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -708,19 +708,6 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
             TestUtils.saveAndFlush(sg2);
         }
 
-        /*
-         * Since adding a server to a group is done by a stored proc, the
-         * server object at this point doesn't know it has any groups; ie.,
-         * newS.getGroups() == null. To fix this, we need to evict newS
-         * from the session and look it back up.
-         * This shouldn't be a problem in prod, just something we have to do
-         * in our test code until we move to hib3 and can work with stored
-         * procs.
-         */
-        // commitAndCloseSession();
-        // System.out.println("COMMITED SESSION!\n\n");
-
-
         Long id = newS.getId();
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().evict(newS);

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/profile/test/SyncActionsTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/profile/test/SyncActionsTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
-import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.rhnpackage.test.PackageTest;
 import com.redhat.rhn.domain.server.Server;
@@ -33,7 +32,6 @@ import com.redhat.rhn.manager.rhnpackage.test.PackageManagerTest;
 import com.redhat.rhn.testing.RhnMockStrutsTestCase;
 import com.redhat.rhn.testing.UserTestUtils;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Set;
@@ -83,6 +81,7 @@ public class SyncActionsTest extends RhnMockStrutsTestCase {
         // which can cause deadlocks.  We are forced commit the transaction
         // and close the session.
         commitAndCloseSession();
+        commitHappened();
 
         SyncSystemsProfilesAction action = new SyncSystemsProfilesAction();
         Set<String> sessionSet = SessionSetHelper.lookupAndBind(getRequest(),
@@ -109,12 +108,4 @@ public class SyncActionsTest extends RhnMockStrutsTestCase {
                 startsWith("/systems/details/packages/profiles/MissingPackages.do"));
     }
 
-    @Override
-    @AfterEach
-    public void tearDown() throws Exception {
-        super.tearDown();
-        // We committed stuff - need to remove it all again
-        OrgFactory.deleteOrg(user.getOrg().getId(), user);
-        commitAndCloseSession();
-    }
 }

--- a/java/code/src/com/redhat/rhn/frontend/events/test/CloneErrataActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/test/CloneErrataActionTest.java
@@ -55,8 +55,8 @@ public class CloneErrataActionTest extends BaseTestCaseWithUser {
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
-        admin = UserTestUtils.createUserInOrgOne();
-        admin.getOrg().addRole(RoleFactory.ORG_ADMIN);
+        admin = UserTestUtils.createUser("admin", user.getOrg().getId());
+        admin.addPermanentRole(RoleFactory.ORG_ADMIN);
         TestUtils.saveAndFlush(admin);
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/chain/test/ActionChainHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/chain/test/ActionChainHandlerTest.java
@@ -157,8 +157,8 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
         ErrataCacheManager.insertNeededErrataCache(
                 this.server2.getId(), this.errata2.getId(), this.pkg.getId());
 
-        this.server = ActionChainHandlerTest.reload(this.server);
-        this.server2 = ActionChainHandlerTest.reload(this.server2);
+        this.server = reload(this.server);
+        this.server2 = reload(this.server2);
 
         ach = new ActionChainHandler();
         actionChain = ActionChainFactory.createActionChain(CHAIN_LABEL, admin);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/profile/test/ImageProfileHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/profile/test/ImageProfileHandlerTest.java
@@ -514,7 +514,7 @@ public class ImageProfileHandlerTest extends BaseHandlerTestCase {
 
 
         // Create additional user
-        User anotherAdmin = UserTestUtils.createUserInOrgOne();
+        User anotherAdmin = UserTestUtils.createUser("anotherAdmin", admin.getOrg().getId());
         anotherAdmin.addPermanentRole(RoleFactory.ORG_ADMIN);
         TestUtils.saveAndFlush(anotherAdmin);
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -1069,8 +1069,11 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         Action action = ActionManager.scheduleHardwareRefreshAction(admin, server, new Date());
         ActionFactory.save(action);
 
-        // Ensure the other actions are created later
+        // Commit in this test is mandatory as creation date keeps updating while the object is not actually stored
+        // in the database
         commitAndCloseSession();
+        commitHappened();
+
         Thread.sleep(2_000);
         final Date earliestDate = new Date();
 
@@ -1533,7 +1536,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         serverAction.setStatus(ActionFactory.STATUS_PICKED_UP);
 
         ActionFactory.save(action);
-        commitAndCloseSession();
+        clearSession();
 
         // Retrieve the action event detail
         final int sid = server.getId().intValue();
@@ -2271,6 +2274,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         // lookup_transaction_package(:operation, :n, :e, :v, :r, :a)
         // which can cause deadlocks.  We are forced to call commitAndCloseTransaction()
         commitAndCloseSession();
+        commitHappened();
         handler.scheduleSyncPackagesWithSystem(admin, s1.getId().
                         intValue(), s2.getId().intValue(), packagesToSync,
                 new Date());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/test/UserHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/test/UserHandlerTest.java
@@ -87,13 +87,10 @@ public class UserHandlerTest extends BaseHandlerTestCase {
     }
 
     @Test
-    public void testListAssignableRoles() throws Exception {
-        assertTrue(handler.listAssignableRoles(admin).
-                                    contains(RoleFactory.ORG_ADMIN.getLabel()));
+    public void testListAssignableRoles() {
+        assertTrue(handler.listAssignableRoles(admin).contains(RoleFactory.ORG_ADMIN.getLabel()));
         assertTrue(handler.listAssignableRoles(regular).isEmpty());
-        User satAdmin = UserTestUtils.createSatAdminInOrgOne();
-        assertTrue(handler.listAssignableRoles(satAdmin).
-                                contains(RoleFactory.SAT_ADMIN.getLabel()));
+        assertTrue(handler.listAssignableRoles(satAdmin).contains(RoleFactory.SAT_ADMIN.getLabel()));
 
     }
 
@@ -219,9 +216,7 @@ public class UserHandlerTest extends BaseHandlerTestCase {
         catch (FaultException e) {
             //success
         }
-        User satAdmin = UserTestUtils.createSatAdminInOrgOne();
-        handler.addRole(satAdmin, regular.getLogin(),
-                            RoleFactory.SAT_ADMIN.getLabel());
+        handler.addRole(satAdmin, regular.getLogin(), RoleFactory.SAT_ADMIN.getLabel());
         assertTrue(regular.hasRole(RoleFactory.SAT_ADMIN));
 
 

--- a/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
@@ -98,7 +98,6 @@ import com.redhat.rhn.manager.system.test.SystemManagerTest;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
-import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
@@ -693,7 +692,7 @@ public class ActionManagerTest extends JMockBaseTestCaseWithUser {
         KickstartSession ksSession = KickstartSessionTest.createKickstartSession(server,
                 ksData, user, parentAction);
         TestUtils.saveAndFlush(ksSession);
-        ksSession = RhnBaseTestCase.reload(ksSession);
+        ksSession = reload(ksSession);
 
         List actionList = createActionList(user, new Action [] {parentAction});
 

--- a/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerTest.java
@@ -229,7 +229,6 @@ public class ChannelManagerTest extends BaseTestCaseWithUser {
 
     @Test
     public void testOrphanedChannelTree() throws Exception {
-        user = UserTestUtils.createUserInOrgOne();
         Channel channel = ChannelFactoryTest.createTestChannel(user);
         channel.setEndOfLife(new Date(System.currentTimeMillis() + 10000000L));
         user.getOrg().addOwnedChannel(channel);

--- a/java/code/src/com/redhat/rhn/manager/configuration/test/ConfigurationManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/configuration/test/ConfigurationManagerTest.java
@@ -834,8 +834,6 @@ public class ConfigurationManagerTest extends BaseTestCaseWithUser {
         addFilesAndDirs(local);
         s.setLocalOverride(local);
         ServerFactory.save(s);
-        //HibernateFactory.commitTransaction();
-        //HibernateFactory.closeSession();
 
         ConfigFileCount actual = cm.countLocallyManagedPaths(s, user,
                                         ConfigChannelType.local()

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/test/CobblerCommandTestBase.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/test/CobblerCommandTestBase.java
@@ -14,14 +14,17 @@
  */
 package com.redhat.rhn.manager.kickstart.cobbler.test;
 
+import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.domain.kickstart.KickstartData;
 import com.redhat.rhn.domain.kickstart.test.KickstartDataTest;
 import com.redhat.rhn.domain.kickstart.test.KickstartableTreeTest;
 import com.redhat.rhn.domain.role.RoleFactory;
+import com.redhat.rhn.domain.user.UserFactory;
 import com.redhat.rhn.manager.kickstart.cobbler.CobblerDistroCreateCommand;
+import com.redhat.rhn.manager.kickstart.cobbler.CobblerXMLRPCHelper;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
-import com.redhat.rhn.testing.UserTestUtils;
 
+import org.cobbler.CobblerConnection;
 import org.junit.jupiter.api.BeforeEach;
 
 /**
@@ -31,6 +34,24 @@ import org.junit.jupiter.api.BeforeEach;
 public abstract class CobblerCommandTestBase extends BaseTestCaseWithUser {
 
     protected KickstartData ksdata;
+
+    private final boolean connectToCobbler;
+
+    /**
+     * Default constructor
+     */
+    protected CobblerCommandTestBase() {
+        this(false);
+    }
+
+    /**
+     * Alternative constructor
+     * @param connectToCobblerIn true to actually connect to cobbler
+     */
+    protected CobblerCommandTestBase(boolean connectToCobblerIn) {
+        connectToCobbler = connectToCobblerIn;
+    }
+
 
     /**
      * {@inheritDoc}
@@ -42,21 +63,22 @@ public abstract class CobblerCommandTestBase extends BaseTestCaseWithUser {
     public void setUp() throws Exception {
         super.setUp();
 
-        user = UserTestUtils.createUserInOrgOne();
+        // Make the default user admin
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
+        UserFactory.save(user);
+
         this.ksdata = KickstartDataTest.createKickstartWithDefaultKey(this.user.getOrg());
         this.ksdata.getTree().setBasePath("/tmp/opt/repo/f9-x86_64/");
 
-        // Uncomment this if you want the tests to actually talk to cobbler
-        //Config.get().setString(CobblerXMLRPCHelper.class.getName(),
-        //        CobblerXMLRPCHelper.class.getName());
-        //Config.get().setString(CobblerConnection.class.getName(),
-        //        CobblerConnection.class.getName());
-        //commitAndCloseSession();
+        if (connectToCobbler) {
+            Config.get().setString(CobblerXMLRPCHelper.class.getName(), CobblerXMLRPCHelper.class.getName());
+            Config.get().setString(CobblerConnection.class.getName(), CobblerConnection.class.getName());
+            commitAndCloseSession();
+            commitHappened();
+        }
 
         KickstartableTreeTest.createKickstartTreeItems(this.ksdata.getTree());
-        CobblerDistroCreateCommand dcreate = new
-            CobblerDistroCreateCommand(ksdata.getTree(), user);
+        CobblerDistroCreateCommand dcreate = new CobblerDistroCreateCommand(ksdata.getTree(), user);
         dcreate.store();
     }
 

--- a/java/code/src/com/redhat/rhn/manager/ssm/test/SsmOperationDataPopulatorTest.java
+++ b/java/code/src/com/redhat/rhn/manager/ssm/test/SsmOperationDataPopulatorTest.java
@@ -26,6 +26,7 @@ import com.redhat.rhn.manager.ssm.SsmOperationManager;
 import com.redhat.rhn.testing.RhnBaseTestCase;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -50,12 +51,8 @@ public class SsmOperationDataPopulatorTest extends RhnBaseTestCase {
     }
 
     @Test
-    public void testDummy() {
-        // Stub to have at least one test when all of the actual populate ones are
-        // disabled so JUnit doesn't complain
-    }
-
-    public void aTestPopulateDataSet1() throws Exception {
+    @Disabled
+    public void populateDataSet() throws Exception {
         // The following control the data that are created in this call
         String userLoginName = "admin";
         int numInProgressOperations = 3;
@@ -85,7 +82,7 @@ public class SsmOperationDataPopulatorTest extends RhnBaseTestCase {
         // Cleanup; after the creates the RhnSet is no longer needed
         RhnSetManager.remove(serverSet);
 
-        super.commitAndCloseSession();
+        commitAndCloseSession();
     }
 
     private List<Server> createServersForUser(User user, int count) {

--- a/java/code/src/com/redhat/rhn/manager/system/entitling/test/SystemEntitlementManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/entitling/test/SystemEntitlementManagerTest.java
@@ -14,7 +14,6 @@
  */
 package com.redhat.rhn.manager.system.entitling.test;
 
-import static com.redhat.rhn.testing.RhnBaseTestCase.reload;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -16,7 +16,6 @@ package com.redhat.rhn.manager.system.test;
 
 import static com.redhat.rhn.domain.formula.FormulaFactory.PROMETHEUS_EXPORTERS;
 import static com.redhat.rhn.manager.action.test.ActionManagerTest.assertNotEmpty;
-import static com.redhat.rhn.testing.RhnBaseTestCase.reload;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
@@ -338,7 +337,6 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
             will(returnValue(Optional.of(new MgrUtilRunner.RemoveKnowHostResult("removed", ""))));
         }});
         systemManager.deleteServer(user, minion.getId());
-        HibernateFactory.commitTransaction();
 
         assertFalse(MinionServerFactory.findByMinionId(minion.getMinionId()).isPresent());
         assertFalse(formulaValues.exists());
@@ -360,8 +358,6 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
             will(returnValue(Optional.of(new MgrUtilRunner.RemoveKnowHostResult("removed", ""))));
         }});
         systemManager.deleteServer(user, minion.getId());
-
-        HibernateFactory.commitTransaction();
 
         assertFalse(MinionServerFactory.findByMinionId(minion.getMinionId()).isPresent());
         assertFalse(formulaValues.exists());

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
@@ -22,13 +22,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.ActionStatus;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.action.test.ActionFactoryTest;
-import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.taskomatic.task.checkin.SystemSummary;
@@ -219,10 +217,8 @@ public class SSHPushWorkerSaltTest extends JMockBaseTestCaseWithUser {
         assertNull(futureServerAction.getResultCode());
         assertTrue(minion.getLastBoot() > 1L);
 
-        // explicitly remove any row created by the worker, as it commits
-        OrgFactory.deleteOrg(user.getOrg().getId(), user);
-        HibernateFactory.commitTransaction();
-        HibernateFactory.closeSession();
+        // The worker commits, so mark the session for cleanup
+        commitHappened();
     }
 
     @Test

--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/ErrataQueueTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/ErrataQueueTest.java
@@ -56,7 +56,5 @@ public class ErrataQueueTest extends BaseTestCaseWithUser {
         TaskoFactory.delete(template);
         TaskoFactory.delete(template.getBunch());
         TaskoFactory.delete(template.getTask());
-        commitAndCloseSession();
-        commitHappened();
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/KickstartFileSyncTaskTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/KickstartFileSyncTaskTest.java
@@ -21,26 +21,23 @@ import com.redhat.rhn.domain.kickstart.KickstartData;
 import com.redhat.rhn.domain.kickstart.KickstartFactory;
 import com.redhat.rhn.domain.kickstart.test.KickstartDataTest;
 import com.redhat.rhn.domain.role.RoleFactory;
-import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.kickstart.cobbler.CobblerXMLRPCHelper;
 import com.redhat.rhn.taskomatic.task.KickstartFileSyncTask;
-import com.redhat.rhn.testing.RhnBaseTestCase;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.TestUtils;
-import com.redhat.rhn.testing.UserTestUtils;
 
 import org.cobbler.Profile;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-public class KickstartFileSyncTaskTest extends RhnBaseTestCase {
+public class KickstartFileSyncTaskTest extends BaseTestCaseWithUser {
 
 
 
     @Test
     public void testTask() throws Exception {
 
-        User user = UserTestUtils.createUserInOrgOne();
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
 
         KickstartData ks = KickstartDataTest.createTestKickstartData(user.getOrg());
@@ -49,14 +46,14 @@ public class KickstartFileSyncTaskTest extends RhnBaseTestCase {
         KickstartFactory.saveKickstartData(ks);
 
 
-        ks = (KickstartData) TestUtils.saveAndReload(ks);
+        ks = TestUtils.saveAndReload(ks);
 
         Profile p = Profile.lookupById(CobblerXMLRPCHelper.getConnection(user),
                 ks.getCobblerId());
 
         File f = new File(p.getKickstart());
         assertTrue(f.exists());
-        f.delete();
+        assertTrue(f.delete());
         assertFalse(f.exists());
         KickstartFileSyncTask task = new KickstartFileSyncTask();
         task.execute(null);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/MinionActionChainExecutorTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/MinionActionChainExecutorTest.java
@@ -130,8 +130,7 @@ public class MinionActionChainExecutorTest extends JMockBaseTestCaseWithUser {
         String expectedMessage = LOCALIZATION.getMessage("task.action.rejection.reason",
             MinionActionExecutor.MAXIMUM_TIMEDELTA_FOR_SCHEDULED_ACTIONS);
 
-        HibernateFactory.commitTransaction();
-        HibernateFactory.closeSession();
+        HibernateFactory.getSession().clear();
 
         sa1 = HibernateFactory.reload(sa1);
         sa2 = HibernateFactory.reload(sa2);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/MinionActionExecutorTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/MinionActionExecutorTest.java
@@ -122,8 +122,7 @@ public class MinionActionExecutorTest extends JMockBaseTestCaseWithUser {
         MinionActionExecutor actionExecutor = new MinionActionExecutor(saltServerActionService);
         actionExecutor.execute(context);
 
-        HibernateFactory.commitTransaction();
-        HibernateFactory.closeSession();
+        HibernateFactory.getSession().clear();
 
         sa1 = HibernateFactory.reload(sa1);
         sa2 = HibernateFactory.reload(sa2);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/SessionCleanupTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/SessionCleanupTest.java
@@ -49,18 +49,20 @@ public class SessionCleanupTest extends RhnBaseTestCase {
         Config c = Config.get();
         TestUtils.saveAndFlush(s);
 
-        /* commit it to the database in order for the py/sql calls to work correctly
-        due to py/sql and Hibernate's JUnit test behavior not playing well together */
+        /*
+            commit it to the database in order for the py/sql calls to work correctly
+            due to py/sql and Hibernate's JUnit test behavior not playing well together
+        */
         commitAndCloseSession();
 
-        /*set the delete batch size to 1 to make sure only one entry is deleted.
-        We set session_database_lifetime to the current time such that when
-        the deletion boundary is calculated by SessionCleanup, the result will be
-        a negative value, but one that ensures our test websession is selected
-        and deleted. */
-
-        c.setString("session_database_lifetime",
-                     Long.valueOf(System.currentTimeMillis() / 1000).toString());
+        /*
+            set delete batch size to 1 to make sure only one entry is deleted.
+            We set session_database_lifetime to the current time such that when
+            the deletion boundary is calculated by SessionCleanup, the result will be
+            a negative value, but one that ensures our test websession is selected
+            and deleted.
+         */
+        c.setString("session_database_lifetime", Long.toString(System.currentTimeMillis() / 1000));
 
         SessionCleanup sc = new SessionCleanup();
         sc.execute(null);

--- a/java/code/src/com/redhat/rhn/testing/HibernateTestCaseUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/HibernateTestCaseUtils.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.testing;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+
+import org.hibernate.HibernateException;
+import org.hibernate.Session;
+
+import java.io.Serializable;
+
+/**
+ * Utils for handling hibernate entities during the session. Implemented as interface default methods in order
+ * to be shared among {@link  RhnBaseTestCase} and {@link RhnJmockBaseTestCase}
+ */
+public interface HibernateTestCaseUtils {
+
+    /**
+     * Clears hibernate session
+     */
+    default void clearSession() {
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+    }
+
+    /**
+     * PLEASE Refrain from using this unless you really have to.
+     *
+     * Try clearSession() instead
+     * @throws HibernateException hibernate exception
+     */
+    default void commitAndCloseSession() throws HibernateException {
+        HibernateFactory.commitTransaction();
+        HibernateFactory.closeSession();
+    }
+
+    /**
+     * Flush an object and removes it from the session
+     * @param obj the object
+     * @throws HibernateException hibernate exception
+     */
+    default void flushAndEvict(Object obj) throws HibernateException {
+        Session session = HibernateFactory.getSession();
+        session.flush();
+        session.evict(obj);
+    }
+
+    /**
+     * Reload a Hibernate entity.
+     * @param objClass The class of the object
+     * @param id the id
+     * @return the request object reloaded
+     * @param <T> the type of the object
+     * @throws HibernateException hibernate exception
+     */
+    default <T> T reload(Class<T> objClass, Serializable id) throws HibernateException {
+        assertNotNull(id);
+        T obj = TestUtils.reload(objClass, id);
+        return reload(obj);
+    }
+
+    /**
+     * Reload a Hibernate entity.
+     * @param obj the entity to reload
+     * @param <T> type of object to reload
+     * @return the new instance
+     * @throws HibernateException in case of error
+     */
+    default <T> T reload(T obj) throws HibernateException {
+        assertNotNull(obj);
+        T result = TestUtils.reload(obj);
+        assertNotSame(obj, result);
+        return result;
+    }
+
+}

--- a/java/code/src/com/redhat/rhn/testing/RhnBaseTestCase.java
+++ b/java/code/src/com/redhat/rhn/testing/RhnBaseTestCase.java
@@ -15,7 +15,6 @@
 package com.redhat.rhn.testing;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -26,13 +25,10 @@ import com.redhat.rhn.common.messaging.MessageQueue;
 import com.suse.manager.webui.services.SaltStateGeneratorService;
 import com.suse.manager.webui.services.test.TestSaltApi;
 
-import org.hibernate.HibernateException;
-import org.hibernate.Session;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
 import java.io.File;
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.Date;
 
@@ -42,7 +38,7 @@ import java.util.Date;
  * test to similuate what happens when the code is run
  * in a web application server.
  */
-public abstract class RhnBaseTestCase  {
+public abstract class RhnBaseTestCase implements HibernateTestCaseUtils  {
 
     /**
      * Default Constructor
@@ -67,43 +63,6 @@ public abstract class RhnBaseTestCase  {
     @AfterEach
     public void tearDown() throws Exception {
         TestCaseHelper.tearDownHelper();
-    }
-
-    /**
-     * PLEASE Refrain from using this unless you really have to.
-     *
-     * Try clearSession() instead
-     * @throws HibernateException hibernate exception
-     */
-    protected void commitAndCloseSession() throws HibernateException {
-        HibernateFactory.commitTransaction();
-        HibernateFactory.closeSession();
-    }
-
-    protected void flushAndEvict(Object obj) throws HibernateException {
-        Session session = HibernateFactory.getSession();
-        session.flush();
-        session.evict(obj);
-    }
-
-    protected <T> T reload(Class<T> objClass, Serializable id) throws HibernateException {
-        assertNotNull(id);
-        T obj = TestUtils.reload(objClass, id);
-        return reload(obj);
-    }
-
-    /**
-     * Reload a Hibernate entity.
-     * @param obj the entity to reload
-     * @param <T> type of object to reload
-     * @return the new instance
-     * @throws HibernateException in case of error
-     */
-    public static <T> T reload(T obj) throws HibernateException {
-        assertNotNull(obj);
-        T result = TestUtils.reload(obj);
-        assertNotSame(obj, result);
-        return result;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/testing/RhnJmockBaseTestCase.java
+++ b/java/code/src/com/redhat/rhn/testing/RhnJmockBaseTestCase.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.AfterEach;
  * RhnJmockBaseTestCase - This is the same thing as {@link RhnBaseTestCase}
  * but it extends from {@link MockObjectTestCase}.
  */
-public abstract class RhnJmockBaseTestCase extends MockObjectTestCase {
+public abstract class RhnJmockBaseTestCase extends MockObjectTestCase implements HibernateTestCaseUtils {
 
     /**
      * Called once per test method to clean up.

--- a/java/code/src/com/redhat/rhn/testing/RhnMockStrutsTestCase.java
+++ b/java/code/src/com/redhat/rhn/testing/RhnMockStrutsTestCase.java
@@ -19,9 +19,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.kickstart.test.KickstartDataTest;
+import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.session.WebSession;
 import com.redhat.rhn.domain.user.User;
@@ -36,7 +36,6 @@ import com.suse.manager.webui.services.SaltStateGeneratorService;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
 
 import org.apache.struts.action.DynaActionForm;
-import org.hibernate.HibernateException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,9 +56,10 @@ import servletunit.struts.MockStrutsTestCase;
  * RhnMockStrutsTestCase - simple base class that adds a User to the test since all our
  * Struts Actions use a User.
  */
-public class RhnMockStrutsTestCase extends MockStrutsTestCase {
+public class RhnMockStrutsTestCase extends MockStrutsTestCase implements HibernateTestCaseUtils {
 
     protected User user;
+    private boolean committed = false;
 
     /**
      * {@inheritDoc}
@@ -113,6 +113,12 @@ public class RhnMockStrutsTestCase extends MockStrutsTestCase {
     public void tearDown() throws Exception {
         super.tearDown();
         TestCaseHelper.tearDownHelper();
+        if (committed) {
+            OrgFactory.deleteOrg(user.getOrg().getId(), user);
+            commitAndCloseSession();
+        }
+        committed = false;
+        user = null;
     }
 
 
@@ -235,16 +241,8 @@ public class RhnMockStrutsTestCase extends MockStrutsTestCase {
         assertTrue(getActualForward().indexOf("/errors") > 0);
     }
 
-    /**
-     * PLEASE Refrain from using this unless you really have to.
-     *
-     * Try clearSession() instead
-     * @throws HibernateException Hibernate exception
-     */
-    protected void commitAndCloseSession() throws HibernateException {
-        HibernateFactory.commitTransaction();
-        HibernateFactory.closeSession();
+    // If we have to commit in mid-test, set up the next transaction correctly
+    protected void commitHappened() {
+        committed = true;
     }
-
-
 }

--- a/java/code/src/com/redhat/rhn/testing/TestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/TestUtils.java
@@ -23,7 +23,6 @@ import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.hibernate.HibernateRuntimeException;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.util.MethodUtil;
-import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.session.WebSession;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.servlets.PxtCookieManager;
@@ -210,14 +209,8 @@ public class TestUtils {
         req.setupServerName("mymachine.rhndev.redhat.com");
         req.setSession(session);
 
-        User u = null;
-        try {
-            u = UserTestUtils.createUserInOrgOne();
-        }
-        catch (Exception e) {
-            e.printStackTrace();
-        }
-        u.removePermanentRole(RoleFactory.ORG_ADMIN);
+        User u = UserTestUtils.findNewUser("testUser",
+            "testOrg_getRequestWithSessionAndUser" + RandomStringUtils.randomAlphanumeric(5));
         Long userid = u.getId();
 
         RequestContext requestContext = new RequestContext(req);

--- a/java/code/src/com/redhat/rhn/testing/UserTestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/UserTestUtils.java
@@ -139,29 +139,6 @@ public class UserTestUtils  {
     }
 
     /**
-     * Useful for legacy tests that arent multi-org aware.
-     * @return User from org_id = 1
-     */
-    public static User createUserInOrgOne() {
-        User retval = createUser("testUser", 1L);
-        retval.addPermanentRole(RoleFactory.ORG_ADMIN);
-        UserFactory.save(retval);
-        return retval;
-    }
-
-
-    /**
-     * Useful for legacy tests that arent multi-org aware.
-     * @return New Sat Admin User from org_id = 1
-     */
-    public static User createSatAdminInOrgOne() {
-        User retval = createUser("testUser", 1L);
-        retval.addPermanentRole(RoleFactory.SAT_ADMIN);
-        UserFactory.save(retval);
-        return retval;
-    }
-
-    /**
      * Creates a new User and Org with the given userName and orgName.
      * The current time is appended to the given username and orgName.
      * @param userName Name of user.

--- a/java/code/src/com/suse/manager/utils/test/SaltUtilsTest.java
+++ b/java/code/src/com/suse/manager/utils/test/SaltUtilsTest.java
@@ -23,8 +23,7 @@ import com.redhat.rhn.domain.rhnpackage.PackageType;
 import com.redhat.rhn.domain.server.InstalledPackage;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
-import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.testing.UserTestUtils;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
 
 import com.suse.manager.utils.SaltUtils;
 import com.suse.salt.netapi.calls.modules.Pkg;
@@ -40,7 +39,7 @@ import java.io.InputStreamReader;
 import java.util.List;
 import java.util.Map;
 
-public class SaltUtilsTest  {
+public class SaltUtilsTest extends BaseTestCaseWithUser {
 
     @Test
     public void testPackageToKey() {
@@ -104,7 +103,6 @@ public class SaltUtilsTest  {
      */
     @Test
     public void testPackageChangeOutcomeWithLivePatchPackages() throws Exception {
-        User user = UserTestUtils.createSatAdminInOrgOne();
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
 
         Map<String, Change<Xor<String, List<Pkg.Info>>>> installLivePatch =

--- a/java/code/src/com/suse/manager/webui/controllers/admin/handlers/test/PaygApiControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/admin/handlers/test/PaygApiControllerTest.java
@@ -27,6 +27,7 @@ import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.domain.cloudpayg.CloudRmtHostFactory;
 import com.redhat.rhn.domain.cloudpayg.PaygSshData;
 import com.redhat.rhn.domain.cloudpayg.PaygSshDataFactory;
+import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
@@ -66,7 +67,8 @@ public class PaygApiControllerTest extends BaseControllerTestCase {
         super.setUp();
         clearDb();
 
-        satAdmin = UserTestUtils.createSatAdminInOrgOne();
+        satAdmin = UserTestUtils.createUser("satUser", user.getOrg().getId());
+        satAdmin.addPermanentRole(RoleFactory.SAT_ADMIN);
 
         context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         taskomaticMock = context.mock(TaskomaticApi.class);


### PR DESCRIPTION
## What does this PR change?

This PR refactor the unit tests in order to:

- Avoid unneeded commits during the execution of the tests
- Clean up the APIs to ensure that state is clean after a mandatory commit by providing the `commitHappened()` mechanism in every base test classes where relevant
- Remove the use of the legacy organization 1 since unit test no longer require it

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Tests updated

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
