### PR TITLE
Add monitoring tag to sle15sp3 repository synchronization.

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -63,6 +63,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I see "SUSE Linux Enterprise Server 15 SP2 x86_64" product has been added
 
 @sle15sp3_minion
+@monitoring_server
   Scenario: Add SUSE Linux Enterprise Server 15 SP3
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text


### PR DESCRIPTION
## What does this PR change?

Make sure sles15sp3 repositories are synchronized for Monitoring  even if we don't test sle15sp3.
It should improve monitoring server idempotent

## GUI diff



- [x] **DONE**

## Documentation

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links
CI : https://github.com/SUSE/susemanager-ci/pull/814
SM42 : https://github.com/SUSE/spacewalk/pull/20978
Uyuni : https://github.com/uyuni-project/uyuni/pull/6811  

- [x] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
