### PR TITLE
Cleaning of spacewalk-java.spec/susemanager.spec/spacewalk-setup.spec

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Simplify Java package dependencies.
 - Recurring custom states
 - Update Cobbler profile when a new image is deployed
 - Add mapping of image URLs for containerized proxy
@@ -40,7 +41,6 @@ Wed Apr 19 12:47:06 CEST 2023 - marina.latini@suse.com
   * Make API method systemgroup.listSystemsMinimal read-only (bsc#1208550)
   * Allow single-value lists in query strings in HTTP API (bsc#1207297)
   * Do not include channels from different orgs when listing mandatory channels (bsc#1204270)
-
 
 -------------------------------------------------------------------
 Thu Apr 13 15:22:40 CEST 2023 - marina.latini@suse.com

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Ensure installation of 'xalan-j2' for building.
 - Simplify Java package dependencies.
 - Recurring custom states
 - Update Cobbler profile when a new image is deployed

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -243,7 +243,7 @@ Requires:       mvn(org.hibernate:hibernate-core)
 Requires:       mvn(org.hibernate:hibernate-ehcache)
 # libtcnative-1-0 is only recommended in tomcat.
 # We want it always to prevent warnings about openssl cannot be used
-Requires:       libtcnative-1-0
+Requires:       tomcat-native
 Requires(pre):  salt
 Requires(pre):  tomcat >= 7
 Requires(pre):  uyuni-base-server

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -90,6 +90,7 @@ BuildRequires:  bcel
 BuildRequires:  byte-buddy
 BuildRequires:  c3p0 >= 0.9.1
 BuildRequires:  cglib
+BuildRequires:  classmate
 BuildRequires:  concurrent
 BuildRequires:  dom4j
 BuildRequires:  dwr >= 3
@@ -151,11 +152,9 @@ BuildRequires:  mvn(org.hibernate:hibernate-core)
 BuildRequires:  mvn(org.hibernate:hibernate-ehcache)
 %if 0%{?suse_version}
 BuildRequires:  ant-nodeps
-BuildRequires:  classmate
 BuildRequires:  libxml2-tools
 %endif
 %if 0%{?rhel}
-BuildRequires:  glassfish-jaxb-core
 BuildRequires:  libxml2-devel
 %endif
 
@@ -177,9 +176,12 @@ Requires:       bcel
 Requires:       byte-buddy
 Requires:       c3p0 >= 0.9.1
 Requires:       cglib
+Requires:       classmate
 Requires:       cobbler
 Requires:       concurrent
 Requires:       dwr >= 3
+Requires:       glassfish-activation-api
+Requires:       glassfish-jaxb-api
 Requires:       glassfish-jaxb-runtime
 Requires:       glassfish-jaxb-txw2
 Requires:       google-gson >= 2.2.4
@@ -245,15 +247,7 @@ Requires(pre):  salt
 Requires(pre):  tomcat >= 7
 Requires(pre):  uyuni-base-server
 
-%if 0%{?suse_version}
-Requires:       classmate
-Requires:       glassfish-activation-api
-Requires:       glassfish-jaxb-api
-%endif
 %if 0%{?rhel}
-Requires:       glassfish-jaxb-core
-Requires:       jakarta-activation
-Requires:       jaxb-api
 Recommends:     rng-tools
 %endif
 
@@ -355,6 +349,7 @@ Requires:       bcel
 Requires:       byte-buddy
 Requires:       c3p0 >= 0.9.1
 Requires:       cglib
+Requires:       classmate
 Requires:       cobbler
 Requires:       concurrent
 Requires:       hibernate-commons-annotations
@@ -381,9 +376,6 @@ Requires:       (/sbin/unix2_chkpwd or /usr/sbin/unix2_chkpwd)
 Requires:       mvn(org.hibernate:hibernate-c3p0)
 Requires:       mvn(org.hibernate:hibernate-core)
 Requires:       mvn(org.hibernate:hibernate-ehcache)
-%if 0%{?suse_version}
-Requires:       classmate
-%endif
 
 Conflicts:      quartz < 2.0
 

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -143,6 +143,7 @@ BuildRequires:  tomcat-lib >= 7
 BuildRequires:  tomcat-taglibs-standard
 BuildRequires:  uyuni-base-server
 BuildRequires:  woodstox
+BuildRequires:  xalan-j2
 BuildRequires:  xmlsec
 BuildRequires:  (glassfish-activation-api or jakarta-activation)
 BuildRequires:  (glassfish-jaxb-api or jaxb-api)

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -145,8 +145,8 @@ BuildRequires:  uyuni-base-server
 BuildRequires:  woodstox
 BuildRequires:  xalan-j2
 BuildRequires:  xmlsec
-BuildRequires:  (glassfish-activation-api or jakarta-activation)
-BuildRequires:  (glassfish-jaxb-api or jaxb-api)
+BuildRequires:  glassfish-activation-api
+BuildRequires:  glassfish-jaxb-api
 BuildRequires:  mvn(org.apache.velocity:velocity-engine-core) >= 2.2
 BuildRequires:  mvn(org.hibernate:hibernate-c3p0)
 BuildRequires:  mvn(org.hibernate:hibernate-core)
@@ -633,19 +633,10 @@ mv $RPM_BUILD_ROOT%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/jboss-loggingjboss
 
 # Prettifying symlinks for RHEL
 %if 0%{?rhel}
-mv $RPM_BUILD_ROOT%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/jakarta-activationjakarta.activation.jar $RPM_BUILD_ROOT%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/jaf.jar
 mv $RPM_BUILD_ROOT%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/javamailjavax.mail.jar $RPM_BUILD_ROOT%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/javamail.jar
 mv $RPM_BUILD_ROOT%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/jta.jar $RPM_BUILD_ROOT%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/geronimo-jta-1.1-api.jar
 # Removing unused symlinks.
-rm -rf $RPM_BUILD_ROOT%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/jakarta-activationjakarta.activation-api.jar
-rm -rf $RPM_BUILD_ROOT%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/javamaildsn.jar
-rm -rf $RPM_BUILD_ROOT%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/javamailgimap.jar
-rm -rf $RPM_BUILD_ROOT%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/javamailimap.jar
-rm -rf $RPM_BUILD_ROOT%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/javamailjavax.mail-api.jar
 rm -rf $RPM_BUILD_ROOT%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/javamailmail.jar
-rm -rf $RPM_BUILD_ROOT%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/javamailmailapi.jar
-rm -rf $RPM_BUILD_ROOT%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/javamailpop3.jar
-rm -rf $RPM_BUILD_ROOT%{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/javamailsmtp.jar
 %endif
 
 # show all JAR symlinks

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,5 @@
+- Corrected tomcat requirement.
+
 -------------------------------------------------------------------
 Wed Apr 19 13:00:08 CEST 2023 - marina.latini@suse.com
 

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,4 +1,4 @@
-- Corrected tomcat requirement.
+- Corrected requirement to install Tomcat before spacewalk-setup.
 
 -------------------------------------------------------------------
 Wed Apr 19 13:00:08 CEST 2023 - marina.latini@suse.com

--- a/spacewalk/setup/spacewalk-setup.spec
+++ b/spacewalk/setup/spacewalk-setup.spec
@@ -94,7 +94,7 @@ Requires:       perl-Satcon
 Requires:       spacewalk-admin
 Requires:       spacewalk-backend-tools
 Requires:       spacewalk-certs-tools
-Requires(pre):  tomcat
+Requires:       tomcat
 %if 0%{?build_py3}
 Requires:       (python3-PyYAML or python3-pyyaml)
 %else

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Ensure installation of make for building.
 - Adjust product name in setup script output (bsc#1195380)
 
 -------------------------------------------------------------------

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -61,6 +61,8 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  gettext
 %endif
 
+BuildRequires:  make
+
 %if 0%{?build_py3}
 BuildRequires:  python3-devel
 %else


### PR DESCRIPTION
## What does this PR change?
spacewalk-java:
- Cleanup of spacewalk-java file to reduce complexity.
- Remove glassfish-jaxb-core requirement for Enterprise Linux.
- Update package requirement libtcnative-1-0 to tomcat-native to have common name between EL and SUSE.

spacewalk-setup:
- Corrected tomcat installation requirement.

susemanager.spec
- Ensure installation of make for building. Build might fail (does fail on copr) otherwise.


## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests" (Test skipped, there are no changes to test)
