### PR TITLE
Testsuite: Wait for solv file to be filled

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -396,7 +396,10 @@ Then(/^"([^"]*)" package should have been stored$/) do |pkg|
 end
 
 Then(/^solver file for "([^"]*)" should reference "([^"]*)"$/) do |channel, pkg|
-  $server.run("dumpsolv /var/cache/rhn/repodata/#{channel}/solv | grep #{pkg}")
+  repeat_until_timeout(timeout: 300, message: "Reference #{pkg} not found in file.") do
+    _result, code = $server.run("dumpsolv /var/cache/rhn/repodata/#{channel}/solv | grep #{pkg}", check_errors: false)
+    break if code.zero?
+  end
 end
 
 When(/^I wait until the channel "([^"]*)" has been synced$/) do |channel|


### PR DESCRIPTION
## What does this PR change?
If the environment is slow, the solv file from the fake rpm package might not be ready on time and the package that is being grepped might not be present yet. This PR encapsulates the dumpsolv package grep in a `repeat_until_timeout` clause to wait for the reference to appear.
This PR aims to resolve the failure of `Reposync works as expected. Check reposync of custom channel` which can happen from time to time in Uyuni CI and is caused by the solv file not being ready in time.
## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Fixes #
Tracks # 
4.2
4.3
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
