### PR TITLE
Force migration from Salt 3000 clients to Salt Bundle

### DIFF
--- a/susemanager-utils/susemanager-sls/modules/tops/mgr_master_tops.py
+++ b/susemanager-utils/susemanager-sls/modules/tops/mgr_master_tops.py
@@ -34,7 +34,8 @@ MANAGER_BASE_TOP = [
     "services.salt-minion",
     "services.docker",
     "services.kiwi-image-server",
-    "ansible"
+    "ansible",
+    "switch_to_bundle.mgr_switch_to_venv_minion"
 ]
 
 

--- a/susemanager-utils/susemanager-sls/salt/switch_to_bundle/mgr_switch_to_venv_minion.sls
+++ b/susemanager-utils/susemanager-sls/salt/switch_to_bundle/mgr_switch_to_venv_minion.sls
@@ -1,0 +1,19 @@
+{%- set avoid_venv_salt_minion = salt['pillar.get']('mgr_avoid_venv_salt_minion') %}
+{%- set is_salt_ssh = salt['pillar.get']('contact_method') in ['ssh-push', 'ssh-push-tunnel'] %}
+{%- set is_saltboot = salt['file.file_exists']('/etc/ImageVersion') %}
+
+{%- if grains['saltversion'] == '3000' and not is_salt_ssh and 
+       not avoid_venv_salt_minion == true and not is_saltboot %}
+
+include:
+  - util.mgr_switch_to_venv_minion
+
+mgr_remove_susemanagerconf:
+  file.absent:
+    - name: /etc/salt/minion.d/susemanager.conf
+    - require:
+      - service: mgr_disable_salt_minion
+    - order: last
+
+{%- endif %}
+

--- a/susemanager-utils/susemanager-sls/salt/util/mgr_switch_to_venv_minion.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/mgr_switch_to_venv_minion.sls
@@ -11,6 +11,9 @@
 {%- set venv_minion_installed = pkgs_installed.get('venv-salt-minion', False) and True %}
 {%- set venv_minion_available = venv_minion_installed or salt['pkg.latest_version']('venv-salt-minion') or False %}
 {%- if venv_minion_available %}
+include:
+  - services.salt-minion
+ 
 mgr_venv_salt_minion_pkg:
   pkg.installed:
     - name: venv-salt-minion
@@ -66,6 +69,7 @@ mgr_disable_salt_minion:
     - enable: False
     - require:
       - service: mgr_enable_venv_salt_minion
+      - sls: services.salt-minion
 
 {%- if salt['pillar.get']('mgr_purge_non_venv_salt') %}
 mgr_purge_non_venv_salt_packages:

--- a/susemanager-utils/susemanager-sls/src/tests/test_mgr_master_tops.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_mgr_master_tops.py
@@ -24,7 +24,8 @@ TEST_MANAGER_STATIC_TOP = {
         "services.salt-minion",
         "services.docker",
         "services.kiwi-image-server",
-        "ansible"
+        "ansible",
+        "switch_to_bundle.mgr_switch_to_venv_minion"
     ]
 }
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Include automatic migration from Salt 3000 to Salt Bundle in highstate
 - fix duplicate packages in state
 - Fix enabling bundle build via custom info
 - Rename internal state 'synccustomall' to 'syncall'


### PR DESCRIPTION
## What does this PR change?

This is the implementation corresponding to the Uyuni RFC [#00096 ](https://github.com/uyuni-project/uyuni-rfc/blob/master/accepted/00096-automatic-migration-salt-bundle.md)

The intention of this PR is to automatically perform the migration for Salt 3000 clients to Salt Bundle, as Salt 3000 is EOL. This process should be transparent to the user.

The implementation adds a migration state to the highstate that checks the conditions to performe the migration are satisfied.

NOTE: This has been manually tested with an SLE 12 SP5 and a CentOS 7 client in the development environment.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage

- No tests: already covered

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/21145

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
