### PR TITLE
Avoid conflict names for openSUSE channels

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1076,7 +1076,7 @@ repo_url = http://download.opensuse.org/update/leap/15.3/non-oss/
 
 [opensuse_leap15_3-sle-updates]
 label    = %(base_channel)s-sle-updates
-name     = Update repository with updates from SUSE Linux Enterprise 15 (%(arch)s)
+name     = Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.3 (%(arch)s)
 archs    = x86_64, aarch64
 checksum = sha256
 base_channels = opensuse_leap15_3-%(arch)s
@@ -1084,7 +1084,7 @@ repo_url = http://download.opensuse.org/update/leap/15.3/sle/
 
 [opensuse_leap15_3-backports-updates]
 label    = %(base_channel)s-backports-updates
-name     = Update repository of openSUSE Backports (%(arch)s)
+name     = Update repository of openSUSE Leap 15.3 Backports (%(arch)s)
 archs    = x86_64, aarch64
 checksum = sha256
 base_channels = opensuse_leap15_3-%(arch)s
@@ -1148,7 +1148,7 @@ repo_url = http://download.opensuse.org/update/leap/15.4/non-oss/
 
 [opensuse_leap15_4-sle-updates]
 label    = %(base_channel)s-sle-updates
-name     = Update repository with updates from SUSE Linux Enterprise 15 (%(arch)s)
+name     = Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.4 (%(arch)s)
 archs    = x86_64, aarch64
 checksum = sha256
 base_channels = opensuse_leap15_4-%(arch)s
@@ -1156,7 +1156,7 @@ repo_url = http://download.opensuse.org/update/leap/15.4/sle/
 
 [opensuse_leap15_4-backports-updates]
 label    = %(base_channel)s-backports-updates
-name     = Update repository of openSUSE Backports (%(arch)s)
+name     = Update repository of openSUSE Leap 15.4 Backports (%(arch)s)
 archs    = x86_64, aarch64
 checksum = sha256
 base_channels = opensuse_leap15_4-%(arch)s
@@ -1220,7 +1220,7 @@ repo_url = http://download.opensuse.org/update/leap/15.5/non-oss/
 
 [opensuse_leap15_5-sle-updates]
 label    = %(base_channel)s-sle-updates
-name     = Update repository with updates from SUSE Linux Enterprise 15 (%(arch)s)
+name     = Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (%(arch)s)
 archs    = x86_64, aarch64
 checksum = sha256
 base_channels = opensuse_leap15_5-%(arch)s
@@ -1228,7 +1228,7 @@ repo_url = http://download.opensuse.org/update/leap/15.5/sle/
 
 [opensuse_leap15_5-backports-updates]
 label    = %(base_channel)s-backports-updates
-name     = Update repository of openSUSE Backports (%(arch)s)
+name     = Update repository of openSUSE Leap 15.5 Backports (%(arch)s)
 archs    = x86_64, aarch64
 checksum = sha256
 base_channels = opensuse_leap15_5-%(arch)s
@@ -1268,7 +1268,7 @@ dist_map_release = 15.4
 
 [opensuse_micro5_3-sle-updates]
 label    = %(base_channel)s-sle-updates
-name     = SLE Micro Update Repository (%(arch)s)
+name     = SLE Micro 5.3 Update Repository (%(arch)s)
 archs    = x86_64, aarch64
 checksum = sha256
 base_channels = opensuse_micro5_3-%(arch)s

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- Avoid conflicting names for openSUSE channels
 - Add openEuler 22.03 repositories
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Avoid conflict names for openSUSE channels (I was aware that labels could conflict, but not names)

Problem reported at the mailing list: https://lists.opensuse.org/archives/list/users@lists.uyuni-project.org/thread/ALGZ7DZHN3E6ZGI2WDWCOCV35MQJ3OOP/

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: The channel labels are used for spacewalk-common-channel, so this change is not relevant.

- [x] **DONE**

## Test coverage
- No tests: We don't have tests for `spacewalk-common-channels` for now.

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/6831 and fixes https://github.com/SUSE/spacewalk/issues/21043

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
