### PR TITLE
use dist-upgrade for updating all packages on a debian system

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/packages/pkgupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/pkgupdate.sls
@@ -6,6 +6,7 @@ mgr_pkg_update:
     - refresh: True
 {%- if grains['os_family'] == 'Debian' %}
     - skip_verify: {{ not pillar.get('mgr_metadata_signing_enabled', false) }}
+    - dist_upgrade: True
 {%- endif %}
     - diff_attr: ['epoch', 'version', 'release', 'arch', 'install_date_time_t']
     - require:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- to update everything on a debian system, call dist-upgrade to
+  be able to install and remove packages
 - Add openEuler 22.03 support
 - support multiple gpgkey urls for a channel (bsc#1208540)
 - make SUSE Addon GPG key available on all instance (bsc#1208540)


### PR DESCRIPTION
## What does this PR change?

Updating all packages fail on debian systems when kernel needs to be added or removed.
To do this, we need to call "dist-upgrade" according to https://itsfoss.com/apt-get-upgrade-vs-dist-upgrade/

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/6595
Tracks https://github.com/SUSE/spacewalk/pull/21062 https://github.com/SUSE/spacewalk/pull/21063

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
