### PR TITLE
Add kiwi supported disk images to be collectable

### DIFF
--- a/susemanager-utils/susemanager-sls/src/modules/kiwi_info.py
+++ b/susemanager-utils/susemanager-sls/src/modules/kiwi_info.py
@@ -164,10 +164,16 @@ _compression_types = [
     { 'suffix': '.gz', 'compression': 'gzip' },
     { 'suffix': '.bz', 'compression': 'bzip' },
     { 'suffix': '.xz', 'compression': 'xz' },
-    { 'suffix': '.install.iso',    'compression': None },
-    { 'suffix': '.iso',            'compression': None },
-    { 'suffix': '.qcow2',          'compression': None },
-    { 'suffix': '.raw',            'compression': None },
+    { 'suffix': '.install.iso', 'compression': None },
+    { 'suffix': '.iso',         'compression': None },
+    { 'suffix': '.qcow2',       'compression': None },
+    { 'suffix': '.ova',         'compression': None },
+    { 'suffix': '.vmdk',        'compression': None },
+    { 'suffix': '.vmx',         'compression': None },
+    { 'suffix': '.vhd',         'compression': None },
+    { 'suffix': '.vhdx',        'compression': None },
+    { 'suffix': '.vdi',         'compression': None },
+    { 'suffix': '.raw',         'compression': None },
     { 'suffix': '',    'compression': None }
     ]
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Add kiwi supported disk images to be collectable (bsc#1208522)
 - Add openEuler 22.03 support
 - support multiple gpgkey urls for a channel (bsc#1208540)
 - make SUSE Addon GPG key available on all instance (bsc#1208540)


### PR DESCRIPTION
## What does this PR change?

Our kiwi inspection code looks for specific file suffixes. If image is present but suffix is unknown then the image is not collected and inspection phase will fails. This PR adds kiwi supported file formats.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/21052
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
