### PR TITLE
Enable KiwiNG to be used on SLE12 buildhosts

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
+++ b/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
@@ -15,10 +15,11 @@
 {%- set cache_dir  = root_dir + '/cache/' %}
 {%- set bundle_id  = pillar.get('build_id') %}
 {%- set activation_key = pillar.get('activation_key') %}
-{%- set use_bundle_build = pillar.get('use_bundle_build', False) %}
+{%- set use_bundle_build = pillar.get('use_bundle_build', salt['pillar.get']('custom_info:use_bundle_build', False)) %}
+{%- set force_kiwi_ng = pillar.get('use_kiwi_ng', salt['pillar.get']('custom_info:use_kiwi_ng', False)) %}
 
 # on SLES11 and SLES12 use legacy Kiwi, use Kiwi NG elsewhere
-{%- set use_kiwi_ng = not (salt['grains.get']('osfullname') == 'SLES' and salt['grains.get']('osmajorrelease')|int() < 15) %}
+{%- set use_kiwi_ng = not (salt['grains.get']('osfullname') == 'SLES' and salt['grains.get']('osmajorrelease')|int() < 15) or force_kiwi_ng %}
 
 mgr_buildimage_prepare_source:
   file.directory:

--- a/susemanager-utils/susemanager-sls/salt/services/kiwi-image-server.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/kiwi-image-server.sls
@@ -1,41 +1,35 @@
 # Image Server installation state - part of SUSE Manager for Retail
 #
-# Copyright (c) 2017 - 2021 SUSE LLC
+# Copyright (c) 2017 - 2022 SUSE LLC
 
 {% if pillar['addon_group_types'] is defined and 'osimage_build_host' in pillar['addon_group_types'] %}
-{% set kiwi_dir = '/var/lib/Kiwi' %}
+{%- set kiwi_dir = '/var/lib/Kiwi' %}
+{%- set force_kiwi_ng = pillar.get('use_kiwi_ng', salt['pillar.get']('custom_info:use_kiwi_ng', False)) %}
 
-# on SLES11 and SLES12 use legacy Kiwi, use Kiwi NG elsewhere
-{%- set use_kiwi_ng = not (salt['grains.get']('osfullname') == 'SLES' and salt['grains.get']('osmajorrelease')|int() < 15) %}
+{# on SLES11 and SLES12 use legacy Kiwi, use Kiwi NG elsewhere #}
+{%- set use_kiwi_ng = not (salt['grains.get']('osfullname') == 'SLES' and salt['grains.get']('osmajorrelease')|int() < 15) or force_kiwi_ng %}
 {%- set available_packages = salt['pkg.search']('kiwi').keys() %}
 
-{%- if use_kiwi_ng %}
-mgr_install_kiwi:
-  pkg.installed:
-    - pkgs:
-      - python3-kiwi
-{%- if 'kiwi-systemdeps-disk-images' in available_packages %}
-      - kiwi-systemdeps-disk-images
-      - kiwi-systemdeps-image-validation
-      - kiwi-systemdeps-iso-media
-{%- endif %}
-{%- if 'kiwi-systemdeps-containers' in available_packages %}
-      - kiwi-systemdeps-containers
-{%- endif %}
-      - kiwi-boot-descriptions
+{# Set correct package list base on SLES version but independent of kiwi_ng usage #}
+{%- if salt['grains.get']('osfullname') == 'SLES' and salt['grains.get']('osmajorrelease')|int() < 15 %}
+{%-   set kiwi_modules = ['kiwi-desc-netboot', 'kiwi-desc-saltboot', 'kiwi-desc-vmxboot', 'kiwi-desc-oemboot', 'kiwi-desc-isoboot'] %}
 {%- else %}
-{% set kiwi_boot_modules = ['kiwi-desc-netboot', 'kiwi-desc-saltboot', 'kiwi-desc-vmxboot', 'kiwi-desc-oemboot', 'kiwi-desc-isoboot'] %}
+{%-   set kiwi_modules = ['kiwi-systemdeps-disk-images', 'kiwi-systemdeps-disk-images', 'kiwi-systemdeps-image-validation', 'kiwi-systemdeps-iso-media', 'kiwi-systemdeps-containers', 'kiwi-boot-descriptions'] %}
+{%- endif %}
 
 mgr_install_kiwi:
   pkg.installed:
     - pkgs:
+{%- if use_kiwi_ng %}
+      - python3-kiwi
+{%- else %}
       - kiwi
-{% for km in kiwi_boot_modules %}
-    {% if km in available_packages %}
+{%- endif %}
+{%- for km in kiwi_modules %}
+{%-   if km in available_packages %}
       - {{ km }}
-    {% endif %}
-{% endfor %}
-{% endif %}
+{%-   endif %}
+{%- endfor %}
 
 mgr_kiwi_build_tools:
   pkg.installed:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Allow KiwiNG to be used on SLE12 buildhosts (bsc#1204089)
 - Add kiwi supported disk images to be collectable (bsc#1208522)
 - disable salt-minion and remove its config file on cleanup (bsc#1209277)
 


### PR DESCRIPTION
## What does this PR change?

forward port of https://github.com/SUSE/spacewalk/pull/21021

We still use kiwi-legacy to build SLE12 images. Because of old codebase, supportability is very limited and using new kiwi-ng is recommended even for SLE12 images. Since we do not support SLE11 anymore, this PR introduces optional kiwi-ng usage for SLE12 images on SLE12 buildhosts.

To enable kiwi-ng on SLE12 buildhosts either use `use_kiwi_ng: True` pillar, or create custom_info key for build host with `use_kiwi_ng` with `True` value.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19213
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
