### PR TITLE
QE: Validate that recommended products are selected if its parent is selected

### DIFF
--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -39,14 +39,18 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I enter "SUSE Linux Enterprise Server 15 SP4" as the filtered product description
     And I wait until I see "SUSE Linux Enterprise Server 15 SP4 x86_64" text
     And I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP4 x86_64"
-    Then I should see a "Basesystem Module 15 SP4 x86_64" text
-    And I should see that the "Basesystem Module 15 SP4 x86_64" product is "recommended"
+    And I open the sub-list of the product "Basesystem Module 15 SP4 x86_64"
+    And I open the sub-list of the product "Desktop Applications Module 15 SP4 x86_64"
+    And I open the sub-list of the product "SUSE Manager Client Tools for SLE 15 x86_64"
+    Then I should see that the "Basesystem Module 15 SP4 x86_64" product is "recommended"
+    And I should see that the "Server Applications Module 15 SP4 x86_64" product is "recommended"
+    And I should see that the "SUSE Manager Client Tools for SLE 15 x86_64" product is "recommended"
     When I select "SUSE Linux Enterprise Server 15 SP4 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server 15 SP4 x86_64" selected
     And I should see the "Basesystem Module 15 SP4 x86_64" selected
-    When I open the sub-list of the product "Basesystem Module 15 SP4 x86_64"
-    And I select "Desktop Applications Module 15 SP4 x86_64" as a product
-    And I open the sub-list of the product "Desktop Applications Module 15 SP4 x86_64"
+    And I should see the "Server Applications Module 15 SP4 x86_64" selected
+    And I should see the "SUSE Manager Client Tools for SLE 15 x86_64" selected
+    When I select "Desktop Applications Module 15 SP4 x86_64" as a product
     And I select "Development Tools Module 15 SP4 x86_64" as a product
     Then I should see the "Desktop Applications Module 15 SP4 x86_64" selected
     And I should see the "Development Tools Module 15 SP4 x86_64" selected

--- a/testsuite/features/step_definitions/setup_steps.rb
+++ b/testsuite/features/step_definitions/setup_steps.rb
@@ -155,9 +155,12 @@ end
 Then(/^the SLE15 (SP3|SP4) product should be added$/) do |sp_version|
   output, _code = $server.run('echo -e "admin\nadmin\n" | mgr-sync list channels', check_errors: false, buffer_size: 1_000_000)
   STDOUT.puts "Products list:\n#{output}"
-  raise unless output.include? "[I] SLE-Product-SLES15-#{sp_version}-Pool for x86_64 SUSE Linux Enterprise Server 15 #{sp_version} x86_64 [sle-product-sles15-#{sp_version.downcase}-pool-x86_64]"
-  raise unless output.include? "[I] SLE-Module-Basesystem15-#{sp_version}-Updates for x86_64 Basesystem Module 15 #{sp_version} x86_64 [sle-module-basesystem15-#{sp_version.downcase}-updates-x86_64]"
-  raise unless output.include? "[I] SLE-Module-Server-Applications15-#{sp_version}-Pool for x86_64 Server Applications Module 15 #{sp_version} x86_64 [sle-module-server-applications15-#{sp_version.downcase}-pool-x86_64]"
+  match = "[I] SLE-Product-SLES15-#{sp_version}-Pool for x86_64 SUSE Linux Enterprise Server 15 #{sp_version} x86_64 [sle-product-sles15-#{sp_version.downcase}-pool-x86_64]"
+  raise "Not included:\n #{match}" unless output.include? match
+  match = "[I] SLE-Module-Basesystem15-#{sp_version}-Updates for x86_64 Basesystem Module 15 #{sp_version} x86_64 [sle-module-basesystem15-#{sp_version.downcase}-updates-x86_64]"
+  raise "Not included:\n #{match}" unless output.include? match
+  match = "[I] SLE-Module-Server-Applications15-#{sp_version}-Pool for x86_64 Server Applications Module 15 #{sp_version} x86_64 [sle-module-server-applications15-#{sp_version.downcase}-pool-x86_64]"
+  raise "Not included:\n #{match}" unless output.include? match
 end
 
 When(/^I click the channel list of product "(.*?)"$/) do |product|


### PR DESCRIPTION
## What does this PR change?

Validate that recommended products are selected if its parent is selected.
This PR wants to give us more information about an issue we are experiencing in our testsuite, where apparently one of our recommended products is not selected automatically.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
