### PR TITLE
spacewalk-setup: Remove ownership of /etc/tomcat

### DIFF
--- a/spacewalk/setup/spacewalk-setup.spec
+++ b/spacewalk/setup/spacewalk-setup.spec
@@ -94,6 +94,7 @@ Requires:       perl-Satcon
 Requires:       spacewalk-admin
 Requires:       spacewalk-backend-tools
 Requires:       spacewalk-certs-tools
+Requires(pre):  tomcat
 %if 0%{?build_py3}
 Requires:       (python3-PyYAML or python3-pyyaml)
 %else

--- a/spacewalk/setup/spacewalk-setup.spec
+++ b/spacewalk/setup/spacewalk-setup.spec
@@ -287,8 +287,6 @@ make test
 %dir %attr(0755, root, root) %{_prefix}/share/salt-formulas/
 %dir %attr(0755, root, root) %{_prefix}/share/salt-formulas/states/
 %dir %attr(0755, root, root) %{_prefix}/share/salt-formulas/metadata/
-%dir %attr(0755, root, root) %{_sysconfdir}/tomcat/
-%dir %attr(0755, root, root) %{_sysconfdir}/tomcat/conf.d/
 %dir %{_datadir}/spacewalk
 %{_datadir}/spacewalk/*
 %if 0%{?rhel} || 0%{?fedora}


### PR DESCRIPTION
## What does this PR change?

Remove ownership of `/etc/tomcat` as it should be (and also is) owned by the tomcat package. Keeping this would result in installation conflicts.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

I don't think a changelog is required here as it fixes a previous PR without intermediate release.

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
