### PR TITLE
Fix failing tests in our Cobbler CI due wrong dhcpd testing settings

### DIFF
--- a/susemanager-utils/testing/docker/scripts/Makefile
+++ b/susemanager-utils/testing/docker/scripts/Makefile
@@ -14,8 +14,8 @@ pull_container ::
 
 cobbler_tests :: pull_container
 	@echo "Running cobbler tests"
-	docker run --rm -v $(CURDIR)/../../../../cobbler_reports:/reports -v $(CURDIR)/test_cobbler.sh:/test_cobbler.sh $(DOCKER_CONTAINER) /test_cobbler.sh
+	docker run --cap-add=NET_ADMIN --rm -v $(CURDIR)/../../../../cobbler_reports:/reports -v $(CURDIR)/test_cobbler.sh:/test_cobbler.sh -v $(CURDIR)/docker-setup-cobbler-system-tests-env.sh:/docker-setup-cobbler-system-tests-env.sh $(DOCKER_CONTAINER) /test_cobbler.sh
 
 cobbler_tests_shell ::
 	@echo "Spawning a shell inside of the cobbler tests container"
-	docker run --rm -ti -v $(CURDIR)/../../../../cobbler_reports:/reports -v $(CURDIR)/test_cobbler.sh:/test_cobbler.sh $(DOCKER_CONTAINER) /bin/bash
+	docker run --cap-add=NET_ADMIN --rm -ti -v $(CURDIR)/../../../../cobbler_reports:/reports -v $(CURDIR)/test_cobbler.sh:/test_cobbler.sh -v $(CURDIR)/docker-setup-cobbler-system-tests-env.sh:/docker-setup-cobbler-system-tests-env.sh $(DOCKER_CONTAINER) /bin/bash

--- a/susemanager-utils/testing/docker/scripts/docker-setup-cobbler-system-tests-env.sh
+++ b/susemanager-utils/testing/docker/scripts/docker-setup-cobbler-system-tests-env.sh
@@ -1,0 +1,26 @@
+#!/bin/sh -e
+# Bootstrap the OS for system tests
+
+server=192.168.1.1
+bridge=pxe
+etc_qemu=$(test -e /etc/qemu-kvm && echo /etc/qemu-kvm || echo /etc/qemu)
+
+ip link add ${bridge} type bridge
+ip address add ${server}/24 dev ${bridge}
+ip link set up dev ${bridge}
+
+mkdir -p ${etc_qemu}
+echo allow ${bridge} >>${etc_qemu}/bridge.conf
+
+cat >/etc/cobbler/settings.d/system-tests.settings <<-EOF
+	server: ${server}
+	next_server_v4: ${server}
+	manage_dhcp: true
+	manage_dhcp_v4: true
+	manage_dhcp_v6: false
+	power_management_default_type: 'ipmilan'
+EOF
+
+supervisorctl restart cobblerd
+
+cobbler mkloaders

--- a/susemanager-utils/testing/docker/scripts/test_cobbler.sh
+++ b/susemanager-utils/testing/docker/scripts/test_cobbler.sh
@@ -19,21 +19,15 @@ cp /root/sample.ks /var/lib/cobbler/kickstarts/sample.ks
 # start apache - required by cobbler tests
 /usr/sbin/start_apache2 -D SYSTEMD  -k start
 
-# start cobbler daemon
-cobblerd
-
 ln -s /usr/share/cobbler/ /code
-
-# Configure DHCP
-sed -i 's/DHCPD_INTERFACE=""/DHCPD_INTERFACE="ANY"/' /etc/sysconfig/dhcpd
-echo "subnet 172.17.0.0 netmask 255.255.255.0 {}"  >> /etc/dhcpd.conf
-sed -i "s/dhcpd -4 -f/dhcpd -f/g" /code/docker/develop/supervisord/conf.d/dhcpd.conf
-sed -i "s/nogroup pxe/nogroup/g" /code/docker/develop/supervisord/conf.d/dhcpd.conf
 
 # Configure PAM
 useradd -p $(perl -e 'print crypt("test", "password")') test
 
 sh /code/docker/develop/scripts/setup-supervisor.sh || true
+
+# Run system-tests bootstrap to prepare dhcpd and expected pxe testing interface
+sh /docker-setup-cobbler-system-tests-env.sh
 
 # execute the tests
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes the current failing tests for Cobbler in our Jenkins CI while Cobbler CI images and jobs are being restructured to be aligned with upstream.

It is expected that we get rid of some of the changes in this PR as soon as we finish the alignment with upstream CI testing.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/20850

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
