### PR TITLE
Fix datetimepicker time to match user configured timezone (bsc#1209231)

### DIFF
--- a/web/html/src/components/datetime/DateTimePicker.tsx
+++ b/web/html/src/components/datetime/DateTimePicker.tsx
@@ -146,7 +146,7 @@ export const DateTimePicker = (props: Props) => {
             &nbsp;<i className="fa fa-clock-o"></i>
           </span>
           <ReactDatePicker
-            key="date-picker"
+            key="time-picker"
             portalId="time-picker-portal"
             ref={timePickerRef}
             selected={browserTimezoneValue.toDate()}

--- a/web/html/src/components/datetime/DateTimePicker.tsx
+++ b/web/html/src/components/datetime/DateTimePicker.tsx
@@ -84,8 +84,6 @@ export const DateTimePicker = (props: Props) => {
     }
   };
 
-  window.localizedMoment = localizedMoment;
-
   // We use localizedMoment to clone the date so we don't modify the original
   const browserTimezoneValue = localizedMoment(props.value)
     // We convert the date to the users configured timezone because this is what we want to show the user

--- a/web/html/src/manager/legacy/DateTimePicker.tsx
+++ b/web/html/src/manager/legacy/DateTimePicker.tsx
@@ -54,10 +54,10 @@ function mountDateTimePickerTo(mountingPoint: HTMLElement | null) {
     const [value, setValue] = useState(initialValue);
 
     const onChange = (value: moment.Moment) => {
-      // Per default the picker outputs the time in server timezone. Since in this case converting to
-      // server timezone is already done on the backend side we create a copy of the value in the user
-      // selected timezone to prevent applying the offset between server and user timezone twice.
-      const adjustedValue = localizedMoment(value).utc().tz(localizedMoment.userTimeZone);
+      // We transfer the date without timezone information and the server implicitly expects the values
+      // to match the users configured timezone. Since we get the date in utc we need to convert it to the
+      // users configured timezone again.
+      const adjustedValue = localizedMoment(value).tz(localizedMoment.userTimeZone);
       yearInput.value = adjustedValue.year().toString();
       monthInput.value = adjustedValue.month().toString();
       dateInput.value = adjustedValue.date().toString();

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- fix an issue where the datetimepicker shows wrong date (bsc#1209231)
 - Fix datetime picker appearing behind modal edge
 - Refactor Software / Manage / Packages to use SQL paging (bsc#1206725)
 - Fix UI inconsistencies in susemanager-light and susemanager-dark


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/21027

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
