### PR TITLE
Ci fix reportdb tests 2

### DIFF
--- a/testsuite/dockerfiles/server-all-in-one-dev/Dockerfile
+++ b/testsuite/dockerfiles/server-all-in-one-dev/Dockerfile
@@ -13,6 +13,7 @@ RUN zypper ref && \
       servletapi5 \
       cpio \
       spacecmd \
+      expect \
       wget && \
     zypper addrepo --no-gpgcheck obs://systemsmanagement:Uyuni:Utils systemsmanagement:uyuni:utils && \
     zypper -n install obs-to-maven yarn && \

--- a/testsuite/features/secondary/srv_reportdb.feature
+++ b/testsuite/features/secondary/srv_reportdb.feature
@@ -1,7 +1,6 @@
 # Copyright (c) 2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@skip_if_container
 @scope_reportdb
 Feature: ReportDB
   In order to use reporting tools


### PR DESCRIPTION
## What does this PR change?

Enable reportdb tests.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20961

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
