### PR TITLE
CI: Acceptance tests at PR v2: enable cve id tests

### DIFF
--- a/testsuite/features/secondary/min_cve_id_new_syntax.feature
+++ b/testsuite/features/secondary/min_cve_id_new_syntax.feature
@@ -1,7 +1,6 @@
 # Copyright (c) 2015-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@skip_if_container
 @scope_cve_audit
 Feature: Support for new CVE-ID syntax
 


### PR DESCRIPTION
## What does this PR change?

CI: enable back cve tests

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20953

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
