### PR TITLE
Add debugging UI for DateTimePicker

### DIFF
--- a/web/html/src/components/datetime/DateTimePicker.tsx
+++ b/web/html/src/components/datetime/DateTimePicker.tsx
@@ -6,6 +6,9 @@ import ReactDatePicker from "react-datepicker";
 
 import { localizedMoment } from "utils";
 
+// Turn this on to view internal state under the picker in the UI
+const SHOW_DEBUG_VALUES = false;
+
 type InputPassthroughProps = {
   "data-id": string | undefined;
 };
@@ -107,73 +110,84 @@ export const DateTimePicker = (props: Props) => {
   ];
 
   return (
-    <div className="input-group">
-      {hideDatePicker ? null : (
-        <>
-          <span key="calendar" className="input-group-addon" data-picker-type="date" onClick={() => openDatePicker()}>
-            &nbsp;<i className="fa fa-calendar"></i>
-          </span>
-          <ReactDatePicker
-            key="date-picker"
-            /**
-             * Here and below, since an element with this id doesn't exist it will be created for the portal in the document
-             * body. Please don't remove this as it otherwise breaks z-index stacking.
-             */
-            portalId="date-picker-portal"
-            ref={datePickerRef}
-            selected={browserTimezoneValue.toDate()}
-            onChange={onChange}
-            dateFormat={DATE_FORMAT}
-            wrapperClassName="form-control date-time-picker-wrapper"
-            popperModifiers={popperModifiers}
-            // This is used by Cucumber to check whether the picker is open
-            popperClassName="date-time-picker-popup"
-            customInput={
-              <InputPassthrough
-                data-id={datePickerId}
-                // TODO: The styling logic here is hacky, would be nice to clean it up once everything works
-                className="form-control"
-                // This is used by Cucumber to interact with the component
-                data-testid="date-picker"
-              />
-            }
-          />
-        </>
-      )}
-      {hideTimePicker ? null : (
-        <>
-          <span key="clock" className="input-group-addon" data-picker-type="time" onClick={openTimePicker}>
-            &nbsp;<i className="fa fa-clock-o"></i>
-          </span>
-          <ReactDatePicker
-            key="time-picker"
-            portalId="time-picker-portal"
-            ref={timePickerRef}
-            selected={browserTimezoneValue.toDate()}
-            onChange={onChange}
-            showTimeSelect
-            showTimeSelectOnly
-            // We want the regular primary display to only show the time here, so using TIME_FORMAT is intentional
-            dateFormat={TIME_FORMAT}
-            timeFormat={TIME_FORMAT}
-            wrapperClassName="form-control date-time-picker-wrapper"
-            popperModifiers={popperModifiers}
-            // This is used by Cucumber to check whether the picker is open
-            popperClassName="date-time-picker-popup"
-            customInput={
-              <InputPassthrough
-                data-id={timePickerId}
-                className="form-control"
-                // This is used by Cucumber to interact with the component
-                data-testid="time-picker"
-              />
-            }
-          />
-        </>
-      )}
-      <span className="input-group-addon" key="tz">
-        {timeZone}
-      </span>
-    </div>
+    <>
+      <div className="input-group">
+        {hideDatePicker ? null : (
+          <>
+            <span key="calendar" className="input-group-addon" data-picker-type="date" onClick={() => openDatePicker()}>
+              &nbsp;<i className="fa fa-calendar"></i>
+            </span>
+            <ReactDatePicker
+              key="date-picker"
+              /**
+               * Here and below, since an element with this id doesn't exist it will be created for the portal in the document
+               * body. Please don't remove this as it otherwise breaks z-index stacking.
+               */
+              portalId="date-picker-portal"
+              ref={datePickerRef}
+              selected={browserTimezoneValue.toDate()}
+              onChange={onChange}
+              dateFormat={DATE_FORMAT}
+              wrapperClassName="form-control date-time-picker-wrapper"
+              popperModifiers={popperModifiers}
+              // This is used by Cucumber to check whether the picker is open
+              popperClassName="date-time-picker-popup"
+              customInput={
+                <InputPassthrough
+                  data-id={datePickerId}
+                  // TODO: The styling logic here is hacky, would be nice to clean it up once everything works
+                  className="form-control"
+                  // This is used by Cucumber to interact with the component
+                  data-testid="date-picker"
+                />
+              }
+            />
+          </>
+        )}
+        {hideTimePicker ? null : (
+          <>
+            <span key="clock" className="input-group-addon" data-picker-type="time" onClick={openTimePicker}>
+              &nbsp;<i className="fa fa-clock-o"></i>
+            </span>
+            <ReactDatePicker
+              key="time-picker"
+              portalId="time-picker-portal"
+              ref={timePickerRef}
+              selected={browserTimezoneValue.toDate()}
+              onChange={onChange}
+              showTimeSelect
+              showTimeSelectOnly
+              // We want the regular primary display to only show the time here, so using TIME_FORMAT is intentional
+              dateFormat={TIME_FORMAT}
+              timeFormat={TIME_FORMAT}
+              wrapperClassName="form-control date-time-picker-wrapper"
+              popperModifiers={popperModifiers}
+              // This is used by Cucumber to check whether the picker is open
+              popperClassName="date-time-picker-popup"
+              customInput={
+                <InputPassthrough
+                  data-id={timePickerId}
+                  className="form-control"
+                  // This is used by Cucumber to interact with the component
+                  data-testid="time-picker"
+                />
+              }
+            />
+          </>
+        )}
+        <span className="input-group-addon" key="tz">
+          {timeZone}
+        </span>
+      </div>
+      {process.env.NODE_ENV !== "production" && SHOW_DEBUG_VALUES ? (
+        <pre>
+          user:{"   "}
+          {props.value.toUserDateTimeString()} ({localizedMoment.userTimeZone})<br />
+          server: {props.value.toServerDateTimeString()} ({localizedMoment.serverTimeZone})<br />
+          iso:{"    "}
+          {props.value.toISOString()}
+        </pre>
+      ) : null}
+    </>
   );
 };


### PR DESCRIPTION
## What does this PR change?

Debugging utilities to easily untangle issues with DateTimePicker, cherry-picked from https://github.com/SUSE/spacewalk/pull/21064.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
