### PR TITLE
Sanitize logged data in RenderKickstartFileAction

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/RenderKickstartFileAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/RenderKickstartFileAction.java
@@ -86,7 +86,8 @@ public class RenderKickstartFileAction extends Action {
                 else {
                     if (log.isDebugEnabled()) {
                         log.error("No kickstart filecontents found for: {} params: {} ksdata: {}",
-                                StringUtil.sanitizeLogInput(url), params, ksdata);
+                                StringUtil.sanitizeLogInput(url), StringUtil.sanitizeLogInput(params.toString()),
+                                ksdata);
                     }
                     // send 404 to the user since we don't have a kickstart profile match
                     throw new NoSuchKickstartException();


### PR DESCRIPTION
## What does this PR change?

Fix https://sonarcloud.io/project/issues?resolved=false&severities=BLOCKER%2CCRITICAL%2CMAJOR%2CMINOR&sinceLeakPeriod=true&types=VULNERABILITY&id=uyuni-project_uyuni&open=AYcyhEfpc8r8RCRRorHO&tab=code

## GUI diff

No difference.
- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- []x **DONE**

## Test coverage
- No tests: log output change

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
