### PR TITLE
Testsuite: Correct name of fake channel in feature

### DIFF
--- a/testsuite/features/secondary/minssh_bootstrap_api.feature
+++ b/testsuite/features/secondary/minssh_bootstrap_api.feature
@@ -58,7 +58,7 @@ Feature: Register a salt-ssh system via API
     And I wait until I do not see "Loading..." text
     And I include the recommended child channels
     And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"
-    And I check "Fake-RPM-SLES-Channel"
+    And I check "Fake-RPM-SUSE-Channel"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"


### PR DESCRIPTION
## What does this PR change?
Forgotten change of name in this specific feature causing a failure on this step.
This channel name is now `Fake-RPM-SUSE-Channel` on Uyuni

![image](https://user-images.githubusercontent.com/100688791/231802260-b0a9d140-34c4-4be6-b3fd-fed415f9f14f.png)


## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links
Fixes # https://github.com/SUSE/spacewalk/issues/20944
Tracks # No ports needed
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
