### PR TITLE
Mapping of image URLs

### DIFF
--- a/containers/proxy-httpd-image/proxy-httpd-image.changes
+++ b/containers/proxy-httpd-image/proxy-httpd-image.changes
@@ -1,3 +1,4 @@
+- Redirect /saltboot to the server
 - Integrate the containerized proxy into the usual rel-eng workflow
 
 -------------------------------------------------------------------

--- a/containers/proxy-squid-image/proxy-squid-image.changes
+++ b/containers/proxy-squid-image/proxy-squid-image.changes
@@ -1,3 +1,4 @@
+- Add squid configuration for /saltboot
 - Integrate the containerized proxy into the usual rel-eng workflow
 
 -------------------------------------------------------------------

--- a/containers/proxy-squid-image/squid.conf
+++ b/containers/proxy-squid-image/squid.conf
@@ -36,6 +36,7 @@ refresh_pattern  \.rpm$  10080 100% 525600 override-expire override-lastmod igno
 refresh_pattern  \.deb$  10080 100% 525600 override-expire override-lastmod ignore-reload reload-into-ims
 # once downloaded images will never change. New image will have different revision number
 refresh_pattern /os-images/.*$ 10080 100% 525600 ignore-no-store ignore-reload ignore-private
+refresh_pattern /saltboot/.*$ 10080 100% 525600 ignore-no-store ignore-reload ignore-private
 # kernel and initrd are tied to images, will never change as well
 refresh_pattern /tftp/images/.*$ 10080 100% 525600 ignore-no-store ignore-reload ignore-private
 # rest of tftp are config files prone to change frequently

--- a/java/code/src/com/redhat/rhn/frontend/security/PxtAuthenticationService.java
+++ b/java/code/src/com/redhat/rhn/frontend/security/PxtAuthenticationService.java
@@ -68,6 +68,7 @@ public class PxtAuthenticationService extends BaseAuthenticationService {
         // password-reset-link destination
         set.add("/rhn/ResetLink");
         set.add("/rhn/ResetPasswordSubmit");
+        set.add("/rhn/saltboot");
 
         // HTTP API public endpoints
         set.addAll(HttpApiRegistry.getUnautenticatedRoutes());

--- a/java/code/src/com/redhat/rhn/testing/RhnMockHttpServletResponse.java
+++ b/java/code/src/com/redhat/rhn/testing/RhnMockHttpServletResponse.java
@@ -50,6 +50,15 @@ public class RhnMockHttpServletResponse extends MockHttpServletResponse {
     }
 
     /**
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    public void setHeader(String key, String value) {
+        header.put(key, value);
+    }
+
+    /**
      * Returns the String value matching the given key
      * @param key the header name
      * @return header value or null...

--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -52,6 +52,7 @@ import com.suse.manager.webui.controllers.ProxyController;
 import com.suse.manager.webui.controllers.RecurringActionController;
 import com.suse.manager.webui.controllers.SSOController;
 import com.suse.manager.webui.controllers.SaltSSHController;
+import com.suse.manager.webui.controllers.SaltbootController;
 import com.suse.manager.webui.controllers.SetController;
 import com.suse.manager.webui.controllers.SsmController;
 import com.suse.manager.webui.controllers.StatesAPI;
@@ -229,6 +230,9 @@ public class Router implements SparkApplication {
 
         // HTTP API
         httpApiRegistry.initRoutes();
+
+        // Saltboot
+        SaltbootController.initRoutes();
     }
 
     private void initNotFoundRoutes(JadeTemplateEngine jade) {

--- a/java/code/src/com/suse/manager/webui/controllers/SaltbootController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/SaltbootController.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.webui.controllers;
+
+import com.redhat.rhn.domain.image.ImageInfoFactory;
+import com.redhat.rhn.domain.org.Org;
+import com.redhat.rhn.domain.org.OrgFactory;
+
+import org.apache.http.HttpStatus;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import spark.Request;
+import spark.Response;
+import spark.Spark;
+
+/**
+ * Controller class for image file upload.
+ */
+public class SaltbootController {
+
+    private static final Logger LOG = LogManager.getLogger(SaltbootController.class);
+
+    private SaltbootController() { }
+
+    /**
+     * Initialize request routes for the pages served by SaltbootController
+     *
+     */
+    public static void initRoutes() {
+
+        Spark.get("/saltboot/*", SaltbootController::redirectImage);
+    }
+
+
+    private static Optional<String> mapPillarUrl(Map<String, Object> pillar, String path) {
+        try {
+            Map<String, Object> images = (Map<String, Object>)pillar.get("images");
+            Map<String, Object> image = (Map<String, Object>)images.entrySet().iterator().next().getValue();
+            Map<String, Object> imageVer = (Map<String, Object>)image.entrySet().iterator().next().getValue();
+            String imageUrl = (String)imageVer.get("url");
+            URL parsed = new URL(imageUrl);
+            LOG.debug("Have image {}", parsed.getPath());
+            if (parsed.getPath().equals(path)) {
+                Map<String, Object> sync = (Map<String, Object>)imageVer.get("sync");
+                String mapped = (String)sync.get("url");
+                return Optional.ofNullable(mapped);
+            }
+        }
+        catch (NullPointerException e) {
+            LOG.error("Invalid image pillar", e);
+        }
+        catch (MalformedURLException e) {
+            LOG.error("Malformed image url", e);
+        }
+
+        try {
+            Map<String, Object> images = (Map<String, Object>)pillar.get("boot_images");
+            Map<String, Object> image = (Map<String, Object>)images.entrySet().iterator().next().getValue();
+            Map<String, Object> initrd = (Map<String, Object>)image.get("initrd");
+            Map<String, Object> sync = (Map<String, Object>)image.get("sync");
+            String initrdUrl = (String)initrd.get("url");
+            URL initrdParsed = new URL(initrdUrl);
+            LOG.debug("Have initrd {}", initrdParsed.getPath());
+            if (initrdParsed.getPath().equals(path)) {
+                String mapped = (String)sync.get("initrd_url");
+                return Optional.ofNullable(mapped);
+            }
+            Map<String, Object> kernel = (Map<String, Object>)image.get("kernel");
+            String kernelUrl = (String)kernel.get("url");
+            URL kernelParsed = new URL(kernelUrl);
+            LOG.debug("Have kernel {}", kernelParsed.getPath());
+            if (kernelParsed.getPath().equals(path)) {
+                String mapped = (String)sync.get("kernel_url");
+                return Optional.ofNullable(mapped);
+            }
+        }
+        catch (NullPointerException e) {
+            LOG.error("Invalid boot image pillar", e);
+        }
+        catch (MalformedURLException e) {
+            LOG.error("Malformed boot image url", e);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Redirect image url
+     * this provides the image syncing info to containerized proxy, which
+     * can't access image pillars via salt.
+     *
+     * @param request the request
+     * @param response the response
+     * @return empty string
+     */
+    public static String redirectImage(Request request, Response response) {
+        Long orgId = 1L;
+        try {
+            orgId = Long.parseLong(request.queryParams("orgid"));
+        }
+        catch (NumberFormatException e) {
+            Spark.halt(HttpStatus.SC_BAD_REQUEST);
+        }
+        Org org = OrgFactory.lookupById(orgId);
+
+        Optional<String> mapped = ImageInfoFactory.listImageInfos(org).stream()
+            .map(image -> image.getPillar())
+            .filter(Objects::nonNull)
+            .map(pillar -> mapPillarUrl(pillar.getPillar(), request.pathInfo()))
+            .flatMap(Optional::stream)
+            .findFirst();
+
+        String logPath = request.pathInfo().replaceAll("[\n\r]", "_");
+        if (mapped.isPresent()) {
+            LOG.info("Redirecting {} to {}", logPath, mapped.get());
+            response.redirect(mapped.get(), HttpStatus.SC_MOVED_PERMANENTLY);
+        }
+        else {
+            LOG.error("Image not found in pillars: {}", logPath);
+            Spark.halt(HttpStatus.SC_NOT_FOUND, "Image not found in pillars");
+        }
+        return "";
+    }
+}

--- a/java/code/src/com/suse/manager/webui/controllers/test/SaltbootControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/SaltbootControllerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.controllers.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.domain.image.ImageInfo;
+import com.redhat.rhn.domain.image.ImageStore;
+import com.redhat.rhn.domain.server.Pillar;
+import com.redhat.rhn.testing.ImageTestUtils;
+import com.redhat.rhn.testing.RhnMockHttpServletResponse;
+import com.redhat.rhn.testing.TestUtils;
+
+import com.suse.manager.webui.controllers.SaltbootController;
+import com.suse.manager.webui.utils.SparkTestUtils;
+import com.suse.utils.Json;
+
+import com.google.gson.reflect.TypeToken;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileReader;
+import java.util.HashMap;
+import java.util.Map;
+
+import spark.Request;
+
+public class SaltbootControllerTest extends BaseControllerTestCase {
+    private static final String TEST_DIR = "/com/suse/manager/webui/controllers/test/";
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @Test
+    public void testSaltbootController() throws Exception {
+        ImageStore store = ImageTestUtils.createImageStore("registry.reg", user);
+        ImageInfo imageNoPillar = ImageTestUtils.createImageInfo("myimage1", "1.0.0", store, user);
+        ImageInfo image = ImageTestUtils.createImageInfo("myimage2", "1.0.0", store, user);
+
+        String path = new File(TestUtils.findTestData(TEST_DIR + "image_pillar.json")
+                     .getPath()).getAbsolutePath();
+        Map<String, Object> pillarData = Json.GSON.fromJson(new FileReader(path),
+                                         new TypeToken<Map<String, Object>>() { }.getType());
+
+
+        String category = "Image" + image.getId();
+        Pillar pillarEntry = new Pillar(category, pillarData, image.getOrg());
+        HibernateFactory.getSession().save(pillarEntry);
+        image.setPillar(pillarEntry);
+
+
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("orgid", user.getOrg().getId().toString());
+
+        ((RhnMockHttpServletResponse)response.raw()).setExpectedStatus(301);
+
+        Request request = SparkTestUtils.createMockRequestWithParams(
+            "http://localhost:8080/saltboot/boot/POS_Image_JeOS7.x86_64-7.1.0-1/POS_Image_JeOS7.x86_64-7.1.0.initrd",
+            queryParams);
+        SaltbootController.redirectImage(request, response);
+        assertEquals("https://server.suse.com/os-images/1/POS_Image_JeOS7-7.1.0-1/POS_Image_JeOS7.x86_64-7.1.0.initrd",
+            response.raw().getHeader("Location"));
+        request = SparkTestUtils.createMockRequestWithParams("http://localhost:8080/saltboot/boot/" +
+            "POS_Image_JeOS7.x86_64-7.1.0-1/POS_Image_JeOS7.x86_64-7.1.0-5.14.21-150400.24.55-default.kernel",
+            queryParams);
+        SaltbootController.redirectImage(request, response);
+        assertEquals("https://server.suse.com/os-images/1/" +
+            "POS_Image_JeOS7-7.1.0-1/POS_Image_JeOS7.x86_64-7.1.0-5.14.21-150400.24.55-default.kernel",
+            response.raw().getHeader("Location"));
+        request = SparkTestUtils.createMockRequestWithParams(
+            "http://localhost:8080/saltboot/image/POS_Image_JeOS7.x86_64-7.1.0-1/POS_Image_JeOS7.x86_64-7.1.0",
+            queryParams);
+        SaltbootController.redirectImage(request, response);
+        assertEquals("https://server.suse.com/os-images/1/POS_Image_JeOS7-7.1.0-1/POS_Image_JeOS7.x86_64-7.1.0",
+            response.raw().getHeader("Location"));
+    }
+
+
+    @Test
+    public void testSaltbootControllerWithInvalidUrl() throws Exception {
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("orgid", user.getOrg().getId().toString());
+
+        Request request = SparkTestUtils.createMockRequestWithParams(
+                "http://localhost:8080/saltboot/boot/something",
+                queryParams);
+
+        try {
+            SaltbootController.redirectImage(request, response);
+            fail("Controller should fail on non-existing image");
+        }
+        catch (spark.HaltException e) {
+            assertEquals(404, e.statusCode());
+        }
+    }
+}

--- a/java/code/src/com/suse/manager/webui/controllers/test/image_pillar.json
+++ b/java/code/src/com/suse/manager/webui/controllers/test/image_pillar.json
@@ -1,0 +1,48 @@
+{
+  "images": {
+    "POS_Image_JeOS7": {
+      "7.1.0-1": {
+        "url": "https://ftp/saltboot/image/POS_Image_JeOS7.x86_64-7.1.0-1/POS_Image_JeOS7.x86_64-7.1.0",
+        "arch": "x86_64",
+        "hash": "7368c101e96826053c6efde0588cf365",
+        "size": 1548746752,
+        "sync": {
+          "url": "https://server.suse.com/os-images/1/POS_Image_JeOS7-7.1.0-1/POS_Image_JeOS7.x86_64-7.1.0",
+          "hash": "7368c101e96826053c6efde0588cf365",
+          "local_path": "image/POS_Image_JeOS7.x86_64-7.1.0-1"
+        },
+        "type": "pxe",
+        "fstype": "ext3",
+        "filename": "POS_Image_JeOS7.x86_64-7.1.0",
+        "inactive": false,
+        "boot_image": "POS_Image_JeOS7-7.1.0-1"
+      }
+    }
+  },
+  "boot_images": {
+    "POS_Image_JeOS7-7.1.0-1": {
+      "arch": "x86_64",
+      "name": "POS_Image_JeOS7",
+      "sync": {
+        "initrd_url": "https://server.suse.com/os-images/1/POS_Image_JeOS7-7.1.0-1/POS_Image_JeOS7.x86_64-7.1.0.initrd",
+        "kernel_url": "https://server.suse.com/os-images/1/POS_Image_JeOS7-7.1.0-1/POS_Image_JeOS7.x86_64-7.1.0-5.14.21-150400.24.55-default.kernel",
+        "local_path": "POS_Image_JeOS7.x86_64-7.1.0-1"
+      },
+      "initrd": {
+        "url": "https://ftp/saltboot/boot/POS_Image_JeOS7.x86_64-7.1.0-1/POS_Image_JeOS7.x86_64-7.1.0.initrd",
+        "hash": "d38b74a373bc6c9def1f069a8533d99f",
+        "size": 118252253,
+        "version": "7.1.0",
+        "filename": "POS_Image_JeOS7.x86_64-7.1.0.initrd"
+      },
+      "kernel": {
+        "url": "https://ftp/saltboot/boot/POS_Image_JeOS7.x86_64-7.1.0-1/POS_Image_JeOS7.x86_64-7.1.0-5.14.21-150400.24.55-default.kernel",
+        "hash": "946dac0a19125d78e282afe0e3ebf0b6",
+        "size": 11444416,
+        "version": "5.14.21-150400.24.55-default",
+        "filename": "POS_Image_JeOS7.x86_64-7.1.0-5.14.21-150400.24.55-default.kernel"
+      },
+      "basename": "POS_Image_JeOS7.x86_64-7.1.0"
+    }
+  }
+}

--- a/java/code/webapp/WEB-INF/web.xml
+++ b/java/code/webapp/WEB-INF/web.xml
@@ -172,6 +172,7 @@
   <filter-mapping>
     <filter-name>AuthFilterSpark</filter-name>
     <url-pattern>/manager/*</url-pattern>
+    <url-pattern>/saltboot/*</url-pattern>
   </filter-mapping>
 
   <filter-mapping>
@@ -182,6 +183,7 @@
   <filter-mapping>
     <filter-name>SparkFilter</filter-name>
     <url-pattern>/manager/*</url-pattern>
+    <url-pattern>/saltboot/*</url-pattern>
   </filter-mapping>
 
   <filter-mapping>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add mapping of image URLs for containerized proxy
 - Fix image size entries in xml-rpc
 - kernel options: only add quotes if there is a space in the value (bsc#1209926)
 - fix displaying system channels when no base product is installed

--- a/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
+++ b/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
@@ -48,6 +48,9 @@ RewriteRule ^/ks/dist(.*)$ /rhn/common/DownloadFile.do?url=/ks/dist$1
 RewriteRule ^(/ty/.*)$ /rhn/common/DownloadFile.do?url=$1
 RewriteRule ^/index\.html$ /rhn/manager/login
 
+# for saltboot image redirection
+RewriteRule ^(/saltboot/.*)$ /rhn$1
+
 # For rhn-custom-info
 RewriteRule ^/WEBRPC /rhn/rpc/api
 
@@ -152,6 +155,9 @@ SetEnvIf Request_URI "/javascript" susemanager_static
 SetEnvIf Request_URI "/pub" susemanager_static
 SetEnvIf Request_URI "/errors" susemanager_static
 SetEnvIf Request_URI "/rhn/manager/download" susemanager_static
+SetEnvIf Request_URI "/os-images" susemanager_static
+SetEnvIf Request_URI "/saltboot" susemanager_static
+SetEnvIf Request_URI "/tftp" susemanager_static
 # Any non-whitelisted URI will not be cached by default
 Header set Cache-Control "no-cache,no-store,must-revalidate,private" env=!susemanager_static
 Header set Pragma "no-cache" env=!susemanager_static

--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,3 +1,6 @@
+- Add /saltboot directory
+- Mark /os-images and /tftp as static content
+
 -------------------------------------------------------------------
 Wed Dec 14 14:14:18 CET 2022 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Containerized proxy does not have access to pillars. This provides the mapping from proxy-local image URLs to global ones via http redirects.

Also, it fixes cache setting for `/os-images` and `/tftp` dirs.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: expected behavior
- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18455

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
