### PR TITLE
Added SLE-Micro 5.4 and openSUSE Leap Micro 5.4 to spacewalk-common-channels

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1264,7 +1264,7 @@ gpgkey_url = https://download.opensuse.org/distribution/leap-micro/5.3/product/r
 gpgkey_id = 3DBDC284
 gpgkey_fingerprint = 22C0 7BA5 3417 8CD0 2EFE  22AA B88B 2FD4 3DBD C284
 repo_url = https://download.opensuse.org/distribution/leap-micro/5.3/product/repo/Leap-Micro-5.3-%(arch)s-Media1/
-dist_map_release = 15.4
+dist_map_release = 5.3
 
 [opensuse_micro5_3-sle-updates]
 label    = %(base_channel)s-sle-updates
@@ -1304,7 +1304,7 @@ gpgkey_url = https://download.opensuse.org/distribution/leap-micro/5.4/product/r
 gpgkey_id = 3DBDC284
 gpgkey_fingerprint = 22C0 7BA5 3417 8CD0 2EFE  22AA B88B 2FD4 3DBD C284
 repo_url = https://download.opensuse.org/distribution/leap-micro/5.4/product/repo/Leap-Micro-5.4-%(arch)s-Media1/
-dist_map_release = 15.5
+dist_map_release = 5.4
 
 [opensuse_micro5_4-sle-updates]
 label    = %(base_channel)s-sle-updates
@@ -1370,7 +1370,7 @@ gpgkey_url = https://download.opensuse.org/distribution/leap-micro/5.3/product/r
 gpgkey_id = 3DBDC284
 gpgkey_fingerprint = 22C0 7BA5 3417 8CD0 2EFE  22AA B88B 2FD4 3DBD C284
 repo_url = http://download.opensuse.org/tumbleweed/repo/oss/
-dist_map_release = 15.4
+dist_map_release = 5.3
 
 [opensuse_microos-non-oss]
 label    = %(base_channel)s-non-oss

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1296,6 +1296,46 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
 
+[opensuse_micro5_4]
+checksum = sha256
+archs    = x86_64, aarch64
+name     = openSUSE Leap Micro 5.4 (%(arch)s)
+gpgkey_url = https://download.opensuse.org/distribution/leap-micro/5.4/product/repo/Leap-Micro-5.4-x86_64-Media1/gpg-pubkey-3dbdc284-53674dd4.asc
+gpgkey_id = 3DBDC284
+gpgkey_fingerprint = 22C0 7BA5 3417 8CD0 2EFE  22AA B88B 2FD4 3DBD C284
+repo_url = https://download.opensuse.org/distribution/leap-micro/5.4/product/repo/Leap-Micro-5.4-%(arch)s-Media1/
+dist_map_release = 15.5
+
+[opensuse_micro5_4-sle-updates]
+label    = %(base_channel)s-sle-updates
+name     = SLE Micro 5.4 Update Repository (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_micro5_4-%(arch)s
+repo_url = https://download.opensuse.org/update/leap-micro/5.4/sle/
+
+# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap Micro 5.X releases
+[opensuse_micro5_4-uyuni-client]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = x86_64, aarch64
+base_channels = opensuse_micro5_4-%(arch)s
+checksum = sha256
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+
+# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap Micro 5.X release
+[opensuse_micro5_4-uyuni-client-devel]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = x86_64, aarch64
+base_channels = opensuse_micro5_4-%(arch)s
+checksum = sha256
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+
 [opensuse_tumbleweed]
 checksum = sha256
 archs    = x86_64, aarch64

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1708,6 +1708,26 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
 
+[sle-micro-5.4-uyuni-client]
+name     = Uyuni Client Tools for SLE Micro 5.4 %(arch)s
+archs    =  x86_64, s390x, aarch64
+base_channels = sle-micro-5.4-pool-%(arch)s
+checksum = sha256
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLE15-Uyuni-Client-Tools/SLE_15/
+
+[sle-micro-5.4-devel-uyuni-client]
+name     = Uyuni Client Tools for SLE Micro 5.4 %(arch)s (Development)
+archs    =  x86_64, s390x, aarch64
+base_channels = sle-micro-5.4-pool-%(arch)s
+checksum = sha256
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
+
 [oraclelinux9]
 archs    = x86_64, aarch64
 name     = Oracle Linux 9 (%(arch)s)

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,4 +1,5 @@
-* spacewalk-hostname-rename remains stuck at refreshing pillars (bsc#1207550)
+- Add SLE Micro 5.4 Uyuni Client Tools repositories
+- spacewalk-hostname-rename remains stuck at refreshing pillars (bsc#1207550)
 
 -------------------------------------------------------------------
 Wed Apr 19 12:58:26 CEST 2023 - marina.latini@suse.com

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- Add openSUSE Leap Micro 5.4 repositories
 - Add SLE Micro 5.4 Uyuni Client Tools repositories
 - spacewalk-hostname-rename remains stuck at refreshing pillars (bsc#1207550)
 


### PR DESCRIPTION
## What does this PR change?

This PR adds SLE-Micro 5.4 Uyuni client tools channels to spacewalk-common-channels

## GUI diff

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: change in configuration file

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20737

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
