### PR TITLE
Add bootstrap repository definitions for SLE-Micro 5.4 and openSUSE Leap Micro 5.4

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1057,10 +1057,6 @@ DATA = {
         'PDID' : [2574, 2551], 'BETAPDID' : [2554], 'PKGLIST' : PKGLISTMICRO_BUNDLE_ONLY,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/slemicro/5/4/bootstrap/'
     },
-    'openSUSE-Leap-42.3-x86_64' : {
-        'BASECHANNEL' : 'opensuse_leap42_3-x86_64', 'PKGLIST' : PKGLIST12 + ONLYOPENSUSE42 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
-        'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensuse/42/3/bootstrap/'
-    },
     'openSUSE-Leap-15-x86_64' : {
         'BASECHANNEL' : 'opensuse_leap15_0-x86_64', 'PKGLIST' :  PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensuse/15/0/bootstrap/'
@@ -1144,6 +1140,14 @@ DATA = {
     'openSUSE-Leap-Micro-5.3-aarch64-uyuni' : {
         'BASECHANNEL' : 'opensuse_micro5_3-aarch64', 'PKGLIST' :  PKGLISTMICRO_BUNDLE_ONLY,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensusemicro/5/3/bootstrap/'
+    },
+    'openSUSE-Leap-Micro-5.4-x86_64-uyuni' : {
+        'BASECHANNEL' : 'opensuse_micro5_4-x86_64', 'PKGLIST' :  PKGLISTMICRO_BUNDLE_ONLY,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensusemicro/5/4/bootstrap/'
+    },
+    'openSUSE-Leap-Micro-5.4-aarch64-uyuni' : {
+        'BASECHANNEL' : 'opensuse_micro5_4-aarch64', 'PKGLIST' :  PKGLISTMICRO_BUNDLE_ONLY,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensusemicro/5/4/bootstrap/'
     },
     'openSUSE-MicroOS-x86_64-uyuni' : {
         'BASECHANNEL' : 'opensuse_microos-x86_64', 'PKGLIST' : PKGLISTUMBLEWEED_SALT_NO_BUNDLE,

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1045,6 +1045,22 @@ DATA = {
         'PDID' : [2428, 2551], 'BETAPDID' : [2554], 'PKGLIST' : PKGLISTMICRO_BUNDLE_ONLY,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/slemicro/5/3/bootstrap/'
     },
+    'SLE-MICRO-5.4-aarch64' : {
+        'PDID' : [2572, 2549], 'BETAPDID' : [2552], 'PKGLIST' : PKGLISTMICRO_BUNDLE_ONLY,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/slemicro/5/4/bootstrap/'
+    },
+    'SLE-MICRO-5.4-s390x' : {
+        'PDID' : [2573, 2550], 'BETAPDID' : [2553], 'PKGLIST' : PKGLISTMICRO_BUNDLE_ONLY,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/slemicro/5/4/bootstrap/'
+    },
+    'SLE-MICRO-5.4-x86_64' : {
+        'PDID' : [2574, 2551], 'BETAPDID' : [2554], 'PKGLIST' : PKGLISTMICRO_BUNDLE_ONLY,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/slemicro/5/4/bootstrap/'
+    },
+    'openSUSE-Leap-42.3-x86_64' : {
+        'BASECHANNEL' : 'opensuse_leap42_3-x86_64', 'PKGLIST' : PKGLIST12 + ONLYOPENSUSE42 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensuse/42/3/bootstrap/'
+    },
     'openSUSE-Leap-15-x86_64' : {
         'BASECHANNEL' : 'opensuse_leap15_0-x86_64', 'PKGLIST' :  PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensuse/15/0/bootstrap/'

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Add bootstrap repository definitions for SLE Micro 5.4
 - Ensure installation of make for building.
 - Automatically detect PostgreSQL service and data folder name.
 - Adjust product name in setup script output (bsc#1195380)

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Add bootstrap repository definitions for openSUSE Leap Micro 5.4
 - Add bootstrap repository definitions for SLE Micro 5.4
 - Ensure installation of make for building.
 - Automatically detect PostgreSQL service and data folder name.


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/21108

This PR adds the bootstrap definitions for SLE-Micro 5.4 and for openSUSE Leap Micro 5.4

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20739

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
