### PR TITLE
fix java test

### DIFF
--- a/spacewalk/setup/bin/spacewalk-setup
+++ b/spacewalk/setup/bin/spacewalk-setup
@@ -120,16 +120,18 @@ setup_services();
 
 setup_admin_email(\%opts, \%answers, \%rhnOptions);
 
-print Spacewalk::Setup::loc("* Performing initial configuration.\n");
-my $config_opts = populate_initial_configs(\%opts, \%answers);
-mkdir_mount_points($config_opts->{'mount_point'},
-        $config_opts->{'mount_point'} . '/packages',
-        $config_opts->{'mount_point'} . '/systems',
-        $config_opts->{'kickstart_mount_point'});
-chmod 0775, $config_opts->{'mount_point'} . '/systems';
-# Check for both potential Apache groups (SUSE/RHEL)
-my $www_gid = (getgrnam("www") // "") . (getgrnam("apache") // "");
-chown -1, $www_gid, $config_opts->{'mount_point'} . '/systems';
+if(not $opts{"skip-initial-configuration"}) {
+    print Spacewalk::Setup::loc("* Performing initial configuration.\n");
+    my $config_opts = populate_initial_configs(\%opts, \%answers);
+    mkdir_mount_points($config_opts->{'mount_point'},
+            $config_opts->{'mount_point'} . '/packages',
+            $config_opts->{'mount_point'} . '/systems',
+            $config_opts->{'kickstart_mount_point'});
+    chmod 0775, $config_opts->{'mount_point'} . '/systems';
+    # Check for both potential Apache groups (SUSE/RHEL)
+    my $www_gid = (getgrnam("www") // "") . (getgrnam("apache") // "");
+    chown -1, $www_gid, $config_opts->{'mount_point'} . '/systems';
+}
 
 setup_sudoers();
 

--- a/spacewalk/setup/lib/Spacewalk/Setup.pm
+++ b/spacewalk/setup/lib/Spacewalk/Setup.pm
@@ -129,6 +129,7 @@ $DRY_RUN = 0;
 sub parse_options {
   my @valid_opts = (
             "help",
+            "skip-initial-configuration",
             "skip-system-version-test",
             "skip-selinux-test",
             "skip-fqdn-test",
@@ -165,7 +166,7 @@ sub parse_options {
 
   my $usage = loc("usage: %s %s\n",
                   $0,
-                  "[ --help ] [ --answer-file=<filename> ] [ --non-interactive ] [ --skip-system-version-test ] [ --skip-selinux-test ] [ --skip-fqdn-test ] [ --skip-db-install ] [ --skip-db-diskspace-check ] [ --skip-db-population ] [--skip-reportdb-setup ] [ --skip-ssl-cert-generation ] [--skip-ssl-ca-generation] [--skip-ssl-vhost-setup] [ --skip-services-check ] [ --skip-services-restart ] [ --clear-db ] [ --re-register ] [ --upgrade ] [ --run-updater=<yes|no>] [--run-cobbler] [ --enable-tftp=<yes|no>] [ --external-postgresql [ --external-postgresql-over-ssl ] ] [--scc] [--disconnected]" );
+                  "[ --help ] [ --answer-file=<filename> ] [ --non-interactive ] [ --skip-initial-configuration ] [ --skip-system-version-test ] [ --skip-selinux-test ] [ --skip-fqdn-test ] [ --skip-db-install ] [ --skip-db-diskspace-check ] [ --skip-db-population ] [--skip-reportdb-setup ] [ --skip-ssl-cert-generation ] [--skip-ssl-ca-generation] [--skip-ssl-vhost-setup] [ --skip-services-check ] [ --skip-services-restart ] [ --clear-db ] [ --re-register ] [ --upgrade ] [ --run-updater=<yes|no>] [--run-cobbler] [ --enable-tftp=<yes|no>] [ --external-postgresql [ --external-postgresql-over-ssl ] ] [--scc] [--disconnected]" );
 
   # Terminate if any errors were encountered parsing the command line args:
   my %opts;
@@ -874,7 +875,6 @@ sub postgresql_setup_db {
     write_rhn_conf($answers, 'db-backend', 'db-host', 'db-port', 'db-name', 'db-user', 'db-password', 'db-ssl-enabled');
 
     postgresql_populate_db($opts, $answers, $populate_db);
-    satcon_deploy();
     return 1;
 }
 
@@ -934,7 +934,6 @@ sub postgresql_reportdb_setup {
         ### here we need _ instead of - cause we read them from rhn.conf
         write_rhn_conf(\%dbOptions, 'report_db_backend', 'report_db_host', 'report_db_port', 'report_db_name', 'report_db_user', 'report_db_password', 'report_db_ssl_enabled','report_db_sslrootcert');
     }
-    satcon_deploy();
     print loc("** Database: Installation complete.\n");
 
     return 1;

--- a/susemanager-utils/testing/docker/scripts/schema_migration_reportdb_test_pgsql.sh
+++ b/susemanager-utils/testing/docker/scripts/schema_migration_reportdb_test_pgsql.sh
@@ -59,7 +59,7 @@ cp /root/rhn.conf /etc/rhn/rhn.conf
 smdba system-check autotuning --max_connections=50
 
 # this command will fail with certificate error. This is ok, so ignore the error
-spacewalk-setup --skip-system-version-test --skip-selinux-test --skip-fqdn-test --skip-ssl-cert-generation --skip-ssl-vhost-setup --skip-services-check --clear-db --answer-file=clear-db-answers-pgsql.txt --external-postgresql --non-interactive ||:
+spacewalk-setup --skip-initial-configuration --skip-system-version-test --skip-selinux-test --skip-fqdn-test --skip-ssl-cert-generation --skip-ssl-vhost-setup --skip-services-check --clear-db --answer-file=clear-db-answers-pgsql.txt --external-postgresql --non-interactive ||:
 /manager/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb remove --db reportdb --user pythia ||:
 /manager/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb create --db reportdb --user pythia --password spacewalk --local
 

--- a/susemanager-utils/testing/docker/scripts/schema_migration_test_pgsql.sh
+++ b/susemanager-utils/testing/docker/scripts/schema_migration_test_pgsql.sh
@@ -57,7 +57,7 @@ cp /root/rhn.conf /etc/rhn/rhn.conf
 smdba system-check autotuning --max_connections=50
 
 # this command will fail with certificate error. This is ok, so ignore the error
-spacewalk-setup --skip-system-version-test --skip-selinux-test --skip-fqdn-test --skip-ssl-cert-generation --skip-ssl-vhost-setup --skip-services-check --clear-db --answer-file=clear-db-answers-pgsql.txt --external-postgresql --non-interactive ||:
+spacewalk-setup --skip-initial-configuration --skip-system-version-test --skip-selinux-test --skip-fqdn-test --skip-ssl-cert-generation --skip-ssl-vhost-setup --skip-services-check --clear-db --answer-file=clear-db-answers-pgsql.txt --external-postgresql --non-interactive ||:
 
 
 # this copy the latest schema from the git into the system


### PR DESCRIPTION
## What does this PR change?

After these changes https://github.com/uyuni-project/uyuni/commit/b91d21ebfbb5a01449e4eef06ab6765ccfe51551 we had problems with migration test, and these changes supposed to fix it https://github.com/uyuni-project/uyuni/commit/8684be36ecc53906c14753296fd400a92ea46554, but they break java test.

So I had a deeper analysis about why migration test succeed before  https://github.com/uyuni-project/uyuni/commit/b91d21ebfbb5a01449e4eef06ab6765ccfe51551  and, after enabling debug mode I found:

```
* Configuring tomcat.
Command: '/usr/bin/spacewalk-setup-tomcat '
open3: exec of /usr/bin/spacewalk-setup-tomcat  failed: No such file or directory at /manager/spacewalk/setup/lib/Spacewalk/Setup.pm line 307.
```
so most of the function in `spacewalk-setup` were not executing during migration test.

This PR:
- revert the changes not required
- skip some step in `spacewalk-setup` during migration test

In the future we probably need a complete refactoring of all this part


## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: already covered


- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [x] Re-run test "schema_migration_test_pgsql" (Test skipped, there are no changes to test)
- [x] Re-run test "susemanager_unittests"
- [x] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests" (Test skipped, there are no changes to test)
