### PR TITLE
CI: Acceptance tests at PR v2: enable hw refresh

### DIFF
--- a/.github/workflows/test_all_in_one_common.yml
+++ b/.github/workflows/test_all_in_one_common.yml
@@ -68,7 +68,7 @@ jobs:
       - name: test_from_host
         run: curl --insecure https://localhost:8443/rhn/help/Copyright.do
       - name: test_from_container
-        run: podman exec opensusessh curl --insecure https://uyuni-server-all-in-one-test:443/rhn/help/Copyright.do
+        run: sudo -i podman exec opensusessh curl --insecure https://uyuni-server-all-in-one-test:443/rhn/help/Copyright.do
       - name: setup_sshd
         run: ./testsuite/podman_runner/10_setup_sshd.sh 
       - name: run_cucumber_core

--- a/testsuite/Gemfile
+++ b/testsuite/Gemfile
@@ -10,17 +10,17 @@ gem 'cucumber-html-formatter', "~> 17.0"
 gem 'selenium-webdriver', "~> 3.142"
 gem 'rack', "~> 3.0"
 gem 'rack-test', "~> 2.0"
-gem 'nokogiri', "~> 1.12"
+gem 'nokogiri', "~> 1.12.0"
 gem 'rake', "~> 13.0"
 gem 'jwt', "~> 2.6"
 gem 'mime-types', "~> 3.4"
 gem 'xmlrpc', "~> 0.3"
 gem 'faraday', '1.10.0'
-gem 'minitest', "~> 5.15"
+gem 'minitest', "~> 5.15.0"
 gem 'websocket', "~> 1.2"
 gem 'websocket-driver', "~> 0.7"
 gem 'syntax', "~> 1.2"
-gem 'parallel_tests', "~> 3.12"
+gem 'parallel_tests', "~> 3.12.0"
 gem 'simplecov', "~> 0.22"
 gem 'rubocop', '0.83.0'
 gem 'redis', '~> 5.0'
@@ -29,3 +29,4 @@ gem 'redis', '~> 5.0'
 # or build and install from https://github.com/openSUSE/twopence
 gem 'twopence', "~> 0.4"
 gem 'pg', "~> 1.4"
+gem 'public_suffix', '~> 4.0'

--- a/testsuite/features/secondary/allcli_overview_systems_details.feature
+++ b/testsuite/features/secondary/allcli_overview_systems_details.feature
@@ -1,7 +1,6 @@
 # Copyright (c) 2017-2022 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
-@skip_if_container
 @scope_visualization
 Feature: The system details of each minion and client provides an overview of the system
 

--- a/testsuite/podman_runner/02_setup_network.sh
+++ b/testsuite/podman_runner/02_setup_network.sh
@@ -1,4 +1,24 @@
 #!/bin/bash
 set -ex
-sudo -i podman network create --ipv6 --subnet 2001:db8::/64 uyuni-network-1
+print_usage()
+{
+    echo "Usage: $0 [-s subnet]" 1>&2
+    exit 1
+}
+
+# default subnet
+subnet=2001:db8::/64
+while getopts "s:" options; do
+    case "${options}" in
+        s)
+            subnet=${OPTARG}
+            ;;
+        *)
+            print_usage
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+sudo -i podman network create --ipv6 --subnet ${subnet} uyuni-network-1
 

--- a/testsuite/podman_runner/02_setup_network.sh
+++ b/testsuite/podman_runner/02_setup_network.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -ex
-podman network create uyuni-network-1
+sudo -i podman network create --ipv6 --subnet 2001:db8::/64 uyuni-network-1
 

--- a/testsuite/podman_runner/03_run_controller.sh
+++ b/testsuite/podman_runner/03_run_controller.sh
@@ -2,6 +2,6 @@
 set -ex
 src_dir=$(cd $(dirname "$0")/../.. && pwd -P)
 
-podman run --rm -d --network uyuni-network-1 -v /tmp/test-all-in-one:/tmp --name controller-test -h controller-test -v ${src_dir}/testsuite:/testsuite ghcr.io/$UYUNI_PROJECT/uyuni/ci-test-controller-dev:$UYUNI_VERSION
+sudo -i podman run --rm -d --network uyuni-network-1 -v /tmp/test-all-in-one:/tmp --name controller-test -h controller-test -v ${src_dir}/testsuite:/testsuite ghcr.io/$UYUNI_PROJECT/uyuni/ci-test-controller-dev:$UYUNI_VERSION
 
 podman ps

--- a/testsuite/podman_runner/04_setup_ssh_controller.sh
+++ b/testsuite/podman_runner/04_setup_ssh_controller.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -ex
-podman exec controller-test bash -c "ssh-keygen -f /root/.ssh/id_rsa -t rsa -N \"\" && cp /root/.ssh/id_rsa.pub /tmp/authorized_keys"
+sudo -i podman exec controller-test bash -c "ssh-keygen -f /root/.ssh/id_rsa -t rsa -N \"\" && cp /root/.ssh/id_rsa.pub /tmp/authorized_keys"
 

--- a/testsuite/podman_runner/05_install_gems_in_controller.sh
+++ b/testsuite/podman_runner/05_install_gems_in_controller.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -xe
-podman exec controller-test bash -c "cd /testsuite && bundle.ruby2.5 install --gemfile Gemfile"
+sudo -i podman exec controller-test bash -c "cd /testsuite && bundle.ruby2.5 install --gemfile Gemfile"
 

--- a/testsuite/podman_runner/06_start_server.sh
+++ b/testsuite/podman_runner/06_start_server.sh
@@ -2,5 +2,5 @@
 set -xe
 src_dir=$(cd $(dirname "$0")/../.. && pwd -P)
 
-podman run --rm --tmpfs /run -v ${src_dir}/schema/spacewalk/upgrade/:/etc/sysconfig/rhn/schema-upgrade/ -v ${src_dir}/schema/reportdb/upgrade/:/etc/sysconfig/rhn/reportdb-schema-upgrade/ -v ${src_dir}/web:/web -v ${src_dir}/branding:/branding -v ${src_dir}/java:/java -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /tmp/test-all-in-one:/tmp --cgroupns=host --add-host=download.opensuse.org:195.135.221.134 -h uyuni-server-all-in-one-test -p 8443:443 -p 8080:80 -p 4505:4505 -p 4506:4506 -d --name=uyuni-server-all-in-one-test --network uyuni-network-1 ghcr.io/$UYUNI_PROJECT/uyuni/ci-test-server-all-in-one-dev:$UYUNI_VERSION
+sudo -i podman run --rm --tmpfs /run -v ${src_dir}/schema/spacewalk/upgrade/:/etc/sysconfig/rhn/schema-upgrade/ -v ${src_dir}/schema/reportdb/upgrade/:/etc/sysconfig/rhn/reportdb-schema-upgrade/ -v ${src_dir}/web:/web -v ${src_dir}/branding:/branding -v ${src_dir}/java:/java -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /tmp/test-all-in-one:/tmp --cgroupns=host --add-host=download.opensuse.org:195.135.221.134 -h uyuni-server-all-in-one-test -p 8443:443 -p 8080:80 -p 4505:4505 -p 4506:4506 -d --name=uyuni-server-all-in-one-test --network uyuni-network-1 ghcr.io/$UYUNI_PROJECT/uyuni/ci-test-server-all-in-one-dev:$UYUNI_VERSION
 

--- a/testsuite/podman_runner/07_manager_setup.sh
+++ b/testsuite/podman_runner/07_manager_setup.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -xe
-podman exec uyuni-server-all-in-one-test bash -c "/usr/lib/susemanager/bin/mgr-setup -l /var/log/susemanager_setup.log -s"
+sudo -i podman exec uyuni-server-all-in-one-test bash -c "/usr/lib/susemanager/bin/mgr-setup -l /var/log/susemanager_setup.log -s"

--- a/testsuite/podman_runner/08_build_server_code.sh
+++ b/testsuite/podman_runner/08_build_server_code.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -xe
-podman exec uyuni-server-all-in-one-test bash -c "cd /java && ant -f manager-build.xml ivy refresh-branding-jar deploy-local"
-podman exec uyuni-server-all-in-one-test bash -c "cd /web/html/src;[ -d dist ] || mkdir dist;yarn install --force --ignore-optional --production=true --frozen-lockfile;yarn autoclean --force;yarn build:novalidate; rsync -a dist/ /srv/www/htdocs/"
+sudo -i podman exec uyuni-server-all-in-one-test bash -c "cd /java && ant -f manager-build.xml ivy refresh-branding-jar deploy-local"
+sudo -i podman exec uyuni-server-all-in-one-test bash -c "cd /web/html/src;[ -d dist ] || mkdir dist;yarn install --force --ignore-optional --production=true --frozen-lockfile;yarn autoclean --force;yarn build:novalidate; rsync -a dist/ /srv/www/htdocs/"
 

--- a/testsuite/podman_runner/09_run_sshminion.sh
+++ b/testsuite/podman_runner/09_run_sshminion.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -xe
-podman run --rm -d --network uyuni-network-1 -v /tmp/test-all-in-one:/tmp --name opensusessh -h opensusessh ghcr.io/$UYUNI_PROJECT/uyuni/ci-test-opensuse-minion:$UYUNI_VERSION
+echo opensusesshproductuuid > /tmp/opensuse_ssh_product_uuid
+sudo -i podman run --privileged --rm -d --network uyuni-network-1 -v /tmp/opensuse_ssh_product_uuid:/sys/class/dmi/id/product_uuid -v /tmp/test-all-in-one:/tmp --name opensusessh -h opensusessh ghcr.io/$UYUNI_PROJECT/uyuni/ci-test-opensuse-minion:$UYUNI_VERSION
 

--- a/testsuite/podman_runner/10_setup_sshd.sh
+++ b/testsuite/podman_runner/10_setup_sshd.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -xe
 
-podman exec uyuni-server-all-in-one-test bash -c "ssh-keygen -A && /usr/sbin/sshd -e"
-podman exec uyuni-server-all-in-one-test bash -c "if [ ! -d /root/.ssh ];then mkdir /root/.ssh/;chmod 700 /root/.ssh;fi;cp /tmp/authorized_keys /root/.ssh/"
-podman exec opensusessh bash -c "echo 'root:linux' | chpasswd && echo 123456789 > /etc/machine-id"
-podman exec opensusessh bash -c "if [ ! -d /root/.ssh ];then mkdir /root/.ssh/;chmod 700 /root/.ssh;fi;cp /tmp/authorized_keys /root/.ssh/"
-podman exec controller-test bash -c "if [ ! -d /root/.ssh ];then mkdir /root/.ssh/;chmod 700 /root/.ssh;fi;cp /tmp/authorized_keys /root/.ssh/"
+sudo -i podman exec uyuni-server-all-in-one-test bash -c "ssh-keygen -A && /usr/sbin/sshd -e"
+sudo -i podman exec uyuni-server-all-in-one-test bash -c "if [ ! -d /root/.ssh ];then mkdir /root/.ssh/;chmod 700 /root/.ssh;fi;cp /tmp/authorized_keys /root/.ssh/"
+sudo -i podman exec opensusessh bash -c "echo 'root:linux' | chpasswd && echo 123456789 > /etc/machine-id"
+sudo -i podman exec opensusessh bash -c "if [ ! -d /root/.ssh ];then mkdir /root/.ssh/;chmod 700 /root/.ssh;fi;cp /tmp/authorized_keys /root/.ssh/"
+sudo -i podman exec controller-test bash -c "if [ ! -d /root/.ssh ];then mkdir /root/.ssh/;chmod 700 /root/.ssh;fi;cp /tmp/authorized_keys /root/.ssh/"
 

--- a/testsuite/podman_runner/11_run_core_tests.sh
+++ b/testsuite/podman_runner/11_run_core_tests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -xe
-podman exec controller-test bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=uyuni-server-all-in-one-test && export HOSTNAME=controller-test && cd /testsuite && rake cucumber:container_core"
+sudo -i podman exec controller-test bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=uyuni-server-all-in-one-test && export HOSTNAME=controller-test && cd /testsuite && rake cucumber:container_core"
 

--- a/testsuite/podman_runner/12_run_salt_sle_minion.sh
+++ b/testsuite/podman_runner/12_run_salt_sle_minion.sh
@@ -4,7 +4,10 @@ src_dir=$(cd $(dirname "$0")/../.. && pwd -P)
 
 echo opensuseminionproductuuid > /tmp/opensuse_product_uuid
 
-podman run --rm -d --network uyuni-network-1 -v /tmp/opensuse_product_uuid:/sys/class/dmi/id/product_uuid -v /tmp/test-all-in-one:/tmp -v ${src_dir}/testsuite/podman_runner/salt-minion-entry-point.sh:/salt-minion-entry-point.sh --name sle_minion -h sle_minion ghcr.io/$UYUNI_PROJECT/uyuni/ci-test-opensuse-minion:$UYUNI_VERSION bash -c "/salt-minion-entry-point.sh uyuni-server-all-in-one-test 1-SUSE-KEY-x86_64"
-podman exec sle_minion bash -c "ssh-keygen -A && /usr/sbin/sshd -e"
-podman exec sle_minion bash -c "if [ ! -d /root/.ssh ];then mkdir /root/.ssh/;chmod 700 /root/.ssh;fi;cp /tmp/authorized_keys /root/.ssh/"
+sudo -i podman run --privileged --rm -d --network uyuni-network-1 -v /tmp/opensuse_product_uuid:/sys/class/dmi/id/product_uuid -v /tmp/test-all-in-one:/tmp -v ${src_dir}/testsuite/podman_runner/salt-minion-entry-point.sh:/salt-minion-entry-point.sh --name sle_minion -h sle_minion ghcr.io/$UYUNI_PROJECT/uyuni/ci-test-opensuse-minion:$UYUNI_VERSION bash -c "/salt-minion-entry-point.sh uyuni-server-all-in-one-test 1-SUSE-KEY-x86_64"
+sudo -i podman exec sle_minion bash -c "ssh-keygen -A && /usr/sbin/sshd -e"
+sudo -i podman exec sle_minion bash -c "if [ ! -d /root/.ssh ];then mkdir /root/.ssh/;chmod 700 /root/.ssh;fi;cp /tmp/authorized_keys /root/.ssh/"
+
+sudo -i podman exec sle_minion bash -c "echo DEBUG;cat /sys/class/dmi/id/product_uuid;echo AAA;dmidecode | grep opensuseminionproductuuid ;echo FI_DEBUG"
+
 

--- a/testsuite/podman_runner/12_run_salt_sle_minion.sh
+++ b/testsuite/podman_runner/12_run_salt_sle_minion.sh
@@ -7,7 +7,3 @@ echo opensuseminionproductuuid > /tmp/opensuse_product_uuid
 sudo -i podman run --privileged --rm -d --network uyuni-network-1 -v /tmp/opensuse_product_uuid:/sys/class/dmi/id/product_uuid -v /tmp/test-all-in-one:/tmp -v ${src_dir}/testsuite/podman_runner/salt-minion-entry-point.sh:/salt-minion-entry-point.sh --name sle_minion -h sle_minion ghcr.io/$UYUNI_PROJECT/uyuni/ci-test-opensuse-minion:$UYUNI_VERSION bash -c "/salt-minion-entry-point.sh uyuni-server-all-in-one-test 1-SUSE-KEY-x86_64"
 sudo -i podman exec sle_minion bash -c "ssh-keygen -A && /usr/sbin/sshd -e"
 sudo -i podman exec sle_minion bash -c "if [ ! -d /root/.ssh ];then mkdir /root/.ssh/;chmod 700 /root/.ssh;fi;cp /tmp/authorized_keys /root/.ssh/"
-
-sudo -i podman exec sle_minion bash -c "echo DEBUG;cat /sys/class/dmi/id/product_uuid;echo AAA;dmidecode | grep opensuseminionproductuuid ;echo FI_DEBUG"
-
-

--- a/testsuite/podman_runner/13_run_salt_rhlike_minion.sh
+++ b/testsuite/podman_runner/13_run_salt_rhlike_minion.sh
@@ -4,7 +4,8 @@ src_dir=$(cd $(dirname "$0")/../.. && pwd -P)
 
 echo rhminionproductuuid > /tmp/rh_product_uuid
 
-podman run --rm -d --network uyuni-network-1 -v /tmp/rh_product_uuid:/sys/class/dmi/id/product_uuid -v /tmp/test-all-in-one:/tmp -v ${src_dir}/testsuite/podman_runner/salt-minion-entry-point.sh:/salt-minion-entry-point.sh --name rhlike_minion -h rhlike_minion ghcr.io/$UYUNI_PROJECT/uyuni/ci-test-rocky-minion:$UYUNI_VERSION bash -c "/salt-minion-entry-point.sh uyuni-server-all-in-one-test 1-RH-LIKE-KEY"
+sudo -i podman run --privileged --rm -d --network uyuni-network-1 -v /tmp/rh_product_uuid:/sys/class/dmi/id/product_uuid -v /tmp/test-all-in-one:/tmp -v ${src_dir}/testsuite/podman_runner/salt-minion-entry-point.sh:/salt-minion-entry-point.sh --name rhlike_minion -h rhlike_minion ghcr.io/$UYUNI_PROJECT/uyuni/ci-test-rocky-minion:$UYUNI_VERSION bash -c "/salt-minion-entry-point.sh uyuni-server-all-in-one-test 1-RH-LIKE-KEY"
+
 # sleep 10
-podman exec rhlike_minion bash -c "ssh-keygen -A && /usr/sbin/sshd -e"
-podman exec rhlike_minion bash -c "if [ ! -d /root/.ssh ];then mkdir /root/.ssh/;chmod 700 /root/.ssh;fi;cp /tmp/authorized_keys /root/.ssh/"
+sudo -i podman exec rhlike_minion bash -c "ssh-keygen -A && /usr/sbin/sshd -e"
+sudo -i podman exec rhlike_minion bash -c "if [ ! -d /root/.ssh ];then mkdir /root/.ssh/;chmod 700 /root/.ssh;fi;cp /tmp/authorized_keys /root/.ssh/"

--- a/testsuite/podman_runner/14_run_salt_deblike_minion.sh
+++ b/testsuite/podman_runner/14_run_salt_deblike_minion.sh
@@ -7,4 +7,3 @@ echo ubuntuminionproductuuid > /tmp/ubuntu_product_uuid
 sudo -i podman run --privileged --rm -d --network uyuni-network-1 -v /tmp/ubuntu_product_uuid:/sys/class/dmi/id/product_uuid -v /tmp/test-all-in-one:/tmp -v ${src_dir}/testsuite/podman_runner/salt-minion-entry-point.sh:/salt-minion-entry-point.sh --name deblike_minion -h deblike_minion ghcr.io/$UYUNI_PROJECT/uyuni/ci-test-ubuntu-minion:$UYUNI_VERSION bash -c "/salt-minion-entry-point.sh uyuni-server-all-in-one-test 1-DEBLIKE-KEY"
 sudo -i podman exec deblike_minion bash -c "ssh-keygen -A && /usr/sbin/sshd -e"
 sudo -i podman exec deblike_minion bash -c "if [ ! -d /root/.ssh ];then mkdir /root/.ssh/;chmod 700 /root/.ssh;fi;cp /tmp/authorized_keys /root/.ssh/"
-

--- a/testsuite/podman_runner/14_run_salt_deblike_minion.sh
+++ b/testsuite/podman_runner/14_run_salt_deblike_minion.sh
@@ -4,6 +4,7 @@ src_dir=$(cd $(dirname "$0")/../.. && pwd -P)
 
 echo ubuntuminionproductuuid > /tmp/ubuntu_product_uuid
 
-podman run --rm -d --network uyuni-network-1 -v /tmp/ubuntu_product_uuid:/sys/class/dmi/id/product_uuid -v /tmp/test-all-in-one:/tmp -v ${src_dir}/testsuite/podman_runner/salt-minion-entry-point.sh:/salt-minion-entry-point.sh --name deblike_minion -h deblike_minion ghcr.io/$UYUNI_PROJECT/uyuni/ci-test-ubuntu-minion:$UYUNI_VERSION bash -c "/salt-minion-entry-point.sh uyuni-server-all-in-one-test 1-DEBLIKE-KEY"
-podman exec deblike_minion bash -c "ssh-keygen -A && /usr/sbin/sshd -e"
-podman exec deblike_minion bash -c "if [ ! -d /root/.ssh ];then mkdir /root/.ssh/;chmod 700 /root/.ssh;fi;cp /tmp/authorized_keys /root/.ssh/"
+sudo -i podman run --privileged --rm -d --network uyuni-network-1 -v /tmp/ubuntu_product_uuid:/sys/class/dmi/id/product_uuid -v /tmp/test-all-in-one:/tmp -v ${src_dir}/testsuite/podman_runner/salt-minion-entry-point.sh:/salt-minion-entry-point.sh --name deblike_minion -h deblike_minion ghcr.io/$UYUNI_PROJECT/uyuni/ci-test-ubuntu-minion:$UYUNI_VERSION bash -c "/salt-minion-entry-point.sh uyuni-server-all-in-one-test 1-DEBLIKE-KEY"
+sudo -i podman exec deblike_minion bash -c "ssh-keygen -A && /usr/sbin/sshd -e"
+sudo -i podman exec deblike_minion bash -c "if [ ! -d /root/.ssh ];then mkdir /root/.ssh/;chmod 700 /root/.ssh;fi;cp /tmp/authorized_keys /root/.ssh/"
+

--- a/testsuite/podman_runner/15_accept_all_keys.sh
+++ b/testsuite/podman_runner/15_accept_all_keys.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -xe
-podman exec uyuni-server-all-in-one-test bash -c "salt-key -y -A"
+sudo -i podman exec uyuni-server-all-in-one-test bash -c "salt-key -y -A"

--- a/testsuite/podman_runner/16_run_init_clients_tests.sh
+++ b/testsuite/podman_runner/16_run_init_clients_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -xe
-podman exec controller-test bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=uyuni-server-all-in-one-test && export HOSTNAME=controller-test && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && export DEBLIKE_MINION=deblike_minion && cd /testsuite && rake cucumber:container_init_clients"
+sudo -i podman exec controller-test bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=uyuni-server-all-in-one-test && export HOSTNAME=controller-test && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && export DEBLIKE_MINION=deblike_minion && cd /testsuite && rake cucumber:container_init_clients"

--- a/testsuite/podman_runner/17_run_secondary_tests.sh
+++ b/testsuite/podman_runner/17_run_secondary_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -xe
-podman exec controller-test bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=uyuni-server-all-in-one-test && export HOSTNAME=controller-test && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && export DEBLIKE_MINION=deblike_minion && cd /testsuite && rake cucumber:secondary"
+sudo -i podman exec controller-test bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=uyuni-server-all-in-one-test && export HOSTNAME=controller-test && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && export DEBLIKE_MINION=deblike_minion && cd /testsuite && rake cucumber:secondary"

--- a/testsuite/podman_runner/18_run_secondary_parallelizable_tests.sh
+++ b/testsuite/podman_runner/18_run_secondary_parallelizable_tests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -xe
-podman exec controller-test bash -c "zypper ref && zypper -n install expect"
-podman exec controller-test bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=uyuni-server-all-in-one-test && export HOSTNAME=controller-test && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && export DEBLIKE_MINION=deblike_minion && cd /testsuite && rake cucumber:secondary_parallelizable"
+sudo -i podman exec controller-test bash -c "zypper ref && zypper -n install expect"
+sudo -i podman exec controller-test bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=uyuni-server-all-in-one-test && export HOSTNAME=controller-test && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && export DEBLIKE_MINION=deblike_minion && cd /testsuite && rake cucumber:secondary_parallelizable"

--- a/testsuite/podman_runner/18_run_secondary_parallelizable_tests_subset.sh
+++ b/testsuite/podman_runner/18_run_secondary_parallelizable_tests_subset.sh
@@ -7,4 +7,4 @@ then
     exit 1
 fi
 
-podman exec controller-test bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=uyuni-server-all-in-one-test && export HOSTNAME=controller-test && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && export DEBLIKE_MINION=deblike_minion && cd /testsuite && rake cucumber:secondary_parallelizable_${1}"
+sudo -i podman exec controller-test bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=uyuni-server-all-in-one-test && export HOSTNAME=controller-test && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && export DEBLIKE_MINION=deblike_minion && cd /testsuite && rake cucumber:secondary_parallelizable_${1}"

--- a/testsuite/podman_runner/18_split_secondary_p_tests.sh
+++ b/testsuite/podman_runner/18_split_secondary_p_tests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -xe
-podman exec controller-test bash -c "cd /testsuite && rake utils:split_secondary_p[5]"
+sudo -i podman exec controller-test bash -c "cd /testsuite && rake utils:split_secondary_p[5]"
 


### PR DESCRIPTION
## What does this PR change?

CI: Enable hardware refresh tests

## GUI diff
No difference.
- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/20956

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
