### PR TITLE
Remove the diff column from the scap results page

### DIFF
--- a/java/code/webapp/WEB-INF/pages/common/fragments/audit/scap-list-columns.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/audit/scap-list-columns.jspf
@@ -11,31 +11,6 @@
                 ${current.testResult}
         </a>
 </rl:column>
-<rl:column headerkey="system.audit.listscap.jsp.diff">
-        <c:choose>
-                <c:when test="${not empty current.comparableId}">
-                        <a href="/rhn/audit/scap/DiffSubmit.do?first=${current.comparableId}&second=${current.xid}&view=changed">
-                        <c:choose>
-                                <c:when test="${current.diffIcon == 'checked'}" >
-                                        <rhn:icon type="scap-nochange" title="scapdiff.jsp.i.checked" />
-                                </c:when>
-                                <c:when test="${current.diffIcon == 'alert'}" >
-                                        <rhn:icon type="system-warn" title="scapdiff.jsp.i.alert" />
-                                </c:when>
-                                <c:when test="${current.diffIcon == 'error'}" >
-                                        <rhn:icon type="system-crit" title="scapdiff.jsp.i.error" />
-                                </c:when>
-                                <c:otherwise>
-                                        <rhn:icon type="system-unknown" title="system.audit.xccdfdetails.jsp.nodiff" />
-                                </c:otherwise>
-                        </c:choose>
-                        </a>
-                </c:when>
-                <c:otherwise>
-                        <rhn:icon type="system-unknown" title="system.audit.xccdfdetails.jsp.nodiff" />
-                </c:otherwise>
-        </c:choose>
-</rl:column>
 <rl:column headerkey="system.audit.listscap.jsp.completed">
         ${current.completed}
 </rl:column>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Removed the expensive 'diff' column (bsc#1208427)
 - replace kickstart profile advanced option "md5_crypt_rootpw"
   with "sha256_crypt_rootpw" to use sha256 crypt when password
   is provided in plain text


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/20557

## GUI diff

Before:

![220588513-c138a1c1-ce04-429f-a488-f31af2d47e83](https://user-images.githubusercontent.com/12951268/232016303-0f0844a7-7e98-4227-aed0-f49ce3f548c0.png)


After:
![220588487-8928bb4f-d125-441c-8ea2-7cb24274e16a](https://user-images.githubusercontent.com/12951268/232016327-bdcb0e58-4116-4bf1-9e27-1c49dd1baff3.png)


- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes # https://github.com/uyuni-project/uyuni/issues/6378
Tracks # https://github.com/SUSE/spacewalk/pull/20557

- [ ] **DONE**

