### PR TITLE
Copy monitoring entitlement schema migration script

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Fix renaming monitoring entitlement
 - fix OL9 schema migration
 - Fix update of sql function create_new_org
 - Filter CLM modular packages using release strings (bsc#1207814)

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.5-to-susemanager-schema-4.4.6/100-rename_monitoring_entitlement.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.5-to-susemanager-schema-4.4.6/100-rename_monitoring_entitlement.sql
@@ -1,0 +1,20 @@
+--------------------------------------------------------------------------------
+-- rhnServerGroupType ----------------------------------------------------------
+--------------------------------------------------------------------------------
+UPDATE rhnServerGroupType
+SET name = 'Monitored Host'
+WHERE label = 'monitoring_entitled';
+
+
+--------------------------------------------------------------------------------
+-- existing server groups update -----------------------------------------------
+--------------------------------------------------------------------------------
+UPDATE rhnServerGroup sg
+SET
+    name = sgt.name,
+    description = sgt.name
+FROM rhnServerGroupType sgt
+WHERE
+    sg.group_type = sgt.id AND
+    sgt.label = 'monitoring_entitled'
+;


### PR DESCRIPTION
## What does this PR change?

The migration script for monitoring entitlement renaming had landed in the old directory and had no effect when upgrading from version 4.4.3 or newer.
This change copies the migration script to the next release directory. The rename will be effective in version 4.4.6.

## Links

Fixes migration script from #6321

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
