### PR TITLE
remove channels from client after transfer to a different organization

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/org/MigrationManager.java
+++ b/java/code/src/com/redhat/rhn/manager/org/MigrationManager.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.manager.org;
 
+import com.redhat.rhn.common.messaging.MessageQueue;
 import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.domain.entitlement.Entitlement;
 import com.redhat.rhn.domain.org.Org;
@@ -39,6 +40,7 @@ import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.UpdateChildChannelsCommand;
 
+import com.suse.manager.reactor.messaging.ChannelsChangedEventMessage;
 import com.suse.manager.webui.services.SaltStateGeneratorService;
 
 import java.util.ArrayList;
@@ -99,6 +101,8 @@ public class MigrationManager extends BaseManager {
             else {
                 server.setCreator(UserFactory.findRandomOrgAdmin(toOrg));
             }
+            // remove old channels from system
+            MessageQueue.publish(new ChannelsChangedEventMessage(server.getId(), user.getId(), true));
 
             // update server history to record the migration.
             ServerHistoryEvent event = new ServerHistoryEvent();

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- remove channels from client after transfer to a different
+  organization (bsc#1209220)
 - Fix RHEL9 / SLL9 product discovery (bsc#1209993)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Call channel changed event after migrating a system to a different organization. During this transfer
all channels are unsubscribed, but the repositories stayed on the target system.
Now an action is scheduled to apply the current state which is "no channels" and result in an empty repo file .

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/21096

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
