### PR TITLE
Ignore mandatory channels results that don't match list of channels

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/product/SUSEProductFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/product/SUSEProductFactory.java
@@ -286,6 +286,10 @@ public class SUSEProductFactory extends HibernateFactory {
         if (channel.isCloned()) {
             if (ConfigDefaults.get().getClonedChannelAutoSelection()) {
                 return channel.originChain().filter(c -> !c.isCloned()).findFirst().map(original -> {
+                    // There is a problem that filtering cloned channels by the unique parts does not filter
+                    // out chained channels created via CLM. If you have a CLM project based on another CLM
+                    // project the names of the chained channels contain all the unique parts and are thus
+                    // not filtered out although they should (See bsc#1204270 for more info).
                     List<String> originalParts = List.of(original.getLabel().split("-"));
                     List<String> selectedParts = List.of(channel.getLabel().split("-"));
                     List<String> uniqueParts = selectedParts.stream()

--- a/web/html/src/manager/content-management/shared/components/panels/sources/channels/channels-api-transforms.ts
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/channels/channels-api-transforms.ts
@@ -24,10 +24,12 @@ export const toCanonicalRequires = (
     if (isNaN(channelId) || !channel) {
       throw new RangeError("Invalid channel id");
     }
-
     const requiredChannels = rawRequiresMap[channelIdString]
-      ?.map((id) => channelsMap.get(id) as BaseChannelType | ChildChannelType) // We know these values exist
-      .filter((requiredChannel) => requiredChannel.id !== channel.id); // The original data includes the channel's own id, don't include it in the set
+      ?.map((id) => channelsMap.get(id))
+      .filter((requiredChannel) => {
+        // The original data includes the channel's own id, don't include it in the set
+        return requiredChannel && requiredChannel.id !== channel.id;
+      }) as (BaseChannelType | ChildChannelType)[];
     if (requiredChannels?.length) {
       requiresMap.set(channelId, new Set(requiredChannels));
       requiredChannels.forEach((requiredChannel) => {

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Ignore mandatory channels results that don't match list of channels (bsc#1204270)
 - Show loading indicator on formula details pages (bsc#1179747)
 - Fix systems list sorting buttons
 - Fix wrong credentials error message (bsc#1210456)


### PR DESCRIPTION
## What does this PR change?

When clicking  on a CLM projects `Attach/Detach Sources` prevent the popup from loading forever by ignoring mandatory channel results that don't match the list of channels.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: **Bugfix**

- [x] **DONE**

## Test coverage

- No tests: **Bugfix**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/19250

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
