### PR TITLE
fix NPE in cobbler system sync when server has no creator set

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/ScheduleKickstartWizardAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/ScheduleKickstartWizardAction.java
@@ -787,8 +787,7 @@ public class ScheduleKickstartWizardAction extends RhnWizardAction {
             return mapping.findForward("fifth");
         }
 
-        CobblerSystemCreateCommand cmd = new CobblerSystemCreateCommand(server,
-                profile.getName(), data);
+        CobblerSystemCreateCommand cmd = new CobblerSystemCreateCommand(user, server, profile.getName(), data);
         cmd.store();
         log.debug("cobbler system record created.");
         String[] args = new String[2];

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -1709,7 +1709,7 @@ public class ActionManager extends BaseManager {
             kad.setVirtBridge(pcmd.getVirtBridge());
         }
 
-        CobblerVirtualSystemCommand vcmd = new CobblerVirtualSystemCommand(
+        CobblerVirtualSystemCommand vcmd = new CobblerVirtualSystemCommand(pcmd.getUser(),
                 pcmd.getServer(), cProfile.getName(), pcmd.getGuestName(),
                 pcmd.getKsdata());
         kad.setCobblerSystemName(vcmd.getCobblerSystemRecordName());

--- a/java/code/src/com/redhat/rhn/manager/kickstart/SSMCreateRecordCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/SSMCreateRecordCommand.java
@@ -123,8 +123,7 @@ public class SSMCreateRecordCommand {
                 systemOverview.getName());
         }
 
-        CobblerSystemCreateCommand command = new CobblerSystemCreateCommand(server,
-            profile.getName(), data);
+        CobblerSystemCreateCommand command = new CobblerSystemCreateCommand(user, server, profile.getName(), data);
         ValidatorError error = command.store();
         if (error == null) {
             succeededServers.add(server);

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerSystemCreateCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerSystemCreateCommand.java
@@ -144,14 +144,16 @@ public class CobblerSystemCreateCommand extends CobblerCommand {
     /**
      * Constructor to be used for a system outside tthe context
      * of actually kickstarting it to a specific profile.
-     * @param serverIn profile we want to create in cobbler
+     *
+     * @param userIn             who is requesting the sync
+     * @param serverIn           profile we want to create in cobbler
      * @param cobblerProfileName the name of the cobbler profile
-     * to associate with system
-     * @param ksDataIn the kickstart data to associate the system with
+     *                           to associate with system
+     * @param ksDataIn           the kickstart data to associate the system with
      */
-    public CobblerSystemCreateCommand(Server serverIn, String cobblerProfileName,
-            KickstartData ksDataIn) {
-        super(serverIn.getCreator());
+    public CobblerSystemCreateCommand(User userIn, Server serverIn, String cobblerProfileName,
+                                      KickstartData ksDataIn) {
+        super(userIn);
         this.server = serverIn;
         this.serverName = serverIn.getName();
         this.orgId = serverIn.getOrgId();

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerVirtualSystemCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerVirtualSystemCommand.java
@@ -49,15 +49,16 @@ public class CobblerVirtualSystemCommand extends CobblerSystemCreateCommand {
 
     /**
      * Constructor
+     * @param userIn who is requesting this sync
      * @param serverIn to create in cobbler
      * @param cobblerProfileName to use
      * @param guestNameIn the guest name to create
      * @param ksData the kickstart data to associate
      *      system with
      */
-    public CobblerVirtualSystemCommand(Server serverIn,
+    public CobblerVirtualSystemCommand(User userIn, Server serverIn,
             String cobblerProfileName, String guestNameIn, KickstartData ksData) {
-        super(serverIn, cobblerProfileName, ksData);
+        super(userIn, serverIn, cobblerProfileName, ksData);
         guestName = guestNameIn;
         hostName = serverIn.getName();
     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix NPE in cobbler system sync when server has no creator set
 - remove channels from client after transfer to a different
   organization (bsc#1209220)
 - Fix RHEL9 / SLL9 product discovery (bsc#1209993)


### PR DESCRIPTION
## What does this PR change?

Fix NPE in create cobbler sytem entry when system has no creator set.

## Links

Partial port of https://github.com/SUSE/spacewalk/pull/21133

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
