### PR TITLE
Use Context manager for spacewalk-backend

### DIFF
--- a/python/spacewalk/cdn_tools/candlepin_api.py
+++ b/python/spacewalk/cdn_tools/candlepin_api.py
@@ -19,9 +19,10 @@ import tempfile
 import requests
 
 from spacewalk.cdn_tools.constants import CA_CERT_PATH
-from uyuni.common.cli import getUsernamePassword
 from spacewalk.common.rhnConfig import CFG
 from spacewalk.satellite_tools.syncLib import log, log2
+from uyuni.common.cli import getUsernamePassword
+from uyuni.common.context_managers import cfg_component
 
 
 class CandlepinApi(object):
@@ -30,9 +31,10 @@ class CandlepinApi(object):
     def __init__(self, current_manifest=None, username=None, password=None,
                  http_proxy=None, http_proxy_username=None, http_proxy_password=None):
         self.base_url = current_manifest.get_api_url()
-        if CFG.CANDLEPIN_SERVER_API:
-            log(0, "Overriding Candlepin server to: '%s'" % CFG.CANDLEPIN_SERVER_API)
-            self.base_url = CFG.CANDLEPIN_SERVER_API
+        with cfg_component(component=None) as CFG:
+            if CFG.CANDLEPIN_SERVER_API:
+                log(0, "Overriding Candlepin server to: '%s'" % CFG.CANDLEPIN_SERVER_API)
+                self.base_url = CFG.CANDLEPIN_SERVER_API
 
         if self.base_url.startswith('https'):
             self.protocol = 'https'

--- a/python/spacewalk/cdn_tools/cdn-sync
+++ b/python/spacewalk/cdn_tools/cdn-sync
@@ -4,16 +4,16 @@ import argparse
 import sys
 import os
 
-from spacewalk.common.rhnConfig import CFG, initCFG
-from uyuni.common.fileutils import cleanupAbsPath
 from spacewalk.cdn_tools.common import CustomChannelSyncError, CdnMappingsLoadError, CountingPackagesError
 from spacewalk.cdn_tools.cdnsync import CdnSync
 from spacewalk.server import rhnSQL
-from uyuni.common.usix import raise_with_tb
 from rhn import rhnLockfile
 from rhn.connections import idn_ascii_to_puny
 from spacewalk.server.importlib.importLib import InvalidArchError, \
     InvalidChannelError, InvalidChannelFamilyError, MissingParentChannelError
+from uyuni.common.context_managers import cfg_component
+from uyuni.common.fileutils import cleanupAbsPath
+from uyuni.common.usix import raise_with_tb
 
 
 def system_exit(code, msgs=None):
@@ -30,8 +30,8 @@ def system_exit(code, msgs=None):
 def process_commandline():
     """process the commandline, setting the CFG object"""
 
-    initCFG('server.satellite')
-    CFG.ENABLE_NVREA = 1
+    with cfg_component('server.satellite') as CFG:
+        CFG.ENABLE_NVREA = 1
     parser = argparse.ArgumentParser()
     parser.add_argument("-l", "--list-channels", action="store_true", help="List channels available to sync.")
     parser.add_argument("-r", "--show-repos", action="store_true",
@@ -71,7 +71,8 @@ def process_commandline():
     cmd_args = parser.parse_args()
 
     if cmd_args.print_configuration:
-        CFG.show()
+        with cfg_component('server.satellite') as CFG:
+            CFG.show()
         sys.exit(0)
 
     if cmd_args.http_proxy:
@@ -79,11 +80,13 @@ def process_commandline():
             int(cmd_args.http_proxy.split(':')[1])
         except ValueError:
             system_exit(1, "Incorrect proxy port number: %s" % cmd_args.http_proxy.split(':')[1])
-        CFG.set("HTTP_PROXY", idn_ascii_to_puny(cmd_args.http_proxy))
-        CFG.set("HTTP_PROXY_USERNAME", cmd_args.http_proxy_username)
-        CFG.set("HTTP_PROXY_PASSWORD", cmd_args.http_proxy_password)
+        with cfg_component('server.satellite') as CFG:
+            CFG.set("HTTP_PROXY", idn_ascii_to_puny(cmd_args.http_proxy))
+            CFG.set("HTTP_PROXY_USERNAME", cmd_args.http_proxy_username)
+            CFG.set("HTTP_PROXY_PASSWORD", cmd_args.http_proxy_password)
 
-    CFG.set("TRACEBACK_MAIL", cmd_args.traceback_mail or CFG.TRACEBACK_MAIL)
+    with cfg_component('server.satellite') as CFG:
+        CFG.set("TRACEBACK_MAIL", cmd_args.traceback_mail or CFG.TRACEBACK_MAIL)
 
     if cmd_args.mount_point:
         cmd_args.mount_point = cleanupAbsPath(cmd_args.mount_point)
@@ -129,15 +132,16 @@ if __name__ == '__main__':
 
         args = process_commandline()
 
-        if CFG.get('disconnected') == 1:
-            system_exit(1, 'ERROR: the Satellite server is installed in disconnected mode, cannot continue syncing '
-                        'from CDN')
+        with cfg_component('server.satellite') as CFG:
+            if CFG.get('disconnected') == 1:
+                system_exit(1, 'ERROR: the Satellite server is installed in disconnected mode, cannot continue syncing '
+                            'from CDN')
 
-        if getDbIssParent() or (CFG.get('iss_parent') and CFG.get('disable_iss') == 0):
-            parent = getDbIssParent()
-            if not parent:
-                parent = CFG.get('iss_parent')
-            system_exit(1, 'ERROR: the Satellite server is registered to a parent Satellite "%s".\nTo sync content '
+            if getDbIssParent() or (CFG.get('iss_parent') and CFG.get('disable_iss') == 0):
+                parent = getDbIssParent()
+                if not parent:
+                    parent = CFG.get('iss_parent')
+                system_exit(1, 'ERROR: the Satellite server is registered to a parent Satellite "%s".\nTo sync content '
                         'from the parent Satellite via Inter-Satellite-Sync, please, use the "satellite-sync" command' %
                         parent)
 

--- a/python/spacewalk/cdn_tools/cdnsync.py
+++ b/python/spacewalk/cdn_tools/cdnsync.py
@@ -20,7 +20,7 @@ import fnmatch
 from datetime import datetime, timedelta
 
 from . import constants
-from spacewalk.common.rhnConfig import CFG, initCFG, PRODUCT_NAME
+from spacewalk.common.rhnConfig import PRODUCT_NAME
 from spacewalk.common import rhnLog
 from spacewalk.server import rhnSQL
 from spacewalk.server.rhnChannel import channel_info
@@ -53,7 +53,8 @@ class CdnSync(object):
         if log_level is None:
             log_level = 0
         self.log_level = log_level
-        CFG.set('DEBUG', log_level)
+        with cfg_component(component=None) as CFG:
+            CFG.set('DEBUG', log_level)
         self.email = email
         if self.email:
             initEMAIL_LOG()
@@ -61,7 +62,6 @@ class CdnSync(object):
         log2disk(0, "Command: %s" % str(sys.argv))
 
         rhnSQL.initDB()
-        initCFG('server.satellite')
 
         self.cdn_repository_manager = CdnRepositoryManager(mount_point)
         self.no_packages = no_packages
@@ -79,7 +79,8 @@ class CdnSync(object):
             self.mount_point = "file://" + mount_point
             self.consider_full = consider_full
         else:
-            self.mount_point = CFG.CDN_ROOT
+            with cfg_component('server.satellite') as CFG:
+                self.mount_point = CFG.CDN_ROOT
             self.consider_full = True
 
         verify_mappings()
@@ -491,7 +492,8 @@ class CdnSync(object):
         if add_repos:
             repos = set()
             for repo in add_repos:
-                repo = repo.replace(CFG.CDN_ROOT, '')
+                with cfg_component('server.satellite') as CFG:
+                    repo = repo.replace(CFG.CDN_ROOT, '')
                 repo_dirs = self.cdn_repository_manager.repository_tree.normalize_url(repo)
                 repo = os.path.join('/', '/'.join(repo_dirs))
                 repos.add(repo)
@@ -499,7 +501,8 @@ class CdnSync(object):
         if delete_repos:
             repos = set()
             for repo in delete_repos:
-                repo = repo.replace(CFG.CDN_ROOT, '')
+                with cfg_component('server.satellite') as CFG:
+                    repo = repo.replace(CFG.CDN_ROOT, '')
                 repo_dirs = self.cdn_repository_manager.repository_tree.normalize_url(repo)
                 repo = os.path.join('/', '/'.join(repo_dirs))
                 repos.add(repo)

--- a/python/spacewalk/common/rhnTB.py
+++ b/python/spacewalk/common/rhnTB.py
@@ -27,11 +27,12 @@ except ImportError:
     from io import StringIO
 from rhn.connections import idn_puny_to_unicode
 
-from spacewalk.common.rhnConfig import CFG, PRODUCT_NAME
+from spacewalk.common.rhnConfig import PRODUCT_NAME
 from spacewalk.common.rhnLog import log_error
 from spacewalk.common.rhnTranslate import _
 from spacewalk.common import rhnMail
 from spacewalk.common import rhnFlags
+from uyuni.common.context_managers import cfg_component
 
 # Get the hostname for traceback use
 hostname = socket.gethostname()
@@ -117,7 +118,8 @@ def Traceback(method=None, req=None, mail=1, ostream=sys.stderr,
     if mail:
         # safeguard
         if QUIET_MAIL is None:
-            QUIET_MAIL = CFG.QUIET_MAIL
+            with cfg_component(component=None) as CFG:
+                QUIET_MAIL = CFG.QUIET_MAIL
 
         if QUIET_MAIL < 0:
             QUIET_MAIL = 0
@@ -160,7 +162,8 @@ def Traceback(method=None, req=None, mail=1, ostream=sys.stderr,
         print_env(exc)
         # and send the mail
         # build the headers
-        to = CFG.TRACEBACK_MAIL
+        with cfg_component(component=None) as CFG:
+            to = CFG.TRACEBACK_MAIL
         from_ = to
         if isinstance(to, type([])):
             from_ = to[0].strip()

--- a/python/spacewalk/satellite_tools/mgr-update-pkg-extra-tags
+++ b/python/spacewalk/satellite_tools/mgr-update-pkg-extra-tags
@@ -7,10 +7,10 @@ import argparse
 from debian import debfile
 from rhn import rhnLockfile
 from spacewalk.server import rhnSQL
-from spacewalk.common.rhnConfig import CFG, initCFG
 from spacewalk.server.importlib.backendLib import DBstring, sanitizeValue
 from spacewalk.satellite_tools.progress_bar import ProgressBar
 from spacewalk.server import taskomatic
+from uyuni.common.context_managers import cfg_component
 
 try:
     #  python 2
@@ -123,7 +123,8 @@ class MetadataRefresh(object):
                 pb.printIncrement()
                 pkg_id = pkg['id']
                 pkg_path = pkg['path']
-                deb_path = os.path.join(CFG.MOUNT_POINT, pkg_path)
+                with cfg_component('server.susemanager') as CFG:
+                    deb_path = os.path.join(CFG.MOUNT_POINT, pkg_path)
                 deb = None
                 try:
                     deb = debfile.DebFile(deb_path)
@@ -164,8 +165,8 @@ def main(args):
         systemExit(1, 'ERROR: attempting to run more than one instance of '
                       'mgr-refresh-pkg-metadata Exiting.')
 
-    initCFG('server.satellite')
-    initCFG('server.susemanager')
+#    initCFG('server.satellite')
+#    initCFG('server.susemanager')
     rhnSQL.initDB()
 
     refresh = MetadataRefresh(args.verbose)

--- a/python/spacewalk/satellite_tools/spacewalk-data-fsck
+++ b/python/spacewalk/satellite_tools/spacewalk-data-fsck
@@ -7,11 +7,11 @@ import stat
 import shutil
 from optparse import Option, OptionParser
 import tempfile
+from uyuni.common.context_managers import cfg_component
 
 try:
     from uyuni.common import checksum
     from spacewalk.common.rhnLog import initLOG, log_debug
-    from spacewalk.common.rhnConfig import CFG, initCFG
     from spacewalk.server import rhnSQL
     from spacewalk.server.rhnPackage import unlink_package_file
 except:
@@ -19,7 +19,6 @@ except:
     # add to the path if need be
     if _LIBPATH not in sys.path:
         sys.path.append(_LIBPATH)
-    from common import CFG, initCFG, initLOG, log_debug
     from server import rhnSQL
     from server.rhnPackage import unlink_package_file
 
@@ -53,7 +52,6 @@ def is_sha256_capable():
 
 
 def db_init():
-    initCFG('server')
     rhnSQL.initDB()
 
 
@@ -91,7 +89,8 @@ def check_db_vs_disk(options):
     query = package_query(options)
     h = rhnSQL.prepare(query)
 
-    path_prefix = CFG.MOUNT_POINT
+    with cfg_component('server') as CFG:
+        path_prefix = CFG.MOUNT_POINT
 
     h.execute()
 
@@ -207,7 +206,8 @@ def check_disk_nevrao(abs_path, row, restore=None):
 
 
 def restore_file_path(file, row):
-    prefix = CFG.MOUNT_POINT + '/'
+    with cfg_component('server') as CFG:
+        prefix = CFG.MOUNT_POINT + '/'
     new_path = 'packages/' + row['org_id'] + '/' + row['checksum_prefix'] + '/' + row['name'] + \
         '/' + row['evr'] + '/' + row['arch'] + '/' + row['checksum'] + '/' + row['basename']
     query = "update rhnPackage set path=\'" + new_path + "\' where id=" + str(row['id'])
@@ -306,33 +306,34 @@ def check_disk_vs_db(disk_content=None, db_content=None):
         report[k] = 0
     query = package_query(options, bind_path=True)
     h = rhnSQL.prepare(query)
-    for root, dirs, files in os.walk(os.path.join(CFG.MOUNT_POINT, 'packages')):
-        rel_root = root[len(CFG.MOUNT_POINT) + 1:]
-        for f in files:
-            abs_path = os.path.join(root, f)
-            rel_path = os.path.join(rel_root, f)
-            log(3, abs_path)
-            report['file'] += 1
+    with cfg_component('server') as CFG:
+        for root, dirs, files in os.walk(os.path.join(CFG.MOUNT_POINT, 'packages')):
+            rel_root = root[len(CFG.MOUNT_POINT) + 1:]
+            for f in files:
+                abs_path = os.path.join(root, f)
+                rel_path = os.path.join(rel_root, f)
+                log(3, abs_path)
+                report['file'] += 1
 
-            h.execute(path=rel_path)
-            row = h.fetchone_dict()
+                h.execute(path=rel_path)
+                row = h.fetchone_dict()
 
-            if not row:
-                if (not is_srpm(f)) or is_orphaned_srpm(abs_path, f):
-                    if is_srpm(f):
-                        report['srpmexists'] += 1
-                    else:
-                        report['dbexists'] += 1
-                    not_in_db(abs_path, options)
-                continue
+                if not row:
+                    if (not is_srpm(f)) or is_orphaned_srpm(abs_path, f):
+                        if is_srpm(f):
+                            report['srpmexists'] += 1
+                        else:
+                            report['dbexists'] += 1
+                        not_in_db(abs_path, options)
+                    continue
 
-            if options.size and options.fs_only:
-                report['size'] += check_disk_size(abs_path, row['package_size'])
-            if options.nevrao and options.fs_only:
-                report['nevrao'] += check_disk_nevrao(abs_path, row.copy())
-            if options.checksum and options.fs_only:
-                report['checksum'] += check_disk_checksum(abs_path,
-                                                          row['checksum_type'], row['checksum'])
+                if options.size and options.fs_only:
+                    report['size'] += check_disk_size(abs_path, row['package_size'])
+                if options.nevrao and options.fs_only:
+                    report['nevrao'] += check_disk_nevrao(abs_path, row.copy())
+                if options.checksum and options.fs_only:
+                    report['checksum'] += check_disk_checksum(abs_path,
+                                                              row['checksum_type'], row['checksum'])
     h.close()
     error_found = 0
     for i in ['file', 'dbexists', 'srpmexists', 'size', 'nevrao', 'checksum']:

--- a/python/spacewalk/satellite_tools/spacewalk-repo-sync
+++ b/python/spacewalk/satellite_tools/spacewalk-repo-sync
@@ -44,9 +44,9 @@ def systemExit(code, msg=None):
 try:
     from rhn import rhnLockfile
     from spacewalk.common import rhnLog
-    from spacewalk.common.rhnConfig import CFG, initCFG
     from spacewalk.satellite_tools import reposync
     from spacewalk.satellite_tools.syncLib import log, log2disk
+    from uyuni.common.context_managers import cfg_component
 except KeyboardInterrupt:
     systemExit(0, "\nUser interrupted process.")
 except ImportError:
@@ -134,9 +134,9 @@ def main():
     if log_level is None:
         log_level = 0
 
-    initCFG('server.satellite')
-    CFG.set('DEBUG', log_level)
-    CFG.set("TRACEBACK_MAIL", options.traceback_mail or CFG.TRACEBACK_MAIL)
+    with cfg_component('server.satellite') as CFG:
+        CFG.set('DEBUG', log_level)
+        CFG.set("TRACEBACK_MAIL", options.traceback_mail or CFG.TRACEBACK_MAIL)
     if options.email:
         initEMAIL_LOG()
     rhnLog.initLOG(log_path, log_level)

--- a/python/spacewalk/satellite_tools/spacewalk-update-signatures
+++ b/python/spacewalk/satellite_tools/spacewalk-update-signatures
@@ -22,14 +22,14 @@ import os
 
 from optparse import Option, OptionParser
 from spacewalk.common.rhnLog import initLOG, log_debug
-from spacewalk.common.rhnConfig import CFG, initCFG
 from uyuni.common import rhn_rpm
 from spacewalk.server import rhnSQL
 from spacewalk.server.rhnServer import server_packages
 from spacewalk.satellite_tools.progress_bar import ProgressBar
+from uyuni.common.context_managers import cfg_component
 
-initCFG('server.satellite')
-initLOG(CFG.LOG_FILE, CFG.DEBUG)
+with cfg_component('server.satellite') as CFG:
+    initLOG(CFG.LOG_FILE, CFG.DEBUG)
 
 OPTIONS = None
 debug = 0
@@ -57,11 +57,13 @@ def main():
         sys.exit(-1)
 
     if options.verbose:
-        initLOG(CFG.LOG_FILE, 1)
+        with cfg_component('server.satellite') as CFG:
+            initLOG(CFG.LOG_FILE, 1)
         verbose = 1
 
     if options.debug:
-        initLOG(CFG.LOG_FILE, options.debug or 1)
+        with cfg_component('server.satellite') as CFG:
+            initLOG(CFG.LOG_FILE, options.debug or 1)
         debug = 1
 
     rhnSQL.initDB()
@@ -161,7 +163,8 @@ def process_package_data():
 
         if path is None:
             continue
-        full_path = os.path.join(CFG.MOUNT_POINT, path)
+        with cfg_component('server.satellite') as CFG:
+            full_path = os.path.join(CFG.MOUNT_POINT, path)
         checksum_type = pkg['checksum_type']
         checksum = pkg['checksum']
 

--- a/python/spacewalk/satellite_tools/syncCache.py
+++ b/python/spacewalk/satellite_tools/syncCache.py
@@ -21,7 +21,7 @@ import os
 
 # rhn imports:
 from spacewalk.common import rhnCache
-from spacewalk.common.rhnConfig import CFG, initCFG
+from uyuni.common.context_managers import cfg_component
 from uyuni.common.rhnLib import hash_object_id
 
 # NOTE: this is a python 2.2-ism
@@ -34,7 +34,8 @@ class BaseCache:
     def __init__(self):
         # Kind of kludgy - this may have weird side-effects if called from
         # within the server code
-        rhnCache.CACHEDIR = CFG.SYNC_CACHE_DIR
+        with cfg_component('server.satellite') as CFG:
+            rhnCache.CACHEDIR = CFG.SYNC_CACHE_DIR
 
     def cache_get(self, object_id, timestamp=None):
         # Get the key
@@ -100,7 +101,6 @@ class KickstartableTreesCache(BaseCache):
                                              object_id))
 
 if __name__ == '__main__':
-    initCFG("server.satellite")
     c = PackageCache()
     pid = 'package-12345'
     c.cache_set(pid, {'a': 1, 'b': 2})

--- a/python/spacewalk/satellite_tools/xmlSource.py
+++ b/python/spacewalk/satellite_tools/xmlSource.py
@@ -23,9 +23,9 @@ from xml.sax import make_parser, SAXParseException, ContentHandler, \
 from uyuni.common import usix
 from spacewalk.common import rhnFlags
 from spacewalk.common.rhnLog import log_debug
-from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.rhnTB import Traceback
 from spacewalk.server.importlib import importLib, backendLib
+from uyuni.common.context_managers import cfg_component
 
 RHEL234_REGEX = re.compile("rhel-[^-]*-[aew]s-(4|3|2.1)")
 
@@ -585,11 +585,12 @@ class BaseChecksummedItem(BaseItem):
             for csum in item['checksum_list']:
                 item['checksums'][csum['type']] = csum['value']
             del(item['checksum_list'])
-        for ctype in CFG.CHECKSUM_PRIORITY_LIST:
-            if ctype in item['checksums']:
-                item['checksum_type'] = ctype
-                item['checksum'] = item['checksums'][ctype]
-                break
+        with cfg_component(component=None) as CFG:
+            for ctype in CFG.CHECKSUM_PRIORITY_LIST:
+                if ctype in item['checksums']:
+                    item['checksum_type'] = ctype
+                    item['checksum'] = item['checksums'][ctype]
+                    break
         return item
 addItem(BaseChecksummedItem)
 


### PR DESCRIPTION
## What does this PR change?

Use the context manager for all spacewalk-backend files.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered
Build tested ok on copr for EL9 and Leap 15.4.
Installation on EL9 and basic sanity test also ok (installation, setup, creation of channel and sync).

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

Changelog already exists on this version. Otherwise will add in case of intermediate release.

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
