### PR TITLE
CI: Acceptance tests at PR v2: Add dmidecode package

### DIFF
--- a/testsuite/dockerfiles/opensuse-minion/Dockerfile
+++ b/testsuite/dockerfiles/opensuse-minion/Dockerfile
@@ -2,7 +2,7 @@ FROM opensuse/leap:15.4
 RUN zypper -n ar --no-gpgcheck https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/ Uyuni-Server-POOL-x86_64 && \
     zypper -n ar --no-gpgcheck https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm/systemsmanagement:Uyuni:Test-Packages:Pool.repo && \
     zypper ref -f && \ 
-    zypper -n install openssh-server openssh-clients hostname iproute2 venv-salt-minion andromeda-dummy milkyway-dummy virgo-dummy openscap-utils openscap-content scap-security-guide gzip udev && \
+    zypper -n install openssh-server openssh-clients hostname iproute2 venv-salt-minion andromeda-dummy milkyway-dummy virgo-dummy openscap-utils openscap-content scap-security-guide gzip udev dmidecode && \
     zypper clean -a
 RUN zypper -n ar --no-gpgcheck https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm/ test_repo_rpm_pool
 CMD ssh-keygen -A && /usr/sbin/sshd -De

--- a/testsuite/dockerfiles/rocky-minion/Dockerfile
+++ b/testsuite/dockerfiles/rocky-minion/Dockerfile
@@ -1,5 +1,5 @@
 FROM rockylinux:8
 COPY uyuni-tools-pool.repo /etc/yum.repos.d
-RUN yum -y install openssh-server venv-salt-minion openssh-clients iproute hostname openscap-utils scap-security-guide-redhat udev
+RUN yum -y install openssh-server venv-salt-minion openssh-clients iproute hostname openscap-utils scap-security-guide-redhat udev dmidecode
 COPY test_repo_rpm_pool.repo /etc/yum.repos.d
 CMD ssh-keygen -A && /usr/sbin/sshd -De

--- a/testsuite/dockerfiles/ubuntu-minion/Dockerfile
+++ b/testsuite/dockerfiles/ubuntu-minion/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 RUN echo "deb [trusted=yes] http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Ubuntu2204-Uyuni-Client-Tools/xUbuntu_22.04/ /" > /etc/apt/sources.list.d/uyuni-tools.list
 RUN apt-get update && \
-  apt-get -y install venv-salt-minion openssh-server openssh-client hostname iproute2 libopenscap8 scap-security-guide-ubuntu udev && \
+  apt-get -y install venv-salt-minion openssh-server openssh-client hostname iproute2 libopenscap8 scap-security-guide-ubuntu udev dmidecode && \
   apt-get clean
 RUN echo "deb [trusted=yes] https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/deb/ /" > /etc/apt/sources.list.d/test_repo_deb_pool.list
 RUN mkdir /run/sshd


### PR DESCRIPTION
Otherwise, the hardware refresh won't work.

## What does this PR change?

CI: Adds dmidecode

## GUI diff

No difference.



- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests
- [X] **DONE**

## Links
https://github.com/SUSE/spacewalk/issues/20956
- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
