### PR TITLE
return at least the assigned base channel if no product is installed

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -2558,6 +2558,10 @@ public class ChannelManager extends BaseManager {
         return Opt.fold(baseProductId,
                 () -> {
                     log.info("Server has no base product installed");
+                    if (s.getBaseChannel() != null) {
+                        // but we should return at least the assigned one
+                        return of(new DataResult(List.of(new EssentialChannelDto(s.getBaseChannel()))));
+                    }
                     return empty();
                 },
                 id -> {

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -2558,8 +2558,9 @@ public class ChannelManager extends BaseManager {
         return Opt.fold(baseProductId,
                 () -> {
                     log.info("Server has no base product installed");
-                    if (s.getBaseChannel() != null) {
-                        // but we should return at least the assigned one
+                    if (s.getBaseChannel() != null &&
+                            !s.getBaseChannel().getSuseProductChannels().isEmpty()) {
+                        // but we should return at least the assigned one if it is a SUSE Channel
                         return of(new DataResult(List.of(new EssentialChannelDto(s.getBaseChannel()))));
                     }
                     return empty();

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- fix displaying system channels when no base product is installed
+  (bsc#1206423)
 - fix NPE in cobbler system sync when server has no creator set
 - remove channels from client after transfer to a different
   organization (bsc#1209220)


### PR DESCRIPTION
## What does this PR change?

Method `listPossibleSuseBaseChannelsForServer()` uses the products to detect which base channels could be used.
On a new registered systems often the products are not yet installed but it could be, that the server has already a base channel assigned.
Return at least the assigned base channel as candidate if no products are installed.

This prevent that the assigned base channel is not visible in the list of base channels, but the child channels are visible.

## GUI diff

No difference.

Before:

![image](https://user-images.githubusercontent.com/100688791/207673811-e7268af6-243a-446c-b2e5-6b6e7833b322.png)

After:

![image](https://user-images.githubusercontent.com/1038917/232476893-a99b1a35-a00b-4e80-90aa-ea16f56e5f0d.png)

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19911
Tracks https://github.com/SUSE/spacewalk/pull/21142 https://github.com/SUSE/spacewalk/pull/21143

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
