### PR TITLE
QE: Unify Uyuni and SUMA branches in Cobbler log monitoring

### DIFF
--- a/testsuite/features/step_definitions/cobbler_steps.rb
+++ b/testsuite/features/step_definitions/cobbler_steps.rb
@@ -263,16 +263,10 @@ When(/^I start local monitoring of Cobbler$/) do
                   "level=DEBUG\n" \
                   "formatter=#{formatter_name}\n" \
                   "args=('#{cobbler_log_file}', 'a')\n\n" \
-                  "[formatter_#{formatter_name}]\n"
-    if $product == 'Uyuni'
-      step %(I install package "python3-python-json-logger" on this "server")
-      handler_class += "format =[%(threadName)s] %(asctime)s - %(levelname)s | %(message)s\n" \
-                      "class = pythonjsonlogger.jsonlogger.JsonFormatter\n\""
-    else
-      handler_class += "format ={\\''threadName\\'': \\''%(threadName)s\\'', " \
-                      "\\''asctime\\'': \\''%(asctime)s\\'', \\''levelname\\'':  \\''%(levelname)s\\'', " \
-                      "\\''message\\'': \\''%(message)s\\''}\n\""
-    end
+                  "[formatter_#{formatter_name}]\n" \
+                  "format ={\\''threadName\\'': \\''%(threadName)s\\'', " \
+                  "\\''asctime\\'': \\''%(asctime)s\\'', \\''levelname\\'':  \\''%(levelname)s\\'', " \
+                  "\\''message\\'': \\''%(message)s\\''}\n\""
     command = "cp #{cobbler_conf_file} #{cobbler_conf_file}.old && " \
               "line_number=`awk \"/\\\[handlers\\\]/{ print NR; exit }\" #{cobbler_conf_file}` && " \
               "sed -e \"$(($line_number + 1))s/$/,#{handler_name}/\" -i #{cobbler_conf_file} && " \
@@ -293,8 +287,7 @@ Then(/^the local logs for Cobbler should not contain errors$/) do
   return_code = file_extract($server, cobbler_log_file, local_file)
   raise 'File extraction failed' unless return_code.zero?
 
-  file_data = File.read(local_file).gsub!("\n", ',').chop
-  file_data = file_data.gsub('"', " ' ").gsub("\\''", '"') unless $product == 'Uyuni'
+  file_data = File.read(local_file).gsub!("\n", ',').chop.gsub('"', " ' ").gsub("\\''", '"')
   file_data = "[#{file_data}]"
   data_hash = JSON.parse(file_data)
   output = data_hash.select { |key, _hash| key['levelname'] == 'ERROR' }

--- a/testsuite/features/step_definitions/cobbler_steps.rb
+++ b/testsuite/features/step_definitions/cobbler_steps.rb
@@ -258,26 +258,20 @@ When(/^I start local monitoring of Cobbler$/) do
   if !code.zero?
     handler_name = 'FileLogger02'
     formatter_name = 'JSONlogfile'
+    handler_class = "\"\n[handler_#{handler_name}]\n" \
+                    "class=FileHandler\n" \
+                    "level=DEBUG\n" \
+                    "formatter=#{formatter_name}\n" \
+                    "args=('#{cobbler_log_file}', 'a')\n\n" \
+                    "[formatter_#{formatter_name}]\n"
     if $product == 'Uyuni'
       step %(I install package "python3-python-json-logger" on this "server")
-      handler_class = "\"\n[handler_#{handler_name}]\n" \
-                    "class=FileHandler\n" \
-                    "level=DEBUG\n" \
-                    "formatter=#{formatter_name}\n" \
-                    "args=('#{cobbler_log_file}', 'a')\n\n" \
-                    "[formatter_#{formatter_name}]\n" \
-                    "format =[%(threadName)s] %(asctime)s - %(levelname)s | %(message)s\n" \
-                    "class = pythonjsonlogger.jsonlogger.JsonFormatter\n\""
+      handler_class += "format =[%(threadName)s] %(asctime)s - %(levelname)s | %(message)s\n" \
+                      "class = pythonjsonlogger.jsonlogger.JsonFormatter\n\""
     else
-      handler_class = "\"\n[handler_#{handler_name}]\n" \
-                    "class=FileHandler\n" \
-                    "level=DEBUG\n" \
-                    "formatter=#{formatter_name}\n" \
-                    "args=('#{cobbler_log_file}', 'a')\n\n" \
-                    "[formatter_#{formatter_name}]\n" \
-                    "format ={\\''threadName\\'': \\''%(threadName)s\\'', " \
-                    "\\''asctime\\'': \\''%(asctime)s\\'', \\''levelname\\'':  \\''%(levelname)s\\'', " \
-                    "\\''message\\'': \\''%(message)s\\''}\n\""
+      handler_class += "format ={\\''threadName\\'': \\''%(threadName)s\\'', " \
+                      "\\''asctime\\'': \\''%(asctime)s\\'', \\''levelname\\'':  \\''%(levelname)s\\'', " \
+                      "\\''message\\'': \\''%(message)s\\''}\n\""
     end
     command = "cp #{cobbler_conf_file} #{cobbler_conf_file}.old && " \
               "line_number=`awk \"/\\\[handlers\\\]/{ print NR; exit }\" #{cobbler_conf_file}` && " \

--- a/testsuite/features/step_definitions/cobbler_steps.rb
+++ b/testsuite/features/step_definitions/cobbler_steps.rb
@@ -299,12 +299,8 @@ Then(/^the local logs for Cobbler should not contain errors$/) do
   return_code = file_extract($server, cobbler_log_file, local_file)
   raise 'File extraction failed' unless return_code.zero?
 
-  file_data =
-    if $product == 'Uyuni'
-      File.read(local_file).gsub!("\n", ',').chop
-    else
-      File.read(local_file).gsub!("\n", ',').chop.gsub('"', " ' ").gsub("\\''", '"')
-    end
+  file_data = File.read(local_file).gsub!("\n", ',').chop
+  file_data = file_data.gsub('"', " ' ").gsub("\\''", '"') unless $product == 'Uyuni'
   file_data = "[#{file_data}]"
   data_hash = JSON.parse(file_data)
   output = data_hash.select { |key, _hash| key['levelname'] == 'ERROR' }

--- a/testsuite/features/step_definitions/cobbler_steps.rb
+++ b/testsuite/features/step_definitions/cobbler_steps.rb
@@ -256,17 +256,29 @@ When(/^I start local monitoring of Cobbler$/) do
   $server.run("rm #{cobbler_log_file}", check_errors: false)
   _result, code = $server.run("test -f #{cobbler_conf_file}.old", check_errors: false)
   if !code.zero?
-    step %(I install package "python3-python-json-logger" on this "server")
     handler_name = 'FileLogger02'
     formatter_name = 'JSONlogfile'
-    handler_class = "\"\n[handler_#{handler_name}]\n" \
-                  "class=FileHandler\n" \
-                  "level=DEBUG\n" \
-                  "formatter=#{formatter_name}\n" \
-                  "args=('#{cobbler_log_file}', 'a')\n\n" \
-                  "[formatter_#{formatter_name}]\n" \
-                  "format =[%(threadName)s] %(asctime)s - %(levelname)s | %(message)s\n" \
-                  "class = pythonjsonlogger.jsonlogger.JsonFormatter\n\""
+    if $product == 'Uyuni'
+      step %(I install package "python3-python-json-logger" on this "server")
+      handler_class = "\"\n[handler_#{handler_name}]\n" \
+                    "class=FileHandler\n" \
+                    "level=DEBUG\n" \
+                    "formatter=#{formatter_name}\n" \
+                    "args=('#{cobbler_log_file}', 'a')\n\n" \
+                    "[formatter_#{formatter_name}]\n" \
+                    "format =[%(threadName)s] %(asctime)s - %(levelname)s | %(message)s\n" \
+                    "class = pythonjsonlogger.jsonlogger.JsonFormatter\n\""
+    else
+      handler_class = "\"\n[handler_#{handler_name}]\n" \
+                    "class=FileHandler\n" \
+                    "level=DEBUG\n" \
+                    "formatter=#{formatter_name}\n" \
+                    "args=('#{cobbler_log_file}', 'a')\n\n" \
+                    "[formatter_#{formatter_name}]\n" \
+                    "format ={\\''threadName\\'': \\''%(threadName)s\\'', " \
+                    "\\''asctime\\'': \\''%(asctime)s\\'', \\''levelname\\'':  \\''%(levelname)s\\'', " \
+                    "\\''message\\'': \\''%(message)s\\''}\n\""
+    end
     command = "cp #{cobbler_conf_file} #{cobbler_conf_file}.old && " \
               "line_number=`awk \"/\\\[handlers\\\]/{ print NR; exit }\" #{cobbler_conf_file}` && " \
               "sed -e \"$(($line_number + 1))s/$/,#{handler_name}/\" -i #{cobbler_conf_file} && " \
@@ -287,7 +299,11 @@ Then(/^the local logs for Cobbler should not contain errors$/) do
   return_code = file_extract($server, cobbler_log_file, local_file)
   raise 'File extraction failed' unless return_code.zero?
 
-  file_data = File.read(local_file).gsub!("\n", ',').chop
+  if $product == 'Uyuni'
+    file_data = File.read(local_file).gsub!("\n", ',').chop
+  else
+    file_data = File.read(local_file).gsub!("\n", ',').chop.gsub('"', " ' ").gsub("\\''", '"')
+  end
   file_data = "[#{file_data}]"
   data_hash = JSON.parse(file_data)
   output = data_hash.select { |key, _hash| key['levelname'] == 'ERROR' }

--- a/testsuite/features/step_definitions/cobbler_steps.rb
+++ b/testsuite/features/step_definitions/cobbler_steps.rb
@@ -259,11 +259,11 @@ When(/^I start local monitoring of Cobbler$/) do
     handler_name = 'FileLogger02'
     formatter_name = 'JSONlogfile'
     handler_class = "\"\n[handler_#{handler_name}]\n" \
-                    "class=FileHandler\n" \
-                    "level=DEBUG\n" \
-                    "formatter=#{formatter_name}\n" \
-                    "args=('#{cobbler_log_file}', 'a')\n\n" \
-                    "[formatter_#{formatter_name}]\n"
+                  "class=FileHandler\n" \
+                  "level=DEBUG\n" \
+                  "formatter=#{formatter_name}\n" \
+                  "args=('#{cobbler_log_file}', 'a')\n\n" \
+                  "[formatter_#{formatter_name}]\n"
     if $product == 'Uyuni'
       step %(I install package "python3-python-json-logger" on this "server")
       handler_class += "format =[%(threadName)s] %(asctime)s - %(levelname)s | %(message)s\n" \

--- a/testsuite/features/step_definitions/cobbler_steps.rb
+++ b/testsuite/features/step_definitions/cobbler_steps.rb
@@ -299,11 +299,12 @@ Then(/^the local logs for Cobbler should not contain errors$/) do
   return_code = file_extract($server, cobbler_log_file, local_file)
   raise 'File extraction failed' unless return_code.zero?
 
-  if $product == 'Uyuni'
-    file_data = File.read(local_file).gsub!("\n", ',').chop
-  else
-    file_data = File.read(local_file).gsub!("\n", ',').chop.gsub('"', " ' ").gsub("\\''", '"')
-  end
+  file_data =
+    if $product == 'Uyuni'
+      File.read(local_file).gsub!("\n", ',').chop
+    else
+      File.read(local_file).gsub!("\n", ',').chop.gsub('"', " ' ").gsub("\\''", '"')
+    end
   file_data = "[#{file_data}]"
   data_hash = JSON.parse(file_data)
   output = data_hash.select { |key, _hash| key['levelname'] == 'ERROR' }


### PR DESCRIPTION
## What does this PR change?
Unify Uyuni and SUMA products in Cobbler log monitoring step definition.
This will enable to sync the different branches on that topic.

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Fixes #
Tracks #
4.3 https://github.com/SUSE/spacewalk/pull/21154
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
