### PR TITLE
CI: Acceptance tests at PR v2: add unique product_uuid

### DIFF
--- a/testsuite/podman_runner/12_run_salt_sle_minion.sh
+++ b/testsuite/podman_runner/12_run_salt_sle_minion.sh
@@ -2,7 +2,9 @@
 set -xe
 src_dir=$(cd $(dirname "$0")/../.. && pwd -P)
 
-podman run --rm -d --network uyuni-network-1 -v /tmp/test-all-in-one:/tmp -v ${src_dir}/testsuite/podman_runner/salt-minion-entry-point.sh:/salt-minion-entry-point.sh --name sle_minion -h sle_minion ghcr.io/$UYUNI_PROJECT/uyuni/ci-test-opensuse-minion:$UYUNI_VERSION bash -c "/salt-minion-entry-point.sh uyuni-server-all-in-one-test 1-SUSE-KEY-x86_64"
+echo opensuseminionproductuuid > /tmp/opensuse_product_uuid
+
+podman run --rm -d --network uyuni-network-1 -v /tmp/opensuse_product_uuid:/sys/class/dmi/id/product_uuid -v /tmp/test-all-in-one:/tmp -v ${src_dir}/testsuite/podman_runner/salt-minion-entry-point.sh:/salt-minion-entry-point.sh --name sle_minion -h sle_minion ghcr.io/$UYUNI_PROJECT/uyuni/ci-test-opensuse-minion:$UYUNI_VERSION bash -c "/salt-minion-entry-point.sh uyuni-server-all-in-one-test 1-SUSE-KEY-x86_64"
 podman exec sle_minion bash -c "ssh-keygen -A && /usr/sbin/sshd -e"
 podman exec sle_minion bash -c "if [ ! -d /root/.ssh ];then mkdir /root/.ssh/;chmod 700 /root/.ssh;fi;cp /tmp/authorized_keys /root/.ssh/"
 

--- a/testsuite/podman_runner/13_run_salt_rhlike_minion.sh
+++ b/testsuite/podman_runner/13_run_salt_rhlike_minion.sh
@@ -2,7 +2,9 @@
 set -xe
 src_dir=$(cd $(dirname "$0")/../.. && pwd -P)
 
-podman run --rm -d --network uyuni-network-1 -v /tmp/test-all-in-one:/tmp -v ${src_dir}/testsuite/podman_runner/salt-minion-entry-point.sh:/salt-minion-entry-point.sh --name rhlike_minion -h rhlike_minion ghcr.io/$UYUNI_PROJECT/uyuni/ci-test-rocky-minion:$UYUNI_VERSION bash -c "/salt-minion-entry-point.sh uyuni-server-all-in-one-test 1-RH-LIKE-KEY"
+echo rhminionproductuuid > /tmp/rh_product_uuid
+
+podman run --rm -d --network uyuni-network-1 -v /tmp/rh_product_uuid:/sys/class/dmi/id/product_uuid -v /tmp/test-all-in-one:/tmp -v ${src_dir}/testsuite/podman_runner/salt-minion-entry-point.sh:/salt-minion-entry-point.sh --name rhlike_minion -h rhlike_minion ghcr.io/$UYUNI_PROJECT/uyuni/ci-test-rocky-minion:$UYUNI_VERSION bash -c "/salt-minion-entry-point.sh uyuni-server-all-in-one-test 1-RH-LIKE-KEY"
 # sleep 10
 podman exec rhlike_minion bash -c "ssh-keygen -A && /usr/sbin/sshd -e"
 podman exec rhlike_minion bash -c "if [ ! -d /root/.ssh ];then mkdir /root/.ssh/;chmod 700 /root/.ssh;fi;cp /tmp/authorized_keys /root/.ssh/"

--- a/testsuite/podman_runner/14_run_salt_deblike_minion.sh
+++ b/testsuite/podman_runner/14_run_salt_deblike_minion.sh
@@ -2,6 +2,8 @@
 set -xe
 src_dir=$(cd $(dirname "$0")/../.. && pwd -P)
 
-podman run --rm -d --network uyuni-network-1 -v /tmp/test-all-in-one:/tmp -v ${src_dir}/testsuite/podman_runner/salt-minion-entry-point.sh:/salt-minion-entry-point.sh --name deblike_minion -h deblike_minion ghcr.io/$UYUNI_PROJECT/uyuni/ci-test-ubuntu-minion:$UYUNI_VERSION bash -c "/salt-minion-entry-point.sh uyuni-server-all-in-one-test 1-DEBLIKE-KEY"
+echo ubuntuminionproductuuid > /tmp/ubuntu_product_uuid
+
+podman run --rm -d --network uyuni-network-1 -v /tmp/ubuntu_product_uuid:/sys/class/dmi/id/product_uuid -v /tmp/test-all-in-one:/tmp -v ${src_dir}/testsuite/podman_runner/salt-minion-entry-point.sh:/salt-minion-entry-point.sh --name deblike_minion -h deblike_minion ghcr.io/$UYUNI_PROJECT/uyuni/ci-test-ubuntu-minion:$UYUNI_VERSION bash -c "/salt-minion-entry-point.sh uyuni-server-all-in-one-test 1-DEBLIKE-KEY"
 podman exec deblike_minion bash -c "ssh-keygen -A && /usr/sbin/sshd -e"
 podman exec deblike_minion bash -c "if [ ! -d /root/.ssh ];then mkdir /root/.ssh/;chmod 700 /root/.ssh;fi;cp /tmp/authorized_keys /root/.ssh/"


### PR DESCRIPTION
## What does this PR change?

add a unique product_uuid. Otherwise, they all have the product_uuid of the  host.

## GUI diff

No difference.


- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests
- [X] **DONE**

## Links
https://github.com/SUSE/spacewalk/issues/20956


- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
