### PR TITLE
Adding CLM collection to spacewalk-debug

### DIFF
--- a/python/spacewalk/satellite_tools/spacewalk-debug
+++ b/python/spacewalk/satellite_tools/spacewalk-debug
@@ -248,6 +248,25 @@ if [ -d /usr/share/rhn/config-defaults ]; then
     cp -fa /usr/share/rhn/config-defaults/* $DIR/config-defaults
 fi
 
+# clm history
+echo "    * get CLM project history data"
+if [ -f /usr/bin/spacewalk-sql ] ; then
+  mkdir -p $DIR/clm
+  query_projects="SELECT id, name FROM susecontentproject;"
+  temp_query_output="temp_query_output.txt"
+  echo "$query_projects" | spacewalk-sql --select-mode - | tail -n +3 | head -n -2 > "$temp_query_output"
+
+  while IFS=$'|' read -r project_id project_name; do
+    project_id="$(echo "$project_id" | tr -s ' ' | xargs)"  # Remove extra spaces
+    project_name="$(echo "$project_name" | tr -s ' ' | xargs)"  # Remove extra spaces
+    project_history_file="$DIR/clm/${project_name}_history"
+    echo "Project ID: $project_id, Project Name: $project_name" > "$project_history_file"
+    query_project_history="SELECT message, version, created, user_id FROM susecontentprojecthistoryentry WHERE project_id = $project_id;"
+    echo "$query_project_history" | spacewalk-sql --select-mode - >> "$project_history_file"
+  done < "$temp_query_output"
+  rm "$temp_query_output"
+fi
+
 #cobbler stuff
 echo "    * copying cobbler files"
 if [ -d /etc/cobbler ]; then

--- a/python/spacewalk/satellite_tools/spacewalk-debug
+++ b/python/spacewalk/satellite_tools/spacewalk-debug
@@ -248,24 +248,33 @@ if [ -d /usr/share/rhn/config-defaults ]; then
     cp -fa /usr/share/rhn/config-defaults/* $DIR/config-defaults
 fi
 
-# clm history
-echo "    * get CLM project history data"
-if [ -f /usr/bin/spacewalk-sql ] ; then
-  mkdir -p $DIR/clm
-  query_projects="SELECT id, name FROM susecontentproject;"
-  temp_query_output="temp_query_output.txt"
-  echo "$query_projects" | spacewalk-sql --select-mode - | tail -n +3 | head -n -2 > "$temp_query_output"
+# CLM - Save Current Environment Version Details
+echo "    * querying CLM project history"
+mkdir -p "$DIR/clm/projects"
+echo "SELECT id, label, first_env_id FROM susecontentproject;" | /usr/bin/spacewalk-sql --select-mode - | tail -n +3 | head -n -2 > "$DIR/clm/tmp_projects.txt"
 
-  while IFS=$'|' read -r project_id project_name; do
-    project_id="$(echo "$project_id" | tr -s ' ' | xargs)"  # Remove extra spaces
-    project_name="$(echo "$project_name" | tr -s ' ' | xargs)"  # Remove extra spaces
-    project_history_file="$DIR/clm/${project_name}_history"
-    echo "Project ID: $project_id, Project Name: $project_name" > "$project_history_file"
-    query_project_history="SELECT message, version, created, user_id FROM susecontentprojecthistoryentry WHERE project_id = $project_id;"
-    echo "$query_project_history" | spacewalk-sql --select-mode - >> "$project_history_file"
-  done < "$temp_query_output"
-  rm "$temp_query_output"
-fi
+while read -r project; do
+  project_id=$(echo "$project" | awk '{print $1}' |  tr -d '[:space:]')
+  project_label=$(echo "$project" | awk '{print $3}' | tr -d '[:space:]')
+  first_env_id=$(echo "$project" | awk  '{print $5}' | tr -d '[:space:]')
+
+  curr_env=$first_env_id
+  while [ -n "$curr_env" ]; do
+    env_label=$(echo "SELECT label FROM susecontentenvironment WHERE id=$curr_env;" | /usr/bin/spacewalk-sql --select-mode - | tail -n +3 | head -n -2 | tr -d '[:space:]')
+    env_version=$(echo "SELECT version FROM susecontentenvironment WHERE id=$curr_env;" | /usr/bin/spacewalk-sql --select-mode - | tail -n +3 | head -n -2 | tr -d '[:space:]')
+    echo "## Environment: $env_label" >> "$DIR/clm/projects/$project_label.txt"
+    echo "SELECT message, version, created FROM susecontentprojecthistoryentry WHERE project_id=$project_id AND version=$env_version ;" | /usr/bin/spacewalk-sql --select-mode - | head -n -2 >> "$DIR/clm/projects/$project_label.txt"
+    echo -e "\n\n" >> "$DIR/clm/projects/$project_label.txt"
+    next_env=$(echo "SELECT next_env_id FROM susecontentenvironment WHERE id=$curr_env;" | /usr/bin/spacewalk-sql --select-mode - | tail -n +3 | head -n -2 | awk '{print $1}' | tr -d '[:space:]')
+    curr_env="$next_env"
+  done
+done < "$DIR/clm/tmp_projects.txt"
+
+rm "$DIR/clm/tmp_projects.txt"
+
+# Save all CLM releated DB Tables to clm/full_tables.txt
+echo "    * querying CLM tables"
+for i in $(echo "\\dt;" | /usr/bin/spacewalk-sql --select-mode - |grep susecontent | awk '{print $3}'); do echo "$i"; echo "SELECT * FROM $i;" | /usr/bin/spacewalk-sql --select-mode -; done > "$DIR/clm/full_tables.txt"
 
 #cobbler stuff
 echo "    * copying cobbler files"

--- a/python/spacewalk/spacewalk-backend.changes.slsnow.spacewalk-debug-clm
+++ b/python/spacewalk/spacewalk-backend.changes.slsnow.spacewalk-debug-clm
@@ -1,0 +1,1 @@
+- Add CLM data collection to spacewalk-debug


### PR DESCRIPTION
## What does this PR change?

1. Query and store CLM project history for each project:
    - For each project, the script retrieves the project's environments and their current corresponding version histories.
    - More specifically, the project's environment history (message, version, and created date) is saved in a separate text file for each project under the "clm/projects" directory.

2. Save all CLM related DB tables to "clm/full_tables.txt":
    - The script queries all the tables related to the Content Lifecycle Management (CLM) feature.
    - The output is saved in a single file called "clm/full_tables.txt" in the output.

This should be helpful for users and support engineers, to avoid having to collect this data from the webUI manually. It may be helpful to add something similar to the API and spacecmd.

Fixes https://github.com/uyuni-project/uyuni/issues/6900