### PR TITLE
Prepare the migration for Uyuni 2024.04:

### DIFF
--- a/web/conf/rhn_web.conf
+++ b/web/conf/rhn_web.conf
@@ -66,7 +66,7 @@ web.version = 4.4.0 Alpha1
 # the version of Uyuni to show at the WebUI, it will be prepended
 # to web.version as version for the SPECs, when building them
 # for Uyuni
-web.version.uyuni =  2023.03
+web.version.uyuni =  2023.04
 
 web.buildtimestamp = _OBS_BUILD_TIMESTAMP_
 


### PR DESCRIPTION
## What does this PR change?

Prepare the migration for Uyuni 2024.04:

* Adjust the version number in web/conf/rhn_web.conf
* Add the migration schema from uyuni-reportdb-schema-4.4.2 to uyuni-reportdb-schema-4.4.3

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **already covered**

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks SUSE/spacewalk#20653

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
