### PR TITLE
multiple defaultsort args cause warnings, remove duplicates

### DIFF
--- a/java/code/webapp/WEB-INF/pages/common/fragments/errata/relevant-errata-list.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/errata/relevant-errata-list.jspf
@@ -62,7 +62,6 @@
         <rl:column headerkey="erratalist.jsp.systems"
                    sortable="true"
                    sortattr="systems"
-                   defaultsort="desc"
                    styleclass="text-align: center;">
             <a href="/rhn/errata/details/SystemsAffected.do?eid=${current.id}">${current.affectedSystemCount}</a>
         </rl:column>


### PR DESCRIPTION
## What does this PR change?

Try to fix

```
2023-04-18 05:39:29,032 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-9] WARN  com.redhat.rhn.frontend.taglibs.list.ColumnTag - Trying to set  column [systems] as the default sort.The default sort column has already been set for [advisoryName]. Can't reset it to [systems].
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/21158

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
