### PR TITLE
Improve minion cleanup

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -790,15 +790,18 @@ public class SystemManager extends BaseManager {
     private void removeSaltSSHKnownHosts(Server server) {
         Integer sshPort = server.getProxyInfo() != null ? server.getProxyInfo().getSshPort() : null;
         int port = sshPort != null ? sshPort : SaltSSHService.SSH_DEFAULT_PORT;
-        Optional.ofNullable(server.getHostname()).ifPresent(hostname -> {
-            Optional<MgrUtilRunner.RemoveKnowHostResult> result =
-                    saltApi.removeSaltSSHKnownHost(hostname, port);
-            boolean removed = result.map(r -> "removed".equals(r.getStatus())).orElse(false);
-            if (!removed) {
-                log.warn("Hostname {}:{} could not be removed from /var/lib/salt/.ssh/known_hosts: {}", hostname, port,
-                        result.map(r -> r.getComment()).orElse(""));
-            }
-        });
+        Optional.ofNullable(server.getHostname()).ifPresentOrElse(
+                hostname -> {
+                    Optional<MgrUtilRunner.RemoveKnowHostResult> result =
+                            saltApi.removeSaltSSHKnownHost(hostname, port);
+                    boolean removed = result.map(r -> "removed".equals(r.getStatus())).orElse(false);
+                    if (!removed) {
+                        log.warn("Hostname {}:{} could not be removed from /var/lib/salt/.ssh/known_hosts: {}",
+                                hostname, port, result.map(r -> r.getComment()).orElse(""));
+                    }
+                },
+                () -> log.warn("Unable to remove SSH key for {} from /var/lib/salt/.ssh/known_hosts: unknown hostname",
+                        server.getName()));
     }
 
     /**

--- a/susemanager-utils/susemanager-sls/salt/cleanup_minion/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/cleanup_minion/init.sls
@@ -1,3 +1,11 @@
+{%- set salt_minion_name = 'salt-minion' %}
+{%- set susemanager_minion_config = '/etc/salt/minion.d/susemanager.conf' %}
+{# Prefer venv-salt-minion if installed #}
+{%- if salt['pkg.version']('venv-salt-minion') %}
+{%- set salt_minion_name = 'venv-salt-minion' %}
+{%- set susemanager_minion_config = '/etc/venv-salt-minion/minion.d/susemanager.conf' %}
+{%- endif -%}
+
 {%- if grains['os_family'] == 'RedHat' %}
 mgrchannels_repo_clean_all:
   file.absent:
@@ -24,3 +32,23 @@ mgrchannels_repo_clean_keyring:
 mgr_mark_no_longer_managed:
   file.absent:
     - name: /etc/sysconfig/rhn/systemid
+
+mgr_remove_salt_config:
+  file.absent:
+    - name: {{ susemanager_minion_config }}
+
+mgr_disable_salt:
+  cmd.run:
+    - name: systemctl disable {{ salt_minion_name }}
+    - require:
+      - file: mgr_remove_salt_config
+
+{%- if not grains['transactional'] %}
+mgr_stop_salt:
+  cmd.run:
+    - bg: True
+    - name: sleep 9 && systemctl stop {{ salt_minion_name }}
+    - order: last
+    - require:
+      - file: mgr_remove_salt_config
+{% endif %}

--- a/susemanager-utils/susemanager-sls/salt/cleanup_minion/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/cleanup_minion/init.sls
@@ -1,9 +1,9 @@
 {%- set salt_minion_name = 'salt-minion' %}
-{%- set susemanager_minion_config = '/etc/salt/minion.d/susemanager.conf' %}
+{%- set salt_config_dir = '/etc/salt' %}
 {# Prefer venv-salt-minion if installed #}
 {%- if salt['pkg.version']('venv-salt-minion') %}
 {%- set salt_minion_name = 'venv-salt-minion' %}
-{%- set susemanager_minion_config = '/etc/venv-salt-minion/minion.d/susemanager.conf' %}
+{%- set salt_config_dir = '/etc/venv-salt-minion' %}
 {%- endif -%}
 
 {%- if grains['os_family'] == 'RedHat' %}
@@ -35,7 +35,23 @@ mgr_mark_no_longer_managed:
 
 mgr_remove_salt_config:
   file.absent:
-    - name: {{ susemanager_minion_config }}
+    - name: {{ salt_config_dir }}/minion.d/susemanager.conf
+
+mgr_remove_salt_config_altname:
+  file.absent:
+     - name: {{ salt_config_dir }}/minion.d/master.conf
+
+mgr_remove_salt_priv_key:
+  file.absent:
+     - name: {{ salt_config_dir }}/pki/minion.pem
+
+mgr_remove_salt_pub_key:
+  file.absent:
+     - name: {{ salt_config_dir }}/pki/minion.pub
+
+mgr_remove_salt_master_key:
+  file.absent:
+     - name: {{ salt_config_dir }}/pki/minion_master.pub
 
 mgr_disable_salt:
   cmd.run:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- disable salt-minion and remove its config file on cleanup (bsc#1209277)
+
 -------------------------------------------------------------------
 Wed Apr 19 12:56:27 CEST 2023 - marina.latini@suse.com
 

--- a/testsuite/features/secondary/min_salt_minions_page.feature
+++ b/testsuite/features/secondary/min_salt_minions_page.feature
@@ -25,7 +25,7 @@ Feature: Management of minion keys
 
   Scenario: Minion is visible in the Pending section
     When I configure salt minion on "sle_minion"
-    And I wait until no Salt client is active on "sle_minion"
+    And I wait until Salt client is inactive on "sle_minion"
     And I restart salt-minion on "sle_minion"
     And I wait at most 10 seconds until Salt master sees "sle_minion" as "unaccepted"
     And I follow the left menu "Salt > Keys"

--- a/testsuite/features/secondary/min_salt_minions_page.feature
+++ b/testsuite/features/secondary/min_salt_minions_page.feature
@@ -24,6 +24,8 @@ Feature: Management of minion keys
     Then I should see a "Keys" text in the content area
 
   Scenario: Minion is visible in the Pending section
+    When I configure salt minion on "sle_minion"
+    And I wait until no Salt client is active on "sle_minion"
     And I restart salt-minion on "sle_minion"
     And I wait at most 10 seconds until Salt master sees "sle_minion" as "unaccepted"
     And I follow the left menu "Salt > Keys"

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -83,10 +83,9 @@ When(/^I wait at most (\d+) seconds until Salt master sees "([^"]*)" as "([^"]*)
   end
 end
 
-When(/^I wait until no Salt client is active on "([^"]*)"$/) do |minion|
+When(/^I wait until Salt client is inactive on "([^"]*)"$/) do |minion|
   salt_minion = $use_salt_bundle ? "venv-salt-minion" : "salt-minion"
-  step %(I wait until "#{salt_minion}" service is active on "#{minion}")
-  sleep 2
+  step %(I wait until "#{salt_minion}" service is inactive on "#{minion}")
 end
 
 When(/^I wait until no Salt job is running on "([^"]*)"$/) do |minion|

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -83,6 +83,12 @@ When(/^I wait at most (\d+) seconds until Salt master sees "([^"]*)" as "([^"]*)
   end
 end
 
+When(/^I wait until no Salt client is active on "([^"]*)"$/) do |minion|
+  salt_minion = $use_salt_bundle ? "venv-salt-minion" : "salt-minion"
+  step %(I wait until "#{salt_minion}" service is active on "#{minion}")
+  sleep 2
+end
+
 When(/^I wait until no Salt job is running on "([^"]*)"$/) do |minion|
   target = get_target(minion)
   salt_call = $use_salt_bundle ? "venv-salt-call" : "salt-call"
@@ -217,6 +223,19 @@ When(/^I remove "([^"]*)" from salt minion config directory on "([^"]*)"$/) do |
   node = get_target(host)
   salt_config = $use_salt_bundle ? "/etc/venv-salt-minion/minion.d/" : "/etc/salt/minion.d/"
   file_delete(node, "#{salt_config}#{filename}")
+end
+
+When(/^I configure salt minion on "([^"]*)"$/) do |host|
+  content = %(
+master: #{$server.full_hostname}
+server_id_use_crc: adler32
+enable_legacy_startup_events: False
+enable_fqdns_grains: False
+start_event_grains:
+  - machine_id
+  - saltboot_initrd
+  - susemanager)
+  step %(I store "#{content}" into file "susemanager.conf" in salt minion config directory on "#{host}")
 end
 
 When(/^I store "([^"]*)" into file "([^"]*)" in salt minion config directory on "([^"]*)"$/) do |content, filename, host|


### PR DESCRIPTION
## What does this PR change?

On minion cleanup we do not disable the minion and do not remove the minion config file as this is not easy possible to disable the service which is executing the cleanup.
We found a solution to stop the minion independent of the service to achieve this.

Additionally this PR improve the logging on delete system, when the ssh key could not be removed from known_hosts file.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- https://github.com/uyuni-project/uyuni-docs/pull/2194

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fix https://github.com/SUSE/spacewalk/issues/21187
Tracks 

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
