### PR TITLE
Testsuite: Repeat several times the check for an empty pillar data

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -342,7 +342,11 @@ end
 
 Then(/^the pillar data for "([^"]*)" should be empty on "([^"]*)"$/) do |key, minion|
   output, _code = pillar_get(key, minion)
-  raise "Output has more than one line: #{output}" unless output.split("\n").length == 1
+  repeat_until_timeout(timeout: DEFAULT_TIMEOUT, message: "Output has more than one line: #{output}", report_result: true) do
+    break unless output.split("\n").length != 1
+    sleep 1
+    output, _code = pillar_get(key, minion)
+  end
 end
 
 Given(/^I try to download "([^"]*)" from channel "([^"]*)"$/) do |rpm, channel|

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -341,11 +341,11 @@ Then(/^the pillar data for "([^"]*)" should not contain "([^"]*)" on "([^"]*)"$/
 end
 
 Then(/^the pillar data for "([^"]*)" should be empty on "([^"]*)"$/) do |key, minion|
-  output, _code = pillar_get(key, minion)
+  output = ''
   repeat_until_timeout(timeout: DEFAULT_TIMEOUT, message: "Output has more than one line: #{output}", report_result: true) do
+    output, _code = pillar_get(key, minion)
     break if output.split("\n").length == 1
     sleep 1
-    output, _code = pillar_get(key, minion)
   end
 end
 

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -343,7 +343,7 @@ end
 Then(/^the pillar data for "([^"]*)" should be empty on "([^"]*)"$/) do |key, minion|
   output, _code = pillar_get(key, minion)
   repeat_until_timeout(timeout: DEFAULT_TIMEOUT, message: "Output has more than one line: #{output}", report_result: true) do
-    break unless output.split("\n").length != 1
+    break if output.split("\n").length == 1
     sleep 1
     output, _code = pillar_get(key, minion)
   end


### PR DESCRIPTION
## What does this PR change?
It can happen that the pillar data is not empty yet despite the associated salt job being indicated as done.
This PR adds a `repeat` clause to wait a bit for the data to be emptied.
Additional information: https://github.com/SUSE/spacewalk/issues/18664#issuecomment-1514732996

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/18664
Tracks # 
4.2 https://github.com/SUSE/spacewalk/pull/21219
4.3 https://github.com/SUSE/spacewalk/pull/21218
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
