### PR TITLE
reduce default salt_batch_size to 150

### DIFF
--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -183,7 +183,7 @@ java.salt_presence_ping_gather_job_timeout = 1
 # Upper limit to the number of minions that execute a single Action concurrently. Lowering this value
 # prevents thundering-herd effects from Action execution but can decrease overall performance as the
 # overall level of parallelization is reduced. This is translated to the `--batch-size` Salt option.
-java.salt_batch_size = 200
+java.salt_batch_size = 150
 
 # Delay, in seconds, before a new batch is scheduled. After the first batch is scheduled with a size up to
 # java.salt_batch_size, subsequent batches will contain a smaller number of minions: the exact count will be

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,7 @@
+- reduce default salt_batch_size to 150 to match default for apache
+  worker and reduce the load on the server when big expensive jobs
+  needs to be handled (bsc#1210675)
+
 -------------------------------------------------------------------
 Wed Apr 19 12:47:06 CEST 2023 - marina.latini@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Reduce default salt_batch_size to 150 to match default for apache
worker and reduce the load on the server when big expensive jobs
needs to be handled 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- https://github.com/uyuni-project/uyuni-docs/pull/2197

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
