### PR TITLE
add Debian backports repositories to spacewalk-common-channels.ini

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -3338,6 +3338,15 @@ checksum = sha256
 base_channels = debian-10-pool-amd64-uyuni
 repo_url = http://security-cdn.debian.org/debian-security/dists/buster/updates/main/binary-amd64/
 
+[debian-10-amd64-main-backports-uyuni]
+label    = debian-10-amd64-main-backports-uyuni
+name     = Debian 10 (buster) AMD64 Main Backports for Uyuni
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = debian-10-pool-amd64-uyuni
+repo_url = http://deb.debian.org/debian/dists/buster-backports/main/binary-amd64/
+
 [debian-10-amd64-uyuni-client-devel]
 label    = debian-10-amd64-uyuni-client-devel
 name     = Uyuni Client Tools for Debian 10 Buster AMD64 (Development)
@@ -3384,6 +3393,15 @@ repo_type = deb
 checksum = sha256
 base_channels = debian-11-pool-amd64-uyuni
 repo_url = http://security.debian.org/debian-security/dists/bullseye-security/updates/main/binary-amd64/
+
+[debian-11-amd64-main-backports-uyuni]
+label    = debian-11-amd64-main-backports-uyuni
+name     = Debian 11 (bullseye) AMD64 Main Backports for Uyuni
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = debian-11-pool-amd64-uyuni
+repo_url = http://deb.debian.org/debian/dists/bullseye-backports/main/binary-amd64/
 
 [debian-11-amd64-uyuni-client-devel]
 label    = debian-11-amd64-uyuni-client-devel


### PR DESCRIPTION
## What does this PR change?

Currently, `spacewalk-common-channels.ini` shipped with Uyuni lacks the `backports` repositories for Debian 10 and 11. Anyhow, these repositories might be useful for some users (e.g. because of FreeIPA packages, etc.). This PR adds these appropriate repositories to the configuration file.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: it only adds two repositories

- [x] **DONE**

## Test coverage
- No tests required or changed

- [x] **DONE**

## Links

Fixes #6911

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
