### PR TITLE
Fix image size entries in xml-rpc

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/DeltaImageInfoHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/DeltaImageInfoHandler.java
@@ -21,6 +21,7 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
 import com.redhat.rhn.frontend.xmlrpc.EntityExistsFaultException;
 import com.redhat.rhn.frontend.xmlrpc.NoSuchImageException;
+import com.redhat.rhn.frontend.xmlrpc.util.PillarUtils;
 
 import com.suse.manager.api.ReadOnly;
 
@@ -82,7 +83,8 @@ public class DeltaImageInfoHandler extends BaseHandler {
      * @param pillar pillar data
      * @return 1 on success
      *
-     * @apidoc.doc Import an image and schedule an inspect afterwards
+     * @apidoc.doc Import an image and schedule an inspect afterwards. The "size" entries in the pillar
+     * should be passed as string.
      * @apidoc.param #session_key()
      * @apidoc.param #param("int", "sourceImageId")
      * @apidoc.param #param("int", "targetImageId")
@@ -108,6 +110,7 @@ public class DeltaImageInfoHandler extends BaseHandler {
             throw new EntityExistsFaultException(existing.get());
         }
 
+        pillar = PillarUtils.convertSizeToLong(pillar);
         ImageInfoFactory.createDeltaImageInfo(sourceOpt.get(), targetOpt.get(), file, pillar);
 
         return 1L;

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
@@ -299,9 +299,10 @@ public class ImageInfoHandlerTest extends BaseHandlerTestCase {
         assertEquals("newvalue1", result.get(orgKey1.getLabel()));
     }
 
+    @Test
     public final void testImportOSImage() {
         Integer id1 = handler.importOSImage(admin, "testimg", "1.0.0", "x86_64-redhat-linux").intValue();
-        handler.setPillar(admin, id1, Map.of("name1", "val1", "name2", "val2"));
+        handler.setPillar(admin, id1, Map.of("name1", "val1", "name2", "val2", "size", "10000000000"));
         handler.addImageFile(admin, id1, "testimg.tgz", "bundle", false);
 
         try {
@@ -320,6 +321,12 @@ public class ImageInfoHandlerTest extends BaseHandlerTestCase {
 
         Map<String, Object> pillar1 = handler.getPillar(admin, id1);
         assertEquals("val1", pillar1.get("name1"));
+        assertEquals("10000000000", pillar1.get("size"));
+
+        // image size is stored as Long, but sent through the xml-rpc API as String
+        Optional<ImageInfo> info = ImageInfoFactory.lookupById(id1.longValue());
+        assertEquals(10000000000L, info.get().getPillar().getPillar().get("size"));
+
 
         ImageOverview details2 = handler.getDetails(admin, id2);
         System.out.println("details" + details2.getCurrRevisionNum());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/DeltaImageSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/DeltaImageSerializer.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.frontend.xmlrpc.serializer;
 
 import com.redhat.rhn.domain.image.DeltaImageInfo;
+import com.redhat.rhn.frontend.xmlrpc.util.PillarUtils;
 
 import com.suse.manager.api.ApiResponseSerializer;
 import com.suse.manager.api.SerializationBuilder;
@@ -43,7 +44,7 @@ public class DeltaImageSerializer extends ApiResponseSerializer<DeltaImageInfo> 
                 .add("source_id", src.getSourceImageInfo().getId())
                 .add("target_id", src.getTargetImageInfo().getId())
                 .add("file", src.getFile())
-                .add("pillar", src.getPillar().getPillar())
+                .add("pillar", PillarUtils.convertSizeToString(src.getPillar().getPillar()))
                 .build();
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/util/PillarUtils.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/util/PillarUtils.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.frontend.xmlrpc.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * PillarUtils - converts "size" for xml-rpc
+ */
+public class PillarUtils {
+    private PillarUtils() {
+    }
+
+    /**
+     * Convert all "size" entries in the pillar from Long to String
+     * @param pillar the input pillar
+     * @return processed copy of the input
+     */
+    public static Map<String, Object> convertSizeToString(Map<String, Object> pillar) {
+        Map<String, Object> copy = new HashMap<>();
+        for (String key : pillar.keySet()) {
+            Object value = pillar.get(key);
+            if (key.equals("size") && (value instanceof Integer || value instanceof Long)) {
+                value = String.valueOf(value);
+            }
+            else if (value instanceof Map) {
+                value = convertSizeToString((Map<String, Object>) value);
+            }
+            copy.put(key, value);
+        }
+        return copy;
+    }
+
+    /**
+     * Convert all "size" entries in the pillar from String to Long
+     * @param pillar the input pillar
+     * @return processed copy of the input
+     */
+    public static Map<String, Object> convertSizeToLong(Map<String, Object> pillar) {
+        Map<String, Object> copy = new HashMap<>();
+        for (String key : pillar.keySet()) {
+            Object value = pillar.get(key);
+            if (key.equals("size") && value instanceof String) {
+                value = Long.parseLong((String)value);
+            }
+            else if (value instanceof Map) {
+                value = convertSizeToLong((Map<String, Object>) value);
+            }
+            copy.put(key, value);
+        }
+        return copy;
+    }
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix image size entries in xml-rpc
 - kernel options: only add quotes if there is a space in the value (bsc#1209926)
 - fix displaying system channels when no base product is installed
   (bsc#1206423)


### PR DESCRIPTION
## What does this PR change?

xml-rpc does not support Long type. This PR converts the "size" entry in image pillars to string
before exporting via xml-rpc and back to Long after import.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- API documentation added
- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19990


- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
