### PR TITLE
Make password and user field required on login page

### DIFF
--- a/web/html/src/manager/login/susemanager/login.tsx
+++ b/web/html/src/manager/login/susemanager/login.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
+import { useState } from "react";
 
 import { docsLocale } from "core/user-preferences";
 
-import { AsyncButton } from "components/buttons";
+import { SubmitButton } from "components/buttons";
 import { useInputValue } from "components/hooks/forms/useInputValue";
 import { Messages } from "components/messages";
 
@@ -19,6 +20,7 @@ const SusemanagerThemeLogin = (props: ThemeProps) => {
   const loginInput = useInputValue("");
   const passwordInput = useInputValue("");
   const { onLogin, success, messages } = useLoginApi();
+  const [isLoading, setIsLoading] = useState(false);
 
   const { product } = props;
   const globalMessages = getGlobalMessages(
@@ -53,7 +55,26 @@ const SusemanagerThemeLogin = (props: ThemeProps) => {
               <Messages items={errorMessages} />
             </div>
           </div>
-          <form onSubmit={(event) => event.preventDefault()} className={styles.loginForm}>
+            <form
+               className={styles.loginForm}
+               onSubmit={async (event) => {
+                  event.preventDefault();
+                  if (isLoading) {
+                    return;
+                  }
+
+                  setIsLoading(true);
+                  const success = await onLogin({
+                    login: loginInput.value,
+                    password: passwordInput.value,
+                  });
+                  if (success) {
+                    window.location.replace(props.bounce);
+                  }
+                  setIsLoading(false);
+                }}
+                name="loginForm"
+                >
             <h1 className={flatten([styles.title, styles.loginTitle])}>{t("Sign In")}</h1>
             <label htmlFor="username">{t("Username")}</label>
             <input
@@ -62,6 +83,7 @@ const SusemanagerThemeLogin = (props: ThemeProps) => {
               className={`form-control ${styles.input}`}
               type="text"
               maxLength={parseInt(props.loginLength, 10)}
+              required
               autoFocus={true}
               {...loginInput}
             />
@@ -73,26 +95,17 @@ const SusemanagerThemeLogin = (props: ThemeProps) => {
               type="password"
               autoComplete="password"
               maxLength={parseInt(props.passwordLength, 10)}
+              required
               {...passwordInput}
             />
-            <AsyncButton
+            <SubmitButton
               id="login-btn"
-              className={`btn-block ${styles.button}`}
-              defaultType="btn-primary"
+              className={`btn-block btn-success ${styles.button}`}
               text={t("Sign In")}
-              action={() =>
-                onLogin({
-                  login: loginInput.value,
-                  password: passwordInput.value,
-                }).then((success) => {
-                  if (!success) {
-                    return;
-                  }
-                  window.location.replace(props.bounce);
-                })
-              }
+              disabled={isLoading}
             />
           </form>
+
           <div className={styles.loginFooter}>
             <a href="/rhn/help/Copyright.do">Copyright Notice</a>
             <span>
@@ -101,9 +114,9 @@ const SusemanagerThemeLogin = (props: ThemeProps) => {
             </span>
             {props.customFooter && <span>{props.customFooter}</span>}
           </div>
-        </div>
-      </section>
     </div>
+   </section>
+  </div>
   );
 };
 

--- a/web/html/src/manager/login/susemanager/login.tsx
+++ b/web/html/src/manager/login/susemanager/login.tsx
@@ -55,26 +55,26 @@ const SusemanagerThemeLogin = (props: ThemeProps) => {
               <Messages items={errorMessages} />
             </div>
           </div>
-            <form
-               className={styles.loginForm}
-               onSubmit={async (event) => {
-                  event.preventDefault();
-                  if (isLoading) {
-                    return;
-                  }
+          <form
+            className={styles.loginForm}
+            onSubmit={async (event) => {
+              event.preventDefault();
+              if (isLoading) {
+                return;
+              }
 
-                  setIsLoading(true);
-                  const success = await onLogin({
-                    login: loginInput.value,
-                    password: passwordInput.value,
-                  });
-                  if (success) {
-                    window.location.replace(props.bounce);
-                  }
-                  setIsLoading(false);
-                }}
-                name="loginForm"
-                >
+              setIsLoading(true);
+              const success = await onLogin({
+                login: loginInput.value,
+                password: passwordInput.value,
+              });
+              if (success) {
+                window.location.replace(props.bounce);
+              }
+              setIsLoading(false);
+            }}
+            name="loginForm"
+          >
             <h1 className={flatten([styles.title, styles.loginTitle])}>{t("Sign In")}</h1>
             <label htmlFor="username">{t("Username")}</label>
             <input
@@ -114,9 +114,9 @@ const SusemanagerThemeLogin = (props: ThemeProps) => {
             </span>
             {props.customFooter && <span>{props.customFooter}</span>}
           </div>
+        </div>
+      </section>
     </div>
-   </section>
-  </div>
   );
 };
 

--- a/web/html/src/manager/login/uyuni/login.tsx
+++ b/web/html/src/manager/login/uyuni/login.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
+import { useState } from "react";
 
-import { AsyncButton } from "components/buttons";
+import { SubmitButton } from "components/buttons";
 import { useInputValue } from "components/hooks/forms/useInputValue";
 import { Messages } from "components/messages";
 
@@ -15,6 +16,7 @@ const UyuniThemeLogin = (props: ThemeProps) => {
   const loginInput = useInputValue("");
   const passwordInput = useInputValue("");
   const { onLogin, success, messages } = useLoginApi();
+  const [isLoading, setIsLoading] = useState(false);
 
   const { product } = props;
 
@@ -44,7 +46,25 @@ const UyuniThemeLogin = (props: ThemeProps) => {
             <div className="col-sm-5 col-sm-offset-1">
               <Messages items={getFormMessages(success, messages)} />
               <h2 className="gray-text">{t("Sign In")}</h2>
-              <form onSubmit={(event) => event.preventDefault()} name="loginForm">
+              <form
+                onSubmit={async (event) => {
+                  event.preventDefault();
+                  if (isLoading) {
+                    return;
+                  }
+
+                  setIsLoading(true);
+                  const success = await onLogin({
+                    login: loginInput.value,
+                    password: passwordInput.value,
+                  });
+                  if (success) {
+                    window.location.replace(props.bounce);
+                  }
+                  setIsLoading(false);
+                }}
+                name="loginForm"
+              >
                 <div className="margins-updown">
                   <input
                     id="username-field"
@@ -54,6 +74,7 @@ const UyuniThemeLogin = (props: ThemeProps) => {
                     placeholder={t("Login")}
                     maxLength={parseInt(props.loginLength, 10)}
                     autoFocus={true}
+                    required
                     {...loginInput}
                   />
                   <input
@@ -64,19 +85,14 @@ const UyuniThemeLogin = (props: ThemeProps) => {
                     autoComplete="password"
                     placeholder={t("Password")}
                     maxLength={parseInt(props.passwordLength, 10)}
+                    required
                     {...passwordInput}
                   />
-                  <AsyncButton
+                  <SubmitButton
                     id="login-btn"
-                    className="btn-block"
-                    defaultType="btn-success"
+                    className="btn-block btn-success"
                     text={t("Sign In")}
-                    action={() =>
-                      onLogin({
-                        login: loginInput.value,
-                        password: passwordInput.value,
-                      }).then((success) => success && window.location.replace(props.bounce))
-                    }
+                    disabled={isLoading}
                   />
                 </div>
               </form>

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Disable login button with empty password
+
 -------------------------------------------------------------------
 Wed Apr 19 12:48:03 CEST 2023 - marina.latini@suse.com
 


### PR DESCRIPTION
## What does this PR change?
Port of merged https://github.com/SUSE/spacewalk/pull/20866
 #19753 
The sign in button is disabled with an empty password field 

## GUI diff
 
After:
![image](https://user-images.githubusercontent.com/729087/227168130-7c10b43e-6bfc-4352-96e2-b453c78e3aca.png)

![image](https://user-images.githubusercontent.com/729087/227168399-bc46b9de-c09e-4402-a3e8-a5f6c0a5ff08.png)

- [ ] **DONE**

## Documentation
- No documentation needed: 

- [ ] **DONE**

## Test coverage
- No tests:
- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
