### PR TITLE
Add double quotes around kernel a option value if it contains a space

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/test/CobblerCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/test/CobblerCommandTest.java
@@ -161,7 +161,7 @@ public class CobblerCommandTest extends CobblerCommandTestBase {
         kernelOptions.put("option1", "val1");
         distro.setKernelOptions(Optional.of(kernelOptions));
         Map<String, Object> kernelOptionsPost = new HashMap<>();
-        kernelOptionsPost.put("otherOption", "val2");
+        kernelOptionsPost.put("otherOption", "val2 with space");
         distro.setKernelOptionsPost(Optional.of(kernelOptionsPost));
 
         // backsync
@@ -173,7 +173,7 @@ public class CobblerCommandTest extends CobblerCommandTestBase {
         // after the backsync command, the kickstartable tree in the db should have
         // the kernel options updated
         assertEquals("option1=val1", fromDb.getKernelOptions().trim());
-        assertEquals("otherOption=val2", fromDb.getKernelOptionsPost().trim());
+        assertEquals("otherOption=\"val2 with space\"", fromDb.getKernelOptionsPost().trim());
     }
 
     /**

--- a/java/code/src/org/cobbler/CobblerObject.java
+++ b/java/code/src/org/cobbler/CobblerObject.java
@@ -690,15 +690,22 @@ public abstract class CobblerObject {
                 keyList.add((String) map.get(key));
             }
             if (keyList.isEmpty()) {
-                string.append(key + " ");
+                string.append(key).append(" ");
             }
             else {
                 for (String value : keyList) {
-                    string.append(key + "=" + value + " ");
+                    string.append(key).append("=");
+                    if (value != null && value.contains(" ")) {
+                        string.append('"').append(value).append('"');
+                    }
+                    else {
+                        string.append(value);
+                    }
+                    string.append(" ");
                 }
             }
         }
-        return string.toString();
+        return string.toString().strip();
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- kernel options: only add quotes if there is a space in the value (bsc#1209926)
 - fix displaying system channels when no base product is installed
   (bsc#1206423)
 - fix NPE in cobbler system sync when server has no creator set


### PR DESCRIPTION
## What does this PR change?

The kernel only requires double quotes if there is a space in the value. See https://www.kernel.org/doc/html/v4.14/admin-guide/kernel-parameters.html#the-kernel-s-command-line-parameters for reference.
Port of https://github.com/SUSE/spacewalk/pull/21242

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
