### PR TITLE
Spacecmd distro update fix argparse

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,5 @@
+- fix argument parsing of distribution_update (bsc#1210458)
+
 -------------------------------------------------------------------
 Wed Apr 19 12:49:39 CEST 2023 - marina.latini@suse.com
 

--- a/spacecmd/src/spacecmd/distribution.py
+++ b/spacecmd/src/spacecmd/distribution.py
@@ -65,7 +65,24 @@ def do_distribution_create(self, args, update=False):
             options.name = args[0]
         elif not options.name:
             logging.error(_N('The name of the distribution is required'))
+            self.help_distribution_update()
             return 1
+        details = self.client.kickstart.tree.getDetails(self.session, options.name)
+        channel = \
+            self.client.channel.software.getDetails(self.session,
+                                                    details.get('channel_id'))
+
+        if not options.path:
+            options.path = details.get('abs_path')
+
+        if not options.base_channel:
+            options.base_channel = channel.get('label')
+
+        if not options.install_type:
+            inst_type = details.get('install_type')
+            if inst_type:
+                options.install_type = inst_type.get('label')
+
 
     if is_interactive(options):
         if not update:
@@ -309,10 +326,4 @@ def complete_distribution_update(self, text, line, beg, end):
 
 
 def do_distribution_update(self, args):
-    arguments, _ = parse_command_arguments(args, get_argument_parser())
-    if not arguments:
-        self.help_distribution_update()
-    else:
-        return self.do_distribution_create(args, update=True)
-
-    return None
+    return self.do_distribution_create(args, update=True)


### PR DESCRIPTION
## What does this PR change?

**add description**

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
