### PR TITLE
Remove documentation option from global search

### DIFF
--- a/web/html/src/manager/header/search/search.tsx
+++ b/web/html/src/manager/header/search/search.tsx
@@ -17,10 +17,6 @@ const SEARCH_TYPES = [
     value: "errata",
     name: t("Patches"),
   },
-  {
-    value: "docs",
-    name: t("Documentation"),
-  },
 ];
 
 export class HeaderSearch extends React.PureComponent {


### PR DESCRIPTION
## What does this PR change?

It removes the `Documentation` option from global search tool, considering that this feature was removed.

## GUI diff

No difference.

Before:

![image](https://user-images.githubusercontent.com/17532261/234016050-f3036b71-5604-4215-8855-9ccc834594b6.png)

After:

![image](https://user-images.githubusercontent.com/17532261/234016484-c2ceaa09-2ae7-4ec7-b116-eb96b1ca67b6.png)


- [x] **DONE**

## Documentation
- No documentation needed: bug fix.

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20129

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
