### PR TITLE
Fix the ubuntu version. We do not want suprises

### DIFF
--- a/.github/workflows/test_all_in_one_common.yml
+++ b/.github/workflows/test_all_in_one_common.yml
@@ -11,7 +11,7 @@ env:
   CUCUMBER_PUBLISH_TOKEN: ${{ secrets.CUCUMBER_PUBLISH_TOKEN }}
 jobs:
   test-uyuni:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # create a PR to add yourself if you want to be a beta user and
     # run this action in your Pull Requests
     if: github.actor == 'jordimassaguerpla' || github.actor == 'elariekerboull' ||  github.actor == 'srbarrios' || github.actor == 'etheryte'


### PR DESCRIPTION
## What does this PR change?

CI: Fix the Ubuntu version to have a stable CI. If we use "latest", the ubuntu host could be updated and so the podman version, which could break the CI. Given the ubuntu host is only used to run podman, let's keep this stable.

## GUI diff

No difference.



- [x] **DONE**

## Documentation
- No documentation needed
- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
