### PR TITLE
Datetime tooltips do not show timestamps

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/taglibs/FormatDateTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/FormatDateTag.java
@@ -37,7 +37,7 @@ import javax.servlet.jsp.tagext.TagSupport;
  * <strong>FormatDateTag</strong><br>
  * Displays a value in a human format (eg. 3 minutes ago)
  * <pre>{@literal
- *     <rhn:human-value value="${bean.value}">
+ *     <rhn:formatDate value="${bean.value}">
  * }</pre>
  * <p>
  * Outputs a human readable text for the value relative to now.
@@ -58,7 +58,6 @@ public class FormatDateTag extends TagSupport {
     private static final String CALENDAR = "calendar";
 
     protected Date value;
-    protected Date reference;
     protected Locale locale;
 
     // cache
@@ -73,23 +72,6 @@ public class FormatDateTag extends TagSupport {
     protected String humanStyle;
 
     /**
-     * @return Current set reference
-     */
-    public Date getReference() {
-        return reference;
-    }
-
-    /**
-     * The reference date used instead of now
-     * when calculating intervals or durations
-     *
-     * @param ref date value
-     */
-    public void setReference(Date ref) {
-        this.reference = ref;
-    }
-
-    /**
      * @return The current set human style
      */
     public String getHumanStyle() {
@@ -102,7 +84,7 @@ public class FormatDateTag extends TagSupport {
      *
      * Valid values:
      * "none" (default)
-     * "from" date from now or reference
+     * "from" date from now
      * "calendar" calendar date
      */
     public void setHumanStyle(String style) {
@@ -249,13 +231,10 @@ public class FormatDateTag extends TagSupport {
         try {
             JspWriter out = pageContext.getOut();
 
-            OffsetDateTime refDate = OffsetDateTime.ofInstant(getReference().toInstant(), ZoneId.systemDefault());
             OffsetDateTime valDate = OffsetDateTime.ofInstant(getValue().toInstant(), ZoneId.systemDefault());
 
             out.append("  <time");
             out.append(getCssClass());
-            out.append(" data-reference-date=\"" +
-                    refDate.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME) + "\"");
             out.append(" datetime=\"" +
                     valDate.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME) + "\">");
             out.append(getFormattedDate());
@@ -360,7 +339,6 @@ public class FormatDateTag extends TagSupport {
     // to share with the constructor
     private void reset() {
         value = new Date();
-        reference = new Date();
         humanStyle = null;
         locale = null;
         // cached

--- a/java/code/src/com/suse/manager/webui/utils/UserPreferenceUtils.java
+++ b/java/code/src/com/suse/manager/webui/utils/UserPreferenceUtils.java
@@ -180,9 +180,6 @@ public class UserPreferenceUtils {
     }
 
     /**
-     * TODO
-     * Make the parameter configurable from the configuration file
-     *
      * @param pageContext the current PageContext
      * @return the String format of the Date
      */
@@ -191,9 +188,6 @@ public class UserPreferenceUtils {
     }
 
     /**
-     * TODO
-     * Make the parameter configurable from the configuration file
-     *
      * @param pageContext the current PageContext
      * @return the String format of the Time
      */

--- a/web/html/javascript/spacewalk-essentials.js
+++ b/web/html/javascript/spacewalk-essentials.js
@@ -273,56 +273,6 @@ function onDocumentReadyAutoBootstrapGrid() {
   });
 }
 
-// Humanizes all the time elements with the human class
-function humanizeDates() {
-  // should be consistent with UserPreferencesUtils.java
-  moment.lang(window.preferredLocale, {
-    longDateFormat : {
-      LT: "HH:mm",
-      LTS: "HH:mm:ss",
-      L: "YYYY-MM-DD",
-      LL: "YYYY-MM-DD",
-      LLL: "YYYY-MM-DD",
-      LLLL: "YYYY-MM-DD"
-    },
-  });
-
-  jQuery("time.human-from, time.human-calendar").each(function (index) {
-    var datetime = jQuery(this).attr('datetime');
-    if (datetime == undefined) {
-      // if the attribute is not set, the content
-      // should be a valid date
-      datetime = jQuery(this).html();
-    }
-    var parsed = moment(datetime);
-    if (parsed.isValid()) {
-      var originalContent = jQuery(this).html();
-      if (jQuery(this).hasClass("human-from")) {
-        var ref = jQuery(this).attr("data-reference-date");
-        if (ref) {
-          var refParsed = moment(ref);
-          if (refParsed.isValid()) {
-            jQuery(this).html(parsed.from(refParsed));
-          }
-        }
-        else {
-          jQuery(this).html(parsed.fromNow());
-        }
-      }
-      if (jQuery(this).hasClass("human-calendar")) {
-        jQuery(this).html(parsed.calendar());
-      }
-      // if the original did not had a datetime attribute, add it
-      var datetimeAttr = jQuery(this).attr('datetime');
-      if (datetimeAttr == undefined) {
-        jQuery(this).attr('datetime', datetime);
-      }
-      // add a tooltip
-      jQuery(this).attr('title', originalContent);
-    }
-  });
-}
-
 /**
  * Setups ACE editor in a textarea element
  * textarea is a jQuery object
@@ -546,7 +496,6 @@ function onDocumentReadyInitOldJS() {
   sstScrollBehaviorSetupIsDone = false;
   onDocumentReadyGeneral();
   onDocumentReadyAutoBootstrapGrid();
-  humanizeDates();
   initIEWarningUse();
   listenForGlobalNotificationChanges();
 }
@@ -555,7 +504,6 @@ jQuery(document).ready(function() {
   onDocumentReadyGeneral();
   onDocumentReadyAutoBootstrapGrid();
   registerSpacewalkContentObservers();
-  humanizeDates();
   initIEWarningUse();
   listenForGlobalNotificationChanges();
 });

--- a/web/html/src/components/datetime/DateTime.tsx
+++ b/web/html/src/components/datetime/DateTime.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
-
 import { localizedMoment } from "utils";
+
+import { getTimeProps } from "./timeProps";
 
 type Props = {
   value?: string | moment.Moment;
@@ -8,10 +8,31 @@ type Props = {
 };
 
 export const DateTime = (props: Props) => {
-  const rawValue = props.value ?? props.children;
-  if (!rawValue) {
+  const input = props.value ?? props.children;
+  if (!input) {
     return null;
   }
-  const value = localizedMoment(rawValue).tz(localizedMoment.userTimeZone);
-  return <React.Fragment>{value.toUserString()}</React.Fragment>;
+
+  const value = localizedMoment(input).tz(localizedMoment.userTimeZone);
+  const { title, dateTime } = getTimeProps(value);
+  return (
+    <time title={title} dateTime={dateTime}>
+      {value.toUserString()}
+    </time>
+  );
+};
+
+export const HumanDateTime = (props: Props) => {
+  const input = props.value ?? props.children;
+  if (!input) {
+    return null;
+  }
+
+  const value = localizedMoment(input).tz(localizedMoment.userTimeZone);
+  const { title, dateTime } = getTimeProps(value);
+  return (
+    <time title={title} dateTime={dateTime}>
+      {value.calendar()}
+    </time>
+  );
 };

--- a/web/html/src/components/datetime/DateTimePicker.tsx
+++ b/web/html/src/components/datetime/DateTimePicker.tsx
@@ -194,14 +194,16 @@ export const DateTimePicker = (props: Props) => {
           </>
         )}
         <span className="input-group-addon" key="tz">
-          {timeZone}
+          {props.serverTimeZone ? localizedMoment.serverTimeZoneAbbr : localizedMoment.userTimeZoneAbbr}
         </span>
       </div>
       {process.env.NODE_ENV !== "production" && SHOW_DEBUG_VALUES ? (
         <pre>
           user:{"   "}
-          {props.value.toUserDateTimeString()} ({localizedMoment.userTimeZone})<br />
-          server: {props.value.toServerDateTimeString()} ({localizedMoment.serverTimeZone})<br />
+          {props.value.toUserString()}
+          <br />
+          server: {props.value.toServerString()}
+          <br />
           iso:{"    "}
           {props.value.toISOString()}
         </pre>

--- a/web/html/src/components/datetime/FromNow.stories.md
+++ b/web/html/src/components/datetime/FromNow.stories.md
@@ -1,0 +1,32 @@
+```jsx
+import { useState } from "react";
+
+import { localizedMoment } from "utils";
+
+import { fromNow, FromNow } from "./FromNow";
+import { DateTimePicker } from "./DateTimePicker";
+
+const [value, setValue] = useState(localizedMoment());
+
+<div>
+  <p>value:</p>
+    <p>
+    <DateTimePicker value={value} onChange={(newValue) => setValue(newValue)} />
+  </p>
+
+  <p><code>fromNow</code> function</p>
+  <p>
+    <pre>{fromNow(value)}</pre>
+  </p>
+
+  <p><code>FromNow</code> component with prop value</p>
+  <p>
+    <FromNow value={value} />
+  </p>
+
+  <p><code>FromNow</code> component with child value</p>
+  <p>
+    <FromNow>{value}</FromNow>
+  </p>
+</div>
+```

--- a/web/html/src/components/datetime/FromNow.test.tsx
+++ b/web/html/src/components/datetime/FromNow.test.tsx
@@ -10,15 +10,8 @@ describe("FromNow component", () => {
   test("renders with basic input", () => {
     render(<FromNow value={validISOString} />);
     // Title is given in user's configured time zone
-    const span = screen.getByTitle("2020-01-30 15:00 America/Los_Angeles");
-    expect(span).toBeDefined();
-    expect((span.innerHTML || "").trim()).not.toEqual("");
-  });
-
-  test("renders with child input", () => {
-    render(<FromNow>{validISOString}</FromNow>);
-    const span = screen.getByTitle("2020-01-30 15:00 America/Los_Angeles");
-    expect(span).toBeDefined();
-    expect((span.innerHTML || "").trim()).not.toEqual("");
+    const element = screen.getByTitle("2020-01-30 15:00 PST");
+    expect(element).toBeDefined();
+    expect((element.innerHTML || "").trim()).not.toEqual("");
   });
 });

--- a/web/html/src/components/datetime/FromNow.tsx
+++ b/web/html/src/components/datetime/FromNow.tsx
@@ -1,6 +1,8 @@
-import * as React from "react";
+import { MomentInput } from "moment";
 
 import { localizedMoment } from "utils";
+
+import { getTimeProps } from "./timeProps";
 
 type Props = {
   value?: string | moment.Moment;
@@ -8,16 +10,23 @@ type Props = {
 };
 
 export const FromNow = (props: Props) => {
-  const rawValue = props.value ?? props.children;
-  if (!rawValue) {
+  const input = props.value ?? props.children;
+  if (!input) {
     return null;
   }
-  const value = localizedMoment(rawValue).tz(localizedMoment.userTimeZone);
-  return <span title={value.toUserString()}>{value.fromNow()}</span>;
+
+  const value = localizedMoment(input).tz(localizedMoment.userTimeZone);
+  const { title, dateTime } = getTimeProps(value);
+  return (
+    <time title={title} dateTime={dateTime}>
+      {value.fromNow()}
+    </time>
+  );
 };
 
 // It returns a simple string instead of a component in the `fromNow` localized format
 // Use case: at the moment the `t()` function (to translate strings) does not support complex components
-export const fromNow = (value) => {
+// TODO: Make this obsolete once https://github.com/SUSE/spacewalk/issues/20449 is implemented
+export const fromNow = (value?: MomentInput) => {
   return value ? localizedMoment(value).tz(localizedMoment.userTimeZone).fromNow() : null;
 };

--- a/web/html/src/components/datetime/timeProps.test.ts
+++ b/web/html/src/components/datetime/timeProps.test.ts
@@ -1,0 +1,13 @@
+import { localizedMoment } from "utils";
+
+import { getTimeProps } from "./timeProps";
+
+describe("timeProps", () => {
+  test("keeps timezone information intact", () => {
+    const validISOString = "2020-01-30T23:00:00.000Z";
+
+    const { title, dateTime } = getTimeProps(localizedMoment(validISOString));
+    expect(title).toEqual("2020-01-30 15:00 PST");
+    expect(dateTime).toEqual("2020-01-30T23:00:00.000+00:00");
+  });
+});

--- a/web/html/src/components/datetime/timeProps.ts
+++ b/web/html/src/components/datetime/timeProps.ts
@@ -1,0 +1,13 @@
+import * as React from "react";
+
+export const getTimeProps = (value: moment.Moment): Partial<React.HTMLProps<HTMLTimeElement>> => {
+  /**
+   * NB! This needs to be in sync with java/code/src/com/redhat/rhn/frontend/taglibs/FormatDateTag.java
+   * Convert the value to an ISO 8601, keeping the timezone offset.
+   * This value is used by Cucumber to verify the results of different operations.
+   */
+  return {
+    dateTime: value.toISOString(true),
+    title: value.toUserString(),
+  };
+};

--- a/web/html/src/core/log/loggerhead.ts
+++ b/web/html/src/core/log/loggerhead.ts
@@ -52,7 +52,7 @@ export default class Loggerhead {
 
   private postData(data: { level: Level; message: string }) {
     if (this.url === "") {
-      var errorMessage = "[Loggerhead] ERROR: no server enpoint URL set to send the POST request!! ";
+      const errorMessage = "[Loggerhead] ERROR: no server enpoint URL set to send the POST request!! ";
       if (this.console.error) {
         console.error(errorMessage);
       }

--- a/web/html/src/global.d.ts
+++ b/web/html/src/global.d.ts
@@ -34,7 +34,7 @@ declare global {
     userPrefPageSize?: number;
   }
 
-  // WIP test env setup, see ./utils/test-utils
+  // Test env setup, see ./utils/test-utils/setup/index.ts
   namespace NodeJS {
     interface Global {
       jQuery: (window: Window, noGlobal?: boolean) => JQueryStatic;

--- a/web/html/src/jest.config.js
+++ b/web/html/src/jest.config.js
@@ -28,6 +28,7 @@ module.exports = {
     userTimeZone: "America/Los_Angeles", // GMT-7
     userDateFormat: "YYYY-MM-DD",
     userTimeFormat: "HH:mm",
+    preferredLocale: "en",
   },
   // Until tests with `async (done) => ...` are fixed, we need to use a custom runner, see https://github.com/facebook/jest/issues/11404
   testRunner: "jest-jasmine2",

--- a/web/html/src/manager/legacy/FormatDateTag.tsx
+++ b/web/html/src/manager/legacy/FormatDateTag.tsx
@@ -1,0 +1,68 @@
+// Humanize dates for `FormatDateTag.java` the same way we do in frontend code
+
+import * as React from "react";
+
+import ReactDOM from "react-dom";
+
+import { FromNow, HumanDateTime } from "components/datetime";
+
+import { localizedMoment } from "utils";
+
+const FROM_NOW_CLASSNAME = "human-from";
+const HUMAN_DATE_TIME_CLASSNAME = "human-calendar";
+
+const getValue = (element: HTMLElement) => {
+  // If the attribute is not set, the content should be a valid date
+  const input = element.getAttribute("datetime") ?? element.innerText;
+  const value = localizedMoment(input);
+  if (!value.isValid()) {
+    return undefined;
+  }
+  return value;
+};
+
+function mountFromNow(mountingPoint: HTMLElement | null) {
+  if (!mountingPoint) {
+    Loggerhead.error("Found no mounting point for FromNow");
+    return;
+  }
+  // Only ever bind once
+  mountingPoint.classList.remove(FROM_NOW_CLASSNAME);
+
+  const value = getValue(mountingPoint);
+  if (value) {
+    // Replace the original mounting point with the result since we want to avoid double wrapping
+    const node = document.createElement("div");
+    ReactDOM.render(<FromNow value={value} />, node);
+    mountingPoint.outerHTML = node.innerHTML;
+  }
+}
+
+function mountHumanDateTime(mountingPoint: HTMLElement | null) {
+  if (!mountingPoint) {
+    Loggerhead.error("Found no mounting point for FromNow");
+    return;
+  }
+  // Only ever bind once
+  mountingPoint.classList.remove(HUMAN_DATE_TIME_CLASSNAME);
+
+  const value = getValue(mountingPoint);
+  if (value) {
+    // Replace the original mounting point with the result since we want to avoid double wrapping
+    const node = document.createElement("div");
+    ReactDOM.render(<HumanDateTime value={value} />, node);
+    mountingPoint.outerHTML = node.innerHTML;
+  }
+}
+
+function mountAll() {
+  Array.from(document.querySelectorAll<HTMLDivElement>(`time.${FROM_NOW_CLASSNAME}`)).forEach((node) =>
+    mountFromNow(node)
+  );
+  Array.from(document.querySelectorAll<HTMLDivElement>(`time.${HUMAN_DATE_TIME_CLASSNAME}`)).forEach((node) =>
+    mountHumanDateTime(node)
+  );
+}
+
+jQuery(document).ready(mountAll);
+window.pageRenderers?.spaengine?.onSpaEndNavigation?.(mountAll);

--- a/web/html/src/manager/legacy/index.ts
+++ b/web/html/src/manager/legacy/index.ts
@@ -2,5 +2,6 @@
  * This is the entrypoint for legacy code to integrate with the new React codebase
  */
 import "./DateTimePicker";
-import "./toastr";
+import "./FormatDateTag";
 import "./network";
+import "./toastr";

--- a/web/html/src/styleguide/setup.js
+++ b/web/html/src/styleguide/setup.js
@@ -8,6 +8,7 @@ const guess = moment.tz.guess(true);
 // eslint-disable-next-line no-console
 console.log(`Mocking timezone "${guess}"`);
 
+window.preferredLocale = "en";
 window.userTimeZone = guess;
 window.serverTimeZone = guess;
 // eslint-disable-next-line local-rules/no-raw-date

--- a/web/html/src/utils/datetime/localizedMoment.test.ts
+++ b/web/html/src/utils/datetime/localizedMoment.test.ts
@@ -59,10 +59,27 @@ describe("localizedMoment", () => {
   });
 
   test("full server string keeps offset", () => {
-    expect(localizedMoment().toServerString()).toContain("Asia/Tokyo");
+    expect(localizedMoment().toServerString()).toContain("JST");
   });
 
   test("full user string keeps offset", () => {
-    expect(localizedMoment().toUserString()).toContain("America/Los_Angeles");
+    expect(localizedMoment().toUserString()).toContain("PDT");
+  });
+
+  test("calendar output uses config formats", () => {
+    expect(localizedMoment().subtract(1, "day").calendar()).toContain("Yesterday at");
+    expect(localizedMoment().add(1, "day").calendar()).toContain("Tomorrow at");
+
+    const twoDaysAgo = localizedMoment().subtract(2, "day");
+    expect(twoDaysAgo.calendar()).toEqual(twoDaysAgo.format("YYYY-MM-DD"));
+
+    const inTwoDays = localizedMoment().add(2, "day");
+    expect(inTwoDays.calendar()).toEqual(inTwoDays.format("YYYY-MM-DD"));
+
+    const lastWeek = localizedMoment().subtract(1, "week");
+    expect(lastWeek.calendar()).toEqual(lastWeek.format("YYYY-MM-DD"));
+
+    const nextWeek = localizedMoment().add(1, "week");
+    expect(nextWeek.calendar()).toEqual(nextWeek.format("YYYY-MM-DD"));
   });
 });

--- a/web/html/src/utils/test-utils/setup/index.ts
+++ b/web/html/src/utils/test-utils/setup/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Test env setup
+ * For global variables such as time zones see web/html/src/jest.config.js
+ */
+
 import "manager/polyfills";
 
 import jQuery from "jquery";
@@ -11,4 +16,11 @@ global.jQuery = jQuery;
 
 global.t = t;
 
-global.Loggerhead = new Loggerhead("", (headers) => headers);
+const loggerHead = new Loggerhead("", (headers) => headers);
+
+loggerHead.info = (message: string) => console.info(`[Loggerhead] INFO : ${message}`);
+loggerHead.debug = (message: string) => console.debug(`[Loggerhead] DEBUG : ${message}`);
+loggerHead.warn = (message: string) => console.warn(`[Loggerhead] WARN : ${message}`);
+loggerHead.error = (message: string) => console.error(`[Loggerhead] ERROR : ${message}`);
+
+global.Loggerhead = loggerHead;


### PR DESCRIPTION
## What does this PR change?

Make datetime value fields use machine-readable values and correctly use user configuration in titles. Also remove unused code and migrate related code out of the old `spacewalk-essentials.js`.  

Example output:  

```html
<time title="2023-04-25 09:18 PDT" datetime="2023-04-25T09:18:28.475-07:00">a few seconds ago</time>
```

**TODO:** Check if this also fixes bsc#1195190

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/18451

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
