### PR TITLE
Fix wrong credentials error message

### DIFF
--- a/web/html/src/manager/login/use-login-api.ts
+++ b/web/html/src/manager/login/use-login-api.ts
@@ -58,6 +58,8 @@ const useLoginApi = () => {
         const errMessages =
           xhr.status === 0
             ? [t("Request interrupted or invalid response received from the server. Please try again.")]
+            : xhr.responseJSON?.message
+            ? [xhr.responseJSON.message]
             : Network.errorMessageByStatus(xhr.status);
         setLoginApiState((state) => {
           state.success = false;

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix wrong credentials error message (bsc#1210456)
 - Recurring custom states
 - Increase datetimepicker font sizes (bsc#1210437)
 - Disable login button with empty password


### PR DESCRIPTION
## What does this PR change?

It changes the error message to be the one from backend in case of error in the login request.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bug fix.

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

Fixes https://github.com/SUSE/spacewalk/issues/21118

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
