### PR TITLE
execute highstate on registration with a user if available

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -148,7 +148,11 @@ public class RegistrationUtils {
 
         // Call final highstate to deploy config channels if required
         if (applyHighstate) {
-            MessageQueue.publish(new ApplyStatesEventMessage(minion.getId(), true, emptyList()));
+            MessageQueue.publish(new ApplyStatesEventMessage(
+                    minion.getId(),
+                    minion.getCreator() != null ? minion.getCreator().getId() : null,
+                    true,
+                    emptyList()));
         }
         SystemManager.setReportDbUser(minion, false);
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- execute highstate on registration with a user if available
 - Ensure installation of 'xalan-j2' for building.
 - Simplify Java package dependencies.
 - Safe XSLT processing in SCAP transformations


### PR DESCRIPTION
## What does this PR change?

When executing a full highstate at registration time, it was not executed with a user object.
This lead to invisible result details in the system history as the org does not match.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **detail**

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/21265

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
