### PR TITLE
Fix server error when downloading static assets

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/servlets/SystemDetailsMessageFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/SystemDetailsMessageFilter.java
@@ -57,7 +57,11 @@ public class SystemDetailsMessageFilter implements Filter {
         chain.doFilter(request, response);
         HttpServletRequest req = (HttpServletRequest) request;
         RequestContext rctx = new RequestContext(req);
-        Long sid = rctx.getRequiredParam("sid");
+        Long sid = rctx.getParamAsLong("sid");
+        if (sid == null) {
+            return;
+        }
+
         User user = rctx.getCurrentUser();
         try {
             Server s = SystemManager.lookupByIdAndUser(sid, user);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix Internal Server Error when downloading static assets (bsc#1207691)
 - Recurring custom states
 - Update Cobbler profile when a new image is deployed
 - Add mapping of image URLs for containerized proxy


### PR DESCRIPTION
## What does this PR change?

See title.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bug fix.

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20339

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
