### PR TITLE
CI:Acceptance tests at PR v2: fix salt state tests

### DIFF
--- a/testsuite/features/secondary/min_salt_software_states.feature
+++ b/testsuite/features/secondary/min_salt_software_states.feature
@@ -114,6 +114,9 @@ Feature: Salt package states
     And I wait for "6" seconds
     And I should see a "pkg_removed" or "running as PID" text in element "highstate"
 
+# When run inside containers, we can't kill salt-minion or the
+# container will stop
+@skip_if_container
   Scenario: Use Salt presence mechanism on an unreachable minion
     When I follow "States" in the content area
     And I run "pkill salt-minion" on "sle_minion" without error control
@@ -122,6 +125,7 @@ Feature: Salt package states
     And I click on "Show full highstate output"
     And I wait until I see "No reply from minion" text
 
+@skip_if_container
   Scenario: Cleanup: restart the salt service on SLES minion
     When I restart salt-minion on "sle_minion"
 

--- a/testsuite/features/secondary/min_salt_user_states.feature
+++ b/testsuite/features/secondary/min_salt_user_states.feature
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@skip_if_container
 @scope_salt
 Feature: Coexistence with user-defined states
 


### PR DESCRIPTION
## What does this PR change?

fix salt states tests

## GUI diff

No difference.


- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests
- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20957


- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
