### PR TITLE
Remove unused CSV export logic in JSP ListDisplay tag

### DIFF
--- a/.github/workflows/test_all_in_one_common.yml
+++ b/.github/workflows/test_all_in_one_common.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     # create a PR to add yourself if you want to be a beta user and
     # run this action in your Pull Requests
-    if: github.actor == 'jordimassaguerpla' || github.actor == 'elariekerboull' ||  github.actor == 'srbarrios' || github.actor == 'etheryte'
+    if: github.actor == 'jordimassaguerpla' || github.actor == 'elariekerboull' ||  github.actor == 'srbarrios' || github.actor == 'etheryte' || github.actor == 'cbbayburt'
     steps:
       - name: welcome_message
         run: echo "Running acceptance tests. More info at https://github.com/uyuni-project/uyuni/wiki/Running-Acceptance-Tests-at-PR"

--- a/java/code/src/com/redhat/rhn/frontend/struts/BaseListAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/BaseListAction.java
@@ -77,9 +77,6 @@ public abstract class BaseListAction extends RhnListAction {
      * @return a PageControl if one is necessary
      */
     protected PageControl getNewPageControl(RequestContext rctx) {
-        if (rctx.isRequestedExport()) {
-            return null;
-        }
         PageControl pc =  new PageControl();
         pc.setPageSize(rctx.getCurrentUser().getPageSize());
         return pc;

--- a/java/code/src/com/redhat/rhn/frontend/struts/RequestContext.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/RequestContext.java
@@ -71,7 +71,6 @@ public class RequestContext {
     public static final String COBBLER_ID = "cobbler_id";
     public static final String FILTER_STRING = "filter_string";
     public static final String PREVIOUS_FILTER_STRING = "prev_filter_value";
-    public static final String LIST_DISPLAY_EXPORT = "lde";
     public static final String TOKEN_ID = "tid";
 
     public static final String LIST_SORT = "sort";
@@ -508,21 +507,6 @@ public class RequestContext {
             " is required.");
         }
         return p;
-    }
-
-    /**
-     * If this current Request includes a parameter to indicate the User is attempting
-     * to produce an export of viewable data then return true.
-     *
-     * Only for use with the Old list tag's exporter.  The new list tag doesn't use
-     *      "lde" as a parameter, it uses   lde_unique(listName).
-     *
-     * @return if this request includes an export param
-     */
-    // TODO Write unit tests for isRequestedExport()
-    public boolean isRequestedExport() {
-        String lde = request.getParameter(LIST_DISPLAY_EXPORT);
-        return (lde != null && lde.equals("1"));
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/struts/test/BaseSetListActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/test/BaseSetListActionTest.java
@@ -68,22 +68,6 @@ public class BaseSetListActionTest extends RhnBaseTestCase {
         assertEquals(200, dr.getTotalSize());
     }
 
-    /**
-     * Test to make sure we check for the right filter value string
-     * @throws Exception something bad happened
-     */
-    @Test
-    public void testExport() throws Exception {
-        // Need to fetch the 0 value one and put the 1 back in.
-        sah.getRequest().getParameter(RequestContext.LIST_DISPLAY_EXPORT);
-        sah.getRequest().setupAddParameter(RequestContext.LIST_DISPLAY_EXPORT, "1");
-        sah.executeAction();
-        assertNotNull(sah.getRequest().getAttribute("pageList"));
-        DataResult dr = (DataResult) sah.getRequest().getAttribute("pageList");
-        assertEquals(1, dr.getStart());
-        assertEquals(200, dr.getTotalSize());
-    }
-
     public class TestSetupListAction extends BaseSetListAction {
 
         @Override

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/ListDisplayTagBase.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/ListDisplayTagBase.java
@@ -58,8 +58,6 @@ public class ListDisplayTagBase extends BodyTagSupport {
     private String type = "list";
     /** determines whether we should show the disabled CSS */
     private boolean renderDisabled;
-    /** comma separated list of columns to be exported */
-    private String exportColumns;
     /** optional title attribute for displaying a titled list */
     private String title;
     private String hiddenvars;
@@ -227,20 +225,6 @@ public class ListDisplayTagBase extends BodyTagSupport {
         this.columnCount = columnCountIn;
     }
 
-    /**
-     * @return Returns the exportColumns.
-     */
-    public String getExportColumns() {
-        return exportColumns;
-    }
-
-    /**
-     * @param exportIn The export to set.
-     */
-    public void setExportColumns(String exportIn) {
-        this.exportColumns = exportIn;
-    }
-
     protected void setupPageList() throws JspTagException {
         ListTag listTag = (ListTag) findAncestorWithClass(this, ListTag.class);
         if (listTag == null) {
@@ -356,7 +340,6 @@ public class ListDisplayTagBase extends BodyTagSupport {
         iterator = null;
         filterBy = null;
         renderDisabled = false;
-        exportColumns = null;
         title = null;
         columnCount = 0;
         numberOfColumns = 0;

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/UnpagedListDisplayTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/UnpagedListDisplayTag.java
@@ -17,20 +17,14 @@ package com.redhat.rhn.frontend.taglibs;
 
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.util.DynamicComparator;
-import com.redhat.rhn.common.util.ExportWriter;
-import com.redhat.rhn.common.util.ServletExportHandler;
 import com.redhat.rhn.frontend.dto.BaseListDto;
 import com.redhat.rhn.frontend.dto.UserOverview;
 import com.redhat.rhn.frontend.struts.RequestContext;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.io.IOException;
 import java.io.Writer;
-import java.util.Arrays;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.JspTagException;
 import javax.servlet.jsp.JspWriter;
@@ -232,16 +226,6 @@ public class UnpagedListDisplayTag extends ListDisplayTagBase {
         return (s != null && s.startsWith("c"));
     }
 
-    /**
-     * If the User requested an Export or not.
-     * @return boolean if export or not
-     */
-    public boolean isExport() {
-        RequestContext ctx = new RequestContext((HttpServletRequest)
-                pageContext.getRequest());
-        return (ctx.isRequestedExport() && getExportColumns() != null);
-    }
-
     //////////////////////////////////////////////////////////////////////////
     // JSP Tag lifecycle methods
     //////////////////////////////////////////////////////////////////////////
@@ -255,12 +239,6 @@ public class UnpagedListDisplayTag extends ListDisplayTagBase {
         try {
             out = pageContext.getOut();
             setupPageList();
-
-            // Now that we have setup the proper tag state we
-            // need to return if this is an export render.
-            if (isExport()) {
-                return SKIP_PAGE;
-            }
 
             String sortedColumn = getSortedColumn();
             if (sortedColumn != null) {
@@ -314,21 +292,6 @@ public class UnpagedListDisplayTag extends ListDisplayTagBase {
         try {
             if (getPageList().isEmpty()) {
                 return EVAL_PAGE;
-            }
-
-            if (isExport()) {
-                ExportWriter eh = createExportWriter();
-                String[] columns = StringUtils.split(this.getExportColumns(),
-                        ',');
-                eh.setColumns(Arrays.asList(columns));
-                ServletExportHandler seh = new ServletExportHandler(eh);
-                pageContext.getOut().clear();
-                pageContext.getOut().clearBuffer();
-                pageContext.getResponse().reset();
-                seh.writeExporterToOutput(
-                        (HttpServletResponse) pageContext.getResponse(),
-                        getPageList());
-                return SKIP_PAGE;
             }
 
             // Get the JSPWriter that the body used, then pop the

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/rhn-taglib.tld
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/rhn-taglib.tld
@@ -411,10 +411,6 @@
             <rtexprvalue>true</rtexprvalue>
         </attribute>
         <attribute>
-            <name>exportColumns</name>
-            <rtexprvalue>true</rtexprvalue>
-        </attribute>
-        <attribute>
             <name>renderDisabled</name>
             <required>false</required>
         </attribute>
@@ -493,10 +489,6 @@
         <attribute>
             <name>filterBy</name>
             <required>false</required>
-        </attribute>
-        <attribute>
-            <name>exportColumns</name>
-            <rtexprvalue>true</rtexprvalue>
         </attribute>
         <attribute>
             <name>renderDisabled</name>

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/test/ListDisplayTagTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/test/ListDisplayTagTest.java
@@ -24,7 +24,6 @@ import com.redhat.rhn.frontend.taglibs.ListDisplayTag;
 import com.redhat.rhn.frontend.taglibs.ListTag;
 import com.redhat.rhn.testing.MockObjectTestCase;
 import com.redhat.rhn.testing.RhnMockJspWriter;
-import com.redhat.rhn.testing.RhnMockServletOutputStream;
 import com.redhat.rhn.testing.TestUtils;
 
 import org.jmock.Expectations;
@@ -33,11 +32,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.io.Writer;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.PageContext;
 import javax.servlet.jsp.tagext.Tag;
@@ -50,7 +47,6 @@ public class ListDisplayTagTest extends MockObjectTestCase {
     private ListDisplayTag ldt;
 
     private HttpServletRequest request;
-    private HttpServletResponse response;
     private PageContext pageContext;
     private RhnMockJspWriter writer;
 
@@ -59,7 +55,6 @@ public class ListDisplayTagTest extends MockObjectTestCase {
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         TestUtils.disableLocalizationLogging();
         request = mock(HttpServletRequest.class);
-        response = mock(HttpServletResponse.class);
         pageContext = mock(PageContext.class);
         writer = new RhnMockJspWriter();
 
@@ -87,9 +82,6 @@ public class ListDisplayTagTest extends MockObjectTestCase {
             atLeast(1).of(pageContext).popBody();
             atLeast(1).of(pageContext).pushBody();
             atLeast(1).of(pageContext).pushBody(with(any(Writer.class)));
-
-            atLeast(1).of(request).getParameter(RequestContext.LIST_DISPLAY_EXPORT);
-            will(returnValue(null));
 
             atLeast(1).of(request).getParameter(RequestContext.LIST_SORT);
             will(returnValue(null));
@@ -127,20 +119,10 @@ public class ListDisplayTagTest extends MockObjectTestCase {
 
     @Test
     public void testTag() throws JspException {
-        ldt.setExportColumns("column1,column2,column3");
         context().checking(new Expectations() { {
             atLeast(1).of(pageContext).popBody();
             atLeast(1).of(pageContext).pushBody();
             atLeast(1).of(pageContext).pushBody(with(any(Writer.class)));
-
-            atLeast(1).of(request).getAttribute("requestedUri");
-            will(returnValue("/rhn/somePage.do"));
-
-            atLeast(1).of(request).getQueryString();
-            will(returnValue("sid=12355345"));
-
-            atLeast(1).of(request).getParameter(RequestContext.LIST_DISPLAY_EXPORT);
-            will(returnValue("2"));
 
             atLeast(1).of(request).getParameter(RequestContext.LIST_SORT);
             will(returnValue("column2"));
@@ -157,46 +139,5 @@ public class ListDisplayTagTest extends MockObjectTestCase {
         writer.verify();
         String htmlOut = writer.toString();
         assertPaginationControls(htmlOut);
-        assertTrue(htmlOut.contains("Download CSV"));
     }
-
-    @Test
-    public void testExport() throws JspException, IOException {
-        RhnMockServletOutputStream out = new RhnMockServletOutputStream();
-        ldt.setExportColumns("column1,column2,column3");
-
-        context().checking(new Expectations() { {
-            atLeast(1).of(request).getParameter(RequestContext.LIST_DISPLAY_EXPORT);
-            will(returnValue("1"));
-
-            atLeast(1).of(pageContext).getResponse();
-            will(returnValue(response));
-        } });
-
-        context().checking(CSVMockTestHelper.getCsvExportParameterExpectations(response,
-                out));
-
-        context().checking(new Expectations() { {
-            atLeast(1).of(response).reset();
-        } });
-        int tagval = ldt.doStartTag();
-        assertEquals(tagval, Tag.SKIP_PAGE);
-        tagval = ldt.doEndTag();
-        ldt.release();
-        assertEquals(tagval, Tag.SKIP_PAGE);
-        assertEquals(EXPECTED_CSV_OUT, out.getContents());
-    }
-
-    private static final String EXPECTED_CSV_OUT =
-            "**column1**,**column2**,**column3**\n" +
-            "cval1-0,cval2-0,cval3-0\n" +
-            "cval1-1,cval2-1,cval3-1\n" +
-            "cval1-2,cval2-2,cval3-2\n" +
-            "cval1-3,cval2-3,cval3-3\n" +
-            "cval1-4,cval2-4,cval3-4\n" +
-            "cval1-5,cval2-5,cval3-5\n" +
-            "cval1-6,cval2-6,cval3-6\n" +
-            "cval1-7,cval2-7,cval3-7\n" +
-            "cval1-8,cval2-8,cval3-8\n" +
-            "cval1-9,cval2-9,cval3-9\n";
 }

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/test/UnpagedListDisplayTagTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/test/UnpagedListDisplayTagTest.java
@@ -23,7 +23,6 @@ import com.redhat.rhn.frontend.taglibs.ListTag;
 import com.redhat.rhn.frontend.taglibs.UnpagedListDisplayTag;
 import com.redhat.rhn.testing.MockObjectTestCase;
 import com.redhat.rhn.testing.RhnMockJspWriter;
-import com.redhat.rhn.testing.RhnMockServletOutputStream;
 import com.redhat.rhn.testing.TestUtils;
 
 import org.jmock.Expectations;
@@ -32,10 +31,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.PageContext;
 import javax.servlet.jsp.tagext.Tag;
@@ -46,7 +42,6 @@ import javax.servlet.jsp.tagext.Tag;
 public class UnpagedListDisplayTagTest extends MockObjectTestCase {
     private UnpagedListDisplayTag ldt;
     private HttpServletRequest request;
-    private HttpServletResponse response;
     private PageContext pageContext;
     private RhnMockJspWriter writer;
 
@@ -56,7 +51,6 @@ public class UnpagedListDisplayTagTest extends MockObjectTestCase {
         TestUtils.disableLocalizationLogging();
 
         request = mock(HttpServletRequest.class);
-        response = mock(HttpServletResponse.class);
         pageContext = mock(PageContext.class);
         writer = new RhnMockJspWriter();
 
@@ -81,8 +75,6 @@ public class UnpagedListDisplayTagTest extends MockObjectTestCase {
         context().checking(new Expectations() { {
             atLeast(1).of(pageContext).popBody();
             atLeast(1).of(pageContext).pushBody();
-            atLeast(1).of(request).getParameter(RequestContext.LIST_DISPLAY_EXPORT);
-            will(returnValue(null));
             atLeast(1).of(request).getParameter(RequestContext.LIST_SORT);
             will(returnValue(null));
         } });
@@ -107,42 +99,18 @@ public class UnpagedListDisplayTagTest extends MockObjectTestCase {
         context().checking(new Expectations() { {
             atLeast(1).of(pageContext).popBody();
             atLeast(1).of(pageContext).pushBody();
-            atLeast(1).of(request).getParameter(RequestContext.LIST_DISPLAY_EXPORT);
-            will(returnValue("2"));
             atLeast(1).of(request).getParameter(RequestContext.LIST_SORT);
             will(returnValue("column2"));
             atLeast(1).of(request).getParameter(RequestContext.SORT_ORDER);
             will(returnValue(RequestContext.SORT_ASC));
 
         } });
-        ldt.setExportColumns("column1,column2,column3");
         writer.setExpectedData(EXPECTED_HTML_OUT);
         int tagval = ldt.doStartTag();
         assertEquals(tagval, Tag.EVAL_BODY_INCLUDE);
         tagval = ldt.doEndTag();
         ldt.release();
         assertEquals(tagval, Tag.EVAL_PAGE);
-    }
-
-    @Test
-    public void testExport() throws JspException, IOException {
-        RhnMockServletOutputStream out = new RhnMockServletOutputStream();
-        context().checking(new Expectations() { {
-            atLeast(1).of(request).getParameter(RequestContext.LIST_DISPLAY_EXPORT);
-            will(returnValue("1"));
-            atLeast(1).of(pageContext).getResponse();
-            will(returnValue(response));
-            atLeast(1).of(response).reset();
-        } });
-        context().checking(CSVMockTestHelper.getCsvExportParameterExpectations(response,
-                out));
-        ldt.setExportColumns("column1,column2,column3");
-        int tagval = ldt.doStartTag();
-        assertEquals(tagval, Tag.SKIP_PAGE);
-        tagval = ldt.doEndTag();
-        ldt.release();
-        assertEquals(tagval, Tag.SKIP_PAGE);
-        assertEquals(EXPECTED_CSV_OUT, out.getContents());
     }
 
     private static final String EXPECTED_HTML_OUT =
@@ -160,17 +128,4 @@ public class UnpagedListDisplayTagTest extends MockObjectTestCase {
         "</div></div><table class=\"table table-striped\"><thead><tr></tbody></table>\n" +
         "</div>\n" +
         "</div>\n";
-
-    private static final String EXPECTED_CSV_OUT =
-        "**column1**,**column2**,**column3**\n" +
-        "cval1-0,cval2-0,cval3-0\n" +
-        "cval1-1,cval2-1,cval3-1\n" +
-        "cval1-2,cval2-2,cval3-2\n" +
-        "cval1-3,cval2-3,cval3-3\n" +
-        "cval1-4,cval2-4,cval3-4\n" +
-        "cval1-5,cval2-5,cval3-5\n" +
-        "cval1-6,cval2-6,cval3-6\n" +
-        "cval1-7,cval2-7,cval3-7\n" +
-        "cval1-8,cval2-8,cval3-8\n" +
-        "cval1-9,cval2-9,cval3-9\n";
 }

--- a/java/code/src/com/redhat/rhn/testing/ActionHelper.java
+++ b/java/code/src/com/redhat/rhn/testing/ActionHelper.java
@@ -202,7 +202,6 @@ public class ActionHelper  {
      * @param filterString the filter string we want to test out.
      */
     public void setupClampListBounds(String filterString) {
-        getRequest().setupAddParameter(RequestContext.LIST_DISPLAY_EXPORT, "0");
         getRequest().setupAddParameter(RequestContext.FILTER_STRING, filterString);
         getRequest().setupAddParameter(RequestContext.PREVIOUS_FILTER_STRING, filterString);
         getRequest().setupAddParameter("newset", (String)null);


### PR DESCRIPTION
In addition to the CSV tag, ListDisplay tag also includes some logic for CSV export that is not used anywhere. This patch removes this bit from the codebase.

## Documentation
- No documentation needed: code maintenance

## Test coverage
- No tests: only removal

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20640

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
