### PR TITLE
Fix Rake reference to CustomFormatter

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -56,7 +56,7 @@ namespace :parallel do
       tags = ENV['TAGS']
       include_tags =  tags.nil? ? '' : "--tags #{tags}"
       cucumber_opts = "#{include_profiles} #{include_tags} #{html_results} #{json_results} #{junit_results} " \
-                      '-f PrettyFormatterExtended::PrettyFormatter -r features '
+                      '-f CustomFormatter::PrettyFormatter -r features '
       sh "bundle exec parallel_cucumber -n 6 -o '#{cucumber_opts}' #{features}"
     end
   end


### PR DESCRIPTION
## What does this PR change?

Small fix in Rakefile, when trying to run a task in parallel

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Ports:
- Manager-4.2
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
