### PR TITLE
Add loading indicator to formula details page (bsc#1179747)

### DIFF
--- a/web/html/src/components/table/TableDataHandler.tsx
+++ b/web/html/src/components/table/TableDataHandler.tsx
@@ -4,6 +4,8 @@ import _isEqual from "lodash/isEqual";
 
 import { pageSize } from "core/user-preferences";
 
+import { Loading } from "components/utils";
+
 import { AsyncDataProvider, PageControl, SimpleDataProvider } from "utils/data-providers";
 import { Comparator, PagedData } from "utils/data-providers";
 import { Utils } from "utils/functions";
@@ -372,7 +374,6 @@ export class TableDataHandler extends React.Component<Props, State> {
     };
 
     const emptyText = this.props.emptyText || t("There are no entries to show.");
-    const loadingText = this.props.loadingText || t("Loading...");
     const isSelectable = typeof this.props.selectable !== "undefined" && this.props.selectable !== false;
 
     return (
@@ -412,10 +413,7 @@ export class TableDataHandler extends React.Component<Props, State> {
             </div>
           ) : null}
           {this.state.loading ? (
-            <div className="panel-body text-center">
-              <i className="fa fa-spinner fa-spin fa-1-5x"></i>
-              <h4>{loadingText}</h4>
-            </div>
+            <Loading text={this.props.loadingText} />
           ) : isEmpty ? (
             <div className="panel-body">
               <div className="subheadline">{emptyText}</div>

--- a/web/html/src/components/utils/Loading.tsx
+++ b/web/html/src/components/utils/Loading.tsx
@@ -13,13 +13,8 @@ export function Loading({ withBorders, text }: LoadingProps) {
     <div className="panel-body text-center">
       {withBorders ? <div className="line-separator" /> : null}
       <i className="fa fa-spinner fa-spin fa-1-5x" />
-      <h4>{text}</h4>
+      <h4>{text || t("Loading...")}</h4>
       {withBorders ? <div className="line-separator" /> : null}
     </div>
   );
 }
-
-Loading.defaultProps = {
-  text: undefined,
-  withBorders: false,
-};

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Show loading indicator on formula details pages (bsc#1179747)
 - Fix systems list sorting buttons
 - Fix wrong credentials error message (bsc#1210456)
 - Recurring custom states


### PR DESCRIPTION
Adds a loading indicator to the formula details page to prevent showing an error during loading.

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13387

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
