### PR TITLE
Ci fix podman sshd pam

### DIFF
--- a/testsuite/dockerfiles/controller-dev/Dockerfile
+++ b/testsuite/dockerfiles/controller-dev/Dockerfile
@@ -35,4 +35,5 @@ RUN zypper ref -f && \
       iproute2 \
       && \
     zypper clean -a
+COPY etc_pam.d_sshd /etc/pamd.d/sshd
 CMD ssh-keygen -A && /usr/sbin/sshd -De

--- a/testsuite/dockerfiles/controller-dev/Dockerfile
+++ b/testsuite/dockerfiles/controller-dev/Dockerfile
@@ -35,5 +35,5 @@ RUN zypper ref -f && \
       iproute2 \
       && \
     zypper clean -a
-COPY etc_pam.d_sshd /etc/pamd.d/sshd
+COPY etc_pam.d_sshd /etc/pam.d/sshd
 CMD ssh-keygen -A && /usr/sbin/sshd -De

--- a/testsuite/dockerfiles/controller-dev/etc_pam.d_sshd
+++ b/testsuite/dockerfiles/controller-dev/etc_pam.d_sshd
@@ -1,0 +1,11 @@
+#%PAM-1.0
+auth        requisite   pam_nologin.so
+auth        include     common-auth
+account     requisite   pam_nologin.so
+account     include     common-account
+password    include     common-password
+session     optional    pam_loginuid.so
+session     include     common-session
+session     optional    pam_lastlog.so   silent noupdate showfailed
+session     optional    pam_keyinit.so   force revoke
+

--- a/testsuite/dockerfiles/opensuse-minion/Dockerfile
+++ b/testsuite/dockerfiles/opensuse-minion/Dockerfile
@@ -5,4 +5,5 @@ RUN zypper -n ar --no-gpgcheck https://download.opensuse.org/repositories/system
     zypper -n install openssh-server openssh-clients hostname iproute2 venv-salt-minion andromeda-dummy milkyway-dummy virgo-dummy openscap-utils openscap-content scap-security-guide gzip udev dmidecode && \
     zypper clean -a
 RUN zypper -n ar --no-gpgcheck https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm/ test_repo_rpm_pool
+COPY etc_pam.d_sshd /etc/pam.d/sshd
 CMD ssh-keygen -A && /usr/sbin/sshd -De

--- a/testsuite/dockerfiles/opensuse-minion/etc_pam.d_sshd
+++ b/testsuite/dockerfiles/opensuse-minion/etc_pam.d_sshd
@@ -1,0 +1,11 @@
+#%PAM-1.0
+auth        requisite   pam_nologin.so
+auth        include     common-auth
+account     requisite   pam_nologin.so
+account     include     common-account
+password    include     common-password
+session     optional    pam_loginuid.so
+session     include     common-session
+session     optional    pam_lastlog.so   silent noupdate showfailed
+session     optional    pam_keyinit.so   force revoke
+

--- a/testsuite/dockerfiles/rocky-minion/Dockerfile
+++ b/testsuite/dockerfiles/rocky-minion/Dockerfile
@@ -2,4 +2,5 @@ FROM rockylinux:8
 COPY uyuni-tools-pool.repo /etc/yum.repos.d
 RUN yum -y install openssh-server venv-salt-minion openssh-clients iproute hostname openscap-utils scap-security-guide-redhat udev dmidecode
 COPY test_repo_rpm_pool.repo /etc/yum.repos.d
+COPY etc_pam.d_sshd /etc/pam.d/sshd
 CMD ssh-keygen -A && /usr/sbin/sshd -De

--- a/testsuite/dockerfiles/rocky-minion/etc_pam.d_sshd
+++ b/testsuite/dockerfiles/rocky-minion/etc_pam.d_sshd
@@ -1,0 +1,11 @@
+#%PAM-1.0
+auth        requisite   pam_nologin.so
+auth        include     common-auth
+account     requisite   pam_nologin.so
+account     include     common-account
+password    include     common-password
+session     optional    pam_loginuid.so
+session     include     common-session
+session     optional    pam_lastlog.so   silent noupdate showfailed
+session     optional    pam_keyinit.so   force revoke
+

--- a/testsuite/dockerfiles/server-all-in-one/Dockerfile
+++ b/testsuite/dockerfiles/server-all-in-one/Dockerfile
@@ -11,7 +11,7 @@ RUN zypper ar -G http://download.opensuse.org/repositories/systemsmanagement:/Uy
 copy setup_env.sh /root/setup_env.sh
 
 RUN zypper ref
-RUN zypper -n in vi
+RUN zypper -n in vi openssh-server
 RUN zypper --non-interactive install --auto-agree-with-licenses --force-resolution patterns-uyuni_server
 RUN zypper mr -d repo-backports-update repo-sle-update
 
@@ -20,6 +20,8 @@ RUN cp /usr/bin/uyuni-setup-reportdb /usr/bin/uyuni-setup-reportdb.original
 RUN sed -i 's/sysctl kernel.shmmax/#sysctl kernel.shmmax/g' /usr/bin/uyuni-setup-reportdb
 RUN sed -i 's/-a "$PG_SOCKET"//g' /usr/bin/uyuni-setup-reportdb
 
+# hack to fix pam for podman
+COPY etc_pam.d_sshd /etc/pam.d/sshd
 
 EXPOSE 443/tcp
 EXPOSE 80/tcp

--- a/testsuite/dockerfiles/server-all-in-one/etc_pam.d_sshd
+++ b/testsuite/dockerfiles/server-all-in-one/etc_pam.d_sshd
@@ -1,0 +1,11 @@
+#%PAM-1.0
+auth        requisite   pam_nologin.so
+auth        include     common-auth
+account     requisite   pam_nologin.so
+account     include     common-account
+password    include     common-password
+session     optional    pam_loginuid.so
+session     include     common-session
+session     optional    pam_lastlog.so   silent noupdate showfailed
+session     optional    pam_keyinit.so   force revoke
+

--- a/testsuite/dockerfiles/ubuntu-minion/Dockerfile
+++ b/testsuite/dockerfiles/ubuntu-minion/Dockerfile
@@ -5,5 +5,6 @@ RUN apt-get update && \
   apt-get clean
 RUN echo "deb [trusted=yes] https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/deb/ /" > /etc/apt/sources.list.d/test_repo_deb_pool.list
 RUN mkdir /run/sshd
+COPY etc_pam.d_sshd /etc/pam.d/sshd
 CMD ssh-keygen -A && /usr/sbin/sshd -De
 

--- a/testsuite/dockerfiles/ubuntu-minion/etc_pam.d_sshd
+++ b/testsuite/dockerfiles/ubuntu-minion/etc_pam.d_sshd
@@ -1,0 +1,11 @@
+#%PAM-1.0
+auth        requisite   pam_nologin.so
+auth        include     common-auth
+account     requisite   pam_nologin.so
+account     include     common-account
+password    include     common-password
+session     optional    pam_loginuid.so
+session     include     common-session
+session     optional    pam_lastlog.so   silent noupdate showfailed
+session     optional    pam_keyinit.so   force revoke
+

--- a/testsuite/podman_runner/00_setup_env.sh
+++ b/testsuite/podman_runner/00_setup_env.sh
@@ -14,15 +14,21 @@ fi
 echo "Killing old containers"
 containers="deblike_minion rhlike_minion sle_minion opensusessh uyuni-server-all-in-one-test controller-test"
 for i in ${containers};do
-    podman kill ${i}
+    sudo -i podman kill ${i}
 done
-
-echo "Remove network"
-podman network rm uyuni-network-1
 
 echo "Wait for the containers to stop"
 for i in ${containers};do
-    podman wait ${i}
+    sudo -i podman wait ${i}
 done
+
+echo "Force remove containers"
+containers="deblike_minion rhlike_minion sle_minion opensusessh uyuni-server-all-in-one-test controller-test"
+for i in ${containers};do
+    sudo -i podman rm ${i}
+done
+
+echo "Remove network"
+sudo -i podman network rm uyuni-network-1
 
 sleep 10


### PR DESCRIPTION
## What does this PR change?

Fixes pam/sshd configuration so sshd works inside the containers with podman. This is a known bug. See: https://github.com/containers/podman/issues/3651

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

https://github.com/containers/podman/issues/3651

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
