### PR TITLE
Fix server error in HTTP API authentication

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/user/UserManager.java
+++ b/java/code/src/com/redhat/rhn/manager/user/UserManager.java
@@ -530,6 +530,10 @@ public class UserManager extends BaseManager {
      * @throws LoginException if login fails.  The message is a string resource key.
      */
     public static User loginUser(String username, String password) throws LoginException {
+        if (username == null) {
+            throw new LoginException("error.invalid_login");
+        }
+
         String exceptionType = null;
         try {
             User user = UserFactory.lookupByLogin(username);

--- a/java/code/src/com/suse/manager/webui/controllers/login/LoginController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/login/LoginController.java
@@ -194,6 +194,9 @@ public class LoginController {
      */
     public static class LoginCredentials {
         private String login;
+
+        // You can choose to use either login and username, both should work equally.
+        private String username;
         private String password;
 
         /**
@@ -209,6 +212,7 @@ public class LoginController {
          */
         public LoginCredentials(String loginIn, String passwordIn) {
             this.login = loginIn;
+            this.username = loginIn;
             this.password = passwordIn;
         }
 
@@ -216,7 +220,7 @@ public class LoginController {
          * @return the login
          */
         public String getLogin() {
-            return login;
+            return login != null ? login : username;
         }
 
         /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix server error in HTTP API authentication (bsc#1210394)
 - set swap memory value if available
 - set primary FQDN to hostname if none is set (bsc#1209156)
 - Do not throw on missing saltboot group


### PR DESCRIPTION
## What does this PR change?

It allows to use both `login` and `username` as parameter name for credentials when authenticating in the HTTP API and also avoid server error when the value for this parameter is not passed in the request.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bug fix.

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/21178

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
