### PR TITLE
fix uptime test

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -103,7 +103,7 @@ Then(/^the uptime for "([^"]*)" should be correct$/) do |host|
     step %(I should see a "#{rounded_uptime_hours} hours ago" text)
   elsif rounded_uptime_minutes >= 45 && rounded_uptime_hours == 1 # shows "an hour ago" from 45 minutes onwards up to 1.5 hours
     step %(I should see a "an hour ago" text)
-  elsif rounded_uptime_minutes > 1 && rounded_uptime_hours < 1
+  elsif rounded_uptime_minutes > 1 && rounded_uptime_hours <= 1
     step %(I should see a "#{rounded_uptime_minutes} minutes ago" text)
   elsif uptime[:seconds] >= 45 && rounded_uptime_minutes == 1
     step %(I should see a "a minute ago" text)


### PR DESCRIPTION
With the previous code, if time was greater than half an hour but less than an hour, it was calculating 0 days.

## What does this PR change?

Fixes uptime test

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

N/A

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
