### PR TITLE
Adjust recurring actions cucumbert test

### DIFF
--- a/testsuite/features/secondary/min_recurring_action.feature
+++ b/testsuite/features/secondary/min_recurring_action.feature
@@ -208,33 +208,9 @@ Feature: Recurring Actions
     When I follow the left menu "Schedule > Recurring Actions"
     And I click the "schedule_name_minion" item details button
     Then I should see a "Every Sunday at 00:00" text
-    And I should not see a "Highstate for" text in the content area
-    When I click on "Edit"
-    Then I should see a "Update Schedule" text
-    When I click on "Back to list"
+    And I should not see a "Schedules" text in the content area
+    When I click on "Back"
     Then I should see a "schedule_name_group" text
-
-  Scenario: Edit in list of all actions
-    When I follow the left menu "Schedule > Recurring Actions"
-    And I wait until I see "schedule_name_org" text
-    And I click the "schedule_name_org" item edit button
-    Then I should see a "Update Schedule" text
-    And I should not see a "Highstate for" text in the content area
-    When I enter "schedule_name_edit" as "scheduleName"
-    And I check radio button "schedule-monthly"
-    And I click on "Update Schedule"
-    Then I should not see a "schedule_name_org" text
-    And I should see a "schedule_name_edit" text
-    And I should see a "0 0 0 1 * ?" text
-
-  Scenario: Delete from list of all actions
-    When I follow the left menu "Schedule > Recurring Actions"
-    When I click the "schedule_name_edit" item delete button
-    Then I should see a "Delete Recurring Action Schedule" text
-    When I click on the red confirmation button
-    Then I wait until I see "Schedule 'schedule_name_edit' has been deleted." text
-    And I should not see a "Organization" text in the content area
-    And I should see a "schedule_name_group" text
 
   Scenario: Delete a minion Recurring Action
     When I am on the "Recurring Actions" page of this "sle_minion"


### PR DESCRIPTION
## What does this PR change?

It is not possible to edit or delete an action from the list all table anymore. The PR adapt the related tests to this new behavior.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were adapted

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/21194

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
