### PR TITLE
Fix enabling bundle build via custom info

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/images/kiwi-image-inspect.sls
+++ b/susemanager-utils/susemanager-sls/salt/images/kiwi-image-inspect.sls
@@ -4,7 +4,7 @@
 {%- set dest_dir   = root_dir + '/images.build' %}
 {%- set bundle_dir = root_dir + '/images/' %}
 {%- set build_id  = pillar.get('build_id') %}
-{%- set use_bundle_build = pillar.get('use_bundle_build') %}
+{%- set use_bundle_build = pillar.get('use_bundle_build', salt['pillar.get']('custom_info:use_bundle_build', False)) %}
 
 # the goal is to collect all information required for
 # saltboot image pillar

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix enabling bundle build via custom info
 - Rename internal state 'synccustomall' to 'syncall'
 - Recurring custom states
 - Do not include pillar_only formulas in highstate


### PR DESCRIPTION
## What does this PR change?

Bundle image build can be enabled via custom info. It was however enabled only in build phase, not in inspect phase.
This caused further problems with registering images to cobbler.
This PR fixes it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: fix

- [x] **DONE**

## Test coverage
- covered by openqa tests

- [x] **DONE**

## Links

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
