### PR TITLE
Do not throw on missing saltboot group

### DIFF
--- a/java/code/src/com/suse/manager/saltboot/SaltbootUtils.java
+++ b/java/code/src/com/suse/manager/saltboot/SaltbootUtils.java
@@ -184,12 +184,14 @@ public class SaltbootUtils {
 
         Profile profile = Profile.lookupByName(con, org.getId() + "-" + bootImage);
         if (profile == null) {
-            throw new SaltbootException("Unable to find Cobbler profile for specified boot image " + bootImage);
+            LOG.warn("Unable to find Cobbler profile for specified boot image '{}'", bootImage);
+            return;
         }
 
         Profile group = Profile.lookupByName(con, org.getId() + "-" + saltbootGroup);
         if (group == null) {
-            throw new SaltbootException("Unable to find Cobbler profile for saltboot group " + saltbootGroup);
+            LOG.warn("Unable to find Cobbler profile for saltboot group '{}'", saltbootGroup);
+            return;
         }
 
         // We need to append associated saltboot group settings, particularly MASTER

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Do not throw on missing saltboot group
 - fix ISE when neither SCC credentials nor a local mirror is configured
 - only set self_update URL if functionality is not disabled in
   distro or profile


### PR DESCRIPTION
## What does this PR change?

Registering OS images in Cobbler is optional and must be configured first.
This PR replaces exception with log.warn on systems where it is not configured.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: bugfix
- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
