### PR TITLE
Fix reinstall kernel opts

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerSystemCreateCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerSystemCreateCommand.java
@@ -332,7 +332,13 @@ public class CobblerSystemCreateCommand extends CobblerCommand {
                     kernelOptions = kernelOptions + " install=http://" + kickstartHost +
                             mediaPath;
                 }
-                if (!kernelOptions.contains("self_update=") && ksData != null) {
+
+                Map<String, Object> resKopts = recProfile.getResolvedKernelOptions();
+                boolean selfUpdateDisabled = false;
+                if (resKopts.getOrDefault("self_update", "Enabled").equals("0")) {
+                    selfUpdateDisabled = true;
+                }
+                if (!(selfUpdateDisabled || kernelOptions.contains("self_update=") || ksData == null)) {
                     Optional<Channel> installerUpdated = ksData.getTree().getChannel()
                             .getAccessibleChildrenFor(user)
                             .stream()

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerSystemCreateCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerSystemCreateCommand.java
@@ -431,11 +431,13 @@ public class CobblerSystemCreateCommand extends CobblerCommand {
                     if (n.isPublic()) {
                         Network net = new Network(getCobblerConnection(),
                                 n.getName());
-                        net.setIpAddress(n.getIPv4Addresses().get(0).getAddress());
+                        if (!n.getIPv4Addresses().isEmpty()) {
+                            net.setIpAddress(n.getIPv4Addresses().get(0).getAddress());
+                            net.setNetmask(n.getIPv4Addresses().get(0).getNetmask());
+                        }
                         net.setMacAddress(n.getHwaddr());
-                        net.setNetmask(n.getIPv4Addresses().get(0).getNetmask());
-                        if (!StringUtils.isBlank(networkInterface) &&
-                                n.getName().equals(networkInterface)) {
+
+                        if (!StringUtils.isBlank(networkInterface) && n.getName().equals(networkInterface)) {
                             net.setStaticNetwork(!isDhcp);
                         }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- only set self_update URL if functionality is not disabled in
+  distro or profile
 - execute highstate on registration with a user if available
 - Ensure installation of 'xalan-j2' for building.
 - Simplify Java package dependencies.


### PR DESCRIPTION
## What does this PR change?

When `self_update=0` is set in distro, we should not add the URL to the installer update repo.
Only when no "self_update" option exists, or if it is a URL, it should be written and point to the install server which can be a proxy.
Additionally this fix an index out of bound exception when a network interface without IP addresses is part of the server object.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **add explanation**

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/21284

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
