### PR TITLE
Fix ise no scc creds nor fromdir

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -680,12 +680,19 @@ public class ContentSyncManager {
     public boolean isRefreshNeeded(String mirrorUrl) {
         for (SCCRepositoryAuth a : SCCCachingFactory.lookupRepositoryAuthWithContentSource()) {
             ContentSource cs = a.getContentSource();
-            String overwriteUrl = contentSourceUrlOverwrite(a.getRepo(), a.getUrl(), mirrorUrl);
-            log.debug("Linked ContentSource: '{}' OverwriteURL: '{}' AuthUrl: '{}' Mirror: {}",
-                    cs.getSourceUrl(), overwriteUrl, a.getUrl(), mirrorUrl);
-            if (!cs.getSourceUrl().equals(overwriteUrl)) {
-                log.debug("Source and overwrite urls differ: {} != {}", cs.getSourceUrl(), overwriteUrl);
-                return true;
+            try {
+                String overwriteUrl = contentSourceUrlOverwrite(a.getRepo(), a.getUrl(), mirrorUrl);
+                log.debug("Linked ContentSource: '{}' OverwriteURL: '{}' AuthUrl: '{}' Mirror: {}",
+                        cs.getSourceUrl(), overwriteUrl, a.getUrl(), mirrorUrl);
+                if (!cs.getSourceUrl().equals(overwriteUrl)) {
+                    log.debug("Source and overwrite urls differ: {} != {}", cs.getSourceUrl(), overwriteUrl);
+                    return true;
+                }
+            }
+            catch (ContentSyncException e) {
+                // Can happen when neither SCC Credentials nor fromdir is configured
+                // in such a case, refresh makes no sense.
+                return false;
             }
         }
 
@@ -703,6 +710,11 @@ public class ContentSyncManager {
                         return t.after(modifiedCache) ? true : false;
                     }
             );
+        }
+        else if (CredentialsFactory.lookupSCCCredentials().isEmpty()) {
+            // Can happen when neither SCC Credentials nor fromdir is configured
+            // in such a case, refresh makes no sense.
+            return false;
         }
         return SCCCachingFactory.refreshNeeded(lastRefreshDate);
     }

--- a/java/code/src/com/redhat/rhn/manager/content/MgrSyncUtils.java
+++ b/java/code/src/com/redhat/rhn/manager/content/MgrSyncUtils.java
@@ -240,6 +240,9 @@ public class MgrSyncUtils {
             log.warn("Unable to parse URL: {}", urlString);
         }
         String sccDataPath = Config.get().getString(ContentSyncManager.RESOURCE_PATH, null);
+        if (sccDataPath == null) {
+            throw new ContentSyncException("No local mirror path configured");
+        }
         File dataPath = new File(sccDataPath);
         // Case 4
         File mirrorPath = new File(dataPath.getAbsolutePath(), host + File.separator + path);

--- a/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
@@ -2094,6 +2094,16 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
     }
 
     /**
+     * Tests {@link ContentSyncManager#isRefreshNeeded} when neither scc creds nor fromdir is configured
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    public void testIsRefreshNeededNothingConfigured() throws Exception {
+        ContentSyncManager csm = new ContentSyncManager();
+        assertFalse(csm.isRefreshNeeded(null));
+    }
+
+    /**
      * Test for {@link ContentSyncManager#addChannel}.
      * @throws Exception if anything goes wrong
      */

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix ISE when neither SCC credentials nor a local mirror is configured
 - only set self_update URL if functionality is not disabled in
   distro or profile
 - execute highstate on registration with a user if available


### PR DESCRIPTION
## What does this PR change?

When neither SCC credentials nor a local mirror is configured happens,
the isRefreshNeeded() method result in an NPE and we have only a Internal Server Error.
But in such a case a refresh is not needed, so we now return just false.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/21287

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
