### PR TITLE
CI: Acceptance tests at PR v2: fix rhlike

### DIFF
--- a/testsuite/dockerfiles/rocky-minion/etc_pam.d_sshd
+++ b/testsuite/dockerfiles/rocky-minion/etc_pam.d_sshd
@@ -1,11 +1,18 @@
 #%PAM-1.0
-auth        requisite   pam_nologin.so
-auth        include     common-auth
-account     requisite   pam_nologin.so
-account     include     common-account
-password    include     common-password
-session     optional    pam_loginuid.so
-session     include     common-session
-session     optional    pam_lastlog.so   silent noupdate showfailed
-session     optional    pam_keyinit.so   force revoke
+auth       substack     password-auth
+auth       include      postlogin
+account    required     pam_sepermit.so
+# account    required     pam_nologin.so
+account    include      password-auth
+password   include      password-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    optional     pam_loginuid.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open env_params
+session    required     pam_namespace.so
+session    optional     pam_keyinit.so force revoke
+session    optional     pam_motd.so
+session    include      password-auth
+session    include      postlogin
 


### PR DESCRIPTION
## What does this PR change?

CI: fix rhlike minion

## GUI diff

No difference.



- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests
- [x] **DONE**

## Links

N/A

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
