### PR TITLE
Update system overview in case of manual system reboot

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
@@ -24,6 +24,7 @@ import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.server.VirtualInstance;
 import com.redhat.rhn.manager.action.ActionManager;
+import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
 import com.suse.manager.reactor.hardware.CpuArchUtil;
@@ -229,6 +230,7 @@ public class JobReturnEventMessageAction implements MessageAction {
                             .ifPresent(result-> {
                                 SystemInfo systemInfo = Json.GSON.fromJson(result, SystemInfo.class);
                                 saltUtils.updateSystemInfo(systemInfo, minion);
+                                SystemManager.updateSystemOverview(minion.getId());
                             }));
 
             /* Check in case any Action update it could complete any ActionChain that is still pending on that action.

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Update system overview in case of manual system reboot
 - Add uyuni_systems_scrape_duration_seconds metric
 - OES credentials do not allow access to SCC. Skip them when an
   SCCClientException is thrown and move forward


### PR DESCRIPTION
## What does this PR change?

Whenever a salt action is completed for a system, the system overview (including the requires reboot flag) is refreshed. However, when the system is manually rebooted, the overview is not being updated, causing the reboot need flag to not disappear in certain scenarios. The PR adds a new call to update system overview at minion start-up event.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/21214

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
