### PR TITLE
spacewalk-admin: Minor improvements

### DIFF
--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,5 @@
+- Added missing python3-websockify runtime requirement.
+
 -------------------------------------------------------------------
 Wed Apr 19 12:50:23 CEST 2023 - marina.latini@suse.com
 

--- a/spacewalk/admin/spacewalk-admin.spec
+++ b/spacewalk/admin/spacewalk-admin.spec
@@ -35,6 +35,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Requires:       %{pythonX}
 Requires:       lsof
 Requires:       procps
+Requires:       python3-websockify
 Requires:       spacewalk-base
 Requires:       perl(MIME::Base64)
 BuildRequires:  make

--- a/spacewalk/admin/spacewalk-admin.spec
+++ b/spacewalk/admin/spacewalk-admin.spec
@@ -45,9 +45,7 @@ Provides:       satellite-utils = 5.3.0
 Obsoletes:      rhn-satellite-admin < 5.3.0
 Provides:       rhn-satellite-admin = 5.3.0
 BuildArch:      noarch
-%if 0%{?suse_version}
 BuildRequires:  spacewalk-config
-%endif
 BuildRequires:  uyuni-base-common
 Requires(pre):  uyuni-base-common
 Requires:       susemanager-schema-utility


### PR DESCRIPTION
## What does this PR change?

1. Added missing python3-websockify requirement for mgr-websockify.service.
2. Removed unnecessary SUSE `BuildRequires`limitation.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
