### PR TITLE
Support core testing using SCC repository

### DIFF
--- a/testsuite/features/step_definitions/retail_steps.rb
+++ b/testsuite/features/step_definitions/retail_steps.rb
@@ -100,7 +100,7 @@ When(/^I enable repositories before installing branch server$/) do
   log $proxy.run("zypper mr --enable #{repos}")
 
   # Server Applications
-  if os_family =~ /^sles/ && os_version =~ /^15/
+  if os_family =~ /^sles/ && os_version =~ /^15/ && !$is_using_scc_repositories
     repos = 'module_server_applications_pool_repo module_server_applications_update_repo'
     log $proxy.run("zypper mr --enable #{repos}")
   end
@@ -115,7 +115,7 @@ When(/^I disable repositories after installing branch server$/) do
   log $proxy.run("zypper mr --disable #{repos}")
 
   # Server Applications
-  if os_family =~ /^sles/ && os_version =~ /^15/
+  if os_family =~ /^sles/ && os_version =~ /^15/ && !$is_using_scc_repositories
     repos = 'module_server_applications_pool_repo module_server_applications_update_repo'
     log $proxy.run("zypper mr --disable #{repos}")
   end

--- a/testsuite/features/step_definitions/retail_steps.rb
+++ b/testsuite/features/step_definitions/retail_steps.rb
@@ -96,7 +96,7 @@ When(/^I enable repositories before installing branch server$/) do
   os_family = $proxy.os_family
 
   # Distribution
-  repos = 'os_pool_repo os_update_repo'
+  repos = $is_using_scc_repositories ? OS_REPOS_BY_OS_VERSION[os_version].join(' ') : "os_pool_repo os_update_repo"
   log $proxy.run("zypper mr --enable #{repos}")
 
   # Server Applications
@@ -111,7 +111,7 @@ When(/^I disable repositories after installing branch server$/) do
   os_family = $proxy.os_family
 
   # Distribution
-  repos = 'os_pool_repo os_update_repo'
+  repos = $is_using_scc_repositories ? OS_REPOS_BY_OS_VERSION[os_version].join(' ') : "os_pool_repo os_update_repo"
   log $proxy.run("zypper mr --disable #{repos}")
 
   # Server Applications


### PR DESCRIPTION
## What does this PR change?

When running the tests using SCC repositories, the repositories name are not the same. This changes were done to support AWS testing but lost during refactoring.
Support SCC repository when enabling and disabling repo in core testing 


## Changelogs

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
