### PR TITLE
Set package refresh scheduler if possible

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Action_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Action_queries.xml
@@ -24,7 +24,7 @@ SELECT EVENT_ID as ID,
          WHERE SH.server_id = :sid
          UNION
         SELECT SA.action_id EVENT_ID,
-               AType.name || ' scheduled by ' || NVL(U.login, '(none)') AS SUMMARY,
+               AType.name || ' scheduled by ' || NVL(U.login, '(system)') AS SUMMARY,
                SA.created,
                SA.pickup_time AS picked_up,
                SA.completion_time AS completed,

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -1798,7 +1798,7 @@ select event_id as id,
          where SH.server_id = :sid
          union
         select SA.action_id event_id,
-               COALESCE(A.name, AType.name) || ' scheduled by ' || NVL(U.login, '(none)') as summary,
+               COALESCE(A.name, AType.name) || ' scheduled by ' || NVL(U.login, '(system)') as summary,
                SA.created,
                SA.pickup_time as picked_up,
                SA.completion_time as completed,
@@ -1852,7 +1852,7 @@ order by completed desc, picked_up desc, all_events.created desc, event_id desc
                      AND SH.id = :eid
                union
               select SA.action_id event_id,
-                     COALESCE(A.name, AType.name) || ' scheduled by ' || NVL(U.login, '(none)') as summary,
+                     COALESCE(A.name, AType.name) || ' scheduled by ' || NVL(U.login, '(system)') as summary,
                      SA.created,
                      SA.pickup_time as picked_up,
                      SA.completion_time as completed,
@@ -1888,7 +1888,7 @@ select count(action_id) as count
   class="com.redhat.rhn.frontend.dto.SystemPendingEventDto">
   <query params="sid">
   SELECT SA.action_id AS id
-                , COALESCE(A.name, AType.name) || ' scheduled by ' || NVL(U.login, '(none)') AS summary
+                , COALESCE(A.name, AType.name) || ' scheduled by ' || NVL(U.login, '(system)') AS summary
                 , A.earliest_action AS scheduled_for
                 , AType.label AS history_type
                 , AType.name AS history_type_name
@@ -1910,7 +1910,7 @@ ORDER BY scheduled_for DESC, prereq_aid NULLS FIRST
   class="com.redhat.rhn.frontend.dto.SystemPendingEventDto">
   <query params="sid, user_id, set_label">
   SELECT SA.action_id AS ID
-                , COALESCE(A.name, AType.name) || ' scheduled by ' || NVL(U.login, '(none)') AS summary
+                , COALESCE(A.name, AType.name) || ' scheduled by ' || NVL(U.login, '(system)') AS summary
                 , A.earliest_action AS scheduled_for
                 , AType.label AS history_type
                 , AType.name AS history_type_name

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -1188,37 +1188,37 @@ public class ActionManager extends BaseManager {
     /**
      * Schedule a package list refresh without a user.
      *
-     * @param schedulerOrg the organization the server belongs to
+     * @param user the user that scheduled the action
      * @param server the server
      * @return the scheduled PackageRefreshListAction
      * @throws TaskomaticApiException if there was a Taskomatic error
      * (typically: Taskomatic is down)
      */
-    public static PackageAction schedulePackageRefresh(Org schedulerOrg, Server server)
+    public static PackageAction schedulePackageRefresh(Optional<User> user, Server server)
             throws TaskomaticApiException {
         Date earliest = new Date();
-        return schedulePackageRefresh(schedulerOrg, server, earliest);
+        return schedulePackageRefresh(user, server, earliest);
     }
 
     /**
      * Schedule a package list refresh without a user.
      *
-     * @param schedulerOrg the organization the server belongs to
+     * @param user the organization the server belongs to
      * @param server the server
      * @param earliest The earliest time this action should be run.
      * @return the scheduled PackageRefreshListAction
      * @throws TaskomaticApiException if there was a Taskomatic error
      * (typically: Taskomatic is down)
      */
-    public static PackageAction schedulePackageRefresh(Org schedulerOrg, Server server,
+    public static PackageAction schedulePackageRefresh(Optional<User> user, Server server,
             Date earliest) throws TaskomaticApiException {
         checkSaltOrManagementEntitlement(server.getId());
 
         Action action = ActionFactory.createAction(
                 ActionFactory.TYPE_PACKAGES_REFRESH_LIST);
         action.setName(ActionFactory.TYPE_PACKAGES_REFRESH_LIST.getName());
-        action.setOrg(schedulerOrg);
-        action.setSchedulerUser(null);
+        action.setOrg(server.getOrg());
+        action.setSchedulerUser(user.orElse(null));
         action.setEarliestAction(earliest);
 
         ServerAction sa = new ServerAction();

--- a/java/code/src/com/suse/manager/reactor/SaltReactor.java
+++ b/java/code/src/com/suse/manager/reactor/SaltReactor.java
@@ -313,7 +313,7 @@ public class SaltReactor {
                             () -> MinionServerFactory.findByMinionId(beaconEvent.getMinionId())
                                     .ifPresent(minionServer -> {
                         try {
-                            ActionManager.schedulePackageRefresh(minionServer.getOrg(), minionServer);
+                            ActionManager.schedulePackageRefresh(Optional.empty(), minionServer);
                         }
                         catch (TaskomaticApiException e) {
                             LOG.error("Could not schedule package refresh for minion: {}",

--- a/java/code/src/com/suse/manager/xmlrpc/serializer/test/SystemEventDetailsDtoSerializerTest.java
+++ b/java/code/src/com/suse/manager/xmlrpc/serializer/test/SystemEventDetailsDtoSerializerTest.java
@@ -48,7 +48,7 @@ public class SystemEventDetailsDtoSerializerTest {
         dto.setHistoryType(ActionFactory.TYPE_HARDWARE_REFRESH_LIST.getLabel());
         dto.setHistoryTypeName(ActionFactory.TYPE_HARDWARE_REFRESH_LIST.getName());
         dto.setHistoryStatus(ActionFactory.STATUS_COMPLETED.getName());
-        dto.setSummary("Hardware List Refresh scheduled by (none)");
+        dto.setSummary("Hardware List Refresh scheduled by (system)");
         dto.setCreated(Date.from(LocalDateTime.of(2021, 10, 5, 16, 55)
                 .atZone(ZoneOffset.systemDefault())
                 .toInstant()));
@@ -81,7 +81,7 @@ public class SystemEventDetailsDtoSerializerTest {
         assertTrue(xml.contains("<string>Completed</string>"));
 
         assertTrue(xml.contains("<name>summary</name>"));
-        assertTrue(xml.contains("<string>Hardware List Refresh scheduled by (none)</string>"));
+        assertTrue(xml.contains("<string>Hardware List Refresh scheduled by (system)</string>"));
 
         assertTrue(xml.contains("<name>created</name>"));
         assertTrue(xml.contains("<dateTime.iso8601>20211005T16:55:00</dateTime.iso8601>"));

--- a/java/code/src/com/suse/manager/xmlrpc/serializer/test/SystemEventDtoSerializerTest.java
+++ b/java/code/src/com/suse/manager/xmlrpc/serializer/test/SystemEventDtoSerializerTest.java
@@ -44,7 +44,7 @@ public class SystemEventDtoSerializerTest {
         dto.setHistoryType(ActionFactory.TYPE_HARDWARE_REFRESH_LIST.getLabel());
         dto.setHistoryTypeName(ActionFactory.TYPE_HARDWARE_REFRESH_LIST.getName());
         dto.setHistoryStatus(ActionFactory.STATUS_COMPLETED.getName());
-        dto.setSummary("Hardware List Refresh scheduled by (none)");
+        dto.setSummary("Hardware List Refresh scheduled by (system)");
         dto.setCompleted(Date.from(LocalDateTime.of(2021, 10, 5, 17, 0)
                 .atZone(ZoneOffset.systemDefault())
                 .toInstant()));
@@ -65,7 +65,7 @@ public class SystemEventDtoSerializerTest {
         assertTrue(xml.contains("<string>Completed</string>"));
 
         assertTrue(xml.contains("<name>summary</name>"));
-        assertTrue(xml.contains("<string>Hardware List Refresh scheduled by (none)</string>"));
+        assertTrue(xml.contains("<string>Hardware List Refresh scheduled by (system)</string>"));
 
         assertTrue(xml.contains("<name>completed</name>"));
         assertTrue(xml.contains("<dateTime.iso8601>20211005T17:00:00</dateTime.iso8601>"));

--- a/java/spacewalk-java.changes.parlt.set-package-refresh-scheduler
+++ b/java/spacewalk-java.changes.parlt.set-package-refresh-scheduler
@@ -1,0 +1,2 @@
+- Change default scheduler from (none) to (system)
+- Set user for package list refresh action if possible

--- a/spacecmd/tests/test_system.py
+++ b/spacecmd/tests/test_system.py
@@ -279,7 +279,7 @@ class TestSystem:
         shell.help_system_listeventhistory = MagicMock()
         shell.client.system.getEventHistory = MagicMock(return_value=[{
             "id": 3, "history_type": "Apply states", "status": "Completed",
-            "summary": "Apply states [certs, channels] scheduled by (none)", "completed": "20211015T16:56:27",
+            "summary": "Apply states [certs, channels] scheduled by (system)", "completed": "20211015T16:56:27",
         }, {
             "id": 1, "history_type": "History Event", "status": "(n/a)",
             "summary": "added system entitlement", "completed": "20211015T16:56:14",
@@ -302,7 +302,7 @@ class TestSystem:
             'Id:           3',
             'History type: Apply states',
             'Status:       Completed',
-            'Summary:      Apply states [certs, channels] scheduled by (none)',
+            'Summary:      Apply states [certs, channels] scheduled by (system)',
             'Completed:    20211015T16:56:27',
             '',
             'Id:           1',
@@ -422,7 +422,7 @@ class TestSystem:
         shell.get_system_id = MagicMock(side_effect=[1000010000])
         shell.client.system.getEventDetails = MagicMock(return_value={
             "id": 1, "history_type": "Apply states", "status": "Completed",
-            "summary": "Apply states [certs] scheduled by (none)",
+            "summary": "Apply states [certs] scheduled by (system)",
             "created": "20211005T09:47:53", "picked_up": "20211005T09:48:03",
             "completed": "20211005T09:48:18", "earliest_action": "20211005T09:47:53",
             "result_msg": "Successfully applied state(s): [certs]",
@@ -460,7 +460,7 @@ class TestSystem:
             '',
             'History type:    Apply states',
             'Status:          Completed',
-            'Summary:         Apply states [certs] scheduled by (none)',
+            'Summary:         Apply states [certs] scheduled by (system)',
             '',
             'Created:         20211005T09:47:53',
             'Picked up:       20211005T09:48:03',

--- a/testsuite/features/init_clients/proxy_branch_network.feature
+++ b/testsuite/features/init_clients/proxy_branch_network.feature
@@ -202,7 +202,7 @@ Feature: Setup Uyuni for Retail branch network
   Scenario: Disable repositories after installing branch services
     When I disable repositories after installing branch server
     # WORKAROUND: the following event fails because the proxy needs 10 minutes to become responsive again
-    # And I wait until event "Package List Refresh scheduled by (none)" is completed
+    # And I wait until event "Package List Refresh scheduled by (system)" is completed
     And I wait for "700" seconds
 
 @proxy

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -197,11 +197,11 @@ Feature: PXE boot a Retail terminal
     When I wait until I see the name of "pxeboot_minion", refreshing the page
     And I follow this "pxeboot_minion" link
     # Workaround: Increase timeout temporarily get rid of timeout issues
-    And I wait at most 350 seconds until event "Apply states [saltboot] scheduled by (none)" is completed
+    And I wait at most 350 seconds until event "Apply states [saltboot] scheduled by (system)" is completed
     And I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until radio button "SLE-Product-SLES15-SP4-Pool for x86_64" is checked, refreshing the page
-    And I wait until event "Package List Refresh scheduled by (none)" is completed
+    And I wait until event "Package List Refresh scheduled by (system)" is completed
     Then "pxeboot_minion" should have been reformatted
 
   Scenario: Check connection from terminal to branch server


### PR DESCRIPTION
## What does this PR change?

This PR was originally part of an L3 but it got closed due to noresponse. In the end I forgot to merge it. I think this change is a valuable addition though, so I think we should still merge it.

Change default/fallback scheduler from `(none)` to `(system)`
Set the scheduler on `package list refresh` action if possible

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed:

- [x] **DONE**

## Test coverage

- No tests: already covered (existing tests adapted)

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/21290

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
