### PR TITLE
Move expect package installation to sumaform

### DIFF
--- a/testsuite/features/build_validation/retail/proxy_branch_network.feature
+++ b/testsuite/features/build_validation/retail/proxy_branch_network.feature
@@ -203,6 +203,3 @@ Feature: Prepare the branch server for PXE booting
 
   Scenario: Also let squid know about the new IP and FQDN of the proxy
     When I restart squid service on the proxy
-
-  Scenario: Install package needed for rebooting terminals
-    When I install package "expect" on this "proxy"

--- a/testsuite/features/core/proxy_register_as_minion_with_gui.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_gui.feature
@@ -59,11 +59,6 @@ Feature: Setup Uyuni proxy
     Then I should see "proxy" hostname
     Then I should see a "Proxy" link in the content area
 
-  Scenario: Install expect package on proxy for bootstrapping minion with GUI
-    When I enable repositories before installing branch server
-    And I install package "expect" on this "proxy"
-    And I disable repositories after installing branch server
-
   Scenario: Check events history for failures on the proxy
     Given I am on the Systems overview page of this "proxy"
     Then I check for failed events on history event page

--- a/testsuite/features/core/proxy_register_as_minion_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_script.feature
@@ -70,12 +70,6 @@ Feature: Setup Uyuni proxy
     Then I should see "proxy" hostname
     Then I should see a "Proxy" link in the content area
 
-@skip_if_cloud
-  Scenario: Install expect package on proxy for bootstrapping minion via script
-    When I enable repositories before installing branch server
-    And I install package "expect" on this "proxy"
-    And I disable repositories after installing branch server
-
   Scenario: Cleanup: remove proxy bootstrap scripts
     When I run "rm /srv/www/htdocs/pub/bootstrap/bootstrap-proxy.sh" on "server"
     And I run "rm /root/bootstrap-proxy.sh" on "proxy"


### PR DESCRIPTION
## What does this PR change?
Remove expect package installation for Proxy from testsuite and move it to sumaform


## Links

Issue : https://github.com/SUSE/spacewalk/issues/21328
Sumaform : https://github.com/uyuni-project/sumaform/pull/1295

- [x] **DONE**

## Changelogs

- [x] No changelog needed