### PR TITLE
Add shadow as dependency for osimage certificate package

### DIFF
--- a/spacewalk/certs-tools/mgr-package-rpm-certificate-osimage
+++ b/spacewalk/certs-tools/mgr-package-rpm-certificate-osimage
@@ -54,7 +54,7 @@ def genCaRpm(options):
         OSIMAGE_RPM_REQUIRES = ["openssl-certs", "coreutils"]
     else:
         CA_CERT_RPM_NAME_OSIMAGE = CA_CRT_RPM_NAME + "-osimage"
-        OSIMAGE_RPM_REQUIRES = ["ca-certificates"]
+        OSIMAGE_RPM_REQUIRES = ["ca-certificates", "shadow"]
 
     ca_cert_name = os.path.basename(options.ca_cert_full_path)
     ca_cert = options.ca_cert_full_path

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,6 @@
+- Add shadow as dependency of osimage certificate package
+  (bsc#1210834 bsc#1204089)
+
 -------------------------------------------------------------------
 Wed Apr 19 12:52:17 CEST 2023 - marina.latini@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/21319

Sometimes the order if installing bootstrap packages in kiwi build installs ca-certificate and our package with suma certificate before installing shadow package. When this happens, ca-certificate post install script fails on missing home directory for root user and does not update trust anchors. This then results on zypper  failure to download packages during image build.

This PR adds explicit dependency of our osimage certificate package on shadow package.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/21291
Tracks https://github.com/SUSE/spacewalk/pull/21319

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
