### PR TITLE
QE: Fix MAC address for nested VMs

### DIFF
--- a/testsuite/features/step_definitions/vm_steps.rb
+++ b/testsuite/features/step_definitions/vm_steps.rb
@@ -12,6 +12,7 @@ When(/^I create a (leap|sles|rhlike|deblike) virtual machine named "([^"]*)" (wi
   cloudinit_path = "/tmp/cloudinit-disk-#{os_type}.iso"
   cloudinit_image = "/var/testsuite-data/cloudinit-disk-#{os_type}.iso"
   memory = '512'
+  mac = 'RANDOM'
 
   case os_type
   when 'leap'
@@ -19,7 +20,6 @@ When(/^I create a (leap|sles|rhlike|deblike) virtual machine named "([^"]*)" (wi
     net = 'salt-leap'
     os = 'opensuse15.4'
     memory = '1024'
-    mac = 'RANDOM'
   when 'sles'
     name = 'sles-disk-image-template.qcow2'
     net = 'salt-sles'
@@ -29,12 +29,10 @@ When(/^I create a (leap|sles|rhlike|deblike) virtual machine named "([^"]*)" (wi
     name = 'rhlike-disk-image-template.qcow2'
     net = 'salt-rhlike'
     os = 'rocky8'
-    mac = 'RANDOM'
   when 'deblike'
     name = 'deblike-disk-image-template.qcow2'
     net = 'salt-deblike'
     os = 'ubuntu2204'
-    mac = 'RANDOM'
   else
     name = 'empty'
   end

--- a/testsuite/features/step_definitions/vm_steps.rb
+++ b/testsuite/features/step_definitions/vm_steps.rb
@@ -13,27 +13,28 @@ When(/^I create a (leap|sles|rhlike|deblike) virtual machine named "([^"]*)" (wi
   cloudinit_image = "/var/testsuite-data/cloudinit-disk-#{os_type}.iso"
   memory = '512'
 
-  mac = ENV.fetch('MAC_MIN_NESTED', 'RANDOM')
-  STDOUT.puts 'Random MAC address used' if mac == 'RANDOM'
-
   case os_type
   when 'leap'
     name = 'leap-disk-image-template.qcow2'
     net = 'salt-leap'
     os = 'opensuse15.4'
     memory = '1024'
+    mac = 'RANDOM'
   when 'sles'
     name = 'sles-disk-image-template.qcow2'
     net = 'salt-sles'
     os = 'sle15sp4'
+    mac = ENV.fetch('MAC_MIN_NESTED', 'RANDOM')
   when 'rhlike'
     name = 'rhlike-disk-image-template.qcow2'
     net = 'salt-rhlike'
     os = 'rocky8'
+    mac = 'RANDOM'
   when 'deblike'
     name = 'deblike-disk-image-template.qcow2'
     net = 'salt-deblike'
     os = 'ubuntu2204'
+    mac = 'RANDOM'
   else
     name = 'empty'
   end


### PR DESCRIPTION
## What does this PR change?

Until now the MAC address found in the environment variable
`MAC_MIN_NESTED` in the `.bashrc` of the controller will be always used
when we have a nested VM. In our case it should only be used for the
SLES minion where we test the Salt migration and where we have dedicated MAC- and IP addresses.

## GUI diff

No difference.


- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links

Manager 4.3: 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
