### PR TITLE
Increased timeout for the Rocky 8 case

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -26,7 +26,7 @@ When(/^I mount as "([^"]+)" the ISO from "([^"]+)" in the server$/) do |name, ur
     iso_path = url.sub(/^http:.*\/pub/, '/mirror/pub')
   else
     iso_path = "/tmp/#{name}.iso"
-    $server.run("wget --no-check-certificate -O #{iso_path} #{url}", timeout: 700)
+    $server.run("wget --no-check-certificate -O #{iso_path} #{url}", timeout: 1500)
   end
   mount_point = "/srv/www/htdocs/#{name}"
   $server.run("mkdir -p #{mount_point}")


### PR DESCRIPTION
## What does this PR change?

Follow-up of #6974

Measured 777 seconds to transfer Rocky 8, the timeout was at 700 seconds -> the ISO image was truncated



## Links

Ports together with ports of #6974


## Changelogs

- [x] No changelog needed
