### PR TITLE
QE: Refactor Salt bundle migration tests

### DIFF
--- a/testsuite/features/secondary/min_salt_migration.feature
+++ b/testsuite/features/secondary/min_salt_migration.feature
@@ -98,7 +98,7 @@ Feature: Migrate Salt to bundled Salt on a nested Minion VM
     Then I should see "/etc/salt: directory" in the command output for "salt_migration_minion"
 
   Scenario: Migrate the nested VM to the Salt bundle
-    When the Salt master can reach "salt_migration_minion"
+    Then the Salt master can reach "salt_migration_minion"
     When I migrate "salt_migration_minion" from salt-minion to venv-salt-minion
 
   Scenario: Purge the Minion from the old salt-minion leftovers

--- a/testsuite/features/secondary/min_salt_migration.feature
+++ b/testsuite/features/secondary/min_salt_migration.feature
@@ -98,7 +98,7 @@ Feature: Migrate Salt to bundled Salt on a nested Minion VM
     Then I should see "/etc/salt: directory" in the command output for "salt_migration_minion"
 
   Scenario: Migrate the nested VM to the Salt bundle
-    Then the Salt master can reach "salt_migration_minion"
+    Given the Salt master can reach "salt_migration_minion"
     When I migrate "salt_migration_minion" from salt-minion to venv-salt-minion
 
   Scenario: Purge the Minion from the old salt-minion leftovers

--- a/testsuite/features/secondary/min_salt_migration.feature
+++ b/testsuite/features/secondary/min_salt_migration.feature
@@ -99,7 +99,7 @@ Feature: Migrate Salt to bundled Salt on a nested Minion VM
 
   Scenario: Migrate the nested VM to the Salt bundle
     When the Salt master can reach "salt_migration_minion"
-    Then I migrate "salt_migration_minion" from salt-minion to venv-salt-minion
+    When I migrate "salt_migration_minion" from salt-minion to venv-salt-minion
 
   Scenario: Purge the Minion from the old salt-minion leftovers
     When I purge salt-minion on "salt_migration_minion" after a migration

--- a/testsuite/features/secondary/min_salt_migration.feature
+++ b/testsuite/features/secondary/min_salt_migration.feature
@@ -97,9 +97,15 @@ Feature: Migrate Salt to bundled Salt on a nested Minion VM
     And I expand the results for "salt_migration_minion"
     Then I should see "/etc/salt: directory" in the command output for "salt_migration_minion"
 
-  Scenario: Migrate the nested VM to the Salt bundle and check the result
+  Scenario: Migrate the nested VM to the Salt bundle
+    When the Salt master can reach "salt_migration_minion"
     Then I migrate "salt_migration_minion" from salt-minion to venv-salt-minion
-    And I purge salt-minion on "salt_migration_minion" after a migration
+
+  Scenario: Purge the Minion from the old salt-minion leftovers
+    When I purge salt-minion on "salt_migration_minion" after a migration
+
+  # This will fail until bsc#1209251 will be fixed
+  Scenario: Check if the Salt bundle migration was successful
     When I follow the left menu "Salt > Remote Commands"
     Then I should see a "Remote Commands" text in the content area
     When I enter command "file /etc/salt"


### PR DESCRIPTION
## What does this PR change?

This will refactor the checks after migrating the minion to the Salt bundle in order to have clearer results what fails and to not skip a lot of steps if for example the first step in a scenario fails.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links

- no ports!
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
