### PR TITLE
Increase the maximum size of YAML state result to parse

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesActionResult.java
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesActionResult.java
@@ -16,9 +16,10 @@ package com.redhat.rhn.domain.action.salt;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 
+import com.suse.manager.webui.utils.YamlHelper;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.ConstructorException;
 
 import java.io.Serializable;
@@ -121,11 +122,10 @@ public class ApplyStatesActionResult implements Serializable {
      * @return Optional with list of state results or empty
      */
     public Optional<List<StateResult>> getResult() {
-        Yaml yaml = new Yaml();
         List<StateResult> result = new LinkedList<>();
         try {
             @SuppressWarnings("unchecked")
-            Map<String, Map<String, Object>> payload = yaml.loadAs(getOutputContents(), Map.class);
+            Map<String, Map<String, Object>> payload = YamlHelper.loadAs(getOutputContents(), Map.class);
             payload.entrySet().stream().forEach(e -> result.add(new StateResult(e)));
         }
         catch (ConstructorException ce) {

--- a/java/code/src/com/suse/manager/webui/utils/YamlHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/YamlHelper.java
@@ -15,6 +15,7 @@
 package com.suse.manager.webui.utils;
 
 import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 
 /**
@@ -63,6 +64,22 @@ public enum YamlHelper {
         String result = dump(object);
         options.setDefaultScalarStyle(oldStyle);
         return result;
+    }
+
+    /**
+     * Load potentially big yaml data as a given type.
+     * Allows data up to the max size of a String
+     *
+     * @param data the data to load
+     * @param clazz the class of the return
+     * @return the parsed object
+     * @param <T> the type of the return
+     */
+    public static <T> T loadAs(String data, Class<T> clazz) {
+        LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setCodePointLimit(Integer.MAX_VALUE);
+        Yaml yaml = new Yaml(loaderOptions);
+        return yaml.loadAs(data, clazz);
     }
 }
 

--- a/java/code/src/com/suse/manager/webui/utils/test/YamlHelperTest.java
+++ b/java/code/src/com/suse/manager/webui/utils/test/YamlHelperTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.utils.test;
+
+import com.redhat.rhn.testing.TestUtils;
+
+import com.suse.manager.webui.utils.YamlHelper;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class YamlHelperTest {
+
+    @Test
+    public void testLoadAsBigFile() throws IOException, ClassNotFoundException {
+        YamlHelper.loadAs(TestUtils.readAll(TestUtils.findTestData("big-model.yaml")), Map.class);
+    }
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Allow processing big state results (bsc#1210957)
 - Fix server error in HTTP API authentication (bsc#1210394)
 - set swap memory value if available
 - set primary FQDN to hostname if none is set (bsc#1209156)


### PR DESCRIPTION
## What does this PR change?

In some big setups, the state result file can be huge and Snakeyaml now has a document limit. Set this limit to the maximum value.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/21333

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
