### PR TITLE
Only use TLSv1+ for SSL connections

### DIFF
--- a/python/rhn/rhnlib.changes
+++ b/python/rhn/rhnlib.changes
@@ -1,3 +1,5 @@
+- Only use TLSv1+ for SSL connections
+
 -------------------------------------------------------------------
 Tue Feb 21 14:04:09 CET 2023 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

See title. This should address the sonarcloud issues.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: old TLS versions disabled

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20641

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
