### PR TITLE
show virtualization host info in systems overview page

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -20772,6 +20772,12 @@ The Tree Path, Base Channel, and Installer Generation should always match. This 
           <context context-type="sourcefile">/systems/details/Overview.do</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sdc.details.overview.virtualization.host" xml:space="preserve">
+        <source>Virtualization Host:</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/systems/details/Overview.do</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sdc.details.overview.uuid" xml:space="preserve">
         <source>UUID:</source>
         <context-group name="ctx">

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
@@ -150,6 +150,21 @@
               <td><c:out value="${system.virtualInstance.type.name}"/></td>
             </tr>
             <tr>
+              <td><bean:message key="sdc.details.overview.virtualization.host"/></td>
+              <c:choose>
+                <c:when test="${system.virtualInstance.hostSystem == null}">
+                  <td><bean:message key="sdc.details.overview.unknown"/></td>
+                </c:when>
+                <c:otherwise>
+                  <td>
+                    <a href="/rhn/systems/details/Overview.do?sid=${system.virtualInstance.hostSystem.id}">
+                      <c:out value="${system.virtualInstance.hostSystem.name}"/>
+                    </a>
+                  </td>
+                </c:otherwise>
+              </c:choose>
+            </tr>
+             <tr>
               <td><bean:message key="sdc.details.overview.uuid"/></td>
               <c:choose>
                 <c:when test="${system.virtualInstance.uuid == null}">

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- show virtualization host info in systems overview page
 - Refresh pillars after setting custom values via SSM (bsc#1210659)
 - Report SSM power management errors in 'rhn_web_ui' (bsc#1210406)
 - Allow processing big state results (bsc#1210957)


### PR DESCRIPTION
## What does this PR change?

When a system is a virtual guest and we have the information about the host, show it in the Systems Overview page

## GUI diff

No difference.

After:

![image](https://user-images.githubusercontent.com/1038917/236625338-ce93f36c-a9b9-4a37-a0e6-be474d91836d.png)

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/21379

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
