### PR TITLE
on sccclientexception test for OES credentials and move forward

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -255,24 +255,32 @@ public class ContentSyncManager {
         // stop as soon as a credential pair works
         while (i.hasNext() && productList.isEmpty()) {
             Credentials c = i.next();
+            List<SCCProductJson> products = new LinkedList<>();
             try {
                 SCCClient scc = getSCCClient(c);
-                List<SCCProductJson> products = scc.listProducts();
-                for (SCCProductJson product : products) {
-                    // Check for missing attributes
-                    String missing = verifySCCProduct(product);
-                    if (!StringUtils.isBlank(missing)) {
-                        log.warn("Broken product: {}, Version: {}, Identifier: {}, Product ID: {} " +
-                                "### Missing attributes: {}", product.getName(), product.getVersion(),
-                                product.getIdentifier(), product.getId(), missing);
-                    }
-
-                    // Add product in any case
-                    productList.add(product);
-                }
+                products = scc.listProducts();
             }
-            catch (SCCClientException | URISyntaxException e) {
+            catch (SCCClientException e) {
+                // test for OES credentials
+                if (!accessibleUrl(OES_URL, c.getUsername(), c.getPassword())) {
+                    throw new ContentSyncException(e);
+                }
+                continue;
+            }
+            catch (URISyntaxException e) {
                 throw new ContentSyncException(e);
+            }
+            for (SCCProductJson product : products) {
+                // Check for missing attributes
+                String missing = verifySCCProduct(product);
+                if (!StringUtils.isBlank(missing)) {
+                    log.warn("Broken product: {}, Version: {}, Identifier: {}, Product ID: {} " +
+                                    "### Missing attributes: {}", product.getName(), product.getVersion(),
+                            product.getIdentifier(), product.getId(), missing);
+                }
+
+                // Add product in any case
+                productList.add(product);
             }
         }
 
@@ -535,16 +543,24 @@ public class ContentSyncManager {
 
         // Query repos for all mirror credentials and consolidate
         for (Credentials c : credentials) {
+            List<SCCRepositoryJson> repos = new LinkedList<>();
+            log.debug("Getting repos for: {}", c);
             try {
-                log.debug("Getting repos for: {}", c);
                 SCCClient scc = getSCCClient(c);
-                List<SCCRepositoryJson> repos = scc.listRepositories();
-                repos.addAll(getAdditionalRepositories());
-                refreshRepositoriesAuthentication(repos, c, mirrorUrl);
+                repos = scc.listRepositories();
             }
-            catch (SCCClientException | URISyntaxException e) {
+            catch (SCCClientException e) {
+                // test for OES credentials
+                if (!accessibleUrl(OES_URL, c.getUsername(), c.getPassword())) {
+                    log.info("Credential is not an OES credentials");
+                    throw new ContentSyncException(e);
+                }
+            }
+            catch (URISyntaxException e) {
                 throw new ContentSyncException(e);
             }
+            repos.addAll(getAdditionalRepositories());
+            refreshRepositoriesAuthentication(repos, c, mirrorUrl);
         }
         ensureSUSEProductChannelData();
         linkAndRefreshContentSource(mirrorUrl);
@@ -1271,20 +1287,26 @@ public class ContentSyncManager {
      * @return list of subscriptions as received from SCC.
      * @throws SCCClientException in case of an error
      */
-    public List<SCCSubscriptionJson> updateSubscriptions(Credentials credentials)
-            throws SCCClientException {
+    public List<SCCSubscriptionJson> updateSubscriptions(Credentials credentials) throws SCCClientException {
+        List<SCCSubscriptionJson> subscriptions = new LinkedList<>();
         try {
             SCCClient scc = this.getSCCClient(credentials);
-            List<SCCSubscriptionJson> subscriptions = scc.listSubscriptions();
-            refreshSubscriptionCache(subscriptions, credentials);
-            refreshOrderItemCache(credentials);
-            generateOEMOrderItems(subscriptions, credentials);
-            return subscriptions;
+            subscriptions = scc.listSubscriptions();
+        }
+        catch (SCCClientException e) {
+            // test for OES credentials
+            if (!accessibleUrl(OES_URL, credentials.getUsername(), credentials.getPassword())) {
+                throw new ContentSyncException(e);
+            }
         }
         catch (URISyntaxException e) {
             log.error("Invalid URL:{}", e.getMessage());
             return new ArrayList<>();
         }
+        refreshSubscriptionCache(subscriptions, credentials);
+        refreshOrderItemCache(credentials);
+        generateOEMOrderItems(subscriptions, credentials);
+        return subscriptions;
     }
 
     /**
@@ -1321,26 +1343,33 @@ public class ContentSyncManager {
      * @throws SCCClientException  in case of an error
      */
     public void refreshOrderItemCache(Credentials c) throws SCCClientException  {
+        List<SCCOrderJson> orders = new LinkedList<>();
         try {
             SCCClient scc = this.getSCCClient(c);
-            List<SCCOrderJson> orders = scc.listOrders();
-            List<SCCOrderItem> existingOI = SCCCachingFactory.listOrderItemsByCredentials(c);
-            for (SCCOrderJson order : orders) {
-                for (SCCOrderItemJson j : order.getOrderItems()) {
-                    SCCOrderItem oi = SCCCachingFactory.lookupOrderItemBySccId(j.getSccId())
-                            .orElse(new SCCOrderItem());
-                    oi.update(j, c);
-                    SCCCachingFactory.saveOrderItem(oi);
-                    existingOI.remove(oi);
-                }
+            orders = scc.listOrders();
+        }
+        catch (SCCClientException e) {
+            // test for OES credentials
+            if (!accessibleUrl(OES_URL, c.getUsername(), c.getPassword())) {
+                throw new ContentSyncException(e);
             }
-            existingOI.stream()
-                .filter(item -> item.getSccId() >= 0)
-                .forEach(SCCCachingFactory::deleteOrderItem);
         }
         catch (URISyntaxException e) {
             log.error("Invalid URL:{}", e.getMessage());
         }
+        List<SCCOrderItem> existingOI = SCCCachingFactory.listOrderItemsByCredentials(c);
+        for (SCCOrderJson order : orders) {
+            for (SCCOrderItemJson j : order.getOrderItems()) {
+                SCCOrderItem oi = SCCCachingFactory.lookupOrderItemBySccId(j.getSccId())
+                        .orElse(new SCCOrderItem());
+                oi.update(j, c);
+                SCCCachingFactory.saveOrderItem(oi);
+                existingOI.remove(oi);
+            }
+        }
+        existingOI.stream()
+                .filter(item -> item.getSccId() >= 0)
+                .forEach(SCCCachingFactory::deleteOrderItem);
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- OES credentials do not allow access to SCC. Skip them when an
+  SCCClientException is thrown and move forward
 - show virtualization host info in systems overview page
 - Refresh pillars after setting custom values via SSM (bsc#1210659)
 - Report SSM power management errors in 'rhn_web_ui' (bsc#1210406)


### PR DESCRIPTION
## What does this PR change?

When adding Microfocus NCC Credentials to mirror OES products, the mgr-sync refresh exit with SCCClientException as these credentials do not provide the expected SCC endpoints.

We need to ignore this, if the credentials provide access to OES repositories.

## Links

Port of https://github.com/SUSE/spacewalk/pull/21369

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
