### PR TITLE
force all mandatory channels being selected in software channel change page

### DIFF
--- a/web/html/src/manager/systems/subscribe-channels/subscribe-channels.tsx
+++ b/web/html/src/manager/systems/subscribe-channels/subscribe-channels.tsx
@@ -179,8 +179,13 @@ class SystemChannels extends React.Component<SystemChannelsProps, SystemChannels
       const mandatoryChannels = this.state.requiredChannels.get(newBaseId);
       const selectedChildren = this.getSelectedChildren() || [];
       Array.from(availableChildren.values())
-        .filter((c) => (mandatoryChannels && mandatoryChannels.has(c.id) &&
-                        selectedChildren && !selectedChildren.some((child) => child.id === c.id)))
+        .filter(
+          (c) =>
+            mandatoryChannels &&
+            mandatoryChannels.has(c.id) &&
+            selectedChildren &&
+            !selectedChildren.some((child) => child.id === c.id)
+        )
         .forEach((c) => this.selectChildChannel(c.id, true));
     }
   };

--- a/web/html/src/manager/systems/subscribe-channels/subscribe-channels.tsx
+++ b/web/html/src/manager/systems/subscribe-channels/subscribe-channels.tsx
@@ -173,6 +173,15 @@ class SystemChannels extends React.Component<SystemChannelsProps, SystemChannels
         selectedChildrenIds: this.state.selectedChildrenIds,
       });
       this.enableAllRecommended();
+
+      // force all mandatory channels being selected (bsc#1211062)
+      const availableChildren = this.getAvailableChildren();
+      const mandatoryChannels = this.state.requiredChannels.get(newBaseId);
+      const selectedChildren = this.getSelectedChildren() || [];
+      Array.from(availableChildren.values())
+        .filter((c) => (mandatoryChannels && mandatoryChannels.has(c.id) &&
+                        selectedChildren && !selectedChildren.some((child) => child.id === c.id)))
+        .forEach((c) => this.selectChildChannel(c.id, true));
     }
   };
 

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- force all mandatory channels being selected in software channel
+  change page (bsc#1211062)
 - Fix font contrast in dark theme search field (bsc#1201337)
 - Ignore mandatory channels results that don't match list of channels (bsc#1204270)
 - Show loading indicator on formula details pages (bsc#1179747)


### PR DESCRIPTION
## What does this PR change?

When a product has only mandatory channels synced the selection page of software channel change
show the checkbox checked. But when clicking on confirm, the confirm page show the channels "unchecked" and
only the base channel is subscribed.

The selection page test selected channels and mandatory channels separate, but the confirm page only rely on the selected channels list. This means we need to take care that the mandatory channels are added to the selected channels list.

## Links

Port of https://github.com/SUSE/spacewalk/pull/21373

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
