### PR TITLE
use build-packages-for-obs.sh to compile container without arguments

### DIFF
--- a/rel-eng/build-packages-for-obs.sh
+++ b/rel-eng/build-packages-for-obs.sh
@@ -89,8 +89,8 @@ while read PKG_NAME PKG_VER PKG_DIR; do
   if [[ $PKG_DIR == *"containers"* ]]; then
     CONTAINER_NAME=$(basename "$PKG_DIR")
     echo "=== Building container image [${CONTAINER_NAME}]"
-    if [ -d "$PKG_DIR" ]; then
-      cp -r "$PKG_DIR" "$SRPM_DIR/"
+    if [ -d "$GIT_DIR/$PKG_DIR" ]; then
+      cp -r "$GIT_DIR/$PKG_DIR" "$SRPM_DIR/"
       if [ -f "${PKG_DIR}/Chart.yaml" ]; then
         pushd "${SRPM_DIR}/${CONTAINER_NAME}" >/dev/null
         CHART_FILES="values.yaml values.schema.json charts crds templates LICENSE README.md"


### PR DESCRIPTION
## What does this PR change?

use build-packages-for-obs.sh to compile container without arguments

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage

- No tests: already covered
- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
