### PR TITLE
Add `uyuni_systems_scrape_duration_seconds` metric

### DIFF
--- a/java/code/src/com/suse/manager/metrics/SystemsCollector.java
+++ b/java/code/src/com/suse/manager/metrics/SystemsCollector.java
@@ -27,6 +27,7 @@ public class SystemsCollector extends Collector {
     @Override
     public List<MetricFamilySamples> collect() {
         List<MetricFamilySamples> out = new ArrayList<>();
+        long start = System.nanoTime();
         List<Server> servers = ServerFactory.lookupByIds(SystemManager.listSystemIds());
 
         out.add(CustomCollectorUtils.gaugeFor("all_systems", "Number of all systems",
@@ -37,6 +38,8 @@ public class SystemsCollector extends Collector {
                 getNumberOfInactiveSystems(servers), PRODUCT_NAME));
         out.add(CustomCollectorUtils.gaugeFor("outdated_systems", "Number of systems with outdated packages",
                 getNumberOfOutdatedSystems(), PRODUCT_NAME));
+        out.add(CustomCollectorUtils.gaugeFor("systems_scrape_duration_seconds", "Duration of Uyuni systems " +
+                "statistics scrape", (System.nanoTime() - start) / 1.0E9, PRODUCT_NAME));
 
         return out;
     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add uyuni_systems_scrape_duration_seconds metric
 - OES credentials do not allow access to SCC. Skip them when an
   SCCClientException is thrown and move forward
 - show virtualization host info in systems overview page


### PR DESCRIPTION
## What does this PR change?

Add new metric to measure the time needed for getting systems statistics.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Documentation issue was created: SUSE/spacewalk#19737

- [x] **DONE**

## Test coverage
- No tests: Instrumentation classes not covered yet.

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
