### PR TITLE
CI: Acceptance tests at PR v2: fix srv_notifications.feature

### DIFF
--- a/testsuite/features/secondary/srv_notifications.feature
+++ b/testsuite/features/secondary/srv_notifications.feature
@@ -2,7 +2,6 @@
 # Licensed under the terms of the MIT license.
 
 @scope_visualization
-@skip_if_container
 Feature: Test the notification/notification-messages feature
 
   Scenario: Log in as admin user


### PR DESCRIPTION
## What does this PR change?

CI: fix srv notification feature

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/20962

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
