### PR TITLE
QE: Documenting which features will fail if a given feature fails

### DIFF
--- a/testsuite/features/secondary/allcli_reboot.feature
+++ b/testsuite/features/secondary/allcli_reboot.feature
@@ -6,6 +6,17 @@
 #   (the tests of this feature can be run several times with no change in the results)
 # * However, beware that firmware, kernel or library updates might be activated by the reboot
 #   (thus making changes in the behaviour of the system after the reboot)
+#
+# This feature can cause failures in the following features:
+# - features/secondary/min_rhlike_openscap_audit.feature
+# - features/secondary/min_rhlike_remote_command.feature
+# - features/secondary/min_rhlike_ssh.feature
+# - features/secondary/min_deblike_openscap_audit.feature
+# - features/secondary/min_deblike_remote_command.feature
+# - features/secondary/min_deblike_ssh.feature
+# If the minions take over the alloted 10 minutes to reboot, 
+# the following features could fail due to the minions not being reachable.
+# Depending on how long they take to reboot, even more features could fail.
 
 @skip_if_container
 @scope_onboarding

--- a/testsuite/features/secondary/buildhost_docker_build_image.feature
+++ b/testsuite/features/secondary/buildhost_docker_build_image.feature
@@ -5,7 +5,10 @@
 # so the inspect functionality is not tested here.
 #
 # This feature is a dependency for:
-# - features/secondary/srv_docker_cve_audit.feature : Due to the images listed in the CVE Audit images
+# - features/secondary/srv_docker_cve_audit.feature 
+#
+# This feature can cause failures in the following features:
+# - features/secondary/min_salt_install_with_staging.feature: Due to the images listed in the CVE Audit images
 
 @buildhost
 @scope_building_container_images

--- a/testsuite/features/secondary/buildhost_docker_build_image.feature
+++ b/testsuite/features/secondary/buildhost_docker_build_image.feature
@@ -8,7 +8,8 @@
 # - features/secondary/srv_docker_cve_audit.feature 
 #
 # This feature can cause failures in the following features:
-# - features/secondary/min_salt_install_with_staging.feature: Due to the images listed in the CVE Audit images
+# - features/secondary/min_salt_install_with_staging.feature
+# Due to the images listed in the CVE Audit images
 
 @buildhost
 @scope_building_container_images

--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -11,7 +11,7 @@
 #
 # This feature can cause failures in the following features:
 # - features/secondary/proxy_retail_pxeboot_and_mass_import.feature:
-# This feature leaves an JeOS image built that is used in the "PXE boot a Retail terminal" feature.
+# This feature leaves a JeOS image built that is used in the "PXE boot a Retail terminal" feature.
 
 @skip_if_container
 @skip_if_cloud

--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -9,9 +9,9 @@
 #   java.kiwi_os_image_building_enabled = true
 # which means "Enable Kiwi OS Image building"
 #
-# Idempotency note:
-# This feature leaves an JeOS image built
-# The image is used in proxy_retail_pxeboot_and_mass_import.feature
+# This feature can cause failures in the following features:
+# - features/secondary/proxy_retail_pxeboot_and_mass_import.feature:
+# This feature leaves an JeOS image built that is used in the "PXE boot a Retail terminal" feature.
 
 @skip_if_container
 @skip_if_cloud

--- a/testsuite/features/secondary/min_action_chain.feature
+++ b/testsuite/features/secondary/min_action_chain.feature
@@ -1,6 +1,11 @@
 # Copyright (c) 2018-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
-
+#
+# This feature can cause failures in the following features:
+# - features/secondary/minssh_action_chain.feature
+# - features/secondary/allcli_action_chain.feature
+# If the action chain fails to be completed and run.
+#
 # skip on container. Running actions chains fail on container.
 # This needs to be fixed
 

--- a/testsuite/features/secondary/min_activationkey.feature
+++ b/testsuite/features/secondary/min_activationkey.feature
@@ -1,8 +1,8 @@
 # Copyright (c) 2018-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
-# This feature depends on:
-# - features/secondary/min_bootstrap_script.feature : Due to the deletion of the previous SLES Minion
+# This feature can cause failures in the following features:
+# - features/secondary/min_salt_minions_page.feature: if the minion fails to bootstrap
 
 @skip_if_container
 @scope_onboarding

--- a/testsuite/features/secondary/min_activationkey.feature
+++ b/testsuite/features/secondary/min_activationkey.feature
@@ -2,7 +2,8 @@
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features:
-# - features/secondary/min_salt_minions_page.feature: if the minion fails to bootstrap
+# - features/secondary/min_salt_minions_page.feature
+# If the minion fails to bootstrap.
 
 @skip_if_container
 @scope_onboarding

--- a/testsuite/features/secondary/min_bootstrap_script.feature
+++ b/testsuite/features/secondary/min_bootstrap_script.feature
@@ -1,8 +1,8 @@
 # Copyright (c) 2019-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
-# This feature depends on:
-# - features/secondary/min_bootstrap_ssh_key.feature : Due to the deletion of the previous SLES Minion
+# This feature can cause failures in the following features:
+# - features/secondary/min_ssh_tunnel.feature: if the minion fails to bootstrap
 
 @skip_if_container
 @sle_minion

--- a/testsuite/features/secondary/min_bootstrap_script.feature
+++ b/testsuite/features/secondary/min_bootstrap_script.feature
@@ -2,7 +2,8 @@
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features:
-# - features/secondary/min_ssh_tunnel.feature: if the minion fails to bootstrap
+# - features/secondary/min_ssh_tunnel.feature
+# If the minion fails to bootstrap
 
 @skip_if_container
 @sle_minion

--- a/testsuite/features/secondary/min_bootstrap_ssh_key.feature
+++ b/testsuite/features/secondary/min_bootstrap_ssh_key.feature
@@ -3,7 +3,7 @@
 #
 #
 # This feature can cause failures in the following features:
-# - features/secondary/min_ssh_tunnel.feature
+# - features/secondary/min_bootstrap_script.feature
 # If the minion fails to bootstrap again.
 
 @skip_if_container

--- a/testsuite/features/secondary/min_bootstrap_ssh_key.feature
+++ b/testsuite/features/secondary/min_bootstrap_ssh_key.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2021-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
-# This feature is a dependency for:
+# This feature can cause failures in the following features:
 # - features/secondary/min_bootstrap_script.feature : Due to the registration of a SLES Minion
 
 @skip_if_container

--- a/testsuite/features/secondary/min_bootstrap_ssh_key.feature
+++ b/testsuite/features/secondary/min_bootstrap_ssh_key.feature
@@ -1,8 +1,10 @@
 # Copyright (c) 2021-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
+#
 # This feature can cause failures in the following features:
-# - features/secondary/min_bootstrap_script.feature : Due to the registration of a SLES Minion
+# - features/secondary/min_ssh_tunnel.feature
+# If the minion fails to bootstrap again.
 
 @skip_if_container
 @scope_onboarding

--- a/testsuite/features/secondary/min_change_software_channel.feature
+++ b/testsuite/features/secondary/min_change_software_channel.feature
@@ -1,5 +1,9 @@
 # Copyright (c) 2021 SUSE LLC
 # Licensed under the terms of the MIT license.
+#
+# This feature can cause failures in the following features:
+# - features/secondary/allcli_software_channels.feature:
+# If "SLE15-SP4-Installer-Updates for x86_64" fails to be unchecked
 
 @skip_if_container
 @scc_credentials

--- a/testsuite/features/secondary/min_change_software_channel.feature
+++ b/testsuite/features/secondary/min_change_software_channel.feature
@@ -2,7 +2,7 @@
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features:
-# - features/secondary/allcli_software_channels.feature:
+# - features/secondary/allcli_software_channels.feature
 # If "SLE15-SP4-Installer-Updates for x86_64" fails to be unchecked
 
 @skip_if_container

--- a/testsuite/features/secondary/min_deblike_ssh.feature
+++ b/testsuite/features/secondary/min_deblike_ssh.feature
@@ -6,7 +6,8 @@
 # 3) delete Debian-like SSH minion and register as normal minion
 #
 # This feature can cause failures in the following features:
-# - features/secondary/min_deblike_salt_install_package_and_patch.feature
+# - features/secondary/min_deblike_salt_install_package.feature
+# - features/secondary/min_deblike_salt_install_with_staging.feature
 # - features/secondary/min_deblike_monitoring.feature
 # If the cleanup bootstrap scenario fails,
 # the minion will not be reachable in those features

--- a/testsuite/features/secondary/min_deblike_ssh.feature
+++ b/testsuite/features/secondary/min_deblike_ssh.feature
@@ -10,7 +10,7 @@
 # - features/secondary/min_deblike_salt_install_with_staging.feature
 # - features/secondary/min_deblike_monitoring.feature
 # If the cleanup bootstrap scenario fails,
-# The minion will not be reachable in those features.
+# the minion will not be reachable in those features.
 
 @skip_if_container
 @scope_deblike

--- a/testsuite/features/secondary/min_deblike_ssh.feature
+++ b/testsuite/features/secondary/min_deblike_ssh.feature
@@ -10,7 +10,7 @@
 # - features/secondary/min_deblike_salt_install_with_staging.feature
 # - features/secondary/min_deblike_monitoring.feature
 # If the cleanup bootstrap scenario fails,
-# the minion will not be reachable in those features
+# The minion will not be reachable in those features.
 
 @skip_if_container
 @scope_deblike

--- a/testsuite/features/secondary/min_deblike_ssh.feature
+++ b/testsuite/features/secondary/min_deblike_ssh.feature
@@ -4,6 +4,12 @@
 # 1) delete Debian-like minion and register as SSH minion
 # 2) run a remote command
 # 3) delete Debian-like SSH minion and register as normal minion
+#
+# This feature can cause failures in the following features:
+# - features/secondary/min_deblike_salt_install_package_and_patch.feature
+# - features/secondary/min_deblike_monitoring.feature
+# If the cleanup bootstrap scenario fails,
+# the minion will not be reachable in those features
 
 @skip_if_container
 @scope_deblike

--- a/testsuite/features/secondary/min_move_from_and_to_proxy.feature
+++ b/testsuite/features/secondary/min_move_from_and_to_proxy.feature
@@ -1,6 +1,9 @@
 # Copyright (c) 2021-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
-
+#
+# This feature can cause failures in the following features:
+# - features/secondary/proxy_as_pod_basic_tests.feature:
+# If the minion is not properly bootstrapped again.
 @sle_minion
 @proxy
 Feature: Move a minion from a proxy to direct connection

--- a/testsuite/features/secondary/min_move_from_and_to_proxy.feature
+++ b/testsuite/features/secondary/min_move_from_and_to_proxy.feature
@@ -4,6 +4,7 @@
 # This feature can cause failures in the following features:
 # - features/secondary/proxy_as_pod_basic_tests.feature:
 # If the minion is not properly bootstrapped again.
+
 @sle_minion
 @proxy
 Feature: Move a minion from a proxy to direct connection

--- a/testsuite/features/secondary/min_rhlike_ssh.feature
+++ b/testsuite/features/secondary/min_rhlike_ssh.feature
@@ -7,9 +7,10 @@
 #
 # This feature can cause failures in the following features:
 # - features/secondary/min_rhlike_salt_install_package_and_patch.feature
+# - features/secondary/min_rhlike_salt_install_with_staging.feature
 # - features/secondary/min_rhlike_monitoring.feature
 # If the cleanup bootstrap scenario fails,
-# the minion will not be reachable in those features
+# The minion will not be reachable in those features
 
 @skip_if_container
 @scope_res

--- a/testsuite/features/secondary/min_rhlike_ssh.feature
+++ b/testsuite/features/secondary/min_rhlike_ssh.feature
@@ -4,6 +4,12 @@
 # 1) delete Red Hat-like minion and register as SSH minion
 # 2) run a remote command
 # 3) delete Red Hat-like SSH minion and register as normal minion
+#
+# This feature can cause failures in the following features:
+# - features/secondary/min_rhlike_salt_install_package_and_patch.feature
+# - features/secondary/min_rhlike_monitoring.feature
+# If the cleanup bootstrap scenario fails,
+# the minion will not be reachable in those features
 
 @skip_if_container
 @scope_res

--- a/testsuite/features/secondary/min_rhlike_ssh.feature
+++ b/testsuite/features/secondary/min_rhlike_ssh.feature
@@ -10,7 +10,7 @@
 # - features/secondary/min_rhlike_salt_install_with_staging.feature
 # - features/secondary/min_rhlike_monitoring.feature
 # If the cleanup bootstrap scenario fails,
-# The minion will not be reachable in those features
+# the minion will not be reachable in those features
 
 @skip_if_container
 @scope_res

--- a/testsuite/features/secondary/min_salt_lock_packages.feature
+++ b/testsuite/features/secondary/min_salt_lock_packages.feature
@@ -1,5 +1,9 @@
 # Copyright (c) 2021-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
+#
+# This feature can cause failures in the following features:
+# - features/secondary/min_salt_install_with_staging.feature
+# If the "orion-dummy-1.1-1.1" is not properly unlocked
 
 @sle_minion
 @scope_salt

--- a/testsuite/features/secondary/min_salt_mgrcompat_state.feature
+++ b/testsuite/features/secondary/min_salt_mgrcompat_state.feature
@@ -10,7 +10,7 @@
 # - features/secondary/min_retracted_patches.feature
 # - features/secondary/min_timezone.feature
 # - features/secondary/min_move_from_and_to_proxy.feature
-# If the minion fails to bootstrap
+# If the minion fails to bootstrap again.
 
 @skip_if_container
 @sle_minion

--- a/testsuite/features/secondary/min_salt_mgrcompat_state.feature
+++ b/testsuite/features/secondary/min_salt_mgrcompat_state.feature
@@ -1,5 +1,16 @@
 # Copyright (c) 2015-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
+#
+# This feature can cause failures in the following features:
+# - features/secondary/min_salt_lock_packages.feature
+# - features/secondary/min_action_chain.feature
+# - features/secondary/allcli_action_chain.feature
+# - features/secondary/min_recurring_action.feature
+# - features/secondary/min_change_software_channel.feature
+# - features/secondary/min_retracted_patches.feature
+# - features/secondary/min_timezone.feature
+# - features/secondary/min_move_from_and_to_proxy.feature
+# If the minion fails to bootstrap
 
 @skip_if_container
 @sle_minion

--- a/testsuite/features/secondary/min_salt_minions_page.feature
+++ b/testsuite/features/secondary/min_salt_minions_page.feature
@@ -1,5 +1,8 @@
 # Copyright (c) 2015-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
+#
+# This feature can cause failures in the following features:
+# - features/secondary/min_salt_mgrcompat_state.feature: if the minion fails to bootstrap
 
 @skip_if_container
 @scope_salt

--- a/testsuite/features/secondary/min_salt_minions_page.feature
+++ b/testsuite/features/secondary/min_salt_minions_page.feature
@@ -2,7 +2,8 @@
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features:
-# - features/secondary/min_salt_mgrcompat_state.feature: if the minion fails to bootstrap
+# - features/secondary/min_salt_mgrcompat_state.feature
+# If the minion fails to bootstrap
 
 @skip_if_container
 @scope_salt

--- a/testsuite/features/secondary/min_salt_minions_page.feature
+++ b/testsuite/features/secondary/min_salt_minions_page.feature
@@ -3,7 +3,7 @@
 #
 # This feature can cause failures in the following features:
 # - features/secondary/min_salt_mgrcompat_state.feature
-# If the minion fails to bootstrap
+# If the minion fails to bootstrap again.
 
 @skip_if_container
 @scope_salt

--- a/testsuite/features/secondary/min_ssh_tunnel.feature
+++ b/testsuite/features/secondary/min_ssh_tunnel.feature
@@ -1,5 +1,8 @@
 # Copyright (c) 2020-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
+#
+# This feature can cause failures in the following features:
+# - features/secondary/min_activationkey.feature: if the minion fails to bootstrap
 
 @skip_if_container
 @scope_salt_ssh

--- a/testsuite/features/secondary/min_ssh_tunnel.feature
+++ b/testsuite/features/secondary/min_ssh_tunnel.feature
@@ -2,7 +2,8 @@
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features:
-# - features/secondary/min_activationkey.feature: if the minion fails to bootstrap
+# - features/secondary/min_activationkey.feature
+# If the minion fails to bootstrap again.
 
 @skip_if_container
 @scope_salt_ssh

--- a/testsuite/features/secondary/minssh_action_chain.feature
+++ b/testsuite/features/secondary/minssh_action_chain.feature
@@ -1,6 +1,10 @@
 # Copyright (c) 2018-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
-
+#
+# This feature can cause failures in the following features:
+# - features/secondary/allcli_action_chain.feature
+# If the action chain fails to be completed and run.
+#
 # Skip if container because the action chain fails
 # This needs to be fixed
 

--- a/testsuite/features/secondary/minssh_bootstrap_api.feature
+++ b/testsuite/features/secondary/minssh_bootstrap_api.feature
@@ -2,9 +2,11 @@
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features:
-# - features/secondary/minssh_action_chain.feature: if the current feature fails on bootstrapping,
+# - features/secondary/minssh_action_chain.feature
+# If the current feature fails on bootstrapping,
 # this feature won't be able to perform actions on it.
-# - features/secondary/minssh_move_from_and_to_proxy.feature: if the current feature fails on bootstrapping,
+# - features/secondary/minssh_move_from_and_to_proxy.feature
+# If the current feature fails on bootstrapping,
 # this feature won't be able to delete the minion in its initial setup.
 
 @scope_salt_ssh

--- a/testsuite/features/secondary/minssh_bootstrap_api.feature
+++ b/testsuite/features/secondary/minssh_bootstrap_api.feature
@@ -1,5 +1,11 @@
 # Copyright (c) 2017-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
+#
+# This feature can cause failures in the following features:
+# - features/secondary/minssh_action_chain.feature: if the current feature fails on bootstrapping,
+# this feature won't be able to perform actions on it.
+# - features/secondary/minssh_move_from_and_to_proxy.feature: if the current feature fails on bootstrapping,
+# this feature won't be able to delete the minion in its initial setup.
 
 @scope_salt_ssh
 @scope_onboarding

--- a/testsuite/features/secondary/minssh_bootstrap_api.feature
+++ b/testsuite/features/secondary/minssh_bootstrap_api.feature
@@ -7,7 +7,7 @@
 # this feature won't be able to perform actions on it.
 # - features/secondary/minssh_move_from_and_to_proxy.feature
 # If the current feature fails on bootstrapping,
-# This feature won't be able to delete the minion in its initial setup.
+# this feature won't be able to delete the minion in its initial setup.
 
 @scope_salt_ssh
 @scope_onboarding

--- a/testsuite/features/secondary/minssh_bootstrap_api.feature
+++ b/testsuite/features/secondary/minssh_bootstrap_api.feature
@@ -7,7 +7,7 @@
 # this feature won't be able to perform actions on it.
 # - features/secondary/minssh_move_from_and_to_proxy.feature
 # If the current feature fails on bootstrapping,
-# this feature won't be able to delete the minion in its initial setup.
+# This feature won't be able to delete the minion in its initial setup.
 
 @scope_salt_ssh
 @scope_onboarding

--- a/testsuite/features/secondary/minssh_move_from_and_to_proxy.feature
+++ b/testsuite/features/secondary/minssh_move_from_and_to_proxy.feature
@@ -1,5 +1,15 @@
 # Copyright (c) 2021-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
+#
+# This feature can cause failures in the following features:
+# - features/secondary/minssh_action_chain.feature
+# - features/secondary/allcli_overview_systems_details.feature
+# - features/secondary/allcli_config_channel.feature
+# - features/secondary/minssh_salt_install_package.feature
+# - features/secondary/minssh_ansible_control_node.feature
+# If the current feature fails on bootstrapping,
+# this feature won't be able to perform actions on it.
+
 
 @ssh_minion
 @scope_salt_ssh

--- a/testsuite/features/secondary/minssh_move_from_and_to_proxy.feature
+++ b/testsuite/features/secondary/minssh_move_from_and_to_proxy.feature
@@ -8,7 +8,7 @@
 # - features/secondary/minssh_salt_install_package.feature
 # - features/secondary/minssh_ansible_control_node.feature
 # If the current feature fails on bootstrapping,
-# These features won't be able to perform actions on it.
+# these features won't be able to perform actions on it.
 
 @ssh_minion
 @scope_salt_ssh

--- a/testsuite/features/secondary/minssh_move_from_and_to_proxy.feature
+++ b/testsuite/features/secondary/minssh_move_from_and_to_proxy.feature
@@ -8,8 +8,7 @@
 # - features/secondary/minssh_salt_install_package.feature
 # - features/secondary/minssh_ansible_control_node.feature
 # If the current feature fails on bootstrapping,
-# this feature won't be able to perform actions on it.
-
+# These features won't be able to perform actions on it.
 
 @ssh_minion
 @scope_salt_ssh

--- a/testsuite/features/secondary/proxy_as_pod_basic_tests.feature
+++ b/testsuite/features/secondary/proxy_as_pod_basic_tests.feature
@@ -5,6 +5,19 @@
 # * there is no proxy ($proxy is nil)
 # * there is no salt minion ($sle_minion is nil)
 # * there is no scope @scope_containerized_proxy
+#
+# This feature can cause failures in the following features:
+# - features/secondary/srv_advanced_search.feature
+# - features/secondary/srv_datepicker.feature
+# - features/secondary/srv_group_union_intersection.feature
+# - features/secondary/srv_custom_system_info.feature
+# - features/secondary/srv_reportdb.feature
+# - features/secondary/allcli_overview_systems_details.feature
+# - features/secondary/allcli_system_group.feature
+# - features/secondary/allcli_config_channel.feature
+# - features/secondary/allcli_software_channels.feature
+# - features/secondary/min_bootstrap_api.feature
+# If the minion is not properly bootstrapped again.
 
 @scope_containerized_proxy
 @proxy

--- a/testsuite/features/secondary/srv_delete_channel_from_ui.feature
+++ b/testsuite/features/secondary/srv_delete_channel_from_ui.feature
@@ -1,5 +1,9 @@
 # Copyright (c) 2021 SUSE LLC
 # Licensed under the terms of the MIT License.
+#
+# This feature can cause failures in the following features:
+# - features/secondary/srv_delete_channel_with_tool.feature:
+# If the deletion of "Clone of Fake-RPM-SUSE-Channel" fails, this feature will have a failing scenario.
 
 @scope_configuration_channels
 Feature: Delete channels with child or clone is not allowed

--- a/testsuite/features/secondary/srv_delete_channel_from_ui.feature
+++ b/testsuite/features/secondary/srv_delete_channel_from_ui.feature
@@ -3,7 +3,11 @@
 #
 # This feature can cause failures in the following features:
 # - features/secondary/srv_delete_channel_with_tool.feature:
+# - features/secondary/srv_handle_software_channels_with_ISS_v2.feature:
+# - features/secondary/srv_clone_channel_npn.feature
 # If the deletion of "Clone of Fake-RPM-SUSE-Channel" fails, this feature will have a failing scenario.
+# - features/secondary/srv_dist_channel_mapping.feature
+# If the deletion of "Clone of Fake Base Channel" fails, this feature will have a failing scenario
 
 @scope_configuration_channels
 Feature: Delete channels with child or clone is not allowed

--- a/testsuite/features/secondary/srv_delete_channel_from_ui.feature
+++ b/testsuite/features/secondary/srv_delete_channel_from_ui.feature
@@ -5,9 +5,10 @@
 # - features/secondary/srv_delete_channel_with_tool.feature:
 # - features/secondary/srv_handle_software_channels_with_ISS_v2.feature:
 # - features/secondary/srv_clone_channel_npn.feature
-# If the deletion of "Clone of Fake-RPM-SUSE-Channel" fails, this feature will have a failing scenario.
+# If the deletion of "Clone of Fake-RPM-SUSE-Channel" fails, these features will have failing scenarios.
 # - features/secondary/srv_dist_channel_mapping.feature
-# If the deletion of "Clone of Fake Base Channel" fails, this feature will have a failing scenario
+# - features/secondary/srv_patches_page.feature
+# If the deletion of "Clone of Fake Base Channel" fails, these features will have failing scenarios.
 
 @scope_configuration_channels
 Feature: Delete channels with child or clone is not allowed

--- a/testsuite/features/secondary/srv_delete_channel_with_tool.feature
+++ b/testsuite/features/secondary/srv_delete_channel_with_tool.feature
@@ -1,5 +1,9 @@
 # Copyright (c) 2021 SUSE LLC
 # Licensed under the terms of the MIT License.
+#
+# This feature can cause failures in the following features:
+# - features/secondary/srv_handle_software_channels_with_ISS_v2.feature:
+# If the deletion of "Clone of Fake-RPM-SUSE-Channel" fails, this feature will have a failing scenario.
 
 @scope_configuration_channels
 Feature: Deleting channels with children or clones is not allowed

--- a/testsuite/features/secondary/srv_delete_channel_with_tool.feature
+++ b/testsuite/features/secondary/srv_delete_channel_with_tool.feature
@@ -5,7 +5,7 @@
 # - features/secondary/srv_handle_software_channels_with_ISS_v2.feature
 # - features/secondary/srv_clone_channel_npn.feature
 # If the deletion of "Clone of Fake-RPM-SUSE-Channel" fails,
-# These features will have failing scenarios.
+# these features will have failing scenarios.
 
 @scope_configuration_channels
 Feature: Deleting channels with children or clones is not allowed

--- a/testsuite/features/secondary/srv_delete_channel_with_tool.feature
+++ b/testsuite/features/secondary/srv_delete_channel_with_tool.feature
@@ -2,9 +2,10 @@
 # Licensed under the terms of the MIT License.
 #
 # This feature can cause failures in the following features:
-# - features/secondary/srv_handle_software_channels_with_ISS_v2.feature:
+# - features/secondary/srv_handle_software_channels_with_ISS_v2.feature
 # - features/secondary/srv_clone_channel_npn.feature
-# If the deletion of "Clone of Fake-RPM-SUSE-Channel" fails, this feature will have a failing scenario.
+# If the deletion of "Clone of Fake-RPM-SUSE-Channel" fails,
+# These features will have failing scenarios.
 
 @scope_configuration_channels
 Feature: Deleting channels with children or clones is not allowed

--- a/testsuite/features/secondary/srv_delete_channel_with_tool.feature
+++ b/testsuite/features/secondary/srv_delete_channel_with_tool.feature
@@ -3,6 +3,7 @@
 #
 # This feature can cause failures in the following features:
 # - features/secondary/srv_handle_software_channels_with_ISS_v2.feature:
+# - features/secondary/srv_clone_channel_npn.feature
 # If the deletion of "Clone of Fake-RPM-SUSE-Channel" fails, this feature will have a failing scenario.
 
 @scope_configuration_channels

--- a/testsuite/features/secondary/srv_monitoring.feature
+++ b/testsuite/features/secondary/srv_monitoring.feature
@@ -12,13 +12,13 @@
 # This feature can cause failures in the following features:
 # - features/secondary/min_monitoring.feature
 # If this feature fails,
-# It could let the monitoring feature disabled for the SLE minion
+# it could let the monitoring feature disabled for the SLE minion
 # - features/secondary/min_rhlike_monitoring.feature
 # If this feature fails,
-# It could let the monitoring feature disabled for the Red Hat-like minion
+# it could let the monitoring feature disabled for the Red Hat-like minion
 # - features/secondary/min_deblike_monitoring.feature
 # If this feature fails,
-# It could let the monitoring feature disabled for the Debian-like minion
+# it could let the monitoring feature disabled for the Debian-like minion
 
 @skip_if_container
 @scope_monitoring

--- a/testsuite/features/secondary/srv_monitoring.feature
+++ b/testsuite/features/secondary/srv_monitoring.feature
@@ -11,7 +11,7 @@
 #
 # This feature can cause failures in the following features:
 # - features/secondary/min_monitoring.feature
-# Ff this feature fails,
+# If this feature fails,
 # It could let the monitoring feature disabled for the SLE minion
 # - features/secondary/min_rhlike_monitoring.feature
 # If this feature fails,

--- a/testsuite/features/secondary/srv_monitoring.feature
+++ b/testsuite/features/secondary/srv_monitoring.feature
@@ -2,13 +2,20 @@
 # Licensed under the terms of the MIT license.
 #
 # This feature is a dependency for:
+# - features/secondary/min_monitoring.feature
+# - features/secondary/min_rhlike_monitoring.feature
+# - features/secondary/min_deblike_monitoring.feature
+#
+# This feature depends on:
+# - sumaform: as it is configuring monitoring to be enabled after deployment
+#
+# This feature can cause failures in the following features:
 # - features/secondary/min_monitoring.feature: if this feature fails,
 #   it could let the monitoring feature disabled for the SLE minion
 # - features/secondary/min_rhlike_monitoring.feature: if this feature fails,
 #   it could let the monitoring feature disabled for the Red Hat-like minion
-#
-# This feature depends on:
-# - sumaform: as it is configuring monitoring to be enabled after deployment
+# - features/secondary/min_deblike_monitoring.feature: if this feature fails,
+#   it could let the monitoring feature disabled for the Debian-like minion
 
 @skip_if_container
 @scope_monitoring

--- a/testsuite/features/secondary/srv_monitoring.feature
+++ b/testsuite/features/secondary/srv_monitoring.feature
@@ -10,12 +10,15 @@
 # - sumaform: as it is configuring monitoring to be enabled after deployment
 #
 # This feature can cause failures in the following features:
-# - features/secondary/min_monitoring.feature: if this feature fails,
-#   it could let the monitoring feature disabled for the SLE minion
-# - features/secondary/min_rhlike_monitoring.feature: if this feature fails,
-#   it could let the monitoring feature disabled for the Red Hat-like minion
-# - features/secondary/min_deblike_monitoring.feature: if this feature fails,
-#   it could let the monitoring feature disabled for the Debian-like minion
+# - features/secondary/min_monitoring.feature
+# Ff this feature fails,
+# It could let the monitoring feature disabled for the SLE minion
+# - features/secondary/min_rhlike_monitoring.feature
+# If this feature fails,
+# It could let the monitoring feature disabled for the Red Hat-like minion
+# - features/secondary/min_deblike_monitoring.feature
+# If this feature fails,
+# It could let the monitoring feature disabled for the Debian-like minion
 
 @skip_if_container
 @scope_monitoring

--- a/testsuite/features/secondary/srv_power_management_api.feature
+++ b/testsuite/features/secondary/srv_power_management_api.feature
@@ -8,7 +8,7 @@ Feature: IPMI Power management API
 
   Scenario: Setup an IPMI host for API test
     When the server starts mocking an IPMI host
-    And  I want to operate on this "sle_minion"
+    And I want to operate on this "sle_minion"
 
   Scenario: Check the power management settings for API test
     When I fetch power management values

--- a/testsuite/features/secondary/srv_restart.feature
+++ b/testsuite/features/secondary/srv_restart.feature
@@ -8,7 +8,6 @@
 # This feature can cause failures in the following features:
 # All features following this one if the server fails to restart.
 
-
 Feature: Restart the spacewalk services via UI
 
   Scenario: Restart the SUSE Manager through the WebUI Admin option

--- a/testsuite/features/secondary/srv_restart.feature
+++ b/testsuite/features/secondary/srv_restart.feature
@@ -4,6 +4,10 @@
 # means that the page was refreshed, but in case of a timeout or other error,
 # we included a manual refresh and a simple navigation step to make sure the UI
 # is indeed up and running after the restart.
+#
+# This feature can cause failures in the following features:
+# All features following this one if the server fails to restart.
+
 
 Feature: Restart the spacewalk services via UI
 

--- a/testsuite/features/secondary/srv_users.feature
+++ b/testsuite/features/secondary/srv_users.feature
@@ -1,9 +1,12 @@
-# Copyright (c) 2015-2022 SUSE LLC
+# Copyright (c) 2015-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 #  1) check users page
 #  2) create and delete users
 #  3) Change permissions and roles in web UI
+#
+# This feature can cause failures in the following features:
+# - None
 
 @scope_visualization
 Feature: Manage users

--- a/testsuite/features/secondary/srv_users.feature
+++ b/testsuite/features/secondary/srv_users.feature
@@ -1,12 +1,9 @@
-# Copyright (c) 2015-2023 SUSE LLC
+# Copyright (c) 2015-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 #  1) check users page
 #  2) create and delete users
 #  3) Change permissions and roles in web UI
-#
-# This feature can cause failures in the following features:
-# - None
 
 @scope_visualization
 Feature: Manage users


### PR DESCRIPTION
## What does this PR change?
This PR adds comments to describe which features in the testsuite can fail when the current feature fails.
This PR only includes this in features part of the `secondary` stage. The `secondary_parrallelizable` features will be included into another PR.
Some differences will appear in 4.2 and 4.3 branches to account for traditional clients.

## GUI diff
No difference.
- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [X] **DONE**

## Test coverage
- No tests: already covered
- [X] **DONE**

## Links

Fixes #
Tracks # 
4.2 https://github.com/SUSE/spacewalk/pull/21479
4.3 https://github.com/SUSE/spacewalk/pull/21480
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
