### PR TITLE
Properly select architectures in setup wizard

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -66,7 +66,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
   Scenario: Add SUSE Linux Enterprise Server 15 SP3
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Linux Enterprise Server 15 SP3 x86_64" as the filtered product description
+    And I enter "SUSE Linux Enterprise Server 15 SP3" as the filtered product description
     And I select "SUSE Linux Enterprise Server 15 SP3 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server 15 SP3 x86_64" selected
     When I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP3 x86_64"
@@ -84,7 +84,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
   Scenario: Add SUSE Linux Enterprise Server 15 SP4
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Linux Enterprise Server 15 SP4 x86_64" as the filtered product description
+    And I enter "SUSE Linux Enterprise Server 15 SP4" as the filtered product description
     And I select "SUSE Linux Enterprise Server 15 SP4 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server 15 SP4 x86_64" selected
     When I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP4 x86_64"
@@ -102,7 +102,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
   Scenario: Add SUSE Linux Enterprise Micro 5.1
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Linux Enterprise Micro 5.1 x86_64" as the filtered product description
+    And I enter "SUSE Linux Enterprise Micro 5.1" as the filtered product description
     And I select "SUSE Linux Enterprise Micro 5.1 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Micro 5.1 x86_64" selected
     When I open the sub-list of the product "SUSE Linux Enterprise Micro 5.1 x86_64"
@@ -116,7 +116,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
   Scenario: Add SUSE Linux Enterprise Micro 5.2
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Linux Enterprise Micro 5.2 x86_64" as the filtered product description
+    And I enter "SUSE Linux Enterprise Micro 5.2" as the filtered product description
     And I select "SUSE Linux Enterprise Micro 5.2 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Micro 5.2 x86_64" selected
     When I open the sub-list of the product "SUSE Linux Enterprise Micro 5.2 x86_64"
@@ -130,7 +130,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
   Scenario: Add SUSE Linux Enterprise Micro 5.3
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Linux Enterprise Micro 5.3 x86_64" as the filtered product description
+    And I enter "SUSE Linux Enterprise Micro 5.3" as the filtered product description
     And I select "SUSE Linux Enterprise Micro 5.3 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Micro 5.3 x86_64" selected
     When I open the sub-list of the product "SUSE Linux Enterprise Micro 5.3 x86_64"
@@ -144,7 +144,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
   Scenario: Add SUSE Linux Enterprise Micro 5.4
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Linux Enterprise Micro 5.4 x86_64" as the filtered product description
+    And I enter "SUSE Linux Enterprise Micro 5.4" as the filtered product description
     And I select "SUSE Linux Enterprise Micro 5.4 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Micro 5.4 x86_64" selected
     When I open the sub-list of the product "SUSE Linux Enterprise Micro 5.4 x86_64"
@@ -169,7 +169,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
   Scenario: Add Alma Linux 9
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
-    And I enter "AlmaLinux 9 x86_64" as the filtered product description
+    And I enter "AlmaLinux 9" as the filtered product description
     And I select "AlmaLinux 9 x86_64" as a product
     Then I should see the "AlmaLinux 9 x86_64" selected
     When I click the Add Product button
@@ -205,10 +205,10 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
     And I enter "Oracle Linux 9" as the filtered product description
-    And I select "Oracle Linux 9" as a product
-    Then I should see the "Oracle Linux 9" selected
+    And I select "Oracle Linux 9 x86_64" as a product
+    Then I should see the "Oracle Linux 9 x86_64" selected
     When I click the Add Product button
-    And I wait until I see "Oracle Linux 9" product has been added
+    And I wait until I see "Oracle Linux 9 x86_64" product has been added
 
 @rhel9_minion
   Scenario: Add RHEL 9
@@ -238,10 +238,10 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
     And I enter "Rocky Linux 9" as the filtered product description
-    And I select "Rocky Linux 9" as a product
-    Then I should see the "Rocky Linux 9" selected
+    And I select "Rocky Linux 9 x86_64" as a product
+    Then I should see the "Rocky Linux 9 x86_64" selected
     When I click the Add Product button
-    And I wait until I see "Rocky Linux 9" product has been added
+    And I wait until I see "Rocky Linux 9 x86_64" product has been added
 
 @ubuntu1804_minion
   Scenario: Add Ubuntu 18.04
@@ -294,10 +294,10 @@ Feature: Synchronize products in the products page of the Setup Wizard
      And I wait until I see "Debian 11" product has been added
 
 @proxy
-  Scenario: Add SUSE Manager Proxy 4.3 x86_64
+  Scenario: Add SUSE Manager Proxy 4.3
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Manager Proxy 4.3 x86_64" as the filtered product description
+    And I enter "SUSE Manager Proxy 4.3" as the filtered product description
     And I select "SUSE Manager Proxy 4.3 x86_64" as a product
     Then I should see the "SUSE Manager Proxy 4.3 x86_64" selected
     When I click the Add Product button
@@ -305,10 +305,10 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I see "SUSE Manager Proxy 4.3 x86_64" product has been added
 
 @proxy
-  Scenario: Add SUSE Manager Retail Branch Server 4.3 x86_64
+  Scenario: Add SUSE Manager Retail Branch Server 4.3
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Manager Retail Branch Server 4.3 x86_64" as the filtered product description
+    And I enter "SUSE Manager Retail Branch Server 4.3" as the filtered product description
     And I select "SUSE Manager Retail Branch Server 4.3 x86_64" as a product
     Then I should see the "SUSE Manager Retail Branch Server 4.3 x86_64" selected
     When I click the Add Product button


### PR DESCRIPTION
## What does this PR change?

This PR specifies x86_64 for Rocky 9 and Oracle 9

It also aligns the way we specify architectures along the various scenarios.



## Links

Ports:
* 4.2: https://github.com/SUSE/spacewalk/pull/21434
* 4.3: https://github.com/SUSE/spacewalk/pull/21433


## Changelogs

- [x] No changelog needed
