### PR TITLE
make redacting sensitive values from api logs more robust

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/BaseHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/BaseHandler.java
@@ -126,6 +126,7 @@ public class BaseHandler implements XmlRpcInvocationHandler {
             foundMethod = fallbackMethod.getA();
             converted = fallbackMethod.getB();
         }
+        XmlRpcLoggingInvocationProcessor.setCalledMethod(foundMethod);
 
         if (user != null && user.isReadOnly()) {
             if (!foundMethod.isAnnotationPresent(ReadOnly.class)) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/XmlRpcLoggingInvocationProcessor.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/XmlRpcLoggingInvocationProcessor.java
@@ -24,7 +24,13 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import redstone.xmlrpc.XmlRpcInvocation;
 import redstone.xmlrpc.XmlRpcInvocationInterceptor;
@@ -39,6 +45,22 @@ public class XmlRpcLoggingInvocationProcessor extends LoggingInvocationProcessor
     private static Logger log = LogManager.getLogger(XmlRpcLoggingInvocationProcessor.class);
 
     private static ThreadLocal<User> caller = new ThreadLocal<>();
+    private static ThreadLocal<Method> calledMethod = new ThreadLocal<>();
+
+    /**
+     * This is a hack to determine the actual method BaseHandler called and recover the
+     * parameter names for filtering sensitive parameters from logging.
+     * @param method the method the BaseHandler called in this request thread.
+     */
+    public static void setCalledMethod(Method method) {
+        calledMethod.set(method);
+    }
+
+    private Optional<Method> getAndResetMethod() {
+        Method method = calledMethod.get();
+        calledMethod.remove();
+        return Optional.ofNullable(method);
+    }
 
     /**
      * {@inheritDoc}
@@ -53,7 +75,7 @@ public class XmlRpcLoggingInvocationProcessor extends LoggingInvocationProcessor
         getStopWatch().reset();
         getStopWatch().start();
 
-        List arguments = invocation.getArguments();
+        List<Object> arguments = invocation.getArguments();
         // HACK ALERT!  We need the caller, would be better in
         // the postProcess, but that works for ALL methods except
         // logout.  So we do it here.
@@ -76,23 +98,41 @@ public class XmlRpcLoggingInvocationProcessor extends LoggingInvocationProcessor
         return true;
     }
 
+    private Map<String, String> getParamMap(XmlRpcInvocation invocation, Method method) {
+        List<Object> rawArguments = invocation.getArguments();
+        List<String> paramNames = Arrays
+                .stream(method.getParameters())
+                .map(p -> p.getName())
+                .collect(Collectors.toList());
+        return IntStream.range(0, rawArguments.size()).boxed().collect(
+                Collectors.toMap(
+                        i -> paramNames.get(i),
+                        i -> {
+                            Object arg = rawArguments.get(i);
+                            if (arg instanceof User) {
+                                return ((User) arg).getLogin();
+                            }
+                            else {
+                                return (String) Translator.convert(arg, String.class);
+                            }
+                        }
+
+                )
+        );
+    }
+
     /**
      * {@inheritDoc}
      */
     @Override
     public Object after(XmlRpcInvocation invocation, Object returnValue) {
-        StringBuilder arguments = processArguments(
-            invocation.getHandlerName(),
-            invocation.getMethodName(),
-            invocation.getArguments()
-        );
         afterProcess(
             invocation.getHandlerName(),
             invocation.getMethodName(),
-            arguments,
+            getAndResetMethod().map(m -> getParamMap(invocation, m)),
+            Optional.ofNullable(getCaller()),
             RhnXmlRpcServer.getCallerIp()
         );
-
         return returnValue;
     }
 
@@ -101,63 +141,14 @@ public class XmlRpcLoggingInvocationProcessor extends LoggingInvocationProcessor
      */
     @Override
     public void onException(XmlRpcInvocation invocation, Throwable exception) {
-        StringBuilder buf = new StringBuilder();
-        try {
-            buf.append("REQUESTED FROM: ");
-            buf.append(RhnXmlRpcServer.getCallerIp());
-            buf.append(" CALL: ");
-            buf.append(invocation.getHandlerName());
-            buf.append(".");
-            buf.append(invocation.getMethodName());
-            buf.append("(");
-            buf.append(processArguments(invocation.getHandlerName(),
-                    invocation.getMethodName(), invocation.getArguments()));
-            buf.append(") CALLER: (");
-            buf.append(getCallerLogin());
-            buf.append(") TIME: ");
-
-            getStopWatch().stop();
-
-            buf.append(getStopWatch().getTime() / 1000.00);
-            buf.append(" seconds");
-
-            buf.append(System.lineSeparator());
-            buf.append(exception);
-
-            log.info(buf);
-        }
-        catch (RuntimeException e) {
-            log.error("postProcess error CALL: {} {}", invocation.getHandlerName(), invocation.getMethodName(), e);
-        }
-    }
-
-    private StringBuilder processArguments(String handler, String method,
-                                  List arguments) {
-        StringBuilder ret = new StringBuilder();
-        if (arguments != null) {
-            int size = arguments.size();
-            for (int i = 0; i < size; i++) {
-                String arg;
-                if (arguments.get(i) instanceof User) {
-                    arg = ((User)arguments.get(i)).getLogin();
-                }
-                else {
-                    if (preventValueLogging(handler, method, i)) {
-                        arg = "******";
-                    }
-                    else {
-                        arg = (String) Translator.convert(arguments.get(i), String.class);
-                    }
-                }
-
-                ret.append(arg);
-
-                if ((i + 1) < size) {
-                    ret.append(", ");
-                }
-            }
-        }
-        return ret;
+        processException(
+            invocation.getHandlerName(),
+            invocation.getMethodName(),
+            getAndResetMethod().map(m -> getParamMap(invocation, m)),
+            Optional.ofNullable(getCaller()),
+            RhnXmlRpcServer.getCallerIp(),
+            exception
+        );
     }
 
     /**
@@ -168,10 +159,7 @@ public class XmlRpcLoggingInvocationProcessor extends LoggingInvocationProcessor
      */
     private User getLoggedInUser(String key) {
         try {
-            User user = BaseHandler.getLoggedInUser(key);
-            if (user != null) {
-                return user;
-            }
+            return BaseHandler.getLoggedInUser(key);
         }
         catch (LookupException le) {
             // do nothing
@@ -179,7 +167,6 @@ public class XmlRpcLoggingInvocationProcessor extends LoggingInvocationProcessor
         catch (Exception e) {
             log.error("problem with getting logged in user for logging", e);
         }
-
         return null;
     }
 
@@ -202,13 +189,8 @@ public class XmlRpcLoggingInvocationProcessor extends LoggingInvocationProcessor
         return StringUtils.isNumeric(keyParts[0]);
     }
 
-    @Override
-    protected String getCallerLogin() {
-        return getCallerLogin(getCaller());
-    }
-
     private static User getCaller() {
-        return (User) caller.get();
+        return caller.get();
     }
 
     private static void setCaller(User c) {

--- a/java/code/src/com/suse/manager/api/LoggingInvocationProcessor.java
+++ b/java/code/src/com/suse/manager/api/LoggingInvocationProcessor.java
@@ -20,14 +20,16 @@ import org.apache.commons.lang3.time.StopWatch;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.HashMap;
+import java.time.Duration;
 import java.util.Map;
-import java.util.stream.Stream;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Base logic for processing logs.
  */
-public abstract class LoggingInvocationProcessor {
+public class LoggingInvocationProcessor {
 
     private static final Logger LOGGER = LogManager.getLogger(LoggingInvocationProcessor.class);
 
@@ -38,43 +40,127 @@ public abstract class LoggingInvocationProcessor {
         }
     };
 
+    public static final Set<String> DEFAULT_SENSITIVE_KEYWORDS =
+            Set.of("pass", "key", "certificate", "token", "secret");
     /**
-     * This map contains the method args whose value is sensible and should not be logged.
+     * This map is a way to explicitly override whether or not a value should be redacted in the
+     * log or not.
+     * If the value for a handler.method / parameter name pair is
      *
-     * The key follows the pattern handler.methodName and the value is a map containing
-     * the restricted args, arg position as key and arg name as value.
+     *  - true it will be redacted
+     *  - false it won't be redacted
+     *  - not present in the map the redaction will be based on the additional filtering for keywords
      */
-    private static final Map<String, Map<Integer, String>> RESTRICTED_ARGS = new HashMap<>();
+    public static final Map<String, Map<String, Boolean>> DEFAULT_EXPLICIT_OVERRIDE = Map.ofEntries(
+    );
 
-    static {
-        RESTRICTED_ARGS.put("auth.login", Map.of(1, "password"));
-        RESTRICTED_ARGS.put("system.bootstrap", Map.of(4, "sshPassword"));
-        RESTRICTED_ARGS.put(
-            "system.bootstrapWithPrivateKey",
-            Map.of(4, "sshPrivKey", 5, "sshPrivKeyPass")
+    /**
+     * @param sensitiveKeywordsIn list of keyword suggesting sensitive values that should be redacted in the log.
+     * @param explicitOverridesIn a map containing explicit overrides to the automatic keyword based filtering to
+     *                          cover false positives/negatives.
+     */
+    public LoggingInvocationProcessor(Set<String> sensitiveKeywordsIn,
+                                      Map<String, Map<String, Boolean>> explicitOverridesIn) {
+        this.sensitiveKeywords = sensitiveKeywordsIn;
+        this.explicitOverrides = explicitOverridesIn;
+    }
+
+    /**
+     * default constructor
+     */
+    public LoggingInvocationProcessor() {
+        this(DEFAULT_SENSITIVE_KEYWORDS, DEFAULT_EXPLICIT_OVERRIDE);
+    }
+
+    private final Map<String, Map<String, Boolean>> explicitOverrides;
+    private final Set<String> sensitiveKeywords;
+
+
+
+    /**
+     * Method for creating the log message taking redaction logic into account
+     *
+     * @param handlerName name of the handler
+     * @param methodName name of the method
+     * @param arguments map from argument name to value
+     * @param ip ip of the caller
+     * @param caller user making the call
+     * @param duration duration of how long the execution took
+     *
+     * @return a string buffer containing the log message
+     */
+    public StringBuilder logMessage(
+        String handlerName,
+        String methodName,
+        Optional<Map<String, String>> arguments,
+        String ip,
+        Optional<User> caller,
+        Duration duration
+    ) {
+        Optional<Map<String, String>> argumentsAfterRedaction = arguments.map(args ->
+                args.entrySet().stream()
+                    .collect(Collectors.toMap(
+                        e -> e.getKey(),
+                        e -> preventValueLogging(handlerName, methodName, e.getKey(), e.getValue()) ?
+                                "******" :
+                                e.getValue()
+                    ))
         );
-        RESTRICTED_ARGS.put(
-            "admin.payg.create",
-            Map.of(
-                5, "password",
-                6, "key",
-                7, "keyPassword",
-                11, "bastionPassword",
-                12, "bastionKey",
-                13, "bastionKeyPassword"
-            )
+        // Create the call in a separate buffer for reuse
+        StringBuilder buf = new StringBuilder();
+        buf.append("REQUESTED FROM: ");
+        buf.append(ip);
+        buf.append(" CALL: ");
+        buf.append(handlerName);
+        buf.append(".");
+        buf.append(methodName);
+        buf.append("(");
+        buf.append(
+            argumentsAfterRedaction.map(args ->
+                args.entrySet().stream()
+                    .map(e -> e.getKey() + "=" + e.getValue())
+                    .collect(Collectors.joining(", "))
+            ).orElse("no argument information provided")
         );
-        RESTRICTED_ARGS.put("admin.payg.setDetails", Map.of(2, "details"));
-        RESTRICTED_ARGS.put(
-            "proxy.container_config",
-            Map.of(
-                6, "caCertificate",
-                7, "caKey",
-                8, "caPassword"
-            )
-        );
-        RESTRICTED_ARGS.put("formula.setSystemFormulaData", Map.of(3, "content"));
-        RESTRICTED_ARGS.put("formula.setGroupFormulaData", Map.of(3, "content"));
+        buf.append(")");
+        buf.append(" CALLER: (");
+        buf.append(caller.map(User::getLogin).orElse("none"));
+        buf.append(") TIME: ");
+
+        buf.append(duration.toMillis() / 1000.0);
+        buf.append(" seconds");
+        return buf;
+    }
+
+    /**
+     * Logging method being called in case of an exception.
+     *
+     * @param handlerName name of the handler
+     * @param methodName name of the method
+     * @param arguments map from argument name to value
+     * @param ip ip of the caller
+     * @param caller user making the call
+     * @param exception exception to log
+     *
+     */
+    public void processException(
+            String handlerName,
+            String methodName,
+            Optional<Map<String, String>> arguments,
+            Optional<User> caller,
+            String ip,
+            Throwable exception) {
+        try {
+            StringBuilder buf = logMessage(handlerName, methodName, arguments, ip,
+                    caller, Duration.ofMillis(stopTimer()));
+            buf.append(System.lineSeparator());
+            buf.append(exception);
+
+            LOGGER.info(buf);
+        }
+        catch (RuntimeException e) {
+            LOGGER.error("onException error CALL: {} {}", handlerName, methodName, e);
+        }
     }
 
     /**
@@ -83,42 +169,25 @@ public abstract class LoggingInvocationProcessor {
      *
      * @param handlerName the handler of the request
      * @param methodName the method called
-     * @param arguments the string representation of the arguments passed to the method
+     * @param arguments a map containing argument name / string value pairs
+     * @param caller user making the call
      * @param ip the request's ip
      */
     public void afterProcess(
-        String handlerName,
-        String methodName,
-        StringBuilder arguments,
-        String ip
+            String handlerName,
+            String methodName,
+            Optional<Map<String, String>> arguments,
+            Optional<User> caller,
+            String ip
     ) {
         try {
-            // Create the call in a separate buffer for reuse
-            StringBuilder buf = new StringBuilder();
-            buf.append("REQUESTED FROM: ");
-            buf.append(ip);
-            buf.append(" CALL: ");
-            buf.append(handlerName);
-            buf.append(".");
-            buf.append(methodName);
-            buf.append("(");
-            buf.append(arguments);
-            buf.append(")");
-            buf.append(" CALLER: (");
-            buf.append(getCallerLogin());
-            buf.append(") TIME: ");
-
-            buf.append(stopTimer() / 1000.00);
-            buf.append(" seconds");
-
-            LOGGER.info(buf);
+            LOGGER.info(logMessage(handlerName, methodName, arguments, ip,
+                    caller, Duration.ofMillis(stopTimer())));
         }
         catch (RuntimeException e) {
             LOGGER.error("postProcess error CALL: {} {}", handlerName, methodName, e);
         }
     }
-
-    protected abstract String getCallerLogin();
 
     /**
      * Stop the timer
@@ -129,41 +198,29 @@ public abstract class LoggingInvocationProcessor {
         return getStopWatch().getTime();
     }
 
-    // determines whether the value should be hidden from logging based on argPosition
-    protected static boolean preventValueLogging(String handler, String method, int argPosition) {
-        String handlerAndMethod = handler + "." + method;
-        return RESTRICTED_ARGS.containsKey(handlerAndMethod) &&
-                RESTRICTED_ARGS.get(handlerAndMethod).containsKey(argPosition);
-    }
-
     /**
      * @param handler - name of the handler
      * @param method - name of the method
      * @param argName - name of the argument
      * @return - whether the value should be hidden from logging based on argName
      */
-    protected static boolean preventValueLogging(String handler, String method, String argName) {
-        Stream<String> restrictedArguments = Stream.of("password", "key", "content");
+    private boolean preventValueLogging(String handler, String method, String argName, String value) {
         String handlerAndMethod = handler + "." + method;
-        return restrictedArguments.anyMatch(s -> argName.toLowerCase().contains(s)) ||
-                (RESTRICTED_ARGS.containsKey(handlerAndMethod) &&
-                RESTRICTED_ARGS.get(handlerAndMethod).containsValue(argName));
+        // Look into values as well as some endpoints accept arbitrary json data like custom states which can contain
+        // sensitive information. The current implementation redacts the whole value which could be too much.
+        // In the future it might make sense to at least check the value for complex formats like json and only
+        // redact the part that is necessary.
+        boolean restrictedValue = sensitiveKeywords.stream().anyMatch(s -> value.toLowerCase().contains(s));
+        boolean restrictedArgument = sensitiveKeywords.stream().anyMatch(s -> argName.toLowerCase().contains(s));
+        Optional<Boolean> overrideValue =
+                Optional.ofNullable(explicitOverrides.get(handlerAndMethod))
+                        .flatMap(params -> Optional.ofNullable(params.get(argName)));
+
+        return overrideValue.orElse(restrictedArgument || restrictedValue);
     }
 
     protected static StopWatch getStopWatch() {
         return (StopWatch) timer.get();
     }
 
-    /**
-     * Extracts the login of the caller
-     * @param caller - the user
-     * @return the login of the user or "none" if no user is present
-     */
-    public String getCallerLogin(User caller) {
-        String ret = "none";
-        if (caller != null) {
-            ret = caller.getLogin();
-        }
-        return ret;
-    }
 }

--- a/java/code/src/com/suse/manager/api/test/HttpApiLoggingInvocationProcessorTest.java
+++ b/java/code/src/com/suse/manager/api/test/HttpApiLoggingInvocationProcessorTest.java
@@ -17,14 +17,10 @@ package com.suse.manager.api.test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.domain.user.legacy.UserImpl;
-
 import com.suse.manager.api.HttpApiLoggingInvocationProcessor;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public class HttpApiLoggingInvocationProcessorTest {
@@ -37,25 +33,6 @@ public class HttpApiLoggingInvocationProcessorTest {
         String[] urlTokens = url.split("/");
         String handlerName = processor.getHandlerName(urlTokens);
         assertEquals("system.provisioning.powermanagement", handlerName);
-    }
-
-    @Test
-    public void testGetCallerLogin() {
-        String login = "userLoginTest";
-        User user = new UserImpl();
-        user.setLogin(login);
-        assertEquals("none", processor.getCallerLogin(null));
-        assertEquals(login, processor.getCallerLogin(user));
-    }
-
-    @Test
-    public void getParamValueToLog() {
-        String value = "testValue";
-        String valueToLog = processor.getParamValueToLog("system", "login", "username", value);
-        assertEquals(value, valueToLog);
-
-        valueToLog = processor.getParamValueToLog("auth", "login", "password", value);
-        assertEquals("******", valueToLog);
     }
 
     @Test
@@ -72,14 +49,4 @@ public class HttpApiLoggingInvocationProcessorTest {
         assertEquals("\"value2\"", parsed.get("var2"));
     }
 
-    @Test
-    public void testProcessParams() {
-        Map<String, String> params = new HashMap<>();
-        params.put("sid", "100001");
-        params.put("user", "userTest");
-        StringBuilder result = processor.processParams(
-            params, "system.provisioning.powermanagement", "getDetails"
-        );
-        assertEquals("user=userTest, sid=100001", result.toString());
-    }
 }

--- a/java/code/src/com/suse/manager/api/test/LoggingInvocationProcessorTest.java
+++ b/java/code/src/com/suse/manager/api/test/LoggingInvocationProcessorTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.api.test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+
+import com.suse.manager.api.LoggingInvocationProcessor;
+
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+
+public class LoggingInvocationProcessorTest {
+
+    private final Set<String> sensitiveKeywords = LoggingInvocationProcessor.DEFAULT_SENSITIVE_KEYWORDS;
+    private final LoggingInvocationProcessor processor = new LoggingInvocationProcessor(
+           sensitiveKeywords,
+           LoggingInvocationProcessor.DEFAULT_EXPLICIT_OVERRIDE
+    );
+
+
+    private void testRedaction(String param, String value, boolean shouldRedact) {
+        MatcherAssert.assertThat(processor.logMessage(
+                "system",
+                "login",
+                Optional.of(Map.of(param, value)),
+                "127.0.0.1",
+                Optional.empty(),
+                Duration.ofMillis(1234)
+        ).toString(), shouldRedact ? not(containsString(value)) : containsString(value));
+    }
+
+
+    @Test
+    public void testRedactedScenarios() {
+        sensitiveKeywords.stream()
+            .flatMap(sensitiveKeyword ->
+                Stream.of(
+                    sensitiveKeyword,
+                    sensitiveKeyword.toUpperCase(),
+                    sensitiveKeyword.toLowerCase(),
+                    sensitiveKeyword + "withSuffix",
+                    "withPrefix" + sensitiveKeyword,
+                    "withPrefix" + sensitiveKeyword + "withSuffix"
+                )
+            )
+            .forEach(sensitiveKeyword -> {
+                testRedaction("nonSensitiveParameterName", "{" + sensitiveKeyword + ": \"hello world\"}", true);
+                testRedaction(sensitiveKeyword, "test", true);
+                testRedaction(sensitiveKeyword, "{" + sensitiveKeyword + ": \"hello world\"}", true);
+            });
+    }
+
+    @Test
+    public void testNonRedactedScenarios() {
+        testRedaction("test", "{" + "test" + ": \"hello world\"}", false);
+    }
+
+    @Test
+    public void testExplicitOverrides() {
+        LoggingInvocationProcessor p = new LoggingInvocationProcessor(
+                Set.of("password"),
+                Map.of(
+                    "test.method", Map.of(
+                            "explicitlyRedacted", true,
+                            "explicitlyLoggedPassword", false
+                    )
+                )
+        );
+        String withExplicitOverride = p.logMessage("test", "method", Optional.of(Map.of(
+                "explicitlyRedacted", "shouldBeRedacted",
+                "explicitlyLoggedPassword", "passwordInLogMessage"
+        )), "127.0.0.1", Optional.empty(), Duration.ZERO).toString();
+        MatcherAssert.assertThat(withExplicitOverride, containsString("passwordInLogMessage"));
+        MatcherAssert.assertThat(withExplicitOverride, not(containsString("shouldBeRedacted")));
+
+
+        p = new LoggingInvocationProcessor(
+                Set.of("password"),
+                Map.of()
+        );
+        String withoutExplicitOverride = p.logMessage("test", "method", Optional.of(Map.of(
+                        "explicitlyRedacted", "shouldBeRedacted",
+                        "explicitlyLoggedPassword", "passwordInLogMessage"
+        )), "127.0.0.1", Optional.empty(), Duration.ZERO).toString();
+        MatcherAssert.assertThat(withoutExplicitOverride, not(containsString("passwordInLogMessage")));
+        MatcherAssert.assertThat(withoutExplicitOverride, containsString("shouldBeRedacted"));
+    }
+
+}


### PR DESCRIPTION
port of https://github.com/SUSE/spacewalk/pull/21376

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
