### PR TITLE
Migrate uyuni server to container

### DIFF
--- a/containers/server-systemd-services/uyuni-server-services.config
+++ b/containers/server-systemd-services/uyuni-server-services.config
@@ -15,24 +15,26 @@ TAG=latest
 # Add -p 8000:8000 -p 8001:8001 to enable java remote debugging
 EXTRA_POD_ARGS=''
 
+#all these fields are required if it's a migration and should match with the current migrated instance
+REPORT_DB_PASS=pythia_susemanager
 # Initial setup configuration options
-MANAGER_USER="spacewalk"
-MANAGER_PASS="spacewalk"
-MANAGER_ADMIN_EMAIL="galaxy-noise@suse.de"
-CERT_O="SUSE"
-CERT_OU="SUSE"
-CERT_CITY="Nuernberg"
-CERT_STATE="Bayern"
-CERT_COUNTRY="DE"
-CERT_EMAIL="galaxy-noise@suse.de"
-CERT_PASS="spacewalk"
-USE_EXISTING_CERTS="N"
-MANAGER_DB_NAME="susemanager"
-MANAGER_DB_HOST="localhost"
-MANAGER_DB_PORT="5432"
-MANAGER_DB_PROTOCOL="TCP"
-MANAGER_ENABLE_TFTP="Y"
-SCC_USER=""
-SCC_PASS=""
-REPORT_DB_HOST="uyuni-server"
-UYUNI_FQDN="uyuni-server"
+MANAGER_USER=spacewalk
+MANAGER_PASS=spacewalk
+MANAGER_ADMIN_EMAIL=galaxy-noise@suse.de
+CERT_O=SUSE
+CERT_OU=SUSE
+CERT_CITY=Nuernberg
+CERT_STATE=Bayern
+CERT_COUNTRY=DE
+CERT_EMAIL=galaxy-noise@suse.de
+CERT_PASS=spacewalk
+USE_EXISTING_CERTS=N
+MANAGER_DB_NAME=susemanager
+MANAGER_DB_HOST=localhost
+MANAGER_DB_PORT=5432
+MANAGER_DB_PROTOCOL=TCP
+MANAGER_ENABLE_TFTP=Y
+SCC_USER=
+SCC_PASS=
+REPORT_DB_HOST=uyuni-server
+UYUNI_FQDN=uyuni-server

--- a/containers/server-systemd-services/uyuni-server-systemd-services.changes
+++ b/containers/server-systemd-services/uyuni-server-systemd-services.changes
@@ -1,1 +1,2 @@
+- Migrate uyuni server to container
 - create first draft of uyuni-server-systemd-services

--- a/containers/server-systemd-services/uyuni-server-systemd-services.changes
+++ b/containers/server-systemd-services/uyuni-server-systemd-services.changes
@@ -1,2 +1,1 @@
-- Migrate uyuni server to container
 - create first draft of uyuni-server-systemd-services

--- a/containers/server-systemd-services/uyuni-server.service
+++ b/containers/server-systemd-services/uyuni-server.service
@@ -20,8 +20,8 @@ ExecStart=/usr/bin/podman run \
     --cgroups=no-conmon \
     --rm \
     --sdnotify=conmon \
+    --cap-add NET_RAW \
     -d \
-    --replace \
     --tmpfs /run \
     -p 443:443 \
     -p 80:80 \


### PR DESCRIPTION
## What does this PR change?

Migrate a uyuni server to container. 
`uyuni-server-systemd-service` RPM already provide the script `uyuni-server.sh`. There's a new option called `migrate` to migrate a local uyuni server instance to container.

- [ ] UI works
- [ ] sync repository
- [ ] run highstate

Issue: https://github.com/SUSE/spacewalk/issues/20055


## GUI diff

No difference.


- [ ] **DONE**

## Documentation

- Documentation created https://github.com/uyuni-project/uyuni-docs/pull/2190

- [ ] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
