### PR TITLE
Updated deprecated SafeConfigParser in spacecmd

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Updated deprecated "SafeConfigParser" in spacecmd.
 - Bypass traditional systems check on older SUMA instances (bsc#1208612)
 - fix argument parsing of distribution_update (bsc#1210458)
 

--- a/spacecmd/src/bin/spacecmd
+++ b/spacecmd/src/bin/spacecmd
@@ -20,6 +20,7 @@
 #
 
 """ spacecmd - a command line interface to Spacewalk """
+from configparser import ConfigParser
 from spacecmd.i18n import _N
 
 import errno
@@ -35,10 +36,6 @@ except ImportError:
 import codecs
 import locale
 import argparse
-try: # python 3
-    from configparser import SafeConfigParser
-except ImportError: # python 2
-    from ConfigParser import SafeConfigParser
 import socket
 
 translation = gettext.translation('spacecmd', fallback=True)
@@ -139,7 +136,7 @@ if __name__ == '__main__':
         user_conf_file = os.path.join(conf_dir, 'config')
 
         # server-specifics will be loaded from the configuration file later
-        config = SafeConfigParser()
+        config = ConfigParser()
 
         # prevent readline from outputting escape sequences to non-terminals
         if not sys.stdout.isatty():


### PR DESCRIPTION
## What does this PR change?

Running `spacecmd`outputs the message:

```
# spacecmd
/usr/bin/spacecmd:142: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
  config = SafeConfigParser()
```

SafeConfigParser has been replaced.
In this process, Python2 compatibility has been broken as it is not supported any more.

Change is credited to "A. Braunsdorf"

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: No functional change.

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
