### PR TITLE
Use native queries for collecting systems metrics

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -176,8 +176,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import javax.persistence.Tuple;
-
 
 /**
  * SystemManager
@@ -1079,20 +1077,6 @@ public class SystemManager extends BaseManager {
         pc.setFilterColumn("outdated_packages");
         pc.setFilterData(">0");
         return systemListNew(user, PagedSqlQueryBuilder::parseFilterAsNumber, pc);
-    }
-
-    /**
-     * Returns the number of systems with outdated packages
-     *
-     * @return number of systems with outdated packages
-     */
-    public static long countOutdatedSystems() {
-        String selectCountQuery = "SELECT COUNT(DISTINCT(id)) FROM susesystemoverview WHERE outdated_packages > 0";
-        return HibernateFactory.getSession()
-                .createNativeQuery(selectCountQuery, Tuple.class)
-                .getSingleResult()
-                .get(COUNT, Number.class)
-                .longValue();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -129,6 +129,7 @@ import com.redhat.rhn.testing.TestStatics;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
+import com.suse.manager.metrics.SystemsCollector;
 import com.suse.manager.ssl.SSLCertPair;
 import com.suse.manager.virtualization.test.TestVirtManager;
 import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
@@ -2088,10 +2089,8 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         Server server = ServerFactoryTest.createTestServer(user);
         Long sid = server.getId();
         Package pack = PackageTest.createTestPackage(user.getOrg());
-
         ErrataCacheManager.insertNeededErrataCache(sid, null, pack.getId());
-        SystemsOverviewUpdateWorker.doUpdate(sid);
 
-        assertEquals(1, SystemManager.countOutdatedSystems());
+        assertEquals(1, SystemsCollector.getNumberOfOutdatedSystems());
     }
 }

--- a/java/code/src/com/suse/manager/metrics/SystemsCollector.java
+++ b/java/code/src/com/suse/manager/metrics/SystemsCollector.java
@@ -77,7 +77,7 @@ public class SystemsCollector extends Collector {
                 "FROM rhnServerInfo " +
                 "WHERE checkin < CURRENT_TIMESTAMP - NUMTODSINTERVAL(:checkin_threshold, 'second')";
         long threshold = SatConfigFactory.getSatConfigLongValue(SatConfigFactory.SYSTEM_CHECKIN_THRESHOLD, 1L);
-        long secondsInDay = 60 * 60 * 24;
+        long secondsInDay = 60L * 60 * 24;
         return HibernateFactory.getSession()
                 .createNativeQuery(selectCountQuery, Tuple.class)
                 .setParameter("checkin_threshold", threshold * secondsInDay)

--- a/java/code/src/com/suse/manager/metrics/SystemsCollector.java
+++ b/java/code/src/com/suse/manager/metrics/SystemsCollector.java
@@ -14,9 +14,14 @@ package com.suse.manager.metrics;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.common.SatConfigFactory;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jfree.util.Log;
+
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.persistence.PersistenceException;
 import javax.persistence.Tuple;
 
 import io.prometheus.client.Collector;
@@ -24,6 +29,8 @@ import io.prometheus.client.Collector;
 public class SystemsCollector extends Collector {
 
     public static final String PRODUCT_NAME = "uyuni";
+
+    private static final Logger LOG = LogManager.getLogger(SystemsCollector.class);
 
     private static long getCountFromNativeQuery(String selectCountQuery) {
         return HibernateFactory.getSession()
@@ -40,7 +47,12 @@ public class SystemsCollector extends Collector {
      */
     public static long getNumberOfOutdatedSystems() {
         String selectCountQuery = "SELECT COUNT(DISTINCT(id)) FROM susesystemoverview WHERE outdated_packages > 0";
-        return getCountFromNativeQuery(selectCountQuery);
+        try {
+            return getCountFromNativeQuery(selectCountQuery);
+        } catch (PersistenceException e) {
+            LOG.warn("Failed to get count of outdated packages.", e);
+            return 0L;
+        }
     }
 
     @Override

--- a/java/code/src/com/suse/manager/metrics/SystemsCollector.java
+++ b/java/code/src/com/suse/manager/metrics/SystemsCollector.java
@@ -14,14 +14,9 @@ package com.suse.manager.metrics;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.common.SatConfigFactory;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.jfree.util.Log;
-
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.persistence.PersistenceException;
 import javax.persistence.Tuple;
 
 import io.prometheus.client.Collector;
@@ -29,8 +24,6 @@ import io.prometheus.client.Collector;
 public class SystemsCollector extends Collector {
 
     public static final String PRODUCT_NAME = "uyuni";
-
-    private static final Logger LOG = LogManager.getLogger(SystemsCollector.class);
 
     private static long getCountFromNativeQuery(String selectCountQuery) {
         return HibernateFactory.getSession()
@@ -47,12 +40,7 @@ public class SystemsCollector extends Collector {
      */
     public static long getNumberOfOutdatedSystems() {
         String selectCountQuery = "SELECT COUNT(DISTINCT(id)) FROM susesystemoverview WHERE outdated_packages > 0";
-        try {
-            return getCountFromNativeQuery(selectCountQuery);
-        } catch (PersistenceException e) {
-            LOG.warn("Failed to get count of outdated packages.", e);
-            return 0L;
-        }
+        return getCountFromNativeQuery(selectCountQuery);
     }
 
     @Override

--- a/java/code/src/com/suse/manager/metrics/SystemsCollector.java
+++ b/java/code/src/com/suse/manager/metrics/SystemsCollector.java
@@ -47,17 +47,20 @@ public class SystemsCollector extends Collector {
     public List<MetricFamilySamples> collect() {
         List<MetricFamilySamples> out = new ArrayList<>();
         long start = System.nanoTime();
+        long numberOfSystems = getNumberOfSystems();
 
-        out.add(CustomCollectorUtils.gaugeFor("all_systems", "Number of all systems",
-                getNumberOfSystems(), PRODUCT_NAME));
-        out.add(CustomCollectorUtils.gaugeFor("virtual_systems", "Number of virtual systems",
-                getNumberOfVirtualSystems(), PRODUCT_NAME));
-        out.add(CustomCollectorUtils.gaugeFor("inactive_systems", "Number of inactive systems",
-                getNumberOfInactiveSystems(), PRODUCT_NAME));
-        out.add(CustomCollectorUtils.gaugeFor("outdated_systems", "Number of systems with outdated packages",
-                getNumberOfOutdatedSystems(), PRODUCT_NAME));
-        out.add(CustomCollectorUtils.gaugeFor("systems_scrape_duration_seconds", "Duration of Uyuni systems " +
-                "statistics scrape", (System.nanoTime() - start) / 1.0E9, PRODUCT_NAME));
+        if (numberOfSystems > 0) {
+            out.add(CustomCollectorUtils.gaugeFor("all_systems", "Number of all systems",
+                    numberOfSystems, PRODUCT_NAME));
+            out.add(CustomCollectorUtils.gaugeFor("virtual_systems", "Number of virtual systems",
+                    getNumberOfVirtualSystems(), PRODUCT_NAME));
+            out.add(CustomCollectorUtils.gaugeFor("inactive_systems", "Number of inactive systems",
+                    getNumberOfInactiveSystems(), PRODUCT_NAME));
+            out.add(CustomCollectorUtils.gaugeFor("outdated_systems", "Number of systems with outdated packages",
+                    getNumberOfOutdatedSystems(), PRODUCT_NAME));
+            out.add(CustomCollectorUtils.gaugeFor("systems_scrape_duration_seconds", "Duration of Uyuni systems " +
+                    "statistics scrape", (System.nanoTime() - start) / 1.0E9, PRODUCT_NAME));
+        }
 
         return out;
     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Reimplement queries for system metrics
 - Enforce minimum version of 1.11 for byte-buddy.
 - Updated EL9 jaxb-api symlinks to Uyuni provided package.
 - Fix issue with `aclChannelTypeCapable` that prevented errata view in


### PR DESCRIPTION
## What does this PR change?

Use native queries for collecting systems metrics to achieve better performance.
This is a backport of modified implementation in SUSE Manager.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Only performance improvement.

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Backports SUSE/spacewalk#21419

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
