### PR TITLE
Fixed property to tune for salt events queue processing

### DIFF
--- a/susemanager-utils/supportutils-plugin-susemanager/supportutils-plugin-susemanager.changes
+++ b/susemanager-utils/supportutils-plugin-susemanager/supportutils-plugin-susemanager.changes
@@ -1,3 +1,5 @@
+- Fixed property name to tune for salt events queue processing
+
 -------------------------------------------------------------------
 Wed Apr 19 12:57:55 CEST 2023 - marina.latini@suse.com
 

--- a/susemanager-utils/supportutils-plugin-susemanager/susemanager
+++ b/susemanager-utils/supportutils-plugin-susemanager/susemanager
@@ -72,7 +72,7 @@ plugin_command "salt-master --versions-report"
 
 plugin_command "echo \"select username scc_org from susecredentials sc join susecredentialstype sct on sct.id = sc.type_id where sct.label = 'scc';\" | spacewalk-sql --select-mode-direct -"
 
-plugin_command "echo \"Number of elements in table susesaltevent. If the next number is too high, please verify the large scale tuning guide property 'java.message_queue_thread_pool_size'.\""
+plugin_command "echo \"Number of elements in table susesaltevent. If the next number is too high, please verify the large scale tuning guide property 'java.salt_event_thread_pool_size'.\""
 plugin_command "echo \"select count(*) from susesaltevent;\" | spacewalk-sql --select-mode-direct -"
 
 plugin_command "/sbin/supportconfig-sumalog $LOG"


### PR DESCRIPTION
## What does this PR change?

This PR fixes the name of the property to tune to improve the performances of the salt events queue processing. Currently in fact the supportconfig plugin output is referring to the wrong property. 

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: the property is already correctly documented

- [X] **DONE**

## Test coverage
- No tests: fix in the message the supportconfig plugin prints out.

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
