### PR TITLE
Fix regular expressions in PackageFilter

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
@@ -87,11 +87,17 @@ public class PackageFilter extends ContentFilter<Package> {
 
     private static boolean checkNameAndArch(String field, String value, Package pack) {
         if (field.equals("nevr")) {
-            return value.replaceAll("(.*)-(.*:)?(.*)-(.*)", "$1").equals(pack.getPackageName().getName());
+            int relIdx = value.lastIndexOf('-');
+            int verIdx = value.lastIndexOf('-', relIdx - 1);
+            return (verIdx > 0) && value.substring(0, verIdx).equals(pack.getPackageName().getName());
         }
         else if (field.equals("nevra")) {
-            return value.replaceAll("(.*)-(.*:)?(.*)-(.*)\\.(.*)", "$1$5")
-                    .equals(pack.getPackageName().getName() + pack.getPackageArch().getLabel());
+            int relIdx = value.lastIndexOf('-');
+            int verIdx = value.lastIndexOf('-', relIdx - 1);
+            int archIdx = value.lastIndexOf('.');
+            return (verIdx > 0) && (archIdx > 0) &&
+                   value.substring(0, verIdx).equals(pack.getPackageName().getName()) &&
+                   value.substring(archIdx + 1).equals(pack.getPackageArch().getLabel());
         }
         else {
             throw new UnsupportedOperationException("Field " + field + " not supported for filter Package (NEVRA)");
@@ -100,10 +106,15 @@ public class PackageFilter extends ContentFilter<Package> {
 
     private static String getEvr(String field, String value) {
         if (field.equals("nevr")) {
-            return value.replaceAll("(.*)-(.*:)?(.*)-(.*)", "$2$3-$4");
+            int relIdx = value.lastIndexOf('-');
+            int verIdx = value.lastIndexOf('-', relIdx - 1);
+            return value.substring(verIdx + 1);
         }
         else if (field.equals("nevra")) {
-            return value.replaceAll("(.*)-(.*:)?(.*)-(.*)\\.(.*)", "$2$3-$4");
+            int relIdx = value.lastIndexOf('-');
+            int verIdx = value.lastIndexOf('-', relIdx - 1);
+            int archIdx = value.lastIndexOf('.');
+            return value.substring(verIdx + 1, archIdx);
         }
         else {
             throw new UnsupportedOperationException("Field " + field + " not supported for filter Package (NEVRA)");

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Do not use regex in PackageFilter
 - Fix misleading error message regarding SCC credentials removal (bsc#1207941)
 - Reimplement queries for system metrics
 - Enforce minimum version of 1.11 for byte-buddy.


### PR DESCRIPTION
## What does this PR change?

This PR fixes some of the problematic regular expressions reported by SonnarCloud.
It reduces complexity and makes sure that the regex does not match against substring.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: bugfix

- [ ] **DONE**

## Test coverage
- No tests: already covered

- [ ] **DONE**

## Links

Partially fixes https://github.com/SUSE/spacewalk/issues/21403

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
