### PR TITLE
Remove automatically installed dependency if needed

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -205,6 +205,10 @@ end
 
 When(/^I manually uninstall the "([^"]*)" formula from the server$/) do |package|
   $server.run("zypper --non-interactive remove #{package}-formula")
+  # Remove automatically installed dependency if needed
+  if package == 'uyuni-config'
+    $server.run("zypper --non-interactive remove #{package}-modules")
+  end
 end
 
 When(/^I synchronize all Salt dynamic modules on "([^"]*)"$/) do |host|


### PR DESCRIPTION
## What does this PR change?

When installing `uyuni-config-formula` on server, it automatically drags  `uyuni-config-modules` package.

During the cleanup, when  `uyuni-config-formula` is removed, `uyuni-config-modules` is left behind.

This in turn creates a problem when starting `salt-minion` on a CentOS 7 minion in 4.2 context:
```
mai 16 12:04:43 suma-42-min-centos7 salt-minion[1890]: [ERROR   ] Failed to import module uyuni_config, this is due most likely to a syntax error:
mai 16 12:04:43 suma-42-min-centos7 salt-minion[1890]: Traceback (most recent call last):
mai 16 12:04:43 suma-42-min-centos7 salt-minion[1890]: File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1658, in _load_module
mai 16 12:04:43 suma-42-min-centos7 salt-minion[1890]: mod = imp.load_module(mod_namespace, fn_, fpath, desc)
mai 16 12:04:43 suma-42-min-centos7 salt-minion[1890]: File "/var/cache/salt/minion/extmods/modules/uyuni_config.py", line 16
mai 16 12:04:43 suma-42-min-centos7 salt-minion[1890]: __pillar__: Dict[str, Any] = {}
mai 16 12:04:43 suma-42-min-centos7 salt-minion[1890]: ^
mai 16 12:04:43 suma-42-min-centos7 salt-minion[1890]: SyntaxError: invalid syntax
```

Tested to work on 4.2 CI.


## Links

Ports:
* 4.3:
* 4.2:


## Changelogs

- [x] No changelog needed
