### PR TITLE
QE: Use Leap instead of SLES in the Uyuni CI

### DIFF
--- a/testsuite/features/init_clients/allcli_update_activationkeys.feature
+++ b/testsuite/features/init_clients/allcli_update_activationkeys.feature
@@ -43,8 +43,10 @@ Feature: Update activation keys
     Then I should see a "Repository sync scheduled for Fake-RPM-SUSE-Channel." text
     And I wait until the channel "fake-rpm-suse-channel" has been synced
     And I disable source package syncing
-  
+
+@skip_if_github_validation
 @scc_credentials
+@susemanager
   Scenario: Update SLE key with synced base product
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE Test Key x86_64" in the content area
@@ -66,7 +68,27 @@ Feature: Update activation keys
     When I click on "Update Activation Key"
     Then I should see a "Activation key SUSE Test Key x86_64 has been modified" text
 
+@skip_if_github_validation
+@uyuni
+  Scenario: Update openSUSE Leap key with synced base product
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "SUSE Test Key x86_64" in the content area
+    And I wait until I do not see "Loading..." text
+    And I select "openSUSE Leap 15.4 (x86_64)" from "selectedBaseChannel"
+    And I wait until I do not see "Loading..." text
+    And I check "openSUSE 15.4 non oss (x86_64)"
+    And I check "openSUSE Leap 15.4 non oss Updates (x86_64)"
+    And I check "openSUSE Leap 15.4 Updates (x86_64)"
+    And I check "Update repository of openSUSE Leap 15.4 Backports (x86_64)"
+    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.4 (x86_64)"
+    And I check "Uyuni Client Tools for openSUSE Leap 15.4 (x86_64)"
+    And I check "Fake-RPM-SUSE-Channel"
+    When I click on "Update Activation Key"
+    Then I should see a "Activation key SUSE Test Key x86_64 has been modified" text
+
+@skip_if_github_validation
 @scc_credentials
+@susemanager
   Scenario: Update SSH key with synced base product
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE SSH Test Key x86_64" in the content area
@@ -79,7 +101,27 @@ Feature: Update activation keys
     And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE SSH Test Key x86_64 has been modified" text
 
+@skip_if_github_validation
+@uyuni
+  Scenario: Update SSH key with synced base product
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "SUSE SSH Test Key x86_64" in the content area
+    And I wait until I do not see "Loading..." text
+    And I select "openSUSE Leap 15.4 (x86_64)" from "selectedBaseChannel"
+    And I wait until I do not see "Loading..." text
+    And I check "openSUSE 15.4 non oss (x86_64)"
+    And I check "openSUSE Leap 15.4 non oss Updates (x86_64)"
+    And I check "openSUSE Leap 15.4 Updates (x86_64)"
+    And I check "Update repository of openSUSE Leap 15.4 Backports (x86_64)"
+    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.4 (x86_64)"
+    And I check "Uyuni Client Tools for openSUSE Leap 15.4 (x86_64)"
+    And I check "Fake-RPM-SUSE-Channel"
+    And I click on "Update Activation Key"
+    Then I should see a "Activation key SUSE SSH Test Key x86_64 has been modified" text
+
+@skip_if_github_validation
 @scc_credentials
+@susemanager
   Scenario: Update SSH tunnel key with synced base product
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE SSH Tunnel Test Key x86_64" in the content area
@@ -92,6 +134,25 @@ Feature: Update activation keys
     And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE SSH Tunnel Test Key x86_64 has been modified" text
 
+@skip_if_github_validation
+@uyuni
+  Scenario: Update SSH tunnel key with synced base product
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "SUSE SSH Tunnel Test Key x86_64" in the content area
+    And I wait until I do not see "Loading..." text
+    And I select "openSUSE Leap 15.4 (x86_64)" from "selectedBaseChannel"
+    And I wait until I do not see "Loading..." text
+    And I check "openSUSE 15.4 non oss (x86_64)"
+    And I check "openSUSE Leap 15.4 non oss Updates (x86_64)"
+    And I check "openSUSE Leap 15.4 Updates (x86_64)"
+    And I check "Update repository of openSUSE Leap 15.4 Backports (x86_64)"
+    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.4 (x86_64)"
+    And I check "Uyuni Client Tools for openSUSE Leap 15.4 (x86_64)"
+    And I check "Fake-RPM-SUSE-Channel"
+    And I click on "Update Activation Key"
+    Then I should see a "Activation key SUSE SSH Tunnel Test Key x86_64 has been modified" text
+
+@skip_if_github_validation
 @scc_credentials
 @susemanager
   Scenario: Update the Proxy key with synced base product
@@ -110,20 +171,20 @@ Feature: Update activation keys
     When I click on "Update Activation Key"
     Then I should see a "Activation key Proxy Key x86_64 has been modified" text
 
-# This will be enabled once the Uyuni CI is syncing openSUSE Leap 15.4
-# @uyuni
-#   Scenario: Update the Proxy key with synced base product
-#     When I follow the left menu "Systems > Activation Keys"
-#     And I follow "Proxy Key x86_64" in the content area
-#     And I wait until I do not see "Loading..." text
-#     And I select "openSUSE Leap 15.4 (x86_64)" from "selectedBaseChannel"
-#     And I wait until I do not see "Loading..." text
-#     And I check "openSUSE 15.4 non oss (x86_64)"
-#     And I check "openSUSE Leap 15.4 non oss Updates (x86_64)"
-#     And I check "openSUSE Leap 15.4 Updates (x86_64)"
-#     And I check "Update repository of openSUSE Leap 15.4 Backports (x86_64)"
-#     And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.4 (x86_64)"
-#     And I check "Uyuni Client Tools for openSUSE Leap 15.4 (x86_64)"
-#     And I check "Uyuni Proxy Stable for openSUSE Leap 15.4 (x86_64)"
-#     When I click on "Update Activation Key"
-#     Then I should see a "Activation key Proxy Key x86_64 has been modified" text
+@skip_if_github_validation
+@uyuni
+  Scenario: Update the Proxy key with synced base product
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "Proxy Key x86_64" in the content area
+    And I wait until I do not see "Loading..." text
+    And I select "openSUSE Leap 15.4 (x86_64)" from "selectedBaseChannel"
+    And I wait until I do not see "Loading..." text
+    And I check "openSUSE 15.4 non oss (x86_64)"
+    And I check "openSUSE Leap 15.4 non oss Updates (x86_64)"
+    And I check "openSUSE Leap 15.4 Updates (x86_64)"
+    And I check "Update repository of openSUSE Leap 15.4 Backports (x86_64)"
+    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.4 (x86_64)"
+    And I check "Uyuni Client Tools for openSUSE Leap 15.4 (x86_64)"
+    And I check "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)"
+    When I click on "Update Activation Key"
+    Then I should see a "Activation key Proxy Key x86_64 has been modified" text

--- a/testsuite/features/init_clients/buildhost_bootstrap.feature
+++ b/testsuite/features/init_clients/buildhost_bootstrap.feature
@@ -1,8 +1,8 @@
-# Copyright (c) 2016-2022 SUSE LLC
+# Copyright (c) 2016-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @buildhost
-Feature: Bootstrap a Salt build host via the GUI
+Feature: Bootstrap a build host via the GUI
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
@@ -15,7 +15,7 @@ Feature: Bootstrap a Salt build host via the GUI
     And I check "osimage_build_host"
     And I click on "Update Activation Key"
 
-  Scenario: Bootstrap a SLES build host
+  Scenario: Bootstrap a build host
     When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "build_host" as "hostname"

--- a/testsuite/features/init_clients/proxy_register_as_minion_with_gui.feature
+++ b/testsuite/features/init_clients/proxy_register_as_minion_with_gui.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2022 SUSE LLC
+# Copyright (c) 2017-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # The scenarios in this feature are skipped if there is no proxy
@@ -63,3 +63,25 @@ Feature: Setup Uyuni proxy
   Scenario: Check events history for failures on the proxy
     Given I am on the Systems overview page of this "proxy"
     Then I check for failed events on history event page
+
+@uyuni
+  Scenario: Assign the correct channels to the proxy
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    And I check radio button "openSUSE Leap 15.4 (x86_64)"
+    And I wait until I do not see "Loading..." text
+    And I check "openSUSE 15.4 non oss (x86_64)"
+    And I check "openSUSE Leap 15.4 non oss Updates (x86_64)"
+    And I check "openSUSE Leap 15.4 Updates (x86_64)"
+    And I check "Update repository of openSUSE Leap 15.4 Backports (x86_64)"
+    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.4 (x86_64)"
+    And I check "Uyuni Client Tools for openSUSE Leap 15.4 (x86_64)"
+    And I check "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)"
+    And I click on "Next"
+    Then I should see a "Confirm Software Channel Change" text
+    When I click on "Confirm"
+    Then I should see a "Changing the channels has been scheduled." text
+    When I follow "scheduled" in the content area
+    And I wait until I see "1 system successfully completed this action." text, refreshing the page

--- a/testsuite/features/init_clients/proxy_register_as_minion_with_script.feature
+++ b/testsuite/features/init_clients/proxy_register_as_minion_with_script.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2022 SUSE LLC
+# Copyright (c) 2017-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # The scenarios in this feature are skipped if there is no proxy
@@ -73,3 +73,25 @@ Feature: Setup Uyuni proxy
   Scenario: Cleanup: remove proxy bootstrap scripts
     When I run "rm /srv/www/htdocs/pub/bootstrap/bootstrap-proxy.sh" on "server"
     And I run "rm /root/bootstrap-proxy.sh" on "proxy"
+
+@uyuni
+  Scenario: Assign the correct channels to the proxy
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    And I check radio button "openSUSE Leap 15.4 (x86_64)"
+    And I wait until I do not see "Loading..." text
+    And I check "openSUSE 15.4 non oss (x86_64)"
+    And I check "openSUSE Leap 15.4 non oss Updates (x86_64)"
+    And I check "openSUSE Leap 15.4 Updates (x86_64)"
+    And I check "Update repository of openSUSE Leap 15.4 Backports (x86_64)"
+    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.4 (x86_64)"
+    And I check "Uyuni Client Tools for openSUSE Leap 15.4 (x86_64)"
+    And I check "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)"
+    And I click on "Next"
+    Then I should see a "Confirm Software Channel Change" text
+    When I click on "Confirm"
+    Then I should see a "Changing the channels has been scheduled." text
+    When I follow "scheduled" in the content area
+    And I wait until I see "1 system successfully completed this action." text, refreshing the page

--- a/testsuite/features/init_clients/sle_ssh_minion.feature
+++ b/testsuite/features/init_clients/sle_ssh_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2022 SUSE LLC
+# Copyright (c) 2016-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @ssh_minion
@@ -7,7 +7,7 @@ Feature: Bootstrap a Salt host managed via salt-ssh
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  Scenario: Register this SSH minion for service pack migration
+  Scenario: Bootstrap a SLES SSH minion
     When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"

--- a/testsuite/features/reposync/srv_enable_sync_products.feature
+++ b/testsuite/features/reposync/srv_enable_sync_products.feature
@@ -6,10 +6,17 @@ Feature: Be able to list available products and enable them
   As root user
   I want to be able to list available products and enable them
 
+@susemanager
   Scenario: List available products
     When I execute mgr-sync "list products" with user "admin" and password "admin"
     Then I should get "[ ] SUSE Linux Enterprise Desktop 15 SP3 x86_64"
 
+@uyuni
+  Scenario: List available products
+    When I execute mgr-sync "list products" with user "admin" and password "admin"
+    Then I should get "[ ] openSUSE Leap 15.4 x86_64"
+
+@susemanager
   Scenario: List all available products
     When I execute mgr-sync "list products -e"
     Then I should get "[ ] SUSE Linux Enterprise Desktop 15 SP3 x86_64"

--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -7,6 +7,7 @@ Feature: Be able to list available channels and enable them
   As root user
   I want to be able to list available channels and enable them
 
+@susemanager
   Scenario: List available channels
     # Order matters here, refresh first
     When I refresh SCC
@@ -15,6 +16,7 @@ Feature: Be able to list available channels and enable them
     And I should get "    [ ] SLE-Product-SLES15-SP4-Updates for x86_64 SUSE Linux Enterprise Server 15 SP4 x86_64 [sle-product-sles15-sp4-updates-x86_64]"
     And I should get "    [ ] SLE15-SP4-Installer-Updates for x86_64 SUSE Linux Enterprise Server 15 SP4 x86_64 [sle15-sp4-installer-updates-x86_64]"
 
+@susemanager
   Scenario: List available mandatory channels
     When I execute mgr-sync "list channels -e --no-optional"
     Then I should get "[ ] SLE-Product-SLES15-SP4-Pool for x86_64 SUSE Linux Enterprise Server 15 SP4 x86_64 [sle-product-sles15-sp4-pool-x86_64]"
@@ -35,6 +37,7 @@ Feature: Be able to list available channels and enable them
     And I should get "  [ ] (R) SUSE Manager Client Tools for RHEL, Liberty and Clones 7 x86_64"
     And I should get "  [ ] (R) SUSE Manager Client Tools for SLE 15 x86_64"
 
+@susemanager
   Scenario: List products with filter
     When I execute mgr-sync "list products --expand --filter x86_64"
     Then I should get "[ ] SUSE Linux Enterprise Server 15 SP4 x86_64"

--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -22,6 +22,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     Then I should see a "RHEL or SLES ES or CentOS 8 Base" text
 
 @scc_credentials
+@susemanager
   Scenario: View the channels list in the products page
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
@@ -61,31 +62,9 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I see "SUSE Linux Enterprise Server 15 SP4 x86_64" product has been added
     Then the SLE15 SP4 product should be added
 
-@scc_credentials
 @uyuni
-  Scenario: Add SLES 15 SP4 product with recommended sub-products
-    When I follow the left menu "Admin > Setup Wizard > Products"
-    And I wait until I do not see "Loading" text
-    And I enter "SUSE Linux Enterprise Server 15 SP4" as the filtered product description
-    And I wait until I see "SUSE Linux Enterprise Server 15 SP4 x86_64" text
-    And I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP4 x86_64"
-    And I open the sub-list of the product "Basesystem Module 15 SP4 x86_64"
-    And I open the sub-list of the product "Desktop Applications Module 15 SP4 x86_64"
-    Then I should see that the "Basesystem Module 15 SP4 x86_64" product is "recommended"
-    And I should see that the "Server Applications Module 15 SP4 x86_64" product is "recommended"
-    When I select "SUSE Linux Enterprise Server 15 SP4 x86_64" as a product
-    Then I should see the "SUSE Linux Enterprise Server 15 SP4 x86_64" selected
-    And I should see the "Basesystem Module 15 SP4 x86_64" selected
-    And I should see the "Server Applications Module 15 SP4 x86_64" selected
-    When I select "Desktop Applications Module 15 SP4 x86_64" as a product
-    And I select "Development Tools Module 15 SP4 x86_64" as a product
-    Then I should see the "Desktop Applications Module 15 SP4 x86_64" selected
-    And I should see the "Development Tools Module 15 SP4 x86_64" selected
-    When I select "Containers Module 15 SP4 x86_64" as a product
-    Then I should see the "Containers Module 15 SP4 x86_64" selected
-    When I click the Add Product button
-    And I wait until I see "SUSE Linux Enterprise Server 15 SP4 x86_64" product has been added
-    Then the SLE15 SP4 product should be added
+  Scenario: Add openSUSE Leap 15.4 product, inlcuding Uyuni Client Tools
+    When I use spacewalk-common-channel to add channel "opensuse_leap15_4 opensuse_leap15_4-non-oss opensuse_leap15_4-non-oss-updates opensuse_leap15_4-updates opensuse_leap15_4-backports-updates opensuse_leap15_4-sle-updates uyuni-proxy-devel-leap opensuse_leap15_4-uyuni-client" with arch "x86_64"
 
 @proxy
 @susemanager
@@ -112,6 +91,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I see "SUSE Manager Retail Branch Server 4.3 x86_64" product has been added
 
 @scc_credentials
+@susemanager
   Scenario: Installer update channels got enabled when products were added
     When I execute mgr-sync "list channels" with user "admin" and password "admin"
     And I should get "    [I] SLE15-SP4-Installer-Updates for x86_64 SUSE Linux Enterprise Server 15 SP4 x86_64 [sle15-sp4-installer-updates-x86_64]"

--- a/testsuite/features/reposync/srv_wait_for_reposync.feature
+++ b/testsuite/features/reposync/srv_wait_for_reposync.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022 SUSE LLC
+# Copyright (c) 2019-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Wait for reposync activity to finish in CI context
@@ -17,8 +17,8 @@ Feature: Wait for reposync activity to finish in CI context
     When I kill all running spacewalk-repo-sync, excepted the ones needed to bootstrap
 
 @uyuni
-  Scenario: Enable SLES15 SP4 Uyuni client tools for creating bootstrap repositories
-    When I use spacewalk-common-channel to add channel "sle-product-sles15-sp4-pool-x86_64 sles15-sp4-uyuni-client" with arch "x86_64"
+  Scenario: Sync openSUSE Leap 15.4 product, inlcuding Uyuni Client Tools
+    When I call spacewalk-repo-sync to sync the parent channel "opensuse_leap15_4-x86_64"
 
   Scenario: Wait until all synchronized channels have finished
     When I wait until all synchronized channels have finished

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -778,6 +778,10 @@ When(/^I call spacewalk\-repo\-sync to sync the channel "(.*?)"$/) do |channel|
   @command_output, _code = $server.run("spacewalk-repo-sync -c #{channel}", check_errors: false)
 end
 
+When(/^I call spacewalk\-repo\-sync to sync the parent channel "(.*?)"$/) do |channel|
+  @command_output, _code = $server.run("spacewalk-repo-sync -p #{channel}", check_errors: false)
+end
+
 When(/^I get "(.*?)" file details for channel "(.*?)" via spacecmd$/) do |arg1, arg2|
   @command_output, _code = $server.run("spacecmd -u admin -p admin -q -- configchannel_filedetails #{arg2} '#{arg1}'", check_errors: false)
 end

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -37,7 +37,7 @@ def compute_channels_to_leave_running
     os_family = node.os_family
     next unless ['sles', 'rocky'].include?(os_family)
     os_version = os_version.split('.')[0] if os_family == 'rocky'
-    log "Can't build list of reposyncs to leave running" unless %w[15-SP3 15-SP4 8].include? os_version
+    log "Can't build list of reposyncs to leave running" unless %w[15-SP3 15-SP4 15.4 8].include? os_version
     do_not_kill += CHANNEL_TO_SYNCH_BY_OS_VERSION[os_version]
   end
   do_not_kill.uniq

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -133,13 +133,22 @@ PACKAGE_BY_CLIENT = { 'sle_minion' => 'bison',
 # For containers we do not have SCC, so we set the Fake Base Channel
 # for sle_minion
 sle_base_channel =
-  if ENV['PROVIDER'].include? 'podman'
+  if $is_container_provider
     'Fake Base Channel'
+  elsif $product == 'Uyuni'
+    'openSUSE Leap 15.4 (x86_64)'
   else
     'SLES15-SP4-Pool'
   end
 
-BASE_CHANNEL_BY_CLIENT = { 'proxy' => 'SLE-Product-SUSE-Manager-Proxy-4.3-Pool',
+proxy_base_channel =
+  if $product == 'Uyuni'
+    'openSUSE Leap 15.4 (x86_64)'
+  else
+    'SLE-Product-SUSE-Manager-Proxy-4.3-Pool'
+  end
+
+BASE_CHANNEL_BY_CLIENT = { 'proxy' => proxy_base_channel,
                            'sle_minion' => sle_base_channel,
                            'ssh_minion' => 'SLES15-SP4-Pool',
                            'rhlike_minion' => 'RHEL8-Pool for x86_64',


### PR DESCRIPTION
## What does this PR change?

This will move Uyuni completely to using openSUSE Leap instead of SLES.

- use Leap for the `suse-minion`
- sync Leap 15.4 instead of SLES 15 SP4



![image](https://github.com/uyuni-project/uyuni/assets/12104291/a592cc2b-58f5-4b8f-8541-12cc9042f6a1)
![image](https://github.com/uyuni-project/uyuni/assets/12104291/314f6f3e-5d49-4eed-8591-6244a5016e08)

```bash
uyuni-srv:/var/log/rhn/reposync # ls -lh
total 7.9M
-rw-rw---- 1 wwwrun www 1.7K Aug  2 11:06 fake_base_channel.log
-rw-rw---- 1 wwwrun www 6.5K Aug  2 08:55 fake-i586-channel.log
-rw-rw---- 1 wwwrun www 3.1K Aug  2 13:21 fake-rpm-suse-channel.log
-rw-rw---- 1 wwwrun www  16K Aug  2 11:32 opensuse_leap15_4-uyuni-client-x86_64.log
-rw-rw---- 1 wwwrun www 121K Aug  2 11:32 opensuse_leap15_4-x86_64-backports-updates.log
-rw-rw---- 1 wwwrun www 4.5M Aug  2 11:32 opensuse_leap15_4-x86_64.log
-rw-rw---- 1 wwwrun www 6.2K Aug  2 11:32 opensuse_leap15_4-x86_64-non-oss.log
-rw-rw---- 1 wwwrun www 6.4K Aug  2 11:32 opensuse_leap15_4-x86_64-non-oss-updates.log
-rw-rw---- 1 wwwrun www 3.2M Aug  2 11:33 opensuse_leap15_4-x86_64-sle-updates.log
-rw-rw---- 1 wwwrun www  24K Aug  2 11:33 opensuse_leap15_4-x86_64-updates.log
-rw-rw---- 1 wwwrun www 6.6K Aug  2 08:55 test-channel-x86_64.log
-rw-rw---- 1 wwwrun www 7.2K Aug  2 11:33 uyuni-proxy-devel-leap-x86_64.log
-rw-rw---- 1 wwwrun www 8.3K Aug  2 08:58 uyuni-proxy-stable-leap-154-x86_64.log
```
I will squash the commits before merging.

### TODO

- [x] come up with a solution for syncing openSUSE Leap before onboarding the proxy. Otherwise, move the software channel selection code to after the reposync. See https://github.com/uyuni-project/uyuni/pull/7287
- [x] take care of adding the FAKE RPM channel to Leap

## GUI diff

No difference.


- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links

- No ports.
- https://github.com/SUSE/spacewalk/issues/18099
- https://github.com/SUSE/spacewalk/issues/10235
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
