### PR TITLE
Amend misleading error message when deregistering system that is not in SCC

### DIFF
--- a/java/code/src/com/suse/scc/SCCSystemRegistrationManager.java
+++ b/java/code/src/com/suse/scc/SCCSystemRegistrationManager.java
@@ -114,7 +114,12 @@ public class SCCSystemRegistrationManager {
                         SCCCachingFactory.deleteRegCacheItem(cacheItem);
                     }
                     catch (SCCClientException e) {
-                        LOG.error("SCC error while deregistering system {}", cacheItem.getId(), e);
+                        if (e.getHttpStatusCode() == 404) {
+                            LOG.info("System {} not found in SCC", cacheItem.getId());
+                        }
+                        else {
+                            LOG.error("SCC error while deregistering system {}", cacheItem.getId(), e);
+                        }
                         if (forceDBDeletion || e.getHttpStatusCode() == 404) {
                             SCCCachingFactory.deleteRegCacheItem(cacheItem);
                         }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix misleading error message regarding SCC credentials removal (bsc#1207941)
 - Reimplement queries for system metrics
 - Enforce minimum version of 1.11 for byte-buddy.
 - Updated EL9 jaxb-api symlinks to Uyuni provided package.


### PR DESCRIPTION
## What does this PR change?

This PR changes the error written in logs that happens when deregistering a system that is locally but not in SCC. Now if that scenario takes place, it just prints an info message instead of the error one with the full stacktrace.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20446

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
