### PR TITLE
Testsuite: Wait for package to appear before checking it in the list

### DIFF
--- a/testsuite/features/secondary/min_deblike_salt_install_package.feature
+++ b/testsuite/features/secondary/min_deblike_salt_install_package.feature
@@ -35,6 +35,7 @@ Feature: Install and upgrade package on the Debian-like minion via Salt through 
   Scenario: Update a package on the Debian-like minion
     And I follow "Software" in the content area
     And I follow "Upgrade" in the content area
+    And I wait until I see "virgo-dummy" text, refreshing the page
     And I check "virgo-dummy-2.0-X" in the list
     And I click on "Upgrade Packages"
     And I click on "Confirm"


### PR DESCRIPTION
## What does this PR change?
The `virgo-dummy` package is occasionally not present yet in the upgrade list of the debian minion.
This PR adds a step to wait for the package name to appear before attempting to check it.

## GUI diff

No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were added
- [x] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/18971
Tracks # 
4.2
4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
