### PR TITLE
Add MU/Milestone information to /etc/susemanager-release

### DIFF
--- a/spacewalk/package/spacewalk.changes
+++ b/spacewalk/package/spacewalk.changes
@@ -1,3 +1,4 @@
+- For SUSE Manager, add MU or Milestone to /etc/susemanager-release
 - Link /usr/bin/initdb for Enterprise Linux.
 
 -------------------------------------------------------------------

--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -151,10 +151,11 @@ Version for PostgreSQL database backend.
 RDBMS="postgresql"
 install -d $RPM_BUILD_ROOT/%{_sysconfdir}
 SUMA_REL=$(echo %{version} | awk -F. '{print $1"."$2}')
+SUMA_FULL_REL=$(grep -F 'web.version' %{_datadir}/rhn/config-defaults/rhn_web.conf | sed 's/^.*= *\([[:digit:]\.]\+\) *$/\1/')
 UYUNI_REL=$(grep -F 'web.version.uyuni' %{_datadir}/rhn/config-defaults/rhn_web.conf | sed 's/^.*= *\([[:digit:]\.]\+\) *$/\1/')
 echo "Uyuni release $UYUNI_REL" > $RPM_BUILD_ROOT/%{_sysconfdir}/uyuni-release
 if grep -F 'product_name' %{_datadir}/rhn/config-defaults/rhn.conf | grep 'SUSE Manager' >/dev/null; then
-  echo "SUSE Manager release $SUMA_REL ($UYUNI_REL)" > $RPM_BUILD_ROOT/%{_sysconfdir}/susemanager-release
+  echo "SUSE Manager release $SUMA_REL ($SUMA_FULL_REL)" > $RPM_BUILD_ROOT/%{_sysconfdir}/susemanager-release
 fi
 install -d $RPM_BUILD_ROOT/%{_datadir}/spacewalk/setup/defaults.d
 for i in ${RDBMS} ; do


### PR DESCRIPTION
## What does this PR change?

Add MU/Milestone information to `/etc/susemanager-release`

The information about the Uyuni version is removed, as anyway we provide `/etc/uyuni-release` and that tells from what on what Uyuni version we branched the major SUSE Manager version.

This removes the need to call hacky commands to parse the information present at `rhn_web.conf`, and allows easily checking the version from CLI, not just from UI.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: I did not find any mentions to `susemanager-release` at the doc.

- [x] **DONE**

## Test coverage
- No tests: This just adjust the release files, and we didn't have tests for this.

- [x] **DONE**

## Links

None, but I got this idea from questions at the SUSE Manager mailing list

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
