### PR TITLE
Fix parsing error when showing notification message details

### DIFF
--- a/web/html/src/manager/notifications/notification-messages.tsx
+++ b/web/html/src/manager/notifications/notification-messages.tsx
@@ -351,9 +351,22 @@ class NotificationMessages extends React.Component<Props, State> {
     return escapeHtml(summary);
   };
 
+  /**
+   * Sometimes, in reposync failed messages, the details text may contain an email address
+   * enclosed within angle brackets, like this: <linux-bugs@nvidia.com>. In such cases,
+   * this email address is mistakenly interpreted as an HTML tag, which causes issues when
+   * parsing it into React elements. To resolve this problem, the following function replaces
+   * the angle brackets with parentheses in such cases.
+   * See bsc#1211469
+   */
+  replaceInvalidEmailTag = (text) => {
+    const regex = /<([^\s<>]+@[^\s<>]+)>/;
+    return regex.test(text) ? text.replace(regex, "($1)") : text;
+  };
+
   buildPopupDetails = () => {
     const details = (this.state.popupItem || {}).details || "";
-    return escapeHtml(details);
+    return escapeHtml(this.replaceInvalidEmailTag(details));
   };
 
   retryOnboarding = (minionId) => {

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix parsing error when showing notification message details (bsc#1211469)
 - Fix spelling on monitoring-admin page.
 - force all mandatory channels being selected in software channel
   change page (bsc#1211062)


### PR DESCRIPTION
## What does this PR change?

Sometimes, in reposync failed messages, the details text may contain an email address enclosed within angle brackets, like this: `<linux-bugs@nvidia.com>`. In such cases, this email address is mistakenly interpreted as an HTML tag, which causes issues when parsing it into React elements. To resolve this problem, this PR replaces the angle brackets with parentheses in such cases.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/21510

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
