### PR TITLE
QE: Adapt custom reposync to expected default behavour on uyuni

### DIFF
--- a/testsuite/features/secondary/min_project_lotus.feature
+++ b/testsuite/features/secondary/min_project_lotus.feature
@@ -45,8 +45,8 @@ Feature: Project Lotus
     And I follow "Custom Channel for SLES15SP4 PTFs"
     And I follow "Repositories" in the content area
     And I follow "Sync"
-    And I click on "Sync Now"
-    Then I should see a "Repository sync scheduled" text
+    # no need to click on "Sync Now" as it's automatically enabled by default on Uyuni
+    Then I should see a "Repository sync is running" text
 
   Scenario: Pre-requisite: Wait for reposync to finish
     Then I wait until all spacewalk-repo-sync finished


### PR DESCRIPTION
## What does this PR change?
Uyuni/ Head (and SUSE Manager 5.0) are expected to sync custom repos automatically by default, so test steps have been adapted to account for that.

## Links

Fixes https://github.com/SUSE/spacewalk/issues/21426 and https://github.com/SUSE/spacewalk/issues/21518
No ports needed.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
