### PR TITLE
Fixes for bsc#1207550

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1456,7 +1456,7 @@ When(/^I run spacewalk-hostname-rename command on the server$/) do
   command = "spacewalk-hostname-rename #{$server.public_ip}
             --ssl-country=DE --ssl-state=Bayern --ssl-city=Nuremberg
             --ssl-org=SUSE --ssl-orgunit=SUSE --ssl-email=galaxy-noise@suse.de
-            --ssl-ca-password=spacewalk -u admin -p admin"
+            --ssl-ca-password=spacewalk"
   out_spacewalk, result_code = temp_server.run(command, check_errors: false, timeout: 10)
   log "#{out_spacewalk}"
 

--- a/utils/spacewalk-hostname-rename
+++ b/utils/spacewalk-hostname-rename
@@ -435,7 +435,7 @@ function refresh_pillar {
         then
             SIDS="$SIDS,$ID"
         else
-            SIDS="$SID"
+            SIDS="$ID"
         fi
     done
     SKIPPED=`spacecmd -q api system.refreshPillar -- -A "[\\\\\"general\\\\\",[$SIDS]]"`

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+* spacewalk-hostname-rename remains stuck at refreshing pillars (bsc#1207550)
+
 -------------------------------------------------------------------
 Wed Apr 19 12:58:26 CEST 2023 - marina.latini@suse.com
 


### PR DESCRIPTION
## What does this PR change?

* test suite fix: `spacewalk-hostname-rename` does not have `-u` and `-p` parameters
* product fix: wrong name for loop variable in function `refresh_pillar()` of script `spacewalk-hostname-rename`


## Links

Ports:
* 4.3: https://github.com/SUSE/spacewalk/pull/21531
* 4.2: https://github.com/SUSE/spacewalk/pull/21534
