### PR TITLE
Testsuite: Re-enable and adapt allcli_software_channels_dependencies feature

### DIFF
--- a/testsuite/features/secondary/allcli_software_channels_dependencies.feature
+++ b/testsuite/features/secondary/allcli_software_channels_dependencies.feature
@@ -1,9 +1,5 @@
-# Copyright (c) 2018-2022 SUSE LLC
+# Copyright (c) 2018-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
-#
-# TODO
-# This feature test is currently disabled
-# It has to be rewritten using fake packages (orion-dummy etc) instead of real synched packages
 
 @scope_changing_software_channels
 Feature: Channel subscription with recommended or required dependencies
@@ -17,18 +13,18 @@ Feature: Channel subscription with recommended or required dependencies
     And I follow "Software Channels" in the content area
     # check that the required channel by the base one is selected and disabled
     And I wait until I do not see "Loading..." text
-    And I check radio button "SLE-Product-SLES15-SP3-Pool for x86_64"
+    And I check radio button "SLE-Product-SLES15-SP4-Pool for x86_64"
     And I wait until I do not see "Loading..." text
-    Then I should see the child channel "SLE-Product-SLES15-SP3-Updates for x86_64" "selected" and "disabled"
+    Then I should see the child channel "SLE-Product-SLES15-SP4-Updates for x86_64" "selected" and "disabled"
     And I should see the toggler "disabled"
-    And I should see a "SLE-Module-Basesystem15-SP3-Pool for x86_64" text
-    And I should see the child channel "SLE-Module-Basesystem15-SP3-Pool for x86_64" "unselected"
+    And I should see a "SLE-Module-Basesystem15-SP4-Pool for x86_64" text
+    And I should see the child channel "SLE-Module-Basesystem15-SP4-Pool for x86_64" "unselected"
     # check the a child channel selection that requires some channel trigger the selection of it
-    When I select the child channel "SLE-Module-Basesystem15-SP3-Updates for x86_64"
-    Then I should see the child channel "SLE-Module-Basesystem15-SP3-Pool for x86_64" "selected"
+    When I select the child channel "SLE-Module-Basesystem15-SP4-Updates for x86_64"
+    Then I should see the child channel "SLE-Module-Basesystem15-SP4-Pool for x86_64" "selected"
     # check a recommended channel not yet selected is checked  by the recommended toggler
     When I click on the "disabled" toggler
-    Then I should see the child channel "SLE-Module-Server-Applications15-SP3-Pool for x86_64" "selected"
+    Then I should see the child channel "SLE-Module-Server-Applications15-SP4-Pool for x86_64" "selected"
 
   Scenario: Play with recommended and required child channels selection in SSM
     When I follow the left menu "Systems > System List > All"
@@ -42,11 +38,11 @@ Feature: Channel subscription with recommended or required dependencies
     When I select "System Default Base Channel" from drop-down in table line with "Fake-RPM-SUSE-Channel"
     And I click on "Next"
     Then I should see the toggler "disabled"
-    And I should see a "SLE-Module-Basesystem15-SP3-Pool for x86_64" text
-    And I should see "No change" "selected" for the "SLE-Module-Basesystem15-SP3-Pool for x86_64" channel
+    And I should see a "SLE-Module-Basesystem15-SP4-Pool for x86_64" text
+    And I should see "No change" "selected" for the "SLE-Module-Basesystem15-SP4-Pool for x86_64" channel
     When I click on the "disabled" toggler
-    Then I should see "Subscribe" "selected" for the "SLE-Module-Basesystem15-SP3-Pool for x86_64" channel
-    And I should see "No change" "unselected" for the "SLE-Module-Basesystem15-SP3-Pool for x86_64" channel
+    Then I should see "Subscribe" "selected" for the "SLE-Module-Basesystem15-SP4-Pool for x86_64" channel
+    And I should see "No change" "unselected" for the "SLE-Module-Basesystem15-SP4-Pool for x86_64" channel
 
   Scenario: Cleanup: remove remaining systems from SSM after software channel tests
     When I click on the clear SSM button

--- a/testsuite/features/secondary/allcli_software_channels_dependencies.feature
+++ b/testsuite/features/secondary/allcli_software_channels_dependencies.feature
@@ -16,12 +16,13 @@ Feature: Channel subscription with recommended or required dependencies
     And I check radio button "SLE-Product-SLES15-SP4-Pool for x86_64"
     And I wait until I do not see "Loading..." text
     Then I should see the child channel "SLE-Product-SLES15-SP4-Updates for x86_64" "selected" and "disabled"
-    And I should see the toggler "disabled"
-    And I should see a "SLE-Module-Basesystem15-SP4-Pool for x86_64" text
-    And I should see the child channel "SLE-Module-Basesystem15-SP4-Pool for x86_64" "unselected"
+    When I exclude the recommended child channels
+    Then I should see the toggler "disabled"
+    And I should see a "SLE-Module-Containers15-SP4-Pool for x86_64" text
+    And I should see the child channel "SLE-Module-Containers15-SP4-Pool for x86_64" "unselected"
     # check the a child channel selection that requires some channel trigger the selection of it
-    When I select the child channel "SLE-Module-Basesystem15-SP4-Updates for x86_64"
-    Then I should see the child channel "SLE-Module-Basesystem15-SP4-Pool for x86_64" "selected"
+    When I select the child channel "SLE-Module-Containers15-SP4-Pool for x86_64"
+    Then I should see the child channel "SLE-Module-Containers15-SP4-Pool for x86_64" "selected"
     # check a recommended channel not yet selected is checked  by the recommended toggler
     When I click on the "disabled" toggler
     Then I should see the child channel "SLE-Module-Server-Applications15-SP4-Pool for x86_64" "selected"
@@ -34,8 +35,8 @@ Feature: Channel subscription with recommended or required dependencies
     And I follow "channel memberships" in the content area
     Then I should see a "Base Channel" text
     And I should see a "Next" text
-    And I should see a table line with "Fake-RPM-SUSE-Channel", "1"
-    When I select "System Default Base Channel" from drop-down in table line with "Fake-RPM-SUSE-Channel"
+    And I should see a table line with "SLE-Product-SLES15-SP4-Pool for x86_64", "1"
+    When I select "System Default Base Channel" from drop-down in table line with "SLE-Product-SLES15-SP4-Pool for x86_64"
     And I click on "Next"
     Then I should see the toggler "disabled"
     And I should see a "SLE-Module-Basesystem15-SP4-Pool for x86_64" text

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -43,8 +43,7 @@
 - features/secondary/allcli_system_group.feature
 - features/secondary/allcli_config_channel.feature
 - features/secondary/allcli_software_channels.feature
-# tests to be rewritten using the "dummy" packages instead of real synced packages
-# - features/secondary/allcli_software_channels_dependencies.feature
+- features/secondary/allcli_software_channels_dependencies.feature
 
 - features/secondary/min_rhlike_salt_install_package_and_patch.feature
 - features/secondary/min_rhlike_monitoring.feature


### PR DESCRIPTION
## What does this PR change?
This feature was disabled  since the associated repositories were not necessarily synced (https://github.com/uyuni-project/uyuni/pull/1767).
Now that they are systematically synced, this feature can be re-enabled after being adapted with the right channels.

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were added
- [x] **DONE**

## Links
Tracks # 
4.2 https://github.com/SUSE/spacewalk/pull/21556
4.3 https://github.com/SUSE/spacewalk/pull/21555
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
