### PR TITLE
systemctl is-active does not always return "inactive" if inactive

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -248,14 +248,16 @@ When(/^I apply highstate on "([^"]*)"$/) do |host|
   $server.run_until_ok("#{cmd} #{system_name} state.highstate")
 end
 
-When(/^I wait until "([^"]*)" service is (active|inactive) on "([^"]*)"$/) do |service, status, host|
+When(/^I wait until "([^"]*)" service is active on "([^"]*)"$/) do |service, host|
   node = get_target(host)
   cmd = "systemctl is-active #{service}"
-  repeat_until_timeout do
-    out, _err, _code = node.run(cmd, check_errors: false, separated_results: true)
-    break if out.strip == status
-    sleep 2
-  end
+  node.run_until_ok(cmd)
+end
+
+When(/^I wait until "([^"]*)" service is inactive on "([^"]*)"$/) do |service, host|
+  node = get_target(host)
+  cmd = "systemctl is-active #{service}"
+  node.run_until_fail(cmd)
 end
 
 When(/^I wait until "([^"]*)" exporter service is active on "([^"]*)"$/) do |service, host|


### PR DESCRIPTION
## What does this PR change?

This PR works around this bug https://bugzilla.redhat.com/show_bug.cgi?id=1073481
```
[root@suma-42-min-centos7 ~]# systemctl show venv-salt-minion.service -p ActiveState
ActiveState=inactive
[root@suma-42-min-centos7 ~]# systemctl is-active venv-salt-minion 
unknown
```

--> we can't test for `systemctl is-active` to return `inactive` when the service is inactive.


## Links

Ports:
* 4.2: https://github.com/SUSE/spacewalk/pull/21554
* 4.3: https://github.com/SUSE/spacewalk/pull/21553


## Changelogs

- [x] No changelog needed
