### PR TITLE
Prevent product installation from being executed before executing product migration

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/init.sls
@@ -155,6 +155,9 @@ mgrchannels_install_products:
 {%- else %}
       - mgrcompat: sync_states
 {%- endif %}
+{%- if salt['pillar.get']('susemanager:distupgrade', False) %}
+      - mgrcompat: spmigration
+{%- endif %}
 {%- endif %}
 {%- endif %}
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Prevent product installation from being executed before executing product migration (bsc#1210475)
 - Include automatic migration from Salt 3000 to Salt Bundle in highstate
 - fix duplicate packages in state
 - Fix enabling bundle build via custom info


### PR DESCRIPTION
## What does this PR change?

This merge request addresses an issue where, during the creation of a product migration, a new product was being installed before the product migration was executed. This led to a cascading upgrade of other products that the newly added product depends on.

In certain cases, when the client has LTSS (Long Term Service Support) product installed, this cascading upgrade will fail although the real product migration actually worked. The side effect of this is to have a successfully product migration being marked as Failed in the UI because of problems in product installation.

The changes in this pull request aim to prevent the Salt state responsible for product installation from being executed before the actual product migration. This ensures that the product migration takes place first, allowing for a smooth upgrade process without triggering unnecessary cascading upgrades or causing conflicts when removing certain dependencies. By doing so, we mitigate the issues caused by unintended cascading upgrades and avoid potential conflicts with LTSS removal during the migration process.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bug fix

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/21161

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
