### PR TITLE
Fix low contrast texts in Login page

### DIFF
--- a/web/html/src/branding/css/uyuni/legacy-variables.less
+++ b/web/html/src/branding/css/uyuni/legacy-variables.less
@@ -4,8 +4,10 @@
 @green-dark:             #02A49C;
 @green:                  #00C081;
 @green-light:            #02D35F;
+@green-light-1:          #00D18B;
 @gray-dark:              #5F5F5F;
 @gray-dark-1:            #777777;
+@gray-dark-2:            #B8B8B8;
 @gray:                   #A7A9AC;
 @gray-light:             #DCDDDE;
 @gray-light-2:           #EBEBEB;

--- a/web/html/src/branding/css/uyuni/login.less
+++ b/web/html/src/branding/css/uyuni/login.less
@@ -33,7 +33,7 @@ body.login-page {
     font-size: 32px
   }
   .btn-dark {
-    color: @green;
+    color: @green-light-1;
     border: 1px solid @green;
     display: inline-block;
     text-decoration: none;
@@ -109,7 +109,7 @@ body.login-page {
     position: fixed;
     padding-bottom: 1em;
     padding-left: 0;
-    color: @gray;
+    color: @gray-dark-2;
     div.wrapper {
       background-size: auto 35px;
       min-height: 35px;


### PR DESCRIPTION
## What does this PR change?

**This PR fixes an accessibility issue on the login page. Previously, some texts on the page had very low contrast making them hard to read. This PR lands a fix for those texts**

## GUI diff

No difference.

Before:
<img width="203" alt="before-footer" src="https://github.com/uyuni-project/uyuni/assets/48498778/12190e3f-110a-42f8-8f33-9fec1d0a0bca">
<img width="119" alt="before-button" src="https://github.com/uyuni-project/uyuni/assets/48498778/c6cb5b79-d52d-4f90-86ff-fa1d686dca07">
After:
![now-footer](https://github.com/uyuni-project/uyuni/assets/48498778/110c7383-9904-4726-89a2-6c9be1450f8e)
![now-button](https://github.com/uyuni-project/uyuni/assets/48498778/16d27b37-7b76-4946-bf04-465364f4b37c)
- [x] **DONE**

## Documentation
- No documentation needed: **This is a change in the shade of the color of some tets and so does not require documentation**

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes #6776 

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
