### PR TITLE
QE: View as list the Grafana dashboards to assure they are not collapsed in General folder

### DIFF
--- a/testsuite/features/build_validation/init_clients/monitoring_server.feature
+++ b/testsuite/features/build_validation/init_clients/monitoring_server.feature
@@ -88,6 +88,7 @@ Feature: Bootstrap the monitoring server
   Scenario: Test Grafana dashboards of monitoring server
     When I visit the grafana dashboards of this "monitoring_server"
     And I wait until I do not see "Loading Grafana" text
+    And I click on "View as list"
     # These are the 4 dashboards created by default when enabling the Grafana formula
     Then I should see a "Apache2" text
     And I should see a "PostgreSQL database insights" text

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -97,6 +97,8 @@ Selenium::WebDriver.logger.level = :error unless $debug_mode
 Capybara.default_driver = :headless_chrome
 Capybara.javascript_driver = :headless_chrome
 Capybara.default_normalize_ws = true
+Capybara.enable_aria_label = true
+Capybara.automatic_label_click = true
 Capybara.app_host = "https://#{server}"
 Capybara.server_port = 8888 + ENV['TEST_ENV_NUMBER'].to_i
 STDOUT.puts "Capybara APP Host: #{Capybara.app_host}:#{Capybara.server_port}"


### PR DESCRIPTION
## What does this PR change?

Grafana dashboards are now included inside a folder named "General".
This folder is collapsed by default, but a cookie will keep it expanded if we click on it previously.
To avoid unnecessary idempotency issues, this commit will change the view of the dashboards as a list, where we will have always all visible.

Additionally, this PR enables two general flags of Capybara, that will allow to find a button not only by our default fields (text, id, test_id, value, and so on) but also by label and by arial-label.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage

- Cucumber tests were refactored

- [x] **DONE**

## Links

Ports:

- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
