### PR TITLE
Pass password to spacewalk-hostname-rename command

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1455,7 +1455,8 @@ end
 When(/^I run spacewalk-hostname-rename command on the server$/) do
   temp_server = twopence_init("ssh:#{$server.public_ip}")
   temp_server.extend(LavandaBasic)
-  command = "spacewalk-hostname-rename #{$server.public_ip}
+  command = "spacecmd -q api api.getVersion -u admin -p admin;
+             spacewalk-hostname-rename #{$server.public_ip}
             --ssl-country=DE --ssl-state=Bayern --ssl-city=Nuremberg
             --ssl-org=SUSE --ssl-orgunit=SUSE --ssl-email=galaxy-noise@suse.de
             --ssl-ca-password=spacewalk"


### PR DESCRIPTION
## What does this PR change?

This PR provides the username and the password that are needed now that `spacewalk-hostname-rename` calls `spacecmd` to refresh the pillars.


## Links

Ports:
* 4.2: SUSE/spacewalk#21582
* 4.3: SUSE/spacewalk#21581


## Changelogs

- [x] No changelog needed
