### PR TITLE
QE: BV Add checker for loading text

### DIFF
--- a/testsuite/features/build_validation/add_non_MU_repositories/alma9_minion_build_clm.feature
+++ b/testsuite/features/build_validation/add_non_MU_repositories/alma9_minion_build_clm.feature
@@ -23,6 +23,7 @@ Feature: Add the Alma 9 distribution custom repositories
     And I click on "Create"
     Then I should see a "Content Lifecycle Project - Remove AppStream metadata from Alma 9" text
     When I click on "Attach/Detach Sources"
+    And I wait until I do not see "Loading" text
     And I select "almalinux9 for x86_64" from "selectedBaseChannel"
     # "almalinux9-appstream for x86_64" is already checked
     And I check "Custom Channel for alma9_minion"

--- a/testsuite/features/build_validation/add_non_MU_repositories/liberty9_minion_build_clm.feature
+++ b/testsuite/features/build_validation/add_non_MU_repositories/liberty9_minion_build_clm.feature
@@ -23,6 +23,7 @@ Feature: Add the Liberty Linux 9 distribution custom repositories
     And I click on "Create"
     Then I should see a "Content Lifecycle Project - Remove AppStream metadata from Liberty Linux 9" text
     When I click on "Attach/Detach Sources"
+    And I wait until I do not see "Loading" text
     And I select "EL9-Pool for x86_64" from "selectedBaseChannel"
     And I check "SLL-9-Updates for x86_64"
     And I check "SLL-AS-9-Updates for x86_64"

--- a/testsuite/features/build_validation/add_non_MU_repositories/oracle9_minion_build_clm.feature
+++ b/testsuite/features/build_validation/add_non_MU_repositories/oracle9_minion_build_clm.feature
@@ -23,6 +23,7 @@ Feature: Add the Oracle 9 distribution custom repositories
     And I click on "Create"
     Then I should see a "Content Lifecycle Project - Remove AppStream metadata from Oracle 9" text
     When I click on "Attach/Detach Sources"
+    And I wait until I do not see "Loading" text
     And I select "oraclelinux9 for x86_64" from "selectedBaseChannel"
     # "oraclelinux9-appstream for x86_64" is already checked
     And I check "Custom Channel for oracle9_minion"

--- a/testsuite/features/build_validation/add_non_MU_repositories/rocky8_minion_add_iso_and_build_clm.feature
+++ b/testsuite/features/build_validation/add_non_MU_repositories/rocky8_minion_add_iso_and_build_clm.feature
@@ -74,6 +74,7 @@ Feature: Add the Rocky 8 distribution custom repositories
     And I click on "Create"
     Then I should see a "Content Lifecycle Project - Remove AppStream metadata from Rocky 8" text
     When I click on "Attach/Detach Sources"
+    And I wait until I do not see "Loading" text
     And I select "RHEL8-Pool for x86_64" from "selectedBaseChannel"
     And I check "Custom Channel for Rocky 8 DVD"
     And I check "RES-AS-8-Updates for x86_64"

--- a/testsuite/features/build_validation/add_non_MU_repositories/rocky9_minion_build_clm.feature
+++ b/testsuite/features/build_validation/add_non_MU_repositories/rocky9_minion_build_clm.feature
@@ -23,6 +23,7 @@ Feature: Add the Rocky 9 distribution custom repositories
     And I click on "Create"
     Then I should see a "Content Lifecycle Project - Remove AppStream metadata from Rocky 9" text
     When I click on "Attach/Detach Sources"
+    And I wait until I do not see "Loading" text
     And I select "rockylinux-9 for x86_64" from "selectedBaseChannel"
     # "rockylinux-9-appstream for x86_64" is already checked
     And I check "Custom Channel for rocky9_minion"


### PR DESCRIPTION
## What does this PR change?

This adds a small step to check if the text `Loading...` is not present. Otherwise we run into the following issues because the loading screen is still there.
<img width="1109" alt="image" src="https://github.com/uyuni-project/uyuni/assets/12104291/880f3e85-75cc-47fc-8485-76a0e77f7a88">
<img width="1109" alt="image" src="https://github.com/uyuni-project/uyuni/assets/12104291/5622bcf3-b899-4333-b0f0-d00cab02f268">



## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage

- Cucumber tests were adjusted

- [x] **DONE**

## Links

- Manager 4.3: https://github.com/SUSE/spacewalk/pull/21583
- Manager 4.2: https://github.com/SUSE/spacewalk/pull/21584
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
