### PR TITLE
Fix layout alignment on pages showing failed states logs (bsc#1211713)

### DIFF
--- a/web/html/src/branding/css/base/theme.less
+++ b/web/html/src/branding/css/base/theme.less
@@ -4,11 +4,13 @@
 
 html,
 body {
-  height: 100%;
   min-height: 100%;
-  min-width: fit-content;
-  margin: 0;
+  height: 100%;
   max-height: 100%;
+  min-width: 100%;
+  width: fit-content;
+  max-width: 100%;
+  margin: 0;
   overflow: hidden;
 }
 

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix layout alignment on pages showing failed states logs (bsc#1211713)
 - Fix parsing error when showing notification message details (bsc#1211469)
 - Fix spelling on monitoring-admin page.
 - force all mandatory channels being selected in software channel


### PR DESCRIPTION
## What does this PR change?

Fix page layout blowing out of proportion on pages with logs that have long unwrappable lines.

## GUI diff

Bugfix.

Before:

<img width="2048" alt="Screenshot 2023-05-25 at 14 31 06" src="https://github.com/uyuni-project/uyuni/assets/3171718/535c852d-236a-4e42-bdd2-b361113d396b">


After:

<img width="2048" alt="Screenshot 2023-05-25 at 14 31 13" src="https://github.com/uyuni-project/uyuni/assets/3171718/58aa0247-edec-4ffa-bb7e-00934af3decc">


- [x] **DONE**

## Documentation
- No documentation needed: Bugfix.

- [x] **DONE**

## Test coverage
- No tests: Bugfix.

- [x] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1211713

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
