### PR TITLE
Used synced_date instead of current_timestamp in the SystemInactivityReport

### DIFF
--- a/schema/reportdb/common/views/SystemInactivityReport.sql
+++ b/schema/reportdb/common/views/SystemInactivityReport.sql
@@ -15,7 +15,7 @@ CREATE OR REPLACE VIEW SystemInactivityReport AS
             , profile_name AS system_name
             , organization
             , last_checkin_time
-            , (current_timestamp - last_checkin_time) AS inactivity
+            , (synced_date - last_checkin_time) AS inactivity
             , synced_date
     FROM system
 ORDER BY mgm_id, system_id, organization

--- a/schema/reportdb/upgrade/uyuni-reportdb-schema-4.4.3-to-uyuni-reportdb-schema-4.4.4/01-fix-system-inactivity-report.sql
+++ b/schema/reportdb/upgrade/uyuni-reportdb-schema-4.4.3-to-uyuni-reportdb-schema-4.4.4/01-fix-system-inactivity-report.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE VIEW SystemInactivityReport AS
+  SELECT mgm_id
+            , system_id
+            , profile_name AS system_name
+            , organization
+            , last_checkin_time
+            , (synced_date - last_checkin_time) AS inactivity
+            , synced_date
+    FROM system
+ORDER BY mgm_id, system_id, organization
+;

--- a/schema/reportdb/uyuni-reportdb-schema.changes
+++ b/schema/reportdb/uyuni-reportdb-schema.changes
@@ -1,3 +1,5 @@
+- Use synced_date to compute the inactivity period to correctly
+  describe when reporting database was updated (bsc#1211621)
 -------------------------------------------------------------------
 Wed Apr 19 12:54:31 CEST 2023 - marina.latini@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR changes the view `SystemInactivityReport` of the reporting database to use the `synced_date` column instead of the `current_timestamp` to compute the inactivity. This change is required to make sure the inactive period of a system is correctly calculated at the time of the reporting database synchronization and never changes when extracting the report at different times.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: bugfix of an existing document feature

- [X] **DONE**

## Test coverage
- No tests: non breaking change in the SQL view definition

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/21558
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
