### PR TITLE
Can't use SSL before the new certificate is created

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1455,11 +1455,11 @@ end
 When(/^I run spacewalk-hostname-rename command on the server$/) do
   temp_server = twopence_init("ssh:#{$server.public_ip}")
   temp_server.extend(LavandaBasic)
-  command = "spacecmd -q api api.getVersion -u admin -p admin;
-             spacewalk-hostname-rename #{$server.public_ip}
-            --ssl-country=DE --ssl-state=Bayern --ssl-city=Nuremberg
-            --ssl-org=SUSE --ssl-orgunit=SUSE --ssl-email=galaxy-noise@suse.de
-            --ssl-ca-password=spacewalk"
+  command = "spacecmd --nossl -q api api.getVersion -u admin -p admin; " \
+            "spacewalk-hostname-rename #{$server.public_ip} " \
+            "--ssl-country=DE --ssl-state=Bayern --ssl-city=Nuremberg " \
+            "--ssl-org=SUSE --ssl-orgunit=SUSE --ssl-email=galaxy-noise@suse.de " \
+            "--ssl-ca-password=spacewalk"
   out_spacewalk, result_code = temp_server.run(command, check_errors: false, timeout: 10)
   log "#{out_spacewalk}"
 


### PR DESCRIPTION
## What does this PR change?

We need to call `spacecmd` a first time to pass the API credentials before we call `spacewalk-hostname-rename`. But at this point the new SSL certificate is not created yet, so we need option `--nossl`.


## Links

Ports:
 * 4.2: https://github.com/SUSE/spacewalk/pull/21599
 * 4.3: https://github.com/SUSE/spacewalk/pull/21598


## Changelogs

- [x] No changelog needed
