### PR TITLE
Disable jinja processing for the roster file

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Disable jinja processing for the roster file (bsc#1211650)
 - Make sure that all hibernate connections are closed (bsc#1208687)
 - Add option to disable SSL
 - Removed the expensive 'diff' column (bsc#1208427)


### PR DESCRIPTION
## What does this PR change?

This PR escapes the roster with the tags  `{% raw %}` and `{% endraw %}` to [disable jinja processing](https://jinja.palletsprojects.com/en/3.1.x/templates/#escaping). This escaping is needed to prevent the processing of special character sequences like `{{` that might be contained in the password. This also forbids the user to inject a template from the UI fields.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Unit tests: code is not easily testable, work in progress.

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/21585

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
