### PR TITLE
CI: Acceptance tests at PR v2: skip apply highstate tests

### DIFF
--- a/testsuite/features/secondary/min_salt_formulas.feature
+++ b/testsuite/features/secondary/min_salt_formulas.feature
@@ -1,6 +1,7 @@
 # Copyright (c) 2017-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@skip_if_container
 @scope_formulas
 Feature: Use salt formulas
   In order to use simple forms to apply changes to minions

--- a/testsuite/features/secondary/min_salt_user_states.feature
+++ b/testsuite/features/secondary/min_salt_user_states.feature
@@ -1,6 +1,7 @@
 # Copyright (c) 2018-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@skip_if_container
 @scope_salt
 Feature: Coexistence with user-defined states
 


### PR DESCRIPTION
## What does this PR change?

These tests fail because timectl returns an error:

timedatectl failed: System has not been booted with systemd as init system (PID 1). Can't operate.
Failed to connect to bus: Host is down

Let's skip them.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests
- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20959

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
