### PR TITLE
Correctly handle result_folder variable when calling index.js

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -176,7 +176,7 @@ namespace :utils do
     sh 'rm -rf ./cucumber_report && mkdir cucumber_report', verbose: false
     sh "timeout 180 bash -c -- \"while find #{result_folder}/output*.json -type f -size 0 | grep json; do sleep 10;done\" ; exit 0", verbose: false
     sh 'find . -size 0 -delete', verbose: false
-    sh 'node index.js #{result_folder} &> cucumber_reporter.log', verbose: false
+    sh "node index.js #{result_folder} &> cucumber_reporter.log", verbose: false
     sh "cp cucumber_report/cucumber_report.html #{result_folder}"
   end
 end


### PR DESCRIPTION
## What does this PR change?
Fix issue when calling index.js to generate cucumber report. The result_folder variable was not correctly recognize.


- [x] No changelog needed
