### PR TITLE
QE: Fix deletion of images

### DIFF
--- a/testsuite/features/secondary/buildhost_docker_build_image.feature
+++ b/testsuite/features/secondary/buildhost_docker_build_image.feature
@@ -134,9 +134,11 @@ Feature: Build container images
 
   Scenario: Cleanup: delete all images
     Given I am authorized as "admin" with password "admin"
-    When I delete the image "suse_key" with version "Latest" via API calls
-    And I delete the image "suse_simple" with version "Latest_simple" via API calls
+    When I delete the image "suse_key" with version "latest" via API calls
     And I delete the image "suse_key" with version "Latest_key-activation1" via API calls
+    And I delete the image "suse_simple" with version "latest" via API calls
+    And I delete the image "suse_simple" with version "Latest_simple" via API calls
+    And I delete the image "suse_real_key" with version "latest" via API calls
     And I delete the image "suse_real_key" with version "GUI_BUILT_IMAGE" via API calls
     And I delete the image "suse_real_key" with version "GUI_DOCKERADMIN" via API calls
 


### PR DESCRIPTION
## What does this PR change?

The image deletion cleanup wasn't deleting all the images - made sure all the versions were contemplated in the deletion step.

## Links

- 4.2 https://github.com/SUSE/spacewalk/pull/21651
- 4.3 https://github.com/SUSE/spacewalk/pull/21650
- Part of https://github.com/SUSE/spacewalk/issues/21381

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
