### PR TITLE
Refactoring the step to cleanup salt minion left-overs

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -498,18 +498,23 @@ end
 
 When(/^I perform a full salt minion cleanup on "([^"]*)"$/) do |host|
   node = get_target(host)
-  pkgs = $use_salt_bundle ? "venv-salt-minion" : "salt salt-minion"
-  if rh_host?(host)
-    node.run("yum -y remove --setopt=clean_requirements_on_remove=1 #{pkgs}", check_errors: false)
-  elsif deb_host?(host)
-    pkgs = "salt-common salt-minion" if $product != 'Uyuni'
-    node.run("apt-get --assume-yes remove #{pkgs} && apt-get --assume-yes purge #{pkgs} && apt-get --assume-yes autoremove", check_errors: false)
-  else
-    node.run("zypper --non-interactive remove --clean-deps -y #{pkgs} spacewalk-proxy-salt", check_errors: false)
-  end
   if $use_salt_bundle
+    if rh_host?(host)
+      node.run("yum -y remove --setopt=clean_requirements_on_remove=1 venv-salt-minion", check_errors: false)
+    elsif deb_host?(host)
+      node.run("apt-get --assume-yes remove venv-salt-minion && apt-get --assume-yes purge venv-salt-minion && apt-get --assume-yes autoremove", check_errors: false)
+    else
+      node.run("zypper --non-interactive remove --clean-deps -y venv-salt-minion", check_errors: false)
+    end
     node.run('rm -Rf /root/salt /var/cache/venv-salt-minion /run/venv-salt-minion /var/venv-salt-minion.log /etc/venv-salt-minion /var/tmp/.root*', check_errors: false)
   else
+    if rh_host?(host)
+      node.run("yum -y remove --setopt=clean_requirements_on_remove=1 salt salt-minion", check_errors: false)
+    elsif deb_host?(host)
+      node.run("apt-get --assume-yes remove salt-common salt-minion && apt-get --assume-yes purge salt-common salt-minion && apt-get --assume-yes autoremove", check_errors: false)
+    else
+      node.run("zypper --non-interactive remove --clean-deps -y salt salt-minion", check_errors: false)
+    end
     node.run('rm -Rf /root/salt /var/cache/salt/minion /var/run/salt /run/salt /var/log/salt /etc/salt /var/tmp/.root*', check_errors: false)
   end
   step %(I disable the repositories "tools_update_repo tools_pool_repo" on this "#{host}" without error control)


### PR DESCRIPTION
## What does this PR change?

Refactoring the step to cleanup salt minion left-overs.

- I removed spacewalk-proxy-salt from the packages to remove, until we have a good reason to remove it. I don't find the reason we were doing it in all the minions.
- I fixed the packages we were cleaning in the case of Debian-Like minion in Uyuni
- I re-organized if-statements with the aim to make it easier to read and follow

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage

- Cucumber tests were refactored

- [x] **DONE**

## Links

Ports:
- Manager-4.2
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
