### PR TITLE
Improve ubuntu errata processing

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoJob.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoJob.java
@@ -54,7 +54,7 @@ public class TaskoJob implements Job {
             .withZone(ZoneId.systemDefault());
 
 
-    private Long scheduleId;
+    private final long scheduleId;
 
     static {
         for (TaskoTask task : TaskoFactory.listTasks()) {
@@ -69,8 +69,8 @@ public class TaskoJob implements Job {
      * job is always associated with a schedule
      * @param scheduleIdIn schedule id
      */
-    public TaskoJob(Long scheduleIdIn) {
-        setScheduleId(scheduleIdIn);
+    public TaskoJob(long scheduleIdIn) {
+        this.scheduleId = scheduleIdIn;
     }
 
     private boolean isTaskSingleThreaded(TaskoTask task) {
@@ -253,21 +253,5 @@ public class TaskoJob implements Job {
         }
         log.info("Sending e-mail ... {}", task.getName());
         TaskHelper.sendTaskoEmail(taskRun.getOrgId(), email);
-    }
-
-    /**
-     * setter for scheduleId
-     * @param scheduleIdIn The scheduleId to set.
-     */
-    public void setScheduleId(Long scheduleIdIn) {
-        this.scheduleId = scheduleIdIn;
-    }
-
-    /**
-     * getter for scheduleId
-     * @return Returns the scheduleId.
-     */
-    public Long getScheduleId() {
-        return scheduleId;
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoJob.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoJob.java
@@ -159,8 +159,7 @@ public class TaskoJob implements Job {
         if (!isTaskThreadAvailable(job, task)) {
             int rescheduleSeconds = job.getRescheduleTime();
             log.info("{} RESCHEDULED in {} seconds", schedule.getJobLabel(), rescheduleSeconds);
-            TaskoQuartzHelper.rescheduleJob(schedule,
-                    ZonedDateTime.now().plusSeconds(rescheduleSeconds).toInstant());
+            TaskoQuartzHelper.rescheduleJob(schedule, ZonedDateTime.now().plusSeconds(rescheduleSeconds).toInstant());
             return false;
         }
         return true;
@@ -169,52 +168,61 @@ public class TaskoJob implements Job {
     private TaskoRun runTask(TaskoSchedule schedule, TaskoTask task, TaskoTemplate template,
                              JobExecutionContext context) {
         TaskoRun result = null;
-        if (!isTaskRunning(schedule, task)) {
-            try {
-                Class<RhnJob> jobClass = (Class<RhnJob>) Class.forName(template.getTask().getTaskClass());
-                RhnJob job = jobClass.getDeclaredConstructor().newInstance();
+        if (isTaskRunning(schedule, task)) {
+            return result;
+        }
 
-                if (checkThreadAvailable(schedule, job, task)) {
-                    markTaskRunning(task);
-
-                    try {
-                        log.debug("{}: task {} started", schedule.getJobLabel(), task.getName());
-                        TaskoRun taskRun = new TaskoRun(schedule.getOrgId(), template, scheduleId);
-                        TaskoFactory.save(taskRun);
-                        HibernateFactory.commitTransaction();
-                        HibernateFactory.closeSession();
-                        log.debug("Tasko run for {} created. Running job...", schedule.getJobLabel());
-
-                        doExecute(job, context, taskRun);
-
-                        // rollback everything, what the application changed and didn't committed
-                        if (HibernateFactory.getSession().getTransaction().isActive()) {
-                            HibernateFactory.rollbackTransaction();
-                            HibernateFactory.closeSession();
-                        }
-
-                        if (log.isDebugEnabled()) {
-                            log.debug("{} ({}) ... {}", task.getName(), schedule.getJobLabel(),
-                                    taskRun.getStatus().toLowerCase());
-                        }
-                        if (List.of(TaskoRun.STATUS_FINISHED, TaskoRun.STATUS_FAILED)
-                                .contains(taskRun.getStatus()) &&
-                                !Objects.equals(taskRun.getStatus(), lastStatus.get(task.getName()))) {
-                            sendStatusMail(schedule, taskRun, task);
-                            lastStatus.put(task.getName(), taskRun.getStatus());
-                        }
-                        result = taskRun;
-                    }
-                    finally {
-                        unmarkTaskRunning(task);
-                    }
-                }
+        try {
+            RhnJob job = createJob(template.getTask().getTaskClass());
+            if (!checkThreadAvailable(schedule, job, task)) {
+                return result;
             }
-            catch (Exception e) {
-                log.error(e.getMessage(), e);
+
+            markTaskRunning(task);
+
+            try {
+                log.debug("{}: task {} started", schedule.getJobLabel(), task.getName());
+                TaskoRun taskRun = new TaskoRun(schedule.getOrgId(), template, scheduleId);
+                TaskoFactory.save(taskRun);
+                HibernateFactory.commitTransaction();
+                HibernateFactory.closeSession();
+                log.debug("Tasko run for {} created. Running job...", schedule.getJobLabel());
+
+                doExecute(job, context, taskRun);
+
+                // rollback everything, what the application changed and didn't committed
+                if (HibernateFactory.getSession().getTransaction().isActive()) {
+                    HibernateFactory.rollbackTransaction();
+                    HibernateFactory.closeSession();
+                }
+
+                if (log.isDebugEnabled()) {
+                    log.debug("{} ({}) ... {}", task.getName(), schedule.getJobLabel(),
+                            taskRun.getStatus().toLowerCase());
+                }
+
+                if (List.of(TaskoRun.STATUS_FINISHED, TaskoRun.STATUS_FAILED).contains(taskRun.getStatus()) &&
+                        !Objects.equals(taskRun.getStatus(), lastStatus.get(task.getName()))) {
+                    sendStatusMail(schedule, taskRun, task);
+                    lastStatus.put(task.getName(), taskRun.getStatus());
+                }
+
+                result = taskRun;
+            }
+            finally {
+                unmarkTaskRunning(task);
             }
         }
+        catch (Exception e) {
+            log.error("Unable to run task", e);
+        }
+
         return result;
+    }
+
+    private static RhnJob createJob(String jobClassName) throws ReflectiveOperationException {
+        Class<? extends RhnJob> jobClass = Class.forName(jobClassName).asSubclass(RhnJob.class);
+        return jobClass.getDeclaredConstructor().newInstance();
     }
 
     private void doExecute(RhnJob job, JobExecutionContext context, TaskoRun taskRun) {

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoJob.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoJob.java
@@ -46,9 +46,9 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class TaskoJob implements Job {
 
-    private static Logger log = LogManager.getLogger(TaskoJob.class);
-    private static Map<String, Integer> tasks = new ConcurrentHashMap<>();
-    private static Map<String, Object> lastStatus = new ConcurrentHashMap<>();
+    private static final Logger LOG = LogManager.getLogger(TaskoJob.class);
+    private static final Map<String, Integer> TASKS = new ConcurrentHashMap<>();
+    private static final Map<String, Object> LAST_STATUS = new ConcurrentHashMap<>();
 
     private static final DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss")
             .withZone(ZoneId.systemDefault());
@@ -58,8 +58,8 @@ public class TaskoJob implements Job {
 
     static {
         for (TaskoTask task : TaskoFactory.listTasks()) {
-            tasks.put(task.getName(), 0);
-            lastStatus.put(task.getName(), TaskoRun.STATUS_FINISHED);
+            TASKS.put(task.getName(), 0);
+            LAST_STATUS.put(task.getName(), TaskoRun.STATUS_FINISHED);
         }
         HibernateFactory.closeSession();
     }
@@ -80,29 +80,29 @@ public class TaskoJob implements Job {
         catch (InstantiationException | ClassNotFoundException | IllegalAccessException | NoSuchMethodException |
                InvocationTargetException e) {
             // will be caught later
-            log.error("Error trying to instance a new class of {}: {}", task.getTaskClass(), e.getMessage(), e);
+            LOG.error("Error trying to instance a new class of {}: {}", task.getTaskClass(), e.getMessage(), e);
             return false;
         }
     }
 
     private boolean isTaskRunning(TaskoTask task) {
-        return tasks.get(task.getName()) > 0;
+        return TASKS.get(task.getName()) > 0;
     }
 
     private boolean isTaskThreadAvailable(RhnJob job, TaskoTask task) {
-        return tasks.get(task.getName()) < job.getParallelThreads();
+        return TASKS.get(task.getName()) < job.getParallelThreads();
     }
 
     private static synchronized void markTaskRunning(TaskoTask task) {
-        int count = tasks.get(task.getName());
+        int count = TASKS.get(task.getName());
         count++;
-        tasks.put(task.getName(), count);
+        TASKS.put(task.getName(), count);
     }
 
     private static synchronized void unmarkTaskRunning(TaskoTask task) {
-        int count = tasks.get(task.getName());
+        int count = TASKS.get(task.getName());
         count--;
-        tasks.put(task.getName(), count);
+        TASKS.put(task.getName(), count);
     }
 
     /**
@@ -113,43 +113,43 @@ public class TaskoJob implements Job {
         TaskoSchedule schedule = TaskoFactory.lookupScheduleById(scheduleId);
         if (schedule == null) {
             // means, that schedule was deleted (in the DB), but quartz still schedules it
-            log.error("No such schedule with id  {}", scheduleId);
+            LOG.error("No such schedule with id  {}", scheduleId);
             TaskoQuartzHelper.unscheduleTrigger(context.getTrigger());
             return;
         }
 
         Instant start = Instant.now();
-        log.info("{}: bunch {} STARTED", schedule.getJobLabel(), schedule.getBunch().getName());
+        LOG.info("{}: bunch {} STARTED", schedule.getJobLabel(), schedule.getBunch().getName());
 
         String previousRunStatus = null;
         for (TaskoTemplate template : schedule.getBunch().getTemplates()) {
             // If it's not the first run and the template requires a previous state, check for it
             if (previousRunStatus != null &&
                     template.getStartIf() != null && !template.getStartIf().equals(previousRunStatus)) {
-                log.info("Interrupting {} ({})", schedule.getBunch().getName(), schedule.getJobLabel());
+                LOG.info("Interrupting {} ({})", schedule.getBunch().getName(), schedule.getJobLabel());
                 break;
             }
             TaskoTask task = template.getTask();
             TaskoRun runResult = runTask(schedule, task, template, context);
             if (runResult == null) {
                 // Null result means it was not possible to execute the template. Interrupt the bunch execution
-                log.info("Interrupting {} ({})", schedule.getBunch().getName(), schedule.getJobLabel());
+                LOG.info("Interrupting {} ({})", schedule.getBunch().getName(), schedule.getJobLabel());
                 break;
             }
 
             previousRunStatus = runResult.getStatus();
         }
         HibernateFactory.closeSession();
-        log.info("{}: bunch {} FINISHED", schedule.getJobLabel(), schedule.getBunch().getName());
-        if (log.isDebugEnabled()) {
-            log.debug("{}: bunch {} START: {} END: {}", schedule.getJobLabel(), schedule.getBunch().getName(),
+        LOG.info("{}: bunch {} FINISHED", schedule.getJobLabel(), schedule.getBunch().getName());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("{}: bunch {} START: {} END: {}", schedule.getJobLabel(), schedule.getBunch().getName(),
                     TIMESTAMP_FORMAT.format(start), TIMESTAMP_FORMAT.format(Instant.now()));
         }
     }
 
     private boolean isTaskRunning(TaskoSchedule schedule, TaskoTask task) {
         if (isTaskSingleThreaded(task) && isTaskRunning(task)) {
-            log.debug("{}: task {} already running ... LEAVING", schedule.getJobLabel(), task.getName());
+            LOG.debug("{}: task {} already running ... LEAVING", schedule.getJobLabel(), task.getName());
             return true;
         }
         return false;
@@ -158,7 +158,7 @@ public class TaskoJob implements Job {
     private boolean checkThreadAvailable(TaskoSchedule schedule, RhnJob job, TaskoTask task) throws SchedulerException {
         if (!isTaskThreadAvailable(job, task)) {
             int rescheduleSeconds = job.getRescheduleTime();
-            log.info("{} RESCHEDULED in {} seconds", schedule.getJobLabel(), rescheduleSeconds);
+            LOG.info("{} RESCHEDULED in {} seconds", schedule.getJobLabel(), rescheduleSeconds);
             TaskoQuartzHelper.rescheduleJob(schedule, ZonedDateTime.now().plusSeconds(rescheduleSeconds).toInstant());
             return false;
         }
@@ -181,12 +181,12 @@ public class TaskoJob implements Job {
             markTaskRunning(task);
 
             try {
-                log.debug("{}: task {} started", schedule.getJobLabel(), task.getName());
+                LOG.debug("{}: task {} started", schedule.getJobLabel(), task.getName());
                 TaskoRun taskRun = new TaskoRun(schedule.getOrgId(), template, scheduleId);
                 TaskoFactory.save(taskRun);
                 HibernateFactory.commitTransaction();
                 HibernateFactory.closeSession();
-                log.debug("Tasko run for {} created. Running job...", schedule.getJobLabel());
+                LOG.debug("Tasko run for {} created. Running job...", schedule.getJobLabel());
 
                 doExecute(job, context, taskRun);
 
@@ -196,15 +196,15 @@ public class TaskoJob implements Job {
                     HibernateFactory.closeSession();
                 }
 
-                if (log.isDebugEnabled()) {
-                    log.debug("{} ({}) ... {}", task.getName(), schedule.getJobLabel(),
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("{} ({}) ... {}", task.getName(), schedule.getJobLabel(),
                             taskRun.getStatus().toLowerCase());
                 }
 
                 if (List.of(TaskoRun.STATUS_FINISHED, TaskoRun.STATUS_FAILED).contains(taskRun.getStatus()) &&
-                        !Objects.equals(taskRun.getStatus(), lastStatus.get(task.getName()))) {
+                        !Objects.equals(taskRun.getStatus(), LAST_STATUS.get(task.getName()))) {
                     sendStatusMail(schedule, taskRun, task);
-                    lastStatus.put(task.getName(), taskRun.getStatus());
+                    LAST_STATUS.put(task.getName(), taskRun.getStatus());
                 }
 
                 result = taskRun;
@@ -214,7 +214,7 @@ public class TaskoJob implements Job {
             }
         }
         catch (Exception e) {
-            log.error("Unable to run task", e);
+            LOG.error("Unable to run task", e);
         }
 
         return result;
@@ -251,7 +251,7 @@ public class TaskoJob implements Job {
         else {
             email += " finished successfully and is back to normal.";
         }
-        log.info("Sending e-mail ... {}", task.getName());
+        LOG.info("Sending e-mail ... {}", task.getName());
         TaskHelper.sendTaskoEmail(taskRun.getOrgId(), email);
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoQuartzHelper.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoQuartzHelper.java
@@ -26,6 +26,7 @@ import com.redhat.rhn.frontend.events.TransactionHelper;
 import com.redhat.rhn.taskomatic.core.SchedulerKernel;
 import com.redhat.rhn.taskomatic.domain.TaskoSchedule;
 
+import org.apache.commons.collections.MapUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.quartz.JobBuilder;
@@ -136,39 +137,44 @@ public class TaskoQuartzHelper {
      * start date.
      * @param schedule for the job to be rescheduled
      * @param startAtDate trigger time
+     * @param bunchStartIndex the index of the starting task in the bunch. Different from zero if it was not possible
+     *                        to execute one of the task of the bunch due to missing capacity
      * @return the date of the trigger or null if scheduling was not successful
      * @throws SchedulerException
      */
-    public static Date rescheduleJob(TaskoSchedule schedule, Instant startAtDate) throws SchedulerException {
+    public static Date rescheduleJob(TaskoSchedule schedule, Instant startAtDate, long bunchStartIndex)
+        throws SchedulerException {
         // create trigger
         String timestamp = TIMESTAMP_FORMAT.format(startAtDate);
-        TriggerKey retryTriggerKey = new TriggerKey(schedule.getJobLabel() + "-retry" + timestamp,
-                getGroupName(schedule.getOrgId()));
+        String quartzGroupName = getGroupName(schedule.getOrgId());
+        TriggerKey retryTriggerKey = new TriggerKey(schedule.getJobLabel() + "-retry" + timestamp, quartzGroupName);
+
         Trigger retryTrigger = SchedulerKernel.getScheduler().getTrigger(retryTriggerKey);
         if (retryTrigger != null) {
             log.warn("Retry trigger {} already exists", retryTriggerKey);
             return retryTrigger.getStartTime();
         }
-        Trigger trigger = newTrigger()
-                    .withIdentity(schedule.getJobLabel() +  "-retry" + timestamp, getGroupName(schedule.getOrgId()))
-                    .startAt(Date.from(startAtDate))
-                    .withSchedule(simpleSchedule()
-                            .withMisfireHandlingInstructionFireNow()) // execute job immediately after discovering
-                                                                      // a misfire situation
-                    .forJob(schedule.getJobLabel(), getGroupName(schedule.getOrgId()))
-                    .build();
+
+        Trigger trigger = newTrigger().withIdentity(retryTriggerKey)
+            .startAt(Date.from(startAtDate))
+            // execute job immediately after discovering a misfire situation
+            .withSchedule(simpleSchedule().withMisfireHandlingInstructionFireNow())
+            .forJob(retryTriggerKey.getName(), retryTriggerKey.getGroup())
+            .build();
+
         // create job
-        JobBuilder jobDetail = newJob(TaskoJob.class)
-                .withIdentity(schedule.getJobLabel(),
-                        getGroupName(schedule.getOrgId()));
+        JobBuilder jobDetail = newJob().ofType(TaskoJob.class)
+                                       .withIdentity(retryTriggerKey.getName(), retryTriggerKey.getGroup())
+                                       .usingJobData("schedule_id", schedule.getId())
+                                       .usingJobData("bunch_start_index", bunchStartIndex);
+
         // set job params
-        if (schedule.getDataMap() != null) {
+        if (MapUtils.isNotEmpty(schedule.getDataMap())) {
             jobDetail.usingJobData(new JobDataMap(schedule.getDataMap()));
         }
-        jobDetail.usingJobData("schedule_id", schedule.getId());
 
         // schedule job
-        Date date = SchedulerKernel.getScheduler().scheduleJob(trigger);
+        Date date = SchedulerKernel.getScheduler().scheduleJob(jobDetail.build(), trigger);
         log.info("Job {} rescheduled with trigger {}", schedule.getJobLabel(), trigger.getKey());
         return date;
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/core/RhnJobFactory.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/core/RhnJobFactory.java
@@ -17,6 +17,7 @@ package com.redhat.rhn.taskomatic.core;
 import com.redhat.rhn.taskomatic.TaskoJob;
 
 import org.quartz.Job;
+import org.quartz.JobDataMap;
 import org.quartz.Scheduler;
 import org.quartz.spi.JobFactory;
 import org.quartz.spi.TriggerFiredBundle;
@@ -33,8 +34,11 @@ public class RhnJobFactory implements JobFactory {
      */
     @Override
     public synchronized Job newJob(TriggerFiredBundle trigger, Scheduler s) {
-        Long scheduleId = trigger.getJobDetail().getJobDataMap().getLong("schedule_id");
+        final JobDataMap jobDataMap = trigger.getJobDetail().getJobDataMap();
 
-        return new TaskoJob(scheduleId);
+        long scheduleId = jobDataMap.getLong("schedule_id");
+        long bunchStart = jobDataMap.containsKey("bunch_start_index") ? jobDataMap.getLong("bunch_start_index") : 0L;
+
+        return new TaskoJob(scheduleId, bunchStart);
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/UbuntuErrataTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/UbuntuErrataTask.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.taskomatic.task;
+
+import com.redhat.rhn.manager.content.ubuntu.UbuntuErrataManager;
+
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+
+public class UbuntuErrataTask extends RhnJavaJob {
+    @Override
+    public String getConfigNamespace() {
+        return "ubuntuerrata";
+    }
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        List<Long> channelIds = RepoSyncTask.getChannelIds(context.getJobDetail().getJobDataMap());
+
+        try {
+            UbuntuErrataManager.sync(new HashSet<>(channelIds));
+        }
+        catch (IOException e) {
+            log.error(e);
+            throw new JobExecutionException("Unable to sync erratas", e);
+        }
+    }
+}

--- a/java/spacewalk-java.changes.mackdk.improve-ubuntu-errata-processing
+++ b/java/spacewalk-java.changes.mackdk.improve-ubuntu-errata-processing
@@ -1,0 +1,2 @@
+- Stop the taskomatic bunch execution if it was not possible to
+  execute one of the tasks

--- a/java/spacewalk-java.changes.mackdk.improve-ubuntu-errata-processing
+++ b/java/spacewalk-java.changes.mackdk.improve-ubuntu-errata-processing
@@ -1,3 +1,4 @@
+- Restart the bunch from where it was interrupted when rescheduling
 - Moved the Ubuntu errata processing in its own separate taskomatic
   task (bsc#1211145)
 - Stop the taskomatic bunch execution if it was not possible to

--- a/java/spacewalk-java.changes.mackdk.improve-ubuntu-errata-processing
+++ b/java/spacewalk-java.changes.mackdk.improve-ubuntu-errata-processing
@@ -1,2 +1,4 @@
+- Moved the Ubuntu errata processing in its own separate taskomatic
+  task (bsc#1211145)
 - Stop the taskomatic bunch execution if it was not possible to
   execute one of the tasks

--- a/schema/spacewalk/common/data/rhnTaskoTask.sql
+++ b/schema/spacewalk/common/data/rhnTaskoTask.sql
@@ -18,6 +18,9 @@ INSERT INTO rhnTaskoTask (id, name, class)
          VALUES (sequence_nextval('rhn_tasko_task_id_seq'), 'repo-sync', 'com.redhat.rhn.taskomatic.task.RepoSyncTask');
 
 INSERT INTO rhnTaskoTask (id, name, class)
+         VALUES (sequence_nextval('rhn_tasko_task_id_seq'), 'ubuntu-errata', 'com.redhat.rhn.taskomatic.task.UbuntuErrataTask');
+
+INSERT INTO rhnTaskoTask (id, name, class)
          VALUES (sequence_nextval('rhn_tasko_task_id_seq'), 'satellite-sync', 'com.redhat.rhn.taskomatic.task.SatSyncTask');
 
 INSERT INTO rhnTaskoTask (id, name, class)

--- a/schema/spacewalk/common/data/rhnTaskoTemplate.sql
+++ b/schema/spacewalk/common/data/rhnTaskoTemplate.sql
@@ -79,6 +79,13 @@ INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
 
 INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
              VALUES (sequence_nextval('rhn_tasko_template_id_seq'),
+                        (SELECT id FROM rhnTaskoBunch WHERE name='repo-sync-bunch'),
+                        (SELECT id FROM rhnTaskoTask WHERE name='ubuntu-errata'),
+                        1,
+                        'FINISHED');
+
+INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
+             VALUES (sequence_nextval('rhn_tasko_template_id_seq'),
                         (SELECT id FROM rhnTaskoBunch WHERE name='package-cleanup-bunch'),
                         (SELECT id FROM rhnTaskoTask WHERE name='package-cleanup'),
                         0,

--- a/schema/spacewalk/susemanager-schema.changes.mackdk.improve-ubuntu-errata-processing
+++ b/schema/spacewalk/susemanager-schema.changes.mackdk.improve-ubuntu-errata-processing
@@ -1,0 +1,2 @@
+- Moved the Ubuntu errata processing in its own separate taskomatic
+  task (bsc#1211145) 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.6-to-susemanager-schema-4.4.7/001-improve-ubuntu-errata-processing.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.6-to-susemanager-schema-4.4.7/001-improve-ubuntu-errata-processing.sql
@@ -1,0 +1,16 @@
+INSERT INTO rhnTaskoTask (id, name, class)
+     SELECT sequence_nextval('rhn_tasko_task_id_seq')
+                , 'ubuntu-errata'
+                , 'com.redhat.rhn.taskomatic.task.UbuntuErrataTask'
+      WHERE NOT EXISTS (SELECT id FROM rhnTaskoTask WHERE name = 'ubuntu-errata');
+
+INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
+    SELECT sequence_nextval('rhn_tasko_template_id_seq')
+                , tb.id
+                , tt.id
+                , 1
+                , 'FINISHED'
+      FROM rhnTaskoBunch tb, rhnTaskoTask tt
+    WHERE tb.name = 'repo-sync-bunch'
+                AND tt.name = 'ubuntu-errata'
+                AND NOT EXISTS (SELECT id FROM rhnTaskoTemplate WHERE bunch_id = tb.id AND task_id = tt.id);


### PR DESCRIPTION
## What does this PR change?

This PR aims to avoid repo-sync task starvation by separating the ubuntu errata syncing process. In this way, other reposync process can start without waiting for the download and the processing of the ubuntu errata database (which might take a long time when syncing ubuntu and debian channels).

To support this some improvement were made in the way taskomatic handles the execution of the tasks in the same bunch. In particular:

- If a task execution attempt results in a `null` value (meaning that the task is either already running or no more thread are available to process it) the bunch processing will be stopped and rescheduled if needed.
- When rescheduling the bunch, the new job will start from the index of the task that could not be executed and not from the beginning

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks https://github.com/SUSE/spacewalk/issues/21383

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
