### PR TITLE
Fix missing client tools in Leap json script

### DIFF
--- a/testsuite/ext-tools/maintenance_json_generator.py
+++ b/testsuite/ext-tools/maintenance_json_generator.py
@@ -51,8 +51,10 @@ defaultdict = {
     "ubuntu2204_minion": "/SUSE_Updates_Ubuntu_22.04-CLIENT-TOOLS_x86_64/",
     "debian10_minion": "/SUSE_Updates_Debian_10-CLIENT-TOOLS_x86_64/",
     "debian11_minion": "/SUSE_Updates_Debian_11-CLIENT-TOOLS_x86_64/",
-    "opensuse153arm_minion": "/SUSE_Updates_openSUSE-SLE_15.3/",
-    "opensuse154arm_minion": "/SUSE_Updates_openSUSE-SLE_15.4/",
+    "opensuse153arm_minion": ["/SUSE_Updates_openSUSE-SLE_15.3/",
+                              "/SUSE_Updates_SLE-Manager-Tools_15_aarch64/"],
+    "opensuse154arm_minion": ["/SUSE_Updates_openSUSE-SLE_15.4/",
+                              "/SUSE_Updates_SLE-Manager-Tools_15_aarch64/"],
     "rhel9_minion": "/SUSE_Updates_EL_9-CLIENT-TOOLS_x86_64/",
     "rocky9_minion": "/SUSE_Updates_EL_9-CLIENT-TOOLS_x86_64/",
     "alma9_minion": "/SUSE_Updates_EL_9-CLIENT-TOOLS_x86_64/",
@@ -65,7 +67,7 @@ defaultdict = {
                           "/SUSE_Updates_SUSE-MicroOS_5.3_x86_64/"],
     "slemicro54_minion": ["/SUSE_Updates_SLE-Manager-Tools-For-Micro_5_x86_64/",
                           "/SUSE_Updates_SUSE-MicroOS_5.4_x86_64/"]
-    }
+}
 
 # Dictionary for SUMA 4.2 Server and Proxy, which is then added together with the common dictionary for client tools
 nodesdict42 = {


### PR DESCRIPTION
## What does this PR change?

Fix missing client tools in Leap json script, we were missing one of the possible client tools suffixes that caused a repo to not be included.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes [#21652](https://github.com/SUSE/spacewalk/issues/21652)
Tracks no other PR needed, only uyuni has this script

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
