### PR TITLE
QE: Add step to wait for salt jobs to finish on buildhost as part of cleanup

### DIFF
--- a/testsuite/features/secondary/buildhost_docker_auth_registry.feature
+++ b/testsuite/features/secondary/buildhost_docker_auth_registry.feature
@@ -58,3 +58,6 @@ Feature: Build image with authenticated registry
 
   Scenario: Cleanup: delete registry image
     When I delete the image "auth_registry_profile" with version "latest" via API calls
+
+  Scenario: Cleanup: Make sure no job is left running on buildhost
+    When I wait until no Salt job is running on "build_host"

--- a/testsuite/features/secondary/buildhost_docker_build_image.feature
+++ b/testsuite/features/secondary/buildhost_docker_build_image.feature
@@ -152,3 +152,6 @@ Feature: Build container images
     And I should see a "Are you sure you want to delete selected profiles?" text
     And I click on the red confirmation button
     And I wait until I see "Image profiles have been deleted" text
+
+  Scenario: Cleanup: Make sure no job is left running on buildhost
+    When I wait until no Salt job is running on "build_host"

--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -64,3 +64,6 @@ Feature: Build OS images
     And I should see a "Are you sure you want to delete the selected profile?" text
     And I click on the red confirmation button
     And I wait until I see "Image profile has been deleted" text
+
+  Scenario: Cleanup: Make sure no job is left running on buildhost
+    When I wait until no Salt job is running on "build_host"


### PR DESCRIPTION
## What does this PR change?

One of the likely reasons for issues on the flaky tests on the buildhost, is that we're trying to do a build action while an image profile is still being deleted, as evidenced by the presence of this in the `rhn_web_ui` logs of the server
```yaml
[salt-event-thread-6] WARN  com.suse.manager.utils.SaltUtils - Image Profile ID not found while performing: Image Build suse_real_key in handleImageBuildData
[salt-event-thread-6] WARN  com.suse.manager.utils.SaltUtils - Image Profile ID not found while performing: Image Build suse_real_key in handleImageBuildData
```
These happened after the supposed cleanup and image deletion was done, and we were already trying to build the `auth_registry_profile` image, in the feature that ran after this.
Looking at the code, it gives us a hint of what is going on
```java
            Long imageProfileId = details.getImageProfileId();
            if (imageProfileId == null) { // It happens when the image profile is deleted during a build action
                LOG.error("Image Profile ID not found while performing: {} in handleImageBuildData", action.getName());
                return;
            }
```

This means that the image profile deletion wasn't done in time, likely due to performance issues. Instead of increasing the timeout, we are opting to wait for all salt jobs to be done on the buildhost before moving to the next features, to avoid issues from one feature to another. (Discussion can be seen in [this slack thread](https://suse.slack.com/archives/C02DDMY6R0R/p1685621964169959))

## Links

- 4.2
- 4.3 https://github.com/SUSE/spacewalk/pull/21658
- Fixes https://github.com/SUSE/spacewalk/issues/21381

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
