### PR TITLE
CI: Acceptance tests at PR v2: filter paths

### DIFF
--- a/.github/workflows/acceptance_tests_secondary.yml
+++ b/.github/workflows/acceptance_tests_secondary.yml
@@ -1,5 +1,10 @@
 name: acceptance-tests-secondary
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - 'java/**'
+      - 'web/html/src/**'
+      - 'testsuite/**'
 jobs:
   test-uyuni:
     uses: ./.github/workflows/acceptance_tests_common.yml

--- a/.github/workflows/acceptance_tests_secondary.yml
+++ b/.github/workflows/acceptance_tests_secondary.yml
@@ -5,6 +5,7 @@ on:
       - 'java/**'
       - 'web/html/src/**'
       - 'testsuite/**'
+      - '.github/workflows/acceptance_tests_secondary.yml'
 jobs:
   test-uyuni:
     uses: ./.github/workflows/acceptance_tests_common.yml

--- a/.github/workflows/acceptance_tests_secondary_parallel.yml
+++ b/.github/workflows/acceptance_tests_secondary_parallel.yml
@@ -1,5 +1,10 @@
 name: acceptance-tests-secondary-parallel
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - 'java/**'
+      - 'web/html/src/**'
+      - 'testsuite/**'
 jobs:
   test-uyuni:
     uses: ./.github/workflows/acceptance_tests_common.yml

--- a/.github/workflows/acceptance_tests_secondary_parallel.yml
+++ b/.github/workflows/acceptance_tests_secondary_parallel.yml
@@ -5,6 +5,7 @@ on:
       - 'java/**'
       - 'web/html/src/**'
       - 'testsuite/**'
+      - '.github/workflows/acceptance_tests_secondary_parallel.yml'
 jobs:
   test-uyuni:
     uses: ./.github/workflows/acceptance_tests_common.yml


### PR DESCRIPTION
## What does this PR change?

CI: Run acceptance tests only when java, js or tests have been modified. Othewise, makes no sense.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests
- [X] **DONE**

## Links

Fixes  https://github.com/SUSE/spacewalk/issues/21454

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
