### PR TITLE
Make spacewalk-data-fsck compatible to Enterprise Linux rpm version

### DIFF
--- a/python/spacewalk/satellite_tools/spacewalk-data-fsck
+++ b/python/spacewalk/satellite_tools/spacewalk-data-fsck
@@ -40,13 +40,14 @@ report = {}
 
 def is_sha256_capable():
     import rpm
+    from rhn.stringutils import sstr
     ts = rpm.TransactionSet()
     mi = ts.dbMatch('Providename', 'spacewalk-schema')
     cmp = -1
     try:
         h = next(mi)
-        cmp = rpm.labelCompare([h['name'].decode("utf-8"), h['version'].decode("utf-8"), h['release'].decode("utf-8")],
-                               [h['name'].decode("utf-8"), '0.8.1', '1'])
+        cmp = rpm.labelCompare([sstr(h['name']), sstr(h['version']), sstr(h['release'])],
+                               [sstr(h['name']), '0.8.1', '1'])
     except StopIteration:
         pass
     return (cmp > 0)

--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Make spacewalk-data-fsck compatible to Enterprise Linux rpm version.
+
 -------------------------------------------------------------------
 Wed Apr 19 12:51:32 CEST 2023 - marina.latini@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Make spacewalk-data-fsck compatible to Enterprise Linux rpm version.
SUSE version of `rpm.TransactionSet().dbMatch` returns `bytes` whereas the RHEL version returns `string` despite being the same rpm version.

This change checks on the returned value and only converts them to string if they are not.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
