### PR TITLE
Ship SUSE specific files on Enterprise Linux

### DIFF
--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,4 @@
+- Also ship SUSE specific files on Enterprise Linux.
 - Add shadow as dependency of osimage certificate package
   (bsc#1210834 bsc#1204089)
 

--- a/spacewalk/certs-tools/spacewalk-certs-tools.spec
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.spec
@@ -19,10 +19,12 @@
 
 
 %if 0%{?suse_version}
-%global pub_bootstrap_dir /srv/www/htdocs/pub/bootstrap
+%global pub_dir /srv/www/htdocs/pub
 %else
-%global pub_bootstrap_dir /var/www/html/pub/bootstrap
+%global pub_dir /var/www/html/pub
 %endif
+
+%global pub_bootstrap_dir %{pub_dir}/bootstrap
 %global rhnroot %{_datadir}/rhn
 %global __python /usr/bin/python3
 
@@ -96,13 +98,13 @@ ln -s rhn-bootstrap-%{python3_version} $RPM_BUILD_ROOT%{_bindir}/rhn-bootstrap
 ln -s mgr-ssl-tool.1.gz $RPM_BUILD_ROOT/%{_mandir}/man1/rhn-ssl-tool.1.gz
 ln -s mgr-bootstrap.1.gz $RPM_BUILD_ROOT/%{_mandir}/man1/rhn-bootstrap.1.gz
 
-%if 0%{?suse_version}
 ln -s rhn-bootstrap $RPM_BUILD_ROOT/%{_bindir}/mgr-bootstrap
 ln -s rhn-ssl-tool $RPM_BUILD_ROOT/%{_bindir}/mgr-ssl-tool
 ln -s rhn-sudo-ssl-tool $RPM_BUILD_ROOT/%{_bindir}/mgr-sudo-ssl-tool
 ln -s spacewalk-push-register $RPM_BUILD_ROOT/%{_sbindir}/mgr-push-register
 ln -s spacewalk-ssh-push-init $RPM_BUILD_ROOT/%{_sbindir}/mgr-ssh-push-init
 
+%if 0%{?suse_version}
 %py3_compile -O %{buildroot}/%{python3_sitelib}
 %endif
 
@@ -133,16 +135,14 @@ esac
 %doc ssl-howto-simple.txt ssl-howto.txt
 %license LICENSE
 %{pub_bootstrap_dir}/client_config_update.py*
-%if 0%{?suse_version}
 %dir %{rhnroot}
-%dir /srv/www/htdocs/pub
+%dir %{pub_dir}
 %dir %{pub_bootstrap_dir}
 %{_bindir}/mgr-bootstrap
 %{_bindir}/mgr-ssl-tool
 %{_bindir}/mgr-sudo-ssl-tool
 %{_sbindir}/mgr-push-register
 %{_sbindir}/mgr-ssh-push-init
-%endif
 
 %files -n python3-%{name}
 %{python3_sitelib}/certs


### PR DESCRIPTION
## What does this PR change?

Some of the documented scripts are not available on Enterprise Linux (i.e. mgr-bootstrap).
This change aligns the SUSE specific files to both OS.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: Already documented. This fix lines up with the documentation.

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
