### PR TITLE
Use newest "venv-salt-minion" version available to generate the "venv-enabled-*.txt" files (bsc#1211958)

### DIFF
--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -597,7 +597,7 @@ def create_repo(label, options, mgr_bootstrap_data, additional=[]):
         # create venv-enabled-{ARCH}.txt for repos with salt bundle package
         for file_path in glob.glob(os.path.join(destdirtmp, 'venv-enabled-*.txt')):
             os.remove(file_path)
-        for file_path in glob.glob(os.path.join(destdirtmp, '**/venv-salt-minion*.*'), recursive=True):
+        for file_path in sorted(glob.glob(os.path.join(destdirtmp, '**/venv-salt-minion*.*'), recursive=True)):
             rel_path = os.path.relpath(file_path, start=destdirtmp)
             (l_path, ext) = rel_path.rsplit('.', 1)
             if ext:

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- Use newest venv-salt-minion version available to generate the
+  venv-enabled-*.txt file in bootstrap repos (bsc#1211958)
 - Add bootstrap repository definitions for openSUSE Leap Micro 5.4
 - Add bootstrap repository definitions for SLE Micro 5.4
 - Ensure installation of make for building.


### PR DESCRIPTION
## What does this PR change?

This PR fixes a problem on `mgr-create-bootstrap-repo` when generating the `venv-enabled-*.txt` file in cases where there are multiple versions of `venv-salt-minion` package available in the same bootstrap repository.

As there was not explicit sorting of available packages, we could end up with an older `venv-salt-minion` version as the one finally written at generated `venv-enabled-*.txt` file for this bootstrap repo.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **covered in BV**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/21662

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
