### PR TITLE
Fix Squid "refresh_pattern" for "venv-enabled-*.txt" files (bsc#1211956)

### DIFF
--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,3 +1,6 @@
+- Fix squid refresh_pattern for "venv-enabled-*.txt" files to avoid
+  serving outdated version of the file (bsc#1211956)
+
 -------------------------------------------------------------------
 Wed Dec 14 14:14:01 CET 2022 - jgonzalez@suse.com
 

--- a/proxy/installer/spacewalk-proxy-installer.spec
+++ b/proxy/installer/spacewalk-proxy-installer.spec
@@ -129,6 +129,9 @@ if [ -e /etc/squid/squid.conf ]; then
     if [ -f %{apacheconfdir}/conf.d/cobbler-proxy.conf ]; then
         sed -i -e "s;download//cobbler_api;download/cobbler_api;g" %{apacheconfdir}/conf.d/cobbler-proxy.conf
     fi
+    if ! grep venv-enabled /etc/squid/squid.conf >/dev/null; then
+        sed -i 's;\(refresh_pattern /pub/repositories.*\);\1\nrefresh_pattern /pub/repositories/.*/venv-enabled-.*.txt$ 0 1% 1440 reload-into-ims refresh-ims;' /etc/squid/squid.conf
+    fi
 fi
 %endif
 if [ $1 -eq 2 ]

--- a/proxy/installer/squid.conf
+++ b/proxy/installer/squid.conf
@@ -31,6 +31,7 @@ refresh_pattern /ks/.*/repodata/.*$ 0 1% 1440 reload-into-ims refresh-ims
 refresh_pattern /rhn/manager/download/.*/repodata/.*$ 0 1% 1440 reload-into-ims refresh-ims
 # bootstrap repos needs to be handled as well
 refresh_pattern /pub/repositories/.*/repodata/.*$ 0 1% 1440 reload-into-ims refresh-ims
+refresh_pattern /pub/repositories/.*/venv-enabled-.*.txt$ 0 1% 1440 reload-into-ims refresh-ims
 # rpm will hardly ever change, force to cache it for very long time
 refresh_pattern  \.rpm$  10080 100% 525600 override-expire override-lastmod ignore-reload reload-into-ims
 refresh_pattern  \.deb$  10080 100% 525600 override-expire override-lastmod ignore-reload reload-into-ims


### PR DESCRIPTION
## What does this PR change?

This PR modifies Squid configuration, by adding custom "refresh_pattern" for `venv-enabled-*.txt` files that are part of bootstrap repositories. This way we ensure to provide fresh version of this files when modified on the Uyuni/SUSE Manager server. 

This fix prevents problems for SSH minions behind proxies, which might still keep using an older Salt Bundle version because this PROXY is still serving an outdated `venv-enabled-*.txt` file pointing to an older Salt Bundle version.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **covered by BV**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/21663

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
