### PR TITLE
QE: Use webUI steps for accessing system in retail

### DIFF
--- a/testsuite/features/build_validation/retail/sle12sp5_terminal_deploy.feature
+++ b/testsuite/features/build_validation/retail/sle12sp5_terminal_deploy.feature
@@ -27,7 +27,7 @@ Feature: PXE boot a SLES 12 SP5 retail terminal
     Then "sle12sp5_terminal" should have been reformatted
 
   Scenario: Check connection from SLES 12 SP5 retail terminal to branch server
-    Given I am on the Systems overview page of this "sle12sp5_terminal"
+    Given I navigate to the Systems overview page of this "sle12sp5_terminal"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
     Then I should see a "proxy.example.org" text

--- a/testsuite/features/build_validation/retail/sle15sp4_terminal_deploy.feature
+++ b/testsuite/features/build_validation/retail/sle15sp4_terminal_deploy.feature
@@ -27,7 +27,7 @@ Feature: PXE boot a SLES 15 SP4 retail terminal
     Then "sle15sp4_terminal" should have been reformatted
 
   Scenario: Check connection from SLES 15 SP4 retail terminal to branch server
-    Given I am on the Systems overview page of this "sle15sp4_terminal"
+    Given I navigate to the Systems overview page of this "sle15sp4_terminal"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
     Then I should see a "proxy.example.org" text


### PR DESCRIPTION
## What does this PR change?

In our retail tests we cannot access the retail terminal via the API because we do not have a twopence target for them available. In the past we simply used the webUI for navigation which is slower compared to the API. In this case we have to rely on the slower webUI steps for retail terminals.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage

- Cucumber tests were adjusted
- [x] **DONE**

## Links

- Manager 4.3:
- Manager 4.2:
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
