### PR TITLE
Fix Squid "refresh_pattern" for "venv-enabled-*.txt" files in proxy-squid-container (bsc#1211956)

### DIFF
--- a/containers/proxy-squid-image/proxy-squid-image.changes
+++ b/containers/proxy-squid-image/proxy-squid-image.changes
@@ -1,3 +1,5 @@
+- Fix squid refresh_pattern for "venv-enabled-*.txt" files to avoid
+  serving outdated version of the file (bsc#1211956)
 - Add squid configuration for /saltboot
 - Integrate the containerized proxy into the usual rel-eng workflow
 

--- a/containers/proxy-squid-image/squid.conf
+++ b/containers/proxy-squid-image/squid.conf
@@ -31,6 +31,7 @@ refresh_pattern /ks/.*/repodata/.*$ 0 1% 1440 reload-into-ims refresh-ims
 refresh_pattern /rhn/manager/download/.*/repodata/.*$ 0 1% 1440 reload-into-ims refresh-ims
 # bootstrap repos needs to be handled as well
 refresh_pattern /pub/repositories/.*/repodata/.*$ 0 1% 1440 reload-into-ims refresh-ims
+refresh_pattern /pub/repositories/.*/venv-enabled-.*.txt$ 0 1% 1440 reload-into-ims refresh-ims
 # rpm will hardly ever change, force to cache it for very long time
 refresh_pattern  \.rpm$  10080 100% 525600 override-expire override-lastmod ignore-reload reload-into-ims
 refresh_pattern  \.deb$  10080 100% 525600 override-expire override-lastmod ignore-reload reload-into-ims


### PR DESCRIPTION
## What does this PR change?

This is a continuation of https://github.com/uyuni-project/uyuni/pull/7089 where we missed to include the new "refresh_pattern" into the `squid.conf` file we use for "proxy-squid-container".

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **covered by BV**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/21663

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
