### PR TITLE
Add options to disable ssl in setup

### DIFF
--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -368,6 +368,11 @@ public class ConfigDefaults {
      */
     public static final String UNIFY_CUSTOM_CHANNEL_MANAGEMENT = "java.unify_custom_channel_management";
 
+    /**
+     * Disable SSL redirection
+     */
+    public static final String NO_SSL = "server.no_ssl";
+
     private ConfigDefaults() {
     }
 
@@ -1129,4 +1134,10 @@ public class ConfigDefaults {
         return Config.get().getBoolean(UNIFY_CUSTOM_CHANNEL_MANAGEMENT, true);
     }
 
+    /**
+     * @return true if SSL is enabled, false otherwise
+     */
+    public boolean isSsl() {
+        return !Config.get().getBoolean(NO_SSL, false);
+    }
 }

--- a/java/code/src/com/redhat/rhn/frontend/servlets/EnvironmentFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/EnvironmentFilter.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.frontend.servlets;
 
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.frontend.struts.StrutsDelegate;
@@ -55,6 +56,7 @@ public class EnvironmentFilter implements Filter {
      */
     @Override
     public void init(FilterConfig arg0) {
+        // Not needed in this filter
     }
 
     /**
@@ -78,11 +80,8 @@ public class EnvironmentFilter implements Filter {
         // Have to make this decision here, because once we pass the request
         // off to the next filter, that filter can do work that sends data to
         // the client, meaning that we can't redirect.
-        if (RhnHelper.pathNeedsSecurity(nosslurls, path) &&
-                !hreq.isSecure()) {
-            if (log.isDebugEnabled()) {
-                log.debug("redirecting to secure: {}", path);
-            }
+        if (ConfigDefaults.get().isSsl() && RhnHelper.pathNeedsSecurity(nosslurls, path) && !hreq.isSecure()) {
+            log.debug("redirecting to secure: {}", path);
             redirectToSecure(hreq, hres);
             return;
         }
@@ -91,9 +90,7 @@ public class EnvironmentFilter implements Filter {
         HttpServletRequest req = (HttpServletRequest) request;
         request.setAttribute(RequestContext.REQUESTED_URI, req.getRequestURI());
 
-        if (log.isDebugEnabled()) {
-            log.debug("set REQUESTED_URI: {}", req.getRequestURI());
-        }
+        log.debug("set REQUESTED_URI: {}", req.getRequestURI());
 
         // add messages that were put on the request path.
         addParameterizedMessages(req);

--- a/java/code/src/com/redhat/rhn/frontend/servlets/RhnHttpServletResponse.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/RhnHttpServletResponse.java
@@ -75,7 +75,7 @@ public class RhnHttpServletResponse extends HttpServletResponseWrapper {
                 throw new IllegalArgumentException(location);
             }
         }
-        location = url.toExternalForm();
+        location = url.toExternalForm().replace("http:", "https:");
         super.sendRedirect(location);
     }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add option to disable SSL
 - Removed the expensive 'diff' column (bsc#1208427)
 - replace kickstart profile advanced option "md5_crypt_rootpw"
   with "sha256_crypt_rootpw" to use sha256 crypt when password

--- a/spacewalk/setup/bin/spacewalk-setup
+++ b/spacewalk/setup/bin/spacewalk-setup
@@ -482,13 +482,21 @@ sub setup_mod_ssl {
     return;
   }
 
-  system('/usr/bin/spacewalk-setup-httpd');
+  my $no_ssl_arg = $answers->{"no-ssl"} =~ /^[Yy]/ ? ' --no-ssl' : '';
+
+  system(split / /, "/usr/bin/spacewalk-setup-httpd$no_ssl_arg");
 
 }
 
 sub setup_ssl_certs {
   my $opts = shift;
   my $answers = shift;
+
+  if ($opts{"skip-ssl-cert-generation"} || $opts{"upgrade"}) {
+    print Spacewalk::Setup::loc("** Skipping SSL certificate generation.\n");
+    return;
+  }
+
   Spacewalk::Setup::ask(
     -noninteractive => $opts{"non-interactive"},
     -question => "Do you want to import exising certificates?",
@@ -499,11 +507,6 @@ sub setup_ssl_certs {
 
   my $use_own_certs = $answers->{'ssl-use-existing-certs'} &&
                       $answers->{'ssl-use-existing-certs'} =~ /^[Yy]/;
-
-  if ($opts{"skip-ssl-cert-generation"} || $opts{"upgrade"}) {
-    print Spacewalk::Setup::loc("** Skipping SSL certificate generation.\n");
-    return;
-  }
 
   if (!$use_own_certs) {
       my ($password_1, $password_2);
@@ -852,7 +855,7 @@ sub populate_initial_configs {
      report_db_host => $answers->{'report-db-host'},
      report_db_port => $answers->{'report-db-port'},
      report_db_ssl_enabled => $answers->{'report-db-ssl-enabled'},
-     report_db_sslrootcert => $answers->{'report-db-ca-cert'}
+     report_db_sslrootcert => $answers->{'report-db-ca-cert'},
     );
 
     for ($config_opts{'db_password'}) {
@@ -930,6 +933,11 @@ sub populate_final_configs {
 
   Spacewalk::Setup::satcon_deploy(-tree => '/var/lib/rhn/rhn-satellite-prep/etc/rhn',
                 -dest => '/etc/rhn');
+  if($answers->{"no-ssl"} =~ /^[Yy]/) {
+      open(my $FILE, '>>', '/etc/rhn/rhn.conf');
+      print $FILE "server.no_ssl = 1";
+      close $FILE;
+  }
 
   return;
 }

--- a/spacewalk/setup/bin/spacewalk-setup-httpd
+++ b/spacewalk/setup/bin/spacewalk-setup-httpd
@@ -103,6 +103,20 @@ sub modify_conf_content {
         return $conf_content;
 }
 
+sub setup_mod_nossl {
+    my $sslconf_dir = is_suse_like() ? '/etc/apache2/vhosts.d' : '/etc/httpd/conf.d';
+    my $sslconf     = is_suse_like() ? 'vhost-nossl.conf' : 'nossl.conf';
+
+	my $sslconf_path = "$sslconf_dir/$sslconf";
+    if(is_suse_like() && ! -f $sslconf_path)
+	{
+        my $config_path = Spacewalk::Setup::SHARED_DIR . "/vhost-nossl.conf";
+		`cp "$config_path" "$sslconf_path"`;
+	}
+
+    return;
+}
+
 sub setup_mod_ssl {
         my $fips_mode_on = shift;
 
@@ -164,17 +178,20 @@ sub setup_mod_ssl {
 
 my $help;
 my $fips_mode_on;
+my $no_ssl;
 
 my $usage = <<EOHELP;
-Usage: $0 --help | --fips-mode-on
+Usage: $0 --help | --fips-mode-on | --no-ssl
 Options:
         --help                  Print this help message
         --fips-mode-on  Turn SSL FIPS mode on (when applicable)
+        --no-ssl        Configure without SSL
 EOHELP
 
 GetOptions(
         "help" => \$help,
-        "fips-mode-on" => \$fips_mode_on
+        "fips-mode-on" => \$fips_mode_on,
+        "no-ssl" => \$no_ssl
         ) or die $usage;
 
 if ($help) {
@@ -182,7 +199,11 @@ if ($help) {
         exit 0;
 }
 
-setup_mod_ssl($fips_mode_on);
+if ($no_ssl) {
+    setup_mod_nossl();
+} else {
+    setup_mod_ssl($fips_mode_on);
+}
 
 =head1 NAME
 
@@ -194,6 +215,7 @@ Uyuni / SUSE Manager
 B<spacewalk-setup-httpd>
 [B<--help>]
 [B<--fips-mode-on>]
+[B<--no-ssl>]
 
 =head1 OPTIONS
 
@@ -203,6 +225,10 @@ B<spacewalk-setup-httpd>
 
 Configure httpd to work correctly in FIPS mode. For mod_ssl, this means turning
 the SSLFIPS directive on in ssl.conf where applicable.
+
+=item B<--no-ssl>
+
+Configure httpd without SSL.
 
 =item B<--help>
 

--- a/spacewalk/setup/share/vhost-nossl.conf
+++ b/spacewalk/setup/share/vhost-nossl.conf
@@ -1,0 +1,15 @@
+<VirtualHost _default_:80>
+
+	#  General setup for the virtual host
+	DocumentRoot "/srv/www/htdocs"
+	ErrorLog /var/log/apache2/error_log
+	TransferLog /var/log/apache2/access_log
+
+    RewriteEngine on
+    RewriteOptions inherit
+
+<IfModule mod_jk.c>
+    JkMountCopy On
+</IfModule>
+
+</VirtualHost>

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,4 @@
+- Add option to disable SSL setup
 - Corrected requirement to install Tomcat before spacewalk-setup.
 - Automatically detect PostgreSQL service and data folder name.
 

--- a/spacewalk/setup/spacewalk-setup.spec
+++ b/spacewalk/setup/spacewalk-setup.spec
@@ -169,6 +169,7 @@ install -m 0644 share/tomcat_java_opts_suse.conf %{buildroot}/%{_sysconfdir}/tom
 install -m 0644 share/server.xml.xsl %{buildroot}/%{_datadir}/spacewalk/setup/
 install -m 0644 share/server_update.xml.xsl %{buildroot}/%{_datadir}/spacewalk/setup/
 install -m 0644 share/old-jvm-list %{buildroot}/%{_datadir}/spacewalk/setup/
+install -m 0644 share/vhost-nossl.conf %{buildroot}/%{_datadir}/spacewalk/setup/
 install -d -m 755 %{buildroot}/%{_datadir}/spacewalk/setup/defaults.d/
 install -m 0644 share/defaults.d/defaults.conf %{buildroot}/%{_datadir}/spacewalk/setup/defaults.d/
 install -d -m 755 %{buildroot}/%{_datadir}/spacewalk/setup/cobbler

--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -447,17 +447,28 @@ scc-pass = $SCC_PASS
     elif [ -n "$ISS_PARENT" ]; then
         PARAM_CC="--disconnected"
     fi
-    if [ -n "$CA_CERT" -a -n "$SERVER_CERT" -a -n "$SERVER_KEY" ]; then
-        echo "ssl-use-existing-certs = Y
+
+    if [ "$NO_SSL" == "Y" ]; then
+        echo "no-ssl = Y
+" >>/root/spacewalk-answers
+        PARAM_CC="$PARAM_CC --skip-ssl-cert-generation"
+
+        sed '/ssl/Id' -i /etc/apache2/conf.d/zz-spacewalk-www.conf
+        echo "server.no_ssl = 1" >>/etc/rhn/rhn.conf
+        sed '/<IfDefine SSL/,/<\/IfDefine SSL/d' -i /etc/apache2/listen.conf
+    else
+        if [ -n "$CA_CERT" -a -n "$SERVER_CERT" -a -n "$SERVER_KEY" ]; then
+            echo "ssl-use-existing-certs = Y
 ssl-ca-cert = $CA_CERT
 ssl-server-cert = $SERVER_CERT
 ssl-server-key = $SERVER_KEY" >> /root/spacewalk-answers
-    else
-        echo "ssl-use-existing-certs = N" >> /root/spacewalk-answers
+        else
+            echo "ssl-use-existing-certs = N" >> /root/spacewalk-answers
 
-	# check if CA Cert and Key exists and try to use it to generate the server certs
-	if [ -e /root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT -a -e /root/ssl-build/RHN-ORG-PRIVATE-SSL-KEY ]; then
-            PARAM_CC="$PARAM_CC --skip-ssl-ca-generation"
+        # check if CA Cert and Key exists and try to use it to generate the server certs
+        if [ -e /root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT -a -e /root/ssl-build/RHN-ORG-PRIVATE-SSL-KEY ]; then
+                PARAM_CC="$PARAM_CC --skip-ssl-ca-generation"
+            fi
         fi
     fi
 
@@ -793,6 +804,7 @@ do_migration() {
 }
 
 do_setup() {
+    NO_SSL=
     if [ -f $SETUP_ENV ]; then
         . $SETUP_ENV
     else

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Add option to disable SSL setup
 - Use newest venv-salt-minion version available to generate the
   venv-enabled-*.txt file in bootstrap repos (bsc#1211958)
 - Add bootstrap repository definitions for openSUSE Leap Micro 5.4


### PR DESCRIPTION
## What does this PR change?

Running the server container in kubernetes will require SSL termination at ingress level and certificates generated outside of the cluster. This change allows disabling those.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: setup scripts
- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
