### PR TITLE
Use the CA certificate in the /etc/pki to generate buildhost RPM

### DIFF
--- a/spacewalk/certs-tools/mgr-package-rpm-certificate-osimage
+++ b/spacewalk/certs-tools/mgr-package-rpm-certificate-osimage
@@ -16,7 +16,7 @@ import argparse
 
 from certs.sslToolCli import CertExpTooShortException, \
         CertExpTooLongException, InvalidCountryCodeException
-from certs.sslToolLib import RhnSslToolException, chdir
+from certs.sslToolLib import RhnSslToolException, chdir, gendir
 from uyuni.common.fileutils import cleanupAbsPath, rhn_popen
 from certs.rhn_ssl_tool import legacyTreeFixup, _disableRpmMacros, _reenableRpmMacros, \
     GenCaCertRpmException
@@ -24,7 +24,7 @@ from certs.sslToolConfig import BUILD_DIR, CERT_PATH, CA_CERT_RPM_SUMMARY, \
     CA_CRT_NAME, CA_CRT_RPM_NAME
 from rhn.stringutils import bstr
 
-CA_CERT_FULL_PATH_DEFAULT = BUILD_DIR + os.path.sep + CA_CRT_NAME
+CA_CERT_FULL_PATH_DEFAULT = "/etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT"
 
 def processCommandline():
     parser = argparse.ArgumentParser(description="""Generates RPM certificate for
@@ -48,7 +48,7 @@ def processCommandline():
     return args
 
 def genCaRpm(options):
-    OSIMAGE_RPM_CERTIFICATE_PATH = "/usr/share/susemanager/salt/images"
+    OSIMAGE_RPM_CERTIFICATE_PATH = "/srv/susemanager/salt/images"
     if options.target_os == 'SLE11':
         CA_CERT_RPM_NAME_OSIMAGE = CA_CRT_RPM_NAME + "-osimage-sle11"
         OSIMAGE_RPM_REQUIRES = ["openssl-certs", "coreutils"]
@@ -82,6 +82,9 @@ def genCaRpm(options):
     print("CA Cert for OS Images: Packaging %s into %s.noarch.rpm" % (ca_cert, clientRpmName))
 
     _disableRpmMacros()
+    gendir(OSIMAGE_RPM_CERTIFICATE_PATH)
+    shutil.chown(OSIMAGE_RPM_CERTIFICATE_PATH, "salt", "salt")
+    os.chmod(OSIMAGE_RPM_CERTIFICATE_PATH, int("0755", 8))
     cwd = chdir(OSIMAGE_RPM_CERTIFICATE_PATH)
     try:
         ret, out_stream, err_stream = rhn_popen(args)
@@ -99,6 +102,7 @@ def genCaRpm(options):
         raise GenCaCertRpmException("CA public SSL certificate RPM generation "
                                 "failed:\n%s\n%s" % (out, err))
     os.chmod('%s.noarch.rpm' % clientRpmName, int('0644',8))
+    shutil.chown('%s.noarch.rpm' % clientRpmName, "salt", "salt")
 
     return '%s.noarch.rpm' % clientRpmName
 

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,4 @@
+- Use the CA cert in the pki config to generate build host rpm
 - Add shadow as dependency of osimage certificate package
   (bsc#1210834 bsc#1204089)
 

--- a/spacewalk/certs-tools/spacewalk-certs-tools.spec
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.spec
@@ -106,14 +106,6 @@ ln -s spacewalk-ssh-push-init $RPM_BUILD_ROOT/%{_sbindir}/mgr-ssh-push-init
 %py3_compile -O %{buildroot}/%{python3_sitelib}
 %endif
 
-%post
-case "$1" in
-  2)
-       if [ ! -f /usr/share/susemanager/salt/images/rhn-org-trusted-ssl-cert-osimage-1.0-1.noarch.rpm ]; then
-               /usr/sbin/mgr-package-rpm-certificate-osimage
-       fi
-  ;;
-esac
 
 %files
 %defattr(-,root,root,-)

--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -478,6 +478,10 @@ ssl-server-key = $SERVER_KEY" >> /root/spacewalk-answers
         echo "web.default_mail_from = $MANAGER_MAIL_FROM" >> /etc/rhn/rhn.conf
     fi
 
+    if [ ! -f /srv/susemanager/salt/images/rhn-org-trusted-ssl-cert-osimage-1.0-1.noarch.rpm ]; then
+        /usr/sbin/mgr-package-rpm-certificate-osimage
+    fi
+
     # rm /root/spacewalk-answers
     if [ "$SWRET" != "0" ]; then
         echo "ERROR: spacewalk-setup failed" >&2


### PR DESCRIPTION
## What does this PR change?

In the kubernetes case there is no ssl-build folder and the CA certificate is simply mounted in /etc/pki/trust/anchors. Use this file as default in the mgr-package-rpm-certificate-osimage tool.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
