### PR TITLE
Separate github validation and server container skip flags

### DIFF
--- a/testsuite/features/secondary/allcli_reboot.feature
+++ b/testsuite/features/secondary/allcli_reboot.feature
@@ -18,7 +18,7 @@
 # the following features could fail due to the minions not being reachable.
 # Depending on how long they take to reboot, even more features could fail.
 
-@skip_if_container
+@skip_if_github_validation
 @scope_onboarding
 Feature: Reboot systems managed by Uyuni
 

--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -13,7 +13,7 @@
 # - features/secondary/proxy_retail_pxeboot_and_mass_import.feature:
 # This feature leaves a JeOS image built that is used in the "PXE boot a Retail terminal" feature.
 
-@skip_if_container
+@skip_if_github_validation
 @skip_if_cloud
 @buildhost
 @scope_retail

--- a/testsuite/features/secondary/min_action_chain.feature
+++ b/testsuite/features/secondary/min_action_chain.feature
@@ -136,7 +136,7 @@ Feature: Action chains on Salt minions
     And I check radio button "schedule-by-action-chain"
     And I click on "Apply Highstate"
 
-@skip_if_container    
+@skip_if_github_validation
   Scenario: Add a reboot action to the action chain on Salt minion
     Given I am on the Systems overview page of this "sle_minion"
     When I follow first "Schedule System Reboot"

--- a/testsuite/features/secondary/min_activationkey.feature
+++ b/testsuite/features/secondary/min_activationkey.feature
@@ -5,7 +5,7 @@
 # - features/secondary/min_salt_minions_page.feature
 # If the minion fails to bootstrap.
 
-@skip_if_container
+@skip_if_github_validation
 @scope_onboarding
 Feature: Bootstrap a Salt minion via the GUI with an activation key
 

--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2021-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@skip_if_container
+@skip_if_github_validation
 @scope_ansible
 Feature: Operate an Ansible control node in a normal minion
 

--- a/testsuite/features/secondary/min_bootstrap_api.feature
+++ b/testsuite/features/secondary/min_bootstrap_api.feature
@@ -5,7 +5,7 @@
 # - features/secondary/min_bootstrap_negative.feature
 # If the minion fails to bootstrap again.
 
-@skip_if_container
+@skip_if_github_validation
 @scope_onboarding
 Feature: Register a Salt minion via API
 

--- a/testsuite/features/secondary/min_bootstrap_negative.feature
+++ b/testsuite/features/secondary/min_bootstrap_negative.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2021-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@skip_if_container
+@skip_if_github_validation
 @sle_minion
 @scope_onboarding
 Feature: Negative tests for bootstrapping normal minions

--- a/testsuite/features/secondary/min_bootstrap_reactivation.feature
+++ b/testsuite/features/secondary/min_bootstrap_reactivation.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2021-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@skip_if_container
+@skip_if_github_validation
 @sle_minion
 @scope_onboarding
 Feature: Bootstrapping with reactivation key

--- a/testsuite/features/secondary/min_bootstrap_script.feature
+++ b/testsuite/features/secondary/min_bootstrap_script.feature
@@ -5,7 +5,7 @@
 # - features/secondary/min_ssh_tunnel.feature
 # If the minion fails to bootstrap
 
-@skip_if_container
+@skip_if_github_validation
 @sle_minion
 @scope_onboarding
 Feature: Register a Salt minion with a bootstrap script

--- a/testsuite/features/secondary/min_bootstrap_ssh_key.feature
+++ b/testsuite/features/secondary/min_bootstrap_ssh_key.feature
@@ -6,7 +6,7 @@
 # - features/secondary/min_bootstrap_script.feature
 # If the minion fails to bootstrap again.
 
-@skip_if_container
+@skip_if_github_validation
 @scope_onboarding
 Feature: Bootstrap a Salt minion via the GUI using SSH key
 

--- a/testsuite/features/secondary/min_change_software_channel.feature
+++ b/testsuite/features/secondary/min_change_software_channel.feature
@@ -5,7 +5,7 @@
 # - features/secondary/allcli_software_channels.feature
 # If "SLE15-SP4-Installer-Updates for x86_64" fails to be unchecked
 
-@skip_if_container
+@skip_if_github_validation
 @scc_credentials
 @scope_changing_software_channels
 @sle_minion

--- a/testsuite/features/secondary/min_config_state_channel.feature
+++ b/testsuite/features/secondary/min_config_state_channel.feature
@@ -5,7 +5,7 @@
 # - features/secondary/min_config_state_channel_subscriptions.feature
 # If the state channel fails to be deleted.
 
-@skip_if_container
+@skip_if_github_validation
 @scope_configuration_channels
 Feature: Configuration state channels
   In order to configure systems through Salt

--- a/testsuite/features/secondary/min_config_state_channel_subscriptions.feature
+++ b/testsuite/features/secondary/min_config_state_channel_subscriptions.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2018-2021 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
-@skip_if_container
+@skip_if_github_validation
 @sle_minion
 @scope_configuration_channels
 Feature: State Configuration channels

--- a/testsuite/features/secondary/min_deblike_monitoring.feature
+++ b/testsuite/features/secondary/min_deblike_monitoring.feature
@@ -4,7 +4,7 @@
 # - features/secondary/srv_monitoring.feature: as this feature disables/re-enables monitoring capabilities
 # - sumaform: as it is configuring monitoring to be enabled after deployment
 
-@skip_if_container
+@skip_if_github_validation
 @scope_monitoring
 @scope_res
 @deblike_minion

--- a/testsuite/features/secondary/min_deblike_openscap_audit.feature
+++ b/testsuite/features/secondary/min_deblike_openscap_audit.feature
@@ -12,12 +12,12 @@ Feature: OpenSCAP audit of Debian-like Salt minion
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  @skip_if_container
+  @skip_if_github_validation
   Scenario: Enable all the necessary repositories for OpenSCAP on Debian-like minion
     When I enable Debian-like "universe" repository on "deblike_minion"
     And I enable the repositories "tools_update_repo tools_pool_repo" on this "deblike_minion"
 
-  @skip_if_container  
+  @skip_if_github_validation
   Scenario: Install the OpenSCAP packages on the Debian-like minion
     Given I am on the Systems overview page of this "deblike_minion"
     When I refresh the metadata for "deblike_minion"
@@ -74,11 +74,11 @@ Feature: OpenSCAP audit of Debian-like Salt minion
     And I click on "Update Organization"
     Then I should see a "Organization SUSE Test was successfully updated." text
 
-  @skip_if_container
+  @skip_if_github_validation
   Scenario: Cleanup: remove the OpenSCAP packages from the Debian-like minion
     When I remove OpenSCAP dependencies from "deblike_minion"
 
-  @skip_if_container
+  @skip_if_github_validation
   Scenario: Cleanup: remove all the necessary repositories for OpenSCAP on Debian-like minion
     When I disable the repositories "tools_update_repo tools_pool_repo" on this "deblike_minion"
     And I disable Debian-like "universe" repository on "deblike_minion"

--- a/testsuite/features/secondary/min_deblike_remote_command.feature
+++ b/testsuite/features/secondary/min_deblike_remote_command.feature
@@ -4,7 +4,7 @@
 # Skip if container. This test is broken
 # This needs to be fixed
 
-@skip_if_container
+@skip_if_github_validation
 @scope_deblike
 @deblike_minion
 Feature: Remote command on Debian-like Salt minion

--- a/testsuite/features/secondary/min_deblike_salt_install_package.feature
+++ b/testsuite/features/secondary/min_deblike_salt_install_package.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2019-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@skip_if_container
+@skip_if_github_validation
 @scope_deblike
 @deblike_minion
 Feature: Install and upgrade package on the Debian-like minion via Salt through the UI

--- a/testsuite/features/secondary/min_deblike_salt_install_with_staging.feature
+++ b/testsuite/features/secondary/min_deblike_salt_install_with_staging.feature
@@ -10,7 +10,7 @@
 #   java.salt_content_staging_advance = 0.05 (3 minutes)
 # which means "between 3 and 1 minutes before package installation or patching"
 
-@skip_if_container
+@skip_if_github_validation
 @deblike_minion
 @scope_deblike
 @scope_content_staging

--- a/testsuite/features/secondary/min_deblike_ssh.feature
+++ b/testsuite/features/secondary/min_deblike_ssh.feature
@@ -12,7 +12,7 @@
 # If the cleanup bootstrap scenario fails,
 # the minion will not be reachable in those features.
 
-@skip_if_container
+@skip_if_github_validation
 @scope_deblike
 @scope_salt_ssh
 @deblike_minion

--- a/testsuite/features/secondary/min_docker_api.feature
+++ b/testsuite/features/secondary/min_docker_api.feature
@@ -13,7 +13,7 @@
 # - features/secondary/buildhost_docker_build_image.feature
 # - features/secondary/buildhost_docker_auth_registry.feature
 
-@skip_if_container
+@skip_if_github_validation
 @skip_if_cloud
 @scope_building_container_images
 Feature: API "image" namespace for containers and sub-namespaces

--- a/testsuite/features/secondary/min_monitoring.feature
+++ b/testsuite/features/secondary/min_monitoring.feature
@@ -4,7 +4,7 @@
 # - features/secondary/srv_monitoring.feature : As this feature disable/re-enable monitoring capabilities
 # - sumaform : As it is configuring monitoring to be enabled after deployment
 
-@skip_if_container
+@skip_if_github_validation
 @sle_minion
 @scope_monitoring
 Feature: Monitor SUMA environment with Prometheus on a SLE Salt minion

--- a/testsuite/features/secondary/min_recurring_action.feature
+++ b/testsuite/features/secondary/min_recurring_action.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2021-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@skip_if_container
+@skip_if_github_validation
 @scope_recurring_actions
 Feature: Recurring Actions
 

--- a/testsuite/features/secondary/min_rhlike_monitoring.feature
+++ b/testsuite/features/secondary/min_rhlike_monitoring.feature
@@ -4,7 +4,7 @@
 # - features/secondary/srv_monitoring.feature: as this feature disables/re-enables monitoring capabilities
 # - sumaform: as it is configuring monitoring to be enabled after deployment
 
-@skip_if_container
+@skip_if_github_validation
 @scope_monitoring
 @scope_res
 @rhlike_minion

--- a/testsuite/features/secondary/min_rhlike_openscap_audit.feature
+++ b/testsuite/features/secondary/min_rhlike_openscap_audit.feature
@@ -12,13 +12,13 @@ Feature: OpenSCAP audit of Red Hat-like Salt minion
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  @skip_if_container
+  @skip_if_github_validation
   Scenario: Enable repositories for openSCAP on the Red Hat-like minion
     When I enable the repositories "Rocky-BaseOS Rocky-AppStream" on this "rhlike_minion"
     And I enable the repositories "tools_update_repo tools_pool_repo" on this "rhlike_minion"
     And I refresh the metadata for "rhlike_minion"
 
-  @skip_if_container
+  @skip_if_github_validation
   Scenario: Install the OpenSCAP packages on the Red Hat-like minion
     Given I am on the Systems overview page of this "rhlike_minion"
     And I install OpenSCAP dependencies on "rhlike_minion"
@@ -75,13 +75,13 @@ Feature: OpenSCAP audit of Red Hat-like Salt minion
     And I click on "Update Organization"
     Then I should see a "Organization SUSE Test was successfully updated." text
 
-  @skip_if_container
+  @skip_if_github_validation
   Scenario: Cleanup: remove the OpenSCAP packages from the Red Hat-like minion
     When I remove OpenSCAP dependencies from "rhlike_minion"
     And I disable repository "Rocky-BaseOS" on this "rhlike_minion"
     And I disable the repositories "tools_update_repo tools_pool_repo" on this "rhlike_minion"
 
-  @skip_if_container
+  @skip_if_github_validation
   Scenario: Cleanup: restore the base channel for the Red Hat-like minion
     Given I am on the Systems overview page of this "rhlike_minion"
     When I follow "Software" in the content area

--- a/testsuite/features/secondary/min_rhlike_remote_command.feature
+++ b/testsuite/features/secondary/min_rhlike_remote_command.feature
@@ -4,7 +4,7 @@
 # Skip if container. This test is broken
 # This needs to be fixed
 
-@skip_if_container
+@skip_if_github_validation
 @scope_res
 @rhlike_minion
 Feature: Remote command on the Red Hat-like Salt minion

--- a/testsuite/features/secondary/min_rhlike_salt_install_package_and_patch.feature
+++ b/testsuite/features/secondary/min_rhlike_salt_install_package_and_patch.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2015-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@skip_if_container
+@skip_if_github_validation
 @scope_res
 @scope_salt
 @rhlike_minion

--- a/testsuite/features/secondary/min_rhlike_ssh.feature
+++ b/testsuite/features/secondary/min_rhlike_ssh.feature
@@ -12,7 +12,7 @@
 # If the cleanup bootstrap scenario fails,
 # the minion will not be reachable in those features
 
-@skip_if_container
+@skip_if_github_validation
 @scope_res
 @rhlike_minion
 Feature: Bootstrap a SSH-managed Red Hat-like minion and do some basic operations on it

--- a/testsuite/features/secondary/min_salt_formulas.feature
+++ b/testsuite/features/secondary/min_salt_formulas.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2017-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@skip_if_container
+@skip_if_github_validation
 @scope_formulas
 Feature: Use salt formulas
   In order to use simple forms to apply changes to minions

--- a/testsuite/features/secondary/min_salt_install_with_staging.feature
+++ b/testsuite/features/secondary/min_salt_install_with_staging.feature
@@ -10,7 +10,7 @@
 #   java.salt_content_staging_advance = 0.05 (3 minutes)
 # which means "beetwen 3 and 1 minutes before package installation or patching"
 
-@skip_if_container
+@skip_if_github_validation
 @sle_minion
 @scope_content_staging
 Feature: Install a package on the SLES minion with staging enabled

--- a/testsuite/features/secondary/min_salt_mgrcompat_state.feature
+++ b/testsuite/features/secondary/min_salt_mgrcompat_state.feature
@@ -12,7 +12,7 @@
 # - features/secondary/min_move_from_and_to_proxy.feature
 # If the minion fails to bootstrap again.
 
-@skip_if_container
+@skip_if_github_validation
 @sle_minion
 @scope_salt
 Feature: Verify that Salt mgrcompat state works when the new module.run syntax is enabled

--- a/testsuite/features/secondary/min_salt_minions_page.feature
+++ b/testsuite/features/secondary/min_salt_minions_page.feature
@@ -5,7 +5,7 @@
 # - features/secondary/min_salt_mgrcompat_state.feature
 # If the minion fails to bootstrap again.
 
-@skip_if_container
+@skip_if_github_validation
 @scope_salt
 Feature: Management of minion keys
   In Order to validate the minion onboarding page

--- a/testsuite/features/secondary/min_salt_openscap_audit.feature
+++ b/testsuite/features/secondary/min_salt_openscap_audit.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2017-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@skip_if_container
+@skip_if_github_validation
 @scope_openscap
 Feature: OpenSCAP audit of Salt minion
   In order to audit a Salt minion

--- a/testsuite/features/secondary/min_salt_pkgset_beacon.feature
+++ b/testsuite/features/secondary/min_salt_pkgset_beacon.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@skip_if_container
+@skip_if_github_validation
 @scope_salt
 Feature: System package list is updated if packages are manually installed or removed
 

--- a/testsuite/features/secondary/min_salt_software_states.feature
+++ b/testsuite/features/secondary/min_salt_software_states.feature
@@ -116,7 +116,7 @@ Feature: Salt package states
 
 # When run inside containers, we can't kill salt-minion or the
 # container will stop
-@skip_if_container
+@skip_if_github_validation
   Scenario: Use Salt presence mechanism on an unreachable minion
     When I follow "States" in the content area
     And I run "pkill salt-minion" on "sle_minion" without error control
@@ -125,7 +125,7 @@ Feature: Salt package states
     And I click on "Show full highstate output"
     And I wait until I see "No reply from minion" text
 
-@skip_if_container    
+@skip_if_github_validation
   Scenario: Cleanup: restart the salt service on SLES minion
     When I restart salt-minion on "sle_minion"
 

--- a/testsuite/features/secondary/min_salt_user_states.feature
+++ b/testsuite/features/secondary/min_salt_user_states.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2018-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@skip_if_container
+@skip_if_github_validation
 @scope_salt
 Feature: Coexistence with user-defined states
 

--- a/testsuite/features/secondary/min_ssh_tunnel.feature
+++ b/testsuite/features/secondary/min_ssh_tunnel.feature
@@ -5,7 +5,7 @@
 # - features/secondary/min_activationkey.feature
 # If the minion fails to bootstrap again.
 
-@skip_if_container
+@skip_if_github_validation
 @scope_salt_ssh
 @ssh_minion
 Feature: Register a Salt system to be managed via SSH tunnel

--- a/testsuite/features/secondary/min_timezone.feature
+++ b/testsuite/features/secondary/min_timezone.feature
@@ -4,7 +4,7 @@
 # This is a known bug: https://bugzilla.suse.com/show_bug.cgi?id=1209231
 # Until is fixed, let's skip it in the container, as it will confuse
 # users.
-@skip_if_container
+@skip_if_github_validation
 @scope_visualization
 @sle_minion
 Feature: Correct timezone display 

--- a/testsuite/features/secondary/minssh_action_chain.feature
+++ b/testsuite/features/secondary/minssh_action_chain.feature
@@ -125,7 +125,7 @@ Feature: Salt SSH action chain
     And I check radio button "schedule-by-action-chain"
     And I click on "Apply Highstate"
 
-@skip_if_container    
+@skip_if_github_validation
   Scenario: Add a reboot action to the action chain on SSH minion
     Given I am on the Systems overview page of this "ssh_minion"
     When I follow first "Schedule System Reboot"

--- a/testsuite/features/secondary/minssh_ansible_control_node.feature
+++ b/testsuite/features/secondary/minssh_ansible_control_node.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2021-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@skip_if_container
+@skip_if_github_validation
 @scope_ansible
 @scope_salt_ssh
 @ssh_minion

--- a/testsuite/features/secondary/minssh_bootstrap_api.feature
+++ b/testsuite/features/secondary/minssh_bootstrap_api.feature
@@ -12,7 +12,7 @@
 @scope_salt_ssh
 @scope_onboarding
 @ssh_minion
-@skip_if_container
+@skip_if_github_validation
 Feature: Register a salt-ssh system via API
 
   Scenario: Log in as admin user

--- a/testsuite/features/secondary/minssh_salt_install_package.feature
+++ b/testsuite/features/secondary/minssh_salt_install_package.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2019-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@skip_if_container
+@skip_if_github_validation
 @scope_salt_ssh
 @scope_onboarding
 @ssh_minion

--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -4,7 +4,7 @@
 # We also test 'Bootstrapping using the command line' in this feature with the following script:
 # https://github.com/uyuni-project/uyuni/blob/master/java/conf/cobbler/snippets/minion_script
 
-@skip_if_container
+@skip_if_github_validation
 @proxy
 @private_net
 @pxeboot_minion

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -12,7 +12,7 @@
 # * if there is no private network ($private_net is nil)
 # * if there is no PXE boot minion ($pxeboot_mac is nil)
 
-@skip_if_container
+@skip_if_github_validation
 @buildhost
 @proxy
 @private_net

--- a/testsuite/features/secondary/srv_cobbler_buildiso.feature
+++ b/testsuite/features/secondary/srv_cobbler_buildiso.feature
@@ -2,7 +2,7 @@
 # Licensed under the terms of the MIT license.
 
 @scope_cobbler
-@skip_if_container
+@skip_if_github_validation
 Feature: Cobbler buildiso
   Builds several ISOs with Cobbler and checks the configuration files and ISOs afterwards.
 

--- a/testsuite/features/secondary/srv_cobbler_distro.feature
+++ b/testsuite/features/secondary/srv_cobbler_distro.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2010-2022 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
-@skip_if_container
+@skip_if_github_validation
 @scope_cobbler
 Feature: Cobbler and distribution autoinstallation
 

--- a/testsuite/features/secondary/srv_cobbler_profile.feature
+++ b/testsuite/features/secondary/srv_cobbler_profile.feature
@@ -6,7 +6,7 @@
 # the second one uses the XML-RPC API
 
 @scope_cobbler
-@skip_if_container
+@skip_if_github_validation
 Feature: Edit Cobbler profiles
 
   Background: The Cobbler service should be running

--- a/testsuite/features/secondary/srv_cobbler_sync.feature
+++ b/testsuite/features/secondary/srv_cobbler_sync.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2022-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@skip_if_container
+@skip_if_github_validation
 @scope_cobbler
 Feature: Run Cobbler Sync via WebUI
 

--- a/testsuite/features/secondary/srv_maintenance_windows.feature
+++ b/testsuite/features/secondary/srv_maintenance_windows.feature
@@ -5,7 +5,7 @@
 # javascript validation fails on validating the URL
 # this needs to be fixed
 
-@skip_if_container
+@skip_if_github_validation
 @scope_maintenance_windows
 @sle_minion
 @rhlike_minion

--- a/testsuite/features/secondary/srv_monitoring.feature
+++ b/testsuite/features/secondary/srv_monitoring.feature
@@ -20,7 +20,8 @@
 # If this feature fails,
 # it could let the monitoring feature disabled for the Debian-like minion
 
-@skip_if_container
+@skip_if_github_validation
+@skip_if_container_server
 @scope_monitoring
 Feature: Disable and re-enable monitoring of the server
 

--- a/testsuite/features/secondary/srv_notifications.feature
+++ b/testsuite/features/secondary/srv_notifications.feature
@@ -2,7 +2,7 @@
 # Licensed under the terms of the MIT license.
 
 @scope_visualization
-@skip_if_container
+@skip_if_github_validation
 Feature: Test the notification/notification-messages feature
 
   Scenario: Log in as admin user

--- a/testsuite/features/secondary/srv_power_management.feature
+++ b/testsuite/features/secondary/srv_power_management.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2015-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@skip_if_container
+@skip_if_github_validation
 @scope_power_management
 @scope_cobbler
 @sle_minion

--- a/testsuite/features/secondary/srv_power_management_api.feature
+++ b/testsuite/features/secondary/srv_power_management_api.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2021-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@skip_if_container
+@skip_if_github_validation
 @scope_api
 @sle_minion
 Feature: IPMI Power management API

--- a/testsuite/features/secondary/srv_power_management_redfish.feature
+++ b/testsuite/features/secondary/srv_power_management_redfish.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2021-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@skip_if_container
+@skip_if_github_validation
 @scope_power_management
 @scope_cobbler
 @sle_minion

--- a/testsuite/features/secondary/srv_rename_hostname.feature
+++ b/testsuite/features/secondary/srv_rename_hostname.feature
@@ -6,8 +6,9 @@
 # If the server fails to reboot properly
 # or the cleanup fails and renders the server unreachable.
 
-@skip_if_container
+@skip_if_github_validation
 @skip_if_cloud
+@skip_if_container_server
 Feature: Reconfigure the server's hostname
   As admin 
   In order to change the server's hostname

--- a/testsuite/features/secondary/srv_restart.feature
+++ b/testsuite/features/secondary/srv_restart.feature
@@ -8,7 +8,8 @@
 # This feature can cause failures in the following features:
 # All features following this one if the server fails to restart.
 
-@skip_if_container
+@skip_if_github_validation
+@skip_if_container_server
 Feature: Restart the spacewalk services via UI
 
   Scenario: Restart the SUSE Manager through the WebUI Admin option

--- a/testsuite/features/secondary/srv_scc_user_credentials.feature
+++ b/testsuite/features/secondary/srv_scc_user_credentials.feature
@@ -1,7 +1,7 @@
 # Copyright 2017-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@skip_if_container
+@skip_if_github_validation
 @no_mirror
 Feature: SCC user credentials in the Setup Wizard
   As a systems administrator

--- a/testsuite/features/secondary/srv_virtual_host_manager.feature
+++ b/testsuite/features/secondary/srv_virtual_host_manager.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2017-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@skip_if_container
+@skip_if_github_validation
 @skip_if_cloud
 @scope_virtual_host_manager
 Feature: Virtual host manager web UI

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -42,7 +42,8 @@ STARTTIME = Time.new.to_i
 Capybara.default_max_wait_time = ENV['CAPYBARA_TIMEOUT'] ? ENV['CAPYBARA_TIMEOUT'].to_i : 10
 DEFAULT_TIMEOUT = ENV['DEFAULT_TIMEOUT'] ? ENV['DEFAULT_TIMEOUT'].to_i : 250
 $is_cloud_provider = ENV["PROVIDER"].include? 'aws'
-$is_container_provider = ENV["PROVIDER"].include?('podman') || ['k3s', 'podman'].include?(ENV.fetch("CONTAINER_RUNTIME", ''))
+$is_container_provider = ENV["PROVIDER"].include? 'podman'
+$is_container_server = ['k3s', 'podman'].include? ENV.fetch("CONTAINER_RUNTIME", '')
 $is_using_build_image = ENV.fetch('IS_USING_BUILD_IMAGE') { false }
 $is_using_scc_repositories = (ENV.fetch('IS_USING_SCC_REPOSITORIES', 'False') != 'False')
 
@@ -526,9 +527,14 @@ Before('@skip_if_cloud') do
   skip_this_scenario if $is_cloud_provider
 end
 
-# skip tests if executed in docker
-Before('@skip_if_container') do
+# skip tests if executed in containers for the githug validation
+Before('@skip_if_github_validation') do
   skip_this_scenario if $is_container_provider
+end
+
+# skip tests if the server runs in a container
+Before('@skip_if_container_server') do
+  skip_this_scenario if $is_container_server
 end
 
 # have more infos about the errors


### PR DESCRIPTION
## What does this PR change?

Since the tests to skip are not the same for github validation tests running in containers and the server running in a container, create two skip flags instead of one.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
