### PR TITLE
cert-tools: allow reading the CA password from a files

### DIFF
--- a/spacewalk/certs-tools/rhn_ssl_tool.py
+++ b/spacewalk/certs-tools/rhn_ssl_tool.py
@@ -229,6 +229,13 @@ def getCAPassword(options, confirmYN=1):
     global DEFS
     while not options.password:
         pw = _pw = None
+        if options.password_file:
+            if os.path.isfile(options.password_file):
+                with open(options.password_file, 'r') as fd:
+                    pw = _pw = fd.read().strip()
+            else:
+                print("No such file '{}'".format(options.password_file))
+
         while not pw:
             pw = getpass.getpass("CA password: ")
         if confirmYN:

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,4 @@
+- Read CA password from a file
 - Also ship SUSE specific files on Enterprise Linux.
 - Use the CA cert in the pki config to generate build host rpm
 - Add shadow as dependency of osimage certificate package

--- a/spacewalk/certs-tools/sslToolCli.py
+++ b/spacewalk/certs-tools/sslToolCli.py
@@ -44,6 +44,7 @@ def _getOptionsTree(defs):
     """
 
     _optCAKeyPassword = make_option('-p', '--password', action='store', type="string", help='CA password')
+    _optCAKeyPasswordFile = make_option('--password-file', action='store', type="string", help='file containing the CA password')
     _optCaKey = make_option('--ca-key', action='store', type="string", help='CA private key filename (default: %s)' % defs['--ca-key'])
     _optCaCert = make_option('--ca-cert', action='store', type="string", help='CA certificate filename (default: %s)' % defs['--ca-cert'])
 
@@ -107,6 +108,7 @@ def _getOptionsTree(defs):
     _caOptions = [
         _optCaForce,
         _optCAKeyPassword,
+        _optCAKeyPasswordFile,
         _optCaKey,
         ]
 
@@ -114,6 +116,7 @@ def _getOptionsTree(defs):
     _caCertOptions = [
         _optCaForce,
         _optCAKeyPassword,
+        _optCAKeyPasswordFile,
         _optCaKey,
         _optCaCert,
         _optCertExp,
@@ -135,6 +138,7 @@ def _getOptionsTree(defs):
     # server cert generation options
     _serverCertOptions = [
         _optCAKeyPassword,
+        _optCAKeyPasswordFile,
         _optCaCert,
         _optCaKey,
         _optServerCertReq,
@@ -144,7 +148,7 @@ def _getOptionsTree(defs):
         ]
 
     # SSL key check options
-    _checkOptions = [_optCAKeyPassword]
+    _checkOptions = [_optCAKeyPassword, _optCAKeyPasswordFile]
 
     # SSL cert check options
     # = nothing


### PR DESCRIPTION
## What does this PR change?

In order to avoid the password to stay in shell history, allow users to pass a --password-file /path/to/file to get rhn-ssl-tool read the password from the file.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: will be covered when testing container server

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
