### PR TITLE
Move adding the www group to tomcat user to uyuni-base spec

### DIFF
--- a/spacewalk/setup/bin/spacewalk-setup
+++ b/spacewalk/setup/bin/spacewalk-setup
@@ -113,9 +113,6 @@ if ($opts{'db-only'}) {
 remove_old_jvm(\%opts, \%answers);
 remove_tomcat_cache(\%opts);
 
-print Spacewalk::Setup::loc("* Setting up users and groups.\n");
-setup_users_and_groups();
-
 setup_services();
 
 setup_admin_email(\%opts, \%answers, \%rhnOptions);
@@ -1027,59 +1024,6 @@ sub is_suse_like {
   }
   close $fh;
   return;
-}
-
-sub setup_users_and_groups {
-  if(is_suse_like)
-  {
-    # Check to be sure the required users and groups exist.
-    my @required_groups = qw/www/;
-    Spacewalk::Setup::check_groups_exist(@required_groups);
-
-    # Need user tomcat in the apache group so the Java stack can read the same
-    # configuration files as the rest of the application.
-    (undef, undef, my $apache_group_id, my $apache_group_members) = getgrnam("www");
-    if (not defined $apache_group_id) {
-        print Spacewalk::Setup::loc("The group 'www' should exist.\n");
-    }
-    if (not grep { $_ eq 'tomcat' } split /\s+/, $apache_group_members) {
-        Spacewalk::Setup::system_or_exit(['/usr/sbin/usermod', '-G', 'www', '-a', 'tomcat'], 9,
-            'Could not add tomcat to the www group.');
-        # If you have for example NIS before passwd in nsswitch.conf, the usermod
-        # will not modify what the system uses. Let's check.
-        (undef, undef, undef, my $test_apache_group_members) = getgrnam("www");
-        if (not grep { $_ eq 'tomcat' } split /\s+/, $test_apache_group_members) {
-            print Spacewalk::Setup::loc("The usermod failed to add tomcat to www group.\n");
-            exit 87;
-        }
-    }
-  }
-  else
-  {
-    # Check to be sure the required users and groups exist.
-    my @required_groups = qw/apache/;
-    Spacewalk::Setup::check_groups_exist(@required_groups);
-
-    # Need user tomcat in the apache group so the Java stack can read the same
-    # configuration files as the rest of the application.
-    (undef, undef, my $apache_group_id, my $apache_group_members) = getgrnam("apache");
-    if (not defined $apache_group_id) {
-      print Spacewalk::Setup::loc("The group 'apache' should exist.\n");
-    }
-    if (not grep { $_ eq 'tomcat' } split /\s+/, $apache_group_members) {
-        Spacewalk::Setup::system_or_exit(['/usr/sbin/usermod', '-G', 'apache', '-a', 'tomcat'], 9,
-            'Could not add tomcat to the apache group.');
-        # If you have for example NIS before passwd in nsswitch.conf, the usermod
-        # will not modify what the system uses. Let's check.
-        (undef, undef, undef, my $test_apache_group_members) = getgrnam("apache");
-        if (not grep { $_ eq 'tomcat' } split /\s+/, $test_apache_group_members) {
-            print Spacewalk::Setup::loc("The usermod failed to add tomcat to apache group.\n");
-            exit 87;
-        }
-    }
-  }
-
-    return 1;
 }
 
 sub check_ca_key{

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,4 @@
+- Move set tomcat user setup to uyuni-base spec file
 - Add option to disable SSL setup
 - Corrected requirement to install Tomcat before spacewalk-setup.
 - Automatically detect PostgreSQL service and data folder name.

--- a/uyuni/base/uyuni-base.changes
+++ b/uyuni/base/uyuni-base.changes
@@ -1,3 +1,5 @@
+- Add www group to tomcat user
+
 -------------------------------------------------------------------
 Wed Sep 28 11:08:28 CEST 2022 - jgonzalez@suse.com
 

--- a/uyuni/base/uyuni-base.spec
+++ b/uyuni/base/uyuni-base.spec
@@ -107,7 +107,7 @@ mkdir -p %{buildroot}/%{_prefix}/share/rhn/config-defaults
 %pre server
 getent group susemanager >/dev/null || %{_sbindir}/groupadd -r susemanager
 getent passwd salt >/dev/null && %{_sbindir}/usermod -a -G susemanager salt
-getent passwd tomcat >/dev/null && %{_sbindir}/usermod -a -G susemanager tomcat
+getent passwd tomcat >/dev/null && %{_sbindir}/usermod -a -G susemanager,%{apache_group} tomcat
 getent passwd %{apache_user} >/dev/null && %{_sbindir}/usermod -a -G susemanager %{apache_user}
 %endif
 


### PR DESCRIPTION
## What does this PR change?

Move groups created by the setup script to RPM spec file with the others. This is required to have them in the server container image.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
