### PR TITLE
Testsuite: Enhance hostname rename test feature

### DIFF
--- a/testsuite/features/secondary/srv_rename_hostname.feature
+++ b/testsuite/features/secondary/srv_rename_hostname.feature
@@ -30,3 +30,4 @@ Feature: Reconfigure the server's hostname
 
   Scenario: Cleanup after hostname rename test
     When I clean up the server's hosts file
+    And I restart the spacewalk service

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1472,7 +1472,7 @@ When(/^I run spacewalk-hostname-rename command on the server$/) do
             "--ssl-country=DE --ssl-state=Bayern --ssl-city=Nuremberg " \
             "--ssl-org=SUSE --ssl-orgunit=SUSE --ssl-email=galaxy-noise@suse.de " \
             "--ssl-ca-password=spacewalk"
-  out_spacewalk, result_code = temp_server.run(command, check_errors: false, timeout: 10)
+  out_spacewalk, result_code = temp_server.run(command, check_errors: false)
   log "#{out_spacewalk}"
 
   default_timeout = 300


### PR DESCRIPTION
## What does this PR change?
Remove timeout on command and add spacewalk service restart in cleanup
## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Fixes #
Tracks #
4.2 https://github.com/SUSE/spacewalk/pull/21719 & https://github.com/SUSE/spacewalk/pull/21631
4.3 https://github.com/SUSE/spacewalk/pull/21731
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
