### PR TITLE
Remove wrong dependencies from classpath

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/servlets/test/SystemDetailsMessageFilterTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/test/SystemDetailsMessageFilterTest.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.frontend.servlets.test;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -27,12 +28,12 @@ import com.redhat.rhn.testing.MockObjectTestCase;
 import com.redhat.rhn.testing.RhnMockHttpServletRequest;
 import com.redhat.rhn.testing.UserTestUtils;
 
-import com.google.common.collect.Iterators;
-
 import org.apache.struts.action.ActionMessage;
 import org.apache.struts.action.ActionMessages;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -52,11 +53,15 @@ public class SystemDetailsMessageFilterTest extends MockObjectTestCase {
         HttpServletRequest request = new RhnMockHttpServletRequest();
         SystemDetailsMessageFilter filter = new SystemDetailsMessageFilter();
         filter.processSystemMessages(request, server);
-        ActionMessages messages =
-                ((ActionMessages) request.getSession().getAttribute("org.apache.struts.action.ERROR"));
-        assertEquals(1, Iterators.size(messages.get(ActionMessages.GLOBAL_MESSAGE)));
-        ActionMessage message = (ActionMessage) messages.get(ActionMessages.GLOBAL_MESSAGE).next();
+
+        ActionMessages messages = (ActionMessages) request.getSession().getAttribute("org.apache.struts.action.ERROR");
+        @SuppressWarnings("unchecked")
+        Iterator<ActionMessage> globalMessagesIterator = messages.get(ActionMessages.GLOBAL_MESSAGE);
+
+        ActionMessage message = globalMessagesIterator.next();
         assertEquals(SystemDetailsMessageFilter.TRADITIONAL_STACK_MESSAGE_KEY, message.getKey());
+        // Ensure only one message is present
+        assertFalse(globalMessagesIterator.hasNext());
     }
 
     @Test

--- a/java/code/src/com/redhat/rhn/manager/audit/ScapManager.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/ScapManager.java
@@ -70,7 +70,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import javax.xml.XMLConstants;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
@@ -465,7 +464,6 @@ public class ScapManager extends BaseManager {
         try (OutputStream resumeOut = new FileOutputStream(output)) {
             StreamResult out = new StreamResult(resumeOut);
             TransformerFactory factory = TransformerFactory.newInstance();
-            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             Transformer transformer = factory.newTransformer(xslStream);
             transformer.transform(in, out);
         }

--- a/java/code/src/com/redhat/rhn/testing/SparkTestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/SparkTestUtils.java
@@ -13,10 +13,7 @@
  * in this software or its documentation.
  */
 
-package com.suse.manager.webui.utils;
-
-import com.redhat.rhn.testing.RhnMockHttpServletRequest;
-import com.redhat.rhn.testing.RhnMockHttpSession;
+package com.redhat.rhn.testing;
 
 import com.mockobjects.servlet.MockServletInputStream;
 

--- a/java/code/src/com/suse/manager/api/test/RouteFactoryTest.java
+++ b/java/code/src/com/suse/manager/api/test/RouteFactoryTest.java
@@ -24,6 +24,7 @@ import com.redhat.rhn.frontend.servlets.PxtSessionDelegate;
 import com.redhat.rhn.frontend.servlets.PxtSessionDelegateFactory;
 import com.redhat.rhn.frontend.xmlrpc.serializer.SerializerFactory;
 import com.redhat.rhn.testing.RhnMockHttpServletResponse;
+import com.redhat.rhn.testing.SparkTestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
 import com.suse.manager.api.ApiResponseSerializer;
@@ -34,7 +35,6 @@ import com.suse.manager.api.RouteFactory;
 import com.suse.manager.api.SerializationBuilder;
 import com.suse.manager.api.SerializedApiResponse;
 import com.suse.manager.webui.controllers.test.BaseControllerTestCase;
-import com.suse.manager.webui.utils.SparkTestUtils;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/mappers/test/ResponseMappersTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/mappers/test/ResponseMappersTest.java
@@ -12,7 +12,7 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package com.suse.manager.webui.controllers.contentmanagement.mappers;
+package com.suse.manager.webui.controllers.contentmanagement.mappers.test;
 
 import static com.redhat.rhn.domain.contentmgmt.ProjectSource.Type.SW_CHANNEL;
 import static java.util.Optional.empty;
@@ -30,6 +30,7 @@ import com.redhat.rhn.manager.contentmgmt.ContentManager;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ChannelTestUtils;
 
+import com.suse.manager.webui.controllers.contentmanagement.mappers.ResponseMappers;
 import com.suse.manager.webui.controllers.contentmanagement.response.ProjectPropertiesResponse;
 import com.suse.manager.webui.utils.ViewHelper;
 

--- a/java/code/src/com/suse/manager/webui/controllers/test/BaseControllerTestCase.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/BaseControllerTestCase.java
@@ -15,8 +15,7 @@
 package com.suse.manager.webui.controllers.test; import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.redhat.rhn.testing.RhnMockHttpServletResponse;
-
-import com.suse.manager.webui.utils.SparkTestUtils;
+import com.redhat.rhn.testing.SparkTestUtils;
 
 import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.junit.jupiter.api.BeforeEach;

--- a/java/code/src/com/suse/manager/webui/controllers/test/DownloadControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/DownloadControllerTest.java
@@ -47,11 +47,11 @@ import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ErrataTestUtils;
 import com.redhat.rhn.testing.RhnMockHttpServletResponse;
+import com.redhat.rhn.testing.SparkTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 
 import com.suse.manager.webui.controllers.DownloadController;
 import com.suse.manager.webui.utils.DownloadTokenBuilder;
-import com.suse.manager.webui.utils.SparkTestUtils;
 
 import com.mockobjects.servlet.MockHttpServletResponse;
 

--- a/java/code/src/com/suse/manager/webui/controllers/test/LoginControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/LoginControllerTest.java
@@ -28,11 +28,11 @@ import com.redhat.rhn.manager.user.UserManager;
 import com.redhat.rhn.testing.RhnMockHttpServletRequest;
 import com.redhat.rhn.testing.RhnMockHttpServletResponse;
 import com.redhat.rhn.testing.RhnMockHttpSession;
+import com.redhat.rhn.testing.SparkTestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
 import com.suse.manager.webui.controllers.login.LoginController;
 import com.suse.manager.webui.utils.LoginHelper;
-import com.suse.manager.webui.utils.SparkTestUtils;
 import com.suse.utils.Json;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/java/code/src/com/suse/manager/webui/controllers/test/ProxyControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/ProxyControllerTest.java
@@ -18,12 +18,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.redhat.rhn.common.util.FileUtils;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.testing.SparkTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 
 import com.suse.manager.ssl.SSLCertData;
 import com.suse.manager.ssl.SSLCertPair;
 import com.suse.manager.webui.controllers.ProxyController;
-import com.suse.manager.webui.utils.SparkTestUtils;
 
 import org.jmock.Expectations;
 import org.junit.jupiter.api.BeforeEach;

--- a/java/code/src/com/suse/manager/webui/controllers/test/SaltbootControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/SaltbootControllerTest.java
@@ -23,10 +23,10 @@ import com.redhat.rhn.domain.image.ImageStore;
 import com.redhat.rhn.domain.server.Pillar;
 import com.redhat.rhn.testing.ImageTestUtils;
 import com.redhat.rhn.testing.RhnMockHttpServletResponse;
+import com.redhat.rhn.testing.SparkTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 
 import com.suse.manager.webui.controllers.SaltbootController;
-import com.suse.manager.webui.utils.SparkTestUtils;
 import com.suse.utils.Json;
 
 import com.google.gson.reflect.TypeToken;

--- a/java/code/src/com/suse/manager/webui/controllers/test/SetControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/SetControllerTest.java
@@ -27,9 +27,9 @@ import com.redhat.rhn.frontend.struts.SessionSetHelper;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 import com.redhat.rhn.manager.rhnset.RhnSetManager;
 import com.redhat.rhn.testing.RhnMockHttpServletResponse;
+import com.redhat.rhn.testing.SparkTestUtils;
 
 import com.suse.manager.webui.controllers.SetController;
-import com.suse.manager.webui.utils.SparkTestUtils;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;

--- a/java/code/src/com/suse/manager/webui/controllers/test/VirtualHostManagerControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/VirtualHostManagerControllerTest.java
@@ -15,7 +15,7 @@
 
 package com.suse.manager.webui.controllers.test;
 
-import static com.suse.manager.webui.utils.SparkTestUtils.createMockRequestWithParams;
+import static com.redhat.rhn.testing.SparkTestUtils.createMockRequestWithParams;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -28,6 +28,7 @@ import com.redhat.rhn.domain.server.virtualhostmanager.VirtualHostManagerConfig;
 import com.redhat.rhn.domain.server.virtualhostmanager.VirtualHostManagerFactory;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.RhnMockHttpServletResponse;
+import com.redhat.rhn.testing.SparkTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
@@ -35,7 +36,6 @@ import com.suse.manager.gatherer.GathererJsonIO;
 import com.suse.manager.gatherer.GathererRunner;
 import com.suse.manager.model.gatherer.GathererModule;
 import com.suse.manager.webui.controllers.VirtualHostManagerController;
-import com.suse.manager.webui.utils.SparkTestUtils;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;

--- a/java/code/src/com/suse/manager/webui/utils/salt/test/HwProfileUpdateSlsResultTest.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/test/HwProfileUpdateSlsResultTest.java
@@ -22,7 +22,7 @@ import com.redhat.rhn.testing.TestUtils;
 import com.suse.manager.webui.utils.salt.custom.HwProfileUpdateSlsResult;
 import com.suse.utils.Json;
 
-import com.google.common.reflect.TypeToken;
+import com.google.gson.reflect.TypeToken;
 
 import org.junit.jupiter.api.Test;
 

--- a/java/code/src/com/suse/manager/webui/utils/test/PageControlHelperTest.java
+++ b/java/code/src/com/suse/manager/webui/utils/test/PageControlHelperTest.java
@@ -21,9 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.frontend.listview.PageControl;
+import com.redhat.rhn.testing.SparkTestUtils;
 
 import com.suse.manager.webui.utils.PageControlHelper;
-import com.suse.manager.webui.utils.SparkTestUtils;
 
 import org.junit.jupiter.api.Test;
 

--- a/java/code/src/com/suse/manager/webui/utils/test/SparkTestUtilsTest.java
+++ b/java/code/src/com/suse/manager/webui/utils/test/SparkTestUtilsTest.java
@@ -17,7 +17,7 @@ package com.suse.manager.webui.utils.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.suse.manager.webui.utils.SparkTestUtils;
+import com.redhat.rhn.testing.SparkTestUtils;
 
 import org.junit.jupiter.api.Test;
 

--- a/java/manager-build.xml
+++ b/java/manager-build.xml
@@ -43,10 +43,15 @@
 
   <!-- Paths -->
   <path id="libjars">
-    <fileset dir="${lib.dir}" includes="**/*.jar" />
+    <fileset dir="${lib.dir}">
+      <include name="**/*.jar"/>
+      <!-- Exclude checkstyle and jacoco -->
+      <exclude name="all-8.30.jar" />
+      <exclude name="nodeps-0.8.7.jar" />
+    </fileset>
   </path>
   <path id="managertestjars">
-    <fileset dir="${lib.dir}" includes="**/*.jar" />
+    <path refid="libjars" />
     <fileset file="${build.dir}/rhn.jar" />
   </path>
 
@@ -311,7 +316,7 @@
     <echo message="${tests.includes.text}" />
     <echo message="and excluding:" />
     <echo message="${tests.excludes.text}" />
-    <taskdef resource="org/jacoco/ant/antlib.xml" classpathref="libjars" />
+    <taskdef resource="org/jacoco/ant/antlib.xml" classpath="${lib.dir}/nodeps-0.8.7.jar" />
     <agent property="jacocoagent" destfile="${tests.coverage.destfile}"/>
 
     <!-- Once all CI containers are using ant 1.10+ we can add the printSummary="true" parameter
@@ -350,7 +355,7 @@
   </target>
 
   <target name="checkstyle" depends="compile" description="Runs the checkstyle tool on sources">
-    <taskdef resource="com/puppycrawl/tools/checkstyle/ant/checkstyle-ant-task.properties" classpathref="libjars" />
+    <taskdef resource="com/puppycrawl/tools/checkstyle/ant/checkstyle-ant-task.properties" classpath="${lib.dir}/all-8.30.jar" />
     <checkstyle config="${basedir}/buildconf/checkstyle.xml">
       <classpath>
         <path location="${build.dir}/classes" />

--- a/java/spacewalk-java.changes.mackdk.remove-wrong-dependencies-from-classpath
+++ b/java/spacewalk-java.changes.mackdk.remove-wrong-dependencies-from-classpath
@@ -1,0 +1,1 @@
+- Disable Secure XSLT processing due to Xalan bug


### PR DESCRIPTION
## What does this PR change?

This PR removes CheckStyle and JaCoCo from compilation and runtime classpath. This two jars contains bundled all their dependencies which can be used by mistake while coding. For example, Guava was used in unit test even though it should not be a dependency of Uyuni (which is addressed in this PR as well). Moreover, the presence of Saxon in the CheckStyle jar meant that, during the execution of unit tests, it was used in place of Xalan. 

Finally, this PR also contains a small refactoring, moving class `SparkTestUtils` to `com.redhat.rhn.testing` (the package currently used for test utility classes) and moving `ResponseMappersTest` to `test`.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: only build related refactorings

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
