### PR TITLE
QE: Remove sanity checks from Core stage, as we have a dedicate stage for them

### DIFF
--- a/testsuite/run_sets/build_validation/build_validation_core.yml
+++ b/testsuite/run_sets/build_validation/build_validation_core.yml
@@ -4,8 +4,6 @@
 
 # IMMUTABLE ORDER
 
-- features/build_validation/core/allcli_sanity.feature
-
 # initialize SUSE Manager server
 - features/build_validation/core/srv_first_settings.feature
 - features/build_validation/core/srv_user_preferences.feature


### PR DESCRIPTION
## What does this PR change?

We are running sanity checks twice and chained. Let's remove the feature from the core stage.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed


- [x] **DONE**

## Test coverage
- Cucumber tests were removed from the YAML

- [x] **DONE**

## Links

Ports:
- Manager-4.3 https://github.com/SUSE/spacewalk/pull/21732
- Manager-4.2 https://github.com/SUSE/spacewalk/pull/21733

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
