### PR TITLE
Testsuite: Wait for cobblerd to have restarted at the end of cleanup step

### DIFF
--- a/testsuite/features/step_definitions/cobbler_steps.rb
+++ b/testsuite/features/step_definitions/cobbler_steps.rb
@@ -231,8 +231,12 @@ When(/^I cleanup Cobbler files and restart apache and cobblerd services$/) do
                     'rm -r /srv/tftpboot 2> /dev/null && ' \
                     'cp /etc/cobbler/settings.yaml.bak /etc/cobbler/settings.yaml 2> /dev/null'
   $server.run(cleanup_command.to_s, check_errors: false)
+  result, code = $server.run('systemctl restart apache')
+  raise "Error while restarting apache cleanup.\nLogs:\n#{result}" if code.nonzero?
+
   result, code = $server.run('systemctl restart apache && systemctl restart cobblerd')
-  raise "Error during Cobbler cleanup.\nLogs:\n#{result}" if code.nonzero?
+  raise "Error while restarting cobblerd.\nLogs:\n#{result}" if code.nonzero?
+
   step %(I wait until "cobblerd" service is active on "server")
 end
 

--- a/testsuite/features/step_definitions/cobbler_steps.rb
+++ b/testsuite/features/step_definitions/cobbler_steps.rb
@@ -233,6 +233,7 @@ When(/^I cleanup Cobbler files and restart apache and cobblerd services$/) do
   $server.run(cleanup_command.to_s, check_errors: false)
   result, code = $server.run('systemctl restart apache && systemctl restart cobblerd')
   raise "Error during Cobbler cleanup.\nLogs:\n#{result}" if code.nonzero?
+  step %(I wait until "cobblerd" service is active on "server")
 end
 
 # cobbler commands


### PR DESCRIPTION
## What does this PR change?
In order to be sure that `cobblerd` is ready in the next feature, add a sub-step waiting for `cobblerd` at the end of the cobbler cleanup steps.
## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Fixes # https://github.com/SUSE/spacewalk/issues/21736
Tracks # 
4.3 https://github.com/SUSE/spacewalk/pull/21737
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
