### PR TITLE
CI: Acceptance tests at PRv2: do not run if we only change the changelog

### DIFF
--- a/.github/workflows/acceptance_tests_secondary.yml
+++ b/.github/workflows/acceptance_tests_secondary.yml
@@ -6,7 +6,7 @@ on:
       - 'web/html/src/**'
       - 'testsuite/**'
       - '.github/workflows/acceptance_tests_secondary.yml'
-      - '!java/*.changes'
+      - '!java/*.changes*'
 jobs:
   test-uyuni:
     uses: ./.github/workflows/acceptance_tests_common.yml

--- a/.github/workflows/acceptance_tests_secondary.yml
+++ b/.github/workflows/acceptance_tests_secondary.yml
@@ -6,6 +6,7 @@ on:
       - 'web/html/src/**'
       - 'testsuite/**'
       - '.github/workflows/acceptance_tests_secondary.yml'
+      - '!java/*.changes'
 jobs:
   test-uyuni:
     uses: ./.github/workflows/acceptance_tests_common.yml

--- a/.github/workflows/acceptance_tests_secondary_parallel.yml
+++ b/.github/workflows/acceptance_tests_secondary_parallel.yml
@@ -6,6 +6,7 @@ on:
       - 'web/html/src/**'
       - 'testsuite/**'
       - '.github/workflows/acceptance_tests_secondary_parallel.yml'
+      - '!java/*.changes'
 jobs:
   test-uyuni:
     uses: ./.github/workflows/acceptance_tests_common.yml


### PR DESCRIPTION

## What does this PR change?

CI: excludes running the acceptance tests if only the changelog has changed.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

N/A
- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
