### PR TITLE
Update Enterprise Linux Apache user/group

### DIFF
--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,4 @@
+- Align /var/spacewalk folder permissions with uyuni-base-server package.
 - Move set tomcat user setup to uyuni-base spec file
 - Add option to disable SSL setup
 - Corrected requirement to install Tomcat before spacewalk-setup.

--- a/spacewalk/setup/spacewalk-setup.spec
+++ b/spacewalk/setup/spacewalk-setup.spec
@@ -298,11 +298,7 @@ make test
 %dir %attr(0755, root, root) %{_prefix}/share/salt-formulas/metadata/
 %dir %{_datadir}/spacewalk
 %{_datadir}/spacewalk/*
-%if 0%{?rhel} || 0%{?fedora}
-%{misc_path}/spacewalk
-%else
 %attr(755, %{apache_user}, root) %{misc_path}/spacewalk
-%endif
 %{_mandir}/man8/spacewalk-make-mount-points*
 %license LICENSE
 

--- a/uyuni/base/uyuni-base.changes
+++ b/uyuni/base/uyuni-base.changes
@@ -1,3 +1,5 @@
+- Changed Apache user/group from "root" to "apache" for Enterprise
+  Linux operating systems.
 - Add www group to tomcat user
 
 -------------------------------------------------------------------

--- a/uyuni/base/uyuni-base.spec
+++ b/uyuni/base/uyuni-base.spec
@@ -29,8 +29,8 @@
 %define apache_group www
 %else
 %define www_path %{_var}
-%define apache_user root
-%define apache_group root
+%define apache_user apache
+%define apache_group apache
 %endif
 
 Name:           uyuni-base
@@ -122,11 +122,7 @@ getent passwd %{apache_user} >/dev/null && %{_sbindir}/usermod -a -G susemanager
 %if ! (0%{?suse_version} == 1110)
 %files server
 %defattr(-,root,root)
-%if 0%{?rhel}
-/var/spacewalk
-%else
 %dir %attr(755,%{apache_user}, root) /var/spacewalk
-%endif
 %endif
 
 %files proxy


### PR DESCRIPTION
## What does this PR change?

Updating Enterprise Linux Apache user/group from root:root to apache:apache.
Purpose: Enhance security, simplify recently changed code (keep it simple)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
