### PR TITLE
Fix no-ssl handling in setup script

### DIFF
--- a/spacewalk/setup/bin/spacewalk-setup
+++ b/spacewalk/setup/bin/spacewalk-setup
@@ -479,7 +479,7 @@ sub setup_mod_ssl {
     return;
   }
 
-  my $no_ssl_arg = $answers->{"no-ssl"} =~ /^[Yy]/ ? ' --no-ssl' : '';
+  my $no_ssl_arg = ($answers->{"no-ssl"} && $answers->{"no-ssl"} =~ /^[Yy]/) ? ' --no-ssl' : '';
 
   system(split / /, "/usr/bin/spacewalk-setup-httpd$no_ssl_arg");
 
@@ -930,7 +930,7 @@ sub populate_final_configs {
 
   Spacewalk::Setup::satcon_deploy(-tree => '/var/lib/rhn/rhn-satellite-prep/etc/rhn',
                 -dest => '/etc/rhn');
-  if($answers->{"no-ssl"} =~ /^[Yy]/) {
+  if($answers->{"no-ssl"} && $answers->{"no-ssl"} =~ /^[Yy]/) {
       open(my $FILE, '>>', '/etc/rhn/rhn.conf');
       print $FILE "server.no_ssl = 1";
       close $FILE;


### PR DESCRIPTION
## What does this PR change?

Better handle when `no-ssl` is not defined at setup time.

## Documentation
- No documentation needed: only internal and user invisible changes
- [X] **DONE**

## Test coverage
- No tests: setup message
- [X] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/7129

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
