### PR TITLE
CI: Acceptance tests at PRv2: enable all users

### DIFF
--- a/.github/workflows/acceptance_tests_common.yml
+++ b/.github/workflows/acceptance_tests_common.yml
@@ -12,9 +12,6 @@ env:
 jobs:
   test-uyuni:
     runs-on: ubuntu-22.04
-    # create a PR to add yourself if you want to be a beta user and
-    # run this action in your Pull Requests
-    if: github.actor == 'jordimassaguerpla' || github.actor == 'elariekerboull' ||  github.actor == 'srbarrios' || github.actor == 'etheryte' || github.actor == 'cbbayburt' || github.actor == 'sbluhm' || github.actor == 'wweellddeerr'
     steps:
       - name: welcome_message
         run: echo "Running acceptance tests. More info at https://github.com/uyuni-project/uyuni/wiki/Running-Acceptance-Tests-at-PR"


### PR DESCRIPTION
## What does this PR change?

CI: Enable running acceptance tests for all users

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests
- [X] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/21697


- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
