### PR TITLE
More complete run_set

### DIFF
--- a/testsuite/run_sets/build_validation/build_validation_init_clients.yml
+++ b/testsuite/run_sets/build_validation/build_validation_init_clients.yml
@@ -14,6 +14,8 @@
 - features/build_validation/init_clients/sle15sp3_ssh_minion.feature
 - features/build_validation/init_clients/sle15sp4_minion.feature
 - features/build_validation/init_clients/sle15sp4_ssh_minion.feature
+- features/build_validation/init_clients/sle15sp5_minion.feature
+- features/build_validation/init_clients/sle15sp5_ssh_minion.feature
 
 - features/build_validation/init_clients/alma9_minion.feature
 - features/build_validation/init_clients/alma9_ssh_minion.feature
@@ -45,6 +47,8 @@
 
 - features/build_validation/init_clients/opensuse154arm_minion.feature
 - features/build_validation/init_clients/opensuse154arm_ssh_minion.feature
+- features/build_validation/init_clients/opensuse155arm_minion.feature
+- features/build_validation/init_clients/opensuse155arm_ssh_minion.feature
 
 - features/build_validation/init_clients/slemicro51_minion.feature
 - features/build_validation/init_clients/slemicro51_ssh_minion.feature


### PR DESCRIPTION
## What does this PR change?

This PR adds SLES and openSUSE 15.5 to our run_sets.

@maximenoel8 are these files still needed with the new pipelines? If not, maybe just remove them to reduce the maintenance load and make things simpler.

Note: the 4.2 port also adds 2 missing files.


## Links

Ports:
* 4.2: https://github.com/SUSE/spacewalk/pull/21749
* 4.3: https://github.com/SUSE/spacewalk/pull/21750


## Changelogs

- [x] No changelog needed
