### PR TITLE
Fix to detect correct Apache group instead of assuming it

### DIFF
--- a/projects/perl-Satcon/bin/satcon-deploy-tree.pl
+++ b/projects/perl-Satcon/bin/satcon-deploy-tree.pl
@@ -90,8 +90,9 @@ sub process_file {
     # save permissions also but clear access for other
     my $mode =  (stat("$sourcedir/$relative_path"))[2] & 07770;
     chmod $mode, "$destdir/$relative_path";
-    # chgrp apache (Different OS uses different group name, so use both).
-    chown 0, (getgrnam("www") // "") . (getgrnam("apache") // ""), "$destdir/$relative_path";
+    # chgrp apache (Different OS uses different group name, so check config for it).
+    my $apache_group = getgrnam(`grep -hsoP "(?<=Group ).*" /etc/httpd/conf/*.conf /etc/apache2/*.conf | tr -d '\n'`);
+    chown 0, $apache_group, "$destdir/$relative_path";
 
     system '/sbin/restorecon', '-vv', "$destdir/$relative_path";
 

--- a/projects/perl-Satcon/perl-Satcon.changes
+++ b/projects/perl-Satcon/perl-Satcon.changes
@@ -1,3 +1,5 @@
+- Fix to detect correct Apache group instead of assuming it (gh#7092).
+
 -------------------------------------------------------------------
 Wed Apr 19 12:46:08 CEST 2023 - marina.latini@suse.com
 

--- a/spacewalk/admin/rhn-config-satellite.pl
+++ b/spacewalk/admin/rhn-config-satellite.pl
@@ -65,7 +65,8 @@ umask 0027;
 open(TMP, "> $tmpfile") or die "Could not open $tmpfile for writing: $OS_ERROR";
 if ($tmpfile =~ m!^/etc/rhn/!) {
   # Chown for different potential apache group names (SUSE/RHEL)
-  chown 0, (getgrnam("www") // "") . (getgrnam("apache") // ""), $tmpfile;
+  my $apache_group = getgrnam(`grep -hsoP "(?<=Group ).*" /etc/httpd/conf/*.conf /etc/apache2/*.conf | tr -d '\n'`);
+  chown 0, $apache_group, $tmpfile;
 }
 
 while (my $line = <TARGET>) {

--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,4 @@
+- Fix to detect correct Apache group instead of assuming it (gh#7092).
 - Added missing python3-websockify runtime requirement.
 
 -------------------------------------------------------------------

--- a/spacewalk/setup/bin/spacewalk-setup
+++ b/spacewalk/setup/bin/spacewalk-setup
@@ -126,7 +126,7 @@ if(not $opts{"skip-initial-configuration"}) {
             $config_opts->{'kickstart_mount_point'});
     chmod 0775, $config_opts->{'mount_point'} . '/systems';
     # Check for both potential Apache groups (SUSE/RHEL)
-    my $www_gid = (getgrnam("www") // "") . (getgrnam("apache") // "");
+    my $www_gid = getgrnam(`grep -hsoP "(?<=Group ).*" /etc/httpd/conf/*.conf /etc/apache2/*.conf | tr -d '\n'`);
     chown -1, $www_gid, $config_opts->{'mount_point'} . '/systems';
 }
 
@@ -892,7 +892,7 @@ sub populate_initial_configs {
                                         "echo \"$st\" | spacewalk-sql --select-mode - 2>&1"],
                                        1, "*** Setup Organization Credentials failed.");
 
-      my $apache_gid = getgrnam('www');
+      my $apache_gid = getgrnam(`grep -hsoP "(?<=Group ).*" /etc/httpd/conf/*.conf /etc/apache2/*.conf | tr -d '\n'`);
       if ($apache_gid && -e Spacewalk::Setup::SCC_CREDENTIAL_FILE) {
           chown -1, $apache_gid, Spacewalk::Setup::SCC_CREDENTIAL_FILE;
           chmod 0640, Spacewalk::Setup::SCC_CREDENTIAL_FILE;

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,4 @@
+- Fix to detect correct Apache group instead of assuming it (gh#7092).
 - Align /var/spacewalk folder permissions with uyuni-base-server package.
 - Move set tomcat user setup to uyuni-base spec file
 - Add option to disable SSL setup


### PR DESCRIPTION
## What does this PR change?

When running mgr-setup (or mgr-setup -s) and groups www and apache already exist at the same time on the system, permissions are set wrong. Especially /etc/rhn/rhn.conf.

This change reads the used Apache group from the apache config files.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

Manually tested to install on Leap 15.4 and EL9.

- [x] **DONE**

## Links

Fixes #7092 

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
