### PR TITLE
Show recurring states names in events history

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -2269,7 +2269,7 @@ public class ActionManager extends BaseManager {
      */
     public static ApplyStatesAction scheduleApplyStates(User scheduler, List<Long> sids, List<String> mods,
             Date earliest, Optional<Boolean> test) {
-        return scheduleApplyStates(scheduler, sids, mods, Optional.empty(), earliest, test);
+        return scheduleApplyStates(scheduler, sids, mods, Optional.empty(), earliest, test, false);
     }
 
     /**
@@ -2285,11 +2285,28 @@ public class ActionManager extends BaseManager {
      * @return the action object
      */
     public static ApplyStatesAction scheduleApplyStates(User scheduler, List<Long> sids, List<String> mods,
-            Optional<Map<String, Object>> pillar, Date earliest, Optional<Boolean> test) {
+        Optional<Map<String, Object>> pillar, Date earliest, Optional<Boolean> test) {
+        return scheduleApplyStates(scheduler, sids, mods, pillar, earliest, test, false);
+    }
+
+    /**
+     * Schedule state application given a list of state modules. Salt will apply the
+     * highstate if an empty list of state modules is given.
+     *
+     * @param scheduler the user who is scheduling
+     * @param sids list of server ids
+     * @param mods list of state modules to be applied
+     * @param pillar optional pillar map
+     * @param earliest action will not be executed before this date
+     * @param test run states in test-only mode
+     * @param recurring whether the state is being applied recurring
+     * @return the action object
+     */
+    public static ApplyStatesAction scheduleApplyStates(User scheduler, List<Long> sids, List<String> mods,
+            Optional<Map<String, Object>> pillar, Date earliest, Optional<Boolean> test, boolean recurring) {
         ApplyStatesAction action = (ApplyStatesAction) ActionFactory
                 .createAction(ActionFactory.TYPE_APPLY_STATES, earliest);
-        String states = mods.isEmpty() ? "highstate" : "states " + mods.toString();
-        action.setName("Apply " + states);
+        action.setName(defineStatesActionName(mods, recurring));
         action.setOrg(scheduler != null ?
                 scheduler.getOrg() : OrgFactory.getSatelliteOrg());
         action.setSchedulerUser(scheduler);
@@ -2303,6 +2320,21 @@ public class ActionManager extends BaseManager {
 
         scheduleForExecution(action, new HashSet<>(sids));
         return action;
+    }
+
+    /**
+     * Define apply states action name.
+     * @param mods - the mods applied
+     * @param recurring - whether the states are being applied recurring
+     * @return - the name of the action
+     */
+    public static String defineStatesActionName(List<String> mods, boolean recurring) {
+        StringBuilder statesDescription = new StringBuilder("Apply ");
+        if (recurring) {
+            statesDescription.append("recurring ");
+        }
+        statesDescription.append(mods.isEmpty() ? "highstate" : "states " + mods);
+        return statesDescription.toString();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
@@ -1109,6 +1109,21 @@ public class ActionManagerTest extends JMockBaseTestCaseWithUser {
         assertEquals("Build an Image Profile", action.getActionType().getName());
     }
 
+    @Test
+    public void testDefineApplyStatesActionName() {
+        List<String> states = List.of("util.syncgrains", "hardware.profileupdate", "util.syncmodules");
+        String highstateNonRecurring = ActionManager.defineStatesActionName(Collections.emptyList(), false);
+        String highstateRecurring = ActionManager.defineStatesActionName(Collections.emptyList(), true);
+        String statesNonRecurring = ActionManager.defineStatesActionName(states, false);
+        String statesRecurring = ActionManager.defineStatesActionName(states, true);
+        assertEquals("Apply highstate", highstateNonRecurring);
+        assertEquals("Apply recurring highstate", highstateRecurring);
+        assertEquals("Apply recurring states [util.syncgrains, hardware.profileupdate, util.syncmodules]",
+                statesRecurring);
+        assertEquals("Apply states [util.syncgrains, hardware.profileupdate, util.syncmodules]", statesNonRecurring);
+    }
+
+
     public static void assertNotEmpty(Collection coll) {
         assertNotNull(coll);
         if (coll.isEmpty()) {

--- a/java/spacewalk-java.changes.wweellddeerr.recurring-actions
+++ b/java/spacewalk-java.changes.wweellddeerr.recurring-actions
@@ -1,0 +1,1 @@
+- Show recurring states names in events history (bsc#1211929)


### PR DESCRIPTION
## What does this PR change?

It adds the name of states being applied via a recurring action to the event summary to be shown on the history page.

## GUI diff

Before:

![image](https://github.com/uyuni-project/uyuni/assets/17532261/36d2973d-c6ab-471a-b07c-61a155aad744)

After:

![image](https://github.com/uyuni-project/uyuni/assets/17532261/301da3c2-8f1b-4441-8d0a-a1aa600c7fda)

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

https://bugzilla.suse.com/show_bug.cgi?id=1211929

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
