### PR TITLE
QE: Adapt grafana tests to the new grafana version

### DIFF
--- a/testsuite/features/build_validation/init_clients/monitoring_server.feature
+++ b/testsuite/features/build_validation/init_clients/monitoring_server.feature
@@ -88,7 +88,7 @@ Feature: Bootstrap the monitoring server
   Scenario: Test Grafana dashboards of monitoring server
     When I visit the grafana dashboards of this "monitoring_server"
     And I wait until I do not see "Loading Grafana" text
-    And I click on "View as list"
+    And I check radio button "View as list"
     # These are the 4 dashboards created by default when enabling the Grafana formula
     Then I should see a "Apache2" text
     And I should see a "PostgreSQL database insights" text

--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -181,6 +181,7 @@ Feature: Smoke tests for <client>
   Scenario: Test <client> on Grafana
     When I visit the grafana dashboards of this "monitoring_server"
     And I wait until I do not see "Loading Grafana" text
+    And I check radio button "View as list"
     When I follow "Client Systems"
     Then I should see "<client>" hostname
     When I enter "<client>" hostname on grafana's host field


### PR DESCRIPTION
## What does this PR change?

The button to view the dashboards as a list is actually a radio button - have adapted the grafana tests for that fact.

## Links

- 4.2 https://github.com/SUSE/spacewalk/pull/21767
- 4.3 https://github.com/SUSE/spacewalk/pull/21768

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
