### PR TITLE
Release DB connection in RHN Message Dispatcher thread

### DIFF
--- a/java/code/src/com/redhat/rhn/common/messaging/MessageDispatcher.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/MessageDispatcher.java
@@ -16,6 +16,7 @@ package com.redhat.rhn.common.messaging;
 
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.frontend.events.TraceBackAction;
 import com.redhat.rhn.frontend.events.TraceBackEvent;
 
@@ -115,6 +116,9 @@ public class MessageDispatcher implements Runnable {
                 catch (Throwable t1) {
                     log.error("Error sending traceback email, logging for posterity.", t1);
                 }
+            }
+            finally {
+                HibernateFactory.closeSession();
             }
 
         }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Release DB connection in RHN Message Dispatcher thread
 - Update version of tomcat build dependencies
 - Disable jinja processing for the roster file (bsc#1211650)
 - Make sure that all hibernate connections are closed (bsc#1208687)


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/21744

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
