### PR TITLE
Improve handling of websocket exceptions

### DIFF
--- a/java/code/src/com/suse/manager/webui/websocket/Notification.java
+++ b/java/code/src/com/suse/manager/webui/websocket/Notification.java
@@ -183,7 +183,7 @@ public class Notification {
                     handbreakSession(session);
                 }
             }
-            catch (IOException e) {
+            catch (IOException | IllegalStateException e) {
                 LOG.debug(String.format("Could not send websocket message. Session [id:%s] is already closed.",
                         session.getId()));
                 handbreakSession(session);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Improve handling of websocket exceptions
 - Release DB connection in RHN Message Dispatcher thread
 - Update version of tomcat build dependencies
 - Disable jinja processing for the roster file (bsc#1211650)


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/21766

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
