### PR TITLE
Fix the name of the cert file in osimage package

### DIFF
--- a/spacewalk/certs-tools/mgr-package-rpm-certificate-osimage
+++ b/spacewalk/certs-tools/mgr-package-rpm-certificate-osimage
@@ -77,7 +77,7 @@ def genCaRpm(options):
                repr(CA_CERT_RPM_SUMMARY),
                repr(CA_CERT_RPM_SUMMARY),
                repr(update_trust_script), repr(update_trust_script),
-               repr(ca_cert_name), repr(cleanupAbsPath(ca_cert))))
+               repr(CA_CRT_NAME), repr(cleanupAbsPath(ca_cert))))
     clientRpmName = '%s-%s-%s' % (ca_cert_rpm_osimage, ver, rel)
     print("CA Cert for OS Images: Packaging %s into %s.noarch.rpm" % (ca_cert, clientRpmName))
 


### PR DESCRIPTION
## What does this PR change?

Fix the name of the CA file after https://github.com/uyuni-project/uyuni/pull/7111

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
