### PR TITLE
Testsuite: Replace deprecated references to rhlike minion in feature

### DIFF
--- a/testsuite/features/secondary/allcli_action_chain.feature
+++ b/testsuite/features/secondary/allcli_action_chain.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022 SUSE LLC
+# Copyright (c) 2018-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 # Skip if container because action chains fail on containers

--- a/testsuite/features/secondary/allcli_action_chain.feature
+++ b/testsuite/features/secondary/allcli_action_chain.feature
@@ -4,7 +4,7 @@
 # Skip if container because action chains fail on containers
 # This needs to be fixed
 
-@rhlike_minion
+@ssh_minion
 @sle_minion
 @scope_action_chains
 Feature: Action chains on several systems at once
@@ -56,7 +56,7 @@ Feature: Action chains on several systems at once
     When I delete all action chains
     And I cancel all scheduled actions
 
-  Scenario: Add an action chain using system set manager for Red Hat-like minion and SLE minion
+  Scenario: Add an action chain using system set manager for SSH minion and SLE minion
     When I follow the left menu "Systems > System List > All"
     And I check the "sle_minion" client
     And I check the "ssh_minion" client


### PR DESCRIPTION
## What does this PR change?
The `Action chains on several systems at once` feature was not fully updated when replacing the RedHat-like minion by the SSH minion.
## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Tracks # 
4.2 https://github.com/SUSE/spacewalk/pull/21777
4.3 https://github.com/SUSE/spacewalk/pull/21776
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
