### PR TITLE
Increase timeout after restart of service

### DIFF
--- a/testsuite/features/step_definitions/cobbler_steps.rb
+++ b/testsuite/features/step_definitions/cobbler_steps.rb
@@ -293,8 +293,8 @@ When(/^I start local monitoring of Cobbler$/) do
   else
     $server.run('systemctl restart cobblerd')
   end
-  # give cobbler a second to come up
-  sleep 1
+  # give cobbler a few seconds to come up
+  sleep 3
 end
 
 Then(/^the local logs for Cobbler should not contain errors$/) do


### PR DESCRIPTION
## What does this PR change?

Increase timeout after restart of service slightly

## GUI diff

No difference.



- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes no issue, directly from testsuite review
Tracks # **add downstream PR, if any** needs ports

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
