### PR TITLE
Add openssl3 compatibility to mgr_ssl_cert_setup

### DIFF
--- a/spacewalk/certs-tools/mgr_ssl_cert_setup.py
+++ b/spacewalk/certs-tools/mgr_ssl_cert_setup.py
@@ -265,6 +265,7 @@ def getCertData(cert):
             if nextval == "subjectKeyIdentifier":
                 data["subjectKeyIdentifier"] = line.strip().upper()
             elif nextval == "authorityKeyIdentifier":
+                # OpenSSL v1 adds a prefix 'keyid:'. OenSSL v3 does not.
                 data["authorityKeyIdentifier"] = line.replace("keyid:", "").strip().upper()
         elif "subject_hash" not in data:
             # subject_hash comes first without key to identify it

--- a/spacewalk/certs-tools/mgr_ssl_cert_setup.py
+++ b/spacewalk/certs-tools/mgr_ssl_cert_setup.py
@@ -264,8 +264,8 @@ def getCertData(cert):
         elif line.startswith("    "):
             if nextval == "subjectKeyIdentifier":
                 data["subjectKeyIdentifier"] = line.strip().upper()
-            elif nextval == "authorityKeyIdentifier" and line.startswith("    keyid:"):
-                data["authorityKeyIdentifier"] = line[10:].strip().upper()
+            elif nextval == "authorityKeyIdentifier":
+                data["authorityKeyIdentifier"] = line.replace("keyid:", "").strip().upper()
         elif "subject_hash" not in data:
             # subject_hash comes first without key to identify it
             data["subject_hash"] = line.strip()

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,4 @@
+- Add openssl3 compatibility.
 - Read CA password from a file
 - Also ship SUSE specific files on Enterprise Linux.
 - Use the CA cert in the pki config to generate build host rpm


### PR DESCRIPTION
## What does this PR change?

Allow usage of openssl3 when replacing certificates with mgr_ssl_cert_setup. Currently Leap 15.5 is using openssl 1. Openssl 3 is outputting the text slightly different. This PR allows handling of the openssl input for v1 and v3.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
