### PR TITLE
catch yaml exceptions and report which metadata file is wrong

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
@@ -873,7 +873,16 @@ public class FormulaFactory {
                 return Collections.emptyMap();
             }
         }
+        catch (YAMLException e) {
+            LOG.error("Unable to parse metadata file: " + name, e);
+            return Collections.emptyMap();
+        }
         catch (IOException e) {
+            LOG.error("IO Error at metadata file: " + name, e);
+            return Collections.emptyMap();
+        }
+        catch (Exception e) {
+            LOG.error("Error in metadata file: " + name, e);
             return Collections.emptyMap();
         }
     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- catch yaml exceptions and report which metadata file is wrong (bsc#1208720)
 - Improve handling of websocket exceptions
 - Release DB connection in RHN Message Dispatcher thread
 - Update version of tomcat build dependencies


### PR DESCRIPTION
## What does this PR change?

The monitoring endpoint parse formula metadata files. If they contain yaml errors, they are not properly
catched. Also the information which file is broken is missing in the logs.

Just catch YAML Errors and log the name of the file. Then return an empty collection.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/20699

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
