### PR TITLE
CI: disable acceptance tests for maintenance

### DIFF
--- a/.github/workflows/acceptance_tests_common.yml
+++ b/.github/workflows/acceptance_tests_common.yml
@@ -13,6 +13,8 @@ jobs:
   test-uyuni:
     runs-on: ubuntu-22.04
     steps:
+      - name: maintenance_message
+        run: echo "Disabled for maintenance. See https://github.com/uyuni-project/uyuni/discussions/7164" && exit -1
       - name: welcome_message
         run: echo "Running acceptance tests. More info at https://github.com/uyuni-project/uyuni/wiki/Running-Acceptance-Tests-at-PR"
       - name: Install-Podman

--- a/.github/workflows/acceptance_tests_secondary.yml
+++ b/.github/workflows/acceptance_tests_secondary.yml
@@ -6,6 +6,7 @@ on:
       - 'web/html/src/**'
       - 'testsuite/**'
       - '.github/workflows/acceptance_tests_secondary.yml'
+      - '.github/workflows/acceptance_tests_common.yml'
       - '!java/*.changes*'
 jobs:
   test-uyuni:

--- a/.github/workflows/acceptance_tests_secondary_parallel.yml
+++ b/.github/workflows/acceptance_tests_secondary_parallel.yml
@@ -6,6 +6,7 @@ on:
       - 'web/html/src/**'
       - 'testsuite/**'
       - '.github/workflows/acceptance_tests_secondary_parallel.yml'
+      - '.github/workflows/acceptance_tests_common.yml'
       - '!java/*.changes'
 jobs:
   test-uyuni:


### PR DESCRIPTION
## What does this PR change?

Maintenance mode because of https://github.com/uyuni-project/uyuni/discussions/7164

## Changelogs

- [X] No changelog needed



## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
