### PR TITLE
CI: do not update podman

### DIFF
--- a/.github/workflows/acceptance_tests_common.yml
+++ b/.github/workflows/acceptance_tests_common.yml
@@ -13,12 +13,8 @@ jobs:
   test-uyuni:
     runs-on: ubuntu-22.04
     steps:
-      - name: maintenance_message
-        run: echo "Disabled for maintenance. See https://github.com/uyuni-project/uyuni/discussions/7164" && exit -1
       - name: welcome_message
         run: echo "Running acceptance tests. More info at https://github.com/uyuni-project/uyuni/wiki/Running-Acceptance-Tests-at-PR"
-      - name: Install-Podman
-        run: sh -c "sudo apt-get update && sudo apt-get -y install podman"
       - uses: actions/checkout@v3
       - name: Cache-jar-files
         uses: actions/cache@v3

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -121,7 +121,7 @@
 
         <!-- Compilation and testing -->
         <dependency org="suse" name="velocity-engine-core" rev="2.3"/>
-        <dependency org="suse" name="jetty-util" rev="9.4.48" />
+        <dependency org="suse" name="jetty-util" rev="9.4.51" />
         <dependency org="checkstyle" name="checkstyle" rev="8.30" transitive="false">
           <artifact name="all" type="jar" url="https://github.com/checkstyle/checkstyle/releases/download/checkstyle-8.30/checkstyle-8.30-all.jar"/>
         </dependency>


### PR DESCRIPTION
## What does this PR change?
If we install podman, we will actually update it to the latest version, given podman is already installed in the base image.

If we install the latest version, we will have this issue https://bugs.launchpad.net/ubuntu/+source/libpod/+bug/2024394 https://github.com/actions/runner-images/issues/7753

Until this is fixed upstream, we need to not update podman.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests
- [X] **DONE**

## Links

Fixes  https://github.com/uyuni-project/uyuni/discussions/7164
- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
