### PR TITLE
Uyuni-2023.04: Update jetty-util to version 9.4.51

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -121,7 +121,7 @@
 
         <!-- Compilation and testing -->
         <dependency org="suse" name="velocity-engine-core" rev="2.3"/>
-        <dependency org="suse" name="jetty-util" rev="9.4.48" />
+        <dependency org="suse" name="jetty-util" rev="9.4.51" />
         <dependency org="checkstyle" name="checkstyle" rev="8.30" transitive="false">
           <artifact name="all" type="jar" url="https://github.com/checkstyle/checkstyle/releases/download/checkstyle-8.30/checkstyle-8.30-all.jar"/>
         </dependency>

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -112,12 +112,12 @@
         <dependency org="suse" name="stax-ex" rev="1.8" />
 
         <!-- Tomcat jars -->
-        <dependency org="suse" name="jasper" rev="9.0.43" />
-        <dependency org="suse" name="jasper-el" rev="9.0.43" />
-        <dependency org="suse" name="tomcat-el-3.0-api" rev="9.0.43" />
-        <dependency org="suse" name="tomcat-jsp-2.3-api" rev="9.0.43" />
-        <dependency org="suse" name="tomcat-juli" rev="9.0.43" />
-        <dependency org="suse" name="tomcat-servlet-4.0-api" rev="9.0.43" />
+        <dependency org="suse" name="jasper" rev="9.0.75" />
+        <dependency org="suse" name="jasper-el" rev="9.0.75" />
+        <dependency org="suse" name="tomcat-el-3.0-api" rev="9.0.75" />
+        <dependency org="suse" name="tomcat-jsp-2.3-api" rev="9.0.75" />
+        <dependency org="suse" name="tomcat-juli" rev="9.0.75" />
+        <dependency org="suse" name="tomcat-servlet-4.0-api" rev="9.0.75" />
 
         <!-- Compilation and testing -->
         <dependency org="suse" name="velocity-engine-core" rev="2.3"/>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Update jetty-util to version 9.4.51 (for dev and test)
+
 -------------------------------------------------------------------
 Wed Apr 19 12:47:06 CEST 2023 - marina.latini@suse.com
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Update tomcat jars to version 9.0.75 (for dev and test)
 - Update jetty-util to version 9.4.51 (for dev and test)
 
 -------------------------------------------------------------------

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,5 +1,5 @@
-- Update tomcat jars to version 9.0.75 (for dev and test)
-- Update jetty-util to version 9.4.51 (for dev and test)
+- Update tomcat jars to version 9.0.75
+- Update jetty-util to version 9.4.51
 
 -------------------------------------------------------------------
 Wed Apr 19 12:47:06 CEST 2023 - marina.latini@suse.com


### PR DESCRIPTION
## What does this PR change?

This patch updates the jetty-util (to version 9.4.51) for development and testing purposes. Changelog entry should not be relevant for users, I would suggest we remove it before compiling the final changelog.

## Links

Tracks https://github.com/SUSE/spacewalk/pull/21809.

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
