### PR TITLE
Reposync fixes

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/satellite/SystemCommandThreadedExecutor.java
+++ b/java/code/src/com/redhat/rhn/manager/satellite/SystemCommandThreadedExecutor.java
@@ -14,6 +14,8 @@
  */
 package com.redhat.rhn.manager.satellite;
 
+import com.redhat.rhn.common.RhnRuntimeException;
+
 import org.apache.logging.log4j.Logger;
 
 import java.io.BufferedReader;
@@ -125,16 +127,13 @@ public class SystemCommandThreadedExecutor implements Executor {
             errStream.start();
 
             try {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("execute() - Calling p.waitfor ..");
-                }
+                logger.debug("execute() - Calling p.waitfor ..");
                 retval = p.waitFor();
                 inStream.join();
                 errStream.join();
             }
             catch (InterruptedException e) {
-                throw new RuntimeException(
-                        "InterruptedException while trying to exec: " + e);
+                throw new RhnRuntimeException("InterruptedException while trying to exec: " + e);
             }
             lastCommandError = errStream.getMessage();
             lastCommandOutput = inStream.getMessage();
@@ -142,13 +141,12 @@ public class SystemCommandThreadedExecutor implements Executor {
         catch (IOException ioe) {
             logger.error("execute(String[])", ioe);
 
-            String message = "";
+            StringBuilder message = new StringBuilder();
             for (String argIn : args) {
-                message = message + argIn + " ";
+                message.append(argIn).append(" ");
             }
             logger.error("IOException while trying to exec: {}", message, ioe);
-            throw new RuntimeException(
-                    "IOException while trying to exec: " + message, ioe);
+            throw new RhnRuntimeException("IOException while trying to exec: " + message, ioe);
         }
 
         return retval;

--- a/java/code/src/com/redhat/rhn/taskomatic/task/RepoSyncTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/RepoSyncTask.java
@@ -38,6 +38,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Used for syncing repos (like yum repos) to a channel.
@@ -65,12 +66,10 @@ public class RepoSyncTask extends RhnJavaJob {
 
         List<String> lparams = List.of("no-errata", "latest", "sync-kickstart", "fail");
         List<String> ltrue = List.of("true", "1");
-        List<String> params = new ArrayList<>();
-        for (String p : lparams) {
-            if ((ltrue.contains(jobDataMap.getOrDefault(p, "false").toString().toLowerCase().trim()))) {
-                    params.add("--" + p);
-            }
-        }
+        List<String> params = lparams.stream()
+                .filter(p -> ltrue.contains(jobDataMap.getOrDefault(p, "false").toString().toLowerCase().trim()))
+                .map(p -> "--" + p)
+                .collect(Collectors.toList());
         if (!GlobalInstanceHolder.PAYG_MANAGER.isCompliant()) {
             log.error("Synchronization of repositories is forbidden as SUSE Manager Server PAYG " +
                     "is unable to send accounting data to the cloud provider.");

--- a/java/code/src/com/redhat/rhn/taskomatic/task/RhnJavaJob.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/RhnJavaJob.java
@@ -68,10 +68,8 @@ public abstract class RhnJavaJob implements RhnJob {
      */
     protected void finishJob() { }
 
-    protected void executeExtCmd(String[] args)
-        throws JobExecutionException {
-
-        SystemCommandThreadedExecutor ce = new SystemCommandThreadedExecutor(getLogger());
+    protected void executeExtCmd(String[] args, boolean noStdoutLog) throws JobExecutionException {
+        SystemCommandThreadedExecutor ce = new SystemCommandThreadedExecutor(getLogger(), !noStdoutLog);
         int exitCode = ce.execute(args);
 
         if (exitCode != 0) {
@@ -84,8 +82,12 @@ public abstract class RhnJavaJob implements RhnJob {
             }
             throw new JobExecutionException(
                     "Command '" + Arrays.asList(args) +
-                    "' exited with error code " + exitCode +
-                    (msg.isBlank() ? "" : ": " + msg));
+                            "' exited with error code " + exitCode +
+                            (msg.isBlank() ? "" : ": " + msg));
         }
+    }
+
+    protected void executeExtCmd(String[] args) throws JobExecutionException {
+        executeExtCmd(args, false);
     }
 }

--- a/java/spacewalk-java.changes.cbosdo.reposync-log
+++ b/java/spacewalk-java.changes.cbosdo.reposync-log
@@ -1,0 +1,1 @@
+- Do not store reposync stdout in taskomatic logs


### PR DESCRIPTION
## What does this PR change?

Taskomatic external command line executor stores all the stdout and stderr into a String. Stdout can grow really big for reposync and we already have it in the reposync logs. Disabling the reposync stdout copy to gain some memory.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: memory usage reduction

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
