### PR TITLE
Remove logging tiny url parameters

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/common/TinyUrlAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/TinyUrlAction.java
@@ -14,7 +14,6 @@
  */
 package com.redhat.rhn.frontend.action.common;
 
-import com.redhat.rhn.common.util.StringUtil;
 import com.redhat.rhn.domain.common.CommonFactory;
 import com.redhat.rhn.domain.common.TinyUrl;
 import com.redhat.rhn.frontend.struts.RhnAction;
@@ -24,8 +23,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
-
-import java.util.Enumeration;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -47,15 +44,6 @@ public class TinyUrlAction extends RhnAction {
             HttpServletRequest request, HttpServletResponse response)
         throws Exception {
         String token = request.getParameter(TY_TOKEN);
-        if (log.isDebugEnabled()) {
-            log.debug("token: {}", StringUtil.sanitizeLogInput(token));
-            Enumeration<String> e = request.getParameterNames();
-            while (e.hasMoreElements()) {
-                String name = e.nextElement();
-                log.debug("param.name: {} val: {}", StringUtil.sanitizeLogInput(name),
-                        StringUtil.sanitizeLogInput(request.getParameter(name)));
-            }
-        }
 
         TinyUrl turl = CommonFactory.lookupTinyUrl(token);
         if (turl != null) {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Don't output URL parameters for tiny urls CVE-2023-22644 (bsc#1210101)
 - Do not log SSL certificate / key file content CVE-2023-22644 (bsc#1210094)
 - cache debian package metadata snippets in DB
 - Fixed a bug that caused the tab Autoinstallation to hide when clicking on Power


### PR DESCRIPTION
## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
