### PR TITLE
Do not output XMLRPC token in debug logs

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroCreateCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroCreateCommand.java
@@ -24,9 +24,6 @@ import com.redhat.rhn.domain.kickstart.KickstartableTree;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.satellite.CobblerSyncCommand;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.util.List;
 
 /**
@@ -34,7 +31,6 @@ import java.util.List;
  */
 public class CobblerDistroCreateCommand extends CobblerDistroCommand {
 
-    private static Logger log = LogManager.getLogger(CobblerDistroCreateCommand.class);
     private boolean syncProfiles;
     /**
      * Constructor
@@ -74,8 +70,6 @@ public class CobblerDistroCreateCommand extends CobblerDistroCommand {
      */
     @Override
     public ValidatorError store() {
-        log.debug("Token : [{}]", xmlRpcToken);
-
         CobblerDistroHelper.getInstance().createDistroFromTree(
                 CobblerXMLRPCHelper.getConnection(user),
                 tree);

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerLoginCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerLoginCommand.java
@@ -44,10 +44,10 @@ public class CobblerLoginCommand {
         XMLRPCInvoker helper =
             (XMLRPCInvoker) MethodUtil.getClassFromConfig(
                     CobblerXMLRPCHelper.class.getName());
-        List args = new ArrayList<>();
+        List<String> args = new ArrayList<>();
         args.add(usernameIn);
         args.add(passwordIn);
-        String retval = null;
+        String retval;
         try {
             retval = (String) helper.invokeMethod("login", args);
         }
@@ -73,9 +73,9 @@ public class CobblerLoginCommand {
         XMLRPCInvoker helper =
             (XMLRPCInvoker) MethodUtil.getClassFromConfig(
                     CobblerXMLRPCHelper.class.getName());
-        List args = new ArrayList<>();
+        List<String> args = new ArrayList<>();
         args.add(token);
-        Boolean retval = null;
+        Boolean retval;
         try {
             retval = (Boolean) helper.invokeMethod("token_check", args);
             if (retval == null) {

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerLoginCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerLoginCommand.java
@@ -57,7 +57,7 @@ public class CobblerLoginCommand {
             throw new NoCobblerTokenException(
                     "We had an error trying to login.", e);
         }
-        log.debug("token received from cobbler: {}", retval);
+        log.debug("token received from cobbler");
         return retval;
     }
 
@@ -91,7 +91,7 @@ public class CobblerLoginCommand {
             throw new NoCobblerTokenException(
                     "We errored out trying to check the token.", e);
         }
-        log.debug("token received from cobbler: {}", retval);
+        log.debug("token received from cobbler");
 
         return retval;
     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Do not output cobbler xmlrpc token in debug logs CVE-2023-22644 (bsc#1210162)
 - Don't output URL parameters for tiny urls CVE-2023-22644 (bsc#1210101)
 - Do not log SSL certificate / key file content CVE-2023-22644 (bsc#1210094)
 - cache debian package metadata snippets in DB


### PR DESCRIPTION
## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
