### PR TITLE
CVE-2023-22644 revert

### DIFF
--- a/java/code/src/com/redhat/rhn/common/security/SessionSwap.java
+++ b/java/code/src/com/redhat/rhn/common/security/SessionSwap.java
@@ -147,6 +147,11 @@ public class SessionSwap {
 
         String joinedText = StringUtils.join(text.iterator(), "\0");
 
+
+        if (log.isDebugEnabled()) {
+            log.debug("Data     : [{}]", joinedText);
+            log.debug("Key      : [{}]", swapKey);
+        }
         String retval = HMAC.sha256(joinedText, swapKey.toString());
         if (log.isDebugEnabled()) {
             log.debug("retval: {}", retval);

--- a/java/code/src/com/redhat/rhn/common/util/FileUtils.java
+++ b/java/code/src/com/redhat/rhn/common/util/FileUtils.java
@@ -114,20 +114,6 @@ public class FileUtils {
      * @return String containing file.
      */
     public static String readStringFromFile(String path) {
-        return readStringFromFile(path, false);
-    }
-
-
-    /**
-     * Read a file off disk into a String and return it.
-     *
-     * Expect weird stuff if the file is not textual.
-     *
-     * @param path of file to read in
-     * @param noLog don't log the content of the file
-     * @return String containing file.
-     */
-    public static String readStringFromFile(String path, boolean noLog) {
         if (log.isDebugEnabled()) {
             log.debug("readStringFromFile: {}", StringUtil.sanitizeLogInput(path));
         }
@@ -139,7 +125,7 @@ public class FileUtils {
             StringWriter writer = new StringWriter();
             IOUtils.getInstance().copyWriter(input, writer);
             String contents = writer.toString();
-            if (noLog && log.isDebugEnabled()) {
+            if (log.isDebugEnabled()) {
                 log.debug("contents: {}", contents);
             }
             return contents;

--- a/java/code/src/com/redhat/rhn/frontend/action/common/TinyUrlAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/TinyUrlAction.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.frontend.action.common;
 
+import com.redhat.rhn.common.util.StringUtil;
 import com.redhat.rhn.domain.common.CommonFactory;
 import com.redhat.rhn.domain.common.TinyUrl;
 import com.redhat.rhn.frontend.struts.RhnAction;
@@ -23,6 +24,8 @@ import org.apache.logging.log4j.Logger;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
+
+import java.util.Enumeration;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -44,6 +47,15 @@ public class TinyUrlAction extends RhnAction {
             HttpServletRequest request, HttpServletResponse response)
         throws Exception {
         String token = request.getParameter(TY_TOKEN);
+        if (log.isDebugEnabled()) {
+            log.debug("token: {}", StringUtil.sanitizeLogInput(token));
+            Enumeration<String> e = request.getParameterNames();
+            while (e.hasMoreElements()) {
+                String name = e.nextElement();
+                log.debug("param.name: {} val: {}", StringUtil.sanitizeLogInput(name),
+                        StringUtil.sanitizeLogInput(request.getParameter(name)));
+            }
+        }
 
         TinyUrl turl = CommonFactory.lookupTinyUrl(token);
         if (turl != null) {

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroCreateCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroCreateCommand.java
@@ -24,6 +24,9 @@ import com.redhat.rhn.domain.kickstart.KickstartableTree;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.satellite.CobblerSyncCommand;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.List;
 
 /**
@@ -31,6 +34,7 @@ import java.util.List;
  */
 public class CobblerDistroCreateCommand extends CobblerDistroCommand {
 
+    private static Logger log = LogManager.getLogger(CobblerDistroCreateCommand.class);
     private boolean syncProfiles;
     /**
      * Constructor
@@ -70,6 +74,8 @@ public class CobblerDistroCreateCommand extends CobblerDistroCommand {
      */
     @Override
     public ValidatorError store() {
+        log.debug("Token : [{}]", xmlRpcToken);
+
         CobblerDistroHelper.getInstance().createDistroFromTree(
                 CobblerXMLRPCHelper.getConnection(user),
                 tree);

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerLoginCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerLoginCommand.java
@@ -57,7 +57,7 @@ public class CobblerLoginCommand {
             throw new NoCobblerTokenException(
                     "We had an error trying to login.", e);
         }
-        log.debug("token received from cobbler");
+        log.debug("token received from cobbler: {}", retval);
         return retval;
     }
 
@@ -91,7 +91,7 @@ public class CobblerLoginCommand {
             throw new NoCobblerTokenException(
                     "We errored out trying to check the token.", e);
         }
-        log.debug("token received from cobbler");
+        log.debug("token received from cobbler: {}", retval);
 
         return retval;
     }

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerLoginCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerLoginCommand.java
@@ -44,10 +44,10 @@ public class CobblerLoginCommand {
         XMLRPCInvoker helper =
             (XMLRPCInvoker) MethodUtil.getClassFromConfig(
                     CobblerXMLRPCHelper.class.getName());
-        List<String> args = new ArrayList<>();
+        List args = new ArrayList<>();
         args.add(usernameIn);
         args.add(passwordIn);
-        String retval;
+        String retval = null;
         try {
             retval = (String) helper.invokeMethod("login", args);
         }
@@ -73,9 +73,9 @@ public class CobblerLoginCommand {
         XMLRPCInvoker helper =
             (XMLRPCInvoker) MethodUtil.getClassFromConfig(
                     CobblerXMLRPCHelper.class.getName());
-        List<String> args = new ArrayList<>();
+        List args = new ArrayList<>();
         args.add(token);
-        Boolean retval;
+        Boolean retval = null;
         try {
             retval = (Boolean) helper.invokeMethod("token_check", args);
             if (retval == null) {

--- a/java/code/src/com/suse/manager/ssl/SSLCertManager.java
+++ b/java/code/src/com/suse/manager/ssl/SSLCertManager.java
@@ -94,8 +94,8 @@ public class SSLCertManager {
             File serverFolder = new File(sslBuildDir, data.getMachineName());
             File serverCertFile = new File(serverFolder, "server.crt");
             File serverKeyFile = new File(serverFolder, "server.key");
-            return new SSLCertPair(FileUtils.readStringFromFile(serverCertFile.getAbsolutePath(), true),
-                    FileUtils.readStringFromFile(serverKeyFile.getAbsolutePath(), true));
+            return new SSLCertPair(FileUtils.readStringFromFile(serverCertFile.getAbsolutePath()),
+                    FileUtils.readStringFromFile(serverKeyFile.getAbsolutePath()));
         }
         catch (RhnRuntimeException | IOException err) {
             String msg = err.getMessage();

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,4 +1,3 @@
-- Do not output cobbler xmlrpc token in debug logs CVE-2023-22644 (bsc#1210162)
 - Don't output URL parameters for tiny urls CVE-2023-22644 (bsc#1210101)
 - Do not log SSL certificate / key file content CVE-2023-22644 (bsc#1210094)
 - cache debian package metadata snippets in DB

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,4 +1,3 @@
-- Remove web session swap secrets output in logs CVE-2023-22644 (bsc#1210086)
 - Do not output cobbler xmlrpc token in debug logs CVE-2023-22644 (bsc#1210162)
 - Don't output URL parameters for tiny urls CVE-2023-22644 (bsc#1210101)
 - Do not log SSL certificate / key file content CVE-2023-22644 (bsc#1210094)

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,4 +1,3 @@
-- Don't output URL parameters for tiny urls CVE-2023-22644 (bsc#1210101)
 - Do not log SSL certificate / key file content CVE-2023-22644 (bsc#1210094)
 - cache debian package metadata snippets in DB
 - Fixed a bug that caused the tab Autoinstallation to hide when clicking on Power

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,4 +1,3 @@
-- Do not log SSL certificate / key file content CVE-2023-22644 (bsc#1210094)
 - cache debian package metadata snippets in DB
 - Fixed a bug that caused the tab Autoinstallation to hide when clicking on Power
   Management Management/Operations on SSM -> Provisioning


### PR DESCRIPTION
## What does this PR change?

Revert CVE-2023-22644 fixes committed in master in favor of https://github.com/uyuni-project/uyuni/pull/7180

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
