### PR TITLE
Drop salt.ext.six usage

### DIFF
--- a/reporting/reports.py
+++ b/reporting/reports.py
@@ -3,7 +3,6 @@ import os
 import re
 import sys
 
-from salt.ext import six
 from spacewalk.common.rhnConfig import RHNOptions
 
 BASE_REPORT_DEFINITIONS = "/usr/share/spacewalk/reports"
@@ -31,8 +30,8 @@ class report:
         def _load(self, full_path):
                 try:
                         fd = open(full_path, 'r')
-                except (IOError):
-                        six.reraise(spacewalk_unknown_report, None, sys.exc_info()[2])
+                except IOError as e:
+                        raise spacewalk_unknown_report from e
                 tag = None
                 value = ''
                 re_comment = re.compile('^\s*#')

--- a/reporting/spacewalk-report
+++ b/reporting/spacewalk-report
@@ -28,7 +28,6 @@ def systemExit(code, msgs=None):
 
 import csv
 from optparse import Option, OptionParser
-from salt.ext import six
 import re
 import errno
 
@@ -252,7 +251,7 @@ if __name__ == '__main__':
                     if report.column_types[column] == 'i' and not re.match('^[0-9]+$', v):
                         systemExit(-7, 'Column [%s] in report [%s] only accepts integer value.' % (column, report_name))
 
-                for clause, values in six.iteritems(where[column]):
+                for clause, values in column.items():
                     l = []
                     for v in values:
                         l.append(':p%d' % pi)

--- a/reporting/spacewalk-reports.changes
+++ b/reporting/spacewalk-reports.changes
@@ -1,3 +1,5 @@
+- Drop Python2 compatibility (bsc#1212588)
+
 -------------------------------------------------------------------
 Wed Dec 14 14:13:25 CET 2022 - jgonzalez@suse.com
 

--- a/reporting/spacewalk-reports.spec
+++ b/reporting/spacewalk-reports.spec
@@ -34,7 +34,6 @@ Source0:        https://github.com/spacewalkproject/spacewalk/archive/%{name}-%{
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 Requires:       %{pythonX}
-Requires:       salt
 Requires:       spacewalk-branding
 BuildRequires:  /usr/bin/docbook2man
 

--- a/spacewalk/setup/share/embedded_diskspace_check.py
+++ b/spacewalk/setup/share/embedded_diskspace_check.py
@@ -8,11 +8,6 @@
     Author: Todd Warner <taw@redhat.com>
 """
 
-try:
-    from salt.ext import six
-except ImportError:
-    import six
-
 import os
 import sys
 import stat
@@ -103,7 +98,7 @@ def paths2freespace(paths):
     pathsd = {} # 1:1
     for path in paths:
         vfs = os.statvfs(path)
-        pathsd[path] = (six.PY3 and int)(vfs.f_bavail) * vfs.f_bsize
+        pathsd[path] = int(vfs.f_bavail) * vfs.f_bsize
 
     return pathsd
 

--- a/utils/spacewalk-sync-setup
+++ b/utils/spacewalk-sync-setup
@@ -26,7 +26,6 @@ from optparse import OptionParser, OptionGroup
 from os import path, access, R_OK
 from os.path import expanduser
 import getpass
-from salt.ext import six
 
 try:
     import xmlrpclib
@@ -613,10 +612,7 @@ def describe_master_template(master_setup_filename):
 
 def ask(msg, password=False):
     msg += ": "
-    if six.PY2:
-        inputfn = raw_input
-    else:
-        inputfn = input
+    inputfn = input
     return password and getpass.getpass(msg) or inputfn(msg)
 
 

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,4 +1,5 @@
-* Add RHEL 7, 8, 9 pool and tools channels
+- Drop Python2 compatibility
+- Add RHEL 7, 8, 9 pool and tools channels
 - Add openSUSE Leap Micro 5.4 repositories
 - Add SLE Micro 5.4 Uyuni Client Tools repositories
 - spacewalk-hostname-rename remains stuck at refreshing pillars (bsc#1207550)

--- a/utils/spacewalk-utils.spec
+++ b/utils/spacewalk-utils.spec
@@ -54,8 +54,6 @@ Requires:       (python3-PyYAML or python3-pyyaml)
 Requires:       python3-solv
 # Required by depsolver.py, cloneByDate.py, spacewalk-common-channels
 Requires:       python3-uyuni-common-libs
-# Required by spacewalk-clone-by-date, spacewalk-sync-setup
-Requires:       python3-salt
 # Required by spacewalk-hostname-rename
 Requires:       rpm
 # Required by spacewalk-hostname-rename


### PR DESCRIPTION
## What does this PR change?

spacewalk-report is a server-side tool, i.e. it does not be Python2-compatible. Six is therefore superfluous.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/21851
Tracks https://github.com/SUSE/spacewalk/pull/21852

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
