### PR TITLE
WIP: DO NOT REVIEW: NPE salt

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -140,7 +140,7 @@
         <dependency org="mockobjects" name="mockobjects-jdk1.4-j2ee1.3" rev="0.09" transitive="false"/>
         <dependency org="org.objenesis" name="objenesis" rev="1.0" transitive="false"/>
         <dependency org="jakarta.websocket" name="jakarta.websocket-api" rev="2.0.0" transitive="false"/>
-        <dependency org="jakarta.servlet" name="jakarta.servlet-api" rev="6.0.0"/>
+        <dependency org="jakarta.servlet" name="jakarta.servlet-api" rev="5.0.0"/>
         <dependency org="org.jacoco" name="org.jacoco.ant" rev="0.8.7" transitive="false">
            <artifact name="nodeps" type="jar" url="https://repo1.maven.org/maven2/org/jacoco/org.jacoco.ant/0.8.7/org.jacoco.ant-0.8.7-nodeps.jar"/>
         </dependency>

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -139,7 +139,7 @@
         <dependency org="mockobjects" name="mockobjects-core" rev="0.09" transitive="false"/>
         <dependency org="mockobjects" name="mockobjects-jdk1.4-j2ee1.3" rev="0.09" transitive="false"/>
         <dependency org="org.objenesis" name="objenesis" rev="1.0" transitive="false"/>
-        <dependency org="javax.websocket" name="javax.websocket-api" rev="1.1" transitive="false"/>
+        <dependency org="jakarta.platform" name="jakarta.jakartaee-api" rev="10.0.0" transitive="false"/>
         <dependency org="org.jacoco" name="org.jacoco.ant" rev="0.8.7" transitive="false">
            <artifact name="nodeps" type="jar" url="https://repo1.maven.org/maven2/org/jacoco/org.jacoco.ant/0.8.7/org.jacoco.ant-0.8.7-nodeps.jar"/>
         </dependency>

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -139,7 +139,8 @@
         <dependency org="mockobjects" name="mockobjects-core" rev="0.09" transitive="false"/>
         <dependency org="mockobjects" name="mockobjects-jdk1.4-j2ee1.3" rev="0.09" transitive="false"/>
         <dependency org="org.objenesis" name="objenesis" rev="1.0" transitive="false"/>
-        <dependency org="jakarta.platform" name="jakarta.jakartaee-api" rev="10.0.0" transitive="false"/>
+        <dependency org="jakarta.websocket" name="jakarta.websocket-api" rev="2.0.0" transitive="false"/>
+        <dependency org="jakarta.servlet" name="jakarta.servlet-api" rev="6.0.0"/>
         <dependency org="org.jacoco" name="org.jacoco.ant" rev="0.8.7" transitive="false">
            <artifact name="nodeps" type="jar" url="https://repo1.maven.org/maven2/org/jacoco/org.jacoco.ant/0.8.7/org.jacoco.ant-0.8.7-nodeps.jar"/>
         </dependency>

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -51,6 +51,9 @@ artifacts:
   - artifact: commons-discovery
     package: jakarta-commons-discovery
     repository: Leap
+  - artifact: jakarta.servlet-api
+    package: jakarta-servlet
+    repository: Leap
   - artifact: commons-el
     package: apache-commons-el
     repository: Leap

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -132,9 +132,6 @@ artifacts:
   - artifact: jakarta-persistence-api
     package: jpa-api
     repository: Uyuni_Other
-  - artifact: jakarta.jakartaee-api
-    package: jpa-api
-    repository: Uyuni_Other
   - artifact: java-saml
     jar: java-saml-[0-9.]+
     repository: Uyuni_Other

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -129,7 +129,7 @@ artifacts:
     repository: Leap_sle
   - artifact: jade4j
     repository: Uyuni_Other
-  - artifact: jakarta-persistence-api
+  - artifact: jakarta.jakartaee-api
     package: jpa-api
     repository: Uyuni_Other
   - artifact: java-saml

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -10,6 +10,9 @@ repositories:
     repository: openSUSE_Leap_15.4
   Leap_sle:
     url: https://download.opensuse.org/update/leap/15.4/sle
+  Factory:
+    project: openSUSE:Factory
+    repository: standard
 artifacts:
   - artifact: asm
     package: objectweb-asm
@@ -53,7 +56,7 @@ artifacts:
     repository: Leap
   - artifact: jakarta.servlet-api
     package: jakarta-servlet
-    repository: Leap
+    repository: Factory
   - artifact: commons-el
     package: apache-commons-el
     repository: Leap

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -129,6 +129,9 @@ artifacts:
     repository: Leap_sle
   - artifact: jade4j
     repository: Uyuni_Other
+  - artifact: jakarta-persistence-api
+    package: jpa-api
+    repository: Uyuni_Other
   - artifact: jakarta.jakartaee-api
     package: jpa-api
     repository: Uyuni_Other

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -1492,7 +1492,7 @@ public class SaltUtils {
                     Function.identity()
              ));
 
-        if(result.getInfoInstalled() == null) {
+        if (result.getInfoInstalled() == null) {
             LOG.warn("Cannot find information about installed packages, maybe because action failed");
             return;
         }

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -1492,6 +1492,11 @@ public class SaltUtils {
                     Function.identity()
              ));
 
+        if(result.getInfoInstalled() == null) {
+            LOG.warn("Cannot find information about installed packages, maybe because action failed");
+            return;
+        }
+
         Map<String, Map.Entry<String, Pkg.Info>> newPackageMap =
             result.getInfoInstalled().getChanges().getRet()
                 .entrySet().stream()

--- a/java/code/src/com/suse/manager/webui/websocket/Notification.java
+++ b/java/code/src/com/suse/manager/webui/websocket/Notification.java
@@ -46,13 +46,13 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import javax.websocket.EndpointConfig;
-import javax.websocket.OnClose;
-import javax.websocket.OnError;
-import javax.websocket.OnMessage;
-import javax.websocket.OnOpen;
-import javax.websocket.Session;
-import javax.websocket.server.ServerEndpoint;
+import jakarta.websocket.EndpointConfig;
+import jakarta.websocket.OnClose;
+import jakarta.websocket.OnError;
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.OnOpen;
+import jakarta.websocket.Session;
+import jakarta.websocket.server.ServerEndpoint;
 
 /**
  * WebSocket EndPoint for showing notifications real-time in web UI.

--- a/java/code/src/com/suse/manager/webui/websocket/RemoteMinionCommands.java
+++ b/java/code/src/com/suse/manager/webui/websocket/RemoteMinionCommands.java
@@ -63,12 +63,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
-import javax.websocket.OnClose;
-import javax.websocket.OnError;
-import javax.websocket.OnMessage;
-import javax.websocket.OnOpen;
-import javax.websocket.Session;
-import javax.websocket.server.ServerEndpoint;
+import jakarta.websocket.OnClose;
+import jakarta.websocket.OnError;
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.OnOpen;
+import jakarta.websocket.Session;
+import jakarta.websocket.server.ServerEndpoint;
 
 /**
  * Websocket endpoint for executing remote commands on Salt minions.

--- a/java/code/src/com/suse/manager/webui/websocket/VirtNotifications.java
+++ b/java/code/src/com/suse/manager/webui/websocket/VirtNotifications.java
@@ -52,13 +52,13 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import javax.websocket.EndpointConfig;
-import javax.websocket.OnClose;
-import javax.websocket.OnError;
-import javax.websocket.OnMessage;
-import javax.websocket.OnOpen;
-import javax.websocket.Session;
-import javax.websocket.server.ServerEndpoint;
+import jakarta.websocket.EndpointConfig;
+import jakarta.websocket.OnClose;
+import jakarta.websocket.OnError;
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.OnOpen;
+import jakarta.websocket.Session;
+import jakarta.websocket.server.ServerEndpoint;
 
 /**
  * Websocket endpoint for acting on virtual machines on Salt minions.

--- a/java/code/src/com/suse/manager/webui/websocket/WebsocketHeartbeatService.java
+++ b/java/code/src/com/suse/manager/webui/websocket/WebsocketHeartbeatService.java
@@ -28,7 +28,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-import javax.websocket.Session;
+import jakarta.websocket.Session;
 
 /**
  * Service that sends periodic pings to all the registered websocket connections, making sure the connections are kept

--- a/java/code/src/com/suse/manager/webui/websocket/WebsocketSessionConfigurator.java
+++ b/java/code/src/com/suse/manager/webui/websocket/WebsocketSessionConfigurator.java
@@ -15,10 +15,10 @@
 
 package com.suse.manager.webui.websocket;
 
-import javax.servlet.http.HttpSession;
-import javax.websocket.HandshakeResponse;
-import javax.websocket.server.HandshakeRequest;
-import javax.websocket.server.ServerEndpointConfig;
+import jakarta.servlet.http.HttpSession;
+import jakarta.websocket.HandshakeResponse;
+import jakarta.websocket.server.HandshakeRequest;
+import jakarta.websocket.server.ServerEndpointConfig;
 
 /**
  * A WebSocket Session configuration manager

--- a/java/spacewalk-java.changes.mbussolotto.various_npe
+++ b/java/spacewalk-java.changes.mbussolotto.various_npe
@@ -1,0 +1,2 @@
+- use jakarta ws instead of javax (bsc#1210222)
+- fix NPE in SaltUtil 


### PR DESCRIPTION
## What does this PR change?

```
2023-06-15 02:22:53,481 [salt-event-thread-1] ERROR com.suse.manager.utils.SaltUtils - JSON syntax error while decoding into a StateApplyResult:
2023-06-15 02:22:53,481 [salt-event-thread-1] ERROR com.suse.manager.utils.SaltUtils - {"result":false,"retcode":1,"comment":"Couldn't get lock, is another instance already running?"}
2023-06-15 02:22:53,923 [salt-event-thread-1] ERROR com.suse.manager.webui.services.SaltServerActionService - Error processing Salt job return
java.lang.NullPointerException: null
        at com.suse.manager.utils.SaltUtils.updatePackages(SaltUtils.java:1494) ~[rhn.jar:?]
        at com.suse.manager.utils.SaltUtils.lambda$handlePackageProfileUpdate$81(SaltUtils.java:1346) ~[rhn.jar:?]
        at com.redhat.rhn.common.hibernate.HibernateFactory.lambda$doWithoutAutoFlushing$0(HibernateFactory.java:740) ~[rhn.jar:?]
        at com.redhat.rhn.common.hibernate.HibernateFactory.doWithoutAutoFlushing(HibernateFactory.java:684) ~[rhn.jar:?]
        at com.redhat.rhn.common.hibernate.HibernateFactory.doWithoutAutoFlushing(HibernateFactory.java:739) ~[rhn.jar:?]
        at com.redhat.rhn.common.hibernate.HibernateFactory.doWithoutAutoFlushing(HibernateFactory.java:712) ~[rhn.jar:?]
        at com.suse.manager.utils.SaltUtils.handlePackageProfileUpdate(SaltUtils.java:1346) ~[rhn.jar:?]
        at com.suse.manager.utils.SaltUtils.lambda$updateServerAction$25(SaltUtils.java:580) ~[rhn.jar:?]
        at java.util.Optional.ifPresent(Optional.java:183) ~[?:?]
        at com.suse.manager.utils.SaltUtils.updateServerAction(SaltUtils.java:580) ~[rhn.jar:?]
        at com.suse.manager.webui.services.SaltServerActionService.lambda$handleAction$150(SaltServerActionService.java:2720) ~[rhn.jar:?]
        at java.util.Optional.ifPresent(Optional.java:183) ~[?:?]
        at com.suse.manager.webui.services.SaltServerActionService.lambda$handleAction$151(SaltServerActionService.java:2698) ~[rhn.jar:?]
```
## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
