### PR TITLE
Don't install products on openSUSE client OSes

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/init.sls
@@ -145,7 +145,7 @@ install_gnupg_debian:
 {%- endif %}
 
 {%- if not salt['pillar.get']('susemanager:distupgrade:dryrun', False) %}
-{%- if grains['os_family'] == 'Suse' and grains['osmajorrelease']|int > 11 and not grains['oscodename'] == 'openSUSE Leap 15.3' %}
+{%- if grains['os_family'] == 'Suse' and grains['osmajorrelease']|int > 11 and "opensuse" not in grains['oscodename']|lower %}
 mgrchannels_install_products:
   product.all_installed:
     - require:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.agraul.no-products-for-opensuse
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.agraul.no-products-for-opensuse
@@ -1,0 +1,1 @@
+- Don't install product packages on openSUSE clients


### PR DESCRIPTION

## What does this PR change?
openSUSE repos often contain multiple "product packages", that conflict. The idea is that installer installs the correct product once and that's it. In Uyuni, we currently install all products we can find. That does not work because of the conflict.


## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: this came up when using openSUSE MicroOS. Until we test with client OSes where this happens (like MicroOS or Tumbleweed), we can't test this properly

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/7068

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
