### PR TITLE
show reasons for state apply errors in UI

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesAction.java
@@ -81,6 +81,8 @@ public class ApplyStatesAction extends Action {
             LocalizationService ls = LocalizationService.getInstance();
             retval.append("<strong><span class='text-danger'>");
             retval.append("Error: " + ls.getMessage("system.event.details.syntaxerror"));
+            retval.append('\n');
+            retval.append(result.getOutputContents());
             retval.append("</span></strong>");
             return retval.toString();
         }

--- a/java/spacewalk-java.changes.mcalmer.Manager-4.3-show-parse-error-reason
+++ b/java/spacewalk-java.changes.mcalmer.Manager-4.3-show-parse-error-reason
@@ -1,0 +1,1 @@
+- show reasons for state apply errors in UI


### PR DESCRIPTION
## What does this PR change?

The reason why a state apply failed is stored in DB, but not shown in the UI.
This PR change this and print out also the result output which can contain very useful information

## GUI diff

Before:

![image](https://github.com/SUSE/spacewalk/assets/1038917/c18113c2-6f72-4f16-9ea5-c3c238234734)


After:

![image](https://github.com/SUSE/spacewalk/assets/1038917/1c3e0e3b-4bef-41f1-a2b8-6bbe317637b2)

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/21859

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
