### PR TITLE
Revert "Testsuite: Move bootstrap features in regular secondary stage"

### DIFF
--- a/testsuite/features/secondary/min_activationkey.feature
+++ b/testsuite/features/secondary/min_activationkey.feature
@@ -2,7 +2,7 @@
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features:
-# - features/secondary/min_bootstrap_ssh_key.feature
+# - features/secondary/min_salt_minions_page.feature
 # If the minion fails to bootstrap.
 
 @skip_if_github_validation

--- a/testsuite/features/secondary/min_bootstrap_reactivation.feature
+++ b/testsuite/features/secondary/min_bootstrap_reactivation.feature
@@ -1,9 +1,5 @@
 # Copyright (c) 2021-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
-#
-# This feature can cause failures in the following features:
-# - features/secondary/min_salt_minions_page.feature
-# If the minion fails to bootstrap.
 
 @skip_if_github_validation
 @sle_minion

--- a/testsuite/features/secondary/min_bootstrap_script.feature
+++ b/testsuite/features/secondary/min_bootstrap_script.feature
@@ -2,7 +2,7 @@
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features:
-# - features/secondary/min_bootstrap_api.feature
+# - features/secondary/min_ssh_tunnel.feature
 # If the minion fails to bootstrap
 
 @skip_if_github_validation

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -29,14 +29,11 @@
 - features/secondary/min_deblike_openscap_audit.feature
 - features/secondary/min_deblike_remote_command.feature
 - features/secondary/min_deblike_ssh.feature
-- features/secondary/min_ssh_tunnel.feature
-- features/secondary/min_activationkey.feature
 - features/secondary/minssh_bootstrap_api.feature
 - features/secondary/min_bootstrap_ssh_key.feature
 - features/secondary/min_bootstrap_script.feature
-- features/secondary/min_bootstrap_api.feature
-- features/secondary/min_bootstrap_negative.feature
-- features/secondary/min_bootstrap_reactivation.feature
+- features/secondary/min_ssh_tunnel.feature
+- features/secondary/min_activationkey.feature
 # Bare Metal discovery is not yet supported using Salt Minions https://github.com/SUSE/spacewalk/issues/18932
 # - features/secondary/min_baremetal_discovery.feature
 - features/secondary/min_salt_minions_page.feature

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -52,6 +52,9 @@
 - features/secondary/min_deblike_monitoring.feature
 - features/secondary/min_deblike_salt_install_with_staging.feature
 - features/secondary/min_deblike_salt_install_package.feature
+- features/secondary/min_bootstrap_api.feature
+- features/secondary/min_bootstrap_negative.feature
+- features/secondary/min_bootstrap_reactivation.feature
 - features/secondary/min_salt_software_states.feature
 - features/secondary/min_salt_install_with_staging.feature
 - features/secondary/min_salt_formulas.feature


### PR DESCRIPTION
## What does this PR change?

Reverts uyuni-project/uyuni#7145

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were added
- [x] **DONE**

## Links
Tracks # 
4.3 https://github.com/SUSE/spacewalk/pull/21863
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
