### PR TITLE
Allow both CentOS and Rocky on all branches

### DIFF
--- a/testsuite/features/step_definitions/retail_steps.rb
+++ b/testsuite/features/step_definitions/retail_steps.rb
@@ -154,7 +154,13 @@ When(/^I set up the private network on the terminals$/) do
     next if node.nil?
     domain, _code = node.run("grep '^search' /etc/resolv.conf | sed 's/^search//'")
     conf = "DOMAIN='#{domain.strip}'\\nDEVICE='eth1'\\nSTARTMODE='auto'\\nBOOTPROTO='dhcp'\\nDNS1='#{proxy}'"
-    node.run("echo -e \"#{conf}\" > #{file} && echo -e \"#{conf2}\" > #{file2} && systemctl restart NetworkManager")
+    service =
+      if node.os_family =~ /^rocky/
+        'NetworkManager'
+      else
+        'network'
+      end
+    node.run("echo -e \"#{conf}\" > #{file} && echo -e \"#{conf2}\" > #{file2} && systemctl restart #{service}")
   end
   # /etc/netplan/01-netcfg.yaml
   nodes = [$deblike_minion]


### PR DESCRIPTION
## What does this PR change?

Do not make assumptions about which RH-like minion we use on each branch.

Rocky 8 uses `NetworkManager` service, CentOS uses `network` service.

Alma and others are missing but can be added easily.


## Links

Ports:
* 4.3: https://github.com/SUSE/spacewalk/pull/21865
* 4.2: https://github.com/SUSE/spacewalk/pull/21867

Fixes #21779


## Changelogs

- [x] No changelog needed
