### PR TITLE
Use existing defined step

### DIFF
--- a/testsuite/features/secondary/min_recurring_action.feature
+++ b/testsuite/features/secondary/min_recurring_action.feature
@@ -259,7 +259,7 @@ Feature: Recurring Actions
     And I wait until I see "Configure states to execute" text
     And I enter "schedule_name" as "scheduleName"
     And I check radio button "schedule-daily"
-    And I enter 1 minutes from now as "time-daily_time"
+    And I pick 1 minutes from now as "time-daily_time"
     And I click on the "disabled" toggler
     And I check "Hardware Profile Update-cbox"
     And I click on "Save Changes"
@@ -353,7 +353,7 @@ Feature: Recurring Actions
     And I follow "Delete Group"
     And I click on "Confirm Deletion"
     Then I should see a "Your organization has no system groups." text
-    
+
   Scenario: Cleanup: Remove "My State Channel for Recurring Actions" config channel
     When I follow the left menu "Configuration > Channels"
     And I follow "My State Channel for Recurring Actions"


### PR DESCRIPTION
## What does this PR change?

Use the correct defined step, the previous is undefined. To make it clear this is untested right now.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes no issue, directly from testsuite review
Tracks # **add downstream PR, if any**
needs ports

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
