### PR TITLE
Fix system tab not visible in Ansible / Inventories tab

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
@@ -94,7 +94,7 @@ public class AnsibleController {
                 withCsrfToken(withDocsLocale(withUserAndServer(AnsibleController::playbooks))), jade);
 
         get("/manager/systems/details/ansible/inventories",
-                withCsrfToken(withDocsLocale(withUser(AnsibleController::inventories))), jade);
+                withCsrfToken(withDocsLocale(withUserAndServer(AnsibleController::inventories))), jade);
 
         get("/manager/api/systems/details/ansible/paths/:minionServerId",
                 withUser(AnsibleController::listAnsiblePathsByMinion));
@@ -156,13 +156,11 @@ public class AnsibleController {
      * @param req the request object
      * @param res the response object
      * @param user the authorized user
+     * @param server the server
      * @return the model and view
      */
-    public static ModelAndView inventories(Request req, Response res, User user) {
-        String serverId = req.queryParams("sid");
+    public static ModelAndView inventories(Request req, Response res, User user, Server server) {
         Map<String, Object> data = new HashMap<>();
-        Server server = ServerFactory.lookupById(Long.valueOf(serverId));
-        data.put("server", server);
         data.put("pathContentType", AnsiblePath.Type.INVENTORY.getLabel());
         return new ModelAndView(data, "templates/minion/ansible-path-content.jade");
     }

--- a/java/spacewalk-java.changes.welder.bsc1211897
+++ b/java/spacewalk-java.changes.welder.bsc1211897
@@ -1,0 +1,1 @@
+- Fix system tab not visible in Ansible / Inventories tab (bsc#1211897)


### PR DESCRIPTION
## What does this PR change?

Use `withUserAndServer` template instead of fetching the server manually so the system page tabs work correctly.

## GUI diff

No difference.

Before:
![image](https://github.com/uyuni-project/uyuni/assets/17532261/0824e7ed-74e7-43c1-b37e-50217ca29a4f)


After:
![image](https://github.com/uyuni-project/uyuni/assets/17532261/105f7353-a1d3-40c6-ab70-d690326096a7)


- [x] **DONE**

## Documentation
- No documentation needed: bug fix

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/21632

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
