### PR TITLE
Add missing Salt 3006.0 deps to bootstrap repos

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -142,6 +142,8 @@ RES8 = [
     "python3-distro",
     "python3-immutables",
     "python3-contextvars",
+    "python3-looseversion",
+    "python3-jmespath",
     "venv-salt-minion",
 ]
 
@@ -254,7 +256,9 @@ PKGLIST15_SALT_NO_BUNDLE = [
     "salt-minion",
     "python3-apipkg*",
     "python3-iniconfig*",
-    "xz"
+    "python3-looseversion",
+    "python3-jmespath",
+    "xz",
 ]
 
 PKGLIST15_SALT = PKGLIST15_SALT_NO_BUNDLE + [
@@ -371,6 +375,8 @@ PKGLISTUBUNTU1804 = [
     "gnupg",
     "python3-immutables",
     "python3-contextvars",
+    "python3-looseversion",
+    "python3-jmespath",
     "venv-salt-minion",
 ]
 
@@ -389,6 +395,8 @@ PKGLISTUBUNTU2004 = [
     "python3-pycryptodome",
     "python3-zmq",
     "python3-gnupg",
+    "python3-looseversion",
+    "python3-jmespath",
     "salt-common",
     "salt-minion",
     "gnupg",
@@ -520,6 +528,8 @@ PKGLISTDEBIAN10 = [
     "gnupg",
     "venv-salt-minion",
     "python3-gnupg",
+    "python3-looseversion",
+    "python3-jmespath",
 ]
 
 PKGLISTDEBIAN11 = [

--- a/susemanager/susemanager.changes.agraul.fix-salt-3006-bootstrap-deps
+++ b/susemanager/susemanager.changes.agraul.fix-salt-3006-bootstrap-deps
@@ -1,0 +1,1 @@
+- Add missing Salt 3006.0 dependencies to bootstrap repo definitions (bsc#1212700)


### PR DESCRIPTION
## What does this PR change?

Add missing Salt 3006.0 deps to bootstrap repos
These are new dependencies that are required for Salt 3006.0

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: Bootstrap repos are created in the cucumber test suite.

## Links

Fixes bsc#1212700
Tracks https://github.com/SUSE/spacewalk/pull/21886
Tracks https://github.com/SUSE/spacewalk/pull/21887

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
