### PR TITLE
Revert c37882bc435bea1c147ca416e609398290c69748

### DIFF
--- a/spacewalk/certs-tools/mgr_ssl_cert_setup.py
+++ b/spacewalk/certs-tools/mgr_ssl_cert_setup.py
@@ -264,9 +264,8 @@ def getCertData(cert):
         elif line.startswith("    "):
             if nextval == "subjectKeyIdentifier":
                 data["subjectKeyIdentifier"] = line.strip().upper()
-            elif nextval == "authorityKeyIdentifier":
-                # OpenSSL v1 adds a prefix 'keyid:'. OenSSL v3 does not.
-                data["authorityKeyIdentifier"] = line.replace("keyid:", "").strip().upper()
+            elif nextval == "authorityKeyIdentifier" and line.startswith("    keyid:"):
+                data["authorityKeyIdentifier"] = line[10:].strip().upper()
         elif "subject_hash" not in data:
             # subject_hash comes first without key to identify it
             data["subject_hash"] = line.strip()

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,4 +1,3 @@
-- Revert openssl3 compatibility because it breaks cert validation
 - Add openssl3 compatibility.
 - Read CA password from a file
 - Also ship SUSE specific files on Enterprise Linux.

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,4 @@
+- Revert openssl3 compatibility because it breaks cert validation
 - Add openssl3 compatibility.
 - Read CA password from a file
 - Also ship SUSE specific files on Enterprise Linux.

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes.ktsamis.openssl
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes.ktsamis.openssl
@@ -1,0 +1,1 @@
+- Revert openssl3 compatibility because it breaks cert validation


### PR DESCRIPTION
## What does this PR change?

Reverts c37882bc435bea1c147ca416e609398290c69748 because it broke uyuni and head testsuites. 

Before (with printing the keyId and issuerKeyId and subject for debugging):
```
uyuni-master-srv:~ # /usr/bin/rhn-ssl-tool --gen-server --no-rpm --cert-expiration=3650 --set-org=SUSE --set-org-unit=SUSE --password=spacewalk --set-city=Nuernberg --set-email=uyuni@mgr.suse.de --dir=/root/ssl-
build-fubar --set-state=Bayern --set-hostname=uyuni-master-srv.mgr.suse.de --set-country=DE                                                                                                                        
                                                                                                                                                                                                                   
Generating the web server's SSL private key: /root/ssl-build-fubar/uyuni-master-srv.mgr/server.key                                                                                                                 
                                                                                                                                                                                                                   
Generating web server's SSL certificate request: /root/ssl-build-fubar/uyuni-master-srv.mgr/server.csr                                                                                                             
Using distinguished names:                                                                                                                                                                                         
    --set-country      = "DE"                                                                                                                                                                                      
    --set-state        = "Bayern"                                                                                                                                                                                  
    --set-city         = "Nuernberg"
    --set-org          = "SUSE"
    --set-org-unit     = "SUSE"
    --set-hostname     = "uyuni-master-srv.mgr.suse.de"
    --set-email        = "uyuni@mgr.suse.de"
Rotated: rhn-ca-openssl.cnf --> rhn-ca-openssl.cnf.1 

Generating/signing web server's SSL certificate: server.crt
uyuni-master-srv:~ # /usr/bin/mgr-ssl-cert-setup --root-ca-file=/root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT --server-cert-file=/root/ssl-build-fubar/uyuni-master-srv.mgr/server.crt --server-key-file=/root/ssl-build
-fubar/uyuni-master-srv.mgr/server.key -c                                                                 
C0:0E:AF:F3:61:18:22:08:5B:3A:B8:2B:C3:FF:F3:51:C4:D2:6D:04
SERIAL:3D:A3:21:CD:75:6B:63:77:61:C3:05:C6:45:C0:DC:63:E2:C6:1E:F3
C = DE, ST = Bayern, O = SUSE, OU = SUSE, CN = uyuni-master-srv.mgr.suse.de, emailAddress = uyuni@mgr.suse.de

ERROR: Incomplete CA Chain. Key Identifiers do not match. Unable to find issuer of 'C = DE, ST = Bayern, O = SUSE, OU = SUSE, CN = uyuni-master-srv.mgr.suse.de, emailAddress = uyuni@mgr.suse.de'
```

After this fix:

```
uyuni-master-srv:~ # /usr/bin/rhn-ssl-tool --gen-server --no-rpm --cert-expiration=3650 --set-org=SUSE --set-org-unit=SUSE --password=spacewalk --set-city=Nuernberg --set-email=uyuni@mgr.suse.de --dir=/root/ssl-build-fubar --set-state=Bayern --set-hostname=uyuni-master-srv.mgr.suse.de --set-country=DE

Generating the web server's SSL private key: /root/ssl-build-fubar/uyuni-master-srv.mgr/server.key
Rotated: server.key --> server.key.1
Rotated: rhn-server-openssl.cnf --> rhn-server-openssl.cnf.1

Generating web server's SSL certificate request: /root/ssl-build-fubar/uyuni-master-srv.mgr/server.csr
Using distinguished names:
    --set-country      = "DE"
    --set-state        = "Bayern"
    --set-city         = "Nuernberg"
    --set-org          = "SUSE"
    --set-org-unit     = "SUSE"
    --set-hostname     = "uyuni-master-srv.mgr.suse.de"
    --set-email        = "uyuni@mgr.suse.de"
Rotated: server.csr --> server.csr.1

Generating/signing web server's SSL certificate: server.crt
Rotated: server.crt --> server.crt.1
uyuni-master-srv:~ # /usr/bin/mgr-ssl-cert-setup --root-ca-file=/root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT --server-cert-file=/root/ssl-build-fubar/uyuni-master-srv.mgr/server.crt --server-key-file=/root/ssl-build-fubar/uyuni-master-srv.mgr/server.key -c
C0:0E:AF:F3:61:18:22:08:5B:3A:B8:2B:C3:FF:F3:51:C4:D2:6D:04
C0:0E:AF:F3:61:18:22:08:5B:3A:B8:2B:C3:FF:F3:51:C4:D2:6D:04
C = DE, ST = Bayern, O = SUSE, OU = SUSE, CN = uyuni-master-srv.mgr.suse.de, emailAddress = uyuni@mgr.suse.de
```



## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes no issue directly from testsuite review
Tracks no other PR, only on master this was changed before.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
