### PR TITLE
Add changelog for embedded_diskspace_check change

### DIFF
--- a/spacewalk/setup/spacewalk-setup.changes.agraul.drop-salt-ext-six-embedded-diskspace-check
+++ b/spacewalk/setup/spacewalk-setup.changes.agraul.drop-salt-ext-six-embedded-diskspace-check
@@ -1,0 +1,1 @@
+- Drop usage of salt.ext.six in embedded_diskspace_check


### PR DESCRIPTION
## What does this PR change?

Add changelog entry to be aligned with SUMA 4.2 / 4.3. Those version need the changelog since the embedded_diskspace_check change is the only change for spacewalk-setup in the next submission.


## Links

Tracks https://github.com/SUSE/spacewalk/pull/21900
Tracks https://github.com/SUSE/spacewalk/pull/21899

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
