### PR TITLE
Filter out modules properly with 'none' matcher (bsc#1212770)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/DependencyResolver.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/DependencyResolver.java
@@ -110,9 +110,12 @@ public class DependencyResolver {
         List<ContentFilter> updatedFilters = new ArrayList<>(filters);
 
         // Transform module filters to package filters
-        // If no module filters are attached, no modular package should be filtered out
         DependencyResolutionResult resolved = null;
-        if (!moduleFilters.isEmpty()) {
+        if (isModulesDisabled(filters)) {
+            // If modularity is disabled, no modules should be included
+            updatedFilters.add(new ModularPackageFilter());
+        }
+        else if (!moduleFilters.isEmpty()) {
             resolved = resolveModularDependencies(moduleFilters);
             updatedFilters.addAll(resolved.getFilters());
             updatedFilters.removeAll(moduleFilters);

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/DependencyResolverTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/DependencyResolverTest.java
@@ -218,11 +218,23 @@ public class DependencyResolverTest extends BaseTestCaseWithUser {
         assertTrue(result.stream().anyMatch(f -> isAllowNevraEquals(f, "perl-0:5.24.1-1.module_yyy.x86_64")));
     }
 
+    @Test
+    public void testResolveModularFiltersDisabled() throws DependencyResolutionException {
+        FilterCriteria criteria1 = new FilterCriteria(FilterCriteria.Matcher.MODULE_NONE, "module_stream", null);
+        ContentFilter noModules = contentManager.createFilter("no-modules", ALLOW, MODULE, criteria1, user);
+
+        DependencyResolutionResult result = resolver.resolveFilters(List.of(noModules));
+
+        assertEquals(0, result.getModules().size());
+        assertEquals(2, result.getFilters().size());
+        assertTrue(result.getFilters().stream().anyMatch(f -> f instanceof ModularPackageFilter));
+    }
+
     /**
-     * Test the resolver with modularity disabled
+     * Test the resolver with module filters when modularity is disabled
      */
     @Test
-    public void testResolveModuleFiltersDisabled() {
+    public void testResolveModuleFiltersDisabledWithModuleFilters() {
         FilterCriteria criteria1 = new FilterCriteria(FilterCriteria.Matcher.MODULE_NONE, "module_stream", null);
         ContentFilter noModules = contentManager.createFilter("no-modules", ALLOW, MODULE, criteria1, user);
         FilterCriteria criteria2 = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "module_stream", "perl:5.26");

--- a/java/spacewalk-java.changes.cbbayburt.disable-modularity
+++ b/java/spacewalk-java.changes.cbbayburt.disable-modularity
@@ -1,0 +1,1 @@
+- Filter out modules properly with 'none' matcher (bsc#1212770)


### PR DESCRIPTION
After adding 'None (disable modularity)' filter, modules are still available in the target repository. This patch fixes this behavior.

## Documentation
- No documentation needed: bugfix

## Test coverage
- Unit tests added

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/7133

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
