### PR TITLE
Add cobbler collections to supportconfig

### DIFF
--- a/python/spacewalk/satellite_tools/spacewalk-debug
+++ b/python/spacewalk/satellite_tools/spacewalk-debug
@@ -261,6 +261,7 @@ if [ -d /var/lib/cobbler ]; then
    cp -fa /var/lib/cobbler/config $DIR/cobbler-lib/
    cp -fa /var/lib/cobbler/kickstarts $DIR/cobbler-lib/
    cp -fa /var/lib/cobbler/triggers $DIR/cobbler-lib/
+   cp -fa /var/lib/cobbler/collections $DIR/cobbler-lib/
 fi
 if [ -d /var/lib/rhn/kickstarts ]; then
    cp -fa /var/lib/rhn/kickstarts/* $DIR/kickstarts/

--- a/python/spacewalk/spacewalk-backend.changes.agraul.supportutils-add-cobbler-collections
+++ b/python/spacewalk/spacewalk-backend.changes.agraul.supportutils-add-cobbler-collections
@@ -1,0 +1,1 @@
+- Add cobbler collections to supportconfig


### PR DESCRIPTION
## What does this PR change?

Add cobbler collections to supportconfig.

We have been requesting the contents of /var/lib/cobbler/collections in many of the cobbler bugs in the last year. That's one round-trip we can save by collecting these JSON files upfront with the supportconfig plugin.



## GUI diff

No difference.

## Documentation

No documentation needed: only internal and user invisible changes

## Test coverage

No tests: Testing all the contents of the supportconfig is a lot of work for little gain.


## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
