### PR TITLE
Workaround for python3-debian bug about collecting control file

### DIFF
--- a/python/uyuni/uyuni-common-libs.changes.mbussolotto.fix_deb
+++ b/python/uyuni/uyuni-common-libs.changes.mbussolotto.fix_deb
@@ -1,0 +1,1 @@
+- Workaround for python3-debian bug about collecting control file (bsc#1211525, bsc#1208692)


### PR DESCRIPTION
## What does this PR change?

Python-debian has changed the way it looks up the file names from the tar headers. Somehow they enforce the dot-slash (./) in the file name starting from the version 0.1.44, while it's totally possible to have a tar with file names as simple relative paths like control, not ./control. Since we cannot downgrade the version (introduced to fix https://github.com/SUSE/spacewalk/issues/17726 ) I just introduced a new method to do the same steps performed in version < 0.1.44  (as described here https://github.com/SUSE/spacewalk/issues/21530#issuecomment-1576992005 )

There's already a bug opened to fix issue in `python-debian` library https://www.mail-archive.com/pkg-python-debian-maint@alioth-lists.debian.net/msg00598.html

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed
- [x] **DONE**

## Test coverage
- https://ci.suse.de/view/Manager/view/Uyuni-PRs/job/uyuni-prs-ci-tests/2442/

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/21530
Fixes https://github.com/SUSE/spacewalk/issues/21212
Fixes https://github.com/SUSE/spacewalk/issues/20605
Fixes https://github.com/SUSE/spacewalk/issues/21699
Fixes https://github.com/uyuni-project/uyuni/issues/6396
Fixes https://github.com/SUSE/spacewalk/issues/21700
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
