### PR TITLE
CI: Use "osc api" so that it uses the Multi Factor Authentication

### DIFF
--- a/susemanager-utils/testing/automation/obs-project.py
+++ b/susemanager-utils/testing/automation/obs-project.py
@@ -66,7 +66,9 @@ def add(args):
 
     if (disable_publish):
         print("DEBUG: disabling publishing")
-        root.remove(root.find("publish"))
+        publish_node = root.find("publish")
+        if (publish_node != None):
+            root.remove(publish_node)
         node = ET.fromstring("<publish><disable/></publish>")
         root.append(node)
 

--- a/susemanager-utils/testing/automation/obs-project.py
+++ b/susemanager-utils/testing/automation/obs-project.py
@@ -56,12 +56,12 @@ def add(args):
     root.find("title").text = new_title 
 
     if (maintainer!=""):
-        print("DEBUG: Adding user {} as the only maintainer".format(auth_user))
+        print("DEBUG: Adding user {} as the only maintainer".format(maintainer))
         for user in root.findall("person"):
             root.remove(user)
         for group in root.findall("group"):
             root.remove(group)
-        new_person = ET.fromstring("<person userid=\"{}\" role=\"maintainer\"/>".format(auth_user))
+        new_person = ET.fromstring("<person userid=\"{}\" role=\"maintainer\"/>".format(maintainer))
         root.append(new_person)
 
     if (disable_publish):

--- a/susemanager-utils/testing/automation/publish-rpms.sh
+++ b/susemanager-utils/testing/automation/publish-rpms.sh
@@ -16,12 +16,13 @@ usage()
 
 packages=""
 
-while getopts ":p:r:a:d:q:" opts;do
+while getopts ":p:r:a:d:q:A:" opts;do
     case "${opts}" in
-        p) echo "PPPP";obs_project=${OPTARG};;
-        r) echo "RRRR";obs_repo=${OPTARG};;
-        a) echo "AAA";obs_arch=${OPTARG};;
-        d) echo "DDDD";repo_dir=${OPTARG};;
+        p) obs_project=${OPTARG};;
+        r) obs_repo=${OPTARG};;
+        a) obs_arch=${OPTARG};;
+        d) repo_dir=${OPTARG};;
+        A) obs_api=${OPTARG};;
         q) packages="${packages} ${OPTARG}";;
         \?) usage;exit -1;;
     esac
@@ -39,14 +40,14 @@ fi
 
 repo_dir=$repo_dir/$obs_project/$obs_repo/$obs_arch
 
-osc getbinaries $obs_project $obs_repo $obs_arch -d $repo_dir
+osc -A $obs_api getbinaries $obs_project $obs_repo $obs_arch -d $repo_dir
 
 # Checkout specific packages. For example, multibuild packages won't
 # be downloaded by using "osc getbinaries PROJECT", so we need to
 # be explicit. For example 000product:Uyuni-Server-release
 
 for i in ${packages};do
-    osc getbinaries $obs_project $i $obs_repo $obs_arch -d $repo_dir
+    osc -A $obs_api getbinaries $obs_project $i $obs_repo $obs_arch -d $repo_dir
 done
 
 cd $repo_dir


### PR DESCRIPTION
## What does this PR change?

In order to use the current user MFA setup, we better use "osc api" instead of trying to use urllib python library. Since a call to "osc" will already use the MFA that is setup for the current user. Otherwise, we would have to implement it with python urllib, which is, at least, challenging :)

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links
see https://github.com/SUSE/spacewalk/issues/21471

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
