### PR TITLE
Testsuite: Cancel scheduled actions as cleanup

### DIFF
--- a/testsuite/features/secondary/min_timezone.feature
+++ b/testsuite/features/secondary/min_timezone.feature
@@ -81,8 +81,9 @@ Feature: Correct timezone display
     Given I am authorized as "MalaysianUser" with password "MalaysianUser"
     Then I should see a "MalaysianUser" link
 
-  Scenario: Cleanup: Log in as admin user again
+  Scenario: Cleanup: Log in as admin user again and remove scheduled actions
     Given I am authorized for the "Admin" section
+    And I cancel all scheduled actions
 
   Scenario: Cleanup: Remove role
     When I follow the left menu "Users > User List > Active"


### PR DESCRIPTION
## What does this PR change?
This PR adds a cleanup step to remove the scheduled action in the timezone feature since this action can stay over the next feature and cause failures.

## GUI diff
No difference.
- [ ] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [ ] **DONE**

## Test coverage
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/21122
Tracks # 
4.2
4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
