### PR TITLE
Improvements on mkchlog

### DIFF
--- a/rel-eng/bin/mkchlog
+++ b/rel-eng/bin/mkchlog
@@ -125,7 +125,7 @@ function getEditorCmd() {
 
     # Specific CLI options for common text editors
     case "$cmd" in
-        vi | vim)
+        vi*)
             cmd="$cmd +1 +startinsert!"
             ;;
         *)

--- a/rel-eng/bin/mkchlog
+++ b/rel-eng/bin/mkchlog
@@ -67,9 +67,14 @@ if ! command -v git &>/dev/null; then
     exit 1
 fi
 
-GITROOT=`git rev-parse --show-toplevel`
-CURDIR=`git rev-parse --show-prefix`
-GITMAIL=`git config --get user.email`
+GITROOT=`git rev-parse --show-toplevel 2>/dev/null`
+if [ $? -ne 0 ] || ! [ -d $GITROOT/rel-eng/packages ]; then
+    echo "Error: Not in Uyuni working directory."
+    exit 1
+fi
+
+CURDIR=`git rev-parse --show-prefix` || exit 1
+GITMAIL=`git config --get user.email` || exit 1
 
 if [ -z "$USER" ]; then
     if [ -n "$GITMAIL" ]; then

--- a/rel-eng/bin/mkchlog
+++ b/rel-eng/bin/mkchlog
@@ -27,7 +27,7 @@ Uyuni project: <https://github.com/uyuni-project/uyuni>
 EOF
 }
 
-ARGS=$(getopt -n mkchlog -o rhf:u: --long remove,help,feature:username: -- "$@")
+ARGS=$(getopt -n mkchlog -o rhnf:u: --long remove,help,no-wrap,feature:username: -- "$@")
 if [ $? -ne 0 ]; then
     exit 1
 fi

--- a/rel-eng/bin/mkchlog
+++ b/rel-eng/bin/mkchlog
@@ -74,9 +74,9 @@ if [ $? -ne 0 ] || ! [ -d $GITROOT/rel-eng/packages ]; then
 fi
 
 CURDIR=`git rev-parse --show-prefix` || exit 1
-GITMAIL=`git config --get user.email` || exit 1
 
 if [ -z "$USER" ]; then
+    GITMAIL=`git config --get user.email 2>/dev/null`
     if [ -n "$GITMAIL" ]; then
         USER=${GITMAIL%@*}
     else
@@ -85,7 +85,7 @@ if [ -z "$USER" ]; then
 fi
 
 if [ -z "$FEATURE" ]; then
-    FEATURE=`git rev-parse --abbrev-ref HEAD`
+    FEATURE=`git rev-parse --abbrev-ref HEAD 2>/dev/null`
     if [ -z "$FEATURE" ] || [ "HEAD" == "$FEATURE" ]; then
         echo "Cannot read the branch name from the current HEAD. Omitting the feature name part."
         unset FEATURE

--- a/rel-eng/bin/mkchlog
+++ b/rel-eng/bin/mkchlog
@@ -27,31 +27,36 @@ Uyuni project: <https://github.com/uyuni-project/uyuni>
 EOF
 }
 
-while [[ $# -gt 0 ]]; do
-    case $1 in
+ARGS=$(getopt -n mkchlog -o rhf:u: --long remove,help,feature:username: -- "$@")
+if [ $? -ne 0 ]; then
+    exit 1
+fi
+
+eval set -- "$ARGS"
+while [ : ]; do
+    case "$1" in
         -h|--help)
             usage
             exit
             ;;
         -f|--feature)
             FEATURE=$2
-            shift
-            shift
+            shift 2
             ;;
         -u|--username)
             USER=$2
-            shift
-            shift
+            shift 2
             ;;
         -r|--remove)
             REMOVE=1
             shift
             ;;
         -n|--no-wrap)
-            NO_WRAP=true
+            NO_WRAP=1
             shift
             ;;
-        *)
+        --)
+            shift
             break
             ;;
     esac
@@ -145,10 +150,10 @@ if ! [ -z $REMOVE ]; then
 fi
 
 # Add the new entry
-if [ "$NO_WRAP" = true ]; then
-    echo "- $1" > $CHFILE.new
-else
+if [ -z $NO_WRAP ]; then
     echo "$1" | fold -s -w 65 | sed '1s/^.*$/- &/;2,$s/^.*$/  &/' > $CHFILE.new
+else
+    echo "- $1" > $CHFILE.new
 fi
 
 # Append older entries


### PR DESCRIPTION
## What's changed

- Use 'getopt' for better arg support
- Add checks to see if run inside Uyuni working dir
- Getting the username and feature name from git is not mandatory and will be ignored if fails
- Exit early if an unexpected error occurs

## Documentation
- No documentation needed: already covered

## Test coverage
- No tests: tool not tested

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
