### PR TITLE
Create flag to disable update status

### DIFF
--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -61,6 +61,7 @@ public class ConfigDefaults {
     public static final String WEB_SMTP_STARTTLS = "java.smtp_starttls";
     public static final String WEB_SMTP_USER = "java.smtp_user";
     public static final String WEB_SMTP_PASS = "java.smtp_pass";
+    public static final String WEB_DISABLE_UPDATE_STATUS = "java.disable_update_status";
 
     public static final String ERRATA_CACHE_COMPUTE_THRESHOLD
     = "errata_cache_compute_threshold";

--- a/java/code/src/com/redhat/rhn/common/db/datasource/SelectMode.java
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/SelectMode.java
@@ -80,6 +80,15 @@ public class SelectMode extends BaseMode implements Serializable {
     }
 
     /**
+     * Remove an elaborator query.
+     * @param elaboratorName Elaborator query name to remove.
+     */
+    public void removeElaboratorByName(String elaboratorName) {
+        elaborators.removeIf(x -> x.getName().equals(elaboratorName));
+    }
+
+
+    /**
      * Returns the list of elaborator queries.
      * @return List of elaborator queries.
      */

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -6031,6 +6031,9 @@ organization. You may grant or remove the organization administrator role in the
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="grouplist.jsp.unknown" xml:space="preserve">
+        <source>Security updates unknown, disabled on settings.</source>
+      </trans-unit>
       <trans-unit id="grouplist.jsp.security" xml:space="preserve">
         <source>Security updates needed</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -1228,12 +1228,20 @@ public class SystemManager extends BaseManager {
      */
     public static DataResult<SystemGroupOverview> groupList(User user, PageControl pc) {
         SelectMode m = ModeFactory.getMode("SystemGroup_queries", "visible_to_user");
+        if (Config.get().getBoolean(ConfigDefaults.WEB_DISABLE_UPDATE_STATUS)) {
+            m.removeElaboratorByName("most_severe_errata");
+        }
         Map<String, Object> params = new HashMap<>();
         params.put("user_id", user.getId());
         Map<String, Object> elabParams = new HashMap<>();
         elabParams.put("org_id", user.getOrg().getId());
         elabParams.put("user_id", user.getId());
-        return makeDataResult(params, elabParams, pc, m);
+
+        DataResult<SystemGroupOverview> dr = makeDataResult(params, elabParams, pc, m);
+        if (Config.get().getBoolean(ConfigDefaults.WEB_DISABLE_UPDATE_STATUS)) {
+            dr.stream().forEach(x -> x.setDisabled(true));
+        }
+        return dr;
     }
 
     /**
@@ -1250,10 +1258,18 @@ public class SystemManager extends BaseManager {
                     User user, PageControl pc) {
         SelectMode m = ModeFactory.getMode("SystemGroup_queries",
                         "visible_to_user_and_counts");
+        if (Config.get().getBoolean(ConfigDefaults.WEB_DISABLE_UPDATE_STATUS)) {
+            m.removeElaboratorByName("most_severe_errata");
+        }
         Map<String, Object> params = new HashMap<>();
         params.put("user_id", user.getId());
         Map<String, Object> elabParams = new HashMap<>();
-        return makeDataResult(params, elabParams, pc, m);
+
+        DataResult<SystemGroupOverview> dr = makeDataResult(params, elabParams, pc, m);
+        if (Config.get().getBoolean(ConfigDefaults.WEB_DISABLE_UPDATE_STATUS)) {
+            dr.stream().forEach(x -> x.setDisabled(true));
+        }
+        return dr;
     }
 
     /**

--- a/java/code/webapp/WEB-INF/pages/common/fragments/systems/group_listdisplay.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/systems/group_listdisplay.jspf
@@ -33,6 +33,9 @@
 
     <a href="/rhn/groups/ListErrata.do?sgid=${current.id}" class="js-spa">
     <c:choose>
+      <c:when test="${current.disabled}">
+        <rhn:icon type="system-unknown" title="grouplist.jsp.unknown" />
+      </c:when>
       <c:when test="${current.mostSevereErrata == 'Security Advisory'}">
         <rhn:icon type="system-crit" title="grouplist.jsp.security" />
       </c:when>

--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -253,3 +253,6 @@ java.min_schema_version = 4.4.5
 
 # minimal required DB reporting schema version
 java.min_report_schema_version = 4.3.5
+
+# Disable the update status
+java.disable_update_status = 0

--- a/java/spacewalk-java.changes.mbussolotto.update_status
+++ b/java/spacewalk-java.changes.mbussolotto.update_status
@@ -1,0 +1,1 @@
+- create flag to disable update status (bsc#1212730)


### PR DESCRIPTION
## What does this PR change?

create flag to disable update status (bsc#1212730)

## GUI diff

![Screenshot from 2023-07-03 16-15-14](https://github.com/uyuni-project/uyuni/assets/4320859/b56be1c1-83b8-4b0f-b56b-b42dd0c7ce0e)


- [x] **DONE**

## Documentation
TODO
- [ ] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/21891

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
