### PR TITLE
VHG: read null values

### DIFF
--- a/java/code/src/com/suse/manager/gatherer/GathererJsonIO.java
+++ b/java/code/src/com/suse/manager/gatherer/GathererJsonIO.java
@@ -45,6 +45,7 @@ public class GathererJsonIO {
             .setPrettyPrinting()
             .registerTypeAdapter(GathererModule.class, new GathererModuleAdapter())
             .registerTypeAdapter(VirtualHostManager.class, new VHMAdapter())
+            .serializeNulls()
             .create();
     }
 

--- a/java/spacewalk-java.changes.cbosdo.vhm-null
+++ b/java/spacewalk-java.changes.cbosdo.vhm-null
@@ -1,0 +1,1 @@
+- Read null values from Virtual Host Gatherer data


### PR DESCRIPTION
## What does this PR change?

This is to avoid errors like the following if the libvirt virtual host gatherer module is installed:

```
Caused by: java.lang.IllegalStateException: Expected a string but was NULL at line 36 column 30 path $..sasl_username
```

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [X] **DONE**

## Test coverage
- No tests: covered in the containerized server tests

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
