### PR TITLE
Testsuite: Set the package states as unmanaged for better idempotency

### DIFF
--- a/testsuite/features/secondary/min_salt_software_states.feature
+++ b/testsuite/features/secondary/min_salt_software_states.feature
@@ -33,6 +33,19 @@ Feature: Salt package states
     And I should see a "bunch was scheduled" text
     Then I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
 
+  Scenario: Pre-requisite: set the package states as unmanaged
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "States" in the content area
+    And I follow "Packages"
+    And I follow "Search"
+    And I should see a "Package States" text
+    And I list packages with "dummy"
+    And I wait until I see "andromeda-dummy" text
+    And I change the state of "virgo-dummy" to "Unmanaged" and ""
+    And I change the state of "andromeda-dummy" to "Unmanaged" and ""
+    And I click save
+    Then I wait until I see "Package states have been saved." text
+
   Scenario: Accepted minion has a base channel
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area

--- a/testsuite/features/secondary/min_salt_software_states.feature
+++ b/testsuite/features/secondary/min_salt_software_states.feature
@@ -33,19 +33,6 @@ Feature: Salt package states
     And I should see a "bunch was scheduled" text
     Then I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
 
-  Scenario: Pre-requisite: set the package states as unmanaged
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "States" in the content area
-    And I follow "Packages"
-    And I follow "Search"
-    And I should see a "Package States" text
-    And I list packages with "dummy"
-    And I wait until I see "andromeda-dummy" text
-    And I change the state of "virgo-dummy" to "Unmanaged" and ""
-    And I change the state of "andromeda-dummy" to "Unmanaged" and ""
-    And I click save
-    Then I wait until I see "Package states have been saved." text
-
   Scenario: Accepted minion has a base channel
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
@@ -141,6 +128,19 @@ Feature: Salt package states
 @skip_if_github_validation
   Scenario: Cleanup: restart the salt service on SLES minion
     When I restart salt-minion on "sle_minion"
+
+  Scenario: Cleanup: set the package states as unmanaged
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "States" in the content area
+    And I follow "Packages"
+    And I follow "Search"
+    And I should see a "Package States" text
+    And I list packages with "dummy"
+    And I wait until I see "andromeda-dummy" text
+    And I change the state of "virgo-dummy" to "Unmanaged" and ""
+    And I change the state of "andromeda-dummy" to "Unmanaged" and ""
+    And I click save
+    Then I wait until I see "Package states have been saved." text
 
   Scenario: Cleanup: remove old packages from SLES minion
     When I disable repository "test_repo_rpm_pool" on this "sle_minion"


### PR DESCRIPTION
## What does this PR change?
When running `Salt package states` feature, the initial package state is not always known, which can cause failures in the feature, especially if it already has been run once.
This PR adds a pre-requisite scenario to set those stages as `unmanaged` before running the tests, thus improving the idempotency of the feature.

Example of initial state causing failures after a first run of the feature:

![image](https://github.com/uyuni-project/uyuni/assets/100688791/99c9441d-5982-4047-905f-3da58627702d)


## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were added
- [x] **DONE**

## Links
Fixes #
Tracks # 
4.3 https://github.com/SUSE/spacewalk/pull/21938
4.2 https://github.com/SUSE/spacewalk/pull/21939
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
