### PR TITLE
Defer rhnConfig import to cfg_component

### DIFF
--- a/python/uyuni/common/context_managers.py
+++ b/python/uyuni/common/context_managers.py
@@ -1,6 +1,12 @@
 """Collection of context managers for Uyuni."""
 from contextlib import contextmanager
-from spacewalk.common.rhnConfig import CFG, initCFG
+import importlib
+
+# will hold spacewalk.common.rhnConfig after it was imported lazily in `cfg_component`
+# importing is done lazily to defer the file I/O, which makes it easier to import this
+# (context_managers) module
+rhnConfig = None
+
 
 @contextmanager
 def cfg_component(component, root=None, filename=None):
@@ -21,6 +27,11 @@ def cfg_component(component, root=None, filename=None):
     with cfg_component('my_component') as CFG:
         print(CFG.my_value)
     """
+    global rhnConfig
+    if rhnConfig is None:
+        rhnConfig = importlib.import_module("spacewalk.common.rhnConfig")
+    CFG, initCFG = rhnConfig.CFG, rhnConfig.initCFG
+
     previous = CFG.getComponent()
     initCFG(component=component, root=root, filename=filename)
     try:


### PR DESCRIPTION
## What does this PR change?

This import has file I/O as a side effect. That can get in the way, especially when nothing actually access the config. By defering the import to call-time of cfg_component, there is no file I/O when importing the uyuni.common.context_managers module.


## GUI diff

No difference


## Documentation
- No documentation needed: only internal and user invisible changes


## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
