### PR TITLE
Remove usage of deleted function columnHeight()

### DIFF
--- a/web/html/javascript/susemanager-setup-wizard-mirror-credentials.js
+++ b/web/html/javascript/susemanager-setup-wizard-mirror-credentials.js
@@ -107,7 +107,6 @@ function verifyCredentials(id, refresh) {
   const responseHandler = (result) => {
     jQuery('#' + elemId).html(result);
     jQuery('#' + elemId).fadeIn();
-    columnHeight();
     setDeleteAllowed(id, true);
   };
 

--- a/web/spacewalk-web.changes.mackdk.fix-credential-deletion
+++ b/web/spacewalk-web.changes.mackdk.fix-credential-deletion
@@ -1,0 +1,1 @@
+- Fixed issue that prevented to delete credentials


### PR DESCRIPTION
## What does this PR change?

This PR restore the ability to delete an SCC credential. In fact, in the credentials page there still was an usage of the function `columnHeight()`, which has been removed by commit [`39e960a`](https://github.com/uyuni-project/uyuni/commit/39e960a811153d01659e0d90b5bf2f6452f648aa#diff-a0325cedf530f28bb95f4dd94807045c3129cef550b580bf3ca8617ed93e74a7). The error prevented the delete button to be activated, thus making the delete functionality inaccessible.

## GUI diff

The delete button works again.

- [X] **DONE**

## Documentation
- No documentation needed: fix of an existing documented functionality

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
