### PR TITLE
Hard code product name in rhnConfig

### DIFF
--- a/python/spacewalk/common/rhnConfig.py
+++ b/python/spacewalk/common/rhnConfig.py
@@ -534,13 +534,7 @@ def initCFG(component=None, root=None, filename=None):
     CFG.init(component, root, filename)
     CFG.parse()
 
-try:
-    ALL_CFG = RHNOptions('')
-    ALL_CFG.parse()
-    PRODUCT_NAME = ALL_CFG.PRODUCT_NAME
-except ConfigParserError:
-    PRODUCT_NAME = "SUSE Manager"
-
+PRODUCT_NAME = "Uyuni"
 
 def isUyuni():
     return (PRODUCT_NAME == "Uyuni")

--- a/python/spacewalk/spacewalk-backend.changes.cbosdo.product_name
+++ b/python/spacewalk/spacewalk-backend.changes.cbosdo.product_name
@@ -1,0 +1,1 @@
+- Use a constant to get the product name in python code rather than reading rhn.conf

--- a/python/spacewalk/spacewalk-backend.spec
+++ b/python/spacewalk/spacewalk-backend.spec
@@ -286,6 +286,10 @@ do
 	sed -i '1s=^#!/usr/bin/\(python\|env python\)[0-9.]*=#!/usr/bin/python3=' $i;
 done
 
+%if !0%{?is_opensuse} && 0%{?sle_version}
+sed -i 's/PRODUCT_NAME = "Uyuni"/PRODUCT_NAME = "SUSE Manager"/' common/rhnConfig.py
+%endif
+
 %install
 install -d $RPM_BUILD_ROOT%{rhnroot}
 install -d $RPM_BUILD_ROOT%{python3rhnroot}


### PR DESCRIPTION
## What does this PR change?

rhnConfig parses the rhn.conf file at import time to set the PRODUCT_NAME constant. This causes issues if the code is not running with sufficient permissions.

Instead, define the PRODUCT_NAME to "Uyuni" in the code and change it to "SUSE Manager" in the spec file when needed.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/21905 and https://github.com/SUSE/spacewalk/issues/21934

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
