### PR TITLE
Testsuite: Change staging time input

### DIFF
--- a/testsuite/features/step_definitions/datepicker_steps.rb
+++ b/testsuite/features/step_definitions/datepicker_steps.rb
@@ -12,7 +12,7 @@ require 'date'
 def get_future_time(minutes_to_add)
   now = Time.new
   future_time = now + 60 * minutes_to_add.to_i
-  future_time.strftime('%l:%M %P').to_s.strip
+  future_time.strftime('%k:%M').to_s.strip
 end
 
 Given(/^I pick "([^"]*)" as date$/) do |desired_date|
@@ -73,8 +73,7 @@ When(/^I pick (\d+) minutes from now as schedule time$/) do |arg1|
   action_time = get_future_time(arg1)
   raise unless find(:xpath, "//*[@id='date_timepicker_widget_input']", wait: 2)
 
-  execute_script("$('#date_timepicker_widget_input')
-    .timepicker('setTime', '#{action_time}').trigger('change');")
+  step %(I enter "#{action_time}" as "date_timepicker_widget_input")
 end
 
 When(/^I schedule action to (\d+) minutes from now$/) do |minutes|


### PR DESCRIPTION
## What does this PR change?
The script used to set the timepicker value does not seem to work anymore as the event in `Install a package on the SLES minion with staging enabled` feature is picked immediately instead of 3 minutes later.
This PR replaces this script by an already existing step.

In order to use this existing step, the time formatting when calculating the time ahead has been adapated to be in a 24 hour format and uses the `%k` format argument as indicated by [strftime documentation](https://apidock.com/ruby/DateTime/strftime).

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were added
- [x] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/20942
https://github.com/SUSE/spacewalk/issues/20943
Tracks # 
4.2 https://github.com/SUSE/spacewalk/pull/21949
4.3 https://github.com/SUSE/spacewalk/pull/21950
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
