### PR TITLE
remove python2 leftovers

### DIFF
--- a/spacewalk/admin/salt-secrets-config.py
+++ b/spacewalk/admin/salt-secrets-config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 import grp

--- a/spacewalk/admin/spacewalk-admin.changes.mcalmer.spacewalk-admin-cleanup
+++ b/spacewalk/admin/spacewalk-admin.changes.mcalmer.spacewalk-admin-cleanup
@@ -1,0 +1,1 @@
+- remove python2 leftovers

--- a/spacewalk/admin/spacewalk-admin.spec
+++ b/spacewalk/admin/spacewalk-admin.spec
@@ -17,12 +17,6 @@
 #
 
 
-%if 0%{?fedora} || 0%{?suse_version} > 1320 || 0%{?rhel} >= 8
-%global build_py3   1
-%endif
-
-%define pythonX %{?build_py3: python3}%{!?build_py3: python}
-
 Summary:        Various utility scripts and data files for Spacewalk installations
 License:        GPL-2.0-only
 Group:          Applications/Internet
@@ -32,7 +26,7 @@ Version:        4.4.5
 Release:        1
 Source0:        https://github.com/uyuni-project/uyuni/archive/%{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-Requires:       %{pythonX}
+Requires:       python3
 Requires:       lsof
 Requires:       procps
 Requires:       python3-websockify
@@ -79,9 +73,6 @@ mkdir -p $RPM_BUILD_ROOT%{_mandir}/man8/
 %{_bindir}/pod2man --section=8 man/rhn-deploy-ca-cert.pl.pod > $RPM_BUILD_ROOT%{_mandir}/man8/rhn-deploy-ca-cert.pl.8
 %{_bindir}/pod2man --section=8 man/rhn-install-ssl-cert.pl.pod > $RPM_BUILD_ROOT%{_mandir}/man8/rhn-install-ssl-cert.pl.8
 chmod 0644 $RPM_BUILD_ROOT%{_mandir}/man8/*.8*
-%if 0%{?build_py3}
-sed -i 's|#!/usr/bin/python|#!/usr/bin/python3|' $RPM_BUILD_ROOT/usr/bin/salt-secrets-config.py
-%endif
 
 %post
 if [ -x /usr/bin/systemctl ]; then


### PR DESCRIPTION
## What does this PR change?

Cleanup of some python2 leftovers

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/12358

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
