### PR TITLE
set timezone in the container

### DIFF
--- a/containers/server-helm/templates/config.yaml
+++ b/containers/server-helm/templates/config.yaml
@@ -23,6 +23,7 @@ data:
   NO_SSL: "Y"
   MANAGER_MAIL_FROM: {{ .Values.uyuniMailFrom }}
   UYUNI_FQDN: {{ .Values.fqdn }}
+  TZ: {{ .Values.timeZone | default "Etc/UTC" }} 
 kind: ConfigMap
 metadata:
   name: uyuni-config

--- a/containers/server-image/uyuni-setup.service
+++ b/containers/server-image/uyuni-setup.service
@@ -11,6 +11,7 @@ PassEnvironment=LOCAL_DB MANAGER_DB_NAME MANAGER_DB_HOST MANAGER_DB_PORT MANAGER
 PassEnvironment=MANAGER_ENABLE_TFTP EXTERNALDB_ADMIN_USER EXTERNALDB_ADMIN_PASS EXTERNALDB_PROVIDER
 PassEnvironment=SCC_USER SCC_PASS ISS_PARENT ACTIVATE_SLP MANAGER_MAIL_FROM NO_SSL UYUNI_FQDN MIRROR_PATH
 PassEnvironment=REPORT_DB_NAME REPORT_DB_HOST REPORT_DB_PORT_USER REPORT_DB_PASS REPORT_DB_CA_CERT
+PassEnvironment=TZ
 ExecStart=/usr/lib/susemanager/bin/mgr-setup -l /var/log/susemanager_setup.log -s -n
 ExecStartPost=systemctl disable --now uyuni-setup.service
 Type=oneshot

--- a/containers/server-systemd-services/setup_podman_timezone.sh
+++ b/containers/server-systemd-services/setup_podman_timezone.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+HOST_TZ=$(timedatectl | awk '/Time zone:/{print $3}')
+sed "s|^TZ=.*$|TZ=$HOST_TZ|" -i /etc/sysconfig/uyuni-server-systemd-services

--- a/containers/server-systemd-services/uyuni-server-services.config
+++ b/containers/server-systemd-services/uyuni-server-services.config
@@ -38,3 +38,4 @@ SCC_USER=
 SCC_PASS=
 REPORT_DB_HOST=uyuni-server
 UYUNI_FQDN=uyuni-server
+TZ=Etc/UTC

--- a/containers/server-systemd-services/uyuni-server-systemd-services.spec
+++ b/containers/server-systemd-services/uyuni-server-systemd-services.spec
@@ -48,9 +48,6 @@ install -d -m 755 %{buildroot}%{_sbindir}
 #sed 's|^NAMESPACE=.*$|NAMESPACE=%{susemanager_container_images_path}|' -i uyuni-server-services.config
 #%endif
 
-export HOST_TZ=$(timedatectl | awk '/Time zone:/{print $3}')
-sed "s|^TZ=.*$|TZ=$HOST_TZ|" -i uyuni-server-services.config
-
 %if !0%{?is_opensuse}
 PRODUCT_VERSION=$(echo %{version} | sed 's/^\([0-9]\+\.[0-9]\+\).*$/\1/')
 %endif
@@ -64,6 +61,7 @@ install -D -m 644 uyuni-server.service %{buildroot}%{_unitdir}/uyuni-server.serv
 ln -s /usr/sbin/service %{buildroot}%{_sbindir}/rcuyuni-server
 
 install -m 755 uyuni-server.sh %{buildroot}%{_sbindir}/uyuni-server.sh
+install -m 755 setup_podman_timezone.sh %{buildroot}%{_sbindir}/setup_podman_timezone.sh
 
 %check
 
@@ -109,5 +107,7 @@ install -m 755 uyuni-server.sh %{buildroot}%{_sbindir}/uyuni-server.sh
 %endif
 %{_sysconfdir}/uyuni
 %{_sbindir}/uyuni-server.sh
+%{_sbindir}/setup_podman_timezone.sh
+
 
 %changelog

--- a/containers/server-systemd-services/uyuni-server-systemd-services.spec
+++ b/containers/server-systemd-services/uyuni-server-systemd-services.spec
@@ -48,7 +48,7 @@ install -d -m 755 %{buildroot}%{_sbindir}
 #sed 's|^NAMESPACE=.*$|NAMESPACE=%{susemanager_container_images_path}|' -i uyuni-server-services.config
 #%endif
 
-HOST_TZ=$(timedatectl | awk '/Time zone:/{print $3}')
+export HOST_TZ=$(timedatectl | awk '/Time zone:/{print $3}')
 sed "s|^TZ=.*$|TZ=$HOST_TZ|" -i uyuni-server-services.config
 
 %if !0%{?is_opensuse}

--- a/containers/server-systemd-services/uyuni-server-systemd-services.spec
+++ b/containers/server-systemd-services/uyuni-server-systemd-services.spec
@@ -48,6 +48,9 @@ install -d -m 755 %{buildroot}%{_sbindir}
 #sed 's|^NAMESPACE=.*$|NAMESPACE=%{susemanager_container_images_path}|' -i uyuni-server-services.config
 #%endif
 
+HOST_TZ=$(timedatectl | awk '/Time zone:/{print $3}')
+sed 's|^TZ=.*$|TZ=$HOST_TZ|' -i uyuni-server-services.config
+
 %if !0%{?is_opensuse}
 PRODUCT_VERSION=$(echo %{version} | sed 's/^\([0-9]\+\.[0-9]\+\).*$/\1/')
 %endif

--- a/containers/server-systemd-services/uyuni-server-systemd-services.spec
+++ b/containers/server-systemd-services/uyuni-server-systemd-services.spec
@@ -49,7 +49,7 @@ install -d -m 755 %{buildroot}%{_sbindir}
 #%endif
 
 HOST_TZ=$(timedatectl | awk '/Time zone:/{print $3}')
-sed 's|^TZ=.*$|TZ=$HOST_TZ|' -i uyuni-server-services.config
+sed "s|^TZ=.*$|TZ=$HOST_TZ|" -i uyuni-server-services.config
 
 %if !0%{?is_opensuse}
 PRODUCT_VERSION=$(echo %{version} | sed 's/^\([0-9]\+\.[0-9]\+\).*$/\1/')

--- a/containers/server-systemd-services/uyuni-server.service
+++ b/containers/server-systemd-services/uyuni-server.service
@@ -15,7 +15,6 @@ Restart=on-failure
 ExecStartPre=/bin/rm \
     -f %t/uyuni-server.pid %t/%n.ctr-id
 ExecStart=/usr/bin/podman run \
-    --tz=local \
     --conmon-pidfile %t/uyuni-server.pid \
     --cidfile=%t/%n.ctr-id \
     --cgroups=no-conmon \

--- a/containers/server-systemd-services/uyuni-server.service
+++ b/containers/server-systemd-services/uyuni-server.service
@@ -14,6 +14,7 @@ EnvironmentFile=-/etc/sysconfig/uyuni-server-systemd-services
 Restart=on-failure
 ExecStartPre=/bin/rm \
     -f %t/uyuni-server.pid %t/%n.ctr-id
+ExecStartPre=setup_podman_timezone.sh
 ExecStart=/usr/bin/podman run \
     --conmon-pidfile %t/uyuni-server.pid \
     --cidfile=%t/%n.ctr-id \


### PR DESCRIPTION
## What does this PR change?

set timezone in container
- add TZ to `systemd` configuration. The value in the config file is set to the default one, but it should make more clear to the user that is possible to setup.
- TZ is automatically set if the container is started by systemd ( `timedatectl` is provided by systemd rpm, so it's always present )

To enforce the TZ settings, sumaform enforce the TZ settings using salt grain  https://github.com/uyuni-project/sumaform/pull/1347
## GUI diff

No difference.


- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/21499
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
