### PR TITLE
CODEOWNERS: ignore changelogs in the java directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,8 +66,9 @@ testsuite/ @uyuni-project/qe
 # mgr-libmod
 susemanager-utils/mgr-libmod/ @cbbayburt
 
-# Generic fallback for Java
+# Generic fallback for Java, apart from changelog files
 java/ @uyuni-project/java
+java/*.changes*
 
 # Individual Java packages
 


### PR DESCRIPTION
## What does this PR change?

The generic fallback for Java should not be triggered when there is only a change to a changelog file. This patch adds a pattern to let them be ignored.

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
