### PR TITLE
Added multiple URLs support in FinderFactory

### DIFF
--- a/java/code/src/com/redhat/rhn/common/finder/CompositeFinder.java
+++ b/java/code/src/com/redhat/rhn/common/finder/CompositeFinder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.common.finder;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A Finder implementation that uses multiple finders to search
+ */
+class CompositeFinder implements Finder {
+
+    private final List<Finder> finderList;
+
+    CompositeFinder(Collection<? extends Finder> finders) {
+        this.finderList = new ArrayList<>(finders);
+    }
+
+    @Override
+    public List<String> findExcluding(String[] excluding, String endStr) {
+        return this.finderList.stream()
+                              .flatMap(finder -> finder.findExcluding(excluding, endStr).stream())
+                              .collect(Collectors.toList());
+    }
+}

--- a/java/code/src/com/redhat/rhn/common/finder/FileFinder.java
+++ b/java/code/src/com/redhat/rhn/common/finder/FileFinder.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -41,13 +42,6 @@ class FileFinder implements Finder {
         }
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public List<String> find(String endStr) {
-        return findExcluding(null, endStr);
-    }
-
-    /** {@inheritDoc} */
     @Override
     public List<String> findExcluding(String[] excludes, String endStr) {
         List<String> results = new LinkedList<>();

--- a/java/code/src/com/redhat/rhn/common/finder/FileFinder.java
+++ b/java/code/src/com/redhat/rhn/common/finder/FileFinder.java
@@ -49,7 +49,7 @@ class FileFinder implements Finder {
         if (!startDir.exists()) {
             // Shouldn't ever happen, because the FinderFactory should only
             // return a FileFinder.
-            return null;
+            return Collections.emptyList();
         }
         String[] fileList = startDir.list();
 

--- a/java/code/src/com/redhat/rhn/common/finder/Finder.java
+++ b/java/code/src/com/redhat/rhn/common/finder/Finder.java
@@ -31,7 +31,9 @@ public interface Finder {
      * @return a list of all classes within the package that end with the
      *         specified string
      */
-    List<String> find(String endStr);
+    default List<String> find(String endStr) {
+        return findExcluding(null, endStr);
+    }
 
     /**
      * Find all files within a package that end with the specified string

--- a/java/code/src/com/redhat/rhn/common/finder/FinderFactory.java
+++ b/java/code/src/com/redhat/rhn/common/finder/FinderFactory.java
@@ -15,14 +15,25 @@
 
 package com.redhat.rhn.common.finder;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.File;
+import java.io.IOException;
 import java.net.URL;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * A factory that returns the correct type of finder.
  *
  */
 public class FinderFactory {
+
+    private static final Logger LOGGER = LogManager.getLogger(FinderFactory.class);
 
     private FinderFactory() {
     }
@@ -33,27 +44,53 @@ public class FinderFactory {
      * @return Finder to use for given package name.
      */
     public static Finder getFinder(String packageName) {
-        // Start by translating into an absolute path.
-        String name = packageName;
-        if (!packageName.startsWith("/")) {
-            name = "/" + name;
-        }
-        name = name.replace('.', '/');
-
-        URL packageUrl = FinderFactory.class.getResource(name);
-
-        // This only happens if the .jar file isn't well-formed, so we
-        // shouldn't have this problem, ever.
-        if (packageUrl == null) {
-            throw new IllegalArgumentException("Not a well formed jar file");
+        // Extract all the possible URLs for a package
+        List<URL> possibleUrls = getAllUrlsForPackage(packageName);
+        if (possibleUrls.isEmpty()) {
+            throw new IllegalArgumentException("Not a well-formed jar file");
         }
 
+        if (possibleUrls.size() == 1) {
+            return getFinderForPackage(packageName, possibleUrls.get(0));
+        }
+
+        return possibleUrls.stream()
+                           .map(packageUrl -> getFinderForPackage(packageName, packageUrl))
+                           .collect(Collectors.collectingAndThen(Collectors.toList(), CompositeFinder::new));
+    }
+
+    private static List<URL> getAllUrlsForPackage(String packageName) {
+        try {
+            ClassLoader classLoader = FinderFactory.class.getClassLoader();
+            Enumeration<URL> systemResources = classLoader.getResources(packageName.replace('.', '/'));
+            if (systemResources == null || !systemResources.hasMoreElements()) {
+                LOGGER.warn("No valid URLs found for package {}", packageName);
+                return Collections.emptyList();
+            }
+
+            return Collections.list(systemResources);
+        }
+        catch (SecurityException ex) {
+            throw new IllegalStateException("Unable to access the class loader for searching " + packageName, ex);
+        }
+        catch (IOException ex) {
+            LOGGER.warn("Unable to find URLs for package {}", packageName, ex);
+            return Collections.emptyList();
+        }
+    }
+
+    private static Finder getFinderForPackage(String packageName, URL packageUrl) {
         File directory = new File(packageUrl.getFile());
 
         if (!directory.isFile() && !directory.isDirectory()) {
             // This is a jar file that we are dealing with.
             return new JarFinder(packageUrl);
         }
-        return new FileFinder(directory, name);
+
+        return new FileFinder(directory, getAbsolutePath(packageName));
+    }
+
+    private static String getAbsolutePath(String packageName) {
+        return StringUtils.prependIfMissing(packageName, "/").replace('.', '/');
     }
 }

--- a/java/code/src/com/redhat/rhn/common/finder/JarFinder.java
+++ b/java/code/src/com/redhat/rhn/common/finder/JarFinder.java
@@ -41,13 +41,6 @@ class JarFinder implements Finder {
         url = packageUrl;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public List<String> find(String endStr) {
-        return findExcluding(null, endStr);
-    }
-
-    /** {@inheritDoc} */
     @Override
     public List<String> findExcluding(String[] excludes, String endStr) {
         try {

--- a/java/code/src/com/redhat/rhn/common/finder/test/FileFinderTest.java
+++ b/java/code/src/com/redhat/rhn/common/finder/test/FileFinderTest.java
@@ -51,7 +51,7 @@ public class FileFinderTest extends RhnBaseTestCase {
         assertNotNull(f);
 
         List<String> result = f.find(".class");
-        assertEquals(6, result.size());
+        assertEquals(7, result.size());
     }
 
     @Test
@@ -60,7 +60,7 @@ public class FileFinderTest extends RhnBaseTestCase {
         assertNotNull(f);
         String[] sarr = {"Test"};
         List<String> result = f.findExcluding(sarr, "class");
-        assertEquals(4, result.size());
+        assertEquals(5, result.size());
     }
 }
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes how `FinderFactory` associates the packages to their physical locations. In fact, the class is currently based on the wrong assumption that a package maps to only one physical location. In reality, a package can be available on the classpath from multiple directories/jars. 

This is currently not an issue as the test and production code is compiled and bundled together by the ant build file, but it will be if we want to properly separate them, split the production code into separate modules and/or we move to any other build tool that separates the main and test context (like Maven/Gradle). In this cases the `Finder`, as it is currently implemented, won't be able to resolve the resources (for example, the hibernate mappings) that are in different jar/context but shares the same package.

This change evaluates instead all the possible URLs for a package and processes them all with the correct `Finder`, aggregating the results.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
