### PR TITLE
do not disable salt-minion on salt-ssh managed clients

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/cleanup_minion/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/cleanup_minion/init.sls
@@ -53,6 +53,7 @@ mgr_remove_salt_master_key:
   file.absent:
      - name: {{ salt_config_dir }}/pki/minion_master.pub
 
+{%- if salt['pillar.get']('contact_method') not in ['ssh-push', 'ssh-push-tunnel'] %}
 mgr_disable_salt:
   cmd.run:
     - name: systemctl disable {{ salt_minion_name }}
@@ -67,4 +68,5 @@ mgr_stop_salt:
     - order: last
     - require:
       - file: mgr_remove_salt_config
+{% endif %}
 {% endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.fix-cleanup-minion-saltssh
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.fix-cleanup-minion-saltssh
@@ -1,0 +1,1 @@
+- do not disable salt-minion on salt-ssh managed clients


### PR DESCRIPTION
## What does this PR change?

When deleting a salt-ssh managed system, the cleanup state try do disable and stop salt-minion process.
This can result in a state.apply error which require a force delete when neither salt-minion nor venv-salt-minion is installed.
In case where a customer use salt-minion against an own salt-master, this would disable and remove a working minion.

This resulted also in testsuite errors.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/21968 https://github.com/SUSE/spacewalk/pull/21969

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
