### PR TITLE
Check mgr-create-bootstrap-repo process not running before forcing this command

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -974,6 +974,7 @@ When(/^I create the bootstrap repository for "([^"]*)" on the server$/) do |host
   log 'Creating the boostrap repository on the server:'
   log '  ' + cmd
   $server.run(cmd)
+  $server.wait_while_process_running('mgr-create-bootstrap-repo')
 end
 
 When(/^I install "([^"]*)" product on the proxy$/) do |product|

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -966,6 +966,7 @@ When(/^I create the bootstrap repository for "([^"]*)" on the server$/) do |host
   base_channel = BASE_CHANNEL_BY_CLIENT[host]
   channel = CHANNEL_TO_SYNC_BY_BASE_CHANNEL[base_channel]
   parent_channel = PARENT_CHANNEL_TO_SYNC_BY_BASE_CHANNEL[base_channel]
+  $server.wait_while_process_running('mgr-create-bootstrap-repo')
   cmd = if parent_channel.nil?
           "mgr-create-bootstrap-repo --create #{channel} --with-custom-channels --flush"
         else
@@ -974,7 +975,6 @@ When(/^I create the bootstrap repository for "([^"]*)" on the server$/) do |host
   log 'Creating the boostrap repository on the server:'
   log '  ' + cmd
   $server.run(cmd)
-  $server.wait_while_process_running('mgr-create-bootstrap-repo')
 end
 
 When(/^I install "([^"]*)" product on the proxy$/) do |product|


### PR DESCRIPTION
## What does this PR change?

During parallel BV pipeline, `mgr-create-bootstrap-repo` is not correctly release after create_bootstrap_repository feature finishes. Add a step to wait until `mgr-create-bootstrap-repo` process is finished.



## Links
Related to : https://github.com/SUSE/spacewalk/issues/21827

## Changelogs

- [x] No changelog needed
