### PR TITLE
Testsuite: Wait for checkbox text to appear before trying to check

### DIFF
--- a/testsuite/features/init_clients/buildhost_bootstrap.feature
+++ b/testsuite/features/init_clients/buildhost_bootstrap.feature
@@ -10,6 +10,7 @@ Feature: Bootstrap a Salt build host via the GUI
   Scenario: Update the SLES activation key
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE Test Key x86_64" in the content area
+    And I wait until I see "Container Build Host" text
     And I check "container_build_host"
     And I check "osimage_build_host"
     And I click on "Update Activation Key"
@@ -63,6 +64,7 @@ Feature: Bootstrap a Salt build host via the GUI
   Scenario: Cleanup: Restore the SLES activation key to its original state
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE Test Key x86_64" in the content area
+    And I wait until I see "Container Build Host" text
     And I uncheck "container_build_host"
     And I uncheck "osimage_build_host"
     And I click on "Update Activation Key"


### PR DESCRIPTION
## What does this PR change?
It is possible that we try to check a checkbox that hasn't loaded yet - this PR adds a waiting step to see the associated text beforehand to try and solve this issue.
## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were added
- [x] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/21372
Tracks # 
4.2 https://github.com/SUSE/spacewalk/pull/21973
4.3 https://github.com/SUSE/spacewalk/pull/21974
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
