### PR TITLE
Testsuite: Check package with correct architecture

### DIFF
--- a/testsuite/features/secondary/min_ssh_tunnel.feature
+++ b/testsuite/features/secondary/min_ssh_tunnel.feature
@@ -45,7 +45,7 @@ Feature: Register a Salt system to be managed via SSH tunnel
     And I follow "Install"
     And I enter "milkyway-dummy" as the filtered package name
     And I click on the filter button
-    And I check "milkyway-dummy" in the list
+    And I check row with "milkyway-dummy" and arch of "ssh_minion"
     And I click on "Install Selected Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text


### PR DESCRIPTION
## What does this PR change?
Specifies the architecture to select when installing `milkyway-dummy` in order to avoid having the wrong installed version.
## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were added
- [x] **DONE**

## Links
Fixes # https://github.com/SUSE/spacewalk/issues/21121
Tracks #
4.2 https://github.com/SUSE/spacewalk/pull/21976
4.3 https://github.com/SUSE/spacewalk/pull/21975
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
