### PR TITLE
Testsuite: Move the 2 hour timeout for reposync to a more appropriate place

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -369,6 +369,8 @@ When(/^I kill all running spacewalk\-repo\-sync, excepted the ones needed to boo
       $channels_synchronized.add(channel)
       log "Reposync of channel #{channel} left running" if (reposync_left_running_streak % 60).zero?
       reposync_left_running_streak += 1
+
+      raise 'We have a reposync process that still running after 2 hours' if reposync_left_running_streak > 7200
       sleep 1
       next
     end
@@ -377,8 +379,6 @@ When(/^I kill all running spacewalk\-repo\-sync, excepted the ones needed to boo
     pid = process.split(' ')[0]
     $server.run("kill #{pid}", check_errors: false)
     log "Reposync of channel #{channel} killed"
-
-    raise 'We have a reposync process that still running after 2 hours' if reposync_left_running_streak > 7200
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

The current timeout setup is never reached as expected resulting in the testsuite waiting indefinitely for the reposync to be completed even when it is stuck.
With this fix, the timeout should be about 2 hours instead of 12.

![image](https://github.com/uyuni-project/uyuni/assets/100688791/0c27bba7-96ea-498d-9786-3eead6403790)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were added
- [x] **DONE**

## Links
Fixes #
Tracks # 
4.2 https://github.com/SUSE/spacewalk/pull/21983
4.3 https://github.com/SUSE/spacewalk/pull/21982
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
