### PR TITLE
fix sql join syntax for source package search

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
+++ b/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
@@ -1307,7 +1307,7 @@ public class PackageManager extends BaseManager {
                     .from("rhnPackageSource PS " +
                             "inner join rhnSourceRPM SRPM on PS.source_rpm_id = SRPM.id " +
                             "left join rhnPackage P on SRPM.id = P.source_rpm_id " +
-                            "left join rhnChannelPackage CP on CP.package_id")
+                            "left join rhnChannelPackage CP on CP.package_id = P.id ")
                     .where("PS.org_id = :org_id AND CP.package_id is null")
                     .run(Map.of("org_id", orgId), pc, PagedSqlQueryBuilder::parseFilterAsText, PackageOverview.class);
         }

--- a/java/spacewalk-java.changes.mc.Manager-4.3-fix-source-rpm-sql-query
+++ b/java/spacewalk-java.changes.mc.Manager-4.3-fix-source-rpm-sql-query
@@ -1,0 +1,1 @@
+- fix syntax error in sql query for source package search


### PR DESCRIPTION
## What does this PR change?

Got syntax error when looking for Source Package to Manage

```
ERROR: argument of JOIN/ON must be type boolean, not type numeric
```

## Links

Port of https://github.com/SUSE/spacewalk/pull/21990

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
