### PR TITLE
Support ec crypto keys in certs

### DIFF
--- a/spacewalk/certs-tools/mgr_ssl_cert_setup.py
+++ b/spacewalk/certs-tools/mgr_ssl_cert_setup.py
@@ -56,6 +56,7 @@ class CertCheckError(Exception):
     pass
 
 
+privatekeytype = "unknown"
 FilesContent = namedtuple("FilesContent", ["root_ca", "server_cert", "server_key", "intermediate_cas"])
 
 def log_error(msg):
@@ -298,33 +299,42 @@ def getCertWithText(cert):
     return out.stdout.decode("utf-8")
 
 
-def getRsaKey(key):
+def getPrivateKey(key):
+    if "-----BEGIN RSA PRIVATE KEY-----" in key:
+        privatekeytype = "rsa"
+    elif "-----BEGIN EC PRIVATE KEY-----" in key:
+        privatekeytype = "ec"
+    else:
+        log_error("Unknown Private Key type")
+        return None
+
     # set an invalid password to prevent asking in case of an encrypted one
     out = subprocess.run(
-        ["openssl", "rsa", "-passin", "pass:invalid"],
+        ["openssl", privatekeytype, "-passin", "pass:invalid"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         input=key.encode("utf-8")
     )
+
     if out.returncode:
-        log_error("Invalid RSA Key: {}".format(out.stderr.decode("utf-8")))
+        log_error("Invalid {} Key: {}".format(privatekeytype.upper(), out.stderr.decode("utf-8")))
         return None
     return out.stdout.decode("utf-8")
 
 
 def checkKeyBelongToCert(key, cert):
     out = subprocess.run(
-        ["openssl", "rsa", "-noout", "-modulus"],
+        ["openssl", "pkey", "-pubout"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         input=key.encode("utf-8"),
     )
     if out.returncode:
-        log_error("Invalid RSA Key: {}".format(out.stderr.decode("utf-8")))
+        log_error("Invalid {} Key: {}".format(privatekeytype.upper(), out.stderr.decode("utf-8")))
         raise CertCheckError("Invalid Key")
-    keyModulus = out.stdout.decode("utf-8")
+    keyPubKey = out.stdout.decode("utf-8")
     out = subprocess.run(
-        ["openssl", "x509", "-noout", "-modulus"],
+        ["openssl", "x509", "-noout", "-pubkey"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         input=cert.encode("utf-8"),
@@ -333,9 +343,10 @@ def checkKeyBelongToCert(key, cert):
         log_error("Invalid Cert file: {}".format(out.stderr.decode("utf-8")))
         raise CertCheckError("Invalid Certificate")
 
-    certModulus = out.stdout.decode("utf-8")
-    if keyModulus != certModulus:
+    certPubKey = out.stdout.decode("utf-8")
+    if keyPubKey != certPubKey:
         log_error("The provided key does not belong to the server certificate")
+        log("{} vs. {}".format(keyPubKey, certPubKey), 1)
         raise CertCheckError("Key does not belong to Certificate")
 
 
@@ -501,8 +512,8 @@ def checks(server_key_content,server_cert_content, certData):
     """
     Perform different checks on the input data
     """
-    if not getRsaKey(server_key_content):
-        raise CertCheckError("Unable to read the server key. Encrypted?")
+    if not getPrivateKey(server_key_content):
+        raise CertCheckError("Unable to read the server key. Is it maybe encrypted?")
 
     checkKeyBelongToCert(server_key_content, server_cert_content)
 

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes.mcalmer.support-ec-crypto-keys-in-certs
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes.mcalmer.support-ec-crypto-keys-in-certs
@@ -1,0 +1,1 @@
+- support EC Cryptography with mgr-ssl-cert-setup


### PR DESCRIPTION
## What does this PR change?

SSL Certificates using EC crypographic keys are now supported to get deployed with mgr-ssl-cert-setup tool

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- https://github.com/uyuni-project/uyuni-docs/pull/2360

- [x] **DONE**

## Test coverage
- No tests: manual

- [x] **DONE**

## Links

See also https://github.com/uyuni-project/uyuni/discussions/7236
Tracks https://github.com/uyuni-project/uyuni/pull/7266

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
