### PR TITLE
mgr-ssl-cert-setup: Store ca in db

### DIFF
--- a/python/spacewalk/satellite_tools/rhn_ssl_dbstore.py
+++ b/python/spacewalk/satellite_tools/rhn_ssl_dbstore.py
@@ -29,7 +29,7 @@ def processCommandline():
 
     options = [
         Option('--ca-cert',      action='store', default=DEFAULT_TRUSTED_CERT, type="string",
-               help='public CA certificate, default is %s' % DEFAULT_TRUSTED_CERT),
+               help='public CA certificate, default is %s. If the value is \'-\' the CA is read from STDIN' % DEFAULT_TRUSTED_CERT),
         Option('--label',        action='store', default='RHN-ORG-TRUSTED-SSL-CERT', type="string",
                help='FOR TESTING ONLY - alternative database label for this CA certificate, '
                + 'default is "RHN-ORG-TRUSTED-SSL-CERT"'),
@@ -45,7 +45,9 @@ def processCommandline():
                "--help): %s\n" % repr(args))
         raise ValueError(msg)
 
-    if not os.path.exists(values.ca_cert):
+    if values.ca_cert == '-':
+        values.ca_cert = sys.stdin.read().strip()
+    elif not os.path.exists(values.ca_cert):
         sys.stderr.write("ERROR: can't find CA certificate at this location: "
                          "%s\n" % values.ca_cert)
         sys.exit(10)

--- a/python/spacewalk/satellite_tools/satCerts.py
+++ b/python/spacewalk/satellite_tools/satCerts.py
@@ -160,12 +160,15 @@ def _lobUpdate_rhnCryptoKey(rhn_cryptokey_id, cert):
 def store_CaCert(description, caCert, verbosity=0):
     org_ids = get_all_orgs()
     org_ids.append({'id': None})
-    f = open(caCert, 'rb')
-    try:
-        cert = f.read().strip()
-    finally:
-        if f is not None:
-            f.close()
+    if " CERTIFICATE-----" in caCert:
+        cert = caCert
+    else:
+        f = open(caCert, 'rb')
+        try:
+            cert = f.read().strip()
+        finally:
+            if f is not None:
+                f.close()
     for org_id in org_ids:
         org_id = org_id['id']
         store_rhnCryptoKey(description, cert, org_id, verbosity)

--- a/python/spacewalk/spacewalk-backend.changes.mcalmer.store-ca-in-db
+++ b/python/spacewalk/spacewalk-backend.changes.mcalmer.store-ca-in-db
@@ -1,0 +1,1 @@
+- rhn-ssl-dbstore read ca from STDIN (bsc#1212856)

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes.mcalmer.store-ca-in-db
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes.mcalmer.store-ca-in-db
@@ -1,0 +1,1 @@
+- mgr-ssl-cert-setup: store CA certificate in database (bsc#1212856)

--- a/spacewalk/setup/bin/spacewalk-setup
+++ b/spacewalk/setup/bin/spacewalk-setup
@@ -696,8 +696,6 @@ sub setup_ssl_certs {
 
   Spacewalk::Setup::system_or_exit(['/usr/bin/mgr-ssl-cert-setup', @opts], 37,
                  "Could not deploy the certificates.");
-
-  store_ssl_cert(-ssl_dir => $answers->{'ssl-dir'});
 }
 
 sub print_country_list {
@@ -777,21 +775,6 @@ sub generate_server_cert {
   }
 
   Spacewalk::Setup::system_or_exit(['/usr/bin/rhn-ssl-tool', @opts], 36, 'Could not generate server certificate.');
-
-  return;
-}
-
-sub store_ssl_cert {
-  my %params = validate(@_, { ssl_dir => 1,
-                              ca_cert => { default => DEFAULT_CA_CERT_NAME },
-                            });
-
-
-  my $cert_path = File::Spec->catfile($params{ssl_dir}, $params{ca_cert});
-  my @opts = ("--ca-cert=${cert_path}");
-
-  Spacewalk::Setup::system_or_exit(['/usr/bin/rhn-ssl-dbstore', @opts], 39,
-                 "There was a problem storing the SSL certificate.");
 
   return;
 }

--- a/spacewalk/setup/spacewalk-setup.changes.mcalmer.store-ca-in-db
+++ b/spacewalk/setup/spacewalk-setup.changes.mcalmer.store-ca-in-db
@@ -1,0 +1,1 @@
+- remove storing CA in DB directly as it is now part of mgr-ssl-cert-setup (bsc#1212856)


### PR DESCRIPTION
## What does this PR change?

Use mgr-ssl-cert-setup to store a new CA certificate in the database.
Drop this single task from spacewalk-setup.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- https://github.com/uyuni-project/uyuni-docs/pull/2359

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/21991
Tracks https://github.com/SUSE/spacewalk/pull/22020

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
