### PR TITLE
add Debian 12 repositories to spacewalk-common-channels.ini

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -3580,6 +3580,15 @@ checksum = sha256
 base_channels = debian-12-pool-amd64-uyuni
 repo_url = http://security.debian.org/debian-security/dists/bookworm-security/updates/main/binary-amd64/
 
+[debian-12-amd64-main-backports-uyuni]
+label    = debian-12-amd64-main-backports-uyuni
+name     = Debian 12 (bookworm) AMD64 Main Backports for Uyuni
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = debian-12-pool-amd64-uyuni
+repo_url = http://deb.debian.org/debian/dists/bookworm-backports/main/binary-amd64/
+
 [debian-12-amd64-uyuni-client-devel]
 label    = debian-12-amd64-uyuni-client-devel
 name     = Uyuni Client Tools for Debian 12 bookworm AMD64 (Development)

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -3551,6 +3551,53 @@ checksum = sha256
 base_channels = debian-11-pool-amd64-uyuni
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Debian11-Uyuni-Client-Tools/Debian_11/
 
+[debian-12-pool-amd64-uyuni]
+label    = debian-12-pool-amd64-uyuni
+checksum = sha256
+archs    = amd64-deb
+repo_type = deb
+name     = Debian 12 (bookworm) pool for amd64 for Uyuni
+gpgkey_url =
+gpgkey_id =
+gpgkey_fingerprint =
+repo_url = http://deb.debian.org/debian/dists/bookworm/main/binary-amd64/
+
+[debian-12-amd64-main-updates-uyuni]
+label    = debian-12-amd64-main-updates-uyuni
+name     = Debian 12 (bookworm) AMD64 Main Updates for Uyuni
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = debian-12-pool-amd64-uyuni
+repo_url = http://deb.debian.org/debian/dists/bookworm-updates/main/binary-amd64/
+
+[debian-12-amd64-main-security-uyuni]
+label    = debian-12-amd64-main-security-uyuni
+name     = Debian 12 (bookworm) AMD64 Main Security for Uyuni
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = debian-12-pool-amd64-uyuni
+repo_url = http://security.debian.org/debian-security/dists/bookworm-security/updates/main/binary-amd64/
+
+[debian-12-amd64-uyuni-client-devel]
+label    = debian-12-amd64-uyuni-client-devel
+name     = Uyuni Client Tools for Debian 12 bookworm AMD64 (Development)
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = debian-12-pool-amd64-uyuni
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/Debian12-Uyuni-Client-Tools/Debian_12/
+
+[debian-12-amd64-uyuni-client]
+label    = debian-12-amd64-uyuni-client
+name     = Uyuni Client Tools for Debian 12 bookworm AMD64
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = debian-12-pool-amd64-uyuni
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Debian12-Uyuni-Client-Tools/Debian_12/
+
 [astralinux-orel-pool-amd64]
 label    = astralinux-orel-pool-amd64
 checksum = sha256

--- a/utils/spacewalk-utils.changes.stdevel.debian-12-channels
+++ b/utils/spacewalk-utils.changes.stdevel.debian-12-channels
@@ -1,0 +1,1 @@
+- add missing Debian 12 repositories (including backports) for spacewalk-common-channels


### PR DESCRIPTION
## What does this PR change?

Currently, spacewalk-common-channels.ini shipped with Uyuni lacks the repositories for Debian 12. I assume this might be planned for Uyuni 2023.06 or 2023.07.

This PR adds the missing repositories as well as the backports (*see also related PR #6912*)

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **it only adds additional repositories to an optional CLI tool**

- [x] **DONE**

## Test coverage
- No tests: **`spacewalk-common-channels` is an optional CLI utility and not a crucial part of Uyuni**

- [x] **DONE**

## Links

Fixes #7268

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

```text
- add missing Debian 12 repositories (including backports) for spacewalk-common-channels
```

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
