### PR TITLE
Testsuite: Refactor step so loop can time out

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1534,8 +1534,10 @@ When(/^I check the cloud-init status on "([^"]*)"$/) do |host|
   _hostname, local, remote, node_code = node.test_and_store_results_together('hostname', 'root', 500)
   command_output, _code = node.run("cloud-init status --wait", check_errors: true, verbose: false)
 
-  until command_output.include?("done")
+  repeat_until_timeout(report_result: true) do
     command_output, code = node.run("cloud-init status --wait", check_errors: true, verbose: false)
+    break if command_output.include?("done")
+    sleep 2
     raise StandardError 'Error during cloud-init.' if code == 1
   end
 end


### PR DESCRIPTION
## What does this PR change?

Related to https://github.com/SUSE/spacewalk/issues/21992
Fixes a loop that does not time out by itself, causing a testsuite timeout.

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Related to # https://github.com/SUSE/spacewalk/issues/21992
Tracks # None - only Uyuni (feature is not present as of now on SUSE Manager branches)
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
