### PR TITLE
Use try-with-resources to properly close streams

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/dto/AuditDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/AuditDto.java
@@ -16,6 +16,7 @@ package com.redhat.rhn.frontend.dto;
 
 import java.util.Date;
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * AuditDto
@@ -27,7 +28,7 @@ public class AuditDto extends BaseDto {
     private int milli;
     private String node;
 
-    private LinkedHashMap<String, String> kvmap;
+    private Map<String, String> kvmap;
 
     private String type;
 
@@ -39,8 +40,7 @@ public class AuditDto extends BaseDto {
      * @param nodeIn Audit generating node
      * @param kvmapIn HashMap of audit data
      */
-    public AuditDto(int serialIn, Date timeIn, int milliIn, String nodeIn,
-                LinkedHashMap<String, String> kvmapIn) {
+    public AuditDto(int serialIn, Date timeIn, int milliIn, String nodeIn, Map<String, String> kvmapIn) {
         this.id = (long) serialIn;
         this.serial = serialIn;
         this.time = timeIn;
@@ -91,7 +91,7 @@ public class AuditDto extends BaseDto {
     /**
      * @return Returns the key-value audit data.
      */
-    public LinkedHashMap<String, String> getKvmap() {
+    public Map<String, String> getKvmap() {
         return kvmap;
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/packages/PackagesHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/packages/PackagesHandler.java
@@ -595,11 +595,12 @@ public class PackagesHandler extends BaseHandler {
         }
 
         byte[] toReturn = new byte[(int) file.length()];
-        BufferedInputStream br = new BufferedInputStream(new FileInputStream(file));
-        if (br.read(toReturn) != file.length()) {
-            throw new PackageDownloadException("api.package.download.ioerror");
+        try (BufferedInputStream br = new BufferedInputStream(new FileInputStream(file))) {
+            if (br.read(toReturn) != file.length()) {
+                throw new PackageDownloadException("api.package.download.ioerror");
+            }
+            return toReturn;
         }
-        return toReturn;
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -5672,8 +5672,7 @@ public class SystemHandler extends BaseHandler {
                     break;
                 }
 
-                try {
-                    BufferedReader br = new BufferedReader(new FileReader(file));
+                try (BufferedReader br = new BufferedReader(new FileReader(file))) {
                     String line;
                     String[] header = null;
                     Integer systemIdPos = null, uuidPos = null;
@@ -5719,7 +5718,6 @@ public class SystemHandler extends BaseHandler {
                             }
                        }
                     }
-                    br.close();
                 }
                 catch (IOException e) {
                     log.warn("Cannot read {}", file.getName());

--- a/java/code/src/com/redhat/rhn/manager/satellite/UpgradeCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/satellite/UpgradeCommand.java
@@ -60,6 +60,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Class responsible for executing one-time upgrade logic
@@ -316,10 +317,12 @@ public class UpgradeCommand extends BaseTransactionCommand {
 
     // list of directories with given prefix and natural number suffix in the salt root
     private Set<Path> listDirsWithPrefix(String prefix) throws IOException {
-        return Files.list(saltRootPath)
+        try (Stream<Path> pathStream = Files.list(saltRootPath)) {
+            return pathStream
                 .filter(path -> path.getFileName().toString().matches("^" + prefix + "\\d*$") &&
-                        path.toFile().isDirectory())
+                    path.toFile().isDirectory())
                 .collect(Collectors.toSet());
+        }
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriter.java
@@ -548,13 +548,7 @@ public class RpmRepositoryWriter extends RepositoryWriter {
 
         try (DigestInputStream digestStream = new DigestInputStream(stream, MessageDigest.getInstance(checksumAlgo))) {
 
-            try {
-                byte[] bytes = new byte[10];
-                while (digestStream.read(bytes) != -1) {
-                    // no-op, just consume the stream
-                }
-            }
-            catch (IOException e) {
+            if (!computeDigest(digestStream)) {
                 return null;
             }
 
@@ -569,6 +563,19 @@ public class RpmRepositoryWriter extends RepositoryWriter {
         catch (IOException | NoSuchAlgorithmException nsae) {
             throw new RepomdRuntimeException(nsae);
         }
+    }
+
+    private static boolean computeDigest(DigestInputStream digestStream) {
+        try {
+            byte[] bytes = new byte[10];
+            while (digestStream.read(bytes) != -1) {
+                // no-op, just fully consume the stream so that the digest is computed
+            }
+        }
+        catch (IOException e) {
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/java/code/src/com/suse/manager/reactor/PGEventStream.java
+++ b/java/code/src/com/suse/manager/reactor/PGEventStream.java
@@ -101,9 +101,9 @@ public class PGEventStream extends AbstractEventStream implements PGNotification
             connection = (PGConnection) dataSource.getConnection();
             connection.addNotificationListener(this);
 
-            Statement stmt = connection.createStatement();
-            stmt.execute("LISTEN suseSaltEvent");
-            stmt.close();
+            try (Statement stmt = connection.createStatement()) {
+                stmt.execute("LISTEN suseSaltEvent");
+            }
 
             startConnectionWatchdog();
 

--- a/java/code/src/com/suse/manager/webui/utils/MinionActionUtils.java
+++ b/java/code/src/com/suse/manager/webui/utils/MinionActionUtils.java
@@ -181,17 +181,19 @@ public class MinionActionUtils {
         Path scriptsDir = saltUtils.getScriptsDir();
         if (Files.isDirectory(scriptsDir)) {
             Pattern p = Pattern.compile("script_(\\d*).sh");
-            Files.list(scriptsDir).forEach(file -> {
-                Matcher m = p.matcher(file.getFileName().toString());
-                if (m.find()) {
-                    long actionId = Long.parseLong(m.group(1));
-                    Action action = ActionFactory.lookupById(actionId);
-                    if (action == null || action.allServersFinished()) {
-                        LOG.info("Deleting script file: {}", file);
-                        FileUtils.deleteFile(file);
+            try (Stream<Path> pathStream = Files.list(scriptsDir)) {
+                pathStream.forEach(file -> {
+                    Matcher m = p.matcher(file.getFileName().toString());
+                    if (m.find()) {
+                        long actionId = Long.parseLong(m.group(1));
+                        Action action = ActionFactory.lookupById(actionId);
+                        if (action == null || action.allServersFinished()) {
+                            LOG.info("Deleting script file: {}", file);
+                            FileUtils.deleteFile(file);
+                        }
                     }
-                }
-            });
+                });
+            }
         }
     }
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes some sonarcloud bugs by using try-with-resources to address simple cases of streams not properly closed.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
