### PR TITLE
Remove conflicting line for making it possible to have a clean backport of security fixes in 7189

### DIFF
--- a/java/code/src/com/redhat/rhn/common/security/SessionSwap.java
+++ b/java/code/src/com/redhat/rhn/common/security/SessionSwap.java
@@ -152,7 +152,6 @@ public class SessionSwap {
             log.debug("Data     : [{}]", joinedText);
             log.debug("Key      : [{}]", swapKey);
         }
-        String retval = HMAC.sha256(joinedText, swapKey.toString());
         if (log.isDebugEnabled()) {
             log.debug("retval: {}", retval);
         }


### PR DESCRIPTION
## What does this PR change?

**Remove conflicting line for making it possible to have a clean backport of security fixes in #7189.
This change will be reverted after  the  backport**


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **this is a temp change for allowing the backport of #7189**
(https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.

- [x] **DONE**

## Test coverage
- No tests: **this is a temp change for allowing the backport of #7189**

- [x] **DONE**

## Links

Relates: #7189
Relates: https://github.com/SUSE/spacewalk/issues/21856
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
