### PR TITLE
Remove conflicting lines for making it possible to have a clean backport of security fixes in 7189

### DIFF
--- a/java/code/src/com/redhat/rhn/common/security/SessionSwap.java
+++ b/java/code/src/com/redhat/rhn/common/security/SessionSwap.java
@@ -149,10 +149,6 @@ public class SessionSwap {
 
 
         if (log.isDebugEnabled()) {
-            log.debug("Data     : [{}]", joinedText);
-            log.debug("Key      : [{}]", swapKey);
-        }
-        if (log.isDebugEnabled()) {
             log.debug("retval: {}", retval);
         }
         return retval;


### PR DESCRIPTION
## What does this PR change?

**Remove conflicting lines for making it possible to have a clean backport of security fixes in https://github.com/uyuni-project/uyuni/pull/7189.
This change will be reverted after the backport together with https://github.com/uyuni-project/uyuni/pull/7275**

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **this is a temp change for allowing the backport of #7189**

- [x] **DONE**

## Test coverage
- No tests: **this is a temp change for allowing the backport of #7189**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Relates: https://github.com/uyuni-project/uyuni/pull/7189
Relates: https://github.com/SUSE/spacewalk/issues/21856

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
