### PR TITLE
Revert 7275 and 7277 after the merge of the backport from 7189

### DIFF
--- a/java/code/src/com/redhat/rhn/common/security/SessionSwap.java
+++ b/java/code/src/com/redhat/rhn/common/security/SessionSwap.java
@@ -147,7 +147,7 @@ public class SessionSwap {
 
         String joinedText = StringUtils.join(text.iterator(), "\0");
 
-        String retval = HMAC.sha1(joinedText, swapKey.toString());
+        String retval = HMAC.sha256(joinedText, swapKey.toString());
         if (log.isDebugEnabled()) {
             log.debug("retval: {}", retval);
         }


### PR DESCRIPTION
## What does this PR change?

**Revert #7275 and #7277 after the merge of the backport from #7189**

For having a clean backport of #7189 I had to manually rollback some changes on master. 
* #7275
* #7276
* #7275
This PR should revert the changes that are not needed anymore on master because in the meantime uyuni-2023.04 and  master diverged. A revert of #7276 doesn't look needed anymore

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **Revert #7275 and #7277 after the merge of the backport from #7189**

- [x] **DONE**

## Test coverage
- No tests: **Revert #7275 and #7277 after the merge of the backport from #7189**

- [x] **DONE**

## Links

Related https://github.com/SUSE/spacewalk/issues/20419
Related https://github.com/SUSE/spacewalk/issues/21856

- [x] **DONE**

## Changelogs

This is a revert of  a  temp fix. no changelog needed. 

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
