### PR TITLE
fix CA encoding before storing it into DB

### DIFF
--- a/spacewalk/certs-tools/mgr_ssl_cert_setup.py
+++ b/spacewalk/certs-tools/mgr_ssl_cert_setup.py
@@ -494,7 +494,7 @@ def deployCAInDB(certData):
                 ["/usr/bin/rhn-ssl-dbstore", "--ca-cert", "-"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                input=ca["content"],
+                input=ca["content"].encode("utf-8"),
             )
             if out.returncode:
                 log_error("Failed to upload CA Certificate to DB: {}".format(out.stderr.decode("utf-8")))


### PR DESCRIPTION
## What does this PR change?

The encoding was wrong when providing the CA to the DB tool. Fix that

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Additional to https://github.com/uyuni-project/uyuni/pull/7267
Tracks 

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
