### PR TITLE
parse virtual-host-gatherer null value

### DIFF
--- a/java/code/src/com/suse/manager/gatherer/GathererJsonIO.java
+++ b/java/code/src/com/suse/manager/gatherer/GathererJsonIO.java
@@ -26,6 +26,7 @@ import com.google.gson.JsonSyntaxException;
 import com.google.gson.TypeAdapter;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 
 import java.io.IOException;
@@ -100,11 +101,18 @@ public class GathererJsonIO {
             reader.beginObject();
             while (reader.hasNext()) {
               String key = reader.nextName();
-              if (key.equals("module")) {
-                gm.setName(reader.nextString());
+              String value = null;
+              if (reader.peek() == JsonToken.NULL) {
+                  reader.nextNull();
               }
               else {
-                  gm.addParameter(key, reader.nextString());
+                  value = reader.nextString();
+              }
+              if (key.equals("module")) {
+                  gm.setName(value);
+              }
+              else {
+                  gm.addParameter(key, value);
               }
             }
             reader.endObject();

--- a/java/code/src/com/suse/manager/gatherer/test/GathererJsonIOTest.java
+++ b/java/code/src/com/suse/manager/gatherer/test/GathererJsonIOTest.java
@@ -55,9 +55,10 @@ public class GathererJsonIOTest  {
                 FileUtils.readStringFromFile(TestUtils.findTestData(MODULELIST).getPath());
         Map<String, GathererModule> mods = new GathererJsonIO().readGathererModules(json);
 
-        assertEquals(2, mods.keySet().size());
+        assertEquals(3, mods.keySet().size());
         assertTrue(mods.keySet().contains("VMware"));
         assertTrue(mods.keySet().contains("SUSECloud"));
+        assertTrue(mods.keySet().contains("Libvirt"));
 
         for (GathererModule g : mods.values()) {
             if (g.getName().equals("VMware")) {
@@ -75,6 +76,11 @@ public class GathererJsonIOTest  {
                 assertTrue(g.getParameters().containsKey("password"));
                 assertTrue(g.getParameters().containsKey("protocol"));
                 assertTrue(g.getParameters().containsKey("tenant"));
+            }
+            else if (g.getName().equals("Libvirt")) {
+                assertTrue(g.getParameters().containsKey("uri"));
+                assertTrue(g.getParameters().containsKey("sasl_username"));
+                assertTrue(g.getParameters().containsKey("sasl_password"));
             }
             else {
                 fail("Unknown Module");

--- a/java/code/src/com/suse/manager/gatherer/test/modulelist.json
+++ b/java/code/src/com/suse/manager/gatherer/test/modulelist.json
@@ -14,6 +14,12 @@
         "port": 443,
         "username": "",
         "password": ""
+    },
+    "Libvirt": {
+        "module": "Libvirt",
+        "uri": "",
+        "sasl_username": null,
+        "sasl_password": null
     }
 }
 

--- a/java/spacewalk-java.changes.mbussolotto.parse_null
+++ b/java/spacewalk-java.changes.mbussolotto.parse_null
@@ -1,0 +1,1 @@
+- parse virtual-host-gatherer null value


### PR DESCRIPTION
## What does this PR change?

parse virtual-host-gatherer null value. 
Fix for `Virtual host manager web UI` cucumber tests

## GUI diff
Before:

![Screenshot from 2023-07-18 15-08-58](https://github.com/uyuni-project/uyuni/assets/4320859/999811e2-53a9-47a1-bcc6-88aabbd704a3)

![Screenshot from 2023-07-18 15-10-12](https://github.com/uyuni-project/uyuni/assets/4320859/00096a96-8252-43ea-b8ac-fbccb5be7f65)
- [x] **DONE**

## Documentation
- No documentation needed
- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
