### PR TITLE
Disable default schedule tasks to improve testing stability

### DIFF
--- a/testsuite/features/build_validation/core/srv_disable_default_schedule_tasks.feature
+++ b/testsuite/features/build_validation/core/srv_disable_default_schedule_tasks.feature
@@ -1,0 +1,42 @@
+# Copyright (c) 2023 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Remove schedule tasks to manually trigger them when we consider the best moment
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Delete scheduled reposyncs
+    When I follow the left menu "Admin > Task Schedules"
+    And I follow "mgr-sync-refresh-default"
+    And I choose "disabled"
+    And I click on "Update Schedule"
+    And I click on "Delete Schedule"
+
+  Scenario: Delete scheduled sync of custom channels
+    When I follow the left menu "Admin > Task Schedules"
+    And I follow "channel-repodata-default"
+    And I choose "disabled"
+    And I click on "Update Schedule"
+    And I click on "Delete Schedule"
+
+  Scenario: Delete scheduled sync of cobbler
+    When I follow the left menu "Admin > Task Schedules"
+    And I follow "cobbler-sync-default"
+    And I choose "disabled"
+    And I click on "Update Schedule"
+    And I click on "Delete Schedule"
+
+  Scenario: Delete scheduled errata cache
+    When I follow the left menu "Admin > Task Schedules"
+    And I follow "errata-cache-default"
+    And I choose "disabled"
+    And I click on "Update Schedule"
+    And I click on "Delete Schedule"
+
+  Scenario: Delete scheduled errata queue
+    When I follow the left menu "Admin > Task Schedules"
+    And I follow "errata-queue-default"
+    And I choose "disabled"
+    And I click on "Update Schedule"
+    And I click on "Delete Schedule"

--- a/testsuite/features/build_validation/reposync/srv_wait_for_product_reposync.feature
+++ b/testsuite/features/build_validation/reposync/srv_wait_for_product_reposync.feature
@@ -6,13 +6,6 @@ Feature: Wait for reposync activity to finish after adding products
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  Scenario: Delete scheduled reposyncs
-    When I follow the left menu "Admin > Task Schedules"
-    And I follow "mgr-sync-refresh-default"
-    And I choose "disabled"
-    And I click on "Update Schedule"
-    And I click on "Delete Schedule"
-
   Scenario: Wait for running reposyncs to finish after adding products
     When I wait until all spacewalk-repo-sync finished
 

--- a/testsuite/run_sets/build_validation/build_validation_core.yml
+++ b/testsuite/run_sets/build_validation/build_validation_core.yml
@@ -11,6 +11,9 @@
 # configuration channel and configuration file for smoke tests
 - features/build_validation/core/srv_add_configuration_channel_and_file.feature
 
+# disable default schedule tasks
+- features/build_validation/core/srv_disable_default_schedule_tasks.feature
+
 # Create the CLM filters for RH-like minions
 - features/build_validation/core/srv_prepare_rh_like_clm_filters.feature
 


### PR DESCRIPTION
## What does this PR change?

Disable most of default schedule tasks to avoid instability during our BV and CI tests.
We don't want random mgr-create-bootstrap-repo to stop manual call.

For now this change is only for BV but after review I will add it for acceptance tests too.

## Links

Related to : https://github.com/SUSE/spacewalk/issues/21827

## Changelogs

- [x] No changelog needed
