### PR TITLE
Fix the URL showing the inactive systems list (gh#7067)

### DIFF
--- a/java/code/src/com/suse/manager/webui/menu/MenuTree.java
+++ b/java/code/src/com/suse/manager/webui/menu/MenuTree.java
@@ -148,7 +148,7 @@ public class MenuTree {
                             .withPrimaryUrl("/rhn/manager/systems/list/all?qc=group_count&q=0")
                             .withVisibility(adminRoles.get("org")))
                     .addChild(new MenuItem("Inactive")
-                            .withPrimaryUrl("/rhn/manager/systems/list/all?qc=system_kind&q=awol"))
+                            .withPrimaryUrl("/rhn/manager/systems/list/all?qc=status_type&q=awol"))
                     .addChild(new MenuItem("Recently Registered")
                             .withPrimaryUrl("/rhn/manager/systems/list/all?qc=created_days&q=>6"))
                     .addChild(new MenuItem("Proxy")

--- a/java/spacewalk-java.changes.cbosdo.inactive-systems-fix
+++ b/java/spacewalk-java.changes.cbosdo.inactive-systems-fix
@@ -1,0 +1,1 @@
+- Fix the URL for inactive systems page


### PR DESCRIPTION
## What does this PR change?

Filter inactive systems on `status_type` rather than `system_type`.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: legacy link bound to be dropped sooner or later

- [X] **DONE**

## Links

Fixes #7067
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
