### PR TITLE
Testsuite: SSH tunnel package removal

### DIFF
--- a/testsuite/features/secondary/min_ssh_tunnel.feature
+++ b/testsuite/features/secondary/min_ssh_tunnel.feature
@@ -60,6 +60,7 @@ Feature: Register a Salt system to be managed via SSH tunnel
     And I follow "List / Remove"
     And I enter "milkyway-dummy" as the filtered package name
     And I click on the filter button
+    And I wait until I see "milkyway-dummy" text
     And I check "milkyway-dummy" in the list
     And I click on "Remove Packages"
     And I click on "Confirm"

--- a/testsuite/features/secondary/min_ssh_tunnel.feature
+++ b/testsuite/features/secondary/min_ssh_tunnel.feature
@@ -13,6 +13,9 @@ Feature: Register a Salt system to be managed via SSH tunnel
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
+  Scenario: Pre-requisite: remove package before ssh tunnel test
+    When I remove package "milkyway-dummy" from this "ssh_minion" without error control
+
   Scenario: Delete the Salt minion for SSH tunnel bootstrap
     Given I am on the Systems overview page of this "ssh_minion"
     When I follow "Delete System"


### PR DESCRIPTION
## What does this PR change?
The `milkyway-dummy` package is already installed in the SSH minion at that point in the testsuite, probably due to a missing uninstall in the deploy stage.
Since the package is already installed, this feature cannot find the right package architecture to install and fails.
This PR fixes this failure while the root cause is being looked into.

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were added
- [x] **DONE**

## Links
Fixes # https://github.com/SUSE/spacewalk/issues/18885
Tracks # 
4.2 https://github.com/SUSE/spacewalk/pull/22056
4.3 https://github.com/SUSE/spacewalk/pull/22055
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
