### PR TITLE
proxy container config is created on server where CA should not be added to DB

### DIFF
--- a/spacewalk/certs-tools/mgr_ssl_cert_setup.py
+++ b/spacewalk/certs-tools/mgr_ssl_cert_setup.py
@@ -555,7 +555,6 @@ def getContainersSetup(root_ca_content, intermediate_ca_content, server_cert_con
     apache_cert_content = generateApacheCert(server_cert_content, certData)
     if not apache_cert_content:
         raise CertCheckError("Failed to generate certificates")
-    deployCAInDB(certData)
     return apache_cert_content
 
 


### PR DESCRIPTION
## What does this PR change?

Do not try to deploy the proxy CA for containerized proxy into DB.
This code is executed on the Server and not on the proxy.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

See https://github.com/SUSE/spacewalk/issues/22046
Additional fix for https://github.com/uyuni-project/uyuni/pull/7267
Tracks https://github.com/SUSE/spacewalk/pull/22048

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
