### PR TITLE
Add support for saltboot pillar force_redeploy and force_repartition

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/org/test/CustomDataKeyTest.java
+++ b/java/code/src/com/redhat/rhn/domain/org/test/CustomDataKeyTest.java
@@ -59,4 +59,15 @@ public class CustomDataKeyTest extends RhnBaseTestCase {
 
         return key;
     }
+
+    public static CustomDataKey createTestCustomDataKey(User user, String label) {
+        CustomDataKey key = new CustomDataKey();
+        key.setCreator(user);
+        key.setLabel(label);
+        key.setDescription("testkey description");
+        key.setOrg(user.getOrg());
+        TestUtils.saveAndFlush(key);
+
+        return key;
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
@@ -193,6 +193,13 @@ public class MinionServer extends Server implements SaltConfigurable {
     }
 
     /**
+     * @param pillarIn value of pillar
+     */
+    public void addPillar(Pillar pillarIn) {
+        pillars.add(pillarIn);
+    }
+
+    /**
      * Get the pillar corresponding to a category.
      *
      * @param category the category of the pillar to look for

--- a/java/code/src/com/redhat/rhn/domain/server/test/CustomDataValueTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/CustomDataValueTest.java
@@ -69,4 +69,15 @@ public class CustomDataValueTest extends RhnBaseTestCase {
 
         return val;
     }
+
+    public static CustomDataValue createTestCustomDataValue(User user, CustomDataKey key, Server server, String value) {
+        CustomDataValue val = new CustomDataValue();
+        val.setCreator(user);
+        val.setKey(key);
+        val.setServer(server);
+        val.setValue(value);
+        TestUtils.saveAndFlush(val);
+
+        return val;
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/server/test/MinionServerTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/MinionServerTest.java
@@ -26,6 +26,7 @@ import com.redhat.rhn.testing.TestUtils;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -55,8 +56,7 @@ public class MinionServerTest extends BaseTestCaseWithUser {
         pillars.add(new Pillar("category2", pillar2, minionServer));
 
         minionServer.setPillars(pillars);
-        TestUtils.saveAndFlush(minionServer);
-        minionServer = reload(minionServer);
+        minionServer = TestUtils.saveAndReload(minionServer);
 
         Pillar actual = minionServer.getPillarByCategory("category1").get();
         assertNotNull(actual);
@@ -65,5 +65,27 @@ public class MinionServerTest extends BaseTestCaseWithUser {
         assertFalse(actual.isGlobalPillar());
         assertFalse(actual.isGroupPillar());
         assertFalse(actual.isOrgPillar());
+    }
+
+    @Test
+    public void testMinionPillarAdding() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+
+        Set<Pillar> pillars = new HashSet<>();
+        for (int i = 0; i < 2; i++) {
+            Map<String, Object> data = Collections.singletonMap("key", String.format("value%d", i));
+            Pillar pillar = new Pillar(String.format("original_pillar%d", i), data, minion);
+            pillars.add(pillar);
+        }
+        minion.setPillars(pillars);
+        minion = TestUtils.saveAndReload(minion);
+        assertEquals(3, minion.getPillars().size());
+
+        Pillar newPillar = new Pillar("new_pillar", Collections.singletonMap("key", "value"), minion);
+        minion.addPillar(newPillar);
+
+        minion = TestUtils.saveAndReload(minion);
+
+        assertEquals(4, minion.getPillars().size());
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -3453,6 +3453,43 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
     }
 
     /**
+     * Test the SystemHandler.getPillar method
+     * @throws Exception if anything fail
+     */
+    @Test
+    public void testGetPillar() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(admin);
+        Pillar newPillar = new Pillar("new_pillar", Collections.singletonMap("key", "value"), minion);
+        minion.addPillar(newPillar);
+        minion = TestUtils.saveAndReload(minion);
+        assertEquals(2, minion.getPillars().size());
+
+        SystemHandler systemHandler = getMockedHandler();
+        Map<String, Object> pillar = systemHandler.getPillar(admin, minion.getId().intValue(), "new_pillar");
+        assertNotNull(pillar);
+        assertEquals("value", pillar.get("key"));
+    }
+
+    /**
+     * Test the SystemHandler.setPillar method
+     * @throws Exception if anything fail
+     */
+    @Test
+    public void testSetPillar() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(admin);
+        assertEquals(1, minion.getPillars().size());
+
+        SystemHandler systemHandler = getMockedHandler();
+        Map<String, Object> pillarData = Collections.singletonMap("key", "value");
+        systemHandler.setPillar(admin, minion.getId().intValue(), "stored_pillar", pillarData);
+
+        minion = reload(minion);
+        assertEquals(2, minion.getPillars().size());
+        assertTrue(minion.getPillarByCategory("stored_pillar").isPresent());
+        assertEquals("value", minion.getPillarByCategory("stored_pillar").get().getPillar().get("key"));
+    }
+
+    /**
      * Test the SystemHandler.changeProxy method
      * @throws Exception if anything failed
      */

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -3490,6 +3490,43 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
     }
 
     /**
+     * Test the SystemHandler.getPillar method
+     * @throws Exception if anything fail
+     */
+    @Test
+    public void testGetPillarByMinionId() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(admin);
+        Pillar newPillar = new Pillar("new_pillar", Collections.singletonMap("key", "value"), minion);
+        minion.addPillar(newPillar);
+        minion = TestUtils.saveAndReload(minion);
+        assertEquals(2, minion.getPillars().size());
+
+        SystemHandler systemHandler = getMockedHandler();
+        Map<String, Object> pillar = systemHandler.getPillar(admin, minion.getMinionId(), "new_pillar");
+        assertNotNull(pillar);
+        assertEquals("value", pillar.get("key"));
+    }
+
+    /**
+     * Test the SystemHandler.setPillar method
+     * @throws Exception if anything fail
+     */
+    @Test
+    public void testSetPillarByMinionId() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(admin);
+        assertEquals(1, minion.getPillars().size());
+
+        SystemHandler systemHandler = getMockedHandler();
+        Map<String, Object> pillarData = Collections.singletonMap("key", "value");
+        systemHandler.setPillar(admin, minion.getMinionId(), "stored_pillar", pillarData);
+
+        minion = reload(minion);
+        assertEquals(2, minion.getPillars().size());
+        assertTrue(minion.getPillarByCategory("stored_pillar").isPresent());
+        assertEquals("value", minion.getPillarByCategory("stored_pillar").get().getPillar().get("key"));
+    }
+
+    /**
      * Test the SystemHandler.changeProxy method
      * @throws Exception if anything failed
      */

--- a/java/code/src/com/suse/manager/saltboot/PXEEventMessageAction.java
+++ b/java/code/src/com/suse/manager/saltboot/PXEEventMessageAction.java
@@ -29,7 +29,9 @@ public class PXEEventMessageAction implements MessageAction {
     @Override
     public void execute(EventMessage msg) {
         PXEEvent pxeEvent = ((PXEEventMessage) msg).getPXEEventMessage();
+        LOG.debug("Processing PXEEvent for minion {}", pxeEvent.getMinionId());
 
+        // Part 1 - update PXE entries
         if (pxeEvent.getRoot().isEmpty()) {
             LOG.error("Root device not specified in PXE event for minion {}. Ignoring event", pxeEvent.getMinionId());
             return;
@@ -48,6 +50,9 @@ public class PXEEventMessageAction implements MessageAction {
 
         SaltbootUtils.createSaltbootSystem(pxeEvent.getMinionId(), pxeEvent.getBootImage(), pxeEvent.getSaltbootGroup(),
                 pxeEvent.getHwAddresses(), kernelParameters);
+
+        // Part 2 - reset pillar data "saltboot:force_*" or "custom_info:saltboot_force_*" if present
+        SaltbootUtils.resetSaltbootRedeployFlags(pxeEvent.getMinionId());
     }
 
     @Override

--- a/java/code/src/com/suse/manager/saltboot/SaltbootUtils.java
+++ b/java/code/src/com/suse/manager/saltboot/SaltbootUtils.java
@@ -276,7 +276,7 @@ public class SaltbootUtils {
      * @param minion
      */
     private static void removeSaltbootRedeployPillar(MinionServer minion) {
-        minion.getPillarByCategory("formula-saltboot").ifPresent(
+        minion.getPillarByCategory("tuning-saltboot").ifPresent(
             pillar -> {
                 Map<String, Object> pillarData = pillar.getPillar();
                 Map<String, String> saltboot = (Map<String, String>)pillarData.get("saltboot");

--- a/java/code/src/com/suse/manager/saltboot/SaltbootUtils.java
+++ b/java/code/src/com/suse/manager/saltboot/SaltbootUtils.java
@@ -62,7 +62,7 @@ public class SaltbootUtils {
                 .setKernelOptions(Optional.of("panic=60 splash=silent"))
                 .setArch(imageInfo.getImageArch().getName()).setBreed("generic")
                 .build(con);
-        cd.setComment("Distro for image " + name + "belonging to organization " + imageInfo.getOrg().getName());
+        cd.setComment("Distro for image " + name + " belonging to organization " + imageInfo.getOrg().getName());
         cd.save();
 
         // Each distro have its own private profile for individual system records
@@ -108,8 +108,8 @@ public class SaltbootUtils {
         String distroToUse;
         if (bootImage == null || bootImage.isEmpty()) {
             SaltbootVersionCompare saltbootCompare = new SaltbootVersionCompare();
-            distroToUse = Distro.list(con).stream().map(d -> d.getName()).sorted(saltbootCompare)
-                    .collect(Collectors.toList()).stream().findFirst().orElseThrow(
+            distroToUse = Distro.list(con).stream().map(d -> d.getName()).filter(s -> s.startsWith(org.getId() + "-"))
+                    .sorted(saltbootCompare).collect(Collectors.toList()).stream().findFirst().orElseThrow(
                             () -> new SaltbootException("No registered image found"));
         }
         else if (bootImageVersion == null || bootImageVersion.isEmpty()) {
@@ -224,7 +224,7 @@ public class SaltbootUtils {
      *
      * @param minionId
      */
-    public void deleteSaltbootSystem(String minionId) {
+    public static void deleteSaltbootSystem(String minionId) {
         CobblerConnection con = CobblerXMLRPCHelper.getAutomatedConnection();
         Org org = MinionServerFactory.findByMinionId(minionId).orElseThrow(
                 () -> new SaltbootException("Unable to find minion entry for minion id " + minionId)).getOrg();

--- a/java/code/src/com/suse/manager/saltboot/test/PXEEventTest.java
+++ b/java/code/src/com/suse/manager/saltboot/test/PXEEventTest.java
@@ -20,10 +20,10 @@ import static com.redhat.rhn.domain.server.test.CustomDataValueTest.createTestCu
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static java.util.Optional.empty;
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.rhn.domain.org.CustomDataKey;
@@ -342,8 +342,7 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
         Set<Pillar> pillars = new HashSet<>();
         pillars.add(new Pillar(FORMULA, createSaltbootTestData(null, null), minion));
         minion.setPillars(pillars);
-        TestUtils.saveAndFlush(minion);
-        minion = reload(minion);
+        minion = TestUtils.saveAndReload(minion);
 
         assertTrue(minion.getPillarByCategory(FORMULA).isPresent());
 
@@ -405,8 +404,7 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
         Set<Pillar> pillars = new HashSet<>();
         pillars.add(new Pillar(FORMULA, createSaltbootTestData(null, null), hwtypeGroup));
         hwtypeGroup.setPillars(pillars);
-        TestUtils.saveAndFlush(hwtypeGroup);
-        hwtypeGroup = reload(hwtypeGroup);
+        hwtypeGroup = TestUtils.saveAndReload(hwtypeGroup);
 
         assertFalse(minion.getPillarByCategory(FORMULA).isPresent());
         assertTrue(hwtypeGroup.getPillarByCategory(FORMULA).isPresent());
@@ -463,15 +461,13 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
         Set<Pillar> pillars = new HashSet<>();
         pillars.add(new Pillar(FORMULA, createSaltbootTestData(null, null), hwtypeGroup));
         hwtypeGroup.setPillars(pillars);
-        TestUtils.saveAndFlush(hwtypeGroup);
-        hwtypeGroup = reload(hwtypeGroup);
+        hwtypeGroup = TestUtils.saveAndReload(hwtypeGroup);
 
         // Override by system pillar with redeploy flag
         pillars = new HashSet<>();
         pillars.add(new Pillar(FORMULA, createSaltbootTestData(true, true), minion));
         minion.setPillars(pillars);
-        TestUtils.saveAndFlush(minion);
-        minion = reload(minion);
+        minion = TestUtils.saveAndReload(minion);
 
         assertTrue(hwtypeGroup.getPillarByCategory(FORMULA).isPresent());
         assertTrue(minion.getPillarByCategory(FORMULA).isPresent());
@@ -545,8 +541,7 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
         Set<Pillar> pillars = new HashSet<>();
         pillars.add(new Pillar(FORMULA, createSaltbootTestData(null, null), hwtypeGroup));
         hwtypeGroup.setPillars(pillars);
-        TestUtils.saveAndFlush(hwtypeGroup);
-        hwtypeGroup = reload(hwtypeGroup);
+        hwtypeGroup = TestUtils.saveAndReload(hwtypeGroup);
 
         assertFalse(minion.getPillarByCategory(FORMULA).isPresent());
         assertTrue(hwtypeGroup.getPillarByCategory(FORMULA).isPresent());

--- a/java/code/src/com/suse/manager/saltboot/test/PXEEventTest.java
+++ b/java/code/src/com/suse/manager/saltboot/test/PXEEventTest.java
@@ -130,6 +130,10 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
     }
 
     private Map<String, Object> createSaltbootTestData(Boolean repartition, Boolean redeploy) {
+        return createSaltbootTestData(repartition, redeploy, null);
+    }
+
+    private Map<String, Object> createSaltbootTestData(Boolean repartition, Boolean redeploy, Boolean extraData) {
         Map<String, Object> data = new HashMap<>();
         Map<String, Object> saltbootData = new HashMap<>();
         if (repartition != null) {
@@ -137,6 +141,9 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
         }
         if (redeploy != null) {
             saltbootData.put("force_redeploy", redeploy);
+        }
+        if (extraData != null && extraData) {
+            saltbootData.put("extraData", "are here");
         }
         data.put("saltboot", saltbootData);
         return data;
@@ -342,7 +349,7 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
 
         // Add pillar data without any redeployment flag
         Set<Pillar> pillars = new HashSet<>();
-        pillars.add(new Pillar(SALTBOOT_PILLAR, createSaltbootTestData(null, null), minion));
+        pillars.add(new Pillar(SALTBOOT_PILLAR, createSaltbootTestData(null, null, true), minion));
         minion.setPillars(pillars);
         minion = TestUtils.saveAndReload(minion);
 
@@ -408,9 +415,14 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
         pillars.add(new Pillar(SALTBOOT_FORMULA, createSaltbootTestData(null, null), hwtypeGroup));
         hwtypeGroup.setPillars(pillars);
         hwtypeGroup = TestUtils.saveAndReload(hwtypeGroup);
-
-        assertFalse(minion.getPillarByCategory(SALTBOOT_PILLAR).isPresent());
         assertTrue(hwtypeGroup.getPillarByCategory(SALTBOOT_FORMULA).isPresent());
+
+        // Add pillar data without any redeployment flag
+        pillars = new HashSet<>();
+        pillars.add(new Pillar(SALTBOOT_PILLAR, createSaltbootTestData(false, null), minion));
+        minion.setPillars(pillars);
+        minion = TestUtils.saveAndReload(minion);
+        assertTrue(minion.getPillarByCategory(SALTBOOT_PILLAR).isPresent());
 
         // Do the thing
         action.execute(pxemsg);
@@ -472,7 +484,7 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
 
         // Override by system pillar with redeploy flag
         pillars = new HashSet<>();
-        pillars.add(new Pillar(SALTBOOT_PILLAR, createSaltbootTestData(true, true), minion));
+        pillars.add(new Pillar(SALTBOOT_PILLAR, createSaltbootTestData(true, true, true), minion));
         minion.setPillars(pillars);
         minion = TestUtils.saveAndReload(minion);
 

--- a/java/code/src/com/suse/manager/saltboot/test/PXEEventTest.java
+++ b/java/code/src/com/suse/manager/saltboot/test/PXEEventTest.java
@@ -15,33 +15,84 @@
 
 package com.suse.manager.saltboot.test;
 
+import static com.redhat.rhn.domain.org.test.CustomDataKeyTest.createTestCustomDataKey;
+import static com.redhat.rhn.domain.server.test.CustomDataValueTest.createTestCustomDataValue;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static java.util.Optional.empty;
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.redhat.rhn.domain.org.CustomDataKey;
+import com.redhat.rhn.domain.org.OrgFactory;
+import com.redhat.rhn.domain.server.CustomDataValue;
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.Pillar;
+import com.redhat.rhn.domain.server.ServerGroup;
+import com.redhat.rhn.domain.server.ServerGroupFactory;
+import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
+import com.redhat.rhn.testing.TestUtils;
 
 import com.suse.manager.saltboot.PXEEvent;
+import com.suse.manager.saltboot.PXEEventMessage;
+import com.suse.manager.saltboot.PXEEventMessageAction;
 import com.suse.salt.netapi.datatypes.Event;
 
+import org.cobbler.Distro;
+import org.cobbler.Profile;
+import org.cobbler.SystemRecord;
+import org.cobbler.test.MockConnection;
 import org.jmock.Expectations;
 import org.jmock.imposters.ByteBuddyClassImposteriser;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 public class PXEEventTest extends JMockBaseTestCaseWithUser {
+
+    private MockConnection cobblerMock;
+    private static final String MINION_ID = "minion.local";
+    private static final String FORMULA = "formula-saltboot";
+    private static final String BOOT_IMAGE = "POS_Image_JeOS7-7.0.0-1";
+    private static final String SALTBOOT_GROUP = "groupPrefix";
 
     @Override
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+        cobblerMock = new MockConnection("http://localhost", "token");
+
+        // create cobbler distro and saltboot profile
+        Distro distro = new Distro.Builder<String>()
+                .setName(user.getOrg().getId() + "-" + BOOT_IMAGE)
+                .setKernel("kernel_file")
+                .setInitrd("initrd_file")
+                .setKernelOptions(Optional.of("panic=60 splash=silent"))
+                .build(cobblerMock);
+        distro.save();
+
+        Profile imageProfile = Profile.create(cobblerMock, user.getOrg().getId() + "-" + BOOT_IMAGE, distro);
+        imageProfile.save();
+        Profile profile = Profile.create(cobblerMock, user.getOrg().getId() + "-" + SALTBOOT_GROUP, distro);
+        profile.save();
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+        MockConnection.clear();
     }
 
     private Map<String, Object> createTestData(String minionId, String saltbootGroup, String root, String saltDevice,
@@ -75,6 +126,20 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
 
         return data;
     }
+
+    private Map<String, Object> createSaltbootTestData(Boolean repartition, Boolean redeploy) {
+        Map<String, Object> data = new HashMap<>();
+        Map<String, Object> saltbootData = new HashMap<>();
+        if (repartition != null) {
+            saltbootData.put("force_repartition", repartition);
+        }
+        if (redeploy != null) {
+            saltbootData.put("force_redeploy", redeploy);
+        }
+        data.put("saltboot", saltbootData);
+        return data;
+    }
+
     /**
      * Tests parsing {@link PXEEvent}.
      * "Happy path" scenario.
@@ -82,8 +147,8 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
     @Test
     public void testParse() {
         Event event = mock(Event.class);
-        Map<String, Object> data = createTestData("minion.local", "groupPrefix", "root=/dev/sda1",
-                "/dev/sda1", "POS_Image_JeOS7-7.0.0-1", "custom=option", true);
+        Map<String, Object> data = createTestData(MINION_ID, SALTBOOT_GROUP, "root=/dev/sda1",
+                "/dev/sda1", BOOT_IMAGE, "custom=option", true);
         context().checking(new Expectations() {{
             allowing(event).getTag();
             will(returnValue("suse/manager/pxe_update"));
@@ -95,12 +160,12 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
 
         assertTrue(parsed.isPresent());
         parsed.ifPresent(e -> {
-            assertEquals("minion.local", e.getMinionId());
-            assertEquals("groupPrefix", e.getSaltbootGroup());
+            assertEquals(MINION_ID, e.getMinionId());
+            assertEquals(SALTBOOT_GROUP, e.getSaltbootGroup());
             assertEquals("root=/dev/sda1", e.getRoot());
             assertEquals(Optional.of("/dev/sda1"), e.getSaltDevice());
             assertEquals(Optional.of("custom=option"), e.getKernelParameters());
-            assertEquals("POS_Image_JeOS7-7.0.0-1", e.getBootImage());
+            assertEquals(BOOT_IMAGE, e.getBootImage());
             // Localhost device should be parsed out
             assertEquals(1, e.getHwAddresses().size());
             assertEquals(e.getHwAddresses().get(0), "00:11:22:33:44:55");
@@ -142,8 +207,8 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
     @Test
     public void testParseNoHWaddresses() {
         Event event = mock(Event.class);
-        Map<String, Object> data = createTestData("minion.local", "groupPrefix", "root=/dev/sda1",
-                "/dev/sda1", "POS_Image_JeOS7-7.0.0-1", "custom=option", false);
+        Map<String, Object> data = createTestData(MINION_ID, SALTBOOT_GROUP, "root=/dev/sda1",
+                "/dev/sda1", BOOT_IMAGE, "custom=option", false);
         context().checking(new Expectations() {{
             allowing(event).getTag();
             will(returnValue("suse/manager/pxe_update"));
@@ -159,8 +224,8 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
     @Test
     public void testParseNoRoot() {
         Event event = mock(Event.class);
-        Map<String, Object> data = createTestData("minion.local", "groupPrefix", "",
-                "/dev/sda1", "POS_Image_JeOS7-7.0.0-1", "custom=option", true);
+        Map<String, Object> data = createTestData(MINION_ID, SALTBOOT_GROUP, "",
+                "/dev/sda1", BOOT_IMAGE, "custom=option", true);
         context().checking(new Expectations() {{
             allowing(event).getTag();
             will(returnValue("suse/manager/pxe_update"));
@@ -176,7 +241,7 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
     @Test
     public void testParseNoBootImage() {
         Event event = mock(Event.class);
-        Map<String, Object> data = createTestData("minion.local", "groupPrefix", "root=/dev/sda1",
+        Map<String, Object> data = createTestData(MINION_ID, SALTBOOT_GROUP, "root=/dev/sda1",
                 "/dev/sda1", "", "custom=option", true);
         context().checking(new Expectations() {{
             allowing(event).getTag();
@@ -193,8 +258,8 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
     @Test
     public void testParseNoKernelOptions() {
         Event event = mock(Event.class);
-        Map<String, Object> data = createTestData("minion.local", "groupPrefix", "root=/dev/sda1",
-                "/dev/sda1", "POS_Image_JeOS7-7.0.0-1", "", true);
+        Map<String, Object> data = createTestData(MINION_ID, SALTBOOT_GROUP, "root=/dev/sda1",
+                "/dev/sda1", BOOT_IMAGE, "", true);
         context().checking(new Expectations() {{
             allowing(event).getTag();
             will(returnValue("suse/manager/pxe_update"));
@@ -205,12 +270,12 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
 
         assertTrue(parsed.isPresent());
         parsed.ifPresent(e -> {
-            assertEquals("minion.local", e.getMinionId());
-            assertEquals("groupPrefix", e.getSaltbootGroup());
+            assertEquals(MINION_ID, e.getMinionId());
+            assertEquals(SALTBOOT_GROUP, e.getSaltbootGroup());
             assertEquals("root=/dev/sda1", e.getRoot());
             assertEquals(Optional.of("/dev/sda1"), e.getSaltDevice());
             assertEquals(Optional.empty(), e.getKernelParameters());
-            assertEquals("POS_Image_JeOS7-7.0.0-1", e.getBootImage());
+            assertEquals(BOOT_IMAGE, e.getBootImage());
             // Localhost device should be parsed out
             assertEquals(1, e.getHwAddresses().size());
             assertEquals(e.getHwAddresses().get(0), "00:11:22:33:44:55");
@@ -223,8 +288,8 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
     @Test
     public void testParseNoSaltDevice() {
         Event event = mock(Event.class);
-        Map<String, Object> data = createTestData("minion.local", "groupPrefix", "root=/dev/sda1",
-                "", "POS_Image_JeOS7-7.0.0-1", "custom=option", true);
+        Map<String, Object> data = createTestData(MINION_ID, SALTBOOT_GROUP, "root=/dev/sda1",
+                "", BOOT_IMAGE, "custom=option", true);
         context().checking(new Expectations() {{
             allowing(event).getTag();
             will(returnValue("suse/manager/pxe_update"));
@@ -235,15 +300,289 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
 
         assertTrue(parsed.isPresent());
         parsed.ifPresent(e -> {
-            assertEquals("minion.local", e.getMinionId());
-            assertEquals("groupPrefix", e.getSaltbootGroup());
+            assertEquals(MINION_ID, e.getMinionId());
+            assertEquals(SALTBOOT_GROUP, e.getSaltbootGroup());
             assertEquals("root=/dev/sda1", e.getRoot());
             assertEquals(Optional.empty(), e.getSaltDevice());
             assertEquals(Optional.of("custom=option"), e.getKernelParameters());
-            assertEquals("POS_Image_JeOS7-7.0.0-1", e.getBootImage());
+            assertEquals(BOOT_IMAGE, e.getBootImage());
             // Localhost device should be parsed out
             assertEquals(1, e.getHwAddresses().size());
             assertEquals(e.getHwAddresses().get(0), "00:11:22:33:44:55");
         });
+    }
+
+    /**
+     * Tests default PXE event handling
+     *
+     * Processing the event, when repart or redeploy flags are not set and when saltboot-formula is minion formula
+     * @throws Exception
+     */
+    @Test
+    public void testPXEEventAction() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+
+        Event event = mock(Event.class);
+        Map<String, Object> data = createTestData(minion.getMinionId(), SALTBOOT_GROUP, "root=/dev/sda1",
+                "/dev/sda1", BOOT_IMAGE, "custom=option", true);
+        context().checking(new Expectations() {{
+            allowing(event).getTag();
+            will(returnValue("suse/manager/pxe_update"));
+            allowing(event).getData();
+            will(returnValue(data));
+        }});
+
+        Optional<PXEEvent> pxeevent = PXEEvent.parse(event);
+        assertTrue(pxeevent.isPresent());
+
+        PXEEventMessage pxemsg = new PXEEventMessage(pxeevent.get());
+        PXEEventMessageAction action = new PXEEventMessageAction();
+
+        // Add pillar data without any redeployment flag
+        Set<Pillar> pillars = new HashSet<>();
+        pillars.add(new Pillar(FORMULA, createSaltbootTestData(null, null), minion));
+        minion.setPillars(pillars);
+        TestUtils.saveAndFlush(minion);
+        minion = reload(minion);
+
+        assertTrue(minion.getPillarByCategory(FORMULA).isPresent());
+
+        // Do the thing
+        action.execute(pxemsg);
+
+        // Validate pillar data, there shouldn't be any saltboot redeploy pillars
+        minion = reload(minion);
+        assertTrue(minion.getPillarByCategory(FORMULA).isPresent());
+        Pillar returnedPillar = minion.getPillarByCategory(FORMULA).get();
+        Map<String, Object> saltboot = (Map<String, Object>)returnedPillar.getPillar().get("saltboot");
+        assertNull(saltboot.get("force_redeploy"));
+        assertNull(saltboot.get("force_repartition"));
+
+        // Validate custom info data, there shouldn't be any
+        CustomDataKey saltbootRedeploy = OrgFactory.lookupKeyByLabelAndOrg("saltboot_force_redeploy", minion.getOrg());
+        CustomDataValue redeploy = minion.getCustomDataValue(saltbootRedeploy);
+        assertNull(redeploy);
+
+        CustomDataKey saltbootRepart = OrgFactory.lookupKeyByLabelAndOrg("saltboot_force_repartition", minion.getOrg());
+        CustomDataValue repart = minion.getCustomDataValue(saltbootRepart);
+        assertNull(repart);
+
+        // System should be registered in cobbler
+        assertNotNull(minion.getCobblerId());
+        assertNotNull(SystemRecord.lookupByName(cobblerMock, user.getOrg().getId() + "-" + minion.getMinionId()));
+    }
+
+    /**
+     * Tests default PXE event handling
+     *
+     * Processing the event, when repart or redeploy flags are not set and when saltboot-formula is group formula
+     * @throws Exception
+     */
+    @Test
+    public void testPXEEventActionNoFlag() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        ServerGroup hwtypeGroup = ServerGroupFactory.create("HWTYPE:test", "testgroup", user.getOrg());
+        minion.addGroup(hwtypeGroup);
+
+        Event event = mock(Event.class);
+        Map<String, Object> data = createTestData(minion.getMinionId(), SALTBOOT_GROUP, "root=/dev/sda1",
+                "/dev/sda1", BOOT_IMAGE, "custom=option", true);
+        context().checking(new Expectations() {{
+            allowing(event).getTag();
+            will(returnValue("suse/manager/pxe_update"));
+            allowing(event).getData();
+            will(returnValue(data));
+        }});
+
+        Optional<PXEEvent> pxeevent = PXEEvent.parse(event);
+        assertTrue(pxeevent.isPresent());
+
+        PXEEventMessage pxemsg = new PXEEventMessage(pxeevent.get());
+        PXEEventMessageAction action = new PXEEventMessageAction();
+
+
+        // Create group saltboot pillar
+        Set<Pillar> pillars = new HashSet<>();
+        pillars.add(new Pillar(FORMULA, createSaltbootTestData(null, null), hwtypeGroup));
+        hwtypeGroup.setPillars(pillars);
+        TestUtils.saveAndFlush(hwtypeGroup);
+        hwtypeGroup = reload(hwtypeGroup);
+
+        assertFalse(minion.getPillarByCategory(FORMULA).isPresent());
+        assertTrue(hwtypeGroup.getPillarByCategory(FORMULA).isPresent());
+
+        // Do the thing
+        action.execute(pxemsg);
+
+        // Validate pillar data
+        minion = reload(minion);
+        hwtypeGroup = reload(hwtypeGroup);
+        assertFalse(minion.getPillarByCategory(FORMULA).isPresent());
+        assertTrue(hwtypeGroup.getPillarByCategory(FORMULA).isPresent());
+        Pillar returnedPillar = hwtypeGroup.getPillarByCategory(FORMULA).get();
+        Map<String, Object> saltboot = (Map<String, Object>)returnedPillar.getPillar().get("saltboot");
+        assertNull(saltboot.get("force_redeploy"));
+        assertNull(saltboot.get("force_repartition"));
+
+        // Validate custom info data
+        CustomDataKey saltbootRedeploy = OrgFactory.lookupKeyByLabelAndOrg("saltboot_force_redeploy", minion.getOrg());
+        CustomDataValue redeploy = minion.getCustomDataValue(saltbootRedeploy);
+        assertNull(redeploy);
+
+        CustomDataKey saltbootRepart = OrgFactory.lookupKeyByLabelAndOrg("saltboot_force_repartition", minion.getOrg());
+        CustomDataValue repart = minion.getCustomDataValue(saltbootRepart);
+        assertNull(repart);
+
+        assertNotNull(minion.getCobblerId());
+        assertNotNull(SystemRecord.lookupByName(cobblerMock, user.getOrg().getId() + "-" + minion.getMinionId()));
+    }
+
+    @Test
+    public void testPXEEventActionPillarOnly() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        ServerGroup hwtypeGroup = ServerGroupFactory.create("HWTYPE:test", "testgroup", user.getOrg());
+        minion.addGroup(hwtypeGroup);
+
+        Event event = mock(Event.class);
+        Map<String, Object> data = createTestData(minion.getMinionId(), SALTBOOT_GROUP, "root=/dev/sda1",
+                "/dev/sda1", BOOT_IMAGE, "custom=option", true);
+        context().checking(new Expectations() {{
+            allowing(event).getTag();
+            will(returnValue("suse/manager/pxe_update"));
+            allowing(event).getData();
+            will(returnValue(data));
+        }});
+
+        Optional<PXEEvent> pxeevent = PXEEvent.parse(event);
+        assertTrue(pxeevent.isPresent());
+
+        PXEEventMessage pxemsg = new PXEEventMessage(pxeevent.get());
+        PXEEventMessageAction action = new PXEEventMessageAction();
+
+        // Generic group pillar
+        Set<Pillar> pillars = new HashSet<>();
+        pillars.add(new Pillar(FORMULA, createSaltbootTestData(null, null), hwtypeGroup));
+        hwtypeGroup.setPillars(pillars);
+        TestUtils.saveAndFlush(hwtypeGroup);
+        hwtypeGroup = reload(hwtypeGroup);
+
+        // Override by system pillar with redeploy flag
+        pillars = new HashSet<>();
+        pillars.add(new Pillar(FORMULA, createSaltbootTestData(true, true), minion));
+        minion.setPillars(pillars);
+        TestUtils.saveAndFlush(minion);
+        minion = reload(minion);
+
+        assertTrue(hwtypeGroup.getPillarByCategory(FORMULA).isPresent());
+        assertTrue(minion.getPillarByCategory(FORMULA).isPresent());
+        Pillar returnedPillar = hwtypeGroup.getPillarByCategory(FORMULA).get();
+        Map<String, Object> saltboot = (Map<String, Object>)returnedPillar.getPillar().get("saltboot");
+        assertNull(saltboot.get("force_redeploy"));
+        assertNull(saltboot.get("force_repartition"));
+        returnedPillar = minion.getPillarByCategory(FORMULA).get();
+        saltboot = (Map<String, Object>)returnedPillar.getPillar().get("saltboot");
+        assertNotNull(saltboot.get("force_redeploy"));
+        assertNotNull(saltboot.get("force_repartition"));
+
+        // Do the thing
+        action.execute(pxemsg);
+
+        // Validate pillar data
+        // group data should not be touched, minion data should be reset
+        minion = reload(minion);
+        hwtypeGroup = reload(hwtypeGroup);
+        assertTrue(minion.getPillarByCategory(FORMULA).isPresent());
+        assertTrue(hwtypeGroup.getPillarByCategory(FORMULA).isPresent());
+        returnedPillar = hwtypeGroup.getPillarByCategory(FORMULA).get();
+        saltboot = (Map<String, Object>)returnedPillar.getPillar().get("saltboot");
+        assertNull(saltboot.get("force_redeploy"));
+        assertNull(saltboot.get("force_repartition"));
+        returnedPillar = minion.getPillarByCategory(FORMULA).get();
+        saltboot = (Map<String, Object>)returnedPillar.getPillar().get("saltboot");
+        assertNull(saltboot.get("force_redeploy"));
+        assertNull(saltboot.get("force_repartition"));
+
+        // Validate custom info data
+        CustomDataKey saltbootRedeploy = OrgFactory.lookupKeyByLabelAndOrg("saltboot_force_redeploy", minion.getOrg());
+        CustomDataValue redeploy = minion.getCustomDataValue(saltbootRedeploy);
+        assertNull(redeploy);
+
+        CustomDataKey saltbootRepart = OrgFactory.lookupKeyByLabelAndOrg("saltboot_force_repartition", minion.getOrg());
+        CustomDataValue repart = minion.getCustomDataValue(saltbootRepart);
+        assertNull(repart);
+
+        assertNotNull(minion.getCobblerId());
+        assertNotNull(SystemRecord.lookupByName(cobblerMock, user.getOrg().getId() + "-" + minion.getMinionId()));
+    }
+
+    /**
+     * Tests default PXE event handling
+     *
+     * Processing the event, when repart or redeploy flags are not set and when saltboot-formula is group formula
+     * @throws Exception
+     */
+    @Test
+    public void testPXEEventActionCustomInfoOnly() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        ServerGroup hwtypeGroup = ServerGroupFactory.create("HWTYPE:test", "testgroup", user.getOrg());
+
+        Event event = mock(Event.class);
+        Map<String, Object> data = createTestData(minion.getMinionId(), SALTBOOT_GROUP, "root=/dev/sda1",
+                "/dev/sda1", BOOT_IMAGE, "custom=option", true);
+        context().checking(new Expectations() {{
+            allowing(event).getTag();
+            will(returnValue("suse/manager/pxe_update"));
+            allowing(event).getData();
+            will(returnValue(data));
+        }});
+
+        Optional<PXEEvent> pxeevent = PXEEvent.parse(event);
+        assertTrue(pxeevent.isPresent());
+
+        PXEEventMessage pxemsg = new PXEEventMessage(pxeevent.get());
+        PXEEventMessageAction action = new PXEEventMessageAction();
+
+        Set<Pillar> pillars = new HashSet<>();
+        pillars.add(new Pillar(FORMULA, createSaltbootTestData(null, null), hwtypeGroup));
+        hwtypeGroup.setPillars(pillars);
+        TestUtils.saveAndFlush(hwtypeGroup);
+        hwtypeGroup = reload(hwtypeGroup);
+
+        assertFalse(minion.getPillarByCategory(FORMULA).isPresent());
+        assertTrue(hwtypeGroup.getPillarByCategory(FORMULA).isPresent());
+
+        CustomDataKey saltbootRedeploy = createTestCustomDataKey(user, "saltboot_force_redeploy");
+        CustomDataKey saltbootRepart = createTestCustomDataKey(user, "saltboot_force_repartition");
+
+        user.getOrg().addCustomDataKey(saltbootRedeploy);
+        user.getOrg().addCustomDataKey(saltbootRepart);
+
+        createTestCustomDataValue(user, saltbootRedeploy, minion, "True");
+        createTestCustomDataValue(user, saltbootRepart, minion, "True");
+
+        // Do the thing
+        action.execute(pxemsg);
+
+        // Validate pillar data
+        minion = reload(minion);
+        hwtypeGroup = reload(hwtypeGroup);
+        assertFalse(minion.getPillarByCategory(FORMULA).isPresent());
+        assertTrue(hwtypeGroup.getPillarByCategory(FORMULA).isPresent());
+        Pillar returnedPillar = hwtypeGroup.getPillarByCategory(FORMULA).get();
+        Map<String, Object> saltboot = (Map<String, Object>)returnedPillar.getPillar().get("saltboot");
+        assertNull(saltboot.get("force_redeploy"));
+        assertNull(saltboot.get("force_repartition"));
+
+        // Validate custom info data
+        saltbootRedeploy = OrgFactory.lookupKeyByLabelAndOrg("saltboot_force_redeploy", minion.getOrg());
+        CustomDataValue redeploy = minion.getCustomDataValue(saltbootRedeploy);
+        assertNull(redeploy);
+
+        saltbootRepart = OrgFactory.lookupKeyByLabelAndOrg("saltboot_force_repartition", minion.getOrg());
+        CustomDataValue repart = minion.getCustomDataValue(saltbootRepart);
+        assertNull(repart);
+
+        assertNotNull(minion.getCobblerId());
+        assertNotNull(SystemRecord.lookupByName(cobblerMock, user.getOrg().getId() + "-" + minion.getMinionId()));
     }
 }

--- a/java/spacewalk-java.changes.oholecek.saltboot_pillars
+++ b/java/spacewalk-java.changes.oholecek.saltboot_pillars
@@ -1,0 +1,2 @@
+- Add saltboot redeploy and repartition based on pillars
+  (jsc#SUMA-158)

--- a/java/spacewalk-java.changes.oholecek.saltboot_pillars
+++ b/java/spacewalk-java.changes.oholecek.saltboot_pillars
@@ -1,2 +1,3 @@
 - Add saltboot redeploy and repartition based on pillars
   (jsc#SUMA-158)
+- Add system pillar API access {get|set}Pillar

--- a/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
+++ b/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
@@ -156,11 +156,13 @@ def ext_pillar(minion_id, pillar, *args):
         ret = load_global_pillars(cursor, ret)
         ret = load_org_pillars(minion_id, cursor, ret)
         group_formulas, ret = load_group_pillars(minion_id, cursor, ret)
-        system_formulas, ret= load_system_pillars(minion_id, cursor, ret)
+        system_formulas, ret = load_system_pillars(minion_id, cursor, ret)
 
     # Including formulas into pillar data
     try:
-        ret.update(formula_pillars(system_formulas, group_formulas, ret))
+        ret = salt.utils.dictupdate.merge(ret,
+                   formula_pillars(system_formulas, group_formulas, ret),
+                   strategy='recurse')
     except Exception as error:
         log.error('Error accessing formula pillar data: %s', error)
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.oholecek.recurse_formula_pillar
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.oholecek.recurse_formula_pillar
@@ -1,0 +1,1 @@
+- Use recurse stratedy to merge formula pillar with existing pillars


### PR DESCRIPTION
## What does this PR change?

This PR add java side handling of saltboot pillars and custom info to be able to force disk repartitioning and/or image redeployment.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pull/2375)

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/21884
Tracks https://github.com/SUSE/spacewalk/pull/22057

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
