### PR TITLE
Add scenario to ensure that uptodate state works properly on recurring actions

### DIFF
--- a/testsuite/features/secondary/min_recurring_action.feature
+++ b/testsuite/features/secondary/min_recurring_action.feature
@@ -140,6 +140,35 @@ Feature: Recurring Actions
     And I click on "Join Selected Groups"
     Then I wait until I see "1 system groups added" text
 
+  Scenario: Pre-requisite: subscribe system to Fake Channel
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    And I check radio button "Fake Base Channel"
+    And I wait until I do not see "Loading..." text
+    And I check "Fake Child Channel"
+    And I click on "Next"
+    Then I should see a "Confirm Software Channel Change" text
+    When I click on "Confirm"
+    Then I should see a "Changing the channels has been scheduled." text
+    And I wait until event "Subscribe channels scheduled by admin" is completed
+
+  Scenario: Pre-requisite: downgrade milkyway-dummy to lower version
+    When I enable repository "test_repo_rpm_pool" on this "sle_minion"
+    And I install old package "milkyway-dummy-1.0" on this "sle_minion"
+    And I refresh the metadata for "sle_minion"
+    And I follow the left menu "Admin > Task Schedules"
+    And I follow "errata-cache-default"
+    And I follow "errata-cache-bunch"
+    And I click on "Single Run Schedule"
+    Then I should see a "bunch was scheduled" text
+    And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
+
+  Scenario: Pre-requisite: check that there are updates available
+    Given I am on the Systems overview page of this "sle_minion"
+    Then I should see a "Software Updates Available" text
+
   Scenario: Create a recurring action to apply "uptodate" state to a system group
     When I follow the left menu "Systems > System Groups"
     And I follow "Recurring-Action-test-group"
@@ -163,6 +192,21 @@ Feature: Recurring Actions
     When I am on the "Events" page of this "sle_minion"
     And I follow "History"
     Then I wait until I see the event "Apply recurring states [uptodate] scheduled by admin" completed during last minute, refreshing the page
+    When I am on the Systems overview page of this "sle_minion"
+    Then I wait until I see "System is up to date" text, refreshing the page
+
+  Scenario: Cleanup: subscribe system back to default base channel
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    And I check default base channel radio button of this "sle_minion"
+    And I wait until I do not see "Loading..." text
+    And I click on "Next"
+    Then I should see a "Confirm Software Channel Change" text
+    When I click on "Confirm"
+    Then I should see a "Changing the channels has been scheduled." text
+    And I wait until event "Subscribe channels scheduled by admin" is completed
 
   Scenario: Edit the group Recurring Action
     When I follow the left menu "Systems > System Groups"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -201,6 +201,11 @@ When(/^I check radio button "(.*?)"$/) do |arg1|
   raise "#{arg1} can't be checked" unless choose(arg1)
 end
 
+When(/^I check default base channel radio button of this "([^"]*)"$/) do |host|
+  default_base_channel = BASE_CHANNEL_BY_CLIENT[product][host]
+  raise "#{default_base_channel} can't be checked" unless choose(default_base_channel)
+end
+
 When(/^I enter as remote command this script in$/) do |multiline|
   find(:xpath, '//textarea[@name="script_body"]').set(multiline)
 end


### PR DESCRIPTION
## What does this PR change?

See title.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: testsuite

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/21488

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
