### PR TITLE
fix logging of libraries using apache-commons-logging

### DIFF
--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -71,7 +71,8 @@
 
   <available file="${java.lib.dir}/log4j/log4j-core.jar" type="file" property="log4j-core" value="log4j/log4j-core" />
   <available file="${java.lib.dir}/log4j/log4j-api.jar" type="file" property="log4j-api" value="log4j/log4j-api" />
-  <property name="log4j-jars" value="${log4j-core} ${log4j-api}"/>
+  <available file="${java.lib.dir}/log4j/log4j-jcl.jar" type="file" property="log4j-jcl" value="log4j/log4j-jcl" />
+  <property name="log4j-jars" value="${log4j-core} ${log4j-api} ${log4j-jcl}"/>
 
   <condition property="jta11-jars" value="geronimo-jta-1.1-api" else="jta">
     <available file="${java.lib.dir}/geronimo-jta-1.1-api.jar" />

--- a/java/spacewalk-java.changes.mc.fix-lib-logging
+++ b/java/spacewalk-java.changes.mc.fix-lib-logging
@@ -1,0 +1,1 @@
+- fix logging of libraries using apache-commons-logging

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -119,6 +119,7 @@ BuildRequires:  jsch
 BuildRequires:  jta
 BuildRequires:  libxml2
 BuildRequires:  log4j
+BuildRequires:  log4j-jcl
 BuildRequires:  log4j-slf4j
 BuildRequires:  netty
 BuildRequires:  objectweb-asm >= 9.2
@@ -206,6 +207,7 @@ Requires:       jpa-api
 Requires:       jta
 Requires:       libsolv-tools
 Requires:       log4j
+Requires:       log4j-jcl
 Requires:       log4j-slf4j
 Requires:       mgr-libmod
 Requires:       netty
@@ -363,6 +365,7 @@ Requires:       jcommon
 Requires:       jpa-api
 Requires:       jsch
 Requires:       log4j
+Requires:       log4j-jcl
 Requires:       quartz
 Requires:       simple-core
 Requires:       spacewalk-java-config


### PR DESCRIPTION
## What does this PR change?

Some libs we use, use apache-commons-logging and we want to print such messages also in our logs.
Example:  `org.apache.http` 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **just additional logging**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/22059

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
