### PR TITLE
Mask uyuni roster module password on logs

### DIFF
--- a/susemanager-utils/susemanager-sls/modules/roster/uyuni.py
+++ b/susemanager-utils/susemanager-sls/modules/roster/uyuni.py
@@ -89,9 +89,9 @@ class UyuniRoster:
                 )
             )
 
-        log.trace("db_connect dbname: %s", db_config['db'])
-        log.trace("db_connect   user: %s", db_config['user'])
-        log.trace("db_connect   host: %s", db_config['host'])
+        log.trace("db_connect dbname: %s", db_config["db"])
+        log.trace("db_connect   user: %s", db_config["user"])
+        log.trace("db_connect   host: %s", db_config["host"])
         log.debug("ssh_pre_flight_script: %s", self.ssh_pre_flight_script)
         log.debug("ssh_push_port_https: %d", self.ssh_push_port_https)
         log.debug("ssh_push_sudo_user: %s", self.ssh_push_sudo_user)


### PR DESCRIPTION
## What does this PR change?

Fixing single (to double) quotes on log. 
(should have be included in https://github.com/SUSE/spacewalk/pull/22016)

## What does this PR change?

Creating Uyuni connection instances ends up logging db connection password. 
This PR masks it.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage
- No tests: Cosmetic change on logs

- [ ] **DONE**

## Links

Fixes #19859

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
