### PR TITLE
Optimize memory usage in UbuntuErrataManager

### DIFF
--- a/java/spacewalk-java.changes.nadvornik.ubuntu_errata_opt
+++ b/java/spacewalk-java.changes.nadvornik.ubuntu_errata_opt
@@ -1,0 +1,1 @@
+- Optimize memory usage in UbuntuErrataManager


### PR DESCRIPTION
## What does this PR change?

This PR optimizes memory usage in UbuntuErrataManager. 
Without this change, calling UbuntuErrataManager increased the memory used by freshly started taskomatic process
from 0.5GB to 2.5GB. With this PR it is 0.5GB to 1.5GB

Most of the memory was consumed by the `cveByName` lookup table, which contained hibernate objects for all CVEs mentioned in errata file.
With this PR, the CVEs are created only when they are referenced from `Errata` entry and only if they do not exist yet.

Additional memory is saved by removing unnecessary conversion from stream to list and back.

The speed is about the same as before.

There is a change in the behavior regarding CVE entries, that are not referenced by any package from synced channels.
Before, such entries were written to the DB, now they are skipped. I am not sure if this is a problem.
Update: `Cve` entries are used only with `Errata`, so skipping CVEs that are not referenced is OK.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: optimization
- [x] **DONE**

## Test coverage
- No tests: already covered by cucumber tests

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
