### PR TITLE
Wrap message at 67 characters with mkchlog

### DIFF
--- a/rel-eng/bin/mkchlog
+++ b/rel-eng/bin/mkchlog
@@ -20,6 +20,7 @@ The default editor can be specified by setting the EDITOR environment variable.
   -f, --feature         set the feature name to use as a filename part
   -u, --username        set the username to use as a filename part
   -r, --remove          remove existing changelog file
+  -n, --no-wrap         do not wrap automatically the message at 67 characters
   -h, --help            display this help and exit
 
 Uyuni project: <https://github.com/uyuni-project/uyuni>
@@ -44,6 +45,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         -r|--remove)
             REMOVE=1
+            shift
+            ;;
+        -n|--no-wrap)
+            NO_WRAP=true
             shift
             ;;
         *)
@@ -140,7 +145,11 @@ if ! [ -z $REMOVE ]; then
 fi
 
 # Add the new entry
-echo "- $1" > $CHFILE.new
+if [ "$NO_WRAP" = true ]; then
+    echo "- $1" > $CHFILE.new
+else
+    echo "$1" | fold -s -w 65 | sed '1s/^.*$/- &/;2,$s/^.*$/  &/' > $CHFILE.new
+fi
 
 # Append older entries
 cat $CHFILE >> $CHFILE.new 2>/dev/null


### PR DESCRIPTION
## What does this PR change?

This PR makes `mkchlog` wrap the message at 67 characters like specified [in the wiki](https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs). This works only for the text specified on the command line. When editing the file with the editor, no changes are made to the user input.

An additional option `-n, --no-wrap` is added to allow avoiding the automatic text wrapping if needed.

 For example:

```
mkchlog "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus ultricies ac metus a varius. Phasellus quis nisi ac libero maximus lobortis accumsan."
```

Will produce the following changelog:
```
- Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus 
  ultricies ac metus a varius. Phasellus quis nisi ac libero 
  maximus lobortis accumsan.
```

while:
```
mkchlog -n "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus ultricies ac metus a varius. Phasellus quis nisi ac libero maximus lobortis accumsan."
```

Will produce:
```
- Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus ultricies ac metus a varius. Phasellus quis nisi ac libero maximus lobortis accumsan.
```

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
