### PR TITLE
backup current cobbler settings.yaml before we restore it

### DIFF
--- a/testsuite/features/secondary/srv_cobbler_buildiso.feature
+++ b/testsuite/features/secondary/srv_cobbler_buildiso.feature
@@ -8,6 +8,7 @@ Feature: Cobbler buildiso
 
   Scenario: Start Cobbler monitoring
     When I start local monitoring of Cobbler
+    And I backup Cobbler settings file
 
   Scenario: Log in as testing user in the cobbler buildiso context
     Given I am authorized as "testing" with password "testing"

--- a/testsuite/features/secondary/srv_cobbler_distro.feature
+++ b/testsuite/features/secondary/srv_cobbler_distro.feature
@@ -7,6 +7,7 @@ Feature: Cobbler and distribution autoinstallation
 
   Scenario: Start Cobbler monitoring
     When I start local monitoring of Cobbler
+    And I backup Cobbler settings file
 
   Scenario: Log in as testing user
     Given I am authorized as "testing" with password "testing"

--- a/testsuite/features/secondary/srv_cobbler_profile.feature
+++ b/testsuite/features/secondary/srv_cobbler_profile.feature
@@ -14,6 +14,7 @@ Feature: Edit Cobbler profiles
 
   Scenario: Copy cobbler profiles on the server
     When I copy autoinstall mocked files on server
+    And I backup Cobbler settings file
 
   Scenario: Log in as testing user
     Given I am authorized as "testing" with password "testing"

--- a/testsuite/features/secondary/srv_cobbler_sync.feature
+++ b/testsuite/features/secondary/srv_cobbler_sync.feature
@@ -10,6 +10,7 @@ Feature: Run Cobbler Sync via WebUI
 
   Scenario: Start Cobbler monitoring
     When I start local monitoring of Cobbler
+    And I backup Cobbler settings file
 
   @uyuni
   Scenario: Check that the Cobbler Settings Page exists

--- a/testsuite/features/step_definitions/cobbler_steps.rb
+++ b/testsuite/features/step_definitions/cobbler_steps.rb
@@ -221,7 +221,6 @@ When(/^I check the Cobbler parameter "([^"]*)" with value "([^"]*)" in the isoli
 end
 
 # backup step
-
 When(/^I backup Cobbler settings file$/) do
   $server.run('cp /etc/cobbler/settings.yaml /etc/cobbler/settings.yaml.bak 2> /dev/null', check_errors: false)
 end

--- a/testsuite/features/step_definitions/cobbler_steps.rb
+++ b/testsuite/features/step_definitions/cobbler_steps.rb
@@ -220,6 +220,12 @@ When(/^I check the Cobbler parameter "([^"]*)" with value "([^"]*)" in the isoli
   raise "error while verifying isolinux.cfg parameter for Cobbler buildiso.\nLogs:\n#{result}" if code.nonzero?
 end
 
+# backup step
+
+When(/^I backup Cobbler settings file$/) do
+  $server.run('cp /etc/cobbler/settings.yaml /etc/cobbler/settings.yaml.bak 2> /dev/null', check_errors: false)
+end
+
 # cleanup steps
 When(/^I cleanup after Cobbler buildiso$/) do
   result, code = $server.run('rm -Rf /var/cache/cobbler')


### PR DESCRIPTION
## What does this PR change?

We restore cobbler settings.yaml from a backup which might be outdated when other tests were skipped before.
So create explicit a backup of this file before we start the test which at the end restore it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/22067

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
