### PR TITLE
Call mgr-libmod with its absolute path

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ModulemdApi.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ModulemdApi.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 public class ModulemdApi {
 
     private static final String MOUNT_POINT_PATH = Config.get().getString(ConfigDefaults.MOUNT_POINT);
-    private static final String API_EXE = "mgr-libmod";
+    private static final String API_EXE = "/usr/bin/mgr-libmod";
     public static final Gson GSON =
             new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create();
 

--- a/java/spacewalk-java.changes.cbbayburt.mgr-libmod-path
+++ b/java/spacewalk-java.changes.cbbayburt.mgr-libmod-path
@@ -1,0 +1,1 @@
+- Call mgr-libmod with its absolute path


### PR DESCRIPTION
Call mgr-libmod using its absolute path to prevent $PATH hijacking.

Reported as a security hotstpot by SonarCloud:
https://sonarcloud.io/project/security_hotspots?id=uyuni-project_uyuni&hotspots=AYMYhYqW5TQr2KFg-0P4

## Documentation
- No documentation needed: Bugfix

## Test coverage
- No tests: already covered

## Links

Fixes https://github.com/SUSE/spacewalk/issues/21416

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
