### PR TITLE
invalidate PAYG client credentials after repeated connection failure

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygAuthDataProcessor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygAuthDataProcessor.java
@@ -139,6 +139,20 @@ public class PaygAuthDataProcessor {
         return credentials;
     }
 
+    /**
+     * Invalidate PAYG Instance credentials
+     * @param instance the instance
+     */
+    public void invalidateCredentials(PaygSshData instance) {
+        Optional.ofNullable(instance.getCredentials())
+                .ifPresent(c -> {
+                    Map<String, String> headers = new HashMap<>();
+                    c.setExtraAuthData(GSON.toJson(headers).getBytes());
+                    c.setPassword("invalidated");
+                    CredentialsFactory.storeCredentials(c);
+                });
+    }
+
     private List<SCCRepository> getReposToInsert(List<PaygProductInfo> products) {
         return products.stream().map(product ->
             SCCCachingFactory.lookupRepositoriesByProductNameAndArchForPayg(product.getName(), product.getArch())

--- a/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygUpdateAuthTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygUpdateAuthTask.java
@@ -108,6 +108,11 @@ public class PaygUpdateAuthTask extends RhnJavaJob {
             UserNotificationFactory.storeNotificationMessageFor(notificationMessage,
                     Collections.singleton(RoleFactory.CHANNEL_ADMIN), Optional.empty());
         }
+        else {
+            // was in error state before. At least second time failed to get the data
+            // invalidate existing credentials
+            paygDataProcessor.invalidateCredentials(instance);
+        }
         instance.setStatus(PaygSshData.Status.E);
         instance.setErrorMessage(errorMessage);
         PaygSshDataFactory.savePaygSshData(instance);

--- a/java/spacewalk-java.changes.mcalmer.invalidate-payg-credentials-after-instance-is-unavailable
+++ b/java/spacewalk-java.changes.mcalmer.invalidate-payg-credentials-after-instance-is-unavailable
@@ -1,0 +1,1 @@
+- invalidate PAYG client credentials after repeated connection failure (bsc#1213445)

--- a/python/spacewalk/satellite_tools/reposync.py
+++ b/python/spacewalk/satellite_tools/reposync.py
@@ -1893,6 +1893,8 @@ class RepoSync(object):
             url.query = ""
             if 'extra_auth' in credentials and credentials['extra_auth']:
                 headers = json.loads(credentials['extra_auth'].tobytes())
+                if not headers:
+                    log2(0, 0, "Empty extra auth headers. Possibly the PAYG instance is down?")
         return {"url": url.getURL(), "http_headers": headers}
 
     def upload_patches(self, notices):

--- a/python/spacewalk/spacewalk-backend.changes.mcalmer.invalidate-payg-credentials-after-instance-is-unavailable
+++ b/python/spacewalk/spacewalk-backend.changes.mcalmer.invalidate-payg-credentials-after-instance-is-unavailable
@@ -1,0 +1,1 @@
+- add hint about missing auth header for PAYG instances (bsc#1213445)


### PR DESCRIPTION
## What does this PR change?

When a connected PAYG client instance is turned off, we should invalidate the credentials to prevent reposync.
Add a hint to reposync so users can fix the issue by turning on the instance again.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- https://github.com/uyuni-project/uyuni-docs/pull/2378

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fix https://github.com/SUSE/spacewalk/issues/22072
Tracks https://github.com/SUSE/spacewalk/pull/22074

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
