### PR TITLE
QE: Fix reposync proxy/Retail branch server

### DIFF
--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -95,12 +95,20 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I enter "SUSE Manager Proxy 4.3" as the filtered product description
     And I select "SUSE Manager Proxy 4.3 x86_64" as a product
     Then I should see the "SUSE Manager Proxy 4.3 x86_64" selected
+    When I click the Add Product button
+    And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
+    And I wait until I see "SUSE Manager Proxy 4.3 x86_64" product has been added
+
+@proxy
+@susemanager
+  Scenario: Add SUSE Manager Retail Branch Server
+    When I follow the left menu "Admin > Setup Wizard > Products"
+    And I wait until I do not see "Loading" text
     And I enter "SUSE Manager Retail Branch Server 4.3" as the filtered product description
     And I select "SUSE Manager Retail Branch Server 4.3 x86_64" as a product
     Then I should see the "SUSE Manager Retail Branch Server 4.3 x86_64" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Manager Proxy 4.3 x86_64" product has been added
     And I wait until I see "SUSE Manager Retail Branch Server 4.3 x86_64" product has been added
 
 @scc_credentials


### PR DESCRIPTION
## What does this PR change?

Fixes 
<img width="1347" alt="image" src="https://github.com/uyuni-project/uyuni/assets/12104291/f3f722d0-6544-48d1-ade8-00c27d3f2c55">

by splitting up the 2 product selections.


Tests on the 4.3. CI in NUE were successful:

```bash
suma-43-ctl:~/spacewalk/testsuite # cucumber features/reposync/dom.feature
Capybara APP Host: https://suma-43-srv.mgr.suse.de:8888
Host 'suma-43-ctl' is alive with determined hostname suma-43-ctl and FQDN suma-43-ctl.mgr.suse.de
Node: suma-43-ctl, OS Version: 15.4, Family: opensuse-leap
Host 'suma-43-srv.mgr.suse.de' is alive with determined hostname suma-43-srv and FQDN suma-43-srv.mgr.suse.de
Node: suma-43-srv, OS Version: 15-SP4, Family: sles
Host 'suma-43-pxy.mgr.suse.de' is alive with determined hostname suma-43-pxy and FQDN suma-43-pxy.mgr.suse.de
Node: suma-43-pxy, OS Version: 15-SP4, Family: sles
Host 'suma-43-min-kvm.mgr.suse.de' is alive with determined hostname suma-43-min-kvm and FQDN suma-43-min-kvm.mgr.suse.de
Node: suma-43-min-kvm, OS Version: 15-SP4, Family: sles
Host 'suma-43-cli-sles15.mgr.suse.de' is alive with determined hostname suma-43-cli-sles15 and FQDN suma-43-cli-sles15.mgr.suse.de
Node: suma-43-cli-sles15, OS Version: 15-SP4, Family: sles
Host 'suma-43-min-sles15.mgr.suse.de' is alive with determined hostname suma-43-min-sles15 and FQDN suma-43-min-sles15.mgr.suse.de
Node: suma-43-min-sles15, OS Version: 15-SP4, Family: sles
Host 'suma-43-minssh-sles15.mgr.suse.de' is alive with determined hostname suma-43-minssh-sles15 and FQDN suma-43-minssh-sles15.mgr.suse.de
Node: suma-43-minssh-sles15, OS Version: 15-SP4, Family: sles
Host 'suma-43-min-centos7.mgr.suse.de' is alive with determined hostname suma-43-min-centos7 and FQDN suma-43-min-centos7.mgr.suse.de
Node: suma-43-min-centos7, OS Version: 7, Family: centos
Host 'suma-43-min-ubuntu2204.mgr.suse.de' is alive with determined hostname suma-43-min-ubuntu2204 and FQDN suma-43-min-ubuntu2204.mgr.suse.de
Node: suma-43-min-ubuntu2204, OS Version: 22.04, Family: ubuntu
Host 'suma-43-min-build.mgr.suse.de' is alive with determined hostname suma-43-min-build and FQDN suma-43-min-build.mgr.suse.de
Node: suma-43-min-build, OS Version: 15-SP4, Family: sles
Activating XML-RPC API
Using the default profile...
Feature: Dom new repositories test

  Scenario: Log in as admin user                  # features/reposync/dom.feature:3
      This scenario ran at: 2023-07-22 10:05:30 +0200
    Given I am authorized for the "Admin" section # features/step_definitions/navigation_steps.rb:408
      This scenario took: 3 seconds

  @proxy @susemanager
  Scenario: Add SUSE Manager Proxy 4.3                                                                # features/reposync/dom.feature:8
      This scenario ran at: 2023-07-22 10:05:33 +0200
    When I follow the left menu "Admin > Setup Wizard > Products"                                     # features/step_definitions/navigation_steps.rb:354
      WARN: Step ends with an ajax transition not finished, let's wait a bit!
    And I wait until I do not see "Loading" text                                                      # features/step_definitions/navigation_steps.rb:43
    And I enter "SUSE Manager Proxy 4.3" as the filtered product description                          # features/step_definitions/navigation_steps.rb:825
    And I select "SUSE Manager Proxy 4.3 x86_64" as a product                                         # features/step_definitions/setup_steps.rb:83
    Then I should see the "SUSE Manager Proxy 4.3 x86_64" selected                                    # features/step_definitions/setup_steps.rb:129
    When I click the Add Product button                                                               # features/step_definitions/setup_steps.rb:151
    And I wait until I see "Selected channels/products were scheduled successfully for syncing." text # features/step_definitions/navigation_steps.rb:39
    And I wait until I see "SUSE Manager Proxy 4.3 x86_64" product has been added                     # features/step_definitions/setup_steps.rb:136
      This scenario took: 19 seconds

  @proxy @susemanager
  Scenario: Add SUSE Manager Retail Branch Server                                                     # features/reposync/dom.feature:20
      This scenario ran at: 2023-07-22 10:05:52 +0200
    When I follow the left menu "Admin > Setup Wizard > Products"                                     # features/step_definitions/navigation_steps.rb:354
      WARN: Step ends with an ajax transition not finished, let's wait a bit!
    And I wait until I do not see "Loading" text                                                      # features/step_definitions/navigation_steps.rb:43
    And I enter "SUSE Manager Retail Branch Server 4.3" as the filtered product description           # features/step_definitions/navigation_steps.rb:825
    And I select "SUSE Manager Retail Branch Server 4.3 x86_64" as a product                          # features/step_definitions/setup_steps.rb:83
    Then I should see the "SUSE Manager Retail Branch Server 4.3 x86_64" selected                     # features/step_definitions/setup_steps.rb:129
    When I click the Add Product button                                                               # features/step_definitions/setup_steps.rb:151
    And I wait until I see "Selected channels/products were scheduled successfully for syncing." text # features/step_definitions/navigation_steps.rb:39
    And I wait until I see "SUSE Manager Retail Branch Server 4.3 x86_64" product has been added      # features/step_definitions/setup_steps.rb:136
      This scenario took: 40 seconds

3 scenarios (3 passed)
17 steps (17 passed)
1m1.995s
```

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links

Manager 4.3: 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
