### PR TITLE
Expand unit tests for Recurring Actions

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/recurringactions/RecurringActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/recurringactions/RecurringActionManager.java
@@ -140,11 +140,7 @@ public class RecurringActionManager extends BaseManager {
                                                                      long minionId, User user) {
         MinionServer minion = MinionServerFactory.lookupById(minionId)
                 .orElseThrow(() -> new EntityNotExistsException(MinionServer.class, minionId));
-        MinionRecurringAction action = new MinionRecurringAction(
-                createRecurringActionType(actionType),
-                true, minion, user
-        );
-        return action;
+        return new MinionRecurringAction(createRecurringActionType(actionType), true, minion, user);
     }
 
     /**
@@ -160,10 +156,7 @@ public class RecurringActionManager extends BaseManager {
         if (group == null) {
             throw new EntityNotExistsException(ServerGroup.class, groupId);
         }
-        GroupRecurringAction action = new GroupRecurringAction(
-                createRecurringActionType(actionType),
-                true, group, user);
-        return action;
+        return new GroupRecurringAction(createRecurringActionType(actionType), true, group, user);
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/RecurringActionController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/RecurringActionController.java
@@ -190,11 +190,12 @@ public class RecurringActionController {
      */
     public static String getStatesConfig(Request request, Response response, User user) {
         String target = request.queryParams("target");
+        String idParam = request.queryParams("id");
         String targetLowerCase = target != null ? target.toLowerCase() : "";
 
         Set<StateConfigJson> result = new HashSet<>(); // use a set to avoid duplicates
-        if (request.queryParams("id") != null) {
-            Long id = Long.parseLong(request.queryParams("id"));
+        if (idParam != null) {
+            Long id = Long.parseLong(idParam);
             Optional<RecurringAction> action = RecurringActionManager.find(id);
             if (action.isEmpty()) {
                 return json(response, HttpStatus.SC_NOT_FOUND, ResultJson.error("Action " + id + " not found"));

--- a/java/code/src/com/suse/manager/webui/controllers/test/BaseControllerTestCase.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/BaseControllerTestCase.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Collections;
+import java.util.Map;
 
 import spark.Request;
 import spark.RequestResponseFactory;
@@ -59,6 +60,20 @@ public class BaseControllerTestCase extends JMockBaseTestCaseWithUser {
      */
     protected Request getRequestWithCsrf(String uri, Object... vars) {
         Request request = SparkTestUtils.createMockRequest(baseUri + uri, vars);
+        request.session(true).attribute("csrf_token", "bleh");
+        return request;
+    }
+
+    /**
+     * Creates a request with csrf token and params.
+     *
+     * @param uri the uri
+     * @param queryParams the params
+     * @param vars the vars
+     * @return the request with csrf
+     */
+    protected Request getRequestWithCsrfAndParams(String uri, Map<String, String> queryParams, Object... vars) {
+        Request request = SparkTestUtils.createMockRequestWithParams(baseUri + uri, queryParams, vars);
         request.session(true).attribute("csrf_token", "bleh");
         return request;
     }

--- a/java/code/src/com/suse/manager/webui/controllers/test/RecurringActionControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/RecurringActionControllerTest.java
@@ -18,17 +18,22 @@ package com.suse.manager.webui.controllers.test;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.recurringactions.RecurringAction;
 import com.redhat.rhn.domain.recurringactions.RecurringActionFactory;
 import com.redhat.rhn.domain.role.RoleFactory;
+import com.redhat.rhn.domain.server.ManagedServerGroup;
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.ServerGroupFactory;
+import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.recurringactions.RecurringActionManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.testing.RhnMockHttpServletResponse;
+import com.redhat.rhn.testing.ServerGroupTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 
 import com.suse.manager.webui.controllers.RecurringActionController;
@@ -48,6 +53,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import spark.HaltException;
+import spark.Request;
 import spark.RequestResponseFactory;
 import spark.Response;
 
@@ -57,6 +63,8 @@ import spark.Response;
 public class RecurringActionControllerTest extends BaseControllerTestCase {
 
     private Response response;
+
+    private MinionServer minionServer;
 
     private static final Gson GSON = new GsonBuilder().create();
 
@@ -75,6 +83,8 @@ public class RecurringActionControllerTest extends BaseControllerTestCase {
 
         response = RequestResponseFactory.create(new RhnMockHttpServletResponse());
 
+        minionServer = MinionServerFactoryTest.createTestMinionServer(user);
+
         // mocking
         taskomaticMock = context().mock(TaskomaticApi.class);
         RecurringActionManager.setTaskomaticApi(taskomaticMock);
@@ -86,34 +96,121 @@ public class RecurringActionControllerTest extends BaseControllerTestCase {
     }
 
     @Test
-    public void testCreateAction() throws UnsupportedEncodingException {
+    public void testCreateOrgHighstateAction() throws UnsupportedEncodingException {
         Long orgId = user.getOrg().getId();
+        String actionName = "org-highstate-1";
+        createOrgHighstateAction(orgId, actionName);
 
-        var actionJsonString = createActionJsonString(empty(), "test-schedule-123", of(orgId));
-        var saveRequest = getPostRequestWithCsrfAndBody("/manager/api/recurringactions/save", actionJsonString);
-        RecurringActionController.save(saveRequest, response, user);
-
-        var listRequest = getRequestWithCsrf("/manager/api/recurringactions/:type/:id", "ORG", orgId);
-
-        var list = GSON.fromJson(RecurringActionController.listByEntity(listRequest, response, user), List.class);
+        var list = listRecurringActions("ORG", orgId);
         assertEquals(1, list.size());
-        Map<String, Object> action = (Map<String, Object>) list.iterator().next();
-        assertNotNull(action.get("targetId"));
-        assertEquals("test-schedule-123", action.get("scheduleName"));
 
-        var detailsRequest = getRequestWithCsrf("/manager/api/recurringactions/:id/details",
-                (long) Double.parseDouble(action.get("recurringActionId").toString()));
-        var details = GSON.fromJson(
-                RecurringActionController.getDetails(detailsRequest, response, user), RecurringActionDetailsDto.class
-        );
+        Map<String, Object> action = list.iterator().next();
+        var details = getDetails(action);
+
+        assertEquals(orgId, extractTargetId(action));
+        assertEquals(actionName, action.get("scheduleName"));
+        assertEquals("HIGHSTATE", action.get("actionType"));
         assertEquals(user.getLogin(), details.getCreatorLogin());
+    }
+
+    @Test
+    public void testCreateMinionHighstateAction() throws Exception {
+        String actionName = "minion-highstate-1";
+        createMinionHighstateAction(minionServer.getId(), actionName);
+        var list = listRecurringActions("MINION", minionServer.getId());
+        assertEquals(1, list.size());
+
+        var action = list.get(0);
+        assertEquals(minionServer.getId(), extractTargetId(action));
+        assertEquals(actionName, action.get("scheduleName"));
+        assertEquals("HIGHSTATE", action.get("actionType"));
+    }
+
+    @Test
+    public void testCreateGroupHighstateAction() throws Exception {
+        ManagedServerGroup group = ServerGroupFactory.create(
+            ServerGroupTestUtils.NAME,
+            ServerGroupTestUtils.DESCRIPTION,
+            user.getOrg()
+        );
+        String actionName = "group-highstate-1";
+        createGroupHighstateAction(group.getId(), actionName);
+        var list = listRecurringActions("GROUP", group.getId());
+        assertEquals(1, list.size());
+
+        var action = list.get(0);
+        assertEquals(group.getId(), extractTargetId(action));
+        assertEquals(actionName, action.get("scheduleName"));
+        assertEquals("HIGHSTATE", action.get("actionType"));
+    }
+
+    @Test
+    public void testGetStatesConfigInternalStates() {
+        var request = getRequestWithCsrf("/manager/api/recurringactions/states");
+        var states = RecurringActionController.getStatesConfig(request, response, user);
+        assertTrue(states.contains("hardware.profileupdate"));
+        assertTrue(states.contains("packages.profileupdate"));
+        assertTrue(states.contains("util.syncstates"));
+        assertTrue(states.contains("util.syncgrains"));
+        assertTrue(states.contains("util.syncmodules"));
+        assertTrue(states.contains("uptodate"));
+    }
+
+    @Test
+    public void testGetStatesConfigActionStates() throws Exception {
+        String actionName = "minion-custom-state-1";
+        String stateName = "packages.profileupdate";
+        createMinionCustomStateAction(minionServer.getId(), actionName, stateName);
+        var action = listRecurringActions("MINION", minionServer.getId()).get(0);
+        var actionDetails = getDetails(action);
+        assertEquals(1, actionDetails.getStates().size());
+        assertEquals(stateName, actionDetails.getStates().iterator().next().getName());
+
+        var params = Map.of("id", extractActionId(action).toString());
+        var request = getRequestWithCsrfAndParams("/manager/api/recurringactions/states", params);
+        var states = RecurringActionController.getStatesConfig(request, response, user);
+        assertTrue(states.contains(stateName));
+    }
+
+    @Test
+    public void testGetStatesConfigHighstateAction() throws UnsupportedEncodingException {
+        Long orgId = user.getOrg().getId();
+        createOrgHighstateAction(orgId, "org-highstate-3");
+        Long actionId = extractActionId(listRecurringActions("ORG", orgId).get(0));
+
+        // Should throw an exception when listing config states for a highstate action
+        var params = Map.of("id", actionId.toString());
+        var request = getRequestWithCsrfAndParams("/manager/api/recurringactions/states", params);
+        try {
+            RecurringActionController.getStatesConfig(request, response, user);
+            fail("An exception should have been thrown");
+        }
+        catch (HaltException e) {
+            assertEquals(400, e.statusCode());
+        }
+    }
+
+    @Test
+    public void testGetStatesConfigInvalidActionId() {
+        var params = Map.of("id", "53");
+        var request = getRequestWithCsrfAndParams("/manager/api/recurringactions/states", params);
+        var states = RecurringActionController.getStatesConfig(request, response, user);
+
+        // Trying to list config states of an action that doesn't exist.
+        assertTrue(states.contains("Action 53 not found"));
     }
 
     @Test
     public void testCreateActionSameName() throws UnsupportedEncodingException {
         Long orgId = user.getOrg().getId();
 
-        var actionJsonString = createActionJsonString(empty(), "test-schedule-123", of(orgId));
+        var actionJsonString = createActionJsonString(
+            empty(),
+            "test-schedule-123",
+            of(orgId),
+            "org",
+            "HIGHSTATE"
+        );
         var saveRequest = getPostRequestWithCsrfAndBody("/manager/api/recurringactions/save", actionJsonString);
         RecurringActionController.save(saveRequest, response, user);
 
@@ -134,13 +231,24 @@ public class RecurringActionControllerTest extends BaseControllerTestCase {
         user.addPermanentRole(RoleFactory.SAT_ADMIN);
 
         var orgId = org.getId();
-        var actionJsonString = createActionJsonString(empty(), "test-schedule-123", of(orgId));
+        var actionJsonString = createActionJsonString(
+            empty(),
+            "test-schedule-123",
+            of(orgId),
+            "org",
+            "HIGHSTATE"
+        );
         var createRequest = getPostRequestWithCsrfAndBody("/manager/api/recurringactions/save", actionJsonString);
         RecurringActionController.save(createRequest, response, user);
 
         var actionId = RecurringActionFactory.listOrgRecurringActions(orgId).iterator().next().getId();
 
-        var updateJsonStr = createActionJsonString(of(actionId), "new-name-123", empty());
+        var updateJsonStr = createActionJsonString(
+            of(actionId),
+            "new-name-123", empty(),
+            "org",
+            "HIGHSTATE"
+        );
         var updateRequest = getPostRequestWithCsrfAndBody("/manager/api/recurringactions/save", updateJsonStr);
         RecurringActionController.save(updateRequest, response, user);
 
@@ -148,15 +256,77 @@ public class RecurringActionControllerTest extends BaseControllerTestCase {
         assertEquals("new-name-123", updated.getName());
     }
 
-    private static String createActionJsonString(Optional<Long> actionId, String scheduleName,
-                                                 Optional<Long> targetId) {
+    @Test
+    public void testDeleteSchedule() throws Exception {
+        // Should throw an exception when trying to delete an action that doesn't exist.
+        var request = getRequestWithCsrf("/manager/api/recurringactions/:id/delete", "55");
+        try {
+            RecurringActionController.deleteSchedule(request, response, user);
+            fail("An exception should have been thrown");
+        }
+        catch (HaltException e) {
+            assertEquals(400, e.statusCode());
+        }
+
+        createMinionHighstateAction(minionServer.getId(), "minion-schedule-to-be-deleted");
+        var list = listRecurringActions("MINION", minionServer.getId());
+        assertEquals(1, list.size());
+
+        var actionId = extractActionId(list.get(0));
+        request = getRequestWithCsrf("/manager/api/recurringactions/:id/delete", actionId);
+        RecurringActionController.deleteSchedule(request, response, user);
+
+        list = listRecurringActions("MINION", minionServer.getId());
+        assertTrue(list.isEmpty());
+    }
+
+    private Request makeSaveRequest(
+        String name,
+        String targetType,
+        Optional<Long> targetId,
+        String actionType,
+        Optional<String> stateName
+    ) throws UnsupportedEncodingException {
+        var actionJsonString = createActionJsonString(empty(), name, targetId, targetType, actionType, stateName);
+        return getPostRequestWithCsrfAndBody("/manager/api/recurringactions/save", actionJsonString);
+    }
+
+    private Request makeSaveRequest(
+        String name,
+        String targetType,
+        Optional<Long> targetId,
+        String actionType
+    ) throws UnsupportedEncodingException {
+        var actionJsonString = createActionJsonString(empty(), name, targetId, targetType, actionType);
+        return getPostRequestWithCsrfAndBody("/manager/api/recurringactions/save", actionJsonString);
+    }
+
+    private static String createActionJsonString(
+        Optional<Long> actionId,
+        String scheduleName,
+        Optional<Long> targetId,
+        String targetType,
+        String actionType
+    ) {
+        return createActionJsonString(actionId, scheduleName, targetId, targetType, actionType, Optional.empty());
+    }
+
+    private static String createActionJsonString(
+        Optional<Long> actionId,
+        String scheduleName,
+        Optional<Long> targetId,
+        String targetType,
+        String actionType,
+        Optional<String> stateName
+    ) {
         return "{" +
                 actionId.map(id -> "'recurringActionId': " + id + ",").orElse("") +
                 "'scheduleName': '" + scheduleName + "'," +
                 targetId.map(id -> "'targetId': " + id + ",").orElse("") +
-                "'targetType': 'org'," +
-                "'actionType': 'HIGHSTATE'," +
+                "'targetType': '" + targetType + "'," +
+                "'actionType': '" + actionType + "'," +
                 "'details': {" +
+                    createStatesJsonString(actionType, stateName) +
                     "'type': 'hourly'," +
                     "'cronTimes': " +
                     "  {'minute': '0'," +
@@ -167,4 +337,56 @@ public class RecurringActionControllerTest extends BaseControllerTestCase {
                 "  }" +
                 "}";
     }
+
+    private static String createStatesJsonString(String actionType, Optional<String> stateName) {
+        if ("HIGHSTATE".equals(actionType)) {
+            return "";
+        }
+
+        return "'states': [" +
+                    "{ 'type': 'internal_state', 'name': '" + stateName.get() + "', 'position': 0 }" +
+                "],";
+    }
+
+    private List<Map<String, Object>> listRecurringActions(String type, Long targetId) {
+        var listRequest = getRequestWithCsrf("/manager/api/recurringactions/:type/:id", type, targetId);
+        return GSON.fromJson(RecurringActionController.listByEntity(listRequest, response, user), List.class);
+    }
+
+    private void createMinionHighstateAction(Long minionId, String name) throws Exception {
+        var saveRequest = makeSaveRequest(name, "minion", of(minionId), "HIGHSTATE");
+        RecurringActionController.save(saveRequest, response, user);
+    }
+
+    private void createMinionCustomStateAction(Long minionId, String name, String stateName) throws Exception {
+        var saveRequest = makeSaveRequest(name, "minion", of(minionId), "CUSTOMSTATE", of(stateName));
+        RecurringActionController.save(saveRequest, response, user);
+    }
+
+    private void createGroupHighstateAction(Long groupId, String name) throws Exception {
+        var saveRequest = makeSaveRequest(name, "group", of(groupId), "HIGHSTATE");
+        RecurringActionController.save(saveRequest, response, user);
+    }
+    private void createOrgHighstateAction(Long orgId, String name) throws UnsupportedEncodingException {
+        var saveRequest = makeSaveRequest(name, "org", of(orgId), "HIGHSTATE");
+        RecurringActionController.save(saveRequest, response, user);
+    }
+
+    private RecurringActionDetailsDto getDetails(Map<String, Object> action) {
+        Long actionId = extractActionId(action);
+        var request = getRequestWithCsrf("/manager/api/recurringactions/:id/details", actionId);
+        var details = GSON.fromJson(
+            RecurringActionController.getDetails(request, response, user), RecurringActionDetailsDto.class
+        );
+        return details;
+    }
+
+    private Long extractTargetId(Map<String, Object> action) {
+        return (long) Double.parseDouble(action.get("targetId").toString());
+    }
+
+    private Long extractActionId(Map<String, Object> action) {
+        return (long) Double.parseDouble(action.get("recurringActionId").toString());
+    }
+
 }


### PR DESCRIPTION
## What does this PR change?

It adds new unit tests for recurring actions and also fixes minor code smells pointed our by Sonar Cloud.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/22063

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
