### PR TITLE
throw and log SchedulerExceptions in taskomatic

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoFactory.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoFactory.java
@@ -29,6 +29,7 @@ import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.criterion.Subqueries;
+import org.quartz.SchedulerException;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -466,21 +467,15 @@ public class TaskoFactory extends HibernateFactory {
      * @return schedule
      */
     public static TaskoSchedule reinitializeScheduleFromNow(TaskoSchedule schedule,
-            Date now) {
+            Date now) throws InvalidParamException, SchedulerException {
         TaskoQuartzHelper.destroyJob(schedule.getOrgId(), schedule.getJobLabel());
         schedule.setActiveFrom(now);
         if (!schedule.isCronSchedule()) {
             schedule.setActiveTill(now);
         }
         TaskoFactory.save(schedule);
-        try {
-            TaskoQuartzHelper.createJob(schedule);
-            return schedule;
-        }
-        catch (InvalidParamException e) {
-            // Pech gehabt()
-        }
-        return null;
+        TaskoQuartzHelper.createJob(schedule);
+        return schedule;
     }
 
     private static boolean runBelongToOrg(Integer orgId, TaskoRun run) {

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoJob.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoJob.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
+import org.quartz.SchedulerException;
 
 import java.lang.reflect.InvocationTargetException;
 import java.time.Instant;
@@ -148,7 +149,7 @@ public class TaskoJob implements Job {
         return false;
     }
 
-    private boolean checkThreadAvailable(TaskoSchedule schedule, RhnJob job, TaskoTask task) {
+    private boolean checkThreadAvailable(TaskoSchedule schedule, RhnJob job, TaskoTask task) throws SchedulerException {
         if (!isTaskThreadAvailable(job, task)) {
             int rescheduleSeconds = job.getRescheduleTime();
             log.info("{} RESCHEDULED in {} seconds", schedule.getJobLabel(), rescheduleSeconds);

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoXmlRpcHandler.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoXmlRpcHandler.java
@@ -117,29 +117,26 @@ public class TaskoXmlRpcHandler {
      */
     public Date scheduleBunch(Integer orgId, String bunchName, String jobLabel,
             Date startTime, Date endTime, String cronExpression, Map params)
-            throws NoSuchBunchTaskException, InvalidParamException {
-        TaskoBunch bunch = null;
-        try {
-            bunch = doBasicCheck(orgId, bunchName, jobLabel);
-        }
-        catch (SchedulerException se) {
-            return null;
-        }
+            throws NoSuchBunchTaskException, InvalidParamException, SchedulerException {
+
+        TaskoBunch bunch = doBasicCheck(orgId, bunchName, jobLabel);
         if (!TaskoQuartzHelper.isValidCronExpression(cronExpression)) {
             throw new InvalidParamException("Cron trigger: " + cronExpression);
         }
         // create schedule
-        TaskoSchedule schedule = new TaskoSchedule(orgId, bunch, jobLabel, params,
-                startTime, endTime, cronExpression);
+        TaskoSchedule schedule = new TaskoSchedule(orgId, bunch, jobLabel, params, startTime, endTime, cronExpression);
         TaskoFactory.save(schedule);
         HibernateFactory.commitTransaction();
         // create job
-        Date scheduleDate = TaskoQuartzHelper.createJob(schedule);
-        if (scheduleDate == null) {
+        try {
+            return TaskoQuartzHelper.createJob(schedule);
+        }
+        catch (SchedulerException | InvalidParamException e) {
+            log.error("Unable to create job {}", schedule.getJobLabel(), e);
             TaskoFactory.delete(schedule);
             HibernateFactory.commitTransaction();
+            throw e;
         }
-        return scheduleDate;
     }
 
     /**
@@ -157,9 +154,9 @@ public class TaskoXmlRpcHandler {
      */
     public Date scheduleSatBunch(String bunchName, String jobLabel,
             Date startTime, Date endTime, String cronExpression, Map params)
-    throws NoSuchBunchTaskException, InvalidParamException {
-        return scheduleBunch(null, bunchName, jobLabel, startTime, endTime,
-                cronExpression, params);
+            throws NoSuchBunchTaskException, InvalidParamException, SchedulerException {
+
+        return scheduleBunch(null, bunchName, jobLabel, startTime, endTime, cronExpression, params);
     }
 
     /**
@@ -176,9 +173,9 @@ public class TaskoXmlRpcHandler {
      */
     public Date scheduleBunch(Integer orgId, String bunchName, String jobLabel,
             String cronExpression, Map params)
-            throws NoSuchBunchTaskException, InvalidParamException {
-        return scheduleBunch(orgId, bunchName, jobLabel, new Date(), null,
-                cronExpression, params);
+            throws NoSuchBunchTaskException, InvalidParamException, SchedulerException {
+
+        return scheduleBunch(orgId, bunchName, jobLabel, new Date(), null, cronExpression, params);
     }
 
     /**
@@ -194,13 +191,14 @@ public class TaskoXmlRpcHandler {
      */
     public Date scheduleSatBunch(String bunchName, String jobLabel,
             String cronExpression, Map params)
-            throws NoSuchBunchTaskException, InvalidParamException {
-        return scheduleBunch(null, bunchName, jobLabel,
-                cronExpression, params);
+            throws NoSuchBunchTaskException, InvalidParamException, SchedulerException {
+
+        return scheduleBunch(null, bunchName, jobLabel, cronExpression, params);
     }
 
-    private TaskoBunch doBasicCheck(Integer orgId, String bunchName, String jobLabel) throws NoSuchBunchTaskException,
-            InvalidParamException, SchedulerException {
+    private TaskoBunch doBasicCheck(Integer orgId, String bunchName, String jobLabel)
+            throws NoSuchBunchTaskException, InvalidParamException, SchedulerException {
+
         TaskoBunch bunch = checkBunchName(orgId, bunchName);
         isAlreadyScheduled(orgId, jobLabel);
         return bunch;
@@ -214,8 +212,7 @@ public class TaskoXmlRpcHandler {
      */
     public Integer unscheduleBunch(Integer orgId, String jobLabel) {
         // one or none shall be returned
-        List<TaskoSchedule> scheduleList =
-            TaskoFactory.listActiveSchedulesByOrgAndLabel(orgId, jobLabel);
+        List<TaskoSchedule> scheduleList = TaskoFactory.listActiveSchedulesByOrgAndLabel(orgId, jobLabel);
         Trigger trigger;
         try {
             trigger = SchedulerKernel.getScheduler().getTrigger(triggerKey(jobLabel,
@@ -262,9 +259,9 @@ public class TaskoXmlRpcHandler {
      * @throws NoSuchBunchTaskException thrown if bunch name not known
      * @throws InvalidParamException shall not be thrown
      */
-    public Date scheduleSingleSatBunchRun(String bunchName, String jobLabel,
-                                          Map<?, ?> params, Date start)
-        throws NoSuchBunchTaskException, InvalidParamException {
+    public Date scheduleSingleSatBunchRun(String bunchName, String jobLabel, Map<?, ?> params, Date start)
+            throws NoSuchBunchTaskException, InvalidParamException, SchedulerException {
+
         return scheduleSingleBunchRun(null, bunchName, jobLabel, params, start);
     }
 
@@ -279,6 +276,7 @@ public class TaskoXmlRpcHandler {
      */
     public List<Date> scheduleRuns(String bunchName, String jobLabel,  List<Map<?, ?>> params)
             throws NoSuchBunchTaskException, InvalidParamException {
+
         return scheduleRuns(null, bunchName, jobLabel, params);
     }
 
@@ -292,17 +290,10 @@ public class TaskoXmlRpcHandler {
      * @throws NoSuchBunchTaskException thrown if bunch name not known
      * @throws InvalidParamException shall not be thrown
      */
-    public Date scheduleSingleBunchRun(Integer orgId, String bunchName, Map params,
-            Date start)
-            throws NoSuchBunchTaskException,
-                   InvalidParamException {
-        String jobLabel = null;
-        try {
-            jobLabel = getUniqueSingleJobLabel(orgId, bunchName);
-        }
-        catch (SchedulerException se) {
-            return null;
-        }
+    public Date scheduleSingleBunchRun(Integer orgId, String bunchName, Map params, Date start)
+            throws NoSuchBunchTaskException, InvalidParamException, SchedulerException {
+
+        String jobLabel = getUniqueSingleJobLabel(orgId, bunchName);
         return scheduleSingleBunchRun(orgId, bunchName, jobLabel, params, start);
     }
 
@@ -317,29 +308,25 @@ public class TaskoXmlRpcHandler {
      * @throws NoSuchBunchTaskException thrown if bunch name not known
      * @throws InvalidParamException shall not be thrown
      */
-    public Date scheduleSingleBunchRun(Integer orgId, String bunchName, String jobLabel,
-            Map params, Date start)
-            throws NoSuchBunchTaskException,
-                   InvalidParamException {
-        TaskoBunch bunch = null;
-        try {
-            bunch = doBasicCheck(orgId, bunchName, jobLabel);
-        }
-        catch (SchedulerException se) {
-            return null;
-        }
+    public Date scheduleSingleBunchRun(Integer orgId, String bunchName, String jobLabel, Map params, Date start)
+            throws NoSuchBunchTaskException, InvalidParamException, SchedulerException {
+
+        TaskoBunch bunch = doBasicCheck(orgId, bunchName, jobLabel);
+
         // create schedule
-        TaskoSchedule schedule = new TaskoSchedule(orgId, bunch, jobLabel, params,
-                start, null, null);
+        TaskoSchedule schedule = new TaskoSchedule(orgId, bunch, jobLabel, params, start, null, null);
         TaskoFactory.save(schedule);
         HibernateFactory.commitTransaction();
         // create job
-        Date scheduleDate = TaskoQuartzHelper.createJob(schedule);
-        if (scheduleDate == null) {
+        try {
+            return TaskoQuartzHelper.createJob(schedule);
+        }
+        catch (SchedulerException | InvalidParamException e) {
+            log.error("Unable to create job {}", schedule.getJobLabel(), e);
             TaskoFactory.delete(schedule);
             HibernateFactory.commitTransaction();
+            throw e;
         }
-        return scheduleDate;
     }
 
     /**
@@ -355,16 +342,18 @@ public class TaskoXmlRpcHandler {
      */
      public List<Date> scheduleRuns(Integer orgId, String bunchName, String jobLabel, List<Map<?, ?>> paramsList)
              throws NoSuchBunchTaskException, InvalidParamException {
+
         List<Date> scheduleDates = new ArrayList<>();
         TaskoBunch bunch = checkBunchName(orgId, bunchName);
-        for (Map params:paramsList) {
+        for (Map params : paramsList) {
            String label = getJobLabel(params, jobLabel);
 
             try {
                 isAlreadyScheduled(orgId, label);
             }
-            catch (SchedulerException se) {
-                return null;
+            catch (SchedulerException | InvalidParamException e) {
+                log.warn("Already scheduled {}: {}", label, e.getMessage(), e);
+                continue;
             }
             // create schedule
             String earliestAction = String.valueOf(params.get("earliest_action"));
@@ -376,11 +365,17 @@ public class TaskoXmlRpcHandler {
             HibernateFactory.commitTransaction();
 
             // create job
-            Date scheduleDate = TaskoQuartzHelper.createJob(schedule);
-            if (scheduleDate == null) {
+            Date scheduleDate = null;
+            try {
+                scheduleDate = TaskoQuartzHelper.createJob(schedule);
+            }
+            catch (InvalidParamException | SchedulerException e) {
+                log.error("Unable to create job {}", schedule.getJobLabel(), e);
                 TaskoFactory.delete(schedule);
             }
-            scheduleDates.add(scheduleDate);
+            if (scheduleDate != null) {
+                scheduleDates.add(scheduleDate);
+            }
         }
         HibernateFactory.commitTransaction();
         return scheduleDates;
@@ -396,7 +391,8 @@ public class TaskoXmlRpcHandler {
      * @throws InvalidParamException shall not be thrown
      */
     public Date scheduleSingleSatBunchRun(String bunchName, Map params, Date start)
-        throws NoSuchBunchTaskException, InvalidParamException {
+            throws NoSuchBunchTaskException, InvalidParamException, SchedulerException {
+
         return scheduleSingleBunchRun(null, bunchName, params, start);
     }
 
@@ -410,7 +406,8 @@ public class TaskoXmlRpcHandler {
      * @throws InvalidParamException shall not be thrown
      */
     public Date scheduleSingleBunchRun(Integer orgId, String bunchName, Map params)
-            throws NoSuchBunchTaskException, InvalidParamException {
+            throws NoSuchBunchTaskException, InvalidParamException, SchedulerException {
+
         return scheduleSingleBunchRun(orgId, bunchName, params, new Date());
     }
 
@@ -423,26 +420,25 @@ public class TaskoXmlRpcHandler {
      * @throws InvalidParamException shall not be thrown
      */
     public Date scheduleSingleSatBunchRun(String bunchName, Map params)
-        throws NoSuchBunchTaskException, InvalidParamException {
+            throws NoSuchBunchTaskException, InvalidParamException, SchedulerException {
+
         return scheduleSingleBunchRun(null, bunchName, params, new Date());
     }
 
-    private String getUniqueSingleJobLabel(Integer orgId, String bunchName)
-        throws SchedulerException {
+    private String getUniqueSingleJobLabel(Integer orgId, String bunchName) throws SchedulerException {
         String jobLabel = "single-" + bunchName + "-";
-        Integer count = 0;
-        while (!TaskoFactory.listSchedulesByOrgAndLabel(orgId, jobLabel + count.toString())
+        int count = 0;
+        while (!TaskoFactory.listSchedulesByOrgAndLabel(orgId, jobLabel + count)
                 .isEmpty() ||
                 (SchedulerKernel.getScheduler()
-                        .getTrigger(triggerKey(jobLabel + count.toString(),
+                        .getTrigger(triggerKey(jobLabel + count,
                                 TaskoQuartzHelper.getGroupName(orgId))) != null)) {
             count++;
         }
-        return jobLabel + count.toString();
+        return jobLabel + count;
     }
 
-    private TaskoBunch checkBunchName(Integer orgId, String bunchName)
-        throws NoSuchBunchTaskException {
+    private TaskoBunch checkBunchName(Integer orgId, String bunchName) throws NoSuchBunchTaskException {
         TaskoBunch bunch = null;
         if (orgId == null) {
             bunch = TaskoFactory.lookupSatBunchByName(bunchName);
@@ -498,7 +494,7 @@ public class TaskoXmlRpcHandler {
      * @throws NoSuchBunchTaskException in case of unknown org bunch name
      */
     public List<TaskoSchedule> listActiveSchedulesByBunch(Integer orgId, String bunchName)
-    throws NoSuchBunchTaskException {
+            throws NoSuchBunchTaskException {
         return TaskoFactory.listActiveSchedulesByOrgAndBunch(orgId, bunchName);
     }
 
@@ -508,8 +504,8 @@ public class TaskoXmlRpcHandler {
      * @return list of schedules
      * @throws NoSuchBunchTaskException in case of unknown sat bunch name
      */
-    public List<TaskoSchedule> listActiveSatSchedulesByBunch(String bunchName)
-    throws NoSuchBunchTaskException {
+    public List<TaskoSchedule> listActiveSatSchedulesByBunch(String bunchName) throws NoSuchBunchTaskException {
+
         return TaskoFactory.listActiveSchedulesByOrgAndBunch(null, bunchName);
     }
 
@@ -551,10 +547,12 @@ public class TaskoXmlRpcHandler {
         List<TaskoSchedule> schedules = new ArrayList<>();
         Date now = new Date();
         for (TaskoSchedule schedule : TaskoFactory.listFuture()) {
-            TaskoSchedule reinited =
-                    TaskoFactory.reinitializeScheduleFromNow(schedule, now);
-            if (reinited != null) {
+            try {
+                TaskoSchedule reinited = TaskoFactory.reinitializeScheduleFromNow(schedule, now);
                 schedules.add(reinited);
+            }
+            catch (InvalidParamException | SchedulerException e) {
+                log.error("Unable to reinitialize schedule for job {}", schedule.getJobLabel(), e);
             }
         }
         return schedules;
@@ -564,7 +562,6 @@ public class TaskoXmlRpcHandler {
      * Get the job label by constructing using partial job label and some other parameters
      * @param paramsMap maps containing data about actionn
      * @param partialJobLabel partial job label
-     * @return
      */
     private String getJobLabel(Map<String, String> paramsMap, String partialJobLabel) {
         StringBuilder label = new StringBuilder(partialJobLabel).append(paramsMap.get("action_id"));
@@ -581,8 +578,8 @@ public class TaskoXmlRpcHandler {
      * @throws SchedulerException
      * @throws InvalidParamException
      */
-    private void isAlreadyScheduled(Integer orgId, String jobLabel)
-            throws SchedulerException, InvalidParamException {
+    private void isAlreadyScheduled(Integer orgId, String jobLabel) throws SchedulerException, InvalidParamException {
+
         if (!TaskoFactory.listActiveSchedulesByOrgAndLabel(orgId, jobLabel).isEmpty() ||
                 (SchedulerKernel.getScheduler().getTrigger(triggerKey(jobLabel,
                         TaskoQuartzHelper.getGroupName(orgId))) != null)) {

--- a/java/code/src/com/redhat/rhn/taskomatic/task/TaskHelper.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/TaskHelper.java
@@ -30,6 +30,7 @@ import com.suse.manager.utils.MailHelper;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.quartz.SchedulerException;
 
 import java.net.InetAddress;
 import java.util.ArrayList;
@@ -141,7 +142,7 @@ public class TaskHelper {
             new TaskoXmlRpcHandler().scheduleSingleSatBunchRun(TaskomaticApi.MINION_ACTION_BUNCH_LABEL,
                     TaskomaticApi.MINION_ACTION_JOB_PREFIX + action.getId(), params, action.getEarliestAction());
         }
-        catch (NoSuchBunchTaskException | InvalidParamException e) {
+        catch (NoSuchBunchTaskException | InvalidParamException | SchedulerException e) {
             LOG.error("Could not schedule action: {}", action.getActionType(), e);
         }
     }

--- a/java/spacewalk-java.changes.mackdk.taskomatic-do-not-hide-scheduling-errors
+++ b/java/spacewalk-java.changes.mackdk.taskomatic-do-not-hide-scheduling-errors
@@ -1,0 +1,1 @@
+- Do not ignore scheduling errors in Taskomatic


### PR DESCRIPTION
## What does this PR change?

In taskomatic we hide and ignore very often SchedulerExceptions. This lead into problems as some jobs might not be executed. Additionally `null` is returned in XMLRPC functions which is forbidden and cause exceptions.

This PR try to avoid returning `null` and throw SchedulerExceptions instead. It also improve logging of errors.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
