### PR TITLE
Fix "HOME" environment for "mgr-salt-ssh" to avoid issues with gitfs (bsc#1210994)

### DIFF
--- a/susemanager/src/mgr-salt-ssh
+++ b/susemanager/src/mgr-salt-ssh
@@ -20,6 +20,8 @@ if __name__ == "__main__":
         os.chdir(tempfile.gettempdir())
         try:
             chugid("salt", "salt")
+            # Change HOME according to salt user
+            os.environ["HOME"] = os.path.expanduser("~salt")
         except (KeyError, CommandExecutionError):
             print("Error: Unable to setuid to `salt` user!", file=sys.stderr)
             exit(1)

--- a/susemanager/susemanager.changes.meaksh.fix-home-env-in-mgr-salt-ssh-to-avoid-gitfs-issues
+++ b/susemanager/susemanager.changes.meaksh.fix-home-env-in-mgr-salt-ssh-to-avoid-gitfs-issues
@@ -1,0 +1,1 @@
+- Make mgr-salt-ssh to properly fix HOME environment to avoid issues with gitfs (bsc#1210994)


### PR DESCRIPTION
## What does this PR change?

This PR fixes `mgr-salt-ssh` script to properly set the `HOME` environment when switching to `salt` user before performing the Salt SSH executions.

Without this change, when having `gitfs` remotes configured in your Salt Master, and after recent changes on the "pygit2" backend, the `mgr-salt-ssh` tool is crashing:

```console
# mgr-salt-ssh MINION test.ping
[CRITICAL] Exception caught while initializing gitfs remote 'xxxx@xxxxxxxx': /var/cache/salt/master/gitfs/b74b8bafb5711478f2833218caa61957fd1b21720da203e692de00d955059627: failed to stat '/root/.gitconfig'
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/salt/utils/gitfs.py", line 466, in __init__
    self.new = self.init_remote()
  File "/usr/lib/python3.6/site-packages/salt/utils/gitfs.py", line 1776, in init_remote
    self.repo = pygit2.Repository(self.cachedir)
  File "/usr/lib64/python3.6/site-packages/pygit2/repository.py", line 1245, in __init__
    path_backend = init_file_backend(path)
_pygit2.GitError: /var/cache/salt/master/gitfs/b74b8bafb5711478f2833218caa61957fd1b21720da203e692de00d955059627: failed to stat '/root/.gitconfig'
[ERROR   ] An un-handled exception was caught by Salt's global exception handler:
FileserverConfigError: Failed to load gitfs
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/salt/utils/gitfs.py", line 466, in __init__
    self.new = self.init_remote()
  File "/usr/lib/python3.6/site-packages/salt/utils/gitfs.py", line 1776, in init_remote
    self.repo = pygit2.Repository(self.cachedir)
  File "/usr/lib64/python3.6/site-packages/pygit2/repository.py", line 1245, in __init__
    path_backend = init_file_backend(path)
_pygit2.GitError: /var/cache/salt/master/gitfs/b74b8bafb5711478f2833218caa61957fd1b21720da203e692de00d955059627: failed to stat '/root/.gitconfig'
```

This happens because the `HOME` environment variable was still set to `/root` even after switching the "user" and "group" to `salt`. This makes `pygit2` backend to read from a wrong directory.

This PR makes `mgr-salt-ssh` to properly fix the HOME environment variable according to `salt` user to avoid this issue from happening.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: manually tested by QE

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/21805

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
