### PR TITLE
prevent NPE when cpu values could not fetched or parsed correctly

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/gatherer/VirtualHostManagerProcessor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/gatherer/VirtualHostManagerProcessor.java
@@ -277,10 +277,14 @@ public class VirtualHostManagerProcessor {
 
         cpu.setArch(ServerFactory.lookupCPUArchByName(host.getCpuArch()));
         cpu.setMHz(Long.toString(Math.round(host.getCpuMhz())));
-        cpu.setNrCPU(host.getTotalCpuThreads().longValue());
-        cpu.setNrsocket(host.getTotalCpuSockets().longValue());
-        cpu.setNrCore(host.getTotalCpuCores().longValue() / host.getTotalCpuSockets().longValue());
-        cpu.setNrThread(host.getTotalCpuThreads().longValue() / host.getTotalCpuCores().longValue());
+        if (host.getTotalCpuSockets().longValue() > 0L) {
+            cpu.setNrsocket(host.getTotalCpuSockets().longValue());
+            cpu.setNrCore(host.getTotalCpuCores().longValue() / host.getTotalCpuSockets().longValue());
+            cpu.setNrThread(host.getTotalCpuThreads().longValue() / host.getTotalCpuCores().longValue());
+            cpu.setNrCPU(host.getTotalCpuThreads().longValue());
+        }
+        // else insufficient data for subscription matching. We keep totalSockets == null as matcher react on it
+        // set no CPU value in that case to prevent division by zero
         cpu.setVendor(host.getCpuVendor());
         cpu.setModel(host.getCpuDescription());
 

--- a/java/code/src/com/suse/manager/gatherer/HostJson.java
+++ b/java/code/src/com/suse/manager/gatherer/HostJson.java
@@ -88,10 +88,10 @@ public class HostJson {
 
     /**
      * Gets the total CPU socket count.
-     * @return the number of sockets
+     * @return the number of sockets - can be 0 if insufficient data were send
      */
     public Integer getTotalCpuSockets() {
-        return totalCpuSockets;
+        return totalCpuSockets == null ? 0 : totalCpuSockets;
     }
 
     /**
@@ -99,7 +99,7 @@ public class HostJson {
      * @return the cpu cores
      */
     public Integer getTotalCpuCores() {
-        return totalCpuCores;
+        return totalCpuCores == null ? 1 : totalCpuCores;
     }
 
     /**
@@ -107,7 +107,7 @@ public class HostJson {
      * @return the CPU thread count
      */
     public Integer getTotalCpuThreads() {
-        return totalCpuThreads;
+        return totalCpuThreads == null ? 1 : totalCpuThreads;
     }
 
     /**


### PR DESCRIPTION
## What does this PR change?

When data from virtual host gatherer have an old format, maybe not all fields could be parsed and stay empty/NULL.
This can cause NPE when working with the data.
Provide default values in case we do not have the data

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Tracks 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
