### PR TITLE
Enhance new systems list filter UI

### DIFF
--- a/web/html/src/components/table/SelectSearchField.tsx
+++ b/web/html/src/components/table/SelectSearchField.tsx
@@ -1,0 +1,26 @@
+import { useState } from "react";
+
+import { Select } from "components/input";
+
+const ALL_OPTION = { value: "ALL", label: t("All") };
+
+export const SelectSearchField = (props) => {
+  const [searchValue, setSearchValue] = useState(props.criteria || "");
+
+  const handleSearchValueChange = (value) => {
+    setSearchValue(value);
+    props.onSearch?.(value === ALL_OPTION.value ? "" : value);
+  };
+
+  const options = [ALL_OPTION].concat(props.options);
+
+  return (
+    <Select
+      name="selectSearchField"
+      placeholder={props.label}
+      defaultValue={searchValue}
+      options={options}
+      onChange={(_name, value) => handleSearchValueChange(value)}
+    />
+  );
+};

--- a/web/html/src/manager/systems/all-list.tsx
+++ b/web/html/src/manager/systems/all-list.tsx
@@ -3,11 +3,12 @@ import * as React from "react";
 import { IconTag } from "components/icontag";
 import * as Systems from "components/systems";
 import { Column } from "components/table/Column";
-import { SearchField } from "components/table/SearchField";
 import { Table } from "components/table/Table";
 
 import { Utils } from "utils/functions";
 import Network from "utils/network";
+
+import { SystemsListFilter } from "./list-filter";
 
 type Props = {
   /** Locale of the help links */
@@ -16,21 +17,6 @@ type Props = {
   queryColumn?: string;
   query?: string;
 };
-
-const allListOptions = [
-  { value: "server_name", label: t("System") },
-  { value: "system_kind", label: t("System Kind") },
-  { value: "status_type", label: t("Updates") },
-  { value: "total_errata_count", label: t("Patches") },
-  { value: "outdated_packages", label: t("Packages") },
-  { value: "extra_pkg_count", label: t("Extra Packages") },
-  { value: "config_files_with_differences", label: t("Config Diffs") },
-  { value: "channel_labels", label: t("Base Channel") },
-  { value: "entitlement_level", label: t("System Type") },
-  { value: "requires_reboot", label: t("Requires Reboot") },
-  { value: "created_days", label: t("Registered Days") },
-  { value: "group_count", label: t("Groups") },
-];
 
 export function AllSystems(props: Props) {
   const [selectedSystems, setSelectedSystems] = React.useState<string[]>([]);
@@ -65,7 +51,7 @@ export function AllSystems(props: Props) {
         selectable={(item) => item.hasOwnProperty("id")}
         selectedItems={selectedSystems}
         onSelect={handleSelectedSystems}
-        searchField={<SearchField options={allListOptions} name="criteria" />}
+        searchField={<SystemsListFilter />}
         defaultSearchField={props.queryColumn || "server_name"}
         initialSearch={props.query}
         emptyText={t("No Systems.")}

--- a/web/html/src/manager/systems/list-filter.tsx
+++ b/web/html/src/manager/systems/list-filter.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+
+import { Select } from "components/input";
+import { Form } from "components/input/Form";
+import { SelectSearchField } from "components/table/SelectSearchField";
+
+const SYSTEM_KIND_OPTIONS = [
+  { value: "mgr_server", label: t("Manager Server") },
+  { value: "physical", label: t("Physical") },
+  { value: "proxy", label: t("Proxy") },
+  { value: "virtual_guest", label: t("Virtual Guest") },
+  { value: "virtual_host", label: t("Virtual Host") },
+];
+
+const SYSTEM_TYPE_OPTIONS = [
+  { value: "ansible_control_node", label: t("Ansible Control Node") },
+  { value: "bootstrap_entitled", label: t("Bootstrap") },
+  { value: "container_build_host", label: t("Container Build Host") },
+  { value: "foreign_entitled", label: t("Foreign") },
+  { value: "enterprise_entitled", label: t("Management") },
+  { value: "monitoring_entitled", label: t("Monitored Host") },
+  { value: "osimage_build_host", label: t("OS Image Build Host") },
+  { value: "salt_entitled", label: t("Salt") },
+  { value: "virtualization_host", label: t("Virtualization Host") },
+];
+
+const STATUS_TYPE_OPTIONS = [
+  { value: "actions scheduled", label: t("Actions scheduled") },
+  { value: "updates scheduled", label: t("All updates scheduled") },
+  { value: "critical", label: t("Critical updates available") },
+  { value: "kickstarting", label: t("Kickstart in progress") },
+  { value: "up2date", label: t("System is up to date") },
+  { value: "awol", label: t("System not checking in") },
+  { value: "unentitled", label: t("System not entitled") },
+  { value: "reboot needed", label: t("System requires reboot") },
+  { value: "updates", label: t("Updates available") },
+];
+
+const YES_NO_OPTIONS = [
+  { value: "true", label: t("Yes") },
+  { value: "false", label: t("No") },
+];
+
+const allListOptions = [
+  { value: "server_name", label: t("System") },
+  { value: "system_kind", label: t("System Kind"), filterOptions: SYSTEM_KIND_OPTIONS },
+  { value: "status_type", label: t("Updates"), filterOptions: STATUS_TYPE_OPTIONS },
+  { value: "total_errata_count", label: t("Patches") },
+  { value: "outdated_packages", label: t("Packages") },
+  { value: "extra_pkg_count", label: t("Extra Packages") },
+  { value: "config_files_with_differences", label: t("Config Diffs") },
+  { value: "channel_labels", label: t("Base Channel") },
+  { value: "entitlement_level", label: t("System Type"), filterOptions: SYSTEM_TYPE_OPTIONS },
+  { value: "requires_reboot", label: t("Requires Reboot"), filterOptions: YES_NO_OPTIONS },
+  { value: "created_days", label: t("Registered Days") },
+  { value: "group_count", label: t("Groups") },
+];
+
+const renderSearchField = (props) => {
+  const { field } = props;
+  const selectedOption = allListOptions.find((it) => it.value === field);
+  if (selectedOption?.filterOptions) {
+    return <SelectSearchField label={selectedOption.label} options={selectedOption.filterOptions} {...props} />;
+  }
+  return (
+    <div className="form-group">
+      <input
+        className="form-control"
+        value={props.criteria || ""}
+        placeholder={props.placeholder}
+        type="text"
+        onChange={(e) => props.onSearch?.(e.target.value)}
+        name={props.name}
+      />
+    </div>
+  );
+};
+
+export const SystemsListFilter = (props) => {
+  // Dummy model and onChange to reuse the Select component as it requires a Form
+  let model = {};
+  const onChange = () => {};
+
+  const [filterValue, setFilterValue] = useState(props.field || "");
+  const handleChangeSearchField = (value) => {
+    setFilterValue(value);
+    props.onSearchField?.(value);
+  };
+
+  return (
+    <Form model={model} onChange={onChange} title={t("Filter")} className="row">
+      <div className="col-sm-4">
+        <Select
+          name="filter"
+          placeholder={t("Select a filter")}
+          defaultValue={filterValue}
+          options={allListOptions}
+          onChange={(_name: string | undefined, value: string) => handleChangeSearchField(value)}
+        />
+      </div>
+      <div className="col-sm-6">{props.field && renderSearchField(props)}</div>
+    </Form>
+  );
+};

--- a/web/spacewalk-web.changes.welder.systems-list-filters
+++ b/web/spacewalk-web.changes.welder.systems-list-filters
@@ -1,0 +1,1 @@
+- Enhance new systems list filter UI


### PR DESCRIPTION
## What does this PR change?

It introduces the `SelectSearchField` component, seamlessly integrated with the `Table` component, to enhance the filtering capabilities of the new systems list. Now, instead of always being a simple text field, some filters are shown as select list (when it is possible).

## GUI diff

Before:
![image](https://github.com/uyuni-project/uyuni/assets/17532261/1d3dd061-a145-4566-a510-5647e99e1f30)

After:

![image](https://github.com/uyuni-project/uyuni/assets/17532261/0e7999aa-1bd3-4ef0-a6e7-f99a0d2dfd7d)


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19409

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
