### PR TITLE
Improve mailer init

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/notification/UserNotificationFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/UserNotificationFactory.java
@@ -53,13 +53,21 @@ import javax.persistence.criteria.Root;
  */
 public class UserNotificationFactory extends HibernateFactory {
 
-    private static UserNotificationFactory singleton = new UserNotificationFactory();
     private static Logger log = LogManager.getLogger(UserNotificationFactory.class);
-
+    private static UserNotificationFactory singleton = new UserNotificationFactory();
     private static Mail mailer;
 
     private UserNotificationFactory() {
         super();
+        try {
+            configureMailer();
+        }
+        catch (Exception e) {
+            log.error("Unable to configure the mailer: {}", e.getMessage(), e);
+        }
+    }
+
+    private static void configureMailer() {
         String clazz = Config.get().getString("web.mailer_class");
         if (clazz == null) {
             mailer = new SmtpMail();
@@ -158,7 +166,7 @@ public class UserNotificationFactory extends HibernateFactory {
                                         .filter(user -> user.getEmailNotify() == 1)
                                         .map(User::getEmail)
                                         .toArray(String[]::new);
-            if (receipients.length > 0) {
+            if (receipients.length > 0 && mailer != null) {
                 String subject = String.format("%s Notification from %s: %s",
                         MailHelper.PRODUCT_PREFIX,
                         ConfigDefaults.get().getHostname(),

--- a/java/code/src/com/redhat/rhn/domain/notification/UserNotificationFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/UserNotificationFactory.java
@@ -87,7 +87,7 @@ public class UserNotificationFactory extends HibernateFactory {
      * @param mailerIn the mailer
      */
     public static void setMailer(Mail mailerIn) {
-        singleton.mailer = mailerIn;
+        mailer = mailerIn;
     }
 
     /**
@@ -98,9 +98,7 @@ public class UserNotificationFactory extends HibernateFactory {
      * @return new UserNotification
      */
     public static UserNotification create(User userIn, NotificationMessage messageIn) {
-        UserNotification userNotification =
-                new UserNotification(userIn, messageIn);
-        return userNotification;
+        return new UserNotification(userIn, messageIn);
     }
 
     /**
@@ -141,8 +139,7 @@ public class UserNotificationFactory extends HibernateFactory {
      * @return new notificationMessage
      */
     public static NotificationMessage createNotificationMessage(NotificationData notification) {
-        NotificationMessage notificationMessage = new NotificationMessage(notification);
-        return notificationMessage;
+        return new NotificationMessage(notification);
     }
 
     /**
@@ -176,8 +173,8 @@ public class UserNotificationFactory extends HibernateFactory {
                 if (!StringUtils.isBlank(data.getDetails())) {
                     message += "\n\n" + data.getDetails();
                 }
-                MailHelper.withMailer(singleton.mailer)
-                        .sendEmail(receipients, subject, message.replaceAll("\\<.*?\\>", ""));
+                MailHelper.withMailer(mailer)
+                        .sendEmail(receipients, subject, message.replaceAll("<.+>", ""));
             }
         }
         // Update Notification WebSocket Sessions right now
@@ -326,7 +323,7 @@ public class UserNotificationFactory extends HibernateFactory {
         CriteriaBuilder builder = getSession().getCriteriaBuilder();
         CriteriaDelete<NotificationMessage> delete = builder.createCriteriaDelete(NotificationMessage.class);
         Root<NotificationMessage> root = delete.from(NotificationMessage.class);
-        delete.where(builder.lessThan(root.<Date>get("created"), before));
+        delete.where(builder.lessThan(root.get("created"), before));
         return getSession().createQuery(delete).executeUpdate();
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/events/BaseMailAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/BaseMailAction.java
@@ -22,6 +22,8 @@ import com.redhat.rhn.domain.user.User;
 
 import com.suse.manager.utils.MailHelper;
 
+import org.apache.logging.log4j.Logger;
+
 /**
  * BaseMailAction - basic abstract class to encapsulate some common Action logic.
  */
@@ -37,7 +39,12 @@ public abstract class BaseMailAction {
      */
     public void execute(EventMessage msg) {
         BaseEvent aevt = (BaseEvent) msg;
-        MailHelper.withMailer(getMail()).sendEmail(getRecipients(aevt.getUser()), getSubject(aevt), msg.toText());
+        try {
+            MailHelper.withMailer(getMail()).sendEmail(getRecipients(aevt.getUser()), getSubject(aevt), msg.toText());
+        }
+        catch (Exception e) {
+            getLogger().error("Unable to configure a mailer: {}", e.getMessage(), e);
+        }
     }
 
     /**
@@ -58,4 +65,12 @@ public abstract class BaseMailAction {
             return new SmtpMail();
         }
     }
+
+    /**
+     * Get the Logger for the derived class so log messages show up on the
+     * correct class
+     * @return Logger for this class.
+     */
+    protected abstract Logger getLogger();
+
 }

--- a/java/code/src/com/redhat/rhn/frontend/events/NewUserAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/NewUserAction.java
@@ -80,7 +80,12 @@ public class NewUserAction extends BaseMailAction implements MessageAction {
                 getMessage("email.newuser.subject", evt.getUserLocale(), subjectArgs);
         String body = LocalizationService.getInstance().
                 getMessage("email.newuser.body", evt.getUserLocale(), bodyArgs);
-        MailHelper.withMailer(getMail()).sendEmail(getEmails(evt), subject, body);
+        try {
+            MailHelper.withMailer(getMail()).sendEmail(getEmails(evt), subject, body);
+        }
+        catch (Exception e) {
+            logger.error("Unable to get a mailer: {}", e.getMessage(), e);
+        }
 
         if (logger.isDebugEnabled()) {
             logger.debug("execute(EventMessage) - end");
@@ -135,5 +140,10 @@ public class NewUserAction extends BaseMailAction implements MessageAction {
     @Override
     public boolean needsTransactionHandling() {
         return false;
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return logger;
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/events/TraceBackAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/TraceBackAction.java
@@ -47,7 +47,7 @@ public class TraceBackAction extends BaseMailAction implements MessageAction {
         }
         catch (java.net.UnknownHostException uhe) {
             String message = "TraceBackAction can't find localhost!";
-            log.warn(message);
+            getLogger().warn(message);
             throw new MessageExecuteException(message);
         }
         subject.append(" (");
@@ -78,5 +78,10 @@ public class TraceBackAction extends BaseMailAction implements MessageAction {
     @Override
     public boolean needsTransactionHandling() {
         return false;
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return log;
     }
 }

--- a/java/spacewalk-java.changes.mc.Manager-4.3-improve-mailer-init
+++ b/java/spacewalk-java.changes.mc.Manager-4.3-improve-mailer-init
@@ -1,0 +1,1 @@
+- catch exceptions and log a message when mailer setup failed (bsc#1213009)


### PR DESCRIPTION
## What does this PR change?

When mailer setup result in an exception, it may not become very visible in the logs and produce
funny unrelated log messages.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/22125

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
