### PR TITLE
Add missing translation wrappers for Salt formula catalog

### DIFF
--- a/web/html/src/manager/salt/formula-catalog/org-formula-catalog.tsx
+++ b/web/html/src/manager/salt/formula-catalog/org-formula-catalog.tsx
@@ -58,16 +58,20 @@ class FormulaCatalog extends React.Component<Props, State> {
         severity: "info",
         text: (
           <p>
-            The formula catalog page enables viewing of currently installed{" "}
-            <a
-              href="https://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Salt Formulas
-            </a>
-            . Apply these formulas to individual systems or server groups. Formulas allow automatic installation and
-            configuration of software and may be installed via RPM packages.
+            {t(
+              "The formula catalog page enables viewing of currently installed <link>Salt Formulas</link>. Apply these formulas to individual systems or server groups. Formulas allow automatic installation and configuration of software and may be installed via RPM packages.",
+              {
+                link: (str) => (
+                  <a
+                    href="https://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {str}
+                  </a>
+                ),
+              }
+            )}
           </p>
         ),
       },

--- a/web/spacewalk-web.changes.eth.translate-salt
+++ b/web/spacewalk-web.changes.eth.translate-salt
@@ -1,0 +1,1 @@
+- Add missing translation wrappers for Salt formula catalog


### PR DESCRIPTION
## What does this PR change?

Currently the Salt formula catalog alert is not translatable, this PR fixes this issue.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: nothing to test

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/3383

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
