### PR TITLE
log the stack trace when an exception happens

### DIFF
--- a/java/code/src/com/redhat/rhn/common/messaging/SmtpMail.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/SmtpMail.java
@@ -248,7 +248,7 @@ public class SmtpMail implements Mail {
             buf.append(this.message.getContent());
         }
         catch (IOException | MessagingException e) {
-            log.error(e);
+            log.error(e.getMessage(), e);
         }
         return buf.toString();
     }

--- a/java/code/src/com/redhat/rhn/frontend/action/audit/ssm/SsmScheduleXccdfConfirmAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/audit/ssm/SsmScheduleXccdfConfirmAction.java
@@ -91,8 +91,7 @@ public class SsmScheduleXccdfConfirmAction extends BaseSsmScheduleXccdfAction {
                 new ActionMessage("message.entitlement.missing", e.getMessage()));
         }
         catch (TaskomaticApiException e) {
-            log.error("Could not schedule XCCDF evaluation:");
-            log.error(e);
+            log.error("Could not schedule XCCDF evaluation:", e);
             strutsDelegate.addError(errors, "taskscheduler.down");
         }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/BaseAddFilesAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/BaseAddFilesAction.java
@@ -136,7 +136,7 @@ public abstract class BaseAddFilesAction extends RhnAction {
             getStrutsDelegate().saveMessages(req, ve.getResult());
         }
         catch (Exception e) {
-            LOG.error(e);
+            LOG.error(e.getMessage(), e);
         }
         // If we got here, something went wrong - try again
         return getStrutsDelegate().forwardParams(

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/files/GlobalRevisionDeployConfirmSubmit.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/files/GlobalRevisionDeployConfirmSubmit.java
@@ -122,8 +122,7 @@ public class GlobalRevisionDeployConfirmSubmit extends RhnListDispatchAction {
                 }
             }
             catch (TaskomaticApiException e) {
-                log.error("Could not schedule configuration deploy:");
-                log.error(e);
+                log.error("Could not schedule configuration deploy:", e);
             }
         }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/overview/TargetSystemsSubmitAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/overview/TargetSystemsSubmitAction.java
@@ -120,8 +120,7 @@ public class TargetSystemsSubmitAction extends RhnSetAction {
             return mapping.findForward("default");
         }
         catch (TaskomaticApiException e) {
-            log.error("Could not schedule configuration enablement:");
-            log.error(e);
+            log.error("Could not schedule configuration enablement:", e);
             ValidatorError verrors = new ValidatorError("taskscheduler.down");
             ActionErrors errors = RhnValidationHelper.validatorErrorToActionErrors(verrors);
             getStrutsDelegate().saveMessages(request, errors);

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/sdc/FileListConfirmSubmitAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/sdc/FileListConfirmSubmitAction.java
@@ -126,8 +126,7 @@ public class FileListConfirmSubmitAction extends RhnListDispatchAction {
             }
         }
         catch (TaskomaticApiException e) {
-            log.error("Could not schedule config upload:");
-            log.error(e);
+            log.error("Could not schedule config upload:", e);
             return createErrorMessage(request, mapping, formIn, server.getId(),
                     "taskscheduler.down");
         }
@@ -203,8 +202,7 @@ public class FileListConfirmSubmitAction extends RhnListDispatchAction {
             }
         }
         catch (TaskomaticApiException e) {
-            log.error("Could not schedule config actions:");
-            log.error(e);
+            log.error("Could not schedule config actions:", e);
             return createErrorMessage(request, mapping, form, sid, "taskscheduler.down");
         }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/ssm/EnableSubmitAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/ssm/EnableSubmitAction.java
@@ -95,8 +95,7 @@ public class EnableSubmitAction extends RhnListDispatchAction {
             return mapping.findForward("default");
         }
         catch (TaskomaticApiException e) {
-            log.error("Could not schedule configuration enablement:");
-            log.error(e);
+            log.error("Could not schedule configuration enablement:", e);
             ValidatorError verrors = new ValidatorError("taskscheduler.down");
             ActionErrors errors = RhnValidationHelper.validatorErrorToActionErrors(verrors);
             getStrutsDelegate().saveMessages(request, errors);

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/ErrataConfirmAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/ErrataConfirmAction.java
@@ -137,8 +137,7 @@ public class ErrataConfirmAction extends RhnListDispatchAction {
                 MinionActionManager.scheduleStagingJobsForMinions(singletonList(update), user.getOrg());
             }
             catch (TaskomaticApiException e) {
-                log.error("Could not schedule errata application:");
-                log.error(e);
+                log.error("Could not schedule errata application:", e);
                 return createErrorMessage(mapping, formIn, request, strutsDelegate,
                         "taskscheduler.down");
             }

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/BaseSystemPackagesConfirmAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/BaseSystemPackagesConfirmAction.java
@@ -228,8 +228,7 @@ public abstract class BaseSystemPackagesConfirmAction extends RhnAction implemen
             strutsDelegate.saveMessages(request, msgs);
         }
         catch (TaskomaticApiException e) {
-            log.error("Could not schedule package action:");
-            log.error(e);
+            log.error("Could not schedule package action:", e);
             ActionErrors errors = new ActionErrors();
             strutsDelegate.addError("taskscheduler.down", errors);
             strutsDelegate.saveMessages(request, errors);

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/LockPackageAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/LockPackageAction.java
@@ -144,8 +144,7 @@ public class LockPackageAction extends BaseSystemPackagesAction {
                     }
                 }
                 catch (TaskomaticApiException e) {
-                    LOG.error("Could not schedule package lock action:");
-                    LOG.error(e);
+                    LOG.error("Could not schedule package lock action:", e);
                     this.getStrutsDelegate().addError(errorMessages, "taskscheduler.down");
                 }
             }

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/PackageIndexAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/PackageIndexAction.java
@@ -88,8 +88,7 @@ public class PackageIndexAction extends LookupDispatchAction {
             SdcHelper.ssmCheck(request, sid, user);
         }
         catch (TaskomaticApiException e) {
-            log.error("Could not schedule package refresh action:");
-            log.error(e);
+            log.error("Could not schedule package refresh action:", e);
 
             ActionErrors errors = new ActionErrors();
             getStrutsDelegate().addError("taskscheduler.down", errors);

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/TargetSystemsConfirmAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/TargetSystemsConfirmAction.java
@@ -182,8 +182,7 @@ public class TargetSystemsConfirmAction extends RhnAction implements Maintenance
             strutsDelegate.saveMessages(request, msgs);
         }
         catch (TaskomaticApiException e) {
-            log.error("Could not schedule package installs:");
-            log.error(e);
+            log.error("Could not schedule package installs:", e);
             ActionErrors errors = new ActionErrors();
             strutsDelegate.addError(errors, "taskscheduler.down");
             strutsDelegate.saveMessages(request, errors);

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/profile/MissingPackageAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/profile/MissingPackageAction.java
@@ -160,8 +160,7 @@ public class MissingPackageAction extends BaseProfilesAction {
             syncToVictim(context, sid, pkgIdCombos, ProfileManager.OPTION_REMOVE);
         }
         catch (TaskomaticApiException e) {
-            log.error("Could not schedule package synchronization:");
-            log.error(e);
+            log.error("Could not schedule package synchronization:", e);
             ActionErrors errors = new ActionErrors();
             getStrutsDelegate().addError(errors, "taskscheduler.down");
             getStrutsDelegate().saveMessages(request, errors);
@@ -195,8 +194,7 @@ public class MissingPackageAction extends BaseProfilesAction {
                     ProfileManager.OPTION_SUBSCRIBE);
         }
         catch (TaskomaticApiException e) {
-            log.error("Could not schedule package synchronization:");
-            log.error(e);
+            log.error("Could not schedule package synchronization:", e);
             ActionErrors errors = new ActionErrors();
             getStrutsDelegate().addError(errors, "taskscheduler.down");
             getStrutsDelegate().saveMessages(request, errors);

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/profile/SyncProfilesAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/profile/SyncProfilesAction.java
@@ -120,8 +120,7 @@ public class SyncProfilesAction extends BaseProfilesAction {
                     params);
         }
         catch (TaskomaticApiException e) {
-            log.error("Could not schedule package synchronization:");
-            log.error(e);
+            log.error("Could not schedule package synchronization:", e);
             ActionErrors errors = new ActionErrors();
             getStrutsDelegate().addError(errors, "taskscheduler.down");
             getStrutsDelegate().saveMessages(request, errors);

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/profile/SyncSystemsProfilesAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/profile/SyncSystemsProfilesAction.java
@@ -120,8 +120,7 @@ public class SyncSystemsProfilesAction extends BaseProfilesAction {
                     params);
         }
         catch (TaskomaticApiException e) {
-            log.error("Could not schedule package synchronization:");
-            log.error(e);
+            log.error("Could not schedule package synchronization:", e);
             ActionErrors errors = new ActionErrors();
             getStrutsDelegate().addError(errors, "taskscheduler.down");
             getStrutsDelegate().saveMessages(request, errors);

--- a/java/code/src/com/redhat/rhn/frontend/action/schedule/FailedSystemsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/schedule/FailedSystemsAction.java
@@ -147,8 +147,7 @@ public class FailedSystemsAction extends RhnAction implements Listable<ActionedS
             getStrutsDelegate().saveMessages(request, msgs);
         }
         catch (TaskomaticApiException e) {
-            log.error("Could not reschedule action:");
-            log.error(e);
+            log.error("Could not reschedule action:", e);
             ActionErrors errors = new ActionErrors();
             getStrutsDelegate().addError(errors, "taskscheduler.down");
             getStrutsDelegate().saveMessages(request, errors);

--- a/java/code/src/com/redhat/rhn/frontend/action/schedule/InProgressSystemsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/schedule/InProgressSystemsAction.java
@@ -110,8 +110,7 @@ public class InProgressSystemsAction extends RhnSetAction {
             strutsDelegate.saveMessages(request, msgs);
         }
         catch (TaskomaticApiException e) {
-            log.error("Could not unschedule action:");
-            log.error(e);
+            log.error("Could not unschedule action:", e);
             ActionErrors errors = new ActionErrors();
             strutsDelegate.addError(errors, "taskscheduler.down");
             strutsDelegate.saveMessages(request, errors);

--- a/java/code/src/com/redhat/rhn/frontend/action/schedule/PendingActionsDeleteConfirmAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/schedule/PendingActionsDeleteConfirmAction.java
@@ -126,7 +126,7 @@ public class PendingActionsDeleteConfirmAction extends RhnAction implements List
             strutsDelegate.saveMessages(request, msgs);
         }
         catch (TaskomaticApiException e) {
-            LOG.error(e);
+            LOG.error(e.getMessage(), e);
             createErrorMessage(request,
                     "message.actionCancelServerFailure.taskscheduler.down",
                     StringUtils.EMPTY);

--- a/java/code/src/com/redhat/rhn/frontend/action/ssm/PowerManagementConfigurationAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/ssm/PowerManagementConfigurationAction.java
@@ -87,7 +87,7 @@ public class PowerManagementConfigurationAction extends RhnAction implements Lis
                     }
                 }
                 catch (XmlRpcException e) {
-                    log.error(e);
+                    log.error(e.getMessage(), e);
                 }
             }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/ssm/RollbackToTagAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/ssm/RollbackToTagAction.java
@@ -64,8 +64,7 @@ public class RollbackToTagAction extends RhnAction implements Listable<Row> {
                 rollback(context, tagId);
             }
             catch (TaskomaticApiException e) {
-                log.error("Could not schedule rollback to tag:");
-                log.error(e);
+                log.error("Could not schedule rollback to tag:", e);
                 ActionErrors errors = new ActionErrors();
                 getStrutsDelegate().addError(errors, "taskscheduler.down");
                 getStrutsDelegate().saveMessages(request, errors);

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/ErrataConfirmSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/ErrataConfirmSetupAction.java
@@ -179,8 +179,7 @@ public class ErrataConfirmSetupAction extends RhnAction implements Listable, Mai
                         hparams);
             }
             catch (TaskomaticApiException e) {
-                log.error("Could not schedule errata application:");
-                log.error(e);
+                log.error("Could not schedule errata application:", e);
                 ActionErrors errors = new ActionErrors();
                 strutsDelegate.addError(errors, "taskscheduler.down");
                 strutsDelegate.saveMessages(request, errors);

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SSMUpdateHardwareProfileConfirm.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SSMUpdateHardwareProfileConfirm.java
@@ -101,8 +101,7 @@ public class SSMUpdateHardwareProfileConfirm extends RhnAction implements Listab
                         mapping.findForward("success"), params);
             }
             catch (TaskomaticApiException e) {
-                log.error("Could not schedule hardware refresh:");
-                log.error(e);
+                log.error("Could not schedule hardware refresh:", e);
                 ActionErrors errors = new ActionErrors();
                 getStrutsDelegate().addError(errors, "taskscheduler.down");
                 getStrutsDelegate().saveMessages(request, errors);

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SSMUpdateSoftwareProfileConfirm.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SSMUpdateSoftwareProfileConfirm.java
@@ -101,8 +101,7 @@ public class SSMUpdateSoftwareProfileConfirm extends RhnAction implements Listab
                         mapping.findForward("success"), params);
             }
             catch (TaskomaticApiException e) {
-                log.error("Could not schedule package refresh:");
-                log.error(e);
+                log.error("Could not schedule package refresh:", e);
                 ActionErrors errors = new ActionErrors();
                 getStrutsDelegate().addError(errors, "taskscheduler.down");
                 getStrutsDelegate().saveMessages(request, errors);

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SystemRemoteCommandAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SystemRemoteCommandAction.java
@@ -337,8 +337,7 @@ public class SystemRemoteCommandAction extends RhnAction implements MaintenanceW
                     }
                 }
                 catch (TaskomaticApiException e) {
-                    log.error("Could not schedule remote command:");
-                    log.error(e);
+                    log.error("Could not schedule remote command:", e);
                     getStrutsDelegate().addError(errorMessages, "taskscheduler.down");
                 }
             }

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/audit/ScheduleXccdfAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/audit/ScheduleXccdfAction.java
@@ -110,8 +110,7 @@ public class ScheduleXccdfAction extends ScapSetupAction {
             return msgs;
         }
         catch (TaskomaticApiException e) {
-            log.error("Could not schedule package refresh:");
-            log.error(e);
+            log.error("Could not schedule package refresh:", e);
             ActionErrors errors = new ActionErrors();
             getStrutsDelegate().addError(errors, "taskscheduler.down");
             return errors;

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SnapshotRollbackAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SnapshotRollbackAction.java
@@ -121,8 +121,7 @@ public class SnapshotRollbackAction extends RhnAction {
             }
         }
         catch (TaskomaticApiException e) {
-            log.error("Could not schedule rollbacks:");
-            log.error(e);
+            log.error("Could not schedule rollbacks:", e);
             createErrorMessage(request, "taskscheduler.down", null);
         }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemHardwareAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemHardwareAction.java
@@ -101,8 +101,7 @@ public class SystemHardwareAction extends RhnAction {
                     createMessage(request, "message.refeshScheduled", messageParams);
                 }
                 catch (TaskomaticApiException e) {
-                    log.error("Could not unschedule action:");
-                    log.error(e);
+                    log.error("Could not unschedule action:", e);
                     createErrorMessage(request, "taskscheduler.down", StringUtils.EMPTY);
                 }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemHistoryEventAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemHistoryEventAction.java
@@ -124,8 +124,7 @@ public class SystemHistoryEventAction extends RhnAction {
                 TASKOMATIC_API.scheduleActionExecution(action);
             }
             catch (TaskomaticApiException e) {
-                log.error("Could not reschedule action {}", action.getId());
-                log.error(e);
+                log.error("Could not reschedule action {}", action.getId(), e);
                 ActionErrors errors = new ActionErrors();
                 getStrutsDelegate().addError(errors, "taskscheduler.down");
                 getStrutsDelegate().saveMessages(request, errors);

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemPendingEventsCancelAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemPendingEventsCancelAction.java
@@ -81,7 +81,7 @@ public class SystemPendingEventsCancelAction extends RhnAction {
                         Integer.toString(result.size()));
             }
             catch (TaskomaticApiException e) {
-                LOG.error(e);
+                LOG.error(e.getMessage(), e);
                 createErrorMessage(request,
                         "system.event.pending.canceled.taskscheduler.down",
                         StringUtils.EMPTY);

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemRebootAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemRebootAction.java
@@ -95,8 +95,7 @@ public class SystemRebootAction extends RhnAction implements MaintenanceWindowsA
                 }
             }
             catch (TaskomaticApiException e) {
-                log.error("Could not schedule rollback to tag:");
-                log.error(e);
+                log.error("Could not schedule rollback to tag:", e);
                 createErrorMessage(request, "taskscheduler.down", StringUtils.EMPTY);
             }
 

--- a/java/code/src/com/redhat/rhn/frontend/dto/HistoryEvent.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/HistoryEvent.java
@@ -77,10 +77,9 @@ public class HistoryEvent extends BaseDto {
         try {
             this.completed = format.parse(completedIn);
         }
-       catch (ParseException e) {
-           logger.error("Cannot parse {} according to format {}", completedIn, dateFormat);
-            logger.error(e);
-       }
+        catch (ParseException e) {
+            logger.error("Cannot parse {} according to format {}", completedIn, dateFormat, e);
+        }
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/events/ScheduleRepoSyncAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/ScheduleRepoSyncAction.java
@@ -69,8 +69,7 @@ public class ScheduleRepoSyncAction implements MessageAction {
                 new TaskomaticApi().scheduleSingleRepoSync(channels);
             }
             catch (TaskomaticApiException e) {
-                logger.error("Could not schedule repository synchronization for: {}", channels);
-                logger.error(e);
+                logger.error("Could not schedule repository synchronization for: {}", channels, e);
             }
         }
     }

--- a/java/code/src/com/redhat/rhn/frontend/events/SsmPackagesAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/SsmPackagesAction.java
@@ -94,8 +94,7 @@ public abstract class SsmPackagesAction implements MessageAction {
             }
         }
         catch (TaskomaticApiException e) {
-            LOG.error("Could not schedule package action:");
-            LOG.error(e);
+            LOG.error("Could not schedule package action:", e);
             throw new RuntimeException(e);
         }
         catch (Exception e) {

--- a/java/code/src/com/redhat/rhn/frontend/events/SsmPowerManagementAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/SsmPowerManagementAction.java
@@ -69,7 +69,7 @@ public class SsmPowerManagementAction implements MessageAction {
                     error = new CobblerPowerCommand(user, server, operation).store();
                 }
                 catch (XmlRpcException e) {
-                    log.error(e);
+                    log.error(e.getMessage(), e);
                     error = new ValidatorError(
                         "ssm.provisioning.powermanagement.cobbler_error");
                 }

--- a/java/code/src/com/redhat/rhn/frontend/events/SsmSystemRebootAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/SsmSystemRebootAction.java
@@ -52,8 +52,7 @@ public class SsmSystemRebootAction implements MessageAction {
                 event.getEarliest(), actionChain);
         }
         catch (TaskomaticApiException e) {
-            log.error("Could not schedule reboot:");
-            log.error(e);
+            log.error("Could not schedule reboot:", e);
             throw new RuntimeException(e);
         }
         SsmOperationManager.completeOperation(user,

--- a/java/code/src/com/redhat/rhn/frontend/events/TransactionHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/TransactionHelper.java
@@ -64,7 +64,7 @@ public abstract class TransactionHelper {
             return empty();
         }
         catch (Exception e) {
-            log.error(e);
+            log.error(e.getMessage(), e);
             return of(e);
         }
     }

--- a/java/code/src/com/redhat/rhn/frontend/struts/StrutsDelegate.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/StrutsDelegate.java
@@ -291,7 +291,7 @@ public class StrutsDelegate {
             }
         }
         catch (IOException e) {
-            LOG.error(e);
+            LOG.error(e.getMessage(), e);
             throw new RuntimeException(e);
         }
         return retval;

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/util/MapBuilder.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/util/MapBuilder.java
@@ -83,7 +83,7 @@ public class MapBuilder {
             }
         }
         catch (Exception e) {
-            log.error(e);
+            log.error(e.getMessage(), e);
             throw new RuntimeException("Caught error trying to describe a bean. ", e);
         }
         return retval;

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -223,7 +223,7 @@ public class ContentSyncManager {
                     SCCClientUtils.toListType(ChannelFamilyJson.class));
         }
         catch (IOException e) {
-            LOG.error(e);
+            LOG.error(e.getMessage(), e);
         }
         if (LOG.isDebugEnabled()) {
             LOG.debug("Read {} channel families from {}", channelFamilies.size(),
@@ -356,7 +356,7 @@ public class ContentSyncManager {
                     SCCClientUtils.toListType(SCCRepositoryJson.class));
         }
         catch (IOException e) {
-            LOG.error(e);
+            LOG.error(e.getMessage(), e);
         }
         repos.addAll(collectRepos(flattenProducts(getAdditionalProducts()).collect(Collectors.toList())));
         return repos;
@@ -396,7 +396,7 @@ public class ContentSyncManager {
                     SCCClientUtils.toListType(SCCProductJson.class));
         }
         catch (IOException e) {
-            LOG.error(e);
+            LOG.error(e.getMessage(), e);
         }
         return fixAdditionalProducts(additionalProducts);
     }
@@ -1342,7 +1342,7 @@ public class ContentSyncManager {
             }
         }
         catch (URISyntaxException e) {
-            LOG.error("Invalid URL:{}", e.getMessage());
+            LOG.error("Invalid URL: {}", e.getMessage(), e);
             return new ArrayList<>();
         }
         refreshSubscriptionCache(subscriptions, credentials);
@@ -1401,7 +1401,7 @@ public class ContentSyncManager {
             }
         }
         catch (URISyntaxException e) {
-            LOG.error("Invalid URL:{}", e.getMessage());
+            LOG.error("Invalid URL: {}", e.getMessage(), e);
         }
         List<SCCOrderItem> existingOI = SCCCachingFactory.listOrderItemsByCredentials(c);
         for (SCCOrderJson order : orders) {
@@ -1637,7 +1637,7 @@ public class ContentSyncManager {
                         SCCClientUtils.toListType(ProductTreeEntry.class));
             }
             catch (IOException e) {
-                LOG.error(e);
+                LOG.error(e.getMessage(), e);
             }
         }
         else {
@@ -2523,7 +2523,7 @@ public class ContentSyncManager {
             return accessibleUrl(url, username, password);
         }
         catch (URISyntaxException e) {
-            LOG.error("accessibleUrl: {} URISyntaxException {}", url, e.getMessage());
+            LOG.error("accessibleUrl: {} URISyntaxException {}", url, e.getMessage(), e);
         }
         return false;
     }
@@ -2559,10 +2559,10 @@ public class ContentSyncManager {
             }
         }
         catch (IOException e) {
-            LOG.error("accessibleUrl: {} IOException {}", url, e.getMessage());
+            LOG.error("accessibleUrl: {} IOException {}", url, e.getMessage(), e);
         }
         catch (URISyntaxException e) {
-            LOG.error("accessibleUrl: {} URISyntaxException {}", url, e.getMessage());
+            LOG.error("accessibleUrl: {} URISyntaxException {}", url, e.getMessage(), e);
         }
         return false;
     }

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
@@ -514,8 +514,7 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
             return storeInternal();
         }
         catch (TaskomaticApiException e) {
-            log.error("Taskomatic Exception during kickstart schedule:");
-            log.error(e);
+            log.error("Taskomatic Exception during kickstart schedule:", e);
             return new ValidatorError("taskscheduler.down");
         }
     }

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerPowerCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerPowerCommand.java
@@ -124,7 +124,7 @@ public class CobblerPowerCommand extends CobblerCommand {
                 }
             }
             catch (XmlRpcException e) {
-                log.error(e);
+                log.error(e.getMessage(), e);
             }
             if (success) {
                 if (server != null) {

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoJob.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoJob.java
@@ -79,7 +79,7 @@ public class TaskoJob implements Job {
         catch (InstantiationException | ClassNotFoundException | IllegalAccessException | NoSuchMethodException |
                InvocationTargetException e) {
             // will be caught later
-            log.error("Error trying to instance a new class of {}: {}", task.getTaskClass(), e.getMessage());
+            log.error("Error trying to instance a new class of {}: {}", task.getTaskClass(), e.getMessage(), e);
             return false;
         }
     }
@@ -203,7 +203,7 @@ public class TaskoJob implements Job {
                 }
             }
             catch (Exception e) {
-                log.error(e);
+                log.error(e.getMessage(), e);
             }
         }
         return result;

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ForwardRegistrationTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ForwardRegistrationTask.java
@@ -114,7 +114,7 @@ public class ForwardRegistrationTask extends RhnJavaJob {
             }
         }
         catch (URISyntaxException e) {
-            log.error(e);
+            log.error(e.getMessage(), e);
         }
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/HubReportDbUpdateWorker.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/HubReportDbUpdateWorker.java
@@ -189,7 +189,7 @@ public class HubReportDbUpdateWorker implements QueueWorker {
         catch (Exception e) {
             parentQueue.getQueueRun().failed();
             parentQueue.changeRun(null);
-            log.error(e);
+            log.error(e.getMessage(), e);
         }
         finally {
             parentQueue.workerDone();

--- a/java/code/src/com/redhat/rhn/taskomatic/task/RepoSyncTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/RepoSyncTask.java
@@ -96,7 +96,7 @@ public class RepoSyncTask extends RhnJavaJob {
                     }
 
 
-                    log.error(e.getMessage());
+                    log.error(e.getMessage(), e);
                 }
                 NotificationMessage notificationMessage = UserNotificationFactory.createNotificationMessage(
                         new ChannelSyncFinished(channel.getId(), channel.getName())
@@ -118,7 +118,7 @@ public class RepoSyncTask extends RhnJavaJob {
             UbuntuErrataManager.sync(new HashSet<>(channelIds));
         }
         catch (IOException e) {
-            log.error(e);
+            log.error(e.getMessage(), e);
         }
     }
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataCacheWorker.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataCacheWorker.java
@@ -88,7 +88,7 @@ public class ErrataCacheWorker implements QueueWorker {
             HibernateFactory.commitTransaction();
         }
         catch (Exception e) {
-            logger.error(e);
+            logger.error(e.getMessage(), e);
             HibernateFactory.rollbackTransaction();
         }
         finally {

--- a/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataQueueWorker.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataQueueWorker.java
@@ -71,7 +71,7 @@ class ErrataQueueWorker implements QueueWorker {
             HibernateFactory.commitTransaction();
         }
         catch (Exception e) {
-            logger.error(e);
+            logger.error(e.getMessage(), e);
             HibernateFactory.rollbackTransaction();
         }
         finally {

--- a/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygAuthDataExtractor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygAuthDataExtractor.java
@@ -209,11 +209,11 @@ public class PaygAuthDataExtractor {
             return processOutput(exitStatus, error, output);
         }
         catch (IOException e) {
-            LOG.error(e);
+            LOG.error(e.getMessage(), e);
         }
         catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            LOG.error(e);
+            LOG.error(e.getMessage(), e);
         }
         return null;
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataWorker.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataWorker.java
@@ -137,7 +137,7 @@ public class ChannelRepodataWorker implements QueueWorker {
             }
         }
         catch (Exception e) {
-            logger.error(e);
+            logger.error(e.getMessage(), e);
             parentQueue.getQueueRun().failed();
             // unmark channel to be worked on
             markInProgress(false);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/systems/SystemsOverviewUpdateWorker.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/systems/SystemsOverviewUpdateWorker.java
@@ -62,7 +62,7 @@ public class SystemsOverviewUpdateWorker implements QueueWorker {
             HibernateFactory.commitTransaction();
         }
         catch (Exception e) {
-            logger.error(e);
+            logger.error(e.getMessage(), e);
             HibernateFactory.rollbackTransaction();
         }
         finally {

--- a/java/code/src/com/redhat/rhn/taskomatic/task/threaded/TaskQueue.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/threaded/TaskQueue.java
@@ -123,7 +123,7 @@ public class TaskQueue {
                 unsetTaskQueueDone();
             }
             catch (InterruptedException e) {
-                queueDriver.getLogger().error(e);
+                queueDriver.getLogger().error(e.getMessage(), e);
                 HibernateFactory.commitTransaction();
                 HibernateFactory.closeSession();
                 HibernateFactory.getSession();
@@ -137,7 +137,7 @@ public class TaskQueue {
                 waitForEmptyQueue();
             }
             catch (InterruptedException e) {
-                queueDriver.getLogger().error(e);
+                queueDriver.getLogger().error(e.getMessage(), e);
                 HibernateFactory.commitTransaction();
                 HibernateFactory.closeSession();
                 HibernateFactory.getSession();
@@ -181,7 +181,7 @@ public class TaskQueue {
                 Thread.sleep(100);
             }
             catch (InterruptedException e) {
-                queueDriver.getLogger().error(e);
+                queueDriver.getLogger().error(e.getMessage(), e);
                 return;
             }
         }

--- a/java/code/src/com/suse/manager/api/RouteFactory.java
+++ b/java/code/src/com/suse/manager/api/RouteFactory.java
@@ -157,7 +157,7 @@ public class RouteFactory {
                 requestParams.putAll(requestParser.parseBody(req.body()));
             }
             catch (ParseException e) {
-                LOG.error(e);
+                LOG.error(e.getMessage(), e);
                 throw Spark.halt(HttpStatus.SC_BAD_REQUEST, e.getMessage());
             }
 

--- a/java/code/src/com/suse/manager/maintenance/rescheduling/CancelRescheduleStrategy.java
+++ b/java/code/src/com/suse/manager/maintenance/rescheduling/CancelRescheduleStrategy.java
@@ -55,7 +55,7 @@ public class CancelRescheduleStrategy implements RescheduleStrategy {
             }
         }
         catch (TaskomaticApiException | RuntimeException e) {
-            LOG.error(e);
+            LOG.error(e.getMessage(), e);
             throw new RescheduleException(e);
         }
         result.setSuccess(true);

--- a/java/code/src/com/suse/manager/reactor/SaltReactor.java
+++ b/java/code/src/com/suse/manager/reactor/SaltReactor.java
@@ -316,8 +316,8 @@ public class SaltReactor {
                             ActionManager.schedulePackageRefresh(minionServer.getOrg(), minionServer);
                         }
                         catch (TaskomaticApiException e) {
-                            LOG.error("Could not schedule package refresh for minion: {}", minionServer.getMinionId());
-                            LOG.error(e);
+                            LOG.error("Could not schedule package refresh for minion: {}",
+                                    minionServer.getMinionId(), e);
                         }
                     }))
             );

--- a/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
@@ -88,7 +88,7 @@ public class JobReturnEventMessageAction implements MessageAction {
                 jobReturnEvent.getData().getResult(JsonElement.class));
         }
         catch (JsonSyntaxException e) {
-            LOG.error("JSON syntax error while decoding into a StateApplyResult:");
+            LOG.error("JSON syntax error while decoding into a StateApplyResult:", e);
             LOG.error(jobReturnEvent.getData().getResult(JsonElement.class).toString());
         }
         return jsonResult;
@@ -306,8 +306,7 @@ public class JobReturnEventMessageAction implements MessageAction {
                     }
                      catch (JsonParseException e) {
                         LOG.warn("Could not determine if packages changed in call to {} because of a parse error",
-                                 function);
-                        LOG.warn(e);
+                                 function, e);
                     }
                     return fullPackageRefreshNeeded;
                 })
@@ -333,7 +332,7 @@ public class JobReturnEventMessageAction implements MessageAction {
                 ActionManager.schedulePackageRefresh(minionServer.getOrg(), minionServer, earliest);
             }
             catch (TaskomaticApiException e) {
-                LOG.error(e);
+                LOG.error(e.getMessage(), e);
             }
         });
     }

--- a/java/code/src/com/suse/manager/webui/controllers/SSOController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/SSOController.java
@@ -141,16 +141,16 @@ public final class SSOController {
                 return response;
             }
             catch (LookupException e) {
-                LOG.error("Unable to find user: {}", e.getMessage());
+                LOG.error("Unable to find user: {}", e.getMessage(), e);
                 return "Internal error during SSO authentication phase. Have you created the corresponding user in " +
                         "SUSE Manager? See product documentation";
             }
             catch (SettingsException e) {
-                LOG.error("Unable to parse settings for SSO: {}", e.getMessage());
+                LOG.error("Unable to parse settings for SSO: {}", e.getMessage(), e);
                 return "Internal error during SSO authentication phase - please check the logs " + e.getMessage();
             }
             catch (Exception e) {
-                LOG.error(e);
+                LOG.error(e.getMessage(), e);
             }
         }
         return null;
@@ -182,10 +182,10 @@ public final class SSOController {
                 }
             }
             catch (IOException | SettingsException | Error | CertificateEncodingException e) {
-                LOG.error("Unable to parse settings for SSO and/or certificate error: {}", e.getMessage());
+                LOG.error("Unable to parse settings for SSO and/or certificate error: {}", e.getMessage(), e);
             }
             catch (Exception e) {
-                LOG.error(e.getMessage());
+                LOG.error(e.getMessage(), e);
             }
             return response;
         }
@@ -210,7 +210,7 @@ public final class SSOController {
                 return response;
             }
             catch (SettingsException | IOException | XMLEntityException e) {
-                LOG.error("Unable to parse settings for SSO and/or XML parsing: {}", e.getMessage());
+                LOG.error("Unable to parse settings for SSO and/or XML parsing: {}", e.getMessage(), e);
             }
         }
 
@@ -234,10 +234,10 @@ public final class SSOController {
                 return "You have been logged out";
             }
             catch (ServletException | SettingsException e) {
-                LOG.error("Unable to parse settings for SSO: {}", e.getMessage());
+                LOG.error("Unable to parse settings for SSO: {}", e.getMessage(), e);
             }
             catch (Exception e) {
-                LOG.error(e.getMessage());
+                LOG.error(e.getMessage(), e);
             }
         }
         return null;

--- a/java/code/src/com/suse/manager/webui/controllers/bootstrap/AbstractMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/bootstrap/AbstractMinionBootstrapper.java
@@ -188,7 +188,7 @@ public abstract class AbstractMinionBootstrapper {
             }
         }
         catch (CommandExecutionException | IOException e) {
-            LOG.error(e);
+            LOG.error(e.getMessage(), e);
             return new BootstrapResult(false, contactMethod,
                     LOC.getMessage("bootstrap.minion.error.permcmdexec", SALT_SSH_DIR_PATH + "/known_hosts"));
         }

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/AppStreamsApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/AppStreamsApiController.java
@@ -66,10 +66,11 @@ public class AppStreamsApiController {
             return json(res, ResultJson.success(API.getAllModulesInChannel(channel)));
         }
         catch (NumberFormatException e) {
+            LOG.error(e.getMessage(), e);
             throw Spark.halt(HttpStatus.SC_BAD_REQUEST);
         }
         catch (ModulemdApiException e) {
-            LOG.error(e);
+            LOG.error(e.getMessage(), e);
             return json(res, ResultJson.error(LOC.getMessage("contentmanagement.modules_error")));
         }
     }

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/FilterApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/FilterApiController.java
@@ -174,7 +174,7 @@ public class FilterApiController {
                     createdFilters = TEMPLATE_MGR.createAppStreamFilters(prefix, channel, user);
                 }
                 catch (ModulemdApiException e) {
-                    LOG.error(e);
+                    LOG.error(e.getMessage(), e);
                     return json(GSON, res, ResultJson.error(LOC.getMessage("contentmanagement.modules_error")));
                 }
                 break;

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -1379,7 +1379,7 @@ public class SaltServerActionService {
         }
         catch (IOException e) {
             String errorMsg = "Could not write script to file " + scriptFile + " - " + e;
-            LOG.error(errorMsg);
+            LOG.error(errorMsg, e);
             scriptAction.getServerActions().stream()
                     .filter(entry -> entry.getServer().asMinionServer()
                             .map(minionServer -> minions.contains(new MinionSummary(minionServer)))
@@ -2468,7 +2468,7 @@ public class SaltServerActionService {
                     result = saltApi.rawJsonCall(call, minion.getMinionId());
                 }
                 catch (RuntimeException e) {
-                    LOG.error("Error executing Salt call for action: {}on minion {}",
+                    LOG.error("Error executing Salt call for action: {} on minion {}",
                             action.getName(), minion.getMinionId(), e);
                     sa.setStatus(STATUS_FAILED);
                     sa.setResultMsg("Error calling Salt: " + e.getMessage());
@@ -2516,8 +2516,7 @@ public class SaltServerActionService {
                                 ActionManager.schedulePackageRefresh(minion.getOrg(), minion);
                             }
                             catch (TaskomaticApiException e) {
-                                LOG.error("Could not schedule package refresh for minion: {}", minion.getMinionId());
-                                LOG.error(e);
+                                LOG.error("Could not schedule package refresh for minion: {}", minion.getMinionId(), e);
                             }
                         }
                     });

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -594,7 +594,7 @@ public class SaltService implements SystemQuery, SaltApi {
                     }
                 }
                 catch (JavaMailException javaMailException) {
-                    LOG.error("Error sending email: {}", javaMailException.getMessage());
+                    LOG.error("Error sending email: {}", javaMailException.getMessage(), javaMailException);
                 }
                 catch (InterruptedException e1) {
                     LOG.error("Interrupted during sleep", e1);
@@ -1063,7 +1063,7 @@ public class SaltService implements SystemQuery, SaltApi {
             }
         }
         catch (RuntimeException e) {
-            LOG.error(e);
+            LOG.error(e.getMessage(), e);
         }
         return uptime;
     }


### PR DESCRIPTION
## What does this PR change?

We have a lot of places where only the message of an exception is logged.
In most cases this happens by accident and the full stacktrace is wanted.
This also help debugging problems.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: only log messages

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/22149

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
