### PR TITLE
Enhance "CONTRIBUTING.md" with notes about Pull Requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,58 @@
+# Contributing
+
+## Getting started
+
 The Contributing page in the wiki provides some guidance on how to get started developing Uyuni.
 
 https://github.com/uyuni-project/uyuni/wiki/Contributing
+
+## Pull Requests
+
+The following roles exist in the context of a Pull Request:
+
+- Creator
+- Reviewer
+- Collaborators
+
+The guidelines noted here describe the expectations that should be met when submitting a Pull request.
+
+### Pull Request Creators
+
+1. Please fill out the Pull Request template.
+2. Please provide a description for someone not familiar with your code changes to be still able to understand your changes in the context of the project.
+3. Please enable the reviewer with the provided information in the description to understand the PR without opening any external resources like bug reports.
+4. Please ensure that before hitting the "Create" button on GitHub you have read and understood the `CONTRIBUTING.md` and linked GitHub Wiki pages.
+5. Please ensure all automation on GitHub receives a positive result checkmark.
+6. Please state in a comment why a negative result - if occurring - is incorrect or not your fault.
+7. Please use the GitHub functionality of re-requesting a review in case you haven't gotten a review after a reasonable time.
+8. Please re-request a review in case you made substantial changes to the Pull Request.
+9. Please write detailed and meaningful commit messages. Avoid the usage of generic messages like "fix bug". Further information can be found here:
+    - https://cbea.ms/git-commit/
+    - https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/
+
+### Pull Request Reviewers
+
+As a Pull Request Reviewer, the most important point is that the Creator is following the points above. In the case that there are things that haven't been followed please kindly ask the Creator to change that. This should also be done for the rest of the contributing guidelines in this document.
+
+Once the points above are fulfilled there are a number of things that should be taken care of:
+
+1. Check that the style guides that cannot be automatically enforced, are fulfilled.
+2. Verify that the description of the Pull Request matches the code that was submitted.
+3. Check that the submitted changes make sense in the context of the project and branch. A not acceptable example would be a feature backport after the target branch was already declared end of life.
+4. Verify that the new and modified test cases are useful to the codebase.
+5. Check that you can understand the code. If you don't understand it the likelihood of a required change is almost given.
+
+Optionally you additionally do the following things as well:
+
+1. If you have a better or different approach to fix the problem, please feel free to point it out. The suggestions shouldn't cause the PR to not be merged.
+2. If you have informal comments or nitpicks, please submit them as early as possible and mark them as such accordingly. Informal comments and nitpicks shouldn't cause the PR to not be merged.
+
+Very important during the whole process is that a reviewer should encourage more contributions by the author. Good things should be highlighted and should make the Pull Request Creator feel appraised.
+
+Finally, if your review is completed and all required suggestions have been followed, please provide approval so PR can be merged.
+
+Use these guidelines, but feel free to go beyond the points listed here if you have the capacity.
+
+### Pull Request Collaborators
+
+Please communicate respectfully with each another. So far no extra guidelines have been created for Collaborators.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,15 +18,15 @@ The guidelines noted here describe the expectations that should be met when subm
 
 ### Pull Request Creators
 
-1. Please fill out the Pull Request template.
-2. Please provide a description for someone not familiar with your code changes to be still able to understand your changes in the context of the project.
-3. Please enable the reviewer with the provided information in the description to understand the PR without opening any external resources like bug reports.
-4. Please ensure that before hitting the "Create" button on GitHub you have read and understood the `CONTRIBUTING.md` and linked GitHub Wiki pages.
-5. Please ensure all automation on GitHub receives a positive result checkmark.
-6. Please state in a comment why a negative result - if occurring - is incorrect or not your fault.
-7. Please use the GitHub functionality of re-requesting a review in case you haven't gotten a review after a reasonable time.
-8. Please re-request a review in case you made substantial changes to the Pull Request.
-9. Please write detailed and meaningful commit messages. Avoid the usage of generic messages like "fix bug". Further information can be found here:
+- Please fill out the Pull Request template.
+- Please provide a description for someone not familiar with your code changes to be still able to understand your changes in the context of the project.
+- Please enable the reviewer with the provided information in the description to understand the PR without opening any external resources like bug reports.
+- Please ensure that before hitting the "Create" button on GitHub you have read and understood the `CONTRIBUTING.md` and linked GitHub Wiki pages.
+- Please ensure all automation on GitHub receives a positive result checkmark.
+- Please state in a comment why a negative result - if occurring - is incorrect or not your fault.
+- Please use the GitHub functionality of re-requesting a review in case you haven't gotten a review after a reasonable time.
+- Please re-request a review in case you made substantial changes to the Pull Request.
+- Please write detailed and meaningful commit messages. Avoid the usage of generic messages like "fix bug". Further information can be found here:
     - https://cbea.ms/git-commit/
     - https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/
 
@@ -36,11 +36,11 @@ As a Pull Request Reviewer, the most important point is that the Creator is foll
 
 Once the points above are fulfilled there are a number of things that should be taken care of:
 
-1. Check that the style guides that cannot be automatically enforced, are fulfilled.
-2. Verify that the description of the Pull Request matches the code that was submitted.
-3. Check that the submitted changes make sense in the context of the project and branch. A not acceptable example would be a feature backport after the target branch was already declared end of life.
-4. Verify that the new and modified test cases are useful to the codebase.
-5. Check that you can understand the code. If you don't understand it the likelihood of a required change is almost given.
+- Check that the style guides that cannot be automatically enforced, are fulfilled.
+- Verify that the description of the Pull Request matches the code that was submitted.
+- Check that the submitted changes make sense in the context of the project and branch. A not acceptable example would be a feature backport after the target branch was already declared end of life.
+- Verify that the new and modified test cases are useful to the codebase.
+- Check that you can understand the code. If you don't understand it the likelihood of a required change is almost given.
 
 Optionally you additionally do the following things as well:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ The guidelines noted here describe the expectations that should be met when subm
 - Please provide a description for someone not familiar with your code changes to be still able to understand your changes in the context of the project.
 - Please enable the reviewer with the provided information in the description to understand the PR without opening any external resources like bug reports.
 - Please ensure that before hitting the "Create" button on GitHub you have read and understood the `CONTRIBUTING.md` and linked GitHub Wiki pages.
+- Please make sure to introduce appropriate tests for any new functionality. Keep in mind that different parts of the codebase has different test infrastructures (JUnit for Java, Jest for JS, etc).
 - Please ensure all automation on GitHub receives a positive result checkmark.
 - Please state in a comment why a negative result - if occurring - is incorrect or not your fault.
 - Please use the GitHub functionality of re-requesting a review in case you haven't gotten a review after a reasonable time.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,18 +18,19 @@ The guidelines noted here describe the expectations that should be met when subm
 
 ### Pull Request Creators
 
-- Please fill out the Pull Request template.
-- Please provide a description for someone not familiar with your code changes to be still able to understand your changes in the context of the project.
-- Please enable the reviewer with the provided information in the description to understand the PR without opening any external resources like bug reports.
-- Please ensure that before hitting the "Create" button on GitHub you have read and understood the `CONTRIBUTING.md` and linked GitHub Wiki pages.
-- Please make sure to introduce appropriate tests for any new functionality. Keep in mind that different parts of the codebase has different test infrastructures (JUnit for Java, Jest for JS, etc).
-- Please ensure all automation on GitHub receives a positive result checkmark.
-- Please state in a comment why a negative result - if occurring - is incorrect or not your fault.
-- Please use the GitHub functionality of re-requesting a review in case you haven't gotten a review after a reasonable time.
-- Please re-request a review in case you made substantial changes to the Pull Request.
-- Please write detailed and meaningful commit messages. Avoid the usage of generic messages like "fix bug". Further information can be found here:
-    - https://cbea.ms/git-commit/
-    - https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/
+Please follow these steps when creating a new Pull Request:
+  - Fill out the Pull Request template.
+  - Provide a description for someone not familiar with your code changes to be still able to understand your changes in the context of the project.
+  - Enable the reviewer with the provided information in the description to understand the PR without opening any external resources like bug reports.
+  - Ensure that before hitting the "Create" button on GitHub you have read and understood the `CONTRIBUTING.md` and linked GitHub Wiki pages.
+  - Make sure to introduce appropriate tests for any new functionality. Keep in mind that different parts of the codebase has different test infrastructures (JUnit for Java, Jest for JS, etc).
+  - Ensure all automation on GitHub receives a positive result checkmark.
+  - State in a comment why a negative result - if occurring - is incorrect or not your fault.
+  - Use the GitHub functionality of re-requesting a review in case you haven't gotten a review after a reasonable time.
+  - Re-request a review in case you made substantial changes to the Pull Request.
+  - Write detailed and meaningful commit messages. Avoid the usage of generic messages like "fix bug". Further information can be found here:
+      - https://cbea.ms/git-commit/
+      - https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/
 
 ### Pull Request Reviewers
 


### PR DESCRIPTION
## What does this PR change?

This PR adds some notes and best practices about "Pull Requests"  to the `CONTRIBUTING.md` file. These notes were collected and agreed internally in our development squad.

We think it could be useful as general contributing notes on "Pull Requests" workflow and expectations.

NOTE: If you think these changes fit better directly in the "Contributing" page of the wiki, then we can agree here on the content and then incorporate it to the wiki. If so, please make your comment when making your review. TIA!

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **no tests needed**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/19311

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
