### PR TITLE
CI: fix obs-project: no publish node

### DIFF
--- a/susemanager-utils/testing/automation/obs-project.py
+++ b/susemanager-utils/testing/automation/obs-project.py
@@ -76,7 +76,9 @@ def add(args):
 
     if (disable_publish):
         print("DEBUG: disabling publishing")
-        root.remove(root.find("publish"))
+        publish_node = root.find("publish")
+        if publish_node != None:
+            root.remove(root.find("publish"))
         node = ET.fromstring("<publish><disable/></publish>")
         root.append(node)
 


### PR DESCRIPTION
## What does this PR change?

CI: fix when there is no publish data. Otherwise, you get the error "publish node is empty", when running the CI.

## GUI diff

No difference.


- [ ] **DONE**

## Documentation
- No documentation needed
- [ ] **DONE**

## Test coverage
- No tests

- [ ] **DONE**

## Links




- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
