### PR TITLE
Skip swap creation and BTRFS checks when we have overlayfs

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -129,8 +129,11 @@ if [ $SWAP -eq 0 ]; then
         echo "Not enough space on /. Not adding swap space. Good luck..."
     else
         FSTYPE=`df -T / | tail -1 | awk '{print $2}'`
+        # Ignore for overlay too
         if [ $FSTYPE == "btrfs" ]; then
             echo "Will *NOT* create swapfile on btrfs. Make sure you have enough RAM!"
+        elif [ $FSTYPE == "overlay" ]; then
+            echo "Will *NOT* create swapfile in a container!"
         else
             if [ -f /SWAPFILE ]; then
                 swapoff /SWAPFILE
@@ -316,47 +319,52 @@ check_mksubvolume() {
 }
 
 check_btrfs_dirs() {
-DIR="/var/spacewalk"
-if [ ! -d $DIR ]; then
-    FSTYPE=`df -T \`dirname $DIR\` | tail -1 | awk '{print $2}'`
+ROOT_FSTYPE=`df -T / | tail -1 | awk '{print $2}'`
+if [ $ROOT_FSTYPE == "overlay" ]; then
+    echo "Skipping btrfs check in containers"
+else
+    DIR="/var/spacewalk"
+    if [ ! -d $DIR ]; then
+        FSTYPE=`df -T \`dirname $DIR\` | tail -1 | awk '{print $2}'`
+        echo -n "Filesystem type for $DIR is $FSTYPE - "
+        if [ $FSTYPE == "btrfs" ]; then
+            check_mksubvolume
+            echo "creating nCoW subvolume."
+            mksubvolume --nocow $DIR
+        else
+            echo "ok."
+        fi
+    else
+        echo "$DIR already exists. Leaving it untouched."
+    fi
+
+    DIR="/var/cache"
+    if [ ! -d $DIR ]; then
+        mkdir $DIR
+    fi
+    FSTYPE=`df -T $DIR | tail -1 | awk '{print $2}'`
     echo -n "Filesystem type for $DIR is $FSTYPE - "
     if [ $FSTYPE == "btrfs" ]; then
-        check_mksubvolume
-        echo "creating nCoW subvolume."
-        mksubvolume --nocow $DIR
+        TESTDIR=`basename $DIR`
+        btrfs subvolume list /var | grep "$TESTDIR" > /dev/null
+        if [ ! $? -eq 0 ]; then
+            check_mksubvolume
+            echo "creating subvolume."
+            mv $DIR ${DIR}.sav
+            mksubvolume $DIR
+            touch ${DIR}.sav/foobar.dummy
+            if [ ! -d $DIR ]; then
+                mkdir $DIR
+            fi
+            mv ${DIR}.sav/* $DIR
+            rmdir ${DIR}.sav
+            rm -f $DIR/foobar.dummy
+        else
+            echo "subvolume for $DIR already exists. Fine."
+        fi
     else
         echo "ok."
     fi
-else
-    echo "$DIR already exists. Leaving it untouched."
-fi
-
-DIR="/var/cache"
-if [ ! -d $DIR ]; then
-    mkdir $DIR
-fi
-FSTYPE=`df -T $DIR | tail -1 | awk '{print $2}'`
-echo -n "Filesystem type for $DIR is $FSTYPE - "
-if [ $FSTYPE == "btrfs" ]; then
-    TESTDIR=`basename $DIR`
-    btrfs subvolume list /var | grep "$TESTDIR" > /dev/null
-    if [ ! $? -eq 0 ]; then
-        check_mksubvolume
-        echo "creating subvolume."
-        mv $DIR ${DIR}.sav
-        mksubvolume $DIR
-        touch ${DIR}.sav/foobar.dummy
-        if [ ! -d $DIR ]; then
-            mkdir $DIR
-        fi
-        mv ${DIR}.sav/* $DIR
-        rmdir ${DIR}.sav
-        rm -f $DIR/foobar.dummy
-    else
-        echo "subvolume for $DIR already exists. Fine."
-    fi
-else
-    echo "ok."
 fi
 }
 

--- a/susemanager/susemanager.changes.mbussolotto.ignore_overlay
+++ b/susemanager/susemanager.changes.mbussolotto.ignore_overlay
@@ -1,0 +1,1 @@
+- Skip swap creation and BTRFS check when we have overlayfs


### PR DESCRIPTION
## What does this PR change?

Skip swap creation and BTRFS checks when we have overlayfs. Required for setup containers.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
