### PR TITLE
be more specific in the filter to get less results

### DIFF
--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -16,7 +16,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
   Scenario: Use the products and architecture filters
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text
-    And I enter "RHEL" as the filtered product description
+    And I enter "RHEL or SLES ES" as the filtered product description
     Then I should see a "RHEL or SLES ES or CentOS 8 Base" text
     When I select "x86_64" in the dropdown list of the architecture filter
     Then I should see a "RHEL or SLES ES or CentOS 8 Base" text


### PR DESCRIPTION
## What does this PR change?

Filter for just "RHEL" produce too many results and the product we look for is not on the first page.
Be more specific to get the expected result on the first page.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

No need to backport to 4.3 as we look for a different product

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
