### PR TITLE
WIP: Introduce numeric search field in table filters

### DIFF
--- a/web/html/src/components/table/NumericSearchField.tsx
+++ b/web/html/src/components/table/NumericSearchField.tsx
@@ -1,0 +1,17 @@
+import { Select } from "components/input";
+
+const operators = [
+  { label: t("lower"), value: "<" },
+  { label: t("lower or equal"), value: "<=" },
+  { label: t("equals"), value: "=" },
+  { label: t("greater or equal"), value: ">=" },
+  { label: t("greater"), value: ">" },
+];
+
+export const NumericSearchField = () => {
+  return (
+    <>
+      <Select name="matcher" divClass="col-md-4" placeholder="Matcher" options={operators} />
+    </>
+  );
+};

--- a/web/html/src/components/table/TableFilter.tsx
+++ b/web/html/src/components/table/TableFilter.tsx
@@ -4,9 +4,34 @@ import { Select } from "components/input";
 import { Form } from "components/input/Form";
 import { SelectSearchField } from "components/table/SelectSearchField";
 
-const renderSearchField = ({ filterOptions, field, criteria, onSearch, placeholder, name }) => {
+import { NumericSearchField } from "./NumericSearchField";
+
+export enum FilterOptionType {
+  TEXT,
+  SELECT,
+  NUMERIC,
+}
+
+type FilterOption = {
+  label: string;
+  value: string;
+  type?: FilterOptionType;
+  filterOptions?: Array<any>;
+};
+
+type SearchFieldProps = {
+  filterOptions: Array<FilterOption>;
+  field: any;
+  criteria: any;
+  onSearch: any;
+  placeholder: any;
+  name: any;
+};
+
+const renderSearchField = (props: SearchFieldProps) => {
+  const { filterOptions, field, criteria, onSearch, placeholder, name } = props;
   const selectedOption = filterOptions.find((it) => it.value === field);
-  if (selectedOption?.filterOptions) {
+  if (selectedOption?.type === FilterOptionType.SELECT) {
     return (
       <SelectSearchField
         label={selectedOption.label}
@@ -16,6 +41,11 @@ const renderSearchField = ({ filterOptions, field, criteria, onSearch, placehold
       />
     );
   }
+
+  if (selectedOption?.type === FilterOptionType.NUMERIC) {
+    return <NumericSearchField />;
+  }
+
   return (
     <div className="form-group">
       <input

--- a/web/html/src/manager/recurring/search/recurring-actions-search-utils.tsx
+++ b/web/html/src/manager/recurring/search/recurring-actions-search-utils.tsx
@@ -1,3 +1,5 @@
+import { FilterOptionType } from "components/table/TableFilter";
+
 // Value options for filtering by Target Type in recurring actions list
 const ORG_OPTION = { value: "ORG", label: t("Organization") };
 const GROUP_OPTION = { value: "GROUP", label: t("Group") };
@@ -10,9 +12,29 @@ const CUSTOM_STATE_OPTION = { value: "CUSTOM_STATE", label: t("Custom State") };
 export const ACTION_TYPE_OPTIONS = [CUSTOM_STATE_OPTION, HIGHSTATE_OPTION];
 
 // Field options for filtering in recurring actions list.
-const SCHEDULE_NAME_OPTION = { value: "schedule_name", label: t("Schedule Name") };
-const TARGET_NAME_OPTION = { value: "target_name", label: t("Target Name") };
-export const TARGET_TYPE_OPTION = { value: "target_type", label: t("Target Type"), filterOptions: TARGET_TYPE_OPTIONS };
-export const ACTION_TYPE_OPTION = { value: "action_type", label: t("Action Type"), filterOptions: ACTION_TYPE_OPTIONS };
+const SCHEDULE_NAME_OPTION = {
+  value: "schedule_name",
+  label: t("Schedule Name"),
+  type: FilterOptionType.TEXT,
+};
+
+const TARGET_NAME_OPTION = {
+  value: "target_name",
+  label: t("Target Name"),
+  type: FilterOptionType.TEXT,
+};
+
+const TARGET_TYPE_OPTION = {
+  value: "target_type",
+  label: t("Target Type"),
+  type: FilterOptionType.SELECT,
+  filterOptions: TARGET_TYPE_OPTIONS,
+};
+export const ACTION_TYPE_OPTION = {
+  value: "action_type",
+  label: t("Action Type"),
+  type: FilterOptionType.SELECT,
+  filterOptions: ACTION_TYPE_OPTIONS,
+};
 
 export const SEARCH_FIELD_OPTIONS = [SCHEDULE_NAME_OPTION, TARGET_TYPE_OPTION, TARGET_NAME_OPTION, ACTION_TYPE_OPTION];

--- a/web/html/src/manager/systems/list-filter.tsx
+++ b/web/html/src/manager/systems/list-filter.tsx
@@ -1,4 +1,4 @@
-import { TableFilter } from "components/table/TableFilter";
+import { FilterOptionType, TableFilter } from "components/table/TableFilter";
 
 const SYSTEM_KIND_OPTIONS = [
   { value: "mgr_server", label: t("Manager Server") },
@@ -38,16 +38,26 @@ const YES_NO_OPTIONS = [
 ];
 
 const allListOptions = [
-  { value: "server_name", label: t("System") },
-  { value: "system_kind", label: t("System Kind"), filterOptions: SYSTEM_KIND_OPTIONS },
-  { value: "status_type", label: t("Updates"), filterOptions: STATUS_TYPE_OPTIONS },
-  { value: "total_errata_count", label: t("Patches") },
-  { value: "outdated_packages", label: t("Packages") },
-  { value: "extra_pkg_count", label: t("Extra Packages") },
-  { value: "config_files_with_differences", label: t("Config Diffs") },
-  { value: "channel_labels", label: t("Base Channel") },
-  { value: "entitlement_level", label: t("System Type"), filterOptions: SYSTEM_TYPE_OPTIONS },
-  { value: "requires_reboot", label: t("Requires Reboot"), filterOptions: YES_NO_OPTIONS },
+  { value: "server_name", label: t("System"), type: FilterOptionType.TEXT },
+  { value: "system_kind", label: t("System Kind"), type: FilterOptionType.SELECT, filterOptions: SYSTEM_KIND_OPTIONS },
+  { value: "status_type", label: t("Updates"), type: FilterOptionType.SELECT, filterOptions: STATUS_TYPE_OPTIONS },
+  { value: "total_errata_count", label: t("Patches"), type: FilterOptionType.NUMERIC },
+  { value: "outdated_packages", label: t("Packages"), type: FilterOptionType.NUMERIC },
+  { value: "extra_pkg_count", label: t("Extra Packages"), type: FilterOptionType.NUMERIC },
+  { value: "config_files_with_differences", label: t("Config Diffs"), type: FilterOptionType.NUMERIC },
+  { value: "channel_labels", label: t("Base Channel"), type: FilterOptionType.TEXT },
+  {
+    value: "entitlement_level",
+    label: t("System Type"),
+    type: FilterOptionType.SELECT,
+    filterOptions: SYSTEM_TYPE_OPTIONS,
+  },
+  {
+    value: "requires_reboot",
+    label: t("Requires Reboot"),
+    type: FilterOptionType.SELECT,
+    filterOptions: YES_NO_OPTIONS,
+  },
   { value: "created_days", label: t("Registered Days") },
   { value: "group_count", label: t("Groups") },
 ];


### PR DESCRIPTION
## What does this PR change?

It introduces the option to search by numeric values using operators (<, <=, =, >=, >) when using the `Table` component. Initially to be used in the systems list filtering.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/19409

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
