### PR TITLE
Extend success message after enabling monitoring

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemDetailsEditAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemDetailsEditAction.java
@@ -39,6 +39,7 @@ import com.redhat.rhn.manager.user.UserManager;
 import com.suse.manager.maintenance.MaintenanceManager;
 import com.suse.manager.model.maintenance.MaintenanceSchedule;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
+import com.suse.manager.webui.utils.UserPreferenceUtils;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -296,9 +297,10 @@ public class SystemDetailsEditAction extends RhnAction {
 
                     log.debug("adding entitlement success msg");
                     if (ConfigDefaults.get().isDocAvailable()) {
-                        createSuccessMessage(request,
+                        createMessage(request,
                                 "system.entitle.added." + e.getLabel(),
-                                s.getId().toString());
+                                s.getId().toString(),
+                                GlobalInstanceHolder.USER_PREFERENCE_UTILS.getDocsLocale(user));
                     }
                     else {
                         createSuccessMessage(request,

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -9061,7 +9061,7 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
         </context-group>
       </trans-unit>
       <trans-unit id="system.entitle.added.monitoring_entitled" xml:space="preserve">
-        <source>&lt;strong&gt;Monitoring&lt;/strong&gt; type has been applied.&lt;br/&gt;&lt;strong&gt;Note:&lt;/strong&gt; Since you added the Monitoring system type we automatically assigned the Prometheus Exporters formula to the system. Please apply the &lt;a href="/rhn/manager/systems/details/highstate?sid={0}"&gt;Highstate&lt;/a&gt; in order to install and enable the Prometheus metrics exporters.</source>
+        <source>&lt;strong&gt;Monitoring&lt;/strong&gt; type has been applied.&lt;br/&gt;&lt;strong&gt;Note:&lt;/strong&gt; Since you added the Monitoring system type we automatically assigned the Prometheus Exporters formula to the system. Please apply the &lt;a href="/rhn/manager/systems/details/highstate?sid={0}"&gt;Highstate&lt;/a&gt; in order to install and enable the Prometheus metrics exporters.&lt;br/&gt;&lt;strong&gt;Note:&lt;/strong&gt; Please make sure to open the &lt;a href="/docs/{1}/installation-and-upgrade/ports.html#_external_client_ports">required network ports&lt;/a&gt; for all installed exporters.</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/details/Overview.do</context>
         </context-group>

--- a/java/code/src/com/suse/manager/webui/utils/UserPreferenceUtils.java
+++ b/java/code/src/com/suse/manager/webui/utils/UserPreferenceUtils.java
@@ -104,6 +104,16 @@ public class UserPreferenceUtils {
         HttpServletRequest request = (HttpServletRequest) pageContext.getRequest();
         User user = new RequestContext(request).getCurrentUser();
 
+        return getDocsLocale(user);
+    }
+
+    /**
+     * Get the user's configured documentation locale. If no user is available return the config default
+     *
+     * @param user the current user
+     * @return the users documentation locale
+     */
+    public String getDocsLocale(User user) {
         if (isUserAuthenticated(user)) {
             String locale = user.getPreferredDocsLocale();
             if (locale != null) {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Extend success message after adding monitoring property (bsc#1212168)
 - show error message in action result even on parser error
 - cache debian package metadata snippets in DB
 - Fixed a bug that caused the tab Autoinstallation to hide when clicking on Power


### PR DESCRIPTION
## What does this PR change?

The message hinting the user to open the required ports and pointing to the documentation was added.

## GUI diff

Before:
![image](https://github.com/uyuni-project/uyuni/assets/12249576/e2475ff8-5b04-470d-81df-b591b15820df)

After:
not tested

- [ ] **DONE**

## Documentation
- No documentation needed: provides helpful information in the UI.

- [x] **DONE**

## Test coverage
- No tests: minor change

- [x] **DONE**

## Links

Fixes #[21944](https://github.com/SUSE/spacewalk/issues/21944)

- [x] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
