### PR TITLE
Testsuite: Add step to filter formulas

### DIFF
--- a/testsuite/features/secondary/min_salt_formulas_advanced.feature
+++ b/testsuite/features/secondary/min_salt_formulas_advanced.feature
@@ -14,6 +14,7 @@ Feature: Use advanced features of Salt formulas
      When I install "form.yml" to custom formula metadata directory "testform"
      And I install "metadata.yml" to custom formula metadata directory "testform"
      When I follow the left menu "Salt > Formula Catalog"
+     And I enter "testform" as the filtered formula name
      Then I should see a "testform" text
 
   Scenario: Assign test formula to minion via group formula

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -841,6 +841,10 @@ When(/^I enter "([^"]*)" as the filtered snippet name$/) do |input|
   find("input[placeholder='Filter by Snippet Name: ']").set(input)
 end
 
+When(/^I enter "([^"]*)" as the filtered formula name$/) do |input|
+  find("input[placeholder='Filter by formula name: ']").set(input)
+end
+
 When(/^I enter the package for "([^"]*)" as the filtered package name$/) do |host|
   step %(I enter "#{PACKAGE_BY_CLIENT[host]}" as the filtered package name)
 end

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -842,7 +842,7 @@ When(/^I enter "([^"]*)" as the filtered snippet name$/) do |input|
 end
 
 When(/^I enter "([^"]*)" as the filtered formula name$/) do |input|
-  find("input[placeholder='Filter by formula name: ']").set(input)
+  find("input[placeholder='Filter by formula name']").set(input)
 end
 
 When(/^I enter the package for "([^"]*)" as the filtered package name$/) do |host|


### PR DESCRIPTION
## What does this PR change?
Adds a step to filter formulas so formulas not on the first page of results are shown.

Filter placeholder:
![image](https://github.com/uyuni-project/uyuni/assets/100688791/48cef260-ef84-425d-8932-927f47f09f3e)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were added
- [x] **DONE**

## Links
Fixes # https://github.com/SUSE/spacewalk/issues/22180
Tracks # 
4.3 https://github.com/SUSE/spacewalk/pull/22189

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
