### PR TITLE
Fix message map translations

### DIFF
--- a/web/html/src/components/FormulaForm.tsx
+++ b/web/html/src/components/FormulaForm.tsx
@@ -20,8 +20,8 @@ import { Loading } from "./utils";
 
 const capitalize = Utils.capitalize;
 
-const defaultMessageTexts = {
-  pillar_only_formula_saved: <p>{t("Formula saved. Applying the highstate is not needed for this formula.")}</p>,
+const defaultMessageMap = {
+  pillar_only_formula_saved: t("Formula saved. Applying the highstate is not needed for this formula."),
 };
 
 export enum SectionState {
@@ -204,11 +204,8 @@ class FormulaForm extends React.Component<Props, State> {
     }
   };
 
-  getMessageText = (msg) => {
-    if (!this.props.messageTexts[msg] && defaultMessageTexts[msg]) {
-      return defaultMessageTexts[msg];
-    }
-    return this.props.messageTexts[msg] ? this.props.messageTexts[msg] : msg;
+  getMessageText = (msg: string) => {
+    return this.props.messageTexts[msg] || defaultMessageMap[msg] || msg;
   };
 
   render() {

--- a/web/html/src/components/messages.tsx
+++ b/web/html/src/components/messages.tsx
@@ -82,7 +82,7 @@ export class Messages extends React.Component<Props> {
 
     var msgs = items.map((item, index) => (
       <div key={"msg" + index} className={"alert alert-" + _classNames[item.severity]}>
-        {Array.isArray(item.text) ? item.text.map((txt, i) => <div key={i}>{txt}</div>) : item.text}
+        {item.text}
       </div>
     ));
 

--- a/web/html/src/core/channels/api/use-mandatory-channels-api.ts
+++ b/web/html/src/core/channels/api/use-mandatory-channels-api.ts
@@ -14,7 +14,7 @@ import { MessageType } from "components/messages";
 import { JsonResult } from "utils/network";
 import Network from "utils/network";
 
-const msgMap = {
+const messageMap = {
   base_not_found_or_not_authorized: t("Base channel not found or not authorized."),
   child_not_found_or_not_authorized: t("Child channel not found or not authorized."),
   invalid_channel_id: t("Invalid channel id"),
@@ -63,7 +63,9 @@ const useMandatoryChannelsApi = (): UseMandatoryChannelsApiReturnType => {
           setRequiredByChannels(dependencies.requiredByChannels);
         })
         .catch((jqXHR: JQueryXHR, arg: string = "") => {
-          const msg = Network.responseErrorMessage(jqXHR, (status, msg) => (msgMap[msg] ? t(msgMap[msg], arg) : null));
+          const msg = Network.responseErrorMessage(jqXHR, (status, msg) =>
+            messageMap[msg] ? t(messageMap[msg], arg) : null
+          );
           setMessages(messages.concat(msg));
         })
         .finally(() => setIsDependencyDataLoaded(true));

--- a/web/html/src/manager/admin/config/monitoring-admin.tsx
+++ b/web/html/src/manager/admin/config/monitoring-admin.tsx
@@ -22,7 +22,7 @@ const { capitalize } = Utils;
 
 const msgRestart = t("Restart is needed for the configuration changes to take effect.");
 
-const msgMap = {
+const messageMap = {
   internal_error: t("An internal error has occurred. See the server logs for details."),
   enabling_failed: t("Enabling monitoring failed. See the server logs for details."),
   enabling_failed_partially: t(
@@ -78,7 +78,7 @@ const ExporterIcon = (props: {
         ? "item-enabled-pending"
         : "item-enabled";
     if (props.message) {
-      tooltip = t("Enabled") + ". " + msgMap[props.name + "_msg_" + props.message];
+      tooltip = t("Enabled") + ". " + messageMap[props.name + "_msg_" + props.message];
     } else {
       tooltip = t("Enabled");
     }
@@ -88,7 +88,7 @@ const ExporterIcon = (props: {
         ? "item-error-pending"
         : "item-error";
     if (props.message) {
-      tooltip = t("Disabled") + ". " + msgMap[props.name + "_msg_" + props.message];
+      tooltip = t("Disabled") + ". " + messageMap[props.name + "_msg_" + props.message];
     } else {
       tooltip = t("Disabled");
     }
@@ -192,7 +192,7 @@ const ExportersMessages = (props: {
           .map((key) => (
             <li key={key}>
               <Icon type="system-warn" className="fa-1-5x" />
-              {msgMap[key + "_msg_" + props.messages[key]]}
+              {messageMap[key + "_msg_" + props.messages[key]]}
             </li>
           ))}
       </ul>
@@ -219,7 +219,9 @@ const MonitoringAdmin = (props: MonitoringAdminProps) => {
   } = useMonitoringApi();
 
   const handleResponseError = (jqXHR: JQueryXHR, arg: string = "") => {
-    const msg = Network.responseErrorMessage(jqXHR, (status, msg) => (msgMap[msg] ? t(msgMap[msg], arg) : null));
+    const msg = Network.responseErrorMessage(jqXHR, (status, msg) =>
+      messageMap[msg] ? t(messageMap[msg], arg) : null
+    );
     setMessages(msg);
   };
 
@@ -234,9 +236,9 @@ const MonitoringAdmin = (props: MonitoringAdminProps) => {
     changeStatus(enable)
       .then((result: any) => {
         if (result.success) {
-          setMessages(MessagesUtils.success(msgMap[result.message]));
+          setMessages(MessagesUtils.success(messageMap[result.message]));
         } else {
-          setMessages(MessagesUtils.error(result.message in msgMap ? msgMap[result.message] : result.message));
+          setMessages(MessagesUtils.error(result.message in messageMap ? messageMap[result.message] : result.message));
         }
       })
       .catch(handleResponseError);

--- a/web/html/src/manager/admin/setup/products/products-scc-dialog.tsx
+++ b/web/html/src/manager/admin/setup/products/products-scc-dialog.tsx
@@ -5,7 +5,7 @@ import { Messages, MessageType } from "components/messages";
 
 import Network from "utils/network";
 
-const msgMap = {
+const messageMap = {
   // Nothing for now
 };
 
@@ -136,7 +136,9 @@ class SCCDialog extends React.Component<Props> {
       currentStep.inProgress = false;
       currentStep.success = false;
     }
-    const msg = Network.responseErrorMessage(jqXHR, (status, msg) => (msgMap[msg] ? t(msgMap[msg], arg) : null));
+    const msg = Network.responseErrorMessage(jqXHR, (status, msg) =>
+      messageMap[msg] ? t(messageMap[msg], arg) : null
+    );
     this.setState({ steps: stepList, errors: this.state.errors.concat(msg) });
   };
 

--- a/web/html/src/manager/admin/setup/products/products.tsx
+++ b/web/html/src/manager/admin/setup/products/products.tsx
@@ -44,7 +44,7 @@ declare global {
   }
 }
 
-const msgMap = {
+const messageMap = {
   // Nothing for now
 };
 
@@ -281,7 +281,9 @@ class ProductsPageWrapper extends React.Component {
   };
 
   handleResponseError = (jqXHR: JQueryXHR, arg = "") => {
-    const msg = Network.responseErrorMessage(jqXHR, (status, msg) => (msgMap[msg] ? t(msgMap[msg], arg) : null));
+    const msg = Network.responseErrorMessage(jqXHR, (status, msg) =>
+      messageMap[msg] ? t(messageMap[msg], arg) : null
+    );
     this.setState({ errors: this.state.errors.concat(msg) });
   };
 

--- a/web/html/src/manager/groups/formula/group-formula-selection.renderer.tsx
+++ b/web/html/src/manager/groups/formula/group-formula-selection.renderer.tsx
@@ -10,7 +10,7 @@ import Network from "utils/network";
 const capitalize = Utils.capitalize;
 
 export const renderer = (renderId, { groupId, warningMessage }) => {
-  const msgMap = {
+  const messageMap = {
     formulas_saved: t(
       "Formula saved. Edit configuration options in the enabled formulas and apply the <link>Highstate</link> for the changes to take effect.",
       {
@@ -25,7 +25,7 @@ export const renderer = (renderId, { groupId, warningMessage }) => {
   };
 
   function getMessageText(msg: string) {
-    return msgMap[msg] || msg;
+    return messageMap[msg] || msg;
   }
 
   function saveRequest(component, selectedFormulas) {

--- a/web/html/src/manager/groups/formula/group-formula-selection.renderer.tsx
+++ b/web/html/src/manager/groups/formula/group-formula-selection.renderer.tsx
@@ -10,19 +10,22 @@ import Network from "utils/network";
 const capitalize = Utils.capitalize;
 
 export const renderer = (renderId, { groupId, warningMessage }) => {
-  const messageTexts = {
-    formulas_saved: (
-      <p>
-        {t("Formula saved. Edit configuration options in the enabled formulas and apply the ")}
-        <a href={"/rhn/manager/groups/details/highstate?sgid=" + groupId}>{t("Highstate")}</a>
-        {t(" for the changes to take effect.")}
-      </p>
+  const msgMap = {
+    formulas_saved: t(
+      "Formula saved. Edit configuration options in the enabled formulas and apply the <link>Highstate</link> for the changes to take effect.",
+      {
+        link: (str) => (
+          <a href={"/rhn/manager/groups/details/highstate?sgid=" + groupId} key="link">
+            {str}
+          </a>
+        ),
+      }
     ),
     error_invalid_target: t("Invalid target type."),
   };
 
-  function getMessageText(msg) {
-    return messageTexts[msg] ? t(messageTexts[msg]) : msg;
+  function getMessageText(msg: string) {
+    return msgMap[msg] || msg;
   }
 
   function saveRequest(component, selectedFormulas) {

--- a/web/html/src/manager/groups/formula/group-formula.renderer.tsx
+++ b/web/html/src/manager/groups/formula/group-formula.renderer.tsx
@@ -11,13 +11,13 @@ const capitalize = Utils.capitalize;
 
 export const renderer = (renderId, { groupId, formulaId }) => {
   const msgMap = {
-    formula_saved: (
-      <p>
-        {t("Formula saved. Apply the ")}
-        <a href={"/rhn/manager/groups/details/highstate?sgid=" + groupId}>{t("Highstate")}</a>
-        {t(" for the changes to take effect.")}
-      </p>
-    ),
+    formula_saved: t("Formula saved. Apply the <link>Highstate</link> for the changes to take effect.", {
+      link: (str) => (
+        <a href={"/rhn/manager/groups/details/highstate?sgid=" + groupId} key="link">
+          {str}
+        </a>
+      ),
+    }),
     error_invalid_target: t("Invalid target type."),
   };
 

--- a/web/html/src/manager/groups/formula/group-formula.renderer.tsx
+++ b/web/html/src/manager/groups/formula/group-formula.renderer.tsx
@@ -10,7 +10,7 @@ import { DEPRECATED_unsafeEquals } from "utils/legacy";
 const capitalize = Utils.capitalize;
 
 export const renderer = (renderId, { groupId, formulaId }) => {
-  const msgMap = {
+  const messageMap = {
     formula_saved: t("Formula saved. Apply the <link>Highstate</link> for the changes to take effect.", {
       link: (str) => (
         <a href={"/rhn/manager/groups/details/highstate?sgid=" + groupId} key="link">
@@ -53,7 +53,7 @@ export const renderer = (renderId, { groupId, formulaId }) => {
         return "/rhn/manager/groups/details/formula/" + id + "?sgid=" + groupId;
       }}
       scope="group"
-      messageTexts={msgMap}
+      messageTexts={messageMap}
     />,
     document.getElementById(renderId)
   );

--- a/web/html/src/manager/images/image-build.tsx
+++ b/web/html/src/manager/images/image-build.tsx
@@ -34,7 +34,7 @@ const typeMap = {
   kiwi: { name: "Kiwi", buildType: "osimage_build_host" },
 };
 
-const msgMap = {
+const messageMap = {
   unknown_error: t("An unknown error has occurred."),
   build_scheduled: t("The image build has been scheduled."),
   taskomatic_error: t(
@@ -222,7 +222,7 @@ class BuildImage extends React.Component<Props, State> {
           messages: (
             <Messages
               items={data.messages.map((msg) => {
-                return { severity: "error", text: msgMap[msg] };
+                return { severity: "error", text: messageMap[msg] };
               })}
             />
           ),

--- a/web/html/src/manager/images/image-import.tsx
+++ b/web/html/src/manager/images/image-import.tsx
@@ -13,7 +13,7 @@ import { TopPanel } from "components/panels/TopPanel";
 import { Utils } from "utils/functions";
 import Network from "utils/network";
 
-const msgMap = {
+const messageMap = {
   not_found: t("Image store not found"),
   build_scheduled: t("The image import has been scheduled."),
   taskomatic_error: t(
@@ -188,7 +188,9 @@ class ImageImport extends React.Component {
             Utils.urlBounce("/rhn/manager/cm/images");
           } else {
             this.setState({
-              messages: MessagesUtils.error(msgMap[data.messages[0]] ? msgMap[data.messages[0]] : data.messages[0]),
+              messages: MessagesUtils.error(
+                messageMap[data.messages[0]] ? messageMap[data.messages[0]] : data.messages[0]
+              ),
             });
           }
         })

--- a/web/html/src/manager/images/image-profile-edit.tsx
+++ b/web/html/src/manager/images/image-profile-edit.tsx
@@ -32,7 +32,7 @@ const typeMap = {
   kiwi: { name: "Kiwi", storeType: "os_image" },
 };
 
-const msgMap = {
+const messageMap = {
   invalid_type: "Invalid image type.",
   activation_key_required: "Please give an activation key",
   "": "There was an error.",
@@ -200,7 +200,7 @@ class CreateImageProfile extends React.Component<Props, State> {
           messages: (
             <Messages
               items={data.messages.map((msg) => {
-                return { severity: "error", text: msgMap[msg] };
+                return { severity: "error", text: messageMap[msg] };
               })}
             />
           ),
@@ -226,7 +226,7 @@ class CreateImageProfile extends React.Component<Props, State> {
           messages: (
             <Messages
               items={data.messages.map((msg) => {
-                return { severity: "error", text: msgMap[msg] };
+                return { severity: "error", text: messageMap[msg] };
               })}
             />
           ),

--- a/web/html/src/manager/images/image-profiles.tsx
+++ b/web/html/src/manager/images/image-profiles.tsx
@@ -27,7 +27,7 @@ const typeMap = {
   kiwi: t("Kiwi"),
 };
 
-const msgMap = {
+const messageMap = {
   not_found: t("Image profile cannot be found."),
   delete_success: t("Image profile has been deleted."),
   delete_success_p: t("Image profiles have been deleted."),
@@ -99,7 +99,7 @@ class ImageProfiles extends React.Component<Props, State> {
               items={[
                 {
                   severity: "success",
-                  text: msgMap[idList.length > 1 ? "delete_success_p" : "delete_success"],
+                  text: messageMap[idList.length > 1 ? "delete_success_p" : "delete_success"],
                 },
               ]}
             />
@@ -112,7 +112,7 @@ class ImageProfiles extends React.Component<Props, State> {
           messages: (
             <Messages
               items={data.messages.map((msg) => {
-                return { severity: "error", text: msgMap[msg] };
+                return { severity: "error", text: messageMap[msg] };
               })}
             />
           ),

--- a/web/html/src/manager/images/image-store-edit.tsx
+++ b/web/html/src/manager/images/image-store-edit.tsx
@@ -26,7 +26,7 @@ const typeMap = {
   os_image: "OS Image",
 };
 
-const msgMap = {
+const messageMap = {
   // Nothing for now
 };
 
@@ -104,7 +104,7 @@ class CreateImageStore extends React.Component<Props, State> {
           messages: (
             <Messages
               items={data.messages.map((msg) => {
-                return { severity: "error", text: msgMap[msg] };
+                return { severity: "error", text: messageMap[msg] };
               })}
             />
           ),
@@ -128,7 +128,7 @@ class CreateImageStore extends React.Component<Props, State> {
           messages: (
             <Messages
               items={data.messages.map((msg) => {
-                return { severity: "error", text: msgMap[msg] };
+                return { severity: "error", text: messageMap[msg] };
               })}
             />
           ),

--- a/web/html/src/manager/images/image-stores.tsx
+++ b/web/html/src/manager/images/image-stores.tsx
@@ -22,7 +22,7 @@ declare global {
   }
 }
 
-const msgMap = {
+const messageMap = {
   not_found: t("Image store cannot be found."),
   delete_success: t("Image store has been deleted."),
   delete_success_p: t("Image stores have been deleted."),
@@ -99,7 +99,7 @@ class ImageStores extends React.Component<Props, State> {
               items={[
                 {
                   severity: "success",
-                  text: msgMap[idList.length > 1 ? "delete_success_p" : "delete_success"],
+                  text: messageMap[idList.length > 1 ? "delete_success_p" : "delete_success"],
                 },
               ]}
             />
@@ -112,7 +112,7 @@ class ImageStores extends React.Component<Props, State> {
           messages: (
             <Messages
               items={data.messages.map((msg) => {
-                return { severity: "error", text: msgMap[msg] };
+                return { severity: "error", text: messageMap[msg] };
               })}
             />
           ),

--- a/web/html/src/manager/images/image-view.tsx
+++ b/web/html/src/manager/images/image-view.tsx
@@ -37,7 +37,7 @@ declare global {
   }
 }
 
-const msgMap = {
+const messageMap = {
   not_found: "Image cannot be found.",
   cluster_info_err:
     "Cannot retrieve data from cluster '{arg}'. Please check the logs and make sure the cluster API is accessible.",
@@ -98,8 +98,8 @@ class ImageView extends React.Component<ImageViewProps, ImageViewState> {
     const add = this.state.messages;
 
     const getMsgObj = (msg) => {
-      if (typeof msgMap[msg] === "string") {
-        return { severity: severity, text: msgMap[msg] };
+      if (typeof messageMap[msg] === "string") {
+        return { severity: severity, text: messageMap[msg] };
       } else {
         return { severity: severity, text: msg };
       }
@@ -152,7 +152,9 @@ class ImageView extends React.Component<ImageViewProps, ImageViewState> {
   };
 
   handleResponseError(jqXHR, arg = "") {
-    const msg = Network.responseErrorMessage(jqXHR, (status, msg) => (msgMap[msg] ? t(msgMap[msg], { arg }) : null));
+    const msg = Network.responseErrorMessage(jqXHR, (status, msg) =>
+      messageMap[msg] ? t(messageMap[msg], { arg }) : null
+    );
     this.setState({ messages: this.state.messages.concat(msg) });
   }
 

--- a/web/html/src/manager/minion/formula/minion-formula-selection.renderer.tsx
+++ b/web/html/src/manager/minion/formula/minion-formula-selection.renderer.tsx
@@ -10,7 +10,7 @@ import Network from "utils/network";
 const capitalize = Utils.capitalize;
 
 export const renderer = (renderId, { serverId, warningMessage }) => {
-  const msgMap = {
+  const messageMap = {
     formulas_saved: t(
       "Formula saved. Edit configuration options in the enabled formulas and apply the <link>Highstate</link> for the changes to take effect.",
       {
@@ -25,7 +25,7 @@ export const renderer = (renderId, { serverId, warningMessage }) => {
   };
 
   function getMessageText(msg: string) {
-    return msgMap[msg] || msg;
+    return messageMap[msg] || msg;
   }
 
   function saveRequest(component, selectedFormulas) {

--- a/web/html/src/manager/minion/formula/minion-formula-selection.renderer.tsx
+++ b/web/html/src/manager/minion/formula/minion-formula-selection.renderer.tsx
@@ -10,19 +10,22 @@ import Network from "utils/network";
 const capitalize = Utils.capitalize;
 
 export const renderer = (renderId, { serverId, warningMessage }) => {
-  const messageTexts = {
-    formulas_saved: (
-      <p>
-        {t("Formula saved. Edit configuration options in the enabled formulas and apply the ")}
-        <a href={"/rhn/manager/systems/details/highstate?sid=" + serverId}>{t("Highstate")}</a>
-        {t(" for the changes to take effect.")}
-      </p>
+  const msgMap = {
+    formulas_saved: t(
+      "Formula saved. Edit configuration options in the enabled formulas and apply the <link>Highstate</link> for the changes to take effect.",
+      {
+        link: (str) => (
+          <a href={"/rhn/manager/systems/details/highstate?sid=" + serverId} key="link">
+            {str}
+          </a>
+        ),
+      }
     ),
     error_invalid_target: t("Invalid target type."),
   };
 
-  function getMessageText(msg) {
-    return messageTexts[msg] ? messageTexts[msg] : msg;
+  function getMessageText(msg: string) {
+    return msgMap[msg] || msg;
   }
 
   function saveRequest(component, selectedFormulas) {

--- a/web/html/src/manager/minion/formula/minion-formula.renderer.tsx
+++ b/web/html/src/manager/minion/formula/minion-formula.renderer.tsx
@@ -10,7 +10,7 @@ import { DEPRECATED_unsafeEquals } from "utils/legacy";
 const capitalize = Utils.capitalize;
 
 export const renderer = (renderId, { serverId, formulaId }) => {
-  const msgMap = {
+  const messageMap = {
     formula_saved: t("Formula saved. Apply the <link>Highstate</link> for the changes to take effect.", {
       link: (str) => (
         <a href={"/rhn/manager/systems/details/highstate?sid=" + serverId} key="link">
@@ -57,7 +57,7 @@ export const renderer = (renderId, { serverId, formulaId }) => {
         return "/rhn/manager/systems/details/formula/" + id + "?sid=" + serverId;
       }}
       scope="system"
-      messageTexts={msgMap}
+      messageTexts={messageMap}
     />,
     document.getElementById(renderId)
   );

--- a/web/html/src/manager/minion/formula/minion-formula.renderer.tsx
+++ b/web/html/src/manager/minion/formula/minion-formula.renderer.tsx
@@ -11,13 +11,13 @@ const capitalize = Utils.capitalize;
 
 export const renderer = (renderId, { serverId, formulaId }) => {
   const msgMap = {
-    formula_saved: (
-      <p>
-        {t("Formula saved. Apply the ")}
-        <a href={"/rhn/manager/systems/details/highstate?sid=" + serverId}>{t("Highstate")}</a>
-        {t(" for the changes to take effect.")}
-      </p>
-    ),
+    formula_saved: t("Formula saved. Apply the <link>Highstate</link> for the changes to take effect.", {
+      link: (str) => (
+        <a href={"/rhn/manager/systems/details/highstate?sid=" + serverId} key="link">
+          {str}
+        </a>
+      ),
+    }),
     error_invalid_target: t("Invalid target type."),
   };
 

--- a/web/html/src/manager/systems/activation-key/activation-key-channels-api.tsx
+++ b/web/html/src/manager/systems/activation-key/activation-key-channels-api.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { DEPRECATED_unsafeEquals } from "utils/legacy";
 import Network from "utils/network";
 
-const msgMap = {
+const messageMap = {
   base_not_found_or_not_authorized: t("Base channel not found or not authorized."),
   child_not_found_or_not_authorized: t("Child channel not found or not authorized."),
   invalid_channel_id: t("Invalid channel id"),
@@ -131,7 +131,9 @@ class ActivationKeyChannelsApi extends React.Component<ActivationKeyChannelsProp
   };
 
   handleResponseError = (jqXHR: JQueryXHR, arg: string = "") => {
-    const msg = Network.responseErrorMessage(jqXHR, (status, msg) => (msgMap[msg] ? t(msgMap[msg], arg) : null));
+    const msg = Network.responseErrorMessage(jqXHR, (status, msg) =>
+      messageMap[msg] ? t(messageMap[msg], arg) : null
+    );
     this.setState((prevState) => ({
       messages: prevState.messages.concat(msg),
     }));

--- a/web/html/src/manager/systems/delete-system.tsx
+++ b/web/html/src/manager/systems/delete-system.tsx
@@ -8,7 +8,7 @@ import { Utils as MessagesUtils } from "components/messages";
 
 import Network from "utils/network";
 
-const msgMap = {
+const messageMap = {
   minion_unreachable: t("Cleanup timed out. Please check if the machine is reachable."),
   apply_result_missing: t("No result found in state apply response."),
 };
@@ -41,7 +41,7 @@ class DeleteSystem extends React.Component<Props, State> {
           this.props.onDeleteSuccess();
         } else {
           this.setState({
-            messages: MessagesUtils.error(data.messages.map((m) => msgMap[m])),
+            messages: MessagesUtils.error(data.messages.map((m) => messageMap[m])),
           });
           this.showErrorDialog();
         }
@@ -53,7 +53,9 @@ class DeleteSystem extends React.Component<Props, State> {
 
   handleResponseError = (jqXHR, arg = "") => {
     this.setState({
-      messages: Network.responseErrorMessage(jqXHR, (status, msg) => (msgMap[msg] ? t(msgMap[msg], arg) : null)),
+      messages: Network.responseErrorMessage(jqXHR, (status, msg) =>
+        messageMap[msg] ? t(messageMap[msg], arg) : null
+      ),
     });
     this.showErrorDialog();
   };

--- a/web/html/src/manager/systems/details/mgr-server-info.tsx
+++ b/web/html/src/manager/systems/details/mgr-server-info.tsx
@@ -26,7 +26,7 @@ type State = {
   messages: MessageType[];
 };
 
-const msgMap = {
+const messageMap = {
   invalid_systemid: t("Not a system id"),
   unknown_system: t("Unknown System"),
   system_not_mgr_server: t("System is not a peripheral server"),
@@ -53,7 +53,7 @@ class MgrServer extends React.Component<Props, State> {
           });
         } else {
           this.setState({
-            messages: MessagesUtils.error(data.messages.map((m) => msgMap[m])),
+            messages: MessagesUtils.error(data.messages.map((m) => messageMap[m])),
           });
         }
       })
@@ -64,7 +64,7 @@ class MgrServer extends React.Component<Props, State> {
 
   handleResponseError = (jqXHR, arg = "") => {
     this.setState({
-      messages: Network.responseErrorMessage(jqXHR, (status, msg) => (msgMap[msg] ? t(msgMap[msg], arg) : msg)),
+      messages: Network.responseErrorMessage(jqXHR, (status, msg) => (messageMap[msg] ? t(messageMap[msg], arg) : msg)),
     });
   };
 

--- a/web/html/src/manager/systems/ssm/ssm-subscribe-channels.tsx
+++ b/web/html/src/manager/systems/ssm/ssm-subscribe-channels.tsx
@@ -28,7 +28,7 @@ declare global {
   }
 }
 
-const msgMap = {
+const messageMap = {
   taskomatic_error: t("Error scheduling job in Taskomatic. Please check the logs."),
   no_base_channel_guess: t("Could not determine system default channel."),
   invalid_change: t("Channel change is invalid."),
@@ -789,7 +789,9 @@ class ResultPage extends React.Component<ResultPageProps> {
               ) : (
                 <span className="text-danger">
                   <i className="fa fa-exclamation-triangle fa-1-5x" aria-hidden="true"></i>
-                  {dto.errorMessage ? msgMap[dto.errorMessage] : t("Unknown error. Could not schedule channel change")}
+                  {dto.errorMessage
+                    ? messageMap[dto.errorMessage]
+                    : t("Unknown error. Could not schedule channel change")}
                 </span>
               );
             }}
@@ -904,7 +906,9 @@ class SsmChannelPage extends React.Component<SsmChannelProps, SsmChannelState> {
   }
 
   handleResponseError = (jqXHR, arg = "") => {
-    const msg = Network.responseErrorMessage(jqXHR, (status, msg) => (msgMap[msg] ? t(msgMap[msg], arg) : null));
+    const msg = Network.responseErrorMessage(jqXHR, (status, msg) =>
+      messageMap[msg] ? t(messageMap[msg], arg) : null
+    );
 
     // check if partially successful
     if (jqXHR.responseJSON.data) {

--- a/web/html/src/manager/systems/subscribe-channels/subscribe-channels.tsx
+++ b/web/html/src/manager/systems/subscribe-channels/subscribe-channels.tsx
@@ -20,7 +20,7 @@ import { JsonResult } from "utils/network";
 
 declare var actionChains: Array<ActionChain>;
 
-const msgMap = {
+const messageMap = {
   taskomatic_error: t("Error scheduling job in Taskomatic. Please check the logs."),
   base_not_found_or_not_authorized: t("Base channel not found or not authorized."),
   child_not_found_or_not_authorized: t("Child channel not found or not authorized."),
@@ -219,7 +219,9 @@ class SystemChannels extends React.Component<SystemChannelsProps, SystemChannels
   }
 
   handleResponseError = (jqXHR: JQueryXHR, arg: string = "") => {
-    const msg = Network.responseErrorMessage(jqXHR, (status, msg) => (msgMap[msg] ? t(msgMap[msg], arg) : null));
+    const msg = Network.responseErrorMessage(jqXHR, (status, msg) =>
+      messageMap[msg] ? t(messageMap[msg], arg) : null
+    );
     this.setState({ messages: this.state.messages.concat(msg) });
   };
 

--- a/web/spacewalk-web.changes.eth.msgmap
+++ b/web/spacewalk-web.changes.eth.msgmap
@@ -1,0 +1,1 @@
+- Fix link interpolation in message maps


### PR DESCRIPTION
## What does this PR change?

Fix link interpolation in message maps, also rename `msgMap` → `messageMap`.

## GUI diff

Bugfix, the following messages are now correctly displayed:

<img width="1621" alt="Screenshot 2023-08-03 at 13 24 58" src="https://github.com/uyuni-project/uyuni/assets/3171718/2125a06f-b5e7-44b6-b2f5-683dc7f50e47">


- [x] **DONE**

## Documentation
- No documentation needed: Bugfix

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
