### PR TITLE
Add BSD getopt error for macOS

### DIFF
--- a/rel-eng/bin/mkchlog
+++ b/rel-eng/bin/mkchlog
@@ -27,6 +27,12 @@ Uyuni project: <https://github.com/uyuni-project/uyuni>
 EOF
 }
 
+# Out of the box macOS ships with BSD getopt which doesn't support long args
+if [ "$(uname -s)" == "Darwin" ] && $(man getopt | grep -i -q "bsd"); then
+    echo "Error: This tool requires GNU getopt, but your system is using BSD getopt. Please install GNU getopt and add it to your PATH."
+    exit 1
+fi
+
 ARGS=$(getopt -n mkchlog -o rhnf:u: --long remove,help,no-wrap,feature:username: -- "$@")
 if [ $? -ne 0 ]; then
     exit 1


### PR DESCRIPTION
## What does this PR change?

Out of the box macOS ships with BSD getopt which doesn't support long args. If we detect that's the case, warn the user and exit early.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: rel-eng tooling

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
