### PR TITLE
Testsuite: Extend waiting time for solv file to 10 minutes

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -403,7 +403,7 @@ Then(/^"([^"]*)" package should have been stored$/) do |pkg|
 end
 
 Then(/^solver file for "([^"]*)" should reference "([^"]*)"$/) do |channel, pkg|
-  repeat_until_timeout(timeout: 300, message: "Reference #{pkg} not found in file.") do
+  repeat_until_timeout(timeout: 600, message: "Reference #{pkg} not found in file.") do
     _result, code = $server.run("dumpsolv /var/cache/rhn/repodata/#{channel}/solv | grep #{pkg}", check_errors: false)
     break if code.zero?
   end


### PR DESCRIPTION
## What does this PR change?
The solv file for `fake-suse-rpm-channel` sometimes does not have time to be fully generated when being tested (as a consequence of https://github.com/uyuni-project/uyuni/pull/7342)  - according to timestamps it can take about 7 minutes to fully generate - raising the waiting time to 10 minutes should be enough to cover this.

## GUI diff
No difference.
- [ ] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [ ] **DONE**

## Test coverage
- Cucumber tests were added
- [ ] **DONE**

## Links
Fixes # https://github.com/SUSE/spacewalk/issues/22187
Tracks # 
4.2
4.3
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
