### PR TITLE
reportdb setup: use pg_isactive to wait for postgres

### DIFF
--- a/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb
+++ b/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb
@@ -289,8 +289,7 @@ EOF
         if $LSOF /proc > /dev/null ; then
             while [ -f "$PG_PIDFILE" ] ; do
                 # wait for postmaster to be ready
-                $LSOF -t -p $(head -1 "$PG_PIDFILE" 2>/dev/null) -a "$PG_SOCKET" > /dev/null  \
-                    && break
+                pg_isready -q -U $(grep -oP '^db_user ?= ?\K.*' $RHN_CONF) && break
                 sleep 1
             done
         fi

--- a/spacewalk/uyuni-setup-reportdb/uyuni-setup-reportdb.changes.mbussolotto.pg_wait
+++ b/spacewalk/uyuni-setup-reportdb/uyuni-setup-reportdb.changes.mbussolotto.pg_wait
@@ -1,0 +1,1 @@
+- use pg_isactive to wait for postgres


### PR DESCRIPTION
## What does this PR change?
reportdb setup: use pg_isactive to wait for postgres

Checking the socket doesnt work in the container world, using the tool coming with postgres is much cleaner and works in both cases.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
