### PR TITLE
Testsuite: Change references to checkboxes

### DIFF
--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -292,7 +292,7 @@ The radio button can be identified by name, id or label text.
 ```gherkin
   When I check "manageWithSSH"
   When I uncheck "role_org_admin"
-  When I check "container_build_host" if not checked
+  When I check "Container Build Host" if not checked
 ```
 
 The check box can be identified by name, id or label text.

--- a/testsuite/features/init_clients/buildhost_bootstrap.feature
+++ b/testsuite/features/init_clients/buildhost_bootstrap.feature
@@ -11,8 +11,8 @@ Feature: Bootstrap a Salt build host via the GUI
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE Test Key x86_64" in the content area
     And I wait until I see "Container Build Host" text
-    And I check "container_build_host"
-    And I check "osimage_build_host"
+    And I check "Container Build Host"
+    And I check "OS Image Build Host"
     And I click on "Update Activation Key"
 
   Scenario: Bootstrap a SLES build host
@@ -65,6 +65,6 @@ Feature: Bootstrap a Salt build host via the GUI
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE Test Key x86_64" in the content area
     And I wait until I see "Container Build Host" text
-    And I uncheck "container_build_host"
-    And I uncheck "osimage_build_host"
+    And I uncheck "Container Build Host"
+    And I uncheck "OS Image Build Host"
     And I click on "Update Activation Key"


### PR DESCRIPTION
## What does this PR change?

Changing the checkbox reference in hopes of reducing the amount of flaky tests linked to the checkbox not being checked as expected.
## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were added
- [x] **DONE**

## Links
Fixes #
Tracks # 
4.2 https://github.com/SUSE/spacewalk/pull/22248
4.3 https://github.com/SUSE/spacewalk/pull/22197
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
