### PR TITLE
Remove server keys to allow reregistering to different master

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -605,7 +605,7 @@ elif [ "$INSTALLER" == zypper ]; then
             call_tukit "zypper --non-interactive update {PKG_NAME_VENV_UPDATE} ||:"
         fi
     else
-        if [ -z "$SNAPSHOT_ID"]; then
+        if [ -z "$SNAPSHOT_ID" ]; then
             zypper --non-interactive up {PKG_NAME_UPDATE} $RHNLIB_PKG ||:
         else
             call_tukit "zypper --non-interactive update {PKG_NAME_UPDATE} $RHNLIB_PKG ||:"
@@ -896,12 +896,14 @@ if [ -n "$SNAPSHOT_ID" ]; then
 fi
 
 MINION_ID_FILE="${{SNAPSHOT_PREFIX}}/etc/salt/minion_id"
+MINION_PKI_CONF="${{SNAPSHOT_PREFIX}}/etc/salt/pki"
 MINION_CONFIG_DIR="${{SNAPSHOT_PREFIX}}/etc/salt/minion.d"
 SUSEMANAGER_MASTER_FILE="${{MINION_CONFIG_DIR}}/susemanager.conf"
 MINION_SERVICE="salt-minion"
 
 if [ $VENV_ENABLED -eq 1 ]; then
     MINION_ID_FILE="${{SNAPSHOT_PREFIX}}/etc/venv-salt-minion/minion_id"
+    MINION_PKI_CONF="${{SNAPSHOT_PREFIX}}/etc/venv-salt-minion/pki"
     MINION_CONFIG_DIR="${{SNAPSHOT_PREFIX}}/etc/venv-salt-minion/minion.d"
     SUSEMANAGER_MASTER_FILE="${{MINION_CONFIG_DIR}}/susemanager.conf"
     MINION_SERVICE="venv-salt-minion"
@@ -950,6 +952,11 @@ system-environment:
       _:
         SALT_RUNNING: 1
 EOF
+
+# Remove old minion keys so reregistration do different master works
+if [ -d "$MINION_PKI_CONF" ]; then
+    rm -r "$MINION_PKI_CONF"
+fi
 
 if [ -n "$SNAPSHOT_ID" ]; then
     cat <<EOF >> "${{MINION_CONFIG_DIR}}/transactional_update.conf"

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes.mbussolotto.reregistering
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes.mbussolotto.reregistering
@@ -1,0 +1,1 @@
+- Remove server keys to allow reregistering to different master


### PR DESCRIPTION
## What does this PR change?

Remove server keys to allow reregistering to different master

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed:

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
