### PR TITLE
parse virtual-host-gatherer null value (#7282)

### DIFF
--- a/java/code/src/com/suse/manager/gatherer/GathererJsonIO.java
+++ b/java/code/src/com/suse/manager/gatherer/GathererJsonIO.java
@@ -26,6 +26,7 @@ import com.google.gson.JsonSyntaxException;
 import com.google.gson.TypeAdapter;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 
 import java.io.IOException;
@@ -100,11 +101,18 @@ public class GathererJsonIO {
             reader.beginObject();
             while (reader.hasNext()) {
               String key = reader.nextName();
-              if (key.equals("module")) {
-                gm.setName(reader.nextString());
+              String value = null;
+              if (reader.peek() == JsonToken.NULL) {
+                  reader.nextNull();
               }
               else {
-                  gm.addParameter(key, reader.nextString());
+                  value = reader.nextString();
+              }
+              if (key.equals("module")) {
+                  gm.setName(value);
+              }
+              else {
+                  gm.addParameter(key, value);
               }
             }
             reader.endObject();

--- a/java/code/src/com/suse/manager/gatherer/test/GathererJsonIOTest.java
+++ b/java/code/src/com/suse/manager/gatherer/test/GathererJsonIOTest.java
@@ -55,9 +55,10 @@ public class GathererJsonIOTest  {
                 FileUtils.readStringFromFile(TestUtils.findTestData(MODULELIST).getPath());
         Map<String, GathererModule> mods = new GathererJsonIO().readGathererModules(json);
 
-        assertEquals(2, mods.keySet().size());
+        assertEquals(3, mods.keySet().size());
         assertTrue(mods.keySet().contains("VMware"));
         assertTrue(mods.keySet().contains("SUSECloud"));
+        assertTrue(mods.keySet().contains("Libvirt"));
 
         for (GathererModule g : mods.values()) {
             if (g.getName().equals("VMware")) {
@@ -75,6 +76,11 @@ public class GathererJsonIOTest  {
                 assertTrue(g.getParameters().containsKey("password"));
                 assertTrue(g.getParameters().containsKey("protocol"));
                 assertTrue(g.getParameters().containsKey("tenant"));
+            }
+            else if (g.getName().equals("Libvirt")) {
+                assertTrue(g.getParameters().containsKey("uri"));
+                assertTrue(g.getParameters().containsKey("sasl_username"));
+                assertTrue(g.getParameters().containsKey("sasl_password"));
             }
             else {
                 fail("Unknown Module");

--- a/java/code/src/com/suse/manager/gatherer/test/modulelist.json
+++ b/java/code/src/com/suse/manager/gatherer/test/modulelist.json
@@ -14,6 +14,12 @@
         "port": 443,
         "username": "",
         "password": ""
+    },
+    "Libvirt": {
+        "module": "Libvirt",
+        "uri": "",
+        "sasl_username": null,
+        "sasl_password": null
     }
 }
 

--- a/java/spacewalk-java.changes.mbussolotto.parse_null
+++ b/java/spacewalk-java.changes.mbussolotto.parse_null
@@ -1,0 +1,1 @@
+- parse virtual-host-gatherer null value


### PR DESCRIPTION
## What does this PR change?

parse virtual-host-gatherer null value 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
- No tests: already covered
- Unit tests were added

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
