### PR TITLE
keep aligned TZ and /etc/localtime

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -46,6 +46,10 @@ if [ ! $? -eq 0 ]; then
     exit 1
 fi
 
+if [[ ! -z "$TZ" ]]; then
+    timedatectl set-timezone $TZ
+fi
+
 TMPDIR="/var/spacewalk/tmp"
 DO_MIGRATION=0
 DO_SETUP=0

--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -46,7 +46,7 @@ if [ ! $? -eq 0 ]; then
     exit 1
 fi
 
-if [[ ! -z "$TZ" ]]; then
+if [[ -n "$TZ" ]]; then
     timedatectl set-timezone $TZ
 fi
 

--- a/susemanager/susemanager.changes.mbussolotto.timezone
+++ b/susemanager/susemanager.changes.mbussolotto.timezone
@@ -1,0 +1,1 @@
+- Align TZ value and /etc/localtime

--- a/susemanager/susemanager.changes.mbussolotto.timezone
+++ b/susemanager/susemanager.changes.mbussolotto.timezone
@@ -1,1 +1,1 @@
-- Align TZ value and /etc/localtime
+- Allow setting the timezone from a TZ variable


### PR DESCRIPTION
## What does this PR change?

`TZ` (if set) is used as timezone by the system, but not everywhere (e.g. UI uses ` /etc/localtime`a and completely ignore `TZ`). With this PR  we ensure during setup that the two values represent the same timezone.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
