### PR TITLE
testsuite: do not install or remove formula if in container

### DIFF
--- a/testsuite/features/init_clients/proxy_branch_network.feature
+++ b/testsuite/features/init_clients/proxy_branch_network.feature
@@ -21,6 +21,7 @@ Feature: Setup Uyuni for Retail branch network
 
 @proxy
 @private_net
+@skip_if_container_server
   Scenario: Install or update branch network formulas on the server
     When I manually install the "branch-network" formula on the server
     And I manually install the "dhcpd" formula on the server

--- a/testsuite/features/secondary/allcli_system_group.feature
+++ b/testsuite/features/secondary/allcli_system_group.feature
@@ -105,6 +105,7 @@ Feature: Manage a group of systems
 
   # Red Hat-like minion is intentionally not removed from group
 
+  @skip_if_container_server 
   Scenario: Cleanup: uninstall formula from the server
     When I manually uninstall the "locale" formula from the server
 

--- a/testsuite/features/secondary/min_salt_formulas.feature
+++ b/testsuite/features/secondary/min_salt_formulas.feature
@@ -165,6 +165,7 @@ Feature: Use salt formulas
      And the keymap on "sle_minion" should be "us"
      And the language on "sle_minion" should be "en_US.UTF-8"
 
+  @skip_if_container_server
   Scenario: Cleanup: uninstall formula package from the server
      When I manually uninstall the "locale" formula from the server
 

--- a/testsuite/features/secondary/srv_user_configuration_salt_states.feature
+++ b/testsuite/features/secondary/srv_user_configuration_salt_states.feature
@@ -6,9 +6,12 @@
 @scope_salt
 Feature: Create organizations, users, groups, and activation keys using Salt states
 
+@skip_if_container_server
   Scenario: Apply configuration salt state to server
     When I manually install the "uyuni-config" formula on the server
-    And I apply "setup_users_configuration" local salt state on "server"
+
+  Scenario: Apply setup_users_configuration state to server
+    When I apply "setup_users_configuration" local salt state on "server"
 
   Scenario: Organization my_org was correctly created
     Given I am authorized as "my_org_user" with password "my_org_user"
@@ -66,6 +69,9 @@ Feature: Create organizations, users, groups, and activation keys using Salt sta
 
   Scenario: Cleanup: apply configuration teardown salt state to server
     When I apply "teardown_users_configuration" local salt state on "server"
+
+@skip_if_container_server
+  Scenario: Cleanup: uninstall the uyuni-config formula from the server
     And I manually uninstall the "uyuni-config" formula from the server
 
   Scenario: Cleanup: all organizations were successfully removed

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -198,6 +198,7 @@ Then(/^I should see "([^"]*)" in the command output for "([^"]*)"$/) do |text, h
 end
 
 # Salt formulas
+
 When(/^I manually install the "([^"]*)" formula on the server$/) do |package|
   get_target('server').run('zypper --non-interactive refresh')
   get_target('server').run("zypper --non-interactive install --force #{package}-formula")


### PR DESCRIPTION
## What does this PR change?

testsuite: do not install or remove formula if in container

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
