### PR TITLE
Improve cucumber test based on container requirements

### DIFF
--- a/testsuite/features/core/allcli_sanity.feature
+++ b/testsuite/features/core/allcli_sanity.feature
@@ -6,8 +6,7 @@ Feature: Sanity checks
   I want to be sure to use a sane environment
 
   Scenario: The server is healthy
-    Then "server" should have a FQDN
-    And reverse resolution should work for "server"
+    Then reverse resolution should work for "server"
     And the clock from "server" should be exact
     And service "apache2" is enabled on "server"
     And service "apache2" is active on "server"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -454,7 +454,7 @@ end
 
 When(/^I fetch "([^"]*)" to "([^"]*)"$/) do |file, host|
   node = get_target(host)
-  node.run("wget http://#{$server.full_hostname}/#{file}")
+  node.run("curl -s -O http://#{$server.full_hostname}/#{file}")
 end
 
 When(/^I wait until file "([^"]*)" contains "([^"]*)" on server$/) do |file, content|

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -452,9 +452,8 @@ When(/^I select the hostname of "([^"]*)" from "([^"]*)"((?: if present)?)$/) do
     system_name = get_system_name(host)
   rescue
     raise "Host #{host} not found" if if_present.empty?
-
     log "Host #{host} is not deployed, not trying to select it"
-    return
+    next
   end
   step %(I select "#{system_name}" from "#{field}")
 end

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -199,13 +199,8 @@ def get_system_name(host)
   when 'containerized_proxy'
     system_name = $proxy.full_hostname.sub('pxy', 'pod-pxy')
   else
-    begin
-      node = get_target(host)
-      system_name = node.full_hostname
-    rescue RuntimeError
-      # If the node for that host is not defined, just return the host parameter as system_name
-      system_name = host
-    end
+    node = get_target(host)
+    system_name = node.full_hostname
   end
   system_name
 end


### PR DESCRIPTION
## What does this PR change?

The PR contains some changes (already tested in `server-container` branch) useful to improve some flaky tests.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
