### PR TITLE
Differency monitoring from sleminion

### DIFF
--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -261,7 +261,6 @@ When(/^I create an activation key including custom channels for "([^"]*)" via AP
   client.sub! 'ssh_minion', 'minion'
   client.sub! 'buildhost', 'minion'
   client.sub! 'terminal', 'minion'
-  client.sub! 'monitoring_server', 'sle15sp4_minion'
   custom_channel = if client.include? 'alma9'
                      'no-appstream-alma-9-result-custom_channel_alma9_minion'
                    elsif client.include? 'liberty9'

--- a/testsuite/features/step_definitions/file_management_steps.rb
+++ b/testsuite/features/step_definitions/file_management_steps.rb
@@ -81,7 +81,7 @@ When(/^I bootstrap "([^"]*)" using bootstrap script with activation key "([^"]*)
   system_name = get_system_name(host)
   output, = target.run("expect -f /tmp/#{boostrap_script} #{system_name}", verbose: true)
   unless output.include? '-bootstrap complete-'
-    log output
+    log output.encode('utf-8', :invalid => :replace, :undef => :replace, :replace => '_')
     raise "Bootstrap didn't finish properly"
   end
 end

--- a/testsuite/features/step_definitions/file_management_steps.rb
+++ b/testsuite/features/step_definitions/file_management_steps.rb
@@ -81,7 +81,7 @@ When(/^I bootstrap "([^"]*)" using bootstrap script with activation key "([^"]*)
   system_name = get_system_name(host)
   output, = target.run("expect -f /tmp/#{boostrap_script} #{system_name}", verbose: true)
   unless output.include? '-bootstrap complete-'
-    log output.encode('utf-8', :invalid => :replace, :undef => :replace, :replace => '_')
+    log output
     raise "Bootstrap didn't finish properly"
   end
 end


### PR DESCRIPTION
## What does this PR change?
Because we are now creating a specific channel for monitoring, remove changing monitoring_server for sle15sp4_minion so the API call when creating the activation key will correctly look for monitoring custom channel

- [x] No changelog needed

