### PR TITLE
Increate bootstrap script timeout and handle ut-8 format

### DIFF
--- a/testsuite/features/step_definitions/file_management_steps.rb
+++ b/testsuite/features/step_definitions/file_management_steps.rb
@@ -79,9 +79,9 @@ When(/^I bootstrap "([^"]*)" using bootstrap script with activation key "([^"]*)
   return_code = file_inject(target, source, dest)
   raise 'File injection failed' unless return_code.zero?
   system_name = get_system_name(host)
-  output, = target.run("expect -f /tmp/#{boostrap_script} #{system_name}", verbose: true)
+  output, = target.run("sed -i '/^set timeout /c\\set timeout #{DEFAULT_TIMEOUT}' /tmp/#{boostrap_script} && expect -f /tmp/#{boostrap_script} #{system_name}")
   unless output.include? '-bootstrap complete-'
-    log output
+    log output.encode('utf-8', :invalid => :replace, :undef => :replace, :replace => '_')
     raise "Bootstrap didn't finish properly"
   end
 end


### PR DESCRIPTION
Related to : https://github.com/SUSE/spacewalk/issues/22164 / Issue 1 
During BV, sometime the bootstrap script takes more than 180 seconds.
The first issue we have is an unsupported utf-8 character "\xE2" that will fail the log.
I fix this issue with the encode solution.

The second issue we have is sometimes the bootstrap will take more than 3 minutes ( we wait up to 500 sec for interface bootstrap).
The timeout for the bootstrap will now be the same than DEFAULT_TIMEOUT.

- [ ] No changelog needed
