### PR TITLE
Check Overview Page is correctly loaded before looking for system

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -110,7 +110,7 @@ When(/^I wait at most (\d+) seconds until the event is completed, refreshing the
 end
 
 When(/^I wait until I see the name of "([^"]*)", refreshing the page$/) do |host|
-  raise 'Overview System page didn\'t load' unless has_content?("System Overview")
+  raise 'Overview System page didn\'t load' unless has_content?('System Overview')
   system_name = get_system_name(host)
   step %(I wait until I see the "#{system_name}" system, refreshing the page)
 end

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -110,6 +110,7 @@ When(/^I wait at most (\d+) seconds until the event is completed, refreshing the
 end
 
 When(/^I wait until I see the name of "([^"]*)", refreshing the page$/) do |host|
+  raise 'Overview System page didn\'t load' unless has_content?("System Overview")
   system_name = get_system_name(host)
   step %(I wait until I see the "#{system_name}" system, refreshing the page)
 end


### PR DESCRIPTION
## What does this PR change?
Wait until the System Overview page is loaded before trying to look for the system.
During BV we had situations where we are refreshing the page before Overview System page was loading. This wrong refresh was keeping us on the page where we were clicking on the left menu ( Bootstrap page or Main Overview)

## Links

Related to this issues : 
- https://github.com/SUSE/spacewalk/issues/22174
- https://github.com/SUSE/spacewalk/issues/22164 / Issue 2

- [x] **DONE**

## Changelogs

- [x] No changelog needed

