### PR TITLE
Check login page is correctly loaded

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -532,6 +532,7 @@ Given(/^I am authorized as "([^"]*)" with password "([^"]*)"$/) do |user, passwd
 
   find(:xpath, "//header//i[@class='fa fa-sign-out']").click if all(:xpath, "//header//i[@class='fa fa-sign-out']", wait: 0).any?
 
+  raise 'Login page is not correctly loaded' unless has_field?('username')
   fill_in('username', with: user)
   fill_in('password', with: passwd)
   click_button_and_wait('Sign In', match: :first)


### PR DESCRIPTION
## What does this PR change?
During the BV testing, on some tests, the fields in the login page are empty but the testsuite is expecting to be log in. 
After investigation, it seems we fill the field too early. With this new step, we make sure the username is correctly loaded.


## Links

Related to : https://github.com/SUSE/spacewalk/issues/22176

- [x] **DONE**

## Changelogs

- [x] No changelog needed
