### PR TITLE
Add waiting text checks between event click link

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -145,7 +145,7 @@ When(/^I wait (\d+) seconds until the event is picked up and (\d+) seconds until
     And I wait until I see "Pending Events" text
     And I follow "Pending"
     And I wait until I see "Pending Events" text
-    And I wait at most 180 seconds until I do not see "#{event}" text, refreshing the page
+    And I wait at most #{pickup_timeout} seconds until I do not see "#{event}" text, refreshing the page
     And I follow "History"
     And I wait until I see "System History" text
     And I wait until I see "#{event}" text, refreshing the page

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -142,12 +142,16 @@ When(/^I wait (\d+) seconds until the event is picked up and (\d+) seconds until
   # same name in the events history - however, that's the best we have so far.
   steps %(
     When I follow "Events"
+    And I wait until I see "Pending Events" text
     And I follow "Pending"
-    And I wait at most #{pickup_timeout} seconds until I do not see "#{event}" text, refreshing the page
+    And I wait until I see "Pending Events" text
+    And I wait at most 180 seconds until I do not see "#{event}" text, refreshing the page
     And I follow "History"
     And I wait until I see "System History" text
     And I wait until I see "#{event}" text, refreshing the page
     And I follow first "#{event}"
+    And I wait until I see "This action will be executed after" text
+    And I wait until I see "#{event}" text
     And I wait at most #{complete_timeout} seconds until the event is completed, refreshing the page
   )
 end


### PR DESCRIPTION
## What does this PR change?
Add waiting steps between click during the onboarding waiting around event tab.
During the BV, some of the refresh methods were starting before the page loaded ( same than https://github.com/uyuni-project/uyuni/pull/7371 )

## Links
Related to : https://github.com/SUSE/spacewalk/issues/22175

## Changelogs

- [x] No changelog needed
