### PR TITLE
QE: Fix Uyuni reposync for openSUSE Leap 15.4

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -30,7 +30,12 @@ end
 # This is a safety net only, the best thing to do is to not start the reposync at all.
 def compute_channels_to_leave_running
   # keep the repos needed for the auto-installation tests
-  do_not_kill = CHANNEL_TO_SYNCH_BY_OS_VERSION['default']
+  do_not_kill =
+    if $product == 'Uyuni'
+      CHANNEL_TO_SYNCH_BY_OS_VERSION['15.4']
+    else
+      CHANNEL_TO_SYNCH_BY_OS_VERSION['default']
+    end
   [$minion, $build_host, $ssh_minion, $rhlike_minion].each do |node|
     next unless node
     os_version = node.os_version

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -454,6 +454,17 @@ CHANNEL_TO_SYNCH_BY_OS_VERSION = {
     res8-manager-tools-pool-x86_64
     res8-manager-tools-updates-x86_64
     sll8-uyuni-client-x86_64
+  ],
+  '15.4' =>
+  %w[
+    opensuse_leap15_4-x86_64
+    opensuse_leap15_4-x86_64-non-oss
+    opensuse_leap15_4-x86_64-non-oss-updates
+    opensuse_leap15_4-x86_64-updates
+    opensuse_leap15_4-x86_64-backports-updates
+    opensuse_leap15_4-x86_64-sle-updates
+    uyuni-proxy-devel-leap-x86_64
+    opensuse_leap15_4-uyuni-client-x86_64
   ]
 }.freeze
 


### PR DESCRIPTION
## What does this PR change?

Do not kill the reposync of openSUSE Leap 15.4 for Uyuni. We recently switched the Uyuni CI from SLES to openSUSE Leap, so we should not kill the reposync of it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage
- Cucumber tests were adjusted

- [x] **DONE**

## Links


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
