### PR TITLE
QE: Wait for pending Salt Jobs after building an image before moving to next build action

### DIFF
--- a/testsuite/features/build_validation/retail/sle12sp5_buildhost_build_kiwi_image.feature
+++ b/testsuite/features/build_validation/retail/sle12sp5_buildhost_build_kiwi_image.feature
@@ -36,6 +36,7 @@ Feature: Prepare buildhost and build OS image for SLES 12 SP5
     And I select "1-sle12sp5_minion_key" from "activationKey"
     And I enter the image filename for "sle12sp5_terminal" relative to profiles as "path"
     And I click on "create-btn"
+    And I wait until no Salt job is running on "sle12sp5_buildhost"
 
   # WORKAROUND
   # Remove as soon as the issue is fixed
@@ -53,6 +54,7 @@ Feature: Prepare buildhost and build OS image for SLES 12 SP5
     Then I should see a "[OS Image Build Host]" text
     When I wait until the image build "suse_os_image_12" is completed
     And I wait until the image inspection for "sle12sp5_terminal" is completed
+    And I wait until no Salt job is running on "sle12sp5_buildhost"
     And I am on the image store of the Kiwi image for organization "1"
     Then I should see the name of the image for "sle12sp5_terminal"
 

--- a/testsuite/features/secondary/buildhost_docker_auth_registry.feature
+++ b/testsuite/features/secondary/buildhost_docker_auth_registry.feature
@@ -41,6 +41,7 @@ Feature: Build image with authenticated registry
     # Verify the status of images in the authenticated image store
     When I wait at most 600 seconds until image "auth_registry_profile" with version "latest" is built successfully via API
     And I wait at most 300 seconds until image "auth_registry_profile" with version "latest" is inspected successfully via API
+    And I wait until no Salt job is running on "build_host"
     And I refresh the page
     Then table row for "auth_registry_profile" should contain "1"
     And the list of packages of image "auth_registry_profile" with version "latest" is not empty

--- a/testsuite/features/secondary/buildhost_docker_build_image.feature
+++ b/testsuite/features/secondary/buildhost_docker_build_image.feature
@@ -83,36 +83,42 @@ Feature: Build container images
     And I wait at most 600 seconds until image "suse_real_key" with version "latest" is built successfully via API
     And I wait at most 300 seconds until image "suse_real_key" with version "latest" is inspected successfully via API
     Then the list of packages of image "suse_real_key" with version "latest" is not empty
+    When I wait until no Salt job is running on "build_host"
 
   Scenario: Build suse_key images with different versions
     When I schedule the build of image "suse_key" with version "Latest_key-activation1" via API calls
     And I wait at most 600 seconds until image "suse_key" with version "Latest_key-activation1" is built successfully via API
     And I wait at most 300 seconds until image "suse_key" with version "Latest_key-activation1" is inspected successfully via API
     Then the list of packages of image "suse_key" with version "Latest_key-activation1" is not empty
-  
+    When I wait until no Salt job is running on "build_host"
+
   Scenario: Build suse_simple image with different versions
     When I schedule the build of image "suse_simple" with version "Latest_simple" via API calls
     And I wait at most 600 seconds until image "suse_simple" with version "Latest_simple" is built successfully via API
     And I wait at most 300 seconds until image "suse_simple" with version "Latest_simple" is inspected successfully via API
-    Then the list of packages of image "suse_simple" with version "Latest_simple" is not empty
+    Then the list of packages of image "suse_simple" with version "Latest_simple" is not
+    When I wait until no Salt job is running on "build_host"
 
   Scenario: Delete image via API calls
     When I delete the image "suse_key" with version "Latest_key-activation1" via API calls
     And I delete the image "suse_simple" with version "Latest_simple" via API calls
     Then the image "suse_simple" with version "Latest_key-activation1" doesn't exist via API calls
     And the image "suse_simple" with version "Latest_simple" doesn't exist via API calls
+    When I wait until no Salt job is running on "build_host"
 
   Scenario: Rebuild suse_simple image
     When I schedule the build of image "suse_simple" with version "Latest_simple" via API calls
     And I wait at most 600 seconds until image "suse_simple" with version "Latest_simple" is built successfully via API
     And I wait at most 300 seconds until image "suse_simple" with version "Latest_simple" is inspected successfully via API
     Then the list of packages of image "suse_simple" with version "Latest_simple" is not empty
+    When I wait until no Salt job is running on "build_host"
 
   Scenario: Rebuild suse_key image
     When I schedule the build of image "suse_key" with version "Latest_key-activation1" via API calls
     And I wait at most 600 seconds until image "suse_key" with version "Latest_key-activation1" is built successfully via API
     And I wait at most 300 seconds until image "suse_key" with version "Latest_key-activation1" is inspected successfully via API
     Then the list of packages of image "suse_key" with version "Latest_key-activation1" is not empty
+    When I wait until no Salt job is running on "build_host"
 
   Scenario: Build an image via the GUI
     When I follow the left menu "Images > Build"
@@ -120,6 +126,7 @@ Feature: Build container images
     And I enter "GUI_BUILT_IMAGE" as "version"
     And I select the hostname of "build_host" from "buildHostId"
     And I click on "submit-btn"
+    And I wait until no Salt job is running on "build_host"
     Then I wait until I see "GUI_BUILT_IMAGE" text
     And I wait at most 600 seconds until image "suse_real_key" with version "GUI_BUILT_IMAGE" is built successfully via API
     And I wait at most 300 seconds until image "suse_real_key" with version "GUI_BUILT_IMAGE" is inspected successfully via API
@@ -131,6 +138,7 @@ Feature: Build container images
     And I enter "GUI_DOCKERADMIN" as "version"
     And I select the hostname of "build_host" from "buildHostId"
     And I click on "submit-btn"
+    And I wait until no Salt job is running on "build_host"
     Then I wait until I see "GUI_DOCKERADMIN" text
     And I wait at most 600 seconds until image "suse_real_key" with version "GUI_DOCKERADMIN" is built successfully via API
     And I wait at most 300 seconds until image "suse_real_key" with version "GUI_DOCKERADMIN" is inspected successfully via API

--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -29,6 +29,7 @@ Feature: Build OS images
     And I select "1-SUSE-KEY-x86_64" from "activationKey"
     And I enter the image filename for "pxeboot_minion" relative to profiles as "path"
     And I click on "create-btn"
+    And I wait until no Salt job is running on "build_host"
 
   # WORKAROUND
   # Remove as soon as the issue is fixed
@@ -50,6 +51,7 @@ Feature: Build OS images
     Then I should see a "[OS Image Build Host]" text
     When I wait until the image build "suse_os_image" is completed
     And I wait until the image inspection for "pxeboot_minion" is completed
+    And I wait until no Salt job is running on "build_host"
     And I am on the image store of the Kiwi image for organization "1"
     Then I should see the name of the image for "pxeboot_minion"
 

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -91,8 +91,8 @@ end
 When(/^I wait until no Salt job is running on "([^"]*)"$/) do |minion|
   target = get_target(minion)
   salt_call = $use_salt_bundle ? "venv-salt-call" : "salt-call"
-  repeat_until_timeout(message: "A Salt job is still running on #{minion}") do
-    output, _code = target.run("#{salt_call} -lquiet saltutil.running")
+  repeat_until_timeout(timeout: 360, message: "A Salt job is still running on #{minion}") do
+    output, _code = target.run("#{salt_call} -lquiet saltutil.running", verbose: true)
     break if output == "local:\n"
     sleep 3
   end


### PR DESCRIPTION
## What does this PR change?

Related card: https://github.com/SUSE/spacewalk/issues/22078

Improve how we handle the validation of each image building, including additional checks to don't perform another image building unless there are no pending Salt jobs in the build host.
I also increase the timeout for Salt jobs related to building images to 6 minutes and make the check verbose so we know what was running if the timeout raise.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were refactored

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/22094

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
