### PR TITLE
PXEBoot: If we raise a previous timeout, we are able to recover and continue with next scenario

### DIFF
--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -100,8 +100,10 @@ Feature: PXE boot a terminal with Cobbler
     And I set the default PXE menu entry to the local boot on the "proxy"
     And I wait at most 1200 seconds until Salt master sees "pxeboot_minion" as "unaccepted"
     And I accept "pxeboot_minion" key in the Salt master
-    And I am on the Systems page
-    And I wait until I see the name of "pxeboot_minion", refreshing the page
+
+  Scenario: Assure the PXE boot minion is onboarded
+    Given I am on the Systems page
+    When I wait until I see the name of "pxeboot_minion", refreshing the page
     And I wait until onboarding is completed for "pxeboot_minion"
     Then "pxeboot_minion" should have been reformatted
 

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -191,8 +191,10 @@ Feature: PXE boot a Retail terminal
     When I reboot the Retail terminal "pxeboot_minion"
     And I wait at most 180 seconds until Salt master sees "pxeboot_minion" as "unaccepted"
     And I accept "pxeboot_minion" key in the Salt master
-    And I follow the left menu "Systems > System List > All"
-    And I wait until I see the name of "pxeboot_minion", refreshing the page
+
+  Scenario: Assure the PXE boot minion is onboarded
+    Given I am on the Systems page
+    When I wait until I see the name of "pxeboot_minion", refreshing the page
     And I follow this "pxeboot_minion" link
     # Workaround: Increase timeout temporarily get rid of timeout issues
     And I wait at most 350 seconds until event "Apply states [saltboot] scheduled by (none)" is completed


### PR DESCRIPTION
## What does this PR change?

PXEBoot: If we raise a previous timeout, we are able to recover and continue with next scenario

![image](https://github.com/SUSE/spacewalk/assets/2827771/7dab4032-6d66-49e7-b183-3e6598d0a7c3)
![image](https://github.com/SUSE/spacewalk/assets/2827771/f58d0fb4-8ab5-4e4b-8942-1149e4f0c67c)

(In the second screenshot we fail because we did not wait for the onboarding)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were refactored

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/22181

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
