### PR TITLE
QE: Increase some timeouts related to Salt Jobs and refresh page for KVM loading page

### DIFF
--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -61,7 +61,8 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
   Scenario: Edit a KVM virtual machine
     When I click on "Edit" in row "test-vm"
-    And I wait until I do not see "Loading..." text
+    # WORKAROUND: bsc#1213220 Virtualization page stuck on Loading
+    And I wait until I do not see "Loading..." text, refreshing the page
     Then I should see "1024" in field identified by "memory"
     And I should see "1" in field identified by "vcpu"
     And option "VNC" is selected as "graphicsType"
@@ -83,7 +84,8 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
   Scenario: Add a network interface to a KVM virtual machine
     When I click on "Edit" in row "test-vm"
-    And I wait until I do not see "Loading..." text
+    # WORKAROUND: bsc#1213220 Virtualization page stuck on Loading
+    And I wait until I do not see "Loading..." text, refreshing the page
     And I click on "add_network"
     And I select "test-net1" from "network1_source"
     And I click on "Update"
@@ -92,7 +94,8 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
   Scenario: Delete a network interface from a KVM virtual machine
     When I click on "Edit" in row "test-vm"
-    And I wait until I do not see "Loading..." text
+    # WORKAROUND: bsc#1213220 Virtualization page stuck on Loading
+    And I wait until I do not see "Loading..." text, refreshing the page
     And I click on "remove_network1"
     And I click on "Update"
     Then I should see a "Hosted Virtual Systems" text
@@ -100,7 +103,8 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
   Scenario: Add a disk and a cdrom to a KVM virtual machine
     When I click on "Edit" in row "test-vm"
-    And I wait until I do not see "Loading..." text
+    # WORKAROUND: bsc#1213220 Virtualization page stuck on Loading
+    And I wait until I do not see "Loading..." text, refreshing the page
     And I click on "add_disk"
     And I click on "add_disk"
     And I select "CDROM" from "disk2_device"
@@ -114,7 +118,8 @@ Feature: Be able to manage KVM virtual machines via the GUI
     When I click on "Edit" in row "test-vm"
     And I wait until I do not see "Loading..." text
     And I store "" into file "/tmp/test-image.iso" on "kvm_server"
-    And I wait until I do not see "Loading..." text
+    # WORKAROUND: bsc#1213220 Virtualization page stuck on Loading
+    And I wait until I do not see "Loading..." text, refreshing the page
     And I enter "/tmp/test-image.iso" as "disk2_source_file"
     And I click on "Update"
     Then I should see a "Hosted Virtual Systems" text
@@ -122,7 +127,8 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
   Scenario: Delete a disk from a KVM virtual machine
     When I click on "Edit" in row "test-vm"
-    And I wait until I do not see "Loading..." text
+    # WORKAROUND: bsc#1213220 Virtualization page stuck on Loading
+    And I wait until I do not see "Loading..." text, refreshing the page
     And I click on "remove_disk2"
     And I click on "Update"
     Then I should see a "Hosted Virtual Systems" text
@@ -256,7 +262,8 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
   Scenario: Delete a virtual volume
     When I follow "Storage"
-    And I wait until I do not see "Loading..." text
+    # WORKAROUND: bsc#1213220 Virtualization page stuck on Loading
+    And I wait until I do not see "Loading..." text, refreshing the page
     And I open the sub-list of the product "tmp"
     And I click on "Delete" in tree item "test-net0.xml"
     And I click on "Delete" in "Delete Virtual Storage Volume" modal

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -91,7 +91,7 @@ end
 When(/^I wait until no Salt job is running on "([^"]*)"$/) do |minion|
   target = get_target(minion)
   salt_call = $use_salt_bundle ? "venv-salt-call" : "salt-call"
-  repeat_until_timeout(timeout: 360, message: "A Salt job is still running on #{minion}") do
+  repeat_until_timeout(timeout: 600, message: "A Salt job is still running on #{minion}") do
     output, _code = target.run("#{salt_call} -lquiet saltutil.running", verbose: true)
     break if output == "local:\n"
     sleep 3
@@ -310,6 +310,12 @@ When(/^I wait until there is no pillar refresh salt job active$/) do
     break unless output.include?("saltutil.refresh_pillar")
     sleep 1
   end
+end
+
+When(/^I wait until there is no Salt job calling the module "([^"]*)" on "([^"]*)"$/) do |salt_module, minion|
+  target = get_target(minion)
+  salt_call = $use_salt_bundle ? "venv-salt-call" : "salt-call"
+  target.run_until_fail("#{salt_call} -lquiet saltutil.running | grep #{salt_module}", timeout: 600)
 end
 
 def pillar_get(key, minion)

--- a/testsuite/features/support/lavanda.rb
+++ b/testsuite/features/support/lavanda.rb
@@ -166,8 +166,8 @@ module LavandaBasic
   #
   # Args:
   #   cmd: The command to run.
-  def run_until_ok(cmd)
-    repeat_until_timeout(report_result: true) do
+  def run_until_ok(cmd, timeout: DEFAULT_TIMEOUT)
+    repeat_until_timeout(timeout: timeout, report_result: true) do
       result, code = run(cmd, check_errors: false)
       break if code.zero?
       sleep 2
@@ -180,8 +180,8 @@ module LavandaBasic
   #
   # Args:
   #   cmd: The command to run.
-  def run_until_fail(cmd)
-    repeat_until_timeout(report_result: true) do
+  def run_until_fail(cmd, timeout: DEFAULT_TIMEOUT)
+    repeat_until_timeout(timeout: timeout, report_result: true) do
       result, code = run(cmd, check_errors: false)
       break if code.nonzero?
       sleep 2


### PR DESCRIPTION
## What does this PR change?

- Increase some timeouts related to Salt Jobs
- Refresh page while waiting for KVM pages to finish loading spinning

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/22138

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
