### PR TITLE
QE: Refactor how we wait for Hardware refresh action by specifying the salt job to wait

### DIFF
--- a/testsuite/features/build_validation/retail/proxy_branch_network.feature
+++ b/testsuite/features/build_validation/retail/proxy_branch_network.feature
@@ -197,6 +197,7 @@ Feature: Prepare the branch server for PXE booting
     And I click on "Schedule Hardware Refresh"
     Then I should see a "You have successfully scheduled a hardware profile refresh" text
     When I wait until event "Hardware List Refresh scheduled by admin" is completed
+    And I wait until there is no Salt job calling the module "hardware.profileupdate" on "proxy"
     And I follow "Details" in the content area
     And I follow "Hardware" in the content area
     Then I should see a "proxy.example.org" text

--- a/testsuite/features/init_clients/proxy_branch_network.feature
+++ b/testsuite/features/init_clients/proxy_branch_network.feature
@@ -225,6 +225,7 @@ Feature: Setup Uyuni for Retail branch network
     And I click on "Schedule Hardware Refresh"
     Then I should see a "You have successfully scheduled a hardware profile refresh" text
     When I wait until event "Hardware List Refresh scheduled by admin" is completed
+    And I wait until there is no Salt job calling the module "hardware.profileupdate" on "proxy"
     And I follow "Details" in the content area
     And I follow "Hardware" in the content area
     Then I should see a "proxy.example.org" text

--- a/testsuite/features/secondary/allcli_overview_systems_details.feature
+++ b/testsuite/features/secondary/allcli_overview_systems_details.feature
@@ -12,7 +12,8 @@ Feature: The system details of each minion and client provides an overview of th
     When I follow "Hardware"
     And I click on "Schedule Hardware Refresh"
     Then I should see a "You have successfully scheduled a hardware profile refresh" text
-    And I wait until event "Hardware List Refresh scheduled by admin" is completed
+    When I wait until event "Hardware List Refresh scheduled by admin" is completed
+    And I wait until there is no Salt job calling the module "hardware.profileupdate" on "sle_minion"
 
 @sle_minion
   Scenario: Minion grains are displayed correctly on the details page
@@ -33,7 +34,8 @@ Feature: The system details of each minion and client provides an overview of th
     When I follow "Hardware"
     And I click on "Schedule Hardware Refresh"
     Then I should see a "You have successfully scheduled a hardware profile refresh" text
-    And I wait until event "Hardware List Refresh scheduled by admin" is completed
+    When I wait until event "Hardware List Refresh scheduled by admin" is completed
+    And I wait until there is no Salt job calling the module "hardware.profileupdate" on "rhlike_minion"
 
 @rhlike_minion
   Scenario: Red Hat-like minion grains are displayed correctly on the details page
@@ -54,7 +56,8 @@ Feature: The system details of each minion and client provides an overview of th
     When I follow "Hardware"
     And I click on "Schedule Hardware Refresh"
     Then I should see a "You have successfully scheduled a hardware profile refresh" text
-    And I wait until event "Hardware List Refresh scheduled by admin" is completed
+    When I wait until event "Hardware List Refresh scheduled by admin" is completed
+    And I wait until there is no Salt job calling the module "hardware.profileupdate" on "deblike_minion"
 
 @deblike_minion
   Scenario: Debian-like minion grains are displayed correctly on the details page
@@ -75,9 +78,10 @@ Feature: The system details of each minion and client provides an overview of th
     When I follow "Hardware"
     And I click on "Schedule Hardware Refresh"
     Then I should see a "You have successfully scheduled a hardware profile refresh" text
-    And I wait until event "Hardware List Refresh scheduled by admin" is completed
+    When I wait until event "Hardware List Refresh scheduled by admin" is completed
+    And I wait until there is no Salt job calling the module "hardware.profileupdate" on "ssh_minion"
 
-@ssh_minion
+  @ssh_minion
   Scenario: SSH-managed minion grains are displayed correctly on the details page
     Given I am on the Systems overview page of this "ssh_minion"
     Then the hostname for "ssh_minion" should be correct

--- a/testsuite/features/secondary/min_salt_mgrcompat_state.feature
+++ b/testsuite/features/secondary/min_salt_mgrcompat_state.feature
@@ -27,7 +27,8 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     When I follow "Hardware"
     And I click on "Schedule Hardware Refresh"
     Then I should see a "You have successfully scheduled a hardware profile refresh" text
-    And I wait until event "Hardware List Refresh scheduled by admin" is completed
+    When I wait until event "Hardware List Refresh scheduled by admin" is completed
+    And I wait until there is no Salt job calling the module "hardware.profileupdate" on "sle_minion"
 
   Scenario: Remove saltutil grain and mgrcompat module from minion and schedule Hardware Refresh
     Given I remove "minion/extmods/states/mgrcompat.py" from salt cache on "sle_minion"
@@ -38,7 +39,8 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     When I follow "Hardware"
     And I click on "Schedule Hardware Refresh"
     Then I should see a "You have successfully scheduled a hardware profile refresh" text
-    And I wait until event "Hardware List Refresh scheduled by admin" is completed
+    When I wait until event "Hardware List Refresh scheduled by admin" is completed
+    And I wait until there is no Salt job calling the module "hardware.profileupdate" on "sle_minion"
 
   Scenario: Delete SLES minion system profile before mgrcompat test
     Given I am on the Systems overview page of this "sle_minion"
@@ -78,7 +80,8 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     And I follow "Hardware"
     And I click on "Schedule Hardware Refresh"
     Then I should see a "You have successfully scheduled a hardware profile refresh" text
-    And I wait until event "Hardware List Refresh scheduled by admin" is completed
+    When I wait until event "Hardware List Refresh scheduled by admin" is completed
+    And I wait until there is no Salt job calling the module "hardware.profileupdate" on "sle_minion"
 
   Scenario: Cleanup: Delete profile of the minion and disable new module.run syntax
     Given I am on the Systems overview page of this "sle_minion"

--- a/testsuite/features/secondary/min_salt_minion_details.feature
+++ b/testsuite/features/secondary/min_salt_minion_details.feature
@@ -23,7 +23,8 @@ Feature: Verify the minion registration
     And I follow "Hardware" in the content area
     And I click on "Schedule Hardware Refresh"
     Then I should see a "You have successfully scheduled a hardware profile refresh" text
-    And I wait until event "Hardware List Refresh scheduled by admin" is completed
+    When I wait until event "Hardware List Refresh scheduled by admin" is completed
+    And I wait until there is no Salt job calling the module "hardware.profileupdate" on "sle_minion"
 
   Scenario: Check that Update Properties button works
     When I follow "Details" in the content area


### PR DESCRIPTION
## What does this PR change?

Refactor how we wait for Hardware refresh action by specifying the salt job to wait.

This new step definition can start to be used for other actions where we want to specifically wait for a concrete Salt Job. 
Like building images, where we should wait for mods:
```
- images.profileupdate
- images.docker
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were refactored

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/22095

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
