### PR TITLE
Revert "Testsuite: Replace steps that use systems filter to navigate to minions"

### DIFF
--- a/testsuite/features/build_validation/retail/sle12sp5_terminal_deploy.feature
+++ b/testsuite/features/build_validation/retail/sle12sp5_terminal_deploy.feature
@@ -27,7 +27,7 @@ Feature: PXE boot a SLES 12 SP5 retail terminal
     Then "sle12sp5_terminal" should have been reformatted
 
   Scenario: Check connection from SLES 12 SP5 retail terminal to branch server
-    Given I am on the Systems overview page of this "sle12sp5_terminal"
+    Given I navigate to the Systems overview page of this "sle12sp5_terminal"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
     Then I should see a "proxy.example.org" text

--- a/testsuite/features/build_validation/retail/sle12sp5_terminal_deploy.feature
+++ b/testsuite/features/build_validation/retail/sle12sp5_terminal_deploy.feature
@@ -27,7 +27,7 @@ Feature: PXE boot a SLES 12 SP5 retail terminal
     Then "sle12sp5_terminal" should have been reformatted
 
   Scenario: Check connection from SLES 12 SP5 retail terminal to branch server
-    Given I navigate to the Systems overview page of this "sle12sp5_terminal"
+    Given I am on the Systems overview page of this "sle12sp5_terminal"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
     Then I should see a "proxy.example.org" text

--- a/testsuite/features/build_validation/retail/sle15sp4_terminal_deploy.feature
+++ b/testsuite/features/build_validation/retail/sle15sp4_terminal_deploy.feature
@@ -27,7 +27,7 @@ Feature: PXE boot a SLES 15 SP4 retail terminal
     Then "sle15sp4_terminal" should have been reformatted
 
   Scenario: Check connection from SLES 15 SP4 retail terminal to branch server
-    Given I am on the Systems overview page of this "sle15sp4_terminal"
+    Given I navigate to the Systems overview page of this "sle15sp4_terminal"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
     Then I should see a "proxy.example.org" text

--- a/testsuite/features/init_clients/sle_minion.feature
+++ b/testsuite/features/init_clients/sle_minion.feature
@@ -30,7 +30,7 @@ Feature: Bootstrap a Salt minion via the GUI
 
 @proxy
   Scenario: Check connection from minion to proxy
-    Given I am on the Systems overview page of this "sle_minion"
+    Given I navigate to the Systems overview page of this "sle_minion"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
     Then I should see "proxy" short hostname

--- a/testsuite/features/init_clients/sle_minion.feature
+++ b/testsuite/features/init_clients/sle_minion.feature
@@ -30,7 +30,7 @@ Feature: Bootstrap a Salt minion via the GUI
 
 @proxy
   Scenario: Check connection from minion to proxy
-    Given I navigate to the Systems overview page of this "sle_minion"
+    Given I am on the Systems overview page of this "sle_minion"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
     Then I should see "proxy" short hostname

--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -141,7 +141,7 @@ Feature: PXE boot a terminal with Cobbler
     And I wait for "tftpboot-installation-SLE-15-SP4-x86_64" to be uninstalled on "server"
 
   Scenario: Cleanup: delete the PXE boot minion
-    Given I am on the Systems overview page of this "pxeboot_minion"
+    Given I navigate to the Systems overview page of this "pxeboot_minion"
     When I follow "Delete System"
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -203,13 +203,13 @@ Feature: PXE boot a Retail terminal
     Then "pxeboot_minion" should have been reformatted
 
   Scenario: Check connection from terminal to branch server
-    Given I am on the Systems overview page of this "pxeboot_minion"
+    Given I navigate to the Systems overview page of this "pxeboot_minion"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
     Then I should see a "proxy.example.org" text
 
   Scenario: Install a package on the new Retail terminal
-    Given I am on the Systems overview page of this "pxeboot_minion"
+    Given I navigate to the Systems overview page of this "pxeboot_minion"
     When I install the GPG key of the test packages repository on the PXE boot minion
     And I follow "Software" in the content area
     And I follow "Install"
@@ -222,7 +222,7 @@ Feature: PXE boot a Retail terminal
     When I wait until event "Package Install/Upgrade scheduled by admin" is completed
 
   Scenario: Cleanup: remove a package on the new Retail terminal
-    Given I am on the Systems overview page of this "pxeboot_minion"
+    Given I navigate to the Systems overview page of this "pxeboot_minion"
     When I follow "Software" in the content area
     And I follow "List / Remove"
     And I enter "virgo" as the filtered package name
@@ -234,7 +234,7 @@ Feature: PXE boot a Retail terminal
     When I wait until event "Package Removal scheduled by admin" is completed
 
   Scenario: Cleanup: delete the new Retail terminal
-    Given I am on the Systems overview page of this "pxeboot_minion"
+    Given I navigate to the Systems overview page of this "pxeboot_minion"
     When I follow "Delete System"
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"


### PR DESCRIPTION
Reverts uyuni-project/uyuni#7339
The `I navigate to` step is necessary for pxe boot and terminals as they cannot be accessed by using the `I am on` step.

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository


Tracks # 
4.3 https://github.com/SUSE/spacewalk/pull/22237

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"