### PR TITLE
Extend list errata names for servers for salt bundle

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
@@ -515,7 +515,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
             CASE
               WHEN (SELECT COUNT(*) FROM rhnErrataPackage k WHERE e.id = k.errata_id AND k.package_id IN
                 (SELECT id FROM rhnPackage p WHERE p.name_id IN
-                  (SELECT id FROM rhnPackageName pn WHERE pn.name = 'salt'))) > 0
+                  (SELECT id FROM rhnPackageName pn WHERE pn.name = 'salt' OR pn.name = 'venv-salt-minion'))) > 0
             THEN 1
             ELSE 0
             END AS includeSalt

--- a/java/spacewalk-java.changes.vzhestkov.extend-listErrataNamesForServers-for-salt-bundle
+++ b/java/spacewalk-java.changes.vzhestkov.extend-listErrataNamesForServers-for-salt-bundle
@@ -1,0 +1,2 @@
+- Consider venv-salt-minion package update as salt update
+  to prevent backtraces on upgrading salt with itself (bsc#1211884)


### PR DESCRIPTION
## What does this PR change?

Extends `listErrataNamesForServers` to consider `venv-salt-minion` as a salt upgrade on the client to prevent tracebacks on upgrading the list of packages if the salt bundle is included in the list.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: Not sure if the test for it is really possible.

## Links

Fixes https://github.com/SUSE/spacewalk/issues/22017

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
