### PR TITLE
CI: set mini_mime gem to specific version

### DIFF
--- a/testsuite/Gemfile
+++ b/testsuite/Gemfile
@@ -13,8 +13,8 @@ gem 'rack-test', "~> 2.0"
 gem 'nokogiri', "~> 1.12.0"
 gem 'rake', "~> 13.0"
 gem 'jwt', "~> 2.6"
-# mini-mime > 1.1.2, requires ruby 2.6
-gem 'mini-mime', '1.1.2'
+# mini_mime > 1.1.2, requires ruby 2.6
+gem 'mini_mime', '1.1.2'
 gem 'mime-types', "~> 3.4"
 gem 'xmlrpc', "~> 0.3"
 gem 'faraday', '1.10.0'

--- a/testsuite/Gemfile
+++ b/testsuite/Gemfile
@@ -13,6 +13,8 @@ gem 'rack-test', "~> 2.0"
 gem 'nokogiri', "~> 1.12.0"
 gem 'rake', "~> 13.0"
 gem 'jwt', "~> 2.6"
+# mini-mime > 1.1.2, requires ruby 2.6
+gem 'mini-mime', '1.1.2'
 gem 'mime-types', "~> 3.4"
 gem 'xmlrpc', "~> 0.3"
 gem 'faraday', '1.10.0'


### PR DESCRIPTION


## What does this PR change?

mini_mime > 1.1.2, requires ruby >= 2.6, but we have an older version of ruby.

## GUI diff

No difference.



- [ ] **DONE**

## Documentation
- No documentation needed
- [ ] **DONE**

## Test coverage
- No tests
- 
- [ ] **DONE**

## Links

N/A

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
