### PR TITLE
Fix NPE in auth endpoint when an empty body is provided

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/login/LoginController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/login/LoginController.java
@@ -53,6 +53,7 @@ import javax.servlet.http.HttpServletResponse;
 import spark.ModelAndView;
 import spark.Request;
 import spark.Response;
+import spark.Spark;
 import spark.template.jade.JadeTemplateEngine;
 
 /**
@@ -160,13 +161,18 @@ public class LoginController {
 
         // External-auth didn't return a user - try local-auth
         if (user == null) {
-            try {
-                user = UserManager.loginUser(creds.getLogin(), creds.getPassword());
-                log.info("LOCAL AUTH SUCCESS: [{}]", user.getLogin());
+            if (creds == null) {
+                Spark.halt(HttpServletResponse.SC_BAD_REQUEST);
             }
-            catch (LoginException e) {
-                log.error("LOCAL AUTH FAILURE: [{}]", creds.getLogin());
-                errorMsg = Optional.of(LocalizationService.getInstance().getMessage(e.getMessage()));
+            else {
+                try {
+                    user = UserManager.loginUser(creds.getLogin(), creds.getPassword());
+                    log.info("LOCAL AUTH SUCCESS: [{}]", user.getLogin());
+                }
+                catch (LoginException e) {
+                    log.error("LOCAL AUTH FAILURE: [{}]", creds.getLogin());
+                    errorMsg = Optional.of(LocalizationService.getInstance().getMessage(e.getMessage()));
+                }
             }
         }
         // External-auth returned a user and no errors

--- a/java/spacewalk-java.changes.welder.fix-npe-auth-empty-body
+++ b/java/spacewalk-java.changes.welder.fix-npe-auth-empty-body
@@ -1,0 +1,1 @@
+- Fix NPE in auth endpoint when an empty body is provided


### PR DESCRIPTION
## What does this PR change?

See title.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
