### PR TITLE
Fix processing of pkg.purged results

### DIFF
--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -476,12 +476,50 @@ public class SaltUtils {
                         .getType()
             ).getRet();
         }
+        else if (json.getAsJsonObject().has("installed") && json.getAsJsonObject().has("removed")) {
+            var installedRemoved =
+            Json.GSON.<InstalledRemoved<Map<String, Change<Xor<String, List<Info>>>>>>fromJson(
+                json,
+                new TypeToken<InstalledRemoved<Map<String, Change<Xor<String, List<Info>>>>>>() { }
+                        .getType()
+            );
+
+            var delta = new HashMap<>(installedRemoved.getInstalled());
+            delta.putAll(installedRemoved.getRemoved());
+            return delta;
+        }
         else {
             return Json.GSON.fromJson(
                 json,
                 new TypeToken<Map<String, Change<Xor<String, List<Pkg.Info>>>>>() { }
                     .getType()
             );
+        }
+    }
+
+    /**
+     * Wrapper object representing a "changes" element containing "installed" and "removed" elements inside:
+     * "changes: { "installed": "pkg_name": { "new": "", "old": "1.7.9" } }
+     *
+     * @deprecated Temporarily here until available in a new version of salt-net-api.
+     *
+     * @param <T> the type that is wrapped
+     */
+    @Deprecated
+    static class InstalledRemoved<T> {
+        private T installed;
+        private T removed;
+
+        InstalledRemoved() {
+            // default constructor
+        }
+
+        public T getInstalled() {
+            return this.installed;
+        }
+
+        public T getRemoved() {
+            return this.removed;
         }
     }
 

--- a/java/spacewalk-java.changes.welder.bsc1213288
+++ b/java/spacewalk-java.changes.welder.bsc1213288
@@ -1,0 +1,1 @@
+- Fix processing of pkg.purged results (bsc#1213288)


### PR DESCRIPTION
## What does this PR change?

For apt-based distros, the results of applying `pkg.purge` state are inconsistent, containing `installed` and `removed` elements nested to `changes` element. For instance:

```
"pkg_|-remove_unwanted_pkgs_|-remove_unwanted_pkgs_|-purged": {
    "__id__": "remove_unwanted_pkgs",
    "__run_num__": 20,
    "__sls__": "manager_org_1.reh-mgmt-remove-packages",
    "changes": {
        "installed": {
            "fwupd": {
                "new": "",
                "old": "1.7.9-1~22.04.3"
            }
        },
        "removed": {}
    },
    "comment": "The following packages were not installed: scx The following packages were purged: fwupd.",
    "duration": 2741.085,
    "name": "remove_unwanted_pkgs",
    "result": true,
    "start_time": "08:34:59.552432"
}
```

The PR improves Java code to properly parse the results in this format, avoiding NPE and also properly identifying package changes.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/22062

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
