### PR TITLE
Testsuite: Correct omitted run method

### DIFF
--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -63,7 +63,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     Then the SLE15 SP4 product should be added
 
 @uyuni
-  Scenario: Add openSUSE Leap 15.4 product, inlcuding Uyuni Client Tools
+  Scenario: Add openSUSE Leap 15.4 product, including Uyuni Client Tools
     When I use spacewalk-common-channel to add channel "opensuse_leap15_4 opensuse_leap15_4-non-oss opensuse_leap15_4-non-oss-updates opensuse_leap15_4-updates opensuse_leap15_4-backports-updates opensuse_leap15_4-sle-updates uyuni-proxy-devel-leap opensuse_leap15_4-uyuni-client" with arch "x86_64"
 
 @proxy

--- a/testsuite/features/reposync/srv_wait_for_reposync.feature
+++ b/testsuite/features/reposync/srv_wait_for_reposync.feature
@@ -17,7 +17,7 @@ Feature: Wait for reposync activity to finish in CI context
     When I kill all running spacewalk-repo-sync, excepted the ones needed to bootstrap
 
 @uyuni
-  Scenario: Sync openSUSE Leap 15.4 product, inlcuding Uyuni Client Tools
+  Scenario: Sync openSUSE Leap 15.4 product, including Uyuni Client Tools
     When I call spacewalk-repo-sync to sync the parent channel "opensuse_leap15_4-x86_64"
 
   Scenario: Wait until all synchronized channels have finished

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -779,7 +779,7 @@ When(/^I call spacewalk\-repo\-sync to sync the channel "(.*?)"$/) do |channel|
 end
 
 When(/^I call spacewalk\-repo\-sync to sync the parent channel "(.*?)"$/) do |channel|
-  @command_output, _code = $server.run("spacewalk-repo-sync -p #{channel}", check_errors: false)
+  @command_output, _code = get_target('server').run("spacewalk-repo-sync -p #{channel}", check_errors: false)
 end
 
 When(/^I get "(.*?)" file details for channel "(.*?)" via spacecmd$/) do |arg1, arg2|


### PR DESCRIPTION
## What does this PR change?
Missed replacement of `server.run` and typo correction.
## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were added
- [x] **DONE**

## Links
Fixes #
Tracks # None - only Uyuni
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
