### PR TITLE
Replace forgotten occurence of product variable

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -31,7 +31,7 @@ end
 def compute_channels_to_leave_running
   # keep the repos needed for the auto-installation tests
   do_not_kill =
-    if $product == 'Uyuni'
+    if product == 'Uyuni'
       CHANNEL_TO_SYNCH_BY_OS_VERSION['15.4']
     else
       CHANNEL_TO_SYNCH_BY_OS_VERSION['default']


### PR DESCRIPTION
## What does this PR change?
The `$product` variable has been redefined, a forgotten reference causes failures in the CI
## GUI diff
No difference.
- [ ] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [ ] **DONE**

## Test coverage
- Cucumber tests were added
- [ ] **DONE**

## Links
Fixes #
Tracks # None
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
