### PR TITLE
We never selected test-net0, there's no reason it appears selected

### DIFF
--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -10,7 +10,7 @@
 @scope_virtualization
 @virthost_kvm
 @scope_cobbler
-Feature: Be able to manage KVM virtual machines via the GUI
+Feature: Manage KVM virtual machines via the GUI
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
@@ -66,7 +66,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     Then I should see "1024" in field identified by "memory"
     And I should see "1" in field identified by "vcpu"
     And option "VNC" is selected as "graphicsType"
-    And option "test-net0" is selected as "network0_source"
     And option "virtio" is selected as "disk0_bus"
     When I enter "512" as "memory"
     And I enter "2" as "vcpu"


### PR DESCRIPTION
## What does this PR change?

This PR removes a test that was not really justified.

We never selected "test-net0" after creating the VM, there's no reason it appears as selected.


## Links

Fixes SUSE/spacewalk#22211

Ports:
* 4.2: SUSE/spacewalk#22253
* 4.3: SUSE/spacewalk#22252


## Changelogs

- [x] No changelog needed
