### PR TITLE
Check for configured rhn.conf instead of rpm run status

### DIFF
--- a/spacewalk/setup/spacewalk-setup.changes.oholecek.tomcat-install-check
+++ b/spacewalk/setup/spacewalk-setup.changes.oholecek.tomcat-install-check
@@ -1,0 +1,1 @@
+- Do not rely on rpm runtime status, rather check rhn.conf if is configured (bsc#1210935)

--- a/spacewalk/setup/spacewalk-setup.spec
+++ b/spacewalk/setup/spacewalk-setup.spec
@@ -191,18 +191,17 @@ install -Dd -m 0755 %{buildroot}%{_prefix}/share/salt-formulas/states
 install -Dd -m 0755 %{buildroot}%{_prefix}/share/salt-formulas/metadata
 
 %post
-if [ $1 == 1 -a -e /etc/tomcat/server.xml ]; then
-#just during new installation. during upgrade the changes are already applied
-    CURRENT_DATE=$(date +"%%Y-%%m-%%dT%%H:%%M:%%S.%%3N")
-    cp /etc/tomcat/server.xml /etc/tomcat/server.xml.$CURRENT_DATE
-    xsltproc %{_datadir}/spacewalk/setup/server.xml.xsl /etc/tomcat/server.xml.$CURRENT_DATE > /etc/tomcat/server.xml
-fi
-
-if [ $1 == 2 -a -e /etc/tomcat/server.xml ]; then
-#during upgrade, setup new connectionTimeout if the user didn't change it. Keeping it until SUMA 4.2 is maintained
+if [ -f /etc/rhn/rhn.conf -a $(filesize /etc/rhn/rhn.conf) -gt 1 ]; then
+    # rhn.conf is configured, this is an upgrade
+    # during upgrade, setup new connectionTimeout if the user didn't change it. Keeping it until SUMA 4.2 is maintained
     CURRENT_DATE=$(date +"%%Y-%%m-%%dT%%H:%%M:%%S.%%3N")
     cp /etc/tomcat/server.xml /etc/tomcat/server.xml.$CURRENT_DATE
     xsltproc %{_datadir}/spacewalk/setup/server_update.xml.xsl /etc/tomcat/server.xml.$CURRENT_DATE > /etc/tomcat/server.xml
+else
+    # rhn.conf does not exists or is empty, this is new installation or update of new installation
+    CURRENT_DATE=$(date +"%%Y-%%m-%%dT%%H:%%M:%%S.%%3N")
+    cp /etc/tomcat/server.xml /etc/tomcat/server.xml.$CURRENT_DATE
+    xsltproc %{_datadir}/spacewalk/setup/server.xml.xsl /etc/tomcat/server.xml.$CURRENT_DATE > /etc/tomcat/server.xml
 fi
 
 if [ -e /etc/zypp/credentials.d/SCCcredentials ]; then


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/22229

Under some circumstances like updating older unconfigured SUMA system, tomcat.xml was not configured properly as source tomcat.xml was not configured. Instead of relying if we are doing rpm update or new install, check status or rhn.conf file.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/21323
Tracks https://github.com/SUSE/spacewalk/pull/22229

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
