### PR TITLE
QE: Create step for database backup

### DIFF
--- a/testsuite/features/finishing/srv_smdba.feature
+++ b/testsuite/features/finishing/srv_smdba.feature
@@ -58,11 +58,11 @@ Feature: SMDBA database helper tool
     Given a postgresql database is running
     And there is no such "/smdba-backup-test" directory
     When I create backup directory "/smdba-backup-test" with UID "root" and GID "root"
-    And I issue command "smdba backup-hot --enable=on --backup-dir=/smdba-backup-test"
+    And I take a backup with smdba in folder "/smdba-backup-test"
     Then I should see error message that asks "/smdba-backup-test" belong to the same UID/GID as "/var/lib/pgsql/data" directory
     And I remove backup directory "/smdba-backup-test"
     When I create backup directory "/smdba-backup-test" with UID "postgres" and GID "postgres"
-    And I issue command "smdba backup-hot --enable=on --backup-dir=/smdba-backup-test"
+    And I take a backup with smdba in folder "/smdba-backup-test"
     Then I should see error message that asks "/smdba-backup-test" has same permissions as "/var/lib/pgsql/data" directory
     And I remove backup directory "/smdba-backup-test"
 
@@ -71,7 +71,7 @@ Feature: SMDBA database helper tool
     And there is no such "/smdba-backup-test" directory
     When I create backup directory "/smdba-backup-test" with UID "postgres" and GID "postgres"
     And I change Access Control List on "/smdba-backup-test" directory to "0700"
-    And I issue command "smdba backup-hot --enable=on --backup-dir=/smdba-backup-test"
+    And I take a backup with smdba in folder "/smdba-backup-test"
     Then base backup is taken
     And in "/smdba-backup-test" directory there is "base.tar.gz" file and at least one backup checkpoint file
     And parameter "archive_command" in the configuration file "/var/lib/pgsql/data/postgresql.conf" is "/usr/bin/smdba-pgarchive"

--- a/testsuite/features/step_definitions/smdba_steps.rb
+++ b/testsuite/features/step_definitions/smdba_steps.rb
@@ -122,6 +122,11 @@ When(/^I change Access Control List on "(.*?)" directory to "(.*?)"$/) do |bkp_d
   log "\n*** Taking backup, this might take a while ***\n"
 end
 
+Then(/^I take a backup with smdba in folder "(.*?)"$/) do |backup_dir|
+  command = "smdba backup-hot --enable=on --backup-dir=#{backup_dir}"
+  $output, _code = get_target('server').run(command, timeout: 600, check_errors: true)
+end
+
 Then(/^base backup is taken$/) do
   assert_includes($output, 'Finished')
 end


### PR DESCRIPTION
## What does this PR change?

Since the switch from SLES to openSUSE Leap 15.4, we sync much more packages, which results in a bigger database. Moving from the default timeout of 250 s to 600 s could help solve failing in the finishing stage of our test suite. Furthermore we enable error checking to fail earlier.

See https://github.com/SUSE/spacewalk/issues/22277

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links


- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

