### PR TITLE
CI: Fix Fake base channel

### DIFF
--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -198,7 +198,7 @@ PACKAGE_BY_CLIENT = { 'sle_minion' => 'bison',
 # For containers we do not have SCC, so we set the Fake Base Channel
 # for sle_minion
 sle_base_channel =
-  if $is_container_provider
+  if ENV["PROVIDER"].include? 'podman'
     'Fake Base Channel'
   elsif ENV['SERVER'].include? 'uyuni'
     'openSUSE Leap 15.4 (x86_64)'


### PR DESCRIPTION
## What does this PR change?

CI: Fix fake base channel. When running inside github actions with podman, we are not syncing any product, to avoid external dependencies. Thus, the base channel for the fake channel, can't be Leap or SLE, but "Fake base channel".

## GUI diff

No difference.



- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests
- [X] **DONE**

## Links

N/A

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
