### PR TITLE
Optimize org channel accessibility query (bsc#1211874)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/channel/Channel.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/Channel.hbm.xml
@@ -600,12 +600,40 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     </sql-query>
 
     <sql-query name="Channel.isAccessibleBy">
-        <return-scalar type="int" column="count"/>
-        SELECT COUNT(*) AS count
-          FROM rhnChannel c
-          JOIN rhnAvailableChannels ac ON c.id = ac.channel_id
-          WHERE c.label = :channel_label
-            AND ac.org_id = :org_id
+        <return-scalar type="int" column="result"/>
+         <![CDATA[SELECT case when (EXISTS (
+              SELECT 1
+              FROM rhnChannel c
+              JOIN rhnChannelFamilyMembers cfm ON cfm.channel_id = c.id
+              JOIN rhnPrivateChannelFamily pcf ON pcf.channel_family_id = cfm.channel_family_id
+              WHERE c.label = :channel_label
+              AND pcf.org_id = :org_id
+              LIMIT 1
+        ) OR EXISTS (
+              SELECT 1
+              FROM rhnChannel c
+              JOIN rhnChannelFamilyMembers cfm ON cfm.channel_id = c.id
+              JOIN rhnPublicChannelFamily pcf ON pcf.channel_family_id = cfm.channel_family_id
+              WHERE c.label = :channel_label
+              LIMIT 1
+        ) OR EXISTS (
+              SELECT 1
+              FROM rhnChannel c
+              JOIN rhnTrustedOrgs tr ON c.org_id = tr.org_id
+              WHERE c.parent_channel IS NULL AND c.channel_access = 'public'
+              AND c.label = :channel_label
+              AND tr.org_trust_id = :org_id
+              LIMIT 1
+        ) OR EXISTS (
+              SELECT 1
+              FROM rhnChannel c
+              JOIN rhnChannelTrust tr ON c.id = tr.channel_id
+              WHERE c.channel_access = 'protected'
+              AND c.label = :channel_label
+              AND tr.org_trust_id = :org_id
+              LIMIT 1
+        )) then 1 else 0 end AS result
+        ]]>
     </sql-query>
 
     <sql-query name="Channel.isAccessibleByUser">

--- a/java/code/src/com/redhat/rhn/domain/channel/test/ChannelFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/test/ChannelFactoryTest.java
@@ -546,6 +546,119 @@ public class ChannelFactoryTest extends RhnBaseTestCase {
     }
 
     /**
+     * Test org channel accessibility
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    public void testOrgAccessibility() throws Exception {
+        User user1 = UserTestUtils.findNewUser("testuser1", "testorg1");
+        User user2 = UserTestUtils.findNewUser("testuser2", "testorg2");
+        User user3 = UserTestUtils.findNewUser("testuser3", "testorg3");
+        User user4 = UserTestUtils.findNewUser("testuser4", "testorg4");
+        Org org1 = user1.getOrg();
+        Org org2 = user2.getOrg();
+        Org org3 = user3.getOrg();
+        Org org4 = user4.getOrg();
+
+
+        Channel c1 = ChannelFactoryTest.createTestChannel(user1);
+        Channel c2 = ChannelFactoryTest.createTestChannel(user2);
+
+        assertTrue(ChannelFactory.isAccessibleBy(c1.getLabel(), org1.getId()));
+        assertFalse(ChannelFactory.isAccessibleBy(c1.getLabel(), org2.getId()));
+        assertFalse(ChannelFactory.isAccessibleBy(c1.getLabel(), org3.getId()));
+        assertFalse(ChannelFactory.isAccessibleBy(c1.getLabel(), org4.getId()));
+
+        assertFalse(ChannelFactory.isAccessibleBy(c2.getLabel(), org1.getId()));
+        assertTrue(ChannelFactory.isAccessibleBy(c2.getLabel(), org2.getId()));
+        assertFalse(ChannelFactory.isAccessibleBy(c2.getLabel(), org3.getId()));
+        assertFalse(ChannelFactory.isAccessibleBy(c2.getLabel(), org4.getId()));
+
+        ChannelFamily privcfam = ChannelFamilyFactoryTest.createTestChannelFamily(user3, false);
+        ChannelFamily pubcfam = ChannelFamilyFactoryTest.createTestChannelFamily(user4, true);
+
+        c1.setChannelFamily(privcfam);
+        TestUtils.saveAndFlush(c1);
+
+        c2.setChannelFamily(pubcfam);
+        TestUtils.saveAndFlush(c2);
+
+        // c1 belongs to user3 org now
+        assertFalse(ChannelFactory.isAccessibleBy(c1.getLabel(), org1.getId()));
+        assertFalse(ChannelFactory.isAccessibleBy(c1.getLabel(), org2.getId()));
+        assertTrue(ChannelFactory.isAccessibleBy(c1.getLabel(), org3.getId()));
+        assertFalse(ChannelFactory.isAccessibleBy(c1.getLabel(), org4.getId()));
+
+        // c2 is public now
+        assertTrue(ChannelFactory.isAccessibleBy(c2.getLabel(), org1.getId()));
+        assertTrue(ChannelFactory.isAccessibleBy(c2.getLabel(), org2.getId()));
+        assertTrue(ChannelFactory.isAccessibleBy(c2.getLabel(), org3.getId()));
+        assertTrue(ChannelFactory.isAccessibleBy(c2.getLabel(), org4.getId()));
+    }
+
+    /**
+     * Test trusted org channel accessibility
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    public void testTrustedOrgAccessibility() throws Exception {
+        User user1 = UserTestUtils.findNewUser("testuser1", "testorg1");
+        User user2 = UserTestUtils.findNewUser("testuser2", "testorg2");
+        User user3 = UserTestUtils.findNewUser("testuser3", "testorg3");
+        User user4 = UserTestUtils.findNewUser("testuser4", "testorg4");
+        Org org1 = user1.getOrg();
+        Org org2 = user2.getOrg();
+        Org org3 = user3.getOrg();
+        Org org4 = user4.getOrg();
+
+        Channel c1 = ChannelFactoryTest.createTestChannel(user1);
+        Channel c2 = ChannelFactoryTest.createTestChannel(user2);
+
+        assertTrue(ChannelFactory.isAccessibleBy(c1.getLabel(), org1.getId()));
+        assertFalse(ChannelFactory.isAccessibleBy(c1.getLabel(), org2.getId()));
+        assertFalse(ChannelFactory.isAccessibleBy(c1.getLabel(), org3.getId()));
+        assertFalse(ChannelFactory.isAccessibleBy(c1.getLabel(), org4.getId()));
+
+        assertFalse(ChannelFactory.isAccessibleBy(c2.getLabel(), org1.getId()));
+        assertTrue(ChannelFactory.isAccessibleBy(c2.getLabel(), org2.getId()));
+        assertFalse(ChannelFactory.isAccessibleBy(c2.getLabel(), org3.getId()));
+        assertFalse(ChannelFactory.isAccessibleBy(c2.getLabel(), org4.getId()));
+
+        // trusted org added to org
+        org1.getTrustedOrgs().add(org3);
+        c1.setAccess(Channel.PUBLIC);
+        flushAndEvict(org1);
+        flushAndEvict(c1);
+
+        assertTrue(ChannelFactory.isAccessibleBy(c1.getLabel(), org1.getId()));
+        assertFalse(ChannelFactory.isAccessibleBy(c1.getLabel(), org2.getId()));
+        assertTrue(ChannelFactory.isAccessibleBy(c1.getLabel(), org3.getId()));
+        assertFalse(ChannelFactory.isAccessibleBy(c1.getLabel(), org4.getId()));
+
+        assertFalse(ChannelFactory.isAccessibleBy(c2.getLabel(), org1.getId()));
+        assertTrue(ChannelFactory.isAccessibleBy(c2.getLabel(), org2.getId()));
+        assertFalse(ChannelFactory.isAccessibleBy(c2.getLabel(), org3.getId()));
+        assertFalse(ChannelFactory.isAccessibleBy(c2.getLabel(), org4.getId()));
+
+        // trusted org added to channel
+        c2.getTrustedOrgs().add(org4);
+        c2.setAccess(Channel.PROTECTED);
+        flushAndEvict(c2);
+
+        assertTrue(ChannelFactory.isAccessibleBy(c1.getLabel(), org1.getId()));
+        assertFalse(ChannelFactory.isAccessibleBy(c1.getLabel(), org2.getId()));
+        assertTrue(ChannelFactory.isAccessibleBy(c1.getLabel(), org3.getId()));
+        assertFalse(ChannelFactory.isAccessibleBy(c1.getLabel(), org4.getId()));
+
+        assertFalse(ChannelFactory.isAccessibleBy(c2.getLabel(), org1.getId()));
+        assertTrue(ChannelFactory.isAccessibleBy(c2.getLabel(), org2.getId()));
+        assertFalse(ChannelFactory.isAccessibleBy(c2.getLabel(), org3.getId()));
+        assertTrue(ChannelFactory.isAccessibleBy(c2.getLabel(), org4.getId()));
+    }
+
+    /**
      * Test "ChannelFactory.findAllByUserOrderByChild"
      * @throws Exception
      */

--- a/java/spacewalk-java.changes.nadvornik.channel_access
+++ b/java/spacewalk-java.changes.nadvornik.channel_access
@@ -1,0 +1,1 @@
+- Optimize org channel accessibility query (bsc#1211874)


### PR DESCRIPTION
## What does this PR change?

This should improve the slow query on channel accessibility by org.
Main changes:
- COUNT replaced with EXISTS
- do not use views
- rhnOrgChannelTreeView uses union of separate SELECTs for parent and child channels. In this case, single SELECT is ok.
- handling of public channel family in rhnOrgChannelFamilyPermissions might be inefficient, not sure

Added unit test to make sure the query behaves the same as before.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Might fix https://bugzilla.suse.com/show_bug.cgi?id=1211874


## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
