### PR TITLE
Remove ConfigDefaults.isDocAvailable

### DIFF
--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -859,14 +859,6 @@ public class ConfigDefaults {
     }
 
     /**
-     * is documentation available
-     * @return true if so
-     */
-    public boolean isDocAvailable() {
-        return !isSpacewalk();
-    }
-
-    /**
      * Returns Max taskomatic channel repodata workers
      * @return Max taskomatic channel repodata workers
      */

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/files/FileDetailsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/files/FileDetailsAction.java
@@ -14,7 +14,6 @@
  */
 package com.redhat.rhn.frontend.action.configuration.files;
 
-import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.util.StringUtil;
 import com.redhat.rhn.common.validator.ValidatorException;
 import com.redhat.rhn.domain.config.ConfigFile;
@@ -98,7 +97,6 @@ public class FileDetailsAction extends RhnAction {
         cff.updateFromRevision(request, cr);
         setupRequestParams(context, cr);
         request.setAttribute("form", cff);
-        request.setAttribute("documentation", ConfigDefaults.get().isDocAvailable());
         request.setAttribute(ManageRevisionSetup.MAX_SIZE, StringUtil
                 .displayFileSize(ConfigFile.getMaxFileSize()));
 

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/files/FileDownloadAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/files/FileDownloadAction.java
@@ -14,7 +14,6 @@
  */
 package com.redhat.rhn.frontend.action.configuration.files;
 
-import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.config.ConfigRevision;
 import com.redhat.rhn.frontend.action.configuration.ConfigActionHelper;
 import com.redhat.rhn.frontend.action.configuration.ConfigFileForm;
@@ -48,7 +47,6 @@ public class FileDownloadAction extends RhnAction {
         ConfigFileForm cff = (ConfigFileForm) form;
 
         request.setAttribute(CSRF_TOKEN, request.getSession().getAttribute("csrf_token"));
-        request.setAttribute("documentation", ConfigDefaults.get().isDocAvailable());
 
         ConfigRevision cr = ConfigActionHelper.findRevision(request);
 

--- a/java/code/src/com/redhat/rhn/frontend/action/renderers/TasksRenderer.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/renderers/TasksRenderer.java
@@ -16,7 +16,6 @@
 package com.redhat.rhn.frontend.action.renderers;
 
 import com.redhat.rhn.GlobalInstanceHolder;
-import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.listview.PageControl;
 import com.redhat.rhn.manager.system.SystemManager;
@@ -37,7 +36,6 @@ public class TasksRenderer extends BaseFragmentRenderer {
     @Override
     protected void render(User user, PageControl pc, HttpServletRequest request) {
         request.setAttribute(TASKS, Boolean.TRUE);
-        request.setAttribute("documentation", ConfigDefaults.get().isDocAvailable());
         request.setAttribute("amountOfMinions",
                 GlobalInstanceHolder.SALT_API.getKeys().getUnacceptedMinions().size());
         request.setAttribute("requiringReboot", SystemManager.requiringRebootList(user).size());

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemDetailsEditAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemDetailsEditAction.java
@@ -15,7 +15,6 @@
 package com.redhat.rhn.frontend.action.systems.sdc;
 
 import com.redhat.rhn.GlobalInstanceHolder;
-import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.validator.ValidatorError;
 import com.redhat.rhn.common.validator.ValidatorResult;
@@ -295,17 +294,10 @@ public class SystemDetailsEditAction extends RhnAction {
                     }
 
                     log.debug("adding entitlement success msg");
-                    if (ConfigDefaults.get().isDocAvailable()) {
-                        createMessage(request,
-                                "system.entitle.added." + e.getLabel(),
-                                s.getId().toString(),
-                                GlobalInstanceHolder.USER_PREFERENCE_UTILS.getDocsLocale(user));
-                    }
-                    else {
-                        createSuccessMessage(request,
-                                "system.entitle.added." + e.getLabel() + ".nodoc",
-                                s.getId().toString());
-                    }
+                    createMessage(request,
+                            "system.entitle.added." + e.getLabel(),
+                            s.getId().toString(),
+                            GlobalInstanceHolder.USER_PREFERENCE_UTILS.getDocsLocale(user));
                 }
             }
             else if ((daForm.get(e.getLabel()) == null ||

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -9039,19 +9039,7 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
           <context context-type="sourcefile">/rhn/systems/details/Overview.do</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="system.entitle.added.container_build_host.nodoc" xml:space="preserve">
-        <source>&lt;strong&gt;Container Build Host&lt;/strong&gt; type has been applied.&lt;br/&gt;&lt;strong&gt;Note:&lt;/strong&gt; This action will &lt;em&gt;not&lt;/em&gt; result in state application. To apply the state, either use the &lt;a href="/rhn/manager/systems/details/highstate?sid={0}"&gt;states page&lt;/a&gt; or run &lt;code class="text-info"&gt;state.highstate&lt;/code&gt; from the command line.</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/systems/details/Overview.do</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="system.entitle.added.osimage_build_host" xml:space="preserve">
-        <source>&lt;strong&gt;OS Image Build Host&lt;/strong&gt; type has been applied.&lt;br/&gt;&lt;strong&gt;Note:&lt;/strong&gt; This action will &lt;em&gt;not&lt;/em&gt; result in state application. To apply the state, either use the &lt;a href="/rhn/manager/systems/details/highstate?sid={0}"&gt;states page&lt;/a&gt; or run &lt;code class="text-info"&gt;state.highstate&lt;/code&gt; from the command line.</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/systems/details/Overview.do</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="system.entitle.added.osimage_build_host.nodoc" xml:space="preserve">
         <source>&lt;strong&gt;OS Image Build Host&lt;/strong&gt; type has been applied.&lt;br/&gt;&lt;strong&gt;Note:&lt;/strong&gt; This action will &lt;em&gt;not&lt;/em&gt; result in state application. To apply the state, either use the &lt;a href="/rhn/manager/systems/details/highstate?sid={0}"&gt;states page&lt;/a&gt; or run &lt;code class="text-info"&gt;state.highstate&lt;/code&gt; from the command line.</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/details/Overview.do</context>
@@ -9063,31 +9051,13 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
           <context context-type="sourcefile">/rhn/systems/details/Overview.do</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="system.entitle.added.virtualization_host.nodoc" xml:space="preserve">
-        <source>Since you added a Virtualization system type to the system we also performed some extra steps to ensure your system will be able to manage virtual guests better.</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/systems/details/Overview.do</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="system.entitle.added.monitoring_entitled" xml:space="preserve">
-        <source>&lt;strong&gt;Monitoring&lt;/strong&gt; type has been applied.&lt;br/&gt;&lt;strong&gt;Note:&lt;/strong&gt; Since you added the Monitoring system type we automatically assigned the Prometheus Exporters formula to the system. Please apply the &lt;a href="/rhn/manager/systems/details/highstate?sid={0}"&gt;Highstate&lt;/a&gt; in order to install and enable the Prometheus metrics exporters.&lt;br/&gt;&lt;strong&gt;Note:&lt;/strong&gt; Please make sure to open the &lt;a href="/docs/{1}/installation-and-upgrade/ports.html#_external_client_ports">required network ports&lt;/a&gt; for all installed exporters.</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/systems/details/Overview.do</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="system.entitle.added.monitoring_entitled.nodoc" xml:space="preserve">
-        <source>&lt;strong&gt;Monitoring&lt;/strong&gt; type has been applied.&lt;br/&gt;&lt;strong&gt;Note:&lt;/strong&gt; Since you added the Monitoring system type we automatically assigned the Prometheus Exporters formula to the system. Please apply the &lt;a href="/rhn/manager/systems/details/highstate?sid={0}"&gt;Highstate&lt;/a&gt; in order to install and enable the Prometheus metrics exporters.</source>
+        <source>&lt;strong&gt;Monitoring&lt;/strong&gt; type has been applied.&lt;br/&gt;&lt;strong&gt;Note:&lt;/strong&gt; Since you added the Monitoring system type we automatically assigned the Prometheus Exporters formula to the system. Please apply the &lt;a href="/rhn/manager/systems/details/highstate?sid={0}"&gt;Highstate&lt;/a&gt; in order to install and enable the Prometheus metrics exporters.&lt;br/&gt;&lt;strong&gt;Note:&lt;/strong&gt; Please make sure to open the &lt;a href="/docs/{1}/installation-and-upgrade/ports.html#_external_client_ports" target="_blank">required network ports&lt;/a&gt; for all installed exporters.</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/details/Overview.do</context>
         </context-group>
       </trans-unit>
       <trans-unit id="system.entitle.added.ansible_control_node" xml:space="preserve">
-        <source>&lt;strong&gt;Ansible Control Node&lt;/strong&gt; type has been applied.&lt;br/&gt;&lt;strong&gt;Note:&lt;/strong&gt; This action will &lt;em&gt;not&lt;/em&gt; result in state application. To apply the state, either use the &lt;a href="/rhn/manager/systems/details/highstate?sid={0}"&gt;states page&lt;/a&gt; or run &lt;code class="text-info"&gt;state.highstate&lt;/code&gt; from the command line.</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/systems/details/Overview.do</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="system.entitle.added.ansible_control_node.nodoc" xml:space="preserve">
         <source>&lt;strong&gt;Ansible Control Node&lt;/strong&gt; type has been applied.&lt;br/&gt;&lt;strong&gt;Note:&lt;/strong&gt; This action will &lt;em&gt;not&lt;/em&gt; result in state application. To apply the state, either use the &lt;a href="/rhn/manager/systems/details/highstate?sid={0}"&gt;states page&lt;/a&gt; or run &lt;code class="text-info"&gt;state.highstate&lt;/code&gt; from the command line.</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/details/Overview.do</context>


### PR DESCRIPTION
## What does this PR change?

The property `ConfigDefaults.isDocAvaialable()` in fact was checking if the installation was SUSE Manager or Uyuni.
As we provide documentation in both we can safely get rid of this check and remove all `*.nodoc` string resources.
Kudos for @parlt91 for the hint.

Follow up of #7348

## GUI diff

Before:
![image](https://github.com/uyuni-project/uyuni/assets/12249576/3b948c93-69ce-40b0-93dc-0fe58580bb9c)

After:
![image](https://github.com/uyuni-project/uyuni/assets/12249576/6c486f61-9c00-4181-b2c2-343f224bf53a)

- [x] **DONE**

## Documentation
- No documentation needed: provides helpful information in the UI.

- [x] **DONE**

## Test coverage
- No tests: minor change

- [x] **DONE**

## Links
Fixes #7348

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
