### PR TITLE
Update dependencies for Leap 15.5

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -7,7 +7,7 @@
         <dependency org="suse" name="bcel" rev="5.2" />
         <dependency org="suse" name="byte-buddy" rev="1.11.12" />
         <dependency org="suse" name="c3p0" rev="0.9.5.5" />
-        <dependency org="suse" name="cglib" rev="3.2.4" />
+        <dependency org="suse" name="cglib" rev="3.3.0" />
         <dependency org="suse" name="classmate" rev="1.5.1" />
         <dependency org="suse" name="javax.mail" rev="1.5.2" />
         <dependency org="suse" name="client" rev="2.1" />
@@ -15,16 +15,16 @@
         <dependency org="suse" name="stringprep" rev="1.1" />
         <dependency org="suse" name="saslprep" rev="1.1" />
         <dependency org="suse" name="commons-beanutils" rev="1.9.4" />
-        <dependency org="suse" name="commons-cli" rev="1.4" />
-        <dependency org="suse" name="commons-codec" rev="1.11" />
+        <dependency org="suse" name="commons-cli" rev="1.5.0" />
+        <dependency org="suse" name="commons-codec" rev="1.15" />
         <dependency org="suse" name="commons-collections" rev="3.2.2" />
         <dependency org="suse" name="commons-digester" rev="2.1" />
         <dependency org="suse" name="commons-discovery" rev="0.4" />
         <dependency org="suse" name="commons-el" rev="1.0" />
         <dependency org="suse" name="commons-fileupload" rev="1.4" />
-        <dependency org="suse" name="commons-io" rev="2.6" />
+        <dependency org="suse" name="commons-io" rev="2.11.0" />
         <dependency org="suse" name="commons-jexl" rev="2.1.1" />
-        <dependency org="suse" name="commons-lang3" rev="3.8.1" />
+        <dependency org="suse" name="commons-lang3" rev="3.12.0" />
         <dependency org="suse" name="commons-logging" rev="1.2" />
         <dependency org="suse" name="commons-validator" rev="1.3.1" />
         <dependency org="suse" name="commons-compress" rev="1.21" />
@@ -40,7 +40,7 @@
         <dependency org="suse" name="hibernate-ehcache" rev="5.3.25" />
         <dependency org="suse" name="hibernate-types-52" rev="2.16.2" />
         <dependency org="suse" name="httpasyncclient" rev="4.1.4" />
-        <dependency org="suse" name="httpclient" rev="4.5.6" />
+        <dependency org="suse" name="httpclient" rev="4.5.12" />
         <dependency org="suse" name="httpcore" rev="4.4.13" />
         <dependency org="suse" name="httpcore-nio" rev="4.4.13" />
         <dependency org="suse" name="ical4j" rev="3.0.18" />
@@ -51,7 +51,7 @@
         <dependency org="suse" name="jakarta-persistence-api" rev="2.2.2" />
         <dependency org="suse" name="java-saml" rev="2.4.0" />
         <dependency org="suse" name="java-saml-core" rev="2.4.0" />
-        <dependency org="suse" name="javassist" rev="3.23.1" />
+        <dependency org="suse" name="javassist" rev="3.29.0" />
         <dependency org="suse" name="jboss-logging" rev="3.4.1" />
         <dependency org="suse" name="jcommon" rev="1.0.16" />
         <dependency org="suse" name="jdom" rev="1.1.3" />
@@ -60,15 +60,15 @@
         <dependency org="suse" name="log4j-api" rev="2.17.2" />
         <dependency org="suse" name="log4j-core" rev="2.17.2" />
         <dependency org="suse" name="jsch" rev="0.1.55" />
-        <dependency org="suse" name="jctools-core" rev="2.1.2" />
+        <dependency org="suse" name="jctools-core" rev="3.3.0" />
         <dependency org="suse" name="mchange-commons-java" rev="0.2.20" />
-        <dependency org="suse" name="netty-buffer" rev="4.1.75" />
-        <dependency org="suse" name="netty-codec" rev="4.1.75" />
-        <dependency org="suse" name="netty-common" rev="4.1.75" />
-        <dependency org="suse" name="netty-handler" rev="4.1.75" />
-        <dependency org="suse" name="netty-resolver" rev="4.1.75" />
-        <dependency org="suse" name="netty-transport" rev="4.1.75" />
-        <dependency org="suse" name="netty-transport-native-unix-common" rev="4.1.75" />
+        <dependency org="suse" name="netty-buffer" rev="4.1.90" />
+        <dependency org="suse" name="netty-codec" rev="4.1.90" />
+        <dependency org="suse" name="netty-common" rev="4.1.90" />
+        <dependency org="suse" name="netty-handler" rev="4.1.90" />
+        <dependency org="suse" name="netty-resolver" rev="4.1.90" />
+        <dependency org="suse" name="netty-transport" rev="4.1.90" />
+        <dependency org="suse" name="netty-transport-native-unix-common" rev="4.1.90" />
         <dependency org="suse" name="oro" rev="2.0.8" />
         <dependency org="suse" name="pgjdbc-ng" rev="0.8.7" />
         <dependency org="suse" name="postgresql-jdbc" rev="42.2.25" />
@@ -84,7 +84,7 @@
         <dependency org="suse" name="simple-core" rev="3.1.3" />
         <dependency org="suse" name="simple-xml" rev="2.6.2" />
         <dependency org="suse" name="sitemesh" rev="2.1" />
-        <dependency org="suse" name="slf4j-api" rev="1.7.30" />
+        <dependency org="suse" name="slf4j-api" rev="1.7.36" />
         <dependency org="suse" name="log4j-slf4j-impl" rev="2.17.2" />
         <dependency org="suse" name="snakeyaml" rev="1.33" />
         <dependency org="suse" name="spark-core" rev="2.9.3" />
@@ -100,7 +100,7 @@
         <dependency org="suse" name="woodstox-core-asl" rev="4.4.2" />
         <dependency org="suse" name="xalan-j2" rev="2.7.2" />
         <dependency org="suse" name="xalan-j2-serializer" rev="2.7.2" />
-        <dependency org="suse" name="xerces-j2" rev="2.12.0" />
+        <dependency org="suse" name="xerces-j2" rev="2.12.2" />
         <dependency org="suse" name="xmlsec" rev="2.0.7" />
         <dependency org="suse" name="glassfish-jaxb-api" rev="2.4.0" />
         <dependency org="suse" name="glassfish-activation" rev="1.2.0" />
@@ -127,7 +127,7 @@
         </dependency>
         <dependency org="suse" name="hamcrest-core" rev="1.3" transitive="false"/>
         <dependency org="suse" name="hamcrest-library" rev="1.3" transitive="false"/>
-        <dependency org="suse" name="junit" rev="4.12" transitive="false"/>
+        <dependency org="suse" name="junit" rev="4.13.2" transitive="false"/>
         <dependency org="org.junit.jupiter" name="junit-jupiter-api" rev="5.8.2" transitive="false"/>
         <dependency org="org.junit.platform" name="junit-platform-commons" rev="1.8.2" transitive="false" />
         <dependency org="org.junit.platform" name="junit-platform-console-standalone" rev="1.8.2" transitive="false" />

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -51,7 +51,7 @@
         <dependency org="suse" name="jakarta-persistence-api" rev="2.2.2" />
         <dependency org="suse" name="java-saml" rev="2.4.0" />
         <dependency org="suse" name="java-saml-core" rev="2.4.0" />
-        <dependency org="suse" name="javassist" rev="3.29.0" />
+        <dependency org="suse" name="javassist" rev="3.29.2" />
         <dependency org="suse" name="jboss-logging" rev="3.4.1" />
         <dependency org="suse" name="jcommon" rev="1.0.16" />
         <dependency org="suse" name="jdom" rev="1.1.3" />
@@ -62,13 +62,13 @@
         <dependency org="suse" name="jsch" rev="0.1.55" />
         <dependency org="suse" name="jctools-core" rev="3.3.0" />
         <dependency org="suse" name="mchange-commons-java" rev="0.2.20" />
-        <dependency org="suse" name="netty-buffer" rev="4.1.90" />
-        <dependency org="suse" name="netty-codec" rev="4.1.90" />
-        <dependency org="suse" name="netty-common" rev="4.1.90" />
-        <dependency org="suse" name="netty-handler" rev="4.1.90" />
-        <dependency org="suse" name="netty-resolver" rev="4.1.90" />
-        <dependency org="suse" name="netty-transport" rev="4.1.90" />
-        <dependency org="suse" name="netty-transport-native-unix-common" rev="4.1.90" />
+        <dependency org="suse" name="netty-buffer" rev="4.1.94" />
+        <dependency org="suse" name="netty-codec" rev="4.1.94" />
+        <dependency org="suse" name="netty-common" rev="4.1.94" />
+        <dependency org="suse" name="netty-handler" rev="4.1.94" />
+        <dependency org="suse" name="netty-resolver" rev="4.1.94" />
+        <dependency org="suse" name="netty-transport" rev="4.1.94" />
+        <dependency org="suse" name="netty-transport-native-unix-common" rev="4.1.94" />
         <dependency org="suse" name="oro" rev="2.0.8" />
         <dependency org="suse" name="pgjdbc-ng" rev="0.8.7" />
         <dependency org="suse" name="postgresql-jdbc" rev="42.2.25" />

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -329,7 +329,7 @@ artifacts:
   - artifact: ical4j
     repository: Uyuni_Other
   - artifact: jetty-util
-    repository: Leap
+    repository: Leap_sle
   - artifact: glassfish-jaxb-api
     repository: Uyuni_Other
   - artifact: jaxb-runtime

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -139,7 +139,7 @@ artifacts:
     package: java-saml
     repository: Uyuni_Other
   - artifact: javassist
-    repository: Leap
+    repository: Leap_sle
   - artifact: jboss-logging
     repository: Leap
   - artifact: jcommon
@@ -172,33 +172,33 @@ artifacts:
     repository: Leap
   - artifact: netty-buffer
     package: netty
-    repository: Leap
+    repository: Leap_sle
   - artifact: netty-codec
     package: netty
     jar: netty-codec.jar
-    repository: Leap
+    repository: Leap_sle
   - artifact: netty-common
     package: netty
-    repository: Leap
+    repository: Leap_sle
   - artifact: netty-handler
     package: netty
     jar: netty-handler.jar
-    repository: Leap
+    repository: Leap_sle
   - artifact: netty-resolver
     package: netty
     jar: netty-resolver.jar
-    repository: Leap
+    repository: Leap_sle
   - artifact: netty-transport
     package: netty
     jar: netty-transport.jar
-    repository: Leap
+    repository: Leap_sle
   - artifact: netty-transport-native-unix-common
     package: netty
     jar: netty-transport-native-unix-common.jar
-    repository: Leap
+    repository: Leap_sle
   - artifact: netty-transport-native-unix-common-linux-x86_64
     package: netty
-    repository: Leap
+    repository: Leap_sle
   - artifact: client
     package: ongres-scram-client
     repository: Leap

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -1,15 +1,15 @@
 repositories:
   Leap:
-    project: openSUSE:Leap:15.4
+    project: openSUSE:Leap:15.5
     repository: standard
   Uyuni_Other:
     project: systemsmanagement:Uyuni:Master:Other
-    repository: openSUSE_Leap_15.4
+    repository: openSUSE_Leap_15.5
   Uyuni:
     project: systemsmanagement:Uyuni:Master
-    repository: openSUSE_Leap_15.4
+    repository: openSUSE_Leap_15.5
   Leap_sle:
-    url: https://download.opensuse.org/update/leap/15.4/sle
+    url: https://download.opensuse.org/update/leap/15.5/sle
 artifacts:
   - artifact: asm
     package: objectweb-asm
@@ -91,7 +91,7 @@ artifacts:
     repository: Leap
   - artifact: google-gson
     jar: gson.jar
-    repository: Leap_sle
+    repository: Leap
   - artifact: hibernate-c3p0
     package: hibernate5-c3p0
     jar: hibernate-c3p0
@@ -100,11 +100,11 @@ artifacts:
     package: hibernate-types
     repository: Uyuni_Other
   - artifact: jackson-annotations
-    repository: Leap_sle
+    repository: Leap
   - artifact: jackson-core
-    repository: Leap_sle
+    repository: Leap
   - artifact: jackson-databind
-    repository: Leap_sle
+    repository: Leap
   - artifact: hibernate-commons-annotations
     repository: Uyuni_Other
   - artifact: hibernate-core
@@ -123,10 +123,10 @@ artifacts:
   - artifact: httpcore
     package: httpcomponents-core
     jar: httpcore.jar
-    repository: Leap_sle
+    repository: Leap
   - artifact: httpcore-nio
     package: httpcomponents-core
-    repository: Leap_sle
+    repository: Leap
   - artifact: jade4j
     repository: Uyuni_Other
   - artifact: jakarta-persistence-api
@@ -156,15 +156,15 @@ artifacts:
   - artifact: log4j-core
     jar: log4j-core.jar
     package: log4j
-    repository: Leap_sle
+    repository: Leap
   - artifact: log4j-api
     jar: log4j-api.jar
     package: log4j
-    repository: Leap_sle
+    repository: Leap
   - artifact: log4j-slf4j-impl
     jar: log4j-slf4j-impl.jar
     package: log4j-slf4j
-    repository: Leap_sle
+    repository: Leap
   - artifact: jsch
     repository: Leap
   - artifact: mchange-commons-java
@@ -256,7 +256,7 @@ artifacts:
     jar: api
     repository: Leap
   - artifact: snakeyaml
-    repository: Leap_sle
+    repository: Leap
   - artifact: spark-core
     repository: Uyuni_Other
   - artifact: spark-template-jade
@@ -286,7 +286,7 @@ artifacts:
     package: woodstox
     repository: Uyuni_Other
   - artifact: xalan-j2
-    jar: xalan-j2-[0-9.]+
+    jar: xalan-j2.jar
     repository: Leap
   - artifact: xalan-j2-serializer
     package: xalan-j2
@@ -329,7 +329,7 @@ artifacts:
   - artifact: ical4j
     repository: Uyuni_Other
   - artifact: jetty-util
-    repository: Leap_sle
+    repository: Leap
   - artifact: glassfish-jaxb-api
     repository: Uyuni_Other
   - artifact: jaxb-runtime


### PR DESCRIPTION
## What does this PR change?

This is a patch for the `obs-to-maven` and `ivy` configurations in order to resolve libraries from Leap 15.5 repositories, for building Uyuni locally or for running tests in CI.

## Links

Downstream issue: https://github.com/SUSE/spacewalk/issues/21561

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository.

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
