### PR TITLE
Add external PR labeler action

### DIFF
--- a/.github/workflows/external_pr_labeler.yml
+++ b/.github/workflows/external_pr_labeler.yml
@@ -1,0 +1,31 @@
+name: External PR labeler
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  label_prs:
+    name: Label external PRs
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - id: is_member
+        name: Check if author is an org member
+        env:
+          GH_TOKEN: ${{ secrets.ORG_READ_TOKEN }}
+        run: |
+          # The following API call returns 404 if user is not a member of the uyuni-project org
+          # See: https://docs.github.com/rest/orgs/members#check-organization-membership-for-a-user--status-codes
+          RESULT=`gh api orgs/uyuni-project/members/${{ github.actor }} -i | head -1 | awk '{ print $2 }'`
+          echo "result=$RESULT" >> "$GITHUB_OUTPUT"
+      - name: Label the PR
+        # If not a member of org
+        if: ${{ steps.is_member.outputs.result == 404 }}
+        uses: christianvuerings/add-labels@v1
+        with:
+          labels: "external-contrib"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a GH Action named "External PR labeler" that adds `external-contrib` label to any newly opened PR by a user who is not a member of the uyuni-project org.

# TODO

This action uses a personal access token with `org:read` permission. The token must be stored as a repository secret with the name `READ_ORG_TOKEN`.

- [x] Create a personal access token (classic) with permission `org:read`
- [x] Store the token as a "Repository Secret" with the name `READ_ORG_TOKEN`

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
