### PR TITLE
Better feature and scenario titles for BV

### DIFF
--- a/testsuite/features/build_validation/add_activation_keys/add_activation_key.template
+++ b/testsuite/features/build_validation/add_activation_keys/add_activation_key.template
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2022 SUSE LLC
+# Copyright (c) 2010-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @<client>
@@ -7,5 +7,5 @@ Feature: Create an activation key for <client>
   As the testing user
   I want to use activation keys
 
-  Scenario: Create an activation key with the channel and child channels for a <client>
+  Scenario: Create an activation key with the channel and child channels for <client>
     When I create an activation key including custom channels for "<client>" via API

--- a/testsuite/features/build_validation/create_bootstrap_repositories/create_bootstrap_repository.template
+++ b/testsuite/features/build_validation/create_bootstrap_repositories/create_bootstrap_repository.template
@@ -2,7 +2,7 @@
 # Licensed under the terms of the MIT license.
 
 @<client>
-Feature: Create bootstrap repositories
+Feature: Create bootstrap repository for <client>
 In order to be able to enroll clients with MU repositories
 As the system administrator
 I create all bootstrap repos with --with-custom-channels option


### PR DESCRIPTION
## What does this PR change?

Currently all feature titles for creating the bootstrap repository are identical, making the test suite report hard to read and making it impossible to run them manually. This PR adds the minion name to the feature title.



## Links

Ports:
 * 4.3: SUSE/spacewalk#22304
 * 4.2: SUSE/spacewalk#22305


## Changelogs

- [x] No changelog needed
