### PR TITLE
QE: Partial revert of how we wait for hw refresh

### DIFF
--- a/testsuite/features/secondary/allcli_overview_systems_details.feature
+++ b/testsuite/features/secondary/allcli_overview_systems_details.feature
@@ -78,8 +78,7 @@ Feature: The system details of each minion and client provides an overview of th
     When I follow "Hardware"
     And I click on "Schedule Hardware Refresh"
     Then I should see a "You have successfully scheduled a hardware profile refresh" text
-    When I wait until event "Hardware List Refresh scheduled by admin" is completed
-    And I wait until there is no Salt job calling the module "hardware.profileupdate" on "ssh_minion"
+    And I wait until event "Hardware List Refresh scheduled by admin" is completed
 
   @ssh_minion
   Scenario: SSH-managed minion grains are displayed correctly on the details page


### PR DESCRIPTION


## What does this PR change?

https://github.com/uyuni-project/uyuni/pull/7380 with commit c618cec137831c719a07620c4938611f38922a8d introduced the "Wait until there is no Salt job calling the module hardware.properties on ssh_minion" . But this is failing for ssh_minion. Reverting this test.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests
- [X] **DONE**

## Links
N/A

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
