### PR TITLE
Fix action executor to prevent blocking Taskomatic for actions that are already finished

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionExecutor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionExecutor.java
@@ -111,7 +111,8 @@ public class MinionActionExecutor extends RhnJavaJob {
         // HACK: it is possible that this Taskomatic task triggered before the corresponding Action was really
         // COMMITted in the database. Wait for some minutes checking if it appears
         int waitedTime = 0;
-        while (countQueuedServerActions(action) == 0 && waitedTime < ACTION_DATABASE_GRACE_TIME) {
+        while (countQueuedServerActions(action) == 0 && waitedTime < ACTION_DATABASE_GRACE_TIME &&
+                !allServerActionsFinished(action)) {
             action = ActionFactory.lookupById(actionId);
             try {
                 Thread.sleep(ACTION_DATABASE_POLL_TIME);
@@ -125,6 +126,14 @@ public class MinionActionExecutor extends RhnJavaJob {
 
         if (action == null) {
             log.error("Action not found: {}", actionId);
+            return;
+        }
+
+        // Instead of putting the thread to sleep in the loop above, checking if all server actions have already
+        // finished (they might have been manually canceled, for example) will prevent blocking the Taskomatic for
+        // actions that will never appear in the database.
+        if (allServerActionsFinished(action)) {
+            log.warn("All server actions for action {} are finished. Skipping it.", actionId);
             return;
         }
 
@@ -191,5 +200,14 @@ public class MinionActionExecutor extends RhnJavaJob {
                      .stream()
                      .filter(serverAction -> ActionFactory.STATUS_QUEUED.equals(serverAction.getStatus()))
                      .count();
+    }
+
+    private boolean allServerActionsFinished(Action action) {
+        return action != null &&
+            !CollectionUtils.isEmpty(action.getServerActions()) &&
+            action.getServerActions().stream().allMatch(serverAction ->
+                    ActionFactory.STATUS_FAILED.equals(serverAction.getStatus()) ||
+                    ActionFactory.STATUS_COMPLETED.equals(serverAction.getStatus())
+            );
     }
 }

--- a/java/spacewalk-java.changes.welder.fix-taskomatic-blocking
+++ b/java/spacewalk-java.changes.welder.fix-taskomatic-blocking
@@ -1,0 +1,1 @@
+- Fix action executor to prevent blocking Taskomatic for actions that are already finished (bsc#1214121)


### PR DESCRIPTION
## What does this PR change?

The server actions can be manually cancelled via Web UI, so this PR changes the code to check if all server actions have already finished before putting the Taskomatic thread to sleep. It should prevent blocking the Taskomatic for actions that will never appear in the database.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/22295

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
