### PR TITLE
QE: Fix server restart via SSH

### DIFF
--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -703,10 +703,10 @@ When implementing a step, to run a command on a target, use:
 
 ```ruby
 get_target('server').run("uptime")
-get_target('minion').run("uptime", check_errors: false)
-get_target('minion').run("uptime", check_errors: true)
-get_target('minion').run("uptime", check_errors: true, timeout: 300)
-get_target('minion').run("uptime", check_errors: false, timeout: 500, user: 'root')
+get_target('sle_minion').run("uptime", check_errors: false)
+get_target('sle_minion').run("uptime", check_errors: true)
+get_target('sle_minion').run("uptime", check_errors: true, timeout: 300)
+get_target('sle_minion').run("uptime", check_errors: false, timeout: 500, user: 'root')
 ```
 
 Arguments taken by method ```run``` are:
@@ -724,7 +724,7 @@ retry several times until ```DEFAULT_TIMEOUT```.
 When implementing a step, to get the FQDN of the host, use:
 
 ```ruby
-  STDOUT.puts get_target('minion').full_hostname
+  STDOUT.puts get_target('sle_minion').full_hostname
 ```
 
 ### Converting between host name and target

--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -702,11 +702,11 @@ of the underlying libraries, have a look at
 When implementing a step, to run a command on a target, use:
 
 ```ruby
-$server.run("uptime")
-$minion.run("uptime", check_errors: false)
-$minion.run("uptime", check_errors: true)
-$minion.run("uptime", check_errors: true, timeout: 300)
-$minion.run("uptime", check_errors: false, timeout: 500, user: 'root')
+get_target('server').run("uptime")
+get_target('minion').run("uptime", check_errors: false)
+get_target('minion').run("uptime", check_errors: true)
+get_target('minion').run("uptime", check_errors: true, timeout: 300)
+get_target('minion').run("uptime", check_errors: false, timeout: 500, user: 'root')
 ```
 
 Arguments taken by method ```run``` are:
@@ -724,7 +724,7 @@ retry several times until ```DEFAULT_TIMEOUT```.
 When implementing a step, to get the FQDN of the host, use:
 
 ```ruby
-  STDOUT.puts $minion.full_hostname
+  STDOUT.puts get_target('minion').full_hostname
 ```
 
 ### Converting between host name and target

--- a/testsuite/documentation/pitfalls.md
+++ b/testsuite/documentation/pitfalls.md
@@ -20,19 +20,19 @@ Put the complexity in the step. Keep the feature free of how the test is execute
 
 ```ruby
 When(/^I start database with the command "(.*?)"$/) do |start_command|
-  $output, _code = $server.run(start_command)
+  $output, _code = get_target('server').run(start_command)
 end
 
 When(/^when I stop the database with the command "(.*?)"$/) do |stop_command|
-  $output, _code = $server.run(stop_command)
+  $output, _code = get_target('server').run(stop_command)
 end
 
 When(/^when I check the database status with the command "(.*?)"$/) do |check_command|
-  $output, _code = $server.run(check_command)
+  $output, _code = get_target('server').run(check_command)
 end
 
 When(/^I stop the database with the command "(.*?)"$/) do |stop_command|
-  $output, _code = $server.run(stop_command)
+  $output, _code = get_target('server').run(stop_command)
 end
 ```
 
@@ -43,7 +43,7 @@ stop databases itself and want to be explicit just use `When I run the command X
 
 ```ruby
 When(/^I start database with the command "(.*?)"$/) do |start_command|
-  $output, _code = $server.run(start_command)
+  $output, _code = get_target('server').run(start_command)
 end
 
 # do something with $output then

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1411,8 +1411,7 @@ end
 
 # rebooting via SSH
 When(/^I reboot the server through SSH$/) do
-  init_string = "ssh:#{get_target('server').public_ip}"
-  temp_server = twopence_init(init_string)
+  temp_server = twopence_init('server')
   temp_server.run('reboot > /dev/null 2> /dev/null &')
   default_timeout = 300
 
@@ -1468,7 +1467,7 @@ end
 
 # changing hostname
 When(/^I run spacewalk-hostname-rename command on the server$/) do
-  temp_server = twopence_init("ssh:#{get_target('server').public_ip}")
+  temp_server = twopence_init('server')
   command = "spacecmd --nossl -q api api.getVersion -u admin -p admin; " \
             "spacewalk-hostname-rename #{get_target('server').public_ip} " \
             "--ssl-country=DE --ssl-state=Bayern --ssl-city=Nuremberg " \
@@ -1491,8 +1490,7 @@ When(/^I run spacewalk-hostname-rename command on the server$/) do
 end
 
 When(/^I change back the server's hostname$/) do
-  init_string = "ssh:#{get_target('server').public_ip}"
-  temp_server = twopence_init(init_string)
+  temp_server = twopence_init('server')
   temp_server.run("echo '#{get_target('server').full_hostname}' > /etc/hostname ")
 end
 

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -198,7 +198,7 @@ PACKAGE_BY_CLIENT = { 'sle_minion' => 'bison',
 # For containers we do not have SCC, so we set the Fake Base Channel
 # for sle_minion
 sle_base_channel =
-  if ENV["PROVIDER"].include? 'podman'
+  if ENV['PROVIDER'].include? 'podman'
     'Fake Base Channel'
   elsif ENV['SERVER'].include? 'uyuni'
     'openSUSE Leap 15.4 (x86_64)'


### PR DESCRIPTION
**add description**

This fixes some of the 4.3 CI issues found by @mcalmer which are leftovers from the Twopence lazy init backport. See https://github.com/SUSE/spacewalk/pull/22269

Twopence uses the following init, so the hostname rename and SSH reboot tests could be a bit simplified because we know what the server target is already and do not have to use its IP address:

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were added

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/22313

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
