### PR TITLE
Remove has_content? Systems when looking for new system

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -110,7 +110,7 @@ When(/^I wait at most (\d+) seconds until the event is completed, refreshing the
 end
 
 When(/^I wait until I see the name of "([^"]*)", refreshing the page$/) do |host|
-  raise 'Overview System page didn\'t load' unless has_content?('System Overview') || has_content?('Systems')
+  raise 'Overview System page didn\'t load' unless has_content?('System Overview')
   system_name = get_system_name(host)
   step %(I wait until I see the "#{system_name}" system, refreshing the page)
 end

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -110,7 +110,7 @@ When(/^I wait at most (\d+) seconds until the event is completed, refreshing the
 end
 
 When(/^I wait until I see the name of "([^"]*)", refreshing the page$/) do |host|
-  raise 'Overview System page didn\'t load' unless has_content?('System Overview')
+  raise 'Overview System page didn\'t load' unless has_content?('Download CSV')
   system_name = get_system_name(host)
   step %(I wait until I see the "#{system_name}" system, refreshing the page)
 end


### PR DESCRIPTION
## What does this PR change?

Systems is always visible. Looking for Systems text and System overview will not wait correctly for the System Overview page to be loaded.

@elariekerboull , I would like to remove the Systems text check. For me this text is always visible on the Left Menu.

## Changelogs

- [x] No changelog needed

