### PR TITLE
Label community PRs as 'community' instead of 'external-contrib'

### DIFF
--- a/.github/workflows/external_pr_labeler.yml
+++ b/.github/workflows/external_pr_labeler.yml
@@ -26,6 +26,6 @@ jobs:
         if: ${{ steps.is_member.outputs.result == 404 }}
         uses: christianvuerings/add-labels@v1
         with:
-          labels: "external-contrib"
+          labels: "community"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Label community PRs as 'community' instead of 'external-contrib' with "External PR labeler" GH action.

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
