### PR TITLE
Use new apache wsgi mod package name

### DIFF
--- a/proxy/proxy/spacewalk-proxy.changes.oholecek.fix-wsgi-pkgname
+++ b/proxy/proxy/spacewalk-proxy.changes.oholecek.fix-wsgi-pkgname
@@ -1,0 +1,1 @@
+- Use new apache wsgi mod package name

--- a/proxy/proxy/spacewalk-proxy.spec
+++ b/proxy/proxy/spacewalk-proxy.spec
@@ -84,7 +84,7 @@ Group:          Applications/Internet
 Requires:       httpd
 Requires:       spacewalk-proxy-package-manager
 %if 0%{?suse_version}
-Requires:       apache2-mod_wsgi-python3
+Requires:       apache2-mod_wsgi
 Requires:       apache2-prefork
 %else
 Requires:       mod_ssl
@@ -127,7 +127,7 @@ Requires(pre):  uyuni-base-common
 BuildRequires:  uyuni-base-common
 %if 0%{?suse_version}
 BuildRequires:  apache2
-Requires:       apache2-mod_wsgi-python3
+Requires:       apache2-mod_wsgi
 %else
 BuildRequires:  httpd
 Requires:       mod_ssl


### PR DESCRIPTION
## What does this PR change?

New package `apache2-mod_wsgi` was introduced instead of `apache2-mod_wsgi-python3` so let's require new package. Should prevent problem with disabling wsgi on package update.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
