### PR TITLE
QE: Add extra wait for Grafana to load in BV

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -181,6 +181,7 @@ Feature: Smoke tests for <client>
   Scenario: Test <client> on Grafana
     When I visit the grafana dashboards of this "monitoring_server"
     And I wait until I do not see "Loading Grafana" text
+    And I wait until I see "General" text
     And I check radio button "View as list"
     When I follow "Client Systems"
     Then I should see "<client>" hostname


### PR DESCRIPTION
## What does this PR change?
Adds an extra wait to account for the time between the Loading text disappearing and the options for dashboards to appear. "General" is a section that always appears when loading is done.

## Links

- 4.2 https://github.com/SUSE/spacewalk/pull/22329
- 4.3 https://github.com/SUSE/spacewalk/pull/22328

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
