### PR TITLE
Add 'Stale PRs' GH action to label and close inactive community PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,28 @@
+name: Stale PRs
+on:
+  schedule:
+    - cron: '0 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Label/close stale PRs
+        uses: actions/stale@v8
+        with:
+          stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
+
+          # Stale after 60 days, close after further 10 days
+          days-before-pr-stale: 60
+          days-before-pr-close: 10
+
+          # Don't work on issues (only PRs)
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          # Delete its branch after closing a PR
+          delete-branch: true


### PR DESCRIPTION
Add "Stale PRs" GH action to label and close inactive community PRs.

The action runs daily at 01:00 UTC to label any PR that is inactive for 60 days with `Stale` label.

After further 10 days, the action closes the PR and deletes its branch. The author has the chance to update the PR or simply remove the `Stale` label to unmark the PR for closing.

If needed, we can extend the action to issues as well.

Check out https://github.com/actions/stale for the full range of options this action supports.

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
