### PR TITLE
Added key import debug logging to reposync

### DIFF
--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -135,6 +135,7 @@ class ZyppoSync:
                line_l = line.decode().split(":")
                if line_l[0] == "sig" and "selfsig" in line_l[10]:
                    spacewalk_gpg_keys.setdefault(line_l[4][8:].lower(), []).append(format(int(line_l[5]), 'x'))
+            log(3, "spacewalk keyIds: {}".format([k for k in sorted(spacewalk_gpg_keys)]))
 
             # Collect GPG keys from reposync Zypper RPM database
             process = subprocess.Popen(['rpm', '-q', 'gpg-pubkey', '--dbpath', REPOSYNC_ZYPPER_RPMDB_PATH], stdout=subprocess.PIPE)
@@ -142,6 +143,7 @@ class ZyppoSync:
                 match = RPM_PUBKEY_VERSION_RELEASE_RE.match(line.decode())
                 if match:
                     zypper_gpg_keys[match.groups()[0]] = match.groups()[1]
+            log(3, "zypper keyIds:    {}".format([k for k in sorted(zypper_gpg_keys)]))
 
             # Compare GPG keys and remove keys from reposync that are going to be imported with a newer release.
             for key in zypper_gpg_keys:
@@ -151,12 +153,25 @@ class ZyppoSync:
                     # This GPG key has a newer release on the Spacewalk GPG keyring that on the reposync Zypper RPM database.
                     # We delete this key from the RPM database to allow importing the newer version.
                     os.system("rpm --dbpath {} -e gpg-pubkey-{}-{}".format(REPOSYNC_ZYPPER_RPMDB_PATH, key, zypper_gpg_keys[key]))
+                    log(3, "new version available for gpg-pubkey-{}-{}".format(key, zypper_gpg_keys[key]))
 
             # Finally, once we deleted the existing old key releases from the Zypper RPM database
             # we proceed to import all keys from the Spacewalk GPG keyring. This will allow new GPG
             # keys release are upgraded in the Zypper keyring since rpmkeys does not handle the upgrade
             # properly
-            os.system("rpmkeys --dbpath {} --import {}".format(REPOSYNC_ZYPPER_RPMDB_PATH, f.name))
+            log(3, "rpmkeys -vv --dbpath {} --import {}".format(REPOSYNC_ZYPPER_RPMDB_PATH, f.name))
+            process = subprocess.Popen(["rpmkeys", "-vv", "--dbpath", REPOSYNC_ZYPPER_RPMDB_PATH, "--import", f.name], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            try:
+                outs, errs = process.communicate(timeout=15)
+                if process.returncode is None or process.returncode > 0:
+                    log(0, "Failed to import keys into rpm database ({}): {}".format(process.returncode, outs.decode('utf-8')))
+                else:
+                    log(3, "CMD out: {}".format(outs.decode('utf-8')))
+            except TimeoutExpired:
+                process.kill()
+                log(0, "Timeout exceeded while importing keys to rpm database")
+            keycont = f.read()
+            rhnLog.log_clean(5, keycont.decode('utf-8'))
 
 
 class ZypperRepo:

--- a/python/spacewalk/spacewalk-backend.changes.mackdk.Manager-4.3-reposync-key-import-debug
+++ b/python/spacewalk/spacewalk-backend.changes.mackdk.Manager-4.3-reposync-key-import-debug
@@ -1,0 +1,1 @@
+- Added key import debug logging to reposync (bsc#1213675)


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/22162

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/22119

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
