### PR TITLE
QE: Change UI element for checking list of salt keys

### DIFF
--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -228,7 +228,9 @@ For a test with a regular expression, there is ```I should see a text like "..."
   When I wait until I see the name of "sle_minion", refreshing the page
   When I wait until I do not see the name of "sle_minion", refreshing the page
   When I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
-  When I refresh page until I see "sle_minion" hostname as text
+  When I refresh systems page until I see "sle_minion" hostname as text
+  When I refresh keys page until I see "sle_minion" hostname as text
+
 ```
 
 (last one should probably be renamed - it looks in the contents area of the page)

--- a/testsuite/features/secondary/min_retracted_patches.feature
+++ b/testsuite/features/secondary/min_retracted_patches.feature
@@ -61,7 +61,7 @@ Feature: Retracted patches
     And I follow "Packages" in the content area
     And I follow "rute-dummy-2.0-1.2.x86_64"
     And I follow "Target Systems"
-    And I refresh page until I see "sle_minion" hostname as text
+    And I refresh systems page until I see "sle_minion" hostname as text
    
   Scenario: Target systems for retracted packages should be empty
     When I follow the left menu "Software > Channel List > All"

--- a/testsuite/features/secondary/min_salt_minions_page.feature
+++ b/testsuite/features/secondary/min_salt_minions_page.feature
@@ -34,7 +34,7 @@ Feature: Management of minion keys
     And I restart salt-minion on "sle_minion"
     And I wait at most 10 seconds until Salt master sees "sle_minion" as "unaccepted"
     And I follow the left menu "Salt > Keys"
-    And I refresh page until I see "sle_minion" hostname as text
+    And I refresh keys page until I see "sle_minion" hostname as text
     Then I should see a "Fingerprint" text
     And I see "sle_minion" fingerprint
     And I should see a "pending" text

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -412,8 +412,14 @@ When(/^I accept "([^"]*)" key$/) do |host|
   raise "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query).click
 end
 
-When(/^I refresh page until I see "(.*?)" hostname as text$/) do |minion|
+When(/^I refresh systems page until I see "(.*?)" hostname as text$/) do |minion|
   within('#spacewalk-content') do
+    step %(I wait until I see the name of "#{minion}", refreshing the page)
+  end
+end
+
+When(/^I refresh keys page until I see "(.*?)" hostname as text$/) do |minion|
+  within('#spacewalk-list') do
     step %(I wait until I see the name of "#{minion}", refreshing the page)
   end
 end


### PR DESCRIPTION
## What does this PR change?

There's been a failing test due to a change in the UI component's name, it seems. This fix is meant to fix the test when it runs on the list of keys instead of the systems' list page.


## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
