### PR TITLE
QE: Kill the openSUSE Leap repo sync

### DIFF
--- a/testsuite/features/reposync/srv_wait_for_reposync.feature
+++ b/testsuite/features/reposync/srv_wait_for_reposync.feature
@@ -16,9 +16,5 @@ Feature: Wait for reposync activity to finish in CI context
   Scenario: Kill running reposyncs or wait for them to finish
     When I kill all running spacewalk-repo-sync, excepted the ones needed to bootstrap
 
-@uyuni
-  Scenario: Sync openSUSE Leap 15.4 product, including Uyuni Client Tools
-    When I call spacewalk-repo-sync to sync the parent channel "opensuse_leap15_4-x86_64"
-
   Scenario: Wait until all synchronized channels have finished
     When I wait until all synchronized channels have finished

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -30,19 +30,14 @@ end
 # This is a safety net only, the best thing to do is to not start the reposync at all.
 def compute_channels_to_leave_running
   # keep the repos needed for the auto-installation tests
-  do_not_kill =
-    if product == 'Uyuni'
-      CHANNEL_TO_SYNCH_BY_OS_VERSION['15.4']
-    else
-      CHANNEL_TO_SYNCH_BY_OS_VERSION['default']
-    end
+  do_not_kill = CHANNEL_TO_SYNCH_BY_OS_VERSION['default']
   [get_target('sle_minion'), get_target('build_host'), get_target('ssh_minion'), get_target('rhlike_minion')].each do |node|
     next unless node
     os_version = node.os_version
     os_family = node.os_family
     next unless ['sles', 'rocky'].include?(os_family)
     os_version = os_version.split('.')[0] if os_family == 'rocky'
-    log 'Can\'t build list of reposyncs to leave running' unless %w[15-SP3 15-SP4 15.4 8].include? os_version
+    log 'Can\'t build list of reposyncs to leave running' unless %w[15-SP3 15-SP4 8].include? os_version
     do_not_kill += CHANNEL_TO_SYNCH_BY_OS_VERSION[os_version]
   end
   do_not_kill.uniq


### PR DESCRIPTION
## What does this PR change?

Kills the openSUSE Leap 15.4 reposyncing to see if we are able to bootstrap the openSUSE minion in the Uyuni CI.
See https://github.com/SUSE/spacewalk/issues/22336

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were added

- [x] **DONE**

## Links



- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
