### PR TITLE
QE: Fix Repo cleanup for Proejct Lotus tests

### DIFF
--- a/testsuite/features/secondary/min_project_lotus.feature
+++ b/testsuite/features/secondary/min_project_lotus.feature
@@ -126,6 +126,6 @@ Feature: Project Lotus
   Scenario: Cleanup: Remove custom repository for PTFs
     When I follow the left menu "Software > Manage > Repositories"
     And I follow "sles15sp4_ptf_repo"
-    And I follow this "Delete Repository" link
+    And I follow "Delete Repository"
     And I click on "Delete Repository"
     Then I should see a "Repository deleted successfully" text


### PR DESCRIPTION
## What does this PR change?
We changed the step to follow links, so I'm updating the cleanup test for the custom repos used on Project Lotus tests

## Links
Already present on 4.3

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
