### PR TITLE
QE: Remove duplicate Leap reposync

### DIFF
--- a/testsuite/features/reposync/srv_wait_for_reposync.feature
+++ b/testsuite/features/reposync/srv_wait_for_reposync.feature
@@ -16,9 +16,5 @@ Feature: Wait for reposync activity to finish in CI context
   Scenario: Kill running reposyncs or wait for them to finish
     When I kill all running spacewalk-repo-sync, excepted the ones needed to bootstrap
 
-@uyuni
-  Scenario: Sync openSUSE Leap 15.4 product, including Uyuni Client Tools
-    When I call spacewalk-repo-sync to sync the parent channel "opensuse_leap15_4-x86_64"
-
   Scenario: Wait until all synchronized channels have finished
     When I wait until all synchronized channels have finished


### PR DESCRIPTION
## What does this PR change?

This will remove the additional step to trigger the openSUSE Leap 15.4 reposync.

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
