### PR TITLE
fix python reposync unit tests

### DIFF
--- a/python/test/unit/spacewalk/satellite_tools/test_reposync.py
+++ b/python/test/unit/spacewalk/satellite_tools/test_reposync.py
@@ -634,7 +634,7 @@ class RepoSyncTest(unittest.TestCase):
                 "http://example.com/?credentials=testcreds_42"
             ]
         }
-        _mock_rhnsql(self.reposync, [{ 'username' : 'foo', 'password': 'c2VjcmV0' , 'extra_auth': memoryview(b'{\"my_header\":  \"my_value\"}')}])
+        _mock_rhnsql(self.reposync, [{ 'username' : 'foo', 'password': 'c2VjcmV0', 'type': 'cloudrmt', 'extra_auth': memoryview(b'{\"my_header\":  \"my_value\"}')}])
         self.assertEqual(
             rs.set_repo_credentials(url), [{"url":"http://foo:secret@example.com/", "http_headers": {"my_header": "my_value"}}])
 
@@ -776,7 +776,8 @@ class SyncTest(unittest.TestCase):
         config = {
             'return_value.fetchone_dict.return_value': {
                 "username": "user#1",
-                "password": base64.encodestring(password.encode()).decode()
+                "password": base64.encodestring(password.encode()).decode(),
+                "type": "SCC"
             }
         }
         patcher = patch(
@@ -788,7 +789,7 @@ class SyncTest(unittest.TestCase):
                 {"url": 'http://{0}:{1}@some.url'.format(username, password), "http_headers": {}}
             )
             mock_prepare.assert_called_once_with(
-                'SELECT username, password, extra_auth FROM suseCredentials WHERE id = :id'
+                '\n                SELECT c.username, c.password, c.extra_auth, ct.label type\n                  FROM suseCredentials c\n                  JOIN suseCredentialsType ct on c.type_id = ct.id\n                  WHERE c.id = :id\n            ' 
             )
             mock_prepare().execute.assert_called_once_with(id=credentials_id)
 


### PR DESCRIPTION
## What does this PR change?

PAYG or RHUI code introduced regressions in reposync unit tests

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port https://github.com/SUSE/spacewalk/pull/22353

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql" 
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
