### PR TITLE
QE: Add a refresh option to invalidate cache in Twopence/Lavanda instances

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -508,7 +508,7 @@ When(/^I execute spacewalk-debug on the server$/) do
 end
 
 When(/^I extract the log files from all our active nodes$/) do
-  $nodes.each do |node|
+  $node_by_host.each do |_host, node|
     # the salt_migration_minion is not available anymore
     next if node.nil? || node == get_target('salt_migration_minion')
 
@@ -1456,52 +1456,56 @@ When(/^I reboot the "([^"]*)" if it is a SLE Micro$/) do |host|
 end
 
 When(/^I change the server's short hostname from hosts and hostname files$/) do
-  old_hostname = get_target('server').hostname
+  server_node = get_target('server')
+  old_hostname = server_node.hostname
   new_hostname = old_hostname + '2'
   log "New short hostname: #{new_hostname}"
-
-  get_target('server').run("sed -i 's/#{old_hostname}/#{new_hostname}/g' /etc/hostname &&
-  echo '#{get_target('server').public_ip} #{get_target('server').full_hostname} #{old_hostname}' >> /etc/hosts &&
-  echo '#{get_target('server').public_ip} #{new_hostname}#{get_target('server').full_hostname.delete_prefix(get_target('server').hostname)} #{new_hostname}' >> /etc/hosts")
+  server_node.run("sed -i 's/#{old_hostname}/#{new_hostname}/g' /etc/hostname &&
+  echo '#{server_node.public_ip} #{server_node.full_hostname} #{old_hostname}' >> /etc/hosts &&
+  echo '#{server_node.public_ip} #{new_hostname}#{server_node.full_hostname.delete_prefix(server_node.hostname)} #{new_hostname}' >> /etc/hosts")
+  get_target('server', refresh: true) # This will refresh the attributes of this node
 end
 
 # changing hostname
 When(/^I run spacewalk-hostname-rename command on the server$/) do
-  temp_server = twopence_init('server')
-  command = "spacecmd --nossl -q api api.getVersion -u admin -p admin; " \
-            "spacewalk-hostname-rename #{get_target('server').public_ip} " \
-            "--ssl-country=DE --ssl-state=Bayern --ssl-city=Nuremberg " \
-            "--ssl-org=SUSE --ssl-orgunit=SUSE --ssl-email=galaxy-noise@suse.de " \
-            "--ssl-ca-password=spacewalk"
-  out_spacewalk, result_code = temp_server.run(command, check_errors: false)
+  server_node = get_target('server')
+  command = 'spacecmd --nossl -q api api.getVersion -u admin -p admin; ' \
+    "spacewalk-hostname-rename #{server_node.public_ip} " \
+    '--ssl-country=DE --ssl-state=Bayern --ssl-city=Nuremberg ' \
+    '--ssl-org=SUSE --ssl-orgunit=SUSE --ssl-email=galaxy-noise@suse.de ' \
+    '--ssl-ca-password=spacewalk'
+  out_spacewalk, result_code = server_node.run(command, check_errors: false)
   log "#{out_spacewalk}"
 
+  server_node = get_target('server', refresh: true) # This will refresh the attributes of this node
+
   default_timeout = 300
-  repeat_until_timeout(timeout: default_timeout, message: "Spacewalk didn't come up") do
-    out, code = temp_server.run('spacewalk-service status', check_errors: false, timeout: 10)
-    if !out.to_s.include? "dead" and out.to_s.include? "running"
-      log "Server: spacewalk service is up"
+  repeat_until_timeout(timeout: default_timeout, message: 'Spacewalk didn\'t come up') do
+    out, _code = server_node.run('spacewalk-service status', check_errors: false, timeout: 10)
+    if !out.to_s.include? 'dead' and out.to_s.include? 'running'
+      log 'Server: spacewalk service is up'
       break
     end
     sleep 1
   end
-  raise "Error while running spacewalk-hostname-rename command - see logs above" unless result_code.zero?
-  raise "Error in the output logs - see logs above" if out_spacewalk.include? "No such file or directory"
+  raise 'Error while running spacewalk-hostname-rename command - see logs above' unless result_code.zero?
+  raise 'Error in the output logs - see logs above' if out_spacewalk.include? 'No such file or directory'
 end
 
 When(/^I change back the server's hostname$/) do
-  temp_server = twopence_init('server')
-  temp_server.run("echo '#{get_target('server').full_hostname}' > /etc/hostname ")
+  server_node = get_target('server')
+  server_node.run("echo '#{server_node.full_hostname}' > /etc/hostname ")
+  get_target('server', refresh: true) # This will refresh the attributes of this node
 end
 
 When(/^I clean up the server's hosts file$/) do
-  command = "sed -i '$d' /etc/hosts && sed -i '$d' /etc/hosts"
+  command = 'sed -i \'$d\' /etc/hosts && sed -i \'$d\' /etc/hosts'
   get_target('server').run(command)
 end
 
 When(/^I enable firewall ports for monitoring on this "([^"]*)"$/) do |host|
   add_ports = ''
-  for port in [9100, 9117, 9187] do
+  [9100, 9117, 9187].each do |port|
     add_ports += "firewall-cmd --add-port=#{port}/tcp --permanent && "
   end
   cmd = "#{add_ports.rstrip!} firewall-cmd --reload"
@@ -1525,13 +1529,13 @@ end
 
 When(/^I execute "([^"]*)" on the "([^"]*)"$/) do |command, host|
   node = get_target(host)
-  command_output, _code = node.run(command, check_errors: true, verbose: true)
+  node.run(command, check_errors: true, verbose: true)
 end
 
 When(/^I check the cloud-init status on "([^"]*)"$/) do |host|
   node = get_target(host)
-  _hostname, local, remote, node_code = node.test_and_store_results_together('hostname', 'root', 500)
-  command_output, _code = node.run("cloud-init status --wait", check_errors: true, verbose: false)
+  node.test_and_store_results_together('hostname', 'root', 500)
+  node.run("cloud-init status --wait", check_errors: true, verbose: false)
 
   repeat_until_timeout(report_result: true) do
     command_output, code = node.run("cloud-init status --wait", check_errors: true, verbose: false)

--- a/testsuite/features/support/twopence_env.rb
+++ b/testsuite/features/support/twopence_env.rb
@@ -22,7 +22,6 @@ unless $build_validation
 end
 
 # Dictionaries to obtain host or node from the Twopence objects
-$nodes = []
 $node_by_host = {}
 $host_by_node = {}
 
@@ -36,8 +35,8 @@ if ENV['SCC_CREDENTIALS']
 end
 
 # Get the Twopence node passing the host (includes lazy initialization)
-def get_target(host)
+def get_target(host, refresh: false)
   node = $node_by_host[host]
-  node = twopence_init(host) if node.nil?
+  node = twopence_init(host) if node.nil? || refresh == true
   node
 end

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -72,7 +72,6 @@ def twopence_init(host)
     node = process_private_and_public_ip(host, node)
   end
 
-  $nodes << node
   $node_by_host[host] = node
   $host_by_node[node] = host
   node

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -54,8 +54,7 @@
 - features/secondary/min_timezone.feature
 - features/secondary/min_move_from_and_to_proxy.feature
 - features/secondary/minssh_move_from_and_to_proxy.feature
-# TODO: Fix the twopence refactor to work for this feature
-# - features/secondary/srv_rename_hostname.feature
+- features/secondary/srv_rename_hostname.feature
 - features/secondary/proxy_as_pod_basic_tests.feature
 - features/secondary/srv_logfile.feature
 - features/secondary/srv_cobbler_sync.feature


### PR DESCRIPTION
## What does this PR change?

Add a refresh option to invalidate cache in Twopence/Lavanda instances

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were refactored

- [x] **DONE**

## Links

Ports:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
