### PR TITLE
check for localhost in correct table

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -25,7 +25,6 @@ import com.redhat.rhn.domain.channel.ChannelFamily;
 import com.redhat.rhn.domain.channel.ChannelFamilyFactory;
 import com.redhat.rhn.domain.channel.ContentSource;
 import com.redhat.rhn.domain.channel.PublicChannelFamily;
-import com.redhat.rhn.domain.cloudpayg.CloudRmtHostFactory;
 import com.redhat.rhn.domain.cloudpayg.PaygProductFactory;
 import com.redhat.rhn.domain.cloudpayg.PaygSshData;
 import com.redhat.rhn.domain.cloudpayg.PaygSshDataFactory;
@@ -786,7 +785,7 @@ public class ContentSyncManager {
             );
         }
         else if (CredentialsFactory.listSCCCredentials().isEmpty() && !(cloudPaygManager.isPaygInstance() &&
-                CloudRmtHostFactory.lookupByHostname("localhost").isPresent())) {
+                PaygSshDataFactory.lookupByHostname("localhost").isPresent())) {
             // Can happen when neither SCC Credentials nor fromdir is configured
             // Also when we are PAYG instance, but localhost connection is not configured
             // in such a case, refresh makes no sense.

--- a/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
@@ -35,6 +35,8 @@ import com.redhat.rhn.domain.channel.ChannelFamily;
 import com.redhat.rhn.domain.channel.ChannelFamilyFactory;
 import com.redhat.rhn.domain.channel.ContentSource;
 import com.redhat.rhn.domain.channel.test.ChannelFamilyFactoryTest;
+import com.redhat.rhn.domain.cloudpayg.PaygSshData;
+import com.redhat.rhn.domain.cloudpayg.PaygSshDataFactory;
 import com.redhat.rhn.domain.common.ManagerInfoFactory;
 import com.redhat.rhn.domain.credentials.Credentials;
 import com.redhat.rhn.domain.credentials.CredentialsFactory;
@@ -66,6 +68,7 @@ import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.TestUtils;
 
+import com.suse.cloud.CloudPaygManager;
 import com.suse.manager.webui.services.pillar.MinionGeneralPillarGenerator;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.mgrsync.MgrSyncStatus;
@@ -2044,6 +2047,30 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
     public void testIsRefreshNeededNothingConfigured() throws Exception {
         ContentSyncManager csm = new ContentSyncManager();
         assertFalse(csm.isRefreshNeeded(null));
+    }
+
+    @Test
+    public void testIsRefreshNeededPAYG() {
+        for (Credentials c : CredentialsFactory.listSCCCredentials()) {
+            CredentialsFactory.removeCredentials(c);
+        }
+        ManagerInfoFactory.setLastMgrSyncRefresh(0);
+        CloudPaygManager mgr = new CloudPaygManager();
+        mgr.setPaygInstance(true);
+        mgr.setCompliant(true);
+        ContentSyncManager csm = new ContentSyncManager(null, mgr);
+        Credentials rmtCreds = CredentialsFactory.createCloudRmtCredentials();
+        rmtCreds.setUsername("RMTUSER");
+        rmtCreds.setPassword("secret");
+        CredentialsFactory.storeCredentials(rmtCreds);
+        PaygSshData sshData = PaygSshDataFactory.createPaygSshData();
+        sshData.setHost("localhost");
+        sshData.setUsername("admin");
+        sshData.setPassword("secret");
+        sshData.setCredentials(rmtCreds);
+        PaygSshDataFactory.savePaygSshData(sshData);
+
+        assertTrue(csm.isRefreshNeeded(null));
     }
 
     /**


### PR DESCRIPTION
## What does this PR change?

Product Refresh is not working as we check for localhost connection in the wrong table

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/22365

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
