### PR TITLE
Fix Most Critical Systems list

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -1016,7 +1016,7 @@ SELECT  DISTINCT ST.element AS ID
   SELECT  DISTINCT S.id,
                    S.name,
                    SI.server_id AS MGR_SERVER,
-                   PI.server_id AS PROXY,
+                   PI.server_id is not null AS PROXY,
                    TO_CHAR(Sinfo.checkin, 'YYYY-MM-DD HH24:MI:SS') AS LAST_CHECKIN,
                    SO.SECURITY_ERRATA, SO.BUG_ERRATA, SO.ENHANCEMENT_ERRATA, SO.LOCKED,
                    SO.OUTDATED_PACKAGES, SO.SERVER_NAME, SO.SERVER_ADMINS, SO.GROUP_COUNT,

--- a/java/spacewalk-java.changes.welder.bsc1214316
+++ b/java/spacewalk-java.changes.welder.bsc1214316
@@ -1,0 +1,1 @@
+- Fix Most Critical Systems list (bsc#1214316)


### PR DESCRIPTION
## What does this PR change?

The `setProxy` method in `SystemOverview` was recently modified to accept a boolean value instead of Long. However, the query for loading the `Most Critical Systems` list was still passing the system ID for this method, causing errors during loading the list when a proxy was present.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/22343

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
