### PR TITLE
Fix the architecture in case of RHEL-based products

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -413,16 +413,17 @@ public class RegistrationUtils {
 
             Optional<RedhatProductInfo> redhatProductInfo = systemQuery.redhatProductInfo(minionId);
 
+            String productArch = arch.replace("-redhat-linux", "");
             Optional<RhelUtils.RhelProduct> rhelProduct =
-                    redhatProductInfo.flatMap(x -> RhelUtils.detectRhelProduct(
-                            channels, arch, x.getWhatProvidesRes(), x.getWhatProvidesSLL(),  x.getRhelReleaseContent(),
-                            x.getCentosReleaseContent(), x.getOracleReleaseContent(), x.getAlibabaReleaseContent(),
-                            x.getAlmaReleaseContent(), x.getAmazonReleaseContent(), x.getRockyReleaseContent()));
+                redhatProductInfo.flatMap(x -> RhelUtils.detectRhelProduct(
+                    channels, productArch, x.getWhatProvidesRes(), x.getWhatProvidesSLL(), x.getRhelReleaseContent(),
+                    x.getCentosReleaseContent(), x.getOracleReleaseContent(), x.getAlibabaReleaseContent(),
+                    x.getAlmaReleaseContent(), x.getAmazonReleaseContent(), x.getRockyReleaseContent()));
             return Opt.stream(rhelProduct).flatMap(rhel -> {
 
                 if (rhel.getSuseBaseProduct().isEmpty()) {
                     LOG.warn("No product match found for: {} {} {} {}", rhel.getName(), rhel.getVersion(),
-                            rhel.getRelease(), arch);
+                            rhel.getRelease(), productArch);
                     return Stream.empty();
                 }
                 return rhel.getAllSuseProducts().stream();

--- a/java/spacewalk-java.changes.mackdk.4.3-fix-product-detection-rhel
+++ b/java/spacewalk-java.changes.mackdk.4.3-fix-product-detection-rhel
@@ -1,0 +1,1 @@
+- Fixed detection in case RHEL-based products (bsc#1214280)


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue when detecting the products installed on a RHEL-based distribution. This is caused by the wrong handling of the architecture.

Port of https://github.com/SUSE/spacewalk/pull/22339

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: code mostly untestable

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/22314
Tracks https://github.com/SUSE/spacewalk/pull/22339

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
