### PR TITLE
Billing adapter checks 2

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFamily.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFamily.java
@@ -136,10 +136,10 @@ public class ChannelFamily extends BaseDomainHelper {
         }
         ChannelFamily castOther = (ChannelFamily) other;
 
-        return new EqualsBuilder().append(id, castOther.id)
-                                  .append(label, castOther.label)
-                                  .append(name, castOther.name)
-                                  .append(org, castOther.org)
+        return new EqualsBuilder().append(id, castOther.getId())
+                                  .append(label, castOther.getLabel())
+                                  .append(name, castOther.getName())
+                                  .append(org, castOther.getOrg())
                                   .isEquals();
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/tasko/SatSchedulesAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/tasko/SatSchedulesAction.java
@@ -56,7 +56,9 @@ public class SatSchedulesAction extends RhnAction implements Listable<Map<String
     public List<Map<String, Object>> getResult(RequestContext contextIn) {
         User user =  contextIn.getCurrentUser();
         try {
-            return new TaskomaticApi().findActiveSchedules(user);
+            List<Map<String, Object>> activeSchedules = new TaskomaticApi().findActiveSchedules(user);
+            activeSchedules.removeIf(s -> s.get("job_label").equals("payg-dimension-computation-default"));
+            return activeSchedules;
         }
         catch (TaskomaticApiException e) {
             createErrorMessage(contextIn.getRequest(),

--- a/java/code/src/com/redhat/rhn/frontend/action/tasko/ScheduleDetailAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/tasko/ScheduleDetailAction.java
@@ -19,7 +19,6 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.frontend.struts.RhnHelper;
-import com.redhat.rhn.taskomatic.TaskoFactory;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
@@ -212,7 +211,9 @@ public class ScheduleDetailAction extends RhnAction {
         List<Map<String, String>> dropDown = new ArrayList<>();
         try {
             List<Map<String, Object>> bunches = new TaskomaticApi().listSatBunchSchedules(loggedInUser);
-            bunches.removeIf(bunch -> TaskoFactory.HIDDEN_BUNCHES.contains(bunch.get("name")));
+            // Since recurring states have their own place in the webUI we don't
+            // want them to show up in the Task Schedules UI
+            bunches.removeIf(bunch -> bunch.get("name").equals("recurring-action-executor-bunch"));
 
             for (Map<String, Object> b : bunches) {
                 addOption(dropDown, (String)b.get("name"), (String)b.get("name"));

--- a/java/code/src/com/redhat/rhn/frontend/action/tasko/ScheduleDetailAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/tasko/ScheduleDetailAction.java
@@ -186,6 +186,10 @@ public class ScheduleDetailAction extends RhnAction {
                 TaskomaticApi tapi = new TaskomaticApi();
                 Map<String, Object> schedule = tapi.lookupScheduleById(loggedInUser, schid);
                 String scheduleName = (String) schedule.get("job_label");
+                if (scheduleName.equals("payg-dimension-computation-default")) {
+                    // not modifiable
+                    return;
+                }
                 String bunchName = (String) schedule.get("bunch");
                 request.setAttribute("schedulename", scheduleName);
                 form.set("schedulename", scheduleName);

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoFactory.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoFactory.java
@@ -43,12 +43,6 @@ public class TaskoFactory extends HibernateFactory {
     private static TaskoFactory singleton = new TaskoFactory();
     private static Logger log = LogManager.getLogger(TaskoFactory.class);
 
-    // Since recurring states have their own place in the webUI we don't
-    // want them to show up in the Task Schedules UI and dimension computation
-    // should also run always without changes from the admin
-    public static final List<String> HIDDEN_BUNCHES =
-            List.of("recurring-action-executor-bunch", "payg-dimension-computation-bunch");
-
     /**
      * default constructor
      */
@@ -216,6 +210,7 @@ public class TaskoFactory extends HibernateFactory {
      */
     public static List<TaskoSchedule> listActiveSchedulesByOrg(Integer orgId) {
         List<TaskoSchedule> schedules;
+        List<String> filter = List.of("recurring-action-executor-bunch");    // List of bunch names to be excluded
         Map<String, Object> params = new HashMap<>();
 
         params.put("timestamp", new Date());    // use server time, not DB time
@@ -227,8 +222,8 @@ public class TaskoFactory extends HibernateFactory {
             schedules = singleton.listObjectsByNamedQuery("TaskoSchedule.listActiveByOrg", params);
         }
 
-        // Remove hidden schedules with blacklisted bunch names
-        schedules.removeIf(schedule -> HIDDEN_BUNCHES.contains(schedule.getBunch().getName()));
+        // Remove schedules with bunch names in 'filter'
+        schedules.removeIf(schedule -> filter.contains(schedule.getBunch().getName()));
         return  schedules;
     }
 
@@ -245,7 +240,6 @@ public class TaskoFactory extends HibernateFactory {
         params.put("timestamp", new Date());    // use server time, not DB time
         if (orgId == null) {
             return singleton.listObjectsByNamedQuery("TaskoSchedule.listActiveInSatByLabel", params);
-
         }
         params.put("org_id", orgId);
         return singleton.listObjectsByNamedQuery("TaskoSchedule.listActiveByOrgAndLabel", params);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygComputeDimensionsTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygComputeDimensionsTask.java
@@ -79,6 +79,7 @@ public class PaygComputeDimensionsTask extends RhnJavaJob {
     @Override
     public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
         if (!cloudManager.isPaygInstance()) {
+            LOGGER.debug("Not a PAYG instance. Exit");
             return;
         }
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/payg/script/payg_extract_repo_data.py
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/payg/script/payg_extract_repo_data.py
@@ -144,6 +144,10 @@ def _get_installed_suse_products():
                 "version": product_xml.find("./version").text,
                 "arch": product_xml.find("./arch").text
             }
+            if product["name"] == "sle-manager-tools":
+                # no payg product has manager tools. When it appears, it comes from
+                # a registration against SUSE Manager
+                continue
             products.append(product)
     return products
 

--- a/java/spacewalk-java.changes.mc.Manager-4.3-suma-payg-billing-adapter-checks
+++ b/java/spacewalk-java.changes.mc.Manager-4.3-suma-payg-billing-adapter-checks
@@ -1,0 +1,1 @@
+- add compliance checks when running as PAYG

--- a/python/billingdataservice/billing-data-service.changes.mc.Manager-4.3-billing-adapter-checks-2
+++ b/python/billingdataservice/billing-data-service.changes.mc.Manager-4.3-billing-adapter-checks-2
@@ -1,0 +1,1 @@
+- require csp-billing-adapter service

--- a/python/billingdataservice/billing-data-service.spec
+++ b/python/billingdataservice/billing-data-service.spec
@@ -27,6 +27,7 @@ Source:         %{name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Requires:       apache2
+Requires:       csp-billing-adapter-service
 Requires:       python3-Flask
 Requires:       spacewalk-backend-sql
 Requires:       spacewalk-taskomatic

--- a/python/billingdataservice/payg-service-override.conf
+++ b/python/billingdataservice/payg-service-override.conf
@@ -1,2 +1,3 @@
 [Unit]
 Requires=billing-data-service.service
+Requires=csp-billing-adapter.service

--- a/spacewalk/admin/spacewalk-startup-helper
+++ b/spacewalk/admin/spacewalk-startup-helper
@@ -35,25 +35,31 @@ isPayg() {
     [ "$TYPE" == "PAYG" ]
 }
 
-check_billing_service() {
-  PACKAGE_NAME=billing-data-service
+enforce_service_installed_running() {
+  PACKAGE_NAME=$1
+  SERVICE_NAME=$2
   isPayg
   if [ $? -eq 0 ]; then
 
     rpm -q $PACKAGE_NAME
     if [ $? -ne 0 ]; then
-      echo "Billing Service not installed. Installing now..."
+      echo "$PACKAGE_NAME not installed. Installing now..."
       zypper --non-interactive install $PACKAGE_NAME
-      systemctl start $PACKAGE_NAME
+      systemctl start $SERVICE_NAME
     fi
 
-    systemctl is-active --quiet $PACKAGE_NAME
+    systemctl is-active --quiet $SERVICE_NAME
     if [ $? -ne 0 ]; then
-      echo "Billing Service needs to be running."
+      echo "$SERVICE_NAME needs to be running."
       exit 1
     fi
 
   fi
+}
+
+check_billing_service() {
+  enforce_service_installed_running billing-data-service billing-data-service
+  enforce_service_installed_running csp-billing-adapter-service csp-billing-adapter
 }
 
 check_schema_version() {

--- a/susemanager-utils/supportutils-plugin-susemanager/susemanager
+++ b/susemanager-utils/supportutils-plugin-susemanager/susemanager
@@ -91,6 +91,15 @@ plugin_command "/usr/bin/instance-flavor-check"
 if [ -e /usr/bin/instance-flavor-check -a $(/usr/bin/instance-flavor-check) == "PAYG" ]; then
         validate_rpm "python-instance-billing-flavor-check"
         validate_rpm "billing-data-service"
+        validate_rpm "csp-billing-adapter-service"
+        validate_rpm "python3-csp-billing-adapter"
+        validate_rpm "python3-csp-billing-adapter-local"
+        validate_rpm "python3-csp-billing-adapter-amazon"
+        validate_rpm "suma-amazon-adapter-config-llc"
+        validate_rpm "suma-amazon-adapter-config-ltd"
+        validate_rpm "python3-csp-billing-adapter-azure"
+        validate_rpm "suma-azure-adapter-config-llc"
+        validate_rpm "suma-azure-adapter-config-ltd"
 fi
 
 plugin_command "/sbin/supportconfig-sumalog $LOG"


### PR DESCRIPTION
## What does this PR change?

Require csp-billing-adapter-service package and enhance the systemd overwrite files to require
also csp-billing-adapater.service running. Same as for the billing-data-service

Also add some bugfixes

## Links

Port of https://github.com/SUSE/spacewalk/pull/22358

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
