### PR TITLE
Disable postgres JIT

### DIFF
--- a/spacewalk/spacewalk-setup-postgresql/setup/postgresql.conf
+++ b/spacewalk/spacewalk-setup-postgresql/setup/postgresql.conf
@@ -9,3 +9,4 @@ max_connections = 600
 shared_buffers = 384MB
 wal_buffers = 4MB
 work_mem = 2560kB
+jit = off

--- a/spacewalk/spacewalk-setup-postgresql/spacewalk-setup-postgresql.changes.nadvornik.disable_jit
+++ b/spacewalk/spacewalk-setup-postgresql/spacewalk-setup-postgresql.changes.nadvornik.disable_jit
@@ -1,0 +1,1 @@
+- Disable postgres JIT


### PR DESCRIPTION
## What does this PR change?

This PR disables JIT in new postgres configurations.
JIT can cause long delays (1-2s) at random queries. In Uyuni/SUMA it probably does not bring any benefits.

JIT is provided by postgresql-llvmjit package. The package is typically installed in Uyuni and not installed in SUMA.

Details in https://github.com/SUSE/spacewalk/issues/22363

## Documentation
- WIP
- [ ] **DONE**

## Test coverage
- No tests: our tests run without JIT

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/22363

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
