### PR TITLE
fix unit test

### DIFF
--- a/python/spacewalk/common/rhnConfig.py
+++ b/python/spacewalk/common/rhnConfig.py
@@ -100,6 +100,9 @@ class RHNOptions:
     def modifiedYN(self):
         """returns last modified time diff if rhn.conf has changed."""
 
+        if not os.path.exists(self.filename):
+            return 0
+
         try:
             si = os.stat(self.filename)
         except OSError:
@@ -142,7 +145,8 @@ class RHNOptions:
 
         # Now that we parsed the defaults, we parse the multi-key
         # self.filename configuration (ie, /etc/rhn/rhn.conf)
-        self.__parsedConfig = parse_file(self.filename)
+        if os.path.exists(self.filename):
+            self.__parsedConfig = parse_file(self.filename)
 
         # And now generate and cache the current component
         self.__merge()


### PR DESCRIPTION
## What does this PR change?

fix susemanager-utils/testing/automation/susemanager-unittest.sh

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests" (Test skipped, there are no changes to test)
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
