### PR TITLE
Allow missing rhn.conf file

### DIFF
--- a/python/spacewalk/common/rhnConfig.py
+++ b/python/spacewalk/common/rhnConfig.py
@@ -100,6 +100,9 @@ class RHNOptions:
     def modifiedYN(self):
         """returns last modified time diff if rhn.conf has changed."""
 
+        if not os.path.exists(self.filename):
+            return 0
+
         try:
             si = os.stat(self.filename)
         except OSError:
@@ -142,7 +145,8 @@ class RHNOptions:
 
         # Now that we parsed the defaults, we parse the multi-key
         # self.filename configuration (ie, /etc/rhn/rhn.conf)
-        self.__parsedConfig = parse_file(self.filename)
+        if os.path.exists(self.filename):
+            self.__parsedConfig = parse_file(self.filename)
 
         # And now generate and cache the current component
         self.__merge()

--- a/python/spacewalk/common/rhnLog.py
+++ b/python/spacewalk/common/rhnLog.py
@@ -100,7 +100,7 @@ def initLOG(log_file="stderr", level=0, component=""):
 
         # fetch uid, gid so we can do a "chown ..."
         with cfg_component(component=None) as CFG:
-            apache_uid, apache_gid = getUidGid(CFG.httpd_user, CFG.httpd_group)
+            apache_uid, apache_gid = getUidGid(CFG.get('httpd_user', 'wwwrun'), CFG.get('httpd_group', 'www'))
 
         try:
             os.makedirs(log_path)
@@ -187,7 +187,7 @@ class rhnLog:
             set_close_on_exec(self.fd)
             if newfileYN:
                 with cfg_component(component=None) as CFG:
-                    apache_uid, apache_gid = getUidGid(CFG.httpd_user, CFG.httpd_group)
+                    apache_uid, apache_gid = getUidGid(CFG.get('httpd_user', 'wwwrun'), CFG.get('httpd_group', 'www'))
                 os.chown(self.file, apache_uid, apache_gid)
                 os.chmod(self.file, int('0660', 8))
         except:

--- a/python/spacewalk/spacewalk-backend.changes.cbosdo.rhnconfig-nofile
+++ b/python/spacewalk/spacewalk-backend.changes.cbosdo.rhnconfig-nofile
@@ -1,0 +1,1 @@
+- Accept missing rhn.conf file

--- a/python/uyuni/common/fileutils.py
+++ b/python/uyuni/common/fileutils.py
@@ -301,9 +301,9 @@ def createPath(path, user=None, group=None, chmod=int('0755', 8)):
     """
     with cfg_component(component=None) as CFG:
         if user is None:
-            user = CFG.httpd_user
+            user = CFG.get('httpd_user', 'wwwrun')
         if group is None:
-            group = CFG.httpd_group
+            group = CFG.get('httpd_group', 'www')
 
     path = cleanupAbsPath(path)
     if not os.path.exists(path):
@@ -324,7 +324,7 @@ def setPermsPath(path, user=None, group='root', chmod=int('0750', 8)):
     """chown user.group and set permissions to chmod"""
     if user is None:
         with cfg_component(component=None) as CFG:
-            user = CFG.httpd_user
+            user = CFG.get('httpd_user', 'wwwrun')
 
     if not os.path.exists(path):
         raise OSError("*** ERROR: Path doesn't exist (can't set permissions): %s" % path)

--- a/python/uyuni/uyuni-common-libs.changes.cbosdo.rhnconfig-nofile
+++ b/python/uyuni/uyuni-common-libs.changes.cbosdo.rhnconfig-nofile
@@ -1,0 +1,1 @@
+- Accept missing rhn.conf file


### PR DESCRIPTION
Now that rhnLog looks for the apache user and group in rhn.conf unit tests are failing if the file is not present. Use openSUSE values as default if rhn.conf is not available.

cherry-pick https://github.com/uyuni-project/uyuni/commit/9d8994eac6459630b5df88c6eb75dc6d8057d3e6 
## What does this PR change?


## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [x] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
