### PR TITLE
Improve the Twopence lazy initzialition refactor

### DIFF
--- a/testsuite/.rubocop_todo.yml
+++ b/testsuite/.rubocop_todo.yml
@@ -281,13 +281,18 @@ Lint/UselessAssignment:
 # Offense count: 9
 # Configuration parameters: IgnoredMethods.
 Metrics/AbcSize:
-  Max: 46
+  Enabled: false
 
 # Offense count: 6
 # Configuration parameters: CountComments, ExcludedMethods.
 # ExcludedMethods: refine
 Metrics/BlockLength:
-  Max: 67
+  Max: 74
+
+# Offense count: 4
+# Configuration parameters: IgnoredMethods.
+Metrics/CyclomaticComplexity:
+  Enabled: false
 
 # Offense count: 21
 # Configuration parameters: CountComments, ExcludedMethods.

--- a/testsuite/features/step_definitions/cobbler_steps.rb
+++ b/testsuite/features/step_definitions/cobbler_steps.rb
@@ -92,9 +92,8 @@ end
 # cobbler reports
 When(/^I trigger cobbler system record on the "([^"]*)"$/) do |host|
   space = 'spacecmd -u admin -p admin'
-  system_name = get_system_name(host)
   get_target('server').run("#{space} clear_caches")
-  out, _code = get_target('server').run("#{space} system_details #{system_name}")
+  out, _code = get_target('server').run("#{space} system_details #{get_target(host).full_hostname}")
   unless out.include? 'ssh-push-tunnel'
     steps %(
       Given I am authorized as "testing" with password "testing"

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -369,8 +369,9 @@ def get_system_name(host)
     begin
       node = get_target(host)
       system_name = node.full_hostname
-    rescue RuntimeError
+    rescue NotImplementedError => e
       # If the node for that host is not defined, just return the host parameter as system_name
+      warn e.message
       system_name = host
     end
   end

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -43,6 +43,13 @@ end
 # Initialize a Twopence node through its host (additionally it will setup some handy maps)
 def twopence_init(host)
   puts "Initializing a twopence node for '#{host}'."
+  raise(NotImplementedError, "Host #{host} is not defined as a valid host in the Test Framework.") unless ENV_VAR_BY_HOST.key? host
+
+  unless ENV.key? ENV_VAR_BY_HOST[host]
+    warn "Host #{host} is not defined as environment variable."
+    return
+  end
+
   target = "ssh:#{ENV[ENV_VAR_BY_HOST[host]]}"
   node = Twopence.init(target)
   raise "Twopence node #{host} initialization has failed." if node.nil?


### PR DESCRIPTION
## What does this PR change?

We had some corner case after the refactor of the twopence node init that are addressed in this PR.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were refactored

- [x] **DONE**

## Links

Adapted port of https://github.com/SUSE/spacewalk/pull/22384 and https://github.com/SUSE/spacewalk/pull/22385

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
