### PR TITLE
Don't force SSL verify-full mode for localhost report DB

### DIFF
--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -851,7 +851,7 @@ public class ConfigDefaults {
         }
         connectionUrl.append(name);
 
-        if (useSsl) {
+        if (!"localhost".equals(host) && useSsl) {
             connectionUrl.append("?ssl=true&sslrootcert=" + sslrootcert + "&sslmode=" + sslmode);
         }
 

--- a/java/spacewalk-java.changes.cbosdo.local-reportdb
+++ b/java/spacewalk-java.changes.cbosdo.local-reportdb
@@ -1,0 +1,1 @@
+- Don't force ssl verification on reportdb using localhost

--- a/spacewalk/setup/lib/Spacewalk/Setup.pm
+++ b/spacewalk/setup/lib/Spacewalk/Setup.pm
@@ -893,7 +893,9 @@ sub postgresql_reportdb_setup {
     }
 
     $ENV{PGSSLROOTCERT} = $answers->{'report-db-ca-cert'};
-    $ENV{PGSSLMODE} = "verify-full";
+    if ($answers->{'report-db-host'} ne 'localhost') {
+        $ENV{PGSSLMODE} = "verify-full";
+    }
 
     write_rhn_conf($answers, 'externaldb-admin-user','externaldb-admin-password', 'report-db-backend', 'report-db-host', 'report-db-port', 'report-db-name', 'report-db-user', 'report-db-password', 'report-db-ssl-enabled');
 

--- a/spacewalk/setup/spacewalk-setup.changes.cbosdo.local-reportdb
+++ b/spacewalk/setup/spacewalk-setup.changes.cbosdo.local-reportdb
@@ -1,0 +1,1 @@
+- Don't force ssl verification to setup reportdb using localhost


### PR DESCRIPTION
## What does this PR change?

When the report database is installed on the server we don't need and can't use SSL to connect to it using localhost hostname. This comes in handy to avoid hairpin requests in the container setup.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: container CI will soon use it

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
