### PR TITLE
Fix debian Packages file generation

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
@@ -73,6 +73,7 @@ public class DebPackageWriter implements Closeable {
         String pkgSnippet = pkgDto.getPrimaryXml();
         if (ConfigDefaults.get().useDBRepodata() && !StringUtils.isBlank(pkgSnippet)) {
             out.write(pkgSnippet);
+            out.newLine();
             return;
         }
         StringWriter wrt = new StringWriter();

--- a/java/spacewalk-java.changes.welder.bsc1213716
+++ b/java/spacewalk-java.changes.welder.bsc1213716
@@ -1,0 +1,1 @@
+- Fix debian Packages file generation (bsc#1213716)


### PR DESCRIPTION
## What does this PR change?

(Port) It adds a missing empty line when generating the `Packages` file for debian like repositories.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/22397

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
