### PR TITLE
Check csp adapter operating state

### DIFF
--- a/java/code/src/com/suse/cloud/CloudPaygManager.java
+++ b/java/code/src/com/suse/cloud/CloudPaygManager.java
@@ -22,6 +22,9 @@ import com.redhat.rhn.manager.satellite.SystemCommandExecutor;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpResponse;
@@ -30,6 +33,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -45,6 +49,9 @@ import java.util.concurrent.ExecutionException;
  */
 public class CloudPaygManager {
     private static final Logger LOG = LogManager.getLogger(CloudPaygManager.class);
+    protected static Path cspBillingAdapterConfig = new File("/var/lib/csp-billing-adapter/csp-config.json").toPath();
+
+    private final Gson gson = new GsonBuilder().setDateFormat(CspBillingAdapterStatus.DATE_FORMAT).create();
 
     private Boolean isPaygInstance;
     private Boolean hasSCCCredentials;
@@ -279,7 +286,26 @@ public class CloudPaygManager {
                 hasPackageModifications("python3-csp-billing-adapter-azure")) {
             return false;
         }
-        return isServiceRunning("csp-billing-adapter.service");
+        if (!isServiceRunning("csp-billing-adapter.service")) {
+            return false;
+        }
+        return checkCspBillingAdapterStatus();
+    }
+
+    protected boolean checkCspBillingAdapterStatus() {
+        try {
+            CspBillingAdapterStatus cspStatus = gson.fromJson(
+                    Files.readString(cspBillingAdapterConfig), CspBillingAdapterStatus.class);
+            if (!cspStatus.getErrors().isEmpty()) {
+                LOG.error("CPS Billing Adapter reported errors: {}", String.join("\n", cspStatus.getErrors()));
+            }
+            return cspStatus.isBillingApiAccessOk();
+        }
+        catch (Exception e) {
+            LOG.error("Unable to read CSP Billing Adapter status file");
+            LOG.info(e.getMessage(), e);
+        }
+        return false;
     }
 
     /**

--- a/java/code/src/com/suse/cloud/CloudPaygManager.java
+++ b/java/code/src/com/suse/cloud/CloudPaygManager.java
@@ -339,7 +339,9 @@ public class CloudPaygManager {
         if (retcode != 0) {
             // missing packages result in message "package ... is not installed" and will not match "5"
             // 5 means checksum changed / file is modified. Example "S.5....T.  /path/to/file"
-            if (scexec.getLastCommandOutput().lines().anyMatch(l -> l.charAt(2) == '5')) {
+            if (scexec.getLastCommandOutput().lines()
+                    .filter(l -> !l.endsWith(".pyc"))
+                    .anyMatch(l -> l.charAt(2) == '5')) {
                 LOG.error("Package '{}' was modifified", pkg);
                 LOG.info(scexec.getLastCommandOutput());
                 return true;

--- a/java/code/src/com/suse/cloud/CspBillingAdapterStatus.java
+++ b/java/code/src/com/suse/cloud/CspBillingAdapterStatus.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.cloud;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * CspBillingAdapter Status
+ */
+public class CspBillingAdapterStatus {
+
+    public static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSz";
+
+    @SerializedName("billing_api_access_ok")
+    private boolean billingApiAccessOk;
+    @SerializedName("timestamp")
+    private Date timestamp;
+    @SerializedName("expire")
+    private Date expire;
+    @SerializedName("errors")
+    private List<String> errors;
+
+    /**
+     * @return return true if api access was ok
+     */
+    public boolean isBillingApiAccessOk() {
+        return billingApiAccessOk;
+    }
+
+    private void setBillingApiAccessOk(Boolean billingApiAccessOkIn) {
+        billingApiAccessOk = billingApiAccessOkIn;
+    }
+
+    /**
+     * @return return the timestamp
+     */
+    public Date getTimestamp() {
+        return timestamp;
+    }
+
+    private void setTimestamp(Date timestampIn) {
+        timestamp = timestampIn;
+    }
+
+    /**
+     * @return return the expire timestamp
+     */
+    public Date getExpire() {
+        return expire;
+    }
+
+    private void setExpire(Date expireIn) {
+        expire = expireIn;
+    }
+
+    /**
+     * @return return a list of errors
+     */
+    public List<String> getErrors() {
+        return errors;
+    }
+
+    private void setErrors(List<String> errorsIn) {
+        errors = errorsIn;
+    }
+}

--- a/java/code/src/com/suse/cloud/test/data/csp-config.nocreds.json
+++ b/java/code/src/com/suse/cloud/test/data/csp-config.nocreds.json
@@ -1,0 +1,31 @@
+{
+    "billing_api_access_ok": false,
+    "timestamp": "2023-08-22T12:50:33.182585+00:00",
+    "expire": "2023-08-22T08:50:32.195449+00:00",
+    "customer_csp_data": {
+        "document": {
+            "accountId": "123456789012",
+            "architecture": "x86_64",
+            "availabilityZone": "eu-central-1c",
+            "billingProducts": null,
+            "devpayProductCodes": null,
+            "marketplaceProductCodes": null,
+            "imageId": "ami-00112233aabbccddf",
+            "instanceId": "i-987654321abcdef00",
+            "instanceType": "m6a.xlarge",
+            "kernelId": null,
+            "pendingTime": "2023-08-22T07:36:54Z",
+            "privateIp": "172.16.1.180",
+            "ramdiskId": null,
+            "region": "eu-central-1",
+            "version": "2017-09-30"
+        },
+        "signature": "Op2zfG4NInG17V3R0uESk7uF6bkt1fb76MTpW4T/96LsKRMJ2yI3ijtxMKWr\nUA/h7dqaiHf42qlNlAw=",
+        "pkcs7": "MIAGCSqGSIb3DQEHAqCAMIACAQExCzAJBgUrDgMCGgUAMIAGCSqENvZGVzIiA6IG51bGwsCiAgIm1hcmtldHBsYWNl\nUHJvZHVjdENvZGVzIiA6IG51bGwsCiAgImltYWdlSWQiIDogImFtaS0wMDM2YTUyZmEyM2IxZDVi\nNyIsCiAgImluc3RhbmNlSWQiIDogImktMDdjNjM0YTZmNTljMjA2ZjIiLAogICJpbnN0YW5jZVR5\ncGUiIDogIm02YS54bGFyZ2UiLAogICJrZXJuZWxJZCIgOiBudWxsLAogICJwZW5kaW5nVGltZSIg\nOiAiMjAyMy0wOC0yMlQwNzozNjo1NFoiLAogICJwcml2YXRlSXAiIDogIjE3Mi4xNi4xLjE4MCIs\nCiAgInJhbWRpc2tJZCIgOiBudWxsLAogICJyZWdpb24iIDogImV1LWNlbnRyYWwtMSIsCiAgInZl\ncnNpb24iIDogIjIwMTctMDktMzAiCn0AAAAAMYIBQTCCAT0CAQEwaTBcMQswCQYDVQQGEwJVUzEZ\nMBcGA1UECBMQV2FzaGluZ3RvbiBTdGF0ZTEQMA4GA1UEBxMHU2VhdHRsZTEgMB4GA1UEChMXQW1h\nem9uIFdlYiBTZXJ2aWNlcyBMTEMCCQCWukjZ5V4aZzAJBgUrDgMCGgUAoIGEMBgGCSqGSIb3DQEJ\nAzELBgkqhkiG9w0BBwEwHAYJKoZIhvcNAQkFMQ8XDTIzMDgyMjA3MzY1NFowIwYJKoZIhvcNAQkE\nMRYEFFP7QEJwA953FMd28MvpC40eGapkMCUGCSqGSIb3DQEJNDEYMBYwCQYFKw4DAhoFAKEJBgcq\nhkjOOAQDMAkGByqGSM44BAMEMDAuAhUAtFf75in1Ey71+LVV0PqU3ZA5vpYCFQCZaLIZDnzeSR/a\n7qGLpMzAnduidAAAAAAAAA==",
+        "cloud_provider": "amazon"
+    },
+    "errors": [
+        "Failed to meter bill dimension managed_systems: Unable to locate credentials",
+        "Failed to meter bill dimension monitoring: Unable to locate credentials"
+    ]
+}

--- a/java/code/src/com/suse/cloud/test/data/csp-config.nonet.json
+++ b/java/code/src/com/suse/cloud/test/data/csp-config.nonet.json
@@ -1,0 +1,32 @@
+{
+    "billing_api_access_ok": false,
+    "timestamp": "2023-08-24T13:51:49.750229+00:00",
+    "expire": "2023-08-24T12:51:11.484066+00:00",
+    "customer_csp_data": {
+        "document": {
+            "accountId": "123456789012",
+            "architecture": "x86_64",
+            "availabilityZone": "eu-central-1c",
+            "billingProducts": null,
+            "devpayProductCodes": null,
+            "marketplaceProductCodes": null,
+            "imageId": "ami-00112233aabbccddf",
+            "instanceId": "i-987654321abcdef00",
+            "instanceType": "m6a.xlarge",
+            "kernelId": null,
+            "pendingTime": "2023-08-24T07:55:52Z",
+            "privateIp": "172.16.1.180",
+            "ramdiskId": null,
+            "region": "eu-central-1",
+            "version": "2017-09-30"
+        },
+        "signature": "gilSJ8lhVKSR7uOpfmMmc4BK4lAVtyy8YTrC29tvTT1duimx4FFXDHc/jTOJv3mrfA8Zfi\ntszOuoUi09bl67bVvG0=",
+        "pkcs7": "MIAGCSqGSIb3DQEHAqCAMIACAQExG51bGwsCiAgIm1hcmtldHBsYWNl\nUHJvZHVjdENvZGVzIiA6IG51bGwsCiAgImltYWdlSWQiIDogImFtaS0wMDM2YTUyZmEyM2IxZDVi\nNyIsCiAgImluc3RhbmNlSWQiIDogImktMDdjNjM0YTZmNTljMjA2ZjIiLAogICJpbnN0YW5jZVR5\ncGUiIDogIm02YS54bGFyZ2UiLAogICJrZXJuZWxJZCIgOiBudWxsLAogICJwZW5kaW5nVGltZSIg\nOiAiMjAyMy0wOC0yNFQwNzo1NTo1MloiLAogICJwcml2YXRlSXAiIDogIjE3Mi4xNi4xLjE4MCIs\nCiAgInJhbWRpc2tJZCIgOiBudWxsLAogICJyZWdpb24iIDogImV1LWNlbnRyYWwtMSIsCiAgInZl\ncnNpb24iIDogIjIwMTctMDktMzAiCn0AAAAAMYIBPzCCATsCAQEwaTBcMQswCQYDVQQGEwJVUzEZ\nMBcGA1UECBMQV2FzaGluZ3RvbiBTdGF0ZTEQMA4GA1UEBxMHU2VhdHRsZTEgMB4GA1UEChMXQW1h\nem9uIFdlYiBTZXJ2aWNlcyBMTEMCCQCWukjZ5V4aZzAJBgUrDgMCGgUAoIGEMBgGCSqGSIb3DQEJ\nAzELBgkqhkiG9w0BBwEwHAYJKoZIhvcNAQkFMQ8XDTIzMDgyNDA3NTU1NFowIwYJKoZIhvcNAQkE\nMRYEFBfiBGpm7B1sQ9Tu6YbGEc22Gc1AMCUGCSqGSIb3DQEJNDEYMBYwCQYFKw4DAhoFAKEJBgcq\nhkjOOAQDMAkGByqGSM44BAMELjAsAhQpmECGTxF1AUTVPHcDJhNtuXVoYAIUeAkwsgh1HR8fnnA8\nzqG6EPiHDYgAAAAAAAA=",
+        "cloud_provider": "amazon"
+    },
+    "errors": [
+        "Failed to meter bill dimension managed_systems: Connect timeout on endpoint URL: \"https://metering.marketplace.eu-central-1.amazonaws.com/\"",
+        "Failed to meter bill dimension monitoring: Connect timeout on endpoint URL: \"https://metering.marketplace.eu-central-1.amazonaws.com/\""
+    ],
+    "base_product": ""
+}

--- a/java/code/src/com/suse/cloud/test/data/csp-config.ok.json
+++ b/java/code/src/com/suse/cloud/test/data/csp-config.ok.json
@@ -1,0 +1,29 @@
+{
+    "billing_api_access_ok": true,
+    "timestamp": "2023-08-24T12:51:06.484066+00:00",
+    "expire": "2023-08-24T12:51:11.484066+00:00",
+    "customer_csp_data": {
+        "document": {
+            "accountId": "123456789012",
+            "architecture": "x86_64",
+            "availabilityZone": "eu-central-1c",
+            "billingProducts": null,
+            "devpayProductCodes": null,
+            "marketplaceProductCodes": null,
+            "imageId": "ami-00112233aabbccddf",
+            "instanceId": "i-987654321abcdef00",
+            "instanceType": "m6a.xlarge",
+            "kernelId": null,
+            "pendingTime": "2023-08-24T07:55:52Z",
+            "privateIp": "172.16.1.180",
+            "ramdiskId": null,
+            "region": "eu-central-1",
+            "version": "2017-09-30"
+        },
+        "signature": "gilSJ8lhVKSR7uOpfmMmc4BkAPbxfvwc4lAVtyy8YTrC29tvTT1duimx4FFXDHc/jTOJv3mrfA8Zfi\ntszOuoUi09bl67bVvG0=",
+        "pkcs7": "MIAGCSqGSIb3DQEHAqCAMIACAQEGV2cGF5UHJvZHVjdENvZGVzIiA6IG51bGwsCiAgIm1hcmtldHBsYWNl\nUHJvZHVjdENvZGVzIiA6IG51bGwsCiAgImltYWdlSWQiIDogImFtaS0wMDM2YTUyZmEyM2IxZDVi\nNyIsCiAgImluc3RhbmNlSWQiIDogImktMDdjNjM0YTZmNTljMjA2ZjIiLAogICJpbnN0YW5jZVR5\ncGUiIDogIm02YS54bGFyZ2UiLAogICJrZXJuZWxJZCIgOiBudWxsLAogICJwZW5kaW5nVGltZSIg\nOiAiMjAyMy0wOC0yNFQwNzo1NTo1MloiLAogICJwcml2YXRlSXAiIDogIjE3Mi4xNi4xLjE4MCIs\nCiAgInJhbWRpc2tJZCIgOiBudWxsLAogICJyZWdpb24iIDogImV1LWNlbnRyYWwtMSIsCiAgInZl\ncnNpb24iIDogIjIwMTctMDktMzAiCn0AAAAAMYIBPzCCATsCAQEwaTBcMQswCQYDVQQGEwJVUzEZ\nMBcGA1UECBMQV2FzaGluZ3RvbiBTdGF0ZTEQMA4GA1UEBxMHU2VhdHRsZTEgMB4GA1UEChMXQW1h\nem9uIFdlYiBTZXJ2aWNlcyBMTEMCCQCWukjZ5V4aZzAJBgUrDgMCGgUAoIGEMBgGCSqGSIb3DQEJ\nAzELBgkqhkiG9w0BBwEwHAYJKoZIhvcNAQkFMQ8XDTIzMDgyNDA3NTU1NFowIwYJKoZIhvcNAQkE\nMRYEFBfiBGpm7B1sQ9Tu6YbGEc22Gc1AMCUGCSqGSIb3DQEJNDEYMBYwCQYFKw4DAhoFAKEJBgcq\nhkjOOAQDMAkGByqGSM44BAMELjAsAhQpmECGTxF1AUTVPHcDJhNtuXVoYAIUeAkwsgh1HR8fnnA8\nzqG6EPiHDYgAAAAAAAA=",
+        "cloud_provider": "amazon"
+    },
+    "errors": [],
+    "base_product": ""
+}

--- a/java/spacewalk-java.changes.mc.Manager-4.3-check-csp-adapter-operating-state
+++ b/java/spacewalk-java.changes.mc.Manager-4.3-check-csp-adapter-operating-state
@@ -1,0 +1,1 @@
+- check csp billing adapter status


### PR DESCRIPTION
## What does this PR change?

Check status of the billing adapter for the compliance check

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/22389

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
