### PR TITLE
start with schema migration tests with 4.3 schema

### DIFF
--- a/susemanager-utils/testing/automation/VERSION.SUSE-Manager
+++ b/susemanager-utils/testing/automation/VERSION.SUSE-Manager
@@ -7,8 +7,8 @@ PUSH2OBS_CONTAINER=devel/galaxy/manager/head/docker/containers/suma-push-to-obs
 REPORTDB_DOC_CONTAINER=devel/galaxy/manager/head/docker/containers/suma-$VER-reportdb-docs
 # Base version for the idempotency test. All PostgreSQL since this version must be idempotent for the test to pass
 # This value is is used if the file for the PR is not found (we assume we are on a branch)
-IDEMPOTENCY_SCHEMA_BASE_VERSION='4.2.4'
+IDEMPOTENCY_SCHEMA_BASE_VERSION='4.3.8'
 IDEMPOTENCY_REPORTDB_SCHEMA_BASE_VERSION='4.3.1'
-SCHEMA_PACKAGES='susemanager-schema-4.2.4-1.3.noarch.rpm'
+SCHEMA_PACKAGES='susemanager-schema-4.3.8-150400.1.5.noarch.rpm'
 REPORTDB_SCHEMA_PACKAGES='susemanager-schema-4.3.8-150400.1.5.noarch.rpm susemanager-schema-utility-4.3.8-150400.1.5.noarch.rpm uyuni-reportdb-schema-4.3.1-150400.1.5.noarch.rpm'
 BRAND_NAME='SUSE Manager'


### PR DESCRIPTION
## What does this PR change?

start schema migration tests with 4.3 schema

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
