### PR TITLE
Fix hostname rename feature

### DIFF
--- a/testsuite/features/secondary/srv_rename_hostname.feature
+++ b/testsuite/features/secondary/srv_rename_hostname.feature
@@ -10,7 +10,7 @@
 @skip_if_cloud
 @skip_if_container_server
 Feature: Reconfigure the server's hostname
-  As admin 
+  As admin user
   In order to change the server's hostname
   I want to use the tool spacewalk-hostname-rename.
 
@@ -18,16 +18,27 @@ Feature: Reconfigure the server's hostname
     Given I am authorized for the "Admin" section
 
   Scenario: Change hostname and reboot server
-    #Command prerequisites
     When I change the server's short hostname from hosts and hostname files
     And I reboot the server through SSH
     And I run spacewalk-hostname-rename command on the server
-  
-  Scenario: Change hostname back
+
+  Scenario: Do some minimal smoke test on the renamed server
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Details" in the content area
+    And I follow "Remote Command" in the content area
+    And I enter as remote command this script in
+      """
+      #!/bin/bash
+      date
+      """
+    And I click on "Schedule"
+    And I follow "Events" in the content area
+    And I follow "Pending" in the content area
+    And I wait at most 180 seconds until I do not see "Remote Command on" text, refreshing the page
+    And I follow "History" in the content area
+    And I wait until I see the event "Remote Command on" completed during last minute, refreshing the page
+
+  Scenario: Change hostname back and reboot server
     When I change back the server's hostname
     And I reboot the server through SSH
     And I run spacewalk-hostname-rename command on the server
-
-  Scenario: Cleanup after hostname rename test
-    When I clean up the server's hosts file
-    And I restart the spacewalk service


### PR DESCRIPTION
## What does this PR change?

This PR fixes the test of hostname rename feature, where the cleanup was not working, and was making all subsequent feature tests fail.

It also adds idempotency, and a smoke test on the renamed server.


## Links

Fixes: https://github.com/SUSE/spacewalk/issues/22323
Ports:
* 4.3: cannot port as the "refresh" parameter of get_target is not implemented yet:
```
# Get the Twopence node passing the host (includes lazy initialization)
def get_target(host)
  node = $node_by_host[host]
  node = twopence_init(host) if node.nil?
  node
end
```
To be clarified with Oscar.


## Changelogs

- [x] No changelog needed
