### PR TITLE
remove dependency to mgr-cfg and drop other deps

### DIFF
--- a/proxy/installer/configure-proxy.sh.sgml
+++ b/proxy/installer/configure-proxy.sh.sgml
@@ -367,7 +367,7 @@ Configuration channel will be named rhn_proxy_config_${SYSTEM_ID}.</para>
 
 <RefSect1><Title>See Also</Title>
 <simplelist>
-    <member>rhn-proxy-activate(8), rhncfg-manager(8)</member>
+    <member>rhn-proxy-activate(8)</member>
 </simplelist>
 </RefSect1>
 

--- a/proxy/installer/spacewalk-proxy-installer.changes.mc.drop-mgr_cfg-from-proxy
+++ b/proxy/installer/spacewalk-proxy-installer.changes.mc.drop-mgr_cfg-from-proxy
@@ -1,0 +1,2 @@
+- remove old provide/obsoletes dependency
+- remove dependency to mgr-cfg which remove the possibility to create config channels for the proxy

--- a/proxy/installer/spacewalk-proxy-installer.spec
+++ b/proxy/installer/spacewalk-proxy-installer.spec
@@ -39,10 +39,6 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 
 Requires:       firewalld
-Requires:       mgr-cfg
-Requires:       mgr-cfg-actions
-Requires:       mgr-cfg-client
-Requires:       mgr-cfg-management
 Requires(pre):  spacewalk-proxy-common
 Requires:       spacewalk-proxy-salt
 %if 0%{?suse_version}
@@ -63,8 +59,13 @@ Requires:       salt
 Requires:       spacewalk-certs-tools >= 1.6.4
 BuildRequires:  /usr/bin/docbook2man
 
-Obsoletes:      proxy-installer < 5.3.0
-Provides:       proxy-installer = 5.3.0
+# weakremover used on SUSE to get rid of orphan packages which are
+# unsupported and do not have a dependency anymore
+Provides:       weakremover(mgr-cfg)
+Provides:       weakremover(mgr-cfg-actions)
+Provides:       weakremover(mgr-cfg-client)
+Provides:       weakremover(mgr-cfg-management)
+
 
 %define defaultdir %{_usr}/share/rhn/proxy-template
 

--- a/proxy/proxy/spacewalk-proxy.changes.mc.drop-mgr_cfg-from-proxy
+++ b/proxy/proxy/spacewalk-proxy.changes.mc.drop-mgr_cfg-from-proxy
@@ -1,0 +1,1 @@
+- remove usage of mgr-cfg tools in post script

--- a/proxy/proxy/spacewalk-proxy.spec
+++ b/proxy/proxy/spacewalk-proxy.spec
@@ -315,22 +315,6 @@ fi
 # Make sure the scriptlet returns with success
 exit 0
 
-%post management
-# The spacewalk-proxy-management package is also our "upgrades" package.
-# We deploy new conf from configuration channel if needed
-# we deploy new conf only if we install from webui and conf channel exist
-if rhncfg-client verify %{_sysconfdir}/rhn/rhn.conf 2>&1|grep 'Not found'; then
-     %{_bindir}/rhncfg-client get %{_sysconfdir}/rhn/rhn.conf
-fi > /dev/null 2>&1
-if rhncfg-client verify %{_sysconfdir}/squid/squid.conf | grep -E '(modified|missing)'; then
-    rhncfg-client get %{_sysconfdir}/squid/squid.conf
-    rm -rf %{_var}/spool/squid/*
-    %{_usr}/sbin/squid -z
-    /sbin/service squid condrestart
-fi > /dev/null 2>&1
-
-exit 0
-
 %pre salt
 %if !0%{?rhel}
 %service_add_pre salt-broker.service


### PR DESCRIPTION
## What does this PR change?

Drop mgr-cfg dependency

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- https://github.com/uyuni-project/uyuni-docs/pull/2427

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**


## Links

Fixes https://github.com/SUSE/spacewalk/issues/18882

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [x] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
