### PR TITLE
QE: Remove SLL8 from Uyuni

### DIFF
--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -667,7 +667,6 @@ CHANNEL_TO_SYNCH_BY_OS_VERSION = {
   %w[
     res8-manager-tools-pool-x86_64
     res8-manager-tools-updates-x86_64
-    sll8-uyuni-client-x86_64
   ],
   '15.4' =>
   %w[


### PR DESCRIPTION
## What does this PR change?

SUSE Liberty Linux does not work/is not supported on Uyuni as of now.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were added

- [x] **DONE**

## Links

No ports. This affects only Uyuni!
- Fixes https://github.com/SUSE/spacewalk/issues/20248
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
