### PR TITLE
QE: Improving how we handle Ruby dependencies

### DIFF
--- a/testsuite/features/support/pretty_formatter.rb
+++ b/testsuite/features/support/pretty_formatter.rb
@@ -2,6 +2,7 @@
 # Licensed under the terms of the MIT license.
 
 require 'cucumber/formatter/pretty'
+require_relative 'custom_formatter'
 
 # CustomFormatter module
 module CustomFormatter

--- a/testsuite/features/support/twopence_env.rb
+++ b/testsuite/features/support/twopence_env.rb
@@ -3,7 +3,7 @@
 
 require 'require_all'
 require 'twopence'
-require_all 'features/support'
+require_relative 'twopence_init'
 
 # Raise a warning if any of these environment variables is missing
 raise 'Server IP address or domain name variable empty' if ENV['SERVER'].nil?

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -2,6 +2,7 @@
 # Licensed under the terms of the MIT license.
 
 require 'twopence'
+require_relative 'lavanda'
 
 # Retrieve and set OS Family and Version of a node
 def process_os_family_and_version(host, fqdn, hostname, node)


### PR DESCRIPTION
## What does this PR change?

While debugging some stuff, I noticed that we were not handling some imported dependencies correctly.
In this PR I changed it to be more precise when requiring them.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were refactored

- [x] **DONE**

## Links

Ports:
- [ ] Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
