### PR TITLE
Add Python DB connections to helper script

### DIFF
--- a/susemanager-utils/supportutils-plugin-susemanager/supportutils-plugin-susemanager.changes.agraul.db-connection-helper-add-python-connections
+++ b/susemanager-utils/supportutils-plugin-susemanager/supportutils-plugin-susemanager.changes.agraul.db-connection-helper-add-python-connections
@@ -1,0 +1,1 @@
+- Add Salt and Reposync connections to min. required DB connections calculation


### PR DESCRIPTION
## What does this PR change?
Salt now selects pillar data from the DB, which needs a varying amount of DB connections based on the number of worker threads.

Reposync chooses the number of subprocesses based on the amount of CPU cores, the same calculation is now included in the calculation of required DB connections.


## GUI diff

No difference.

## Documentation

- [ ] Open Docs PR


## Test coverage
- No tests: we don't have tests for supportconfig tools


## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
