### PR TITLE
fix rebase

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -366,14 +366,8 @@ def get_system_name(host)
   when 'containerized_proxy'
     system_name = get_target('proxy').full_hostname.sub('pxy', 'pod-pxy')
   else
-    begin
-      node = get_target(host)
-      system_name = node.full_hostname
-    rescue NotImplementedError => e
-      # If the node for that host is not defined, just return the host parameter as system_name
-      warn e.message
-      system_name = host
-    end
+    node = get_target(host)
+    system_name = node.full_hostname
   end
   system_name
 end
@@ -398,36 +392,30 @@ end
 
 # This function tests whether a file exists on a node
 def file_exists?(node, file)
-  _out, local, _remote, code = node.test_and_store_results_together("test -f #{file}", 'root', 500)
-  code.zero? && local.zero?
+  node.file_exists(file)
 end
 
 # This function tests whether a folder exists on a node
 def folder_exists?(node, file)
-  _out, local, _remote, code = node.test_and_store_results_together("test -d #{file}", 'root', 500)
-  code.zero? && local.zero?
+  node.folder_exists(file)
 end
 
 # This function deletes a file from a node
 def file_delete(node, file)
-  _out, _local, _remote, code = node.test_and_store_results_together("rm  #{file}", 'root', 500)
-  code
+  node.file_delete(file)
 end
 
 # This function deletes a file from a node
 def folder_delete(node, folder)
-  _out, _local, _remote, code = node.test_and_store_results_together("rm -rf #{folder}", 'root', 500)
-  code
+  node.folder_delete(folder)
 end
 
 # This function extracts a file from a node
 def file_extract(node, remote_file, local_file)
-  code, _remote = node.extract_file(remote_file, local_file, 'root', false)
-  code
+  node.extract(remote_file, local_file, 'root', false)
 end
 
 # This function injects a file into a node
 def file_inject(node, local_file, remote_file)
-  code, _remote = node.inject_file(local_file, remote_file, 'root', false)
-  code
+    node.inject(local_file, remote_file, 'root', false)
 end

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -59,34 +59,38 @@ def twopence_init(host)
   # Lavanda library module extension
   # Look at support/lavanda.rb for more details
   node.extend(LavandaBasic)
-  if host == 'server'
+  if host == $server
     _out, code = node.run('which uyunictl', check_errors: false)
     if code.zero?
       node.init_has_uyunictl
     end
   end
-
-
-  # Initialize hostname
-  hostname, local, remote, code = node.test_and_store_results_together('hostname', 'root', 500)
-
-  # special handling for nested VMs since they will only be created later in the test suite
-  # we to a late hostname initialization in a special step for those
-  unless hostname.empty? || host == 'salt_migration_minion'
-    raise "Cannot connect to get hostname for '#{$named_nodes[node.hash]}'. Response code: #{code}, local: #{local}, remote: #{remote}" if code.nonzero? || remote.nonzero? || local.nonzero?
-    raise "No hostname for '#{$named_nodes[node.hash]}'. Response code: #{code}" if hostname.empty?
-    node.init_hostname(hostname)
-
-    fqdn, local, remote, code = node.test_and_store_results_together('hostname -f', 'root', 500)
-    raise "Cannot connect to get FQDN for '#{$named_nodes[node.hash]}'. Response code: #{code}, local: #{local}, remote: #{remote}" if code.nonzero? || remote.nonzero? || local.nonzero?
+  if node == $server
+    fqdn, code = node.run('sed -n \'s/^java.hostname *= *\(.\+\)$/\1/p\' /etc/rhn/rhn.conf')
+    raise "Cannot connect to get FQDN for '#{$named_nodes[node.hash]}'. Response code: #{code}, local: #{local}, remote: #{remote}" if code.nonzero?
     raise "No FQDN for '#{$named_nodes[node.hash]}'. Response code: #{code}" if fqdn.empty?
     node.init_full_hostname(fqdn)
+    node.init_hostname(fqdn.split(".")[0])
+  else
+    hostname, local, remote, code = node.test_and_store_results_together('hostname', 'root', 500)
+    # special handling for nested VMs since they will only be crated later in the test suite
+    # we to a late hostname initialization in a special step for those
 
-    node = process_os_family_and_version(host, fqdn, hostname, node)
-    node = process_private_and_public_ip(host, node)
+    unless hostname.empty? || node == $salt_migration_minion
+      raise "Cannot connect to get hostname for '#{$named_nodes[node.hash]}'. Response code: #{code}, local: #{local}, remote: #{remote}" if code.nonzero? || remote.nonzero? || local.nonzero?
+      raise "No hostname for '#{$named_nodes[node.hash]}'. Response code: #{code}" if hostname.empty?
+      node.init_hostname(hostname)
+
+      fqdn, local, remote, code = node.test_and_store_results_together('hostname -f', 'root', 500)
+      raise "Cannot connect to get FQDN for '#{$named_nodes[node.hash]}'. Response code: #{code}, local: #{local}, remote: #{remote}" if code.nonzero? || remote.nonzero? || local.nonzero?
+      raise "No FQDN for '#{$named_nodes[node.hash]}'. Response code: #{code}" if fqdn.empty?
+      node.init_full_hostname(fqdn)
+    end
   end
 
-  $node_by_host[host] = node
-  $host_by_node[node] = host
-  node
+  STDOUT.puts "Host '#{$named_nodes[node.hash]}' is alive with determined hostname #{node.hostname} and FQDN #{node.full_hostname}" unless $build_validation
+  os_version, os_family = get_os_version(node)
+  node.init_os_family(os_family)
+  node.init_os_version(os_version)
 end
+


### PR DESCRIPTION
## What does this PR change?

**add description**

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
