### PR TITLE
QE: Fix wrong repo in reference products sync

### DIFF
--- a/testsuite/features/reposync/reference_srv_check_reposync.feature
+++ b/testsuite/features/reposync/reference_srv_check_reposync.feature
@@ -8,6 +8,7 @@ Feature: Reposync works as expected
   Scenario: Check reposync of Rocky Linux 8 channels being finished
     Then I wait until the channel "rockylinux-8-x86_64" has been synced with packages
     And I wait until the channel "rockylinux-8-appstream-x86_64" has been synced with packages
+
 @uyuni
   Scenario: Check reposync of Rocky Linux 8 channels being finished
     Then I wait until the channel "rockylinux8-x86_64" has been synced with packages
@@ -28,6 +29,7 @@ Feature: Reposync works as expected
     And I wait until the channel "ubuntu-2204-amd64-main-security-uyuni" has been synced with packages
 
 @scc_credentials
+@susemanager
   Scenario: Check reposync of SLES 15 SP4 channels being finished
     Then I wait until the channel "sle-module-basesystem15-sp4-updates-x86_64" has been synced with packages
     And I wait until the channel "sle-module-server-applications15-sp4-updates-x86_64" has been synced with packages
@@ -35,9 +37,19 @@ Feature: Reposync works as expected
     And I wait until the channel "sle-module-devtools15-sp4-updates-x86_64" has been synced with packages
     And I wait until the channel "sle-module-containers15-sp4-pool-x86_64" has been synced with packages
 
+@uyuni
+  Scenario: Check reposync of openSUSE Leap 15.4 channels being finished
+    Then I wait until the channel "opensuse_leap15_4" has been synced with packages
+    And I wait until the channel "opensuse_leap15_4-non-oss" has been synced with packages
+    And I wait until the channel "opensuse_leap15_4-non-oss-updates" has been synced with packages
+    And I wait until the channel "opensuse_leap15_4-updates" has been synced with packages
+    And I wait until the channel "opensuse_leap15_4-backports-updates" has been synced with packages
+    And I wait until the channel "opensuse_leap15_4-sle-updates" has been synced with packages
+    And I wait until the channel "uyuni-proxy-devel-leap" has been synced with packages
+
 @scc_credentials
 @susemanager
-  Scenario: Check reposync of SLES 15 Client Tools being finished
+  Scenario: Check reposync of Client Tools being finished
     Then I wait until the channel "sle-manager-tools15-pool-x86_64-sp4" has been synced
     And I wait until the channel "sle-manager-tools15-updates-x86_64-sp4" has been synced with packages
     And I wait until the channel "res8-manager-tools-updates-x86_64-rocky" has been synced with packages
@@ -45,7 +57,7 @@ Feature: Reposync works as expected
     And I wait until the channel "ubuntu-22.04-suse-manager-tools-amd64" has been synced with packages
 
 @uyuni
-  Scenario: Check reposync of SLES 15 Client Tools being finished
-    Then I wait until the channel "sles15-sp4-uyuni-client-x86_64" has been synced with packages
+  Scenario: Check reposync of Client Tools being finished
+    And I wait until the channel "opensuse_leap15_4-uyuni-client" has been synced with packages
     And I wait until the channel "rockylinux8-uyuni-client-x86_64" has been synced with packages
     And I wait until the channel "ubuntu-2204-amd64-uyuni-client" has been synced with packages

--- a/testsuite/features/reposync/reference_srv_sync_products_extra.feature
+++ b/testsuite/features/reposync/reference_srv_sync_products_extra.feature
@@ -11,9 +11,13 @@ Feature: Synchronize extra products in the products page of the Setup Wizard
     Then I should see a "Arch" text
     And I should see a "Channels" text
 
-@uyuni
+@susemanager
   Scenario: Enable SLES15 SP4 Uyuni client tools for creating bootstrap repositories
     When I use spacewalk-common-channel to add channel "sle-product-sles15-sp4-pool-x86_64 sles15-sp4-uyuni-client" with arch "x86_64"
+
+@uyuni
+  Scenario: Add openSUSE Leap 15.4 product, including Uyuni Client Tools
+    When I use spacewalk-common-channel to add channel "opensuse_leap15_4 opensuse_leap15_4-non-oss opensuse_leap15_4-non-oss-updates opensuse_leap15_4-updates opensuse_leap15_4-backports-updates opensuse_leap15_4-sle-updates uyuni-proxy-devel-leap opensuse_leap15_4-uyuni-client" with arch "x86_64"
 
 @scc_credentials
 @susemanager


### PR DESCRIPTION
## What does this PR change?

See https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-master-infra-reference-NUE/754
There is no channel named `sle-product-sles15-sp4-pool-x86_64` available via `spacewalk-common-channels`. Furthermore, we do not sync SLES in Uyuni anymore.

<img width="1022" alt="image" src="https://github.com/uyuni-project/uyuni/assets/12104291/053a6ecc-8fe5-483a-9544-7df710bcf893">

```bash
uyuni-refmaster-srv:~ # spacewalk-common-channels -l | grep sles15
 sles15-sap-sp2-devel-uyuni-client: x86_64, s390x, aarch64, ppc64le
 sles15-sap-sp2-uyuni-client: x86_64, s390x, aarch64, ppc64le
 sles15-sap-sp3-devel-uyuni-client: x86_64, s390x, aarch64, ppc64le
 sles15-sap-sp3-uyuni-client: x86_64, s390x, aarch64, ppc64le
 sles15-sap-sp4-devel-uyuni-client: x86_64, s390x, aarch64, ppc64le
 sles15-sap-sp4-uyuni-client: x86_64, s390x, aarch64, ppc64le
 sles15-sap-sp5-devel-uyuni-client: x86_64, s390x, aarch64, ppc64le
 sles15-sap-sp5-uyuni-client: x86_64, s390x, aarch64, ppc64le
 sles15-sp1-devel-uyuni-client: x86_64, s390x, aarch64, ppc64le
 sles15-sp1-uyuni-client: x86_64, s390x, aarch64, ppc64le
 sles15-sp2-devel-uyuni-client: x86_64, s390x, aarch64, ppc64le
 sles15-sp2-uyuni-client: x86_64, s390x, aarch64, ppc64le
 sles15-sp3-devel-uyuni-client: x86_64, s390x, aarch64, ppc64le
 sles15-sp3-uyuni-client: x86_64, s390x, aarch64, ppc64le
 sles15-sp4-devel-uyuni-client: x86_64, s390x, aarch64, ppc64le
 sles15-sp4-uyuni-client: x86_64, s390x, aarch64, ppc64le
 sles15-sp5-devel-uyuni-client: x86_64, s390x, aarch64, ppc64le
 sles15-sp5-uyuni-client: x86_64, s390x, aarch64, ppc64le
 sles15-uyuni-client: x86_64, s390x, aarch64, ppc64le
 sles15-uyuni-client-devel: x86_64, s390x, aarch64, ppc64le
uyuni-refmaster-srv:~ #
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were added

- [x] **DONE**

## Links


- Manager 4.3: 
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
