### PR TITLE
Fix twopence_init after rebase

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1034,7 +1034,7 @@ When(/^I copy server\'s keys to the proxy$/) do
     # cert-manager takes some time to generate the secret, wait for it before continuing
     repeat_until_timeout(timeout: 600, message: "Kubernetes uyuni-proxy-cert secret has not been defined") do
       _result, code = $server.run_local("kubectl get secret uyuni-proxy-cert", check_errors: false)
-      break if code.zero? 
+      break if code.zero?
       sleep 1
     end
     _out, return_code = $server.run_local("kubectl get secret uyuni-proxy-cert -o jsonpath='{.data.tls\\.crt}' | base64 -d >/tmp/proxy.crt")

--- a/testsuite/features/support/lavanda.rb
+++ b/testsuite/features/support/lavanda.rb
@@ -154,7 +154,6 @@ module LavandaBasic
     cmd_prefixed = cmd
     if @in_has_uyunictl
       cmd_prefixed = "uyunictl exec -i '#{cmd.gsub(/'/, '\'"\'"\'')}'"
-      print "#{cmd_prefixed}\n"
     end
     run_local(cmd_prefixed, separated_results: separated_results, check_errors: check_errors, timeout: timeout, user: user, successcodes: successcodes, buffer_size: buffer_size, verbose: verbose)
   end
@@ -263,8 +262,8 @@ module LavandaBasic
 
   def file_exists(file)
     if @in_has_uyunictl
-     _out, code = run_local("uyunictl exec -- 'test -f #{file}'", check_errors: false)
-     exists = code.zero?
+      _out, code = run_local("uyunictl exec -- 'test -f #{file}'", check_errors: false)
+      exists = code.zero?
     else
       _out, local, _remote, code = test_and_store_results_together("test -f #{file}", 'root', 500)
       exists = code.zero? && local.zero?
@@ -274,8 +273,8 @@ module LavandaBasic
 
   def folder_exists(file)
     if @in_has_uyunictl
-     _out, code = run_local("uyunictl exec -- 'test -d #{file}'", check_errors: false)
-     exists = code.zero?
+      _out, code = run_local("uyunictl exec -- 'test -d #{file}'", check_errors: false)
+      exists = code.zero?
     else
       _out, local, _remote, code = test_and_store_results_together("test -d #{file}", 'root', 500)
       exists = code.zero? && local.zero?

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -2,6 +2,7 @@
 # Licensed under the terms of the MIT license.
 
 require 'twopence'
+require_relative 'lavanda'
 
 # Retrieve and set OS Family and Version of a node
 def process_os_family_and_version(host, fqdn, hostname, node)
@@ -59,24 +60,29 @@ def twopence_init(host)
   # Lavanda library module extension
   # Look at support/lavanda.rb for more details
   node.extend(LavandaBasic)
-  if host == $server
+
+  if host == 'server'
     _out, code = node.run('which uyunictl', check_errors: false)
     if code.zero?
       node.init_has_uyunictl
     end
-  end
-  if node == $server
+
     fqdn, code = node.run('sed -n \'s/^java.hostname *= *\(.\+\)$/\1/p\' /etc/rhn/rhn.conf')
     raise "Cannot connect to get FQDN for '#{$named_nodes[node.hash]}'. Response code: #{code}, local: #{local}, remote: #{remote}" if code.nonzero?
     raise "No FQDN for '#{$named_nodes[node.hash]}'. Response code: #{code}" if fqdn.empty?
     node.init_full_hostname(fqdn)
-    node.init_hostname(fqdn.split(".")[0])
+    node.init_hostname(fqdn.split('.')[0])
+
+    node = process_os_family_and_version(host, fqdn, node.hostname, node)
+    node = process_private_and_public_ip(host, node)
   else
+    # Initialize hostname
     hostname, local, remote, code = node.test_and_store_results_together('hostname', 'root', 500)
+
     # special handling for nested VMs since they will only be crated later in the test suite
     # we to a late hostname initialization in a special step for those
 
-    unless hostname.empty? || node == $salt_migration_minion
+    unless hostname.empty? || host == 'salt_migration_minion'
       raise "Cannot connect to get hostname for '#{$named_nodes[node.hash]}'. Response code: #{code}, local: #{local}, remote: #{remote}" if code.nonzero? || remote.nonzero? || local.nonzero?
       raise "No hostname for '#{$named_nodes[node.hash]}'. Response code: #{code}" if hostname.empty?
       node.init_hostname(hostname)
@@ -85,12 +91,13 @@ def twopence_init(host)
       raise "Cannot connect to get FQDN for '#{$named_nodes[node.hash]}'. Response code: #{code}, local: #{local}, remote: #{remote}" if code.nonzero? || remote.nonzero? || local.nonzero?
       raise "No FQDN for '#{$named_nodes[node.hash]}'. Response code: #{code}" if fqdn.empty?
       node.init_full_hostname(fqdn)
+
+      node = process_os_family_and_version(host, fqdn, hostname, node)
+      node = process_private_and_public_ip(host, node)
     end
   end
 
-  STDOUT.puts "Host '#{$named_nodes[node.hash]}' is alive with determined hostname #{node.hostname} and FQDN #{node.full_hostname}" unless $build_validation
-  os_version, os_family = get_os_version(node)
-  node.init_os_family(os_family)
-  node.init_os_version(os_version)
+  $node_by_host[host] = node
+  $host_by_node[node] = host
+  node
 end
-


### PR DESCRIPTION
## What does this PR change?

More fixes in twopence_init after the rebase on master.

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
