### PR TITLE
spacecmd: updates for compatibility and portability

### DIFF
--- a/spacecmd/setup.py
+++ b/spacecmd/setup.py
@@ -28,6 +28,7 @@ def get_version_changelog():
 setup(
     name='spacecmd',
     version=get_version_changelog(),
+    scripts=['src/bin/spacecmd'],
     packages=find_packages(where="src"),
     package_dir={
         "": "src",

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Various compatibility and portability updates
 - Bypass traditional systems check on older SUMA instances (bsc#1208612)
 - fix argument parsing of distribution_update (bsc#1210458)
 

--- a/spacecmd/src/bin/spacecmd
+++ b/spacecmd/src/bin/spacecmd
@@ -36,7 +36,7 @@ import codecs
 import locale
 import argparse
 try: # python 3
-    from configparser import SafeConfigParser
+    from configparser import ConfigParser as SafeConfigParser
 except ImportError: # python 2
     from ConfigParser import SafeConfigParser
 import socket

--- a/spacecmd/src/bin/spacecmd
+++ b/spacecmd/src/bin/spacecmd
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # Licensed under the GNU General Public License Version 3
 #

--- a/spacecmd/src/spacecmd/utils.py
+++ b/spacecmd/src/spacecmd/utils.py
@@ -58,7 +58,10 @@ try:
 except ImportError:
     import simplejson as json  # python < 2.6
 
-import rpm
+try:
+    import rpm
+except ImportError:
+    from version_utils import rpm
 
 from spacecmd.argumentparser import SpacecmdArgumentParser
 from spacecmd.i18n import _N


### PR DESCRIPTION
## What does this PR change?

This PR changes a few things for spacecmd. 

1. Uses /usr/bin/env to find the local installation of Python 3, for portability.
2. Changes the import of ConfigParser to remove a deprecation warning on Python 3.
3. Includes version_utils as a fallback import if the import of rpm doesn't work, for portability.
4. Adds the `spacecmd` command to the setup.py file, so the command gets installed along with the Python site-package.

## GUI diff

No difference.

Before: N/A

After: N/A

- [x] **DONE**

## Documentation
- No documentation needed: just changes spacecmd so existing documentation doesn't need updating.
- 
- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes N/A
Tracks N/A

- [x] **DONE**

## Changelogs

Changelog updated.

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
