### PR TITLE
fix X-Instance-Identifier header send when doing a product refresh at Cloud RMT Server

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/payg/script/payg_extract_repo_data.py
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/payg/script/payg_extract_repo_data.py
@@ -80,20 +80,15 @@ def _get_suse_cloud_info():
 
 
 def _get_instance_identification():
-    path = next((p for p in map(lambda f: Path(f), ["/etc/os-release", "/usr/lib/os-release"]) if p.exists()), None)
-    if path is None:
-        return []
+    product_xml = ET.parse("/etc/products.d/baseproduct")
+    if product_xml.find("./vendor").text == 'SUSE':
+        return {
+            "X-Instance-Identifier": product_xml.find("./name").text,
+            "X-Instance-Version": product_xml.find("./version").text,
+            "X-Instance-Arch": product_xml.find("./arch").text
+        }
 
-    with open(path) as stream:
-        reader = csv.reader(stream, delimiter="=")
-        os_release = dict(reader)
-
-    return {
-        "X-Instance-Identifier": os_release["NAME"],
-        "X-Instance-Version": os_release["VERSION_ID"],
-        "X-Instance-Arch": platform.machine()
-    }
-
+    return {}
 
 
 def _extract_http_auth(credentials):

--- a/java/spacewalk-java.changes.mc.Manager-4.3-fix-instance-identifier-header-payg
+++ b/java/spacewalk-java.changes.mc.Manager-4.3-fix-instance-identifier-header-payg
@@ -1,0 +1,1 @@
+- fix X-Instance-Identifier header when doing a product refresh at Cloud RMT Server (bsc#1214889)


### PR DESCRIPTION
## What does this PR change?

Doing product refresh against RMT Cloud infrastructure for PAYG images fail as we send the wrong
Header data.
We need to send the data from the base product and not the data from /etc/os-release

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/22441

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
