### PR TITLE
Log mirror path

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/MgrSyncUtils.java
+++ b/java/code/src/com/redhat/rhn/manager/content/MgrSyncUtils.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
  */
 public class MgrSyncUtils {
     // Logger instance
-    private static Logger log = LogManager.getLogger(MgrSyncUtils.class);
+    private static final Logger LOG = LogManager.getLogger(MgrSyncUtils.class);
 
     // Source URL handling
     private static final String OFFICIAL_NOVELL_UPDATE_HOST = "nu.novell.com";
@@ -126,15 +126,22 @@ public class MgrSyncUtils {
         else {
             arch = PRODUCT_ARCHS.stream().filter(channelLabel::contains).findFirst().orElse(arch);
         }
-        if (arch.equals("i686") || arch.equals("i586") ||
-                arch.equals("i486") || arch.equals("i386")) {
-            arch = "ia32";
-        }
-        else if (arch.equals("ppc64")) {
-            arch = "ppc";
-        }
-        else if (arch.equals("amd64")) {
-            arch = "amd64-deb";
+        switch (arch) {
+            case "i686":
+            case "i586":
+            case "i486":
+            case "i386":
+                arch = "ia32";
+                break;
+            case "ppc64":
+                arch = "ppc";
+                break;
+            case "amd64":
+                arch = "amd64-deb";
+                break;
+            default:
+                // keep arch unchanged
+                break;
         }
         return ChannelFactory.findArchByLabel("channel-" + arch);
     }
@@ -227,10 +234,7 @@ public class MgrSyncUtils {
             }
             String qPath = Arrays.stream(Optional.ofNullable(uri.getQuery()).orElse("").split("&"))
                     .filter(p -> p.contains("=")) // filter out possible auth tokens
-                    .map(p ->
-                        Arrays.stream(p.split("=", 2))
-                            .collect(Collectors.joining(File.separator))
-                    )
+                    .map(p -> String.join(File.separator, p.split("=", 2)))
                     .sorted()
                     .collect(Collectors.joining(File.separator));
             if (!qPath.isBlank()) {
@@ -238,7 +242,7 @@ public class MgrSyncUtils {
             }
         }
         catch (URISyntaxException e) {
-            log.warn("Unable to parse URL: {}", urlString);
+            LOG.warn("Unable to parse URL: {}", urlString);
         }
         String sccDataPath = Config.get().getString(ContentSyncManager.RESOURCE_PATH, null);
         if (sccDataPath == null) {
@@ -255,7 +259,7 @@ public class MgrSyncUtils {
         else if (name != null) {
             // Case 3
             // everything after the first space are suffixes added to make things unique
-            String[] parts  = URLDecoder.decode(name, StandardCharsets.UTF_8).split("[\\s//]");
+            String[] parts  = URLDecoder.decode(name, StandardCharsets.UTF_8).split("[\\s/]");
             if (!(parts[0].isBlank() || parts[0].equals(".."))) {
                 File oldMirrorPath = Paths.get(dataPath.getAbsolutePath(), "repo", "RPMMD", parts[0]).toFile();
                 if (oldMirrorPath.exists()) {
@@ -272,7 +276,7 @@ public class MgrSyncUtils {
         }
         Path cleanPath = mirrorPath.toPath().normalize();
         if (!cleanPath.startsWith(sccDataPath)) {
-            log.error("Resulting path outside of configured directory {}: {}", dataPath, urlString);
+            LOG.error("Resulting path outside of configured directory {}: {}", dataPath, urlString);
             cleanPath = dataPath.toPath();
         }
         return cleanPath.toUri().normalize();

--- a/java/code/src/com/redhat/rhn/manager/content/MgrSyncUtils.java
+++ b/java/code/src/com/redhat/rhn/manager/content/MgrSyncUtils.java
@@ -255,6 +255,7 @@ public class MgrSyncUtils {
         // Case 2
         if (OFFICIAL_UPDATE_HOSTS.contains(host)) {
             mirrorPath = new File(dataPath.getAbsolutePath(), path);
+            LOG.info("SCC mirrorpath: {}", mirrorPath);
         }
         else if (name != null) {
             // Case 3
@@ -262,17 +263,25 @@ public class MgrSyncUtils {
             String[] parts  = URLDecoder.decode(name, StandardCharsets.UTF_8).split("[\\s/]");
             if (!(parts[0].isBlank() || parts[0].equals(".."))) {
                 File oldMirrorPath = Paths.get(dataPath.getAbsolutePath(), "repo", "RPMMD", parts[0]).toFile();
+                LOG.info("SMT mirrorpath for '{}': {}", name, oldMirrorPath);
                 if (oldMirrorPath.exists()) {
                     mirrorPath = oldMirrorPath;
                 }
                 else {
                     // mirror in a common folder (bsc#1201753)
                     File commonMirrorPath = Paths.get(dataPath.getAbsolutePath(), path).toFile();
+                    LOG.info("Common mirrorpath for '{}': {}", name, commonMirrorPath);
                     if (commonMirrorPath.exists()) {
                         mirrorPath = commonMirrorPath;
                     }
+                    else {
+                        LOG.info("Default mirrorpath for '{}': {}", name, mirrorPath);
+                    }
                 }
             }
+        }
+        else {
+            LOG.info("Default mirrorpath: {}", mirrorPath);
         }
         Path cleanPath = mirrorPath.toPath().normalize();
         if (!cleanPath.startsWith(sccDataPath)) {

--- a/java/code/src/log4j2.xml
+++ b/java/code/src/log4j2.xml
@@ -57,6 +57,7 @@
         <Logger name="com.suse.manager.webui.controllers.login.LoginController" level="info" />
         <Logger name="com.redhat.rhn.frontend.action.LogoutAction" level="info" />
         <Logger name="com.redhat.rhn.manager.content.ContentSyncManager" level="info" />
+        <Logger name="com.redhat.rhn.manager.content.MgrSyncUtils" level="warn" /> <!-- change to info for getting mirror path info -->
         <Logger name="com.suse.manager.webui.controllers.DownloadController" level="info" />
 
         <!-- these are here to avoid spewing the logs when DEBUG is


### PR DESCRIPTION
## What does this PR change?

We have the option to use a mirror and mount repositories local to Uyuni Server.
But it is not easy to find out where Uyuni search for a repository on which local path.

This PR add now log messages (info level) which print the possible paths to the logs when this class
is turned into logging also info messages. 
They also show alternative paths which are possible for some repositories.

## GUI diff

No difference.

Log Example:

```
2023-09-04 17:11:26,156 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-8] INFO  com.redhat.rhn.manager.content.MgrSyncUtils - SCC mirrorpath: /mirror/SUSE/Products/SLE-Module-Server-Applications/15-SP4/x86_64/product
2023-09-04 17:11:26,160 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-8] INFO  com.redhat.rhn.manager.content.MgrSyncUtils - SMT mirrorpath for 'ubuntu-2204-amd64-main': /mirror/repo/RPMMD/ubuntu-2204-amd64-main
2023-09-04 17:11:26,160 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-8] INFO  com.redhat.rhn.manager.content.MgrSyncUtils - Common mirrorpath for 'ubuntu-2204-amd64-main': /mirror/ubuntu/dists/jammy/main/binary-amd64
2023-09-04 17:11:26,160 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-8] INFO  com.redhat.rhn.manager.content.MgrSyncUtils - Default mirrorpath for 'ubuntu-2204-amd64-main': /mirror/archive.ubuntu.com/ubuntu/dists/jammy/main/binary-amd64
2023-09-04 17:11:26,161 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-8] INFO  com.redhat.rhn.manager.content.MgrSyncUtils - SMT mirrorpath for 'ubuntu-2204-amd64-main-updates': /mirror/repo/RPMMD/ubuntu-2204-amd64-main-updates
2023-09-04 17:11:26,161 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-8] INFO  com.redhat.rhn.manager.content.MgrSyncUtils - Common mirrorpath for 'ubuntu-2204-amd64-main-updates': /mirror/ubuntu/dists/jammy-updates/main/binary-amd64
2023-09-04 17:11:26,162 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-8] INFO  com.redhat.rhn.manager.content.MgrSyncUtils - Default mirrorpath for 'ubuntu-2204-amd64-main-updates': /mirror/archive.ubuntu.com/ubuntu/dists/jammy-updates/main/binary-amd64
```


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: only add log messages for QE

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/20637
Tracks https://github.com/SUSE/spacewalk/pull/22452

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
