### PR TITLE
Taskomatic API endpoint to get the path by channel label

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/test/MgrSyncUtilsTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/MgrSyncUtilsTest.java
@@ -163,4 +163,14 @@ public class MgrSyncUtilsTest extends BaseTestCaseWithUser {
         assertContains(opath.toString(), expected.toString());
         assertFalse(opath.toString().contains("%"), "Decoding error: " + opath);
     }
+
+    @Test
+    public void testurlToFSPathWithoutURL() throws Exception {
+        String channelLabel = "SLE-Module-Basesystem15-SP3-x86_64";
+
+        URI opath = MgrSyncUtils.urlToFSPath(null, channelLabel);
+        URI expected = new URI(
+                String.format("file://%s/SUSE/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update", fromdir));
+        assertContains(opath.toString(), expected.toString());
+    }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoXmlRpcHandler.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoXmlRpcHandler.java
@@ -21,6 +21,7 @@ import com.redhat.rhn.domain.notification.NotificationMessage;
 import com.redhat.rhn.domain.notification.UserNotificationFactory;
 import com.redhat.rhn.domain.notification.types.CreateBootstrapRepoFailed;
 import com.redhat.rhn.domain.role.RoleFactory;
+import com.redhat.rhn.manager.content.MgrSyncUtils;
 import com.redhat.rhn.taskomatic.core.SchedulerKernel;
 import com.redhat.rhn.taskomatic.domain.TaskoBunch;
 import com.redhat.rhn.taskomatic.domain.TaskoRun;
@@ -83,6 +84,21 @@ public class TaskoXmlRpcHandler {
      */
     public TaskoSchedule lookupScheduleById(Integer scheduleId) {
         return TaskoFactory.lookupScheduleById(scheduleId.longValue());
+    }
+
+    /**
+     * looks up file system path according to channel label
+     * @param channelLabel channel label
+     * @return File System Path URI
+     * @throws TaskomaticApiException if there was an error
+     */
+    public String lookupFSPathByChannelLabel(String channelLabel) throws TaskomaticApiException {
+        try {
+            return MgrSyncUtils.urlToFSPath(null, channelLabel).getPath();
+        }
+        catch (Exception e) {
+            throw new TaskomaticApiException(e);
+        }
     }
 
     /**


### PR DESCRIPTION
## What does this PR change?

This is a draft, where I have been playing with the setup of my development environment, plus the creation of a Taskomatic API endpoint.
The idea is to expose a new API endpoint where we can retrieve the Path on the server of a particular channel label.

As this intends to be an internal use-only API, I guess it doesn't make sense to have a changelog entry about it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
