### PR TITLE
QE: Create buildhost activation key

### DIFF
--- a/testsuite/features/core/srv_create_activationkey.feature
+++ b/testsuite/features/core/srv_create_activationkey.feature
@@ -104,3 +104,20 @@ Feature: Create activation keys
     And I enter "PROXY-KEY-x86_64" as "key"
     And I click on "Create Activation Key"
     Then I should see a "Activation key Proxy Key x86_64 has been created" text
+
+  Scenario: Create an activation key for the build host
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "Create Key"
+    And I wait for child channels to appear
+    And I enter "Build host Key x86_64" as "description"
+    And I enter "BUILD-HOST-KEY-x86_64" as "key"
+    And I enter "20" as "usageLimit"
+    And I check "Container Build Host"
+    And I check "OS Image Build Host"
+    And I click on "Create Activation Key"
+    Then I should see a "Activation key Build host Key x86_64 has been created" text
+    And I should see a "Details" link
+    And I should see a "Packages" link
+    And I should see a "Configuration" link in the content area
+    And I should see a "Groups" link
+    And I should see a "Activated Systems" link

--- a/testsuite/features/init_clients/allcli_update_activationkeys.feature
+++ b/testsuite/features/init_clients/allcli_update_activationkeys.feature
@@ -188,3 +188,27 @@ Feature: Update activation keys
     And I check "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64)"
     When I click on "Update Activation Key"
     Then I should see a "Activation key Proxy Key x86_64 has been modified" text
+
+@skip_if_github_validation
+@scc_credentials
+@susemanager
+  Scenario: Update build host key with synced base product
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "Build host Key x86_64" in the content area
+    And I wait for child channels to appear
+    And I select "SLE-Product-SLES15-SP4-Pool for x86_64" from "selectedBaseChannel"
+    And I wait for child channels to appear
+    And I include the recommended child channels
+    And I wait until "SLE-Module-Basesystem15-SP4-Pool for x86_64" has been checked
+    And I wait until "SLE-Module-Basesystem15-SP4-Updates for x86_64" has been checked
+    And I wait until "SLE-Module-Server-Applications15-SP4-Pool for x86_64" has been checked
+    And I wait until "SLE-Module-Server-Applications15-SP4-Updates for x86_64" has been checked
+    And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"
+    And I wait until "SLE-Module-DevTools15-SP4-Updates for x86_64" has been checked
+    And I wait until "SLE-Module-Desktop-Applications15-SP4-Pool for x86_64" has been checked
+    And I wait until "SLE-Module-Desktop-Applications15-SP4-Updates for x86_64" has been checked
+    And I check "SLE-Module-Containers15-SP4-Pool for x86_64"
+    And I wait until "SLE-Module-Containers15-SP4-Updates for x86_64" has been checked
+    And I check "Fake-RPM-SUSE-Channel"
+    When I click on "Update Activation Key"
+    Then I should see a "Activation key Build host Key x86_64 has been modified" text

--- a/testsuite/features/init_clients/buildhost_bootstrap.feature
+++ b/testsuite/features/init_clients/buildhost_bootstrap.feature
@@ -7,14 +7,6 @@ Feature: Bootstrap a build host via the GUI
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  Scenario: Update the SLES activation key
-    When I follow the left menu "Systems > Activation Keys"
-    And I follow "SUSE Test Key x86_64" in the content area
-    And I wait until I see "Container Build Host" text
-    And I check "Container Build Host"
-    And I check "OS Image Build Host"
-    And I click on "Update Activation Key"
-
   Scenario: Bootstrap a build host
     When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
@@ -22,10 +14,17 @@ Feature: Bootstrap a build host via the GUI
     And I enter "22" as "port"
     And I enter "root" as "user"
     And I enter "linux" as "password"
-    And I select "1-SUSE-KEY-x86_64" from "activationKeys"
+    And I select "1-BUILD-HOST-KEY-x86_64" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
     And I wait until I see "Bootstrap process initiated." text
+
+  Scenario: Enable necessary repositories for the build host
+    When I enable repository "os_pool_repo" on this "build_host" without error control
+    And I enable repository "os_update_repo" on this "build_host" without error control
+    And I enable repository "containers_pool_repo" on this "build_host" without error control
+    And I enable repository "containers_updates_repo" on this "build_host" without error control
+    Then I execute "zypper ref" on the "build_host"
 
   Scenario: Check the new bootstrapped build host in System Overview page
     When I follow the left menu "Salt > Keys"
@@ -60,11 +59,3 @@ Feature: Bootstrap a build host via the GUI
   Scenario: Check events history for failures on SLES build host
     Given I am on the Systems overview page of this "build_host"
     Then I check for failed events on history event page
-
-  Scenario: Cleanup: Restore the SLES activation key to its original state
-    When I follow the left menu "Systems > Activation Keys"
-    And I follow "SUSE Test Key x86_64" in the content area
-    And I wait until I see "Container Build Host" text
-    And I uncheck "Container Build Host"
-    And I uncheck "OS Image Build Host"
-    And I click on "Update Activation Key"


### PR DESCRIPTION
## What does this PR change?

This will use a dedicated activation key for the build host.

## GUI diff

No difference.


- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were added
- [x] **DONE**

## Links


- Manager 4.3: 
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
