### PR TITLE
Fix recurring state execution not using correct order

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/RecurringActionJob.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/RecurringActionJob.java
@@ -32,6 +32,7 @@ import com.suse.manager.maintenance.MaintenanceManager;
 
 import org.quartz.JobExecutionContext;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -86,7 +87,9 @@ public class RecurringActionJob extends RhnJavaJob {
             }
             else if (actionType instanceof RecurringState) {
                 Set<RecurringStateConfig> configs = ((RecurringState) action.getRecurringActionType()).getStateConfig();
-                List<String> mods = configs.stream().map(RecurringStateConfig::getStateName)
+                List<String> mods = configs.stream()
+                        .sorted(Comparator.comparingLong(RecurringStateConfig::getPosition))
+                        .map(RecurringStateConfig::getStateName)
                         .collect(Collectors.toList());
                 Action a = ActionManager.scheduleApplyStates(action.getCreator(),
                         minionIds, mods,

--- a/java/spacewalk-java.changes.parlt.fix-recurring-state-ordering
+++ b/java/spacewalk-java.changes.parlt.fix-recurring-state-ordering
@@ -1,0 +1,1 @@
+- Fix recurring state execution not using the correct order (bsc#1215027)


### PR DESCRIPTION
## What does this PR change?

Using a Set instead of a list caused the order of the states to be incorrect.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: Bugfix

- [x] **DONE**

## Test coverage

- No tests: Bugfix

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/22465

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
