### PR TITLE
[GSOC23] - C - Implement a StAX parser for OVAL files

### DIFF
--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -268,6 +268,9 @@ java.disable_remote_commands_from_ui = false
 # Enable the usage of OVAL metadata in CVE auditing
 java.cve_audit.enable_oval_metadata = true
 
+# Bulk size for OVAL definitions parsing
+java.oval_definitions_bulk_size = 500
+
 # Disable the supportdata upload UI and API
 java.disable_supportdata_upload = false
 

--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -366,7 +366,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
@@ -465,7 +464,6 @@
         <dependency>
             <groupId>org.codehaus.woodstox</groupId>
             <artifactId>stax2-api</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.woodstox</groupId>

--- a/java/core/src/main/java/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -244,6 +244,8 @@ public class ConfigDefaults {
 
     public static final String CVE_AUDIT_ENABLE_OVAL_METADATA = "java.cve_audit.enable_oval_metadata";
 
+    public static final String OVAL_DEFINITIONS_BULK_SIZE = "java.oval_definitions_bulk_size";
+
     /**
      * Token lifetime in seconds
      */
@@ -1290,6 +1292,13 @@ public class ConfigDefaults {
      * */
     public boolean isOvalEnabledForCveAudit() {
         return Config.get().getBoolean(CVE_AUDIT_ENABLE_OVAL_METADATA, false);
+    }
+
+    /**
+     * @return the number of OVAL definitions to be parsed in bulk.
+     */
+    public int getOvalDefinitionsBulkSize() {
+        return Config.get().getInt(OVAL_DEFINITIONS_BULK_SIZE, 500);
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/manager/audit/CVEAuditManagerOVAL.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/audit/CVEAuditManagerOVAL.java
@@ -335,7 +335,8 @@ public class CVEAuditManagerOVAL {
     public static void syncOVAL() {
         Set<OVALOsProduct> osProductsToSync = getProductsToSync();
 
-        LOG.debug("Detected {} products eligible for OVAL synchronization: {}", osProductsToSync.size(), osProductsToSync);
+        LOG.debug("Detected {} products eligible for OVAL synchronization: {}",
+            osProductsToSync.size(), osProductsToSync);
 
         OVALDownloader ovalDownloader = new OVALDownloader(OVALConfigLoader.loadDefaultConfig());
         for (OVALOsProduct osProduct : osProductsToSync) {
@@ -349,11 +350,11 @@ public class CVEAuditManagerOVAL {
         }
     }
 
-    private static void syncOVALForProduct(OVALOsProduct product, OVALDownloader ovalDownloader) {
-        LOG.debug("Downloading OVAL for {} {}", product.getOsFamily(), product.getOsVersion());
+    private static void syncOVALForProduct(OVALOsProduct osProduct, OVALDownloader ovalDownloader) {
+        LOG.debug("Downloading OVAL for {} {}", osProduct.getOsFamily(), osProduct.getOsVersion());
         OVALDownloadResult downloadResult;
         try {
-            downloadResult = ovalDownloader.download(product.getOsFamily(), product.getOsVersion());
+            downloadResult = ovalDownloader.download(osProduct.getOsFamily(), osProduct.getOsVersion());
         }
         catch (IOException e) {
             throw new RuntimeException("Failed to download OVAL data", e);
@@ -365,13 +366,16 @@ public class CVEAuditManagerOVAL {
         LOG.debug("OVAL patch file: {}", downloadResult.getPatchFile().map(File::getAbsoluteFile).orElse(null));
 
         downloadResult.getVulnerabilityFile().ifPresent(ovalVulnerabilityFile -> {
-            extractAndSaveOVALData(product, ovalVulnerabilityFile);
-            LOG.debug("Saving Vulnerability OVAL for {} {}", product.getOsFamily(), product.getOsVersion());
+            // we need this to avoid any conflicts with the previously stored OVAL metadata.
+            OVALCachingFactory.clearOVALMetadataByOsProduct(osProduct);
+            extractAndSaveOVALData(osProduct, ovalVulnerabilityFile);
+            LOG.debug("Saving Vulnerability OVAL for {} {}", osProduct.getOsFamily(), osProduct.getOsVersion());
         });
 
         downloadResult.getPatchFile().ifPresent(patchFile -> {
-            extractAndSaveOVALData(product, patchFile);
-            LOG.debug("Saving Patch OVAL for {} {}", product.getOsFamily(), product.getOsVersion());
+            OVALCachingFactory.clearOVALMetadataByOsProduct(osProduct);
+            extractAndSaveOVALData(osProduct, patchFile);
+            LOG.debug("Saving Patch OVAL for {} {}", osProduct.getOsFamily(), osProduct.getOsVersion());
         });
 
         LOG.debug("Saving OVAL finished");

--- a/java/core/src/main/java/com/redhat/rhn/manager/audit/CVEAuditManagerOVAL.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/audit/CVEAuditManagerOVAL.java
@@ -387,7 +387,7 @@ public class CVEAuditManagerOVAL {
     private static void extractAndSaveOVALData(OVALOsProduct product, File ovalFile) {
         OvalParser ovalParser = new OvalParser();
         OVALResources ovalResources = ovalParser.parseResources(ovalFile);
-        ovalParser.parseDefinitionsInBulk(ovalFile, (definitionsBulk) -> {
+        ovalParser.parseDefinitionsInBulk(ovalFile, definitionsBulk -> {
             OvalRootType ovalRoot = new OvalRootType();
             ovalRoot.setDefinitions(definitionsBulk);
             ovalRoot.setTests(ovalResources.getTests());

--- a/java/core/src/main/java/com/redhat/rhn/manager/audit/CVEAuditManagerOVAL.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/audit/CVEAuditManagerOVAL.java
@@ -333,23 +333,23 @@ public class CVEAuditManagerOVAL {
      * Launches the OVAL synchronization process
      * */
     public static void syncOVAL() {
-        Set<OVALProduct> productsToSync = getProductsToSync();
+        Set<OVALOsProduct> osProductsToSync = getProductsToSync();
 
-        LOG.debug("Detected {} products eligible for OVAL synchronization: {}", productsToSync.size(), productsToSync);
+        LOG.debug("Detected {} products eligible for OVAL synchronization: {}", osProductsToSync.size(), osProductsToSync);
 
         OVALDownloader ovalDownloader = new OVALDownloader(OVALConfigLoader.loadDefaultConfig());
-        for (OVALProduct product : productsToSync) {
+        for (OVALOsProduct osProduct : osProductsToSync) {
             try {
-                syncOVALForProduct(product, ovalDownloader);
+                syncOVALForProduct(osProduct, ovalDownloader);
             }
             catch (Exception e) {
-                LOG.error("Failed to sync OVAL for product '{} {}'",
-                        product.getOsFamily().fullname(), product.getOsVersion(), e);
+                LOG.error("Failed to sync OVAL for OS product '{} {}'",
+                        osProduct.getOsFamily().fullname(), osProduct.getOsVersion(), e);
             }
         }
     }
 
-    private static void syncOVALForProduct(OVALProduct product, OVALDownloader ovalDownloader) {
+    private static void syncOVALForProduct(OVALOsProduct product, OVALDownloader ovalDownloader) {
         LOG.debug("Downloading OVAL for {} {}", product.getOsFamily(), product.getOsVersion());
         OVALDownloadResult downloadResult;
         try {
@@ -380,7 +380,7 @@ public class CVEAuditManagerOVAL {
     /**
      * Extracts OVAL metadata from the given {@code ovalFile}, clean it and save it to the database.
      * */
-    private static void extractAndSaveOVALData(OVALProduct product, File ovalFile) {
+    private static void extractAndSaveOVALData(OVALOsProduct product, File ovalFile) {
         OvalParser ovalParser = new OvalParser();
         OVALResources ovalResources = ovalParser.parseResources(ovalFile);
         ovalParser.parseDefinitionsInBulk(ovalFile, (definitionsBulk) -> {
@@ -398,15 +398,15 @@ public class CVEAuditManagerOVAL {
     /**
      * Identifies the OS products to synchronize OVAL data for.
      * */
-    private static Set<OVALProduct> getProductsToSync() {
+    private static Set<OVALOsProduct> getProductsToSync() {
         return ServerFactory.listAllServersOsAndRelease()
                 .stream()
-                .map(OsReleasePair::toOVALProduct)
+                .map(OsReleasePair::toOVALOsProduct)
                 .filter(Optional::isPresent)
                 .map(Optional::get).collect(Collectors.toSet());
     }
 
-    public static class OVALProduct {
+    public static class OVALOsProduct {
         private OsFamily osFamily;
         private String osVersion;
 
@@ -415,7 +415,7 @@ public class CVEAuditManagerOVAL {
          * @param osFamilyIn the os family
          * @param osVersionIn the os version
          * */
-        public OVALProduct(OsFamily osFamilyIn, String osVersionIn) {
+        public OVALOsProduct(OsFamily osFamilyIn, String osVersionIn) {
             this.osFamily = osFamilyIn;
             this.osVersion = osVersionIn;
         }
@@ -444,7 +444,7 @@ public class CVEAuditManagerOVAL {
             if (oIn == null || getClass() != oIn.getClass()) {
                 return false;
             }
-            OVALProduct that = (OVALProduct) oIn;
+            OVALOsProduct that = (OVALOsProduct) oIn;
             return osFamily == that.osFamily && Objects.equals(osVersion, that.osVersion);
         }
 

--- a/java/core/src/main/java/com/redhat/rhn/manager/audit/CVEAuditManagerOVAL.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/audit/CVEAuditManagerOVAL.java
@@ -26,11 +26,12 @@ import com.redhat.rhn.domain.user.User;
 import com.suse.oval.OVALCachingFactory;
 import com.suse.oval.OVALCleaner;
 import com.suse.oval.OsFamily;
-import com.suse.oval.OvalParser;
 import com.suse.oval.config.OVALConfigLoader;
 import com.suse.oval.ovaldownloader.OVALDownloadResult;
 import com.suse.oval.ovaldownloader.OVALDownloader;
 import com.suse.oval.ovaltypes.OvalRootType;
+import com.suse.oval.parser.OVALResources;
+import com.suse.oval.parser.OvalParser;
 import com.suse.oval.vulnerablepkgextractor.VulnerablePackage;
 
 import org.apache.logging.log4j.LogManager;
@@ -380,9 +381,18 @@ public class CVEAuditManagerOVAL {
      * Extracts OVAL metadata from the given {@code ovalFile}, clean it and save it to the database.
      * */
     private static void extractAndSaveOVALData(OVALProduct product, File ovalFile) {
-        OvalRootType ovalRoot = new OvalParser().parse(ovalFile);
-        OVALCleaner.cleanup(ovalRoot, product.getOsFamily(), product.getOsVersion());
-        OVALCachingFactory.savePlatformsVulnerablePackages(ovalRoot);
+        OvalParser ovalParser = new OvalParser();
+        OVALResources ovalResources = ovalParser.parseResources(ovalFile);
+        ovalParser.parseDefinitionsInBulk(ovalFile, (definitionsBulk) -> {
+            OvalRootType ovalRoot = new OvalRootType();
+            ovalRoot.setDefinitions(definitionsBulk);
+            ovalRoot.setTests(ovalResources.getTests());
+            ovalRoot.setObjects(ovalResources.getObjects());
+            ovalRoot.setStates(ovalResources.getStates());
+
+            OVALCleaner.cleanup(ovalRoot, product.getOsFamily(), product.getOsVersion());
+            OVALCachingFactory.savePlatformsVulnerablePackages(ovalRoot);
+        });
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/manager/audit/CVEAuditManagerOVAL.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/audit/CVEAuditManagerOVAL.java
@@ -393,8 +393,10 @@ public class CVEAuditManagerOVAL {
             ovalRoot.setTests(ovalResources.getTests());
             ovalRoot.setObjects(ovalResources.getObjects());
             ovalRoot.setStates(ovalResources.getStates());
+            ovalRoot.setOsFamily(product.getOsFamily());
+            ovalRoot.setOsVersion(product.getOsVersion());
 
-            OVALCleaner.cleanup(ovalRoot, product.getOsFamily(), product.getOsVersion());
+            OVALCleaner.cleanup(ovalRoot);
             OVALCachingFactory.savePlatformsVulnerablePackages(ovalRoot);
         });
     }

--- a/java/core/src/main/java/com/redhat/rhn/manager/audit/OsReleasePair.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/audit/OsReleasePair.java
@@ -42,7 +42,7 @@ public class OsReleasePair {
     }
 
     /**
-     * Derives an {@link com.redhat.rhn.manager.audit.CVEAuditManagerOVAL.OVALProduct} object based on the server's
+     * Derives an {@link CVEAuditManagerOVAL.OVALOsProduct} object based on the server's
      * information, including the operating system name and release version. Used by the OVAL synchronization process
      * to identify the installed product and synchronize OVAL data for it.
      *
@@ -50,7 +50,7 @@ public class OsReleasePair {
      * OVAL synchronization and {@code Optional.empty} otherwise
      * (for example product maintainers don't produce OVAL data)
      * */
-    public Optional<CVEAuditManagerOVAL.OVALProduct> toOVALProduct() {
+    public Optional<CVEAuditManagerOVAL.OVALOsProduct> toOVALOsProduct() {
         return OsFamily.fromOsName(os).flatMap(serverOsFamily -> {
             String serverOsRelease = getOsRelease();
             if (serverOsFamily == OsFamily.REDHAT_ENTERPRISE_LINUX ||
@@ -60,9 +60,9 @@ public class OsReleasePair {
                 serverOsRelease = serverOsRelease.replaceFirst("\\..*$", "");
             }
 
-            CVEAuditManagerOVAL.OVALProduct ovalProduct = null;
+            CVEAuditManagerOVAL.OVALOsProduct ovalProduct = null;
             if (serverOsFamily.isSupportedRelease(serverOsRelease)) {
-                ovalProduct = new CVEAuditManagerOVAL.OVALProduct(serverOsFamily, serverOsRelease);
+                ovalProduct = new CVEAuditManagerOVAL.OVALOsProduct(serverOsFamily, serverOsRelease);
             }
 
             return Optional.ofNullable(ovalProduct);

--- a/java/core/src/main/java/com/suse/manager/webui/controllers/CVEAuditController.java
+++ b/java/core/src/main/java/com/suse/manager/webui/controllers/CVEAuditController.java
@@ -19,6 +19,7 @@ import static com.suse.manager.webui.utils.SparkApplicationHelper.result;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withCsrfToken;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withUserPreferences;
+
 import static spark.Spark.get;
 import static spark.Spark.post;
 
@@ -31,7 +32,6 @@ import com.redhat.rhn.manager.audit.CVEAuditSystem;
 import com.redhat.rhn.manager.audit.PatchStatus;
 import com.redhat.rhn.manager.audit.UnknownCVEIdentifierException;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
-
 import com.suse.manager.webui.utils.gson.ResultJson;
 
 import com.google.gson.Gson;

--- a/java/core/src/main/java/com/suse/manager/webui/controllers/CVEAuditController.java
+++ b/java/core/src/main/java/com/suse/manager/webui/controllers/CVEAuditController.java
@@ -19,7 +19,6 @@ import static com.suse.manager.webui.utils.SparkApplicationHelper.result;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withCsrfToken;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withUserPreferences;
-
 import static spark.Spark.get;
 import static spark.Spark.post;
 
@@ -32,6 +31,7 @@ import com.redhat.rhn.manager.audit.CVEAuditSystem;
 import com.redhat.rhn.manager.audit.PatchStatus;
 import com.redhat.rhn.manager.audit.UnknownCVEIdentifierException;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
+
 import com.suse.manager.webui.utils.gson.ResultJson;
 
 import com.google.gson.Gson;

--- a/java/core/src/main/java/com/suse/oval/OVALCachingFactory.java
+++ b/java/core/src/main/java/com/suse/oval/OVALCachingFactory.java
@@ -65,8 +65,8 @@ public class OVALCachingFactory extends HibernateFactory {
         CallableMode mode = ModeFactory.getCallableMode("oval_queries", "add_product_vulnerable_package");
 
         OVALResourcesCache ovalResourcesCache = new OVALResourcesCache(rootType);
-        CVEAuditManagerOVAL.OVALProduct ovalOsProduct =
-            new CVEAuditManagerOVAL.OVALProduct(rootType.getOsFamily(), rootType.getOsVersion());
+        CVEAuditManagerOVAL.OVALOsProduct ovalOsProduct =
+            new CVEAuditManagerOVAL.OVALOsProduct(rootType.getOsFamily(), rootType.getOsVersion());
 
         List<ProductVulnerablePackages> productVulnerablePackages = new ArrayList<>();
         for (DefinitionType definition : rootType.getDefinitions()) {

--- a/java/core/src/main/java/com/suse/oval/OVALCachingFactory.java
+++ b/java/core/src/main/java/com/suse/oval/OVALCachingFactory.java
@@ -51,9 +51,22 @@ public class OVALCachingFactory extends HibernateFactory {
         // Left empty on purpose
     }
 
-    private static void clearOVALMetadataByPlatform(String platformCpe) {
-        WriteMode mode = ModeFactory.getWriteMode("oval_queries", "clear_oval_metadata_by_platform");
-        mode.executeUpdate(Map.of("cpe", platformCpe));
+    /**
+     * Clears the OVAL metadata for the given OS product, meaning:
+     * <ul>
+     *     <li>Clears all entries in the suseOVALPlatformVulnerablePackage table that correspond
+     *     to the given OS product.</li>
+     *     <li>Deletes the OS product from the suseOVALOsProduct table.</li>
+     * </ul>
+     *
+     * @param osProduct the OS product to clear the OVAL metadata for.
+     * */
+    public static void clearOVALMetadataByOsProduct(CVEAuditManagerOVAL.OVALOsProduct osProduct) {
+        WriteMode mode = ModeFactory.getWriteMode("oval_queries", "clear_oval_metadata_by_os_product");
+        Map<String, String> params = new HashMap<>();
+        params.put("os_product_family", osProduct.getOsFamily().toString());
+        params.put("os_product_version", osProduct.getOsVersion());
+        mode.executeUpdate(params);
     }
 
     /**
@@ -75,11 +88,6 @@ public class OVALCachingFactory extends HibernateFactory {
 
             productVulnerablePackages.addAll(vulnerablePackagesExtractor.extract());
         }
-
-        // Clear previous OVAL metadata
-//        productVulnerablePackages.stream()
-//                .collect(groupingBy(ProductVulnerablePackages::getProductCpe))
-//                .keySet().forEach(OVALCachingFactory::clearOVALMetadataByPlatform);
 
         // Write OVAL metadata in batches
         DataResult<Map<String, Object>> batch = new DataResult<>(new ArrayList<>(1000));

--- a/java/core/src/main/java/com/suse/oval/OVALCachingFactory.java
+++ b/java/core/src/main/java/com/suse/oval/OVALCachingFactory.java
@@ -23,8 +23,8 @@ import com.redhat.rhn.common.db.datasource.SelectMode;
 import com.redhat.rhn.common.db.datasource.WriteMode;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.rhnpackage.PackageEvr;
-
 import com.redhat.rhn.manager.audit.CVEAuditManagerOVAL;
+
 import com.suse.oval.manager.OVALResourcesCache;
 import com.suse.oval.ovaltypes.DefinitionType;
 import com.suse.oval.ovaltypes.OvalRootType;

--- a/java/core/src/main/java/com/suse/oval/OVALCachingFactory.java
+++ b/java/core/src/main/java/com/suse/oval/OVALCachingFactory.java
@@ -26,7 +26,7 @@ import com.redhat.rhn.common.db.datasource.WriteMode;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.rhnpackage.PackageEvr;
 
-import com.suse.oval.manager.OVALLookupHelper;
+import com.suse.oval.manager.OVALResourcesCache;
 import com.suse.oval.ovaltypes.DefinitionType;
 import com.suse.oval.ovaltypes.OvalRootType;
 import com.suse.oval.vulnerablepkgextractor.ProductVulnerablePackages;
@@ -65,12 +65,12 @@ public class OVALCachingFactory extends HibernateFactory {
     public static void savePlatformsVulnerablePackages(OvalRootType rootType) {
         CallableMode mode = ModeFactory.getCallableMode("oval_queries", "add_product_vulnerable_package");
 
-        OVALLookupHelper ovalLookupHelper = new OVALLookupHelper(rootType);
+        OVALResourcesCache ovalResourcesCache = new OVALResourcesCache(rootType);
 
         List<ProductVulnerablePackages> productVulnerablePackages = new ArrayList<>();
         for (DefinitionType definition : rootType.getDefinitions()) {
             VulnerablePackagesExtractor vulnerablePackagesExtractor =
-                    VulnerablePackagesExtractors.create(definition, rootType.getOsFamily(), ovalLookupHelper);
+                    VulnerablePackagesExtractors.create(definition, rootType.getOsFamily(), ovalResourcesCache);
 
             productVulnerablePackages.addAll(vulnerablePackagesExtractor.extract());
         }

--- a/java/core/src/main/java/com/suse/oval/OVALCachingFactory.java
+++ b/java/core/src/main/java/com/suse/oval/OVALCachingFactory.java
@@ -15,8 +15,6 @@
 
 package com.suse.oval;
 
-import static java.util.stream.Collectors.groupingBy;
-
 import com.redhat.rhn.common.db.datasource.CallableMode;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.db.datasource.ModeFactory;
@@ -26,6 +24,7 @@ import com.redhat.rhn.common.db.datasource.WriteMode;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.rhnpackage.PackageEvr;
 
+import com.redhat.rhn.manager.audit.CVEAuditManagerOVAL;
 import com.suse.oval.manager.OVALResourcesCache;
 import com.suse.oval.ovaltypes.DefinitionType;
 import com.suse.oval.ovaltypes.OvalRootType;
@@ -66,6 +65,8 @@ public class OVALCachingFactory extends HibernateFactory {
         CallableMode mode = ModeFactory.getCallableMode("oval_queries", "add_product_vulnerable_package");
 
         OVALResourcesCache ovalResourcesCache = new OVALResourcesCache(rootType);
+        CVEAuditManagerOVAL.OVALProduct ovalOsProduct =
+            new CVEAuditManagerOVAL.OVALProduct(rootType.getOsFamily(), rootType.getOsVersion());
 
         List<ProductVulnerablePackages> productVulnerablePackages = new ArrayList<>();
         for (DefinitionType definition : rootType.getDefinitions()) {
@@ -76,9 +77,9 @@ public class OVALCachingFactory extends HibernateFactory {
         }
 
         // Clear previous OVAL metadata
-        productVulnerablePackages.stream()
-                .collect(groupingBy(ProductVulnerablePackages::getProductCpe))
-                .keySet().forEach(OVALCachingFactory::clearOVALMetadataByPlatform);
+//        productVulnerablePackages.stream()
+//                .collect(groupingBy(ProductVulnerablePackages::getProductCpe))
+//                .keySet().forEach(OVALCachingFactory::clearOVALMetadataByPlatform);
 
         // Write OVAL metadata in batches
         DataResult<Map<String, Object>> batch = new DataResult<>(new ArrayList<>(1000));
@@ -87,6 +88,8 @@ public class OVALCachingFactory extends HibernateFactory {
                 for (VulnerablePackage vp : pvp.getVulnerablePackages()) {
                     Map<String, Object> params = new HashMap<>();
                     params.put("product_name", pvp.getProductCpe());
+                    params.put("os_product_family", ovalOsProduct.getOsFamily().toString());
+                    params.put("os_product_version", ovalOsProduct.getOsVersion());
                     params.put("cve_name", cve);
                     params.put("package_name", vp.getName());
                     params.put("fix_epoch", vp.getFixVersion().map(PackageEvr::getEpoch).orElse(null));

--- a/java/core/src/main/java/com/suse/oval/OVALCleaner.java
+++ b/java/core/src/main/java/com/suse/oval/OVALCleaner.java
@@ -81,7 +81,6 @@ public class OVALCleaner {
 
         if (osFamily == OsFamily.DEBIAN) {
             convertDebianTestRefs(definition.getCriteria(), osVersion);
-            // SUSE-MicroOS-release is ==5.3
         }
     }
 

--- a/java/core/src/main/java/com/suse/oval/OVALCleaner.java
+++ b/java/core/src/main/java/com/suse/oval/OVALCleaner.java
@@ -42,7 +42,6 @@ import java.util.stream.Collectors;
  * OVAL data from multiple sources and make changes to it to have a more predictable format.
  */
 public class OVALCleaner {
-
     private OVALCleaner() {
     }
 
@@ -82,6 +81,7 @@ public class OVALCleaner {
 
         if (osFamily == OsFamily.DEBIAN) {
             convertDebianTestRefs(definition.getCriteria(), osVersion);
+            // SUSE-MicroOS-release is ==5.3
         }
     }
 

--- a/java/core/src/main/java/com/suse/oval/OVALCleaner.java
+++ b/java/core/src/main/java/com/suse/oval/OVALCleaner.java
@@ -49,12 +49,10 @@ public class OVALCleaner {
      * Cleanup the given {@code root} based on {@code osFamily} and {@code osVersion}
      *
      * @param root the OVAL root to clean up
-     * @param osFamily the osFamily of the OVAL
-     * @param osVersion the osVersion of the OVAL
      * */
-    public static void cleanup(OvalRootType root, OsFamily osFamily, String osVersion) {
-        root.setOsFamily(osFamily);
-        root.setOsVersion(osVersion);
+    public static void cleanup(OvalRootType root) {
+        OsFamily osFamily = root.getOsFamily();
+        String osVersion = root.getOsVersion();
 
         if (osFamily == OsFamily.REDHAT_ENTERPRISE_LINUX) {
             root.getDefinitions().removeIf(def -> def.getId().contains("unaffected"));

--- a/java/core/src/main/java/com/suse/oval/OvalParser.java
+++ b/java/core/src/main/java/com/suse/oval/OvalParser.java
@@ -16,15 +16,30 @@
 package com.suse.oval;
 
 import com.suse.oval.exceptions.OvalParserException;
+import com.suse.oval.ovaltypes.ArchType;
+import com.suse.oval.ovaltypes.EVRType;
+import com.suse.oval.ovaltypes.ObjectType;
+import com.suse.oval.ovaltypes.OperationEnumeration;
 import com.suse.oval.ovaltypes.OvalRootType;
-
-import java.io.File;
-import java.net.URISyntaxException;
-import java.net.URL;
+import com.suse.oval.ovaltypes.StateType;
+import com.suse.oval.ovaltypes.VersionType;
 
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.StartElement;
+import javax.xml.stream.events.XMLEvent;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.List;
+import java.util.ArrayList;
 
 /**
  * The Oval Parser is responsible for parsing OVAL(Open Vulnerability and Assessment Language) documents
@@ -61,6 +76,205 @@ public class OvalParser {
         catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public OvalRootType parseStax(File ovalFile) {
+        XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+        try {
+            XMLEventReader reader = xmlInputFactory.createXMLEventReader(new FileInputStream(ovalFile));
+
+            OvalRootType ovalRoot = new OvalRootType();
+
+            while (reader.hasNext()) {
+                XMLEvent nextEvent = reader.nextEvent();
+
+                if (nextEvent.isStartElement()) {
+                    String elementName = nextEvent.asStartElement().getName().getLocalPart();
+                    if (elementName.equals("objects")) {
+                        ovalRoot.setObjects(parseObjects(reader));
+                    }
+                    else if (elementName.equals("states")) {
+                        ovalRoot.setStates(parseStates(reader));
+                    }
+                }
+            }
+
+            return ovalRoot;
+
+        } catch (XMLStreamException | FileNotFoundException e) {
+            throw new OvalParserException("Failed to parse the given OVAL file at: " + ovalFile.getAbsolutePath(), e);
+        }
+    }
+
+    private List<StateType> parseStates(XMLEventReader reader) throws XMLStreamException {
+        List<StateType> states = new ArrayList<>();
+
+        while (reader.hasNext()) {
+            XMLEvent nextEvent = reader.nextEvent();
+
+            if (nextEvent.isStartElement()) {
+                if (nextEvent.asStartElement().getName().getLocalPart().equals("rpminfo_state")) {
+                    StateType stateType = parseStateType(nextEvent.asStartElement(), reader);
+                    states.add(stateType);
+                }
+            }
+
+            if (nextEvent.isEndElement()) {
+                if (nextEvent.asEndElement().getName().getLocalPart().equals("states")) {
+                    return states;
+                }
+            }
+        }
+
+        throw new OvalParserException("Unable to find the closing tag for </states>");
+    }
+
+    private StateType parseStateType(StartElement rpmStateElement, XMLEventReader reader) throws XMLStreamException {
+        StateType stateType = new StateType();
+
+        rpmStateElement.getAttributes().forEachRemaining(attribute -> {
+            String attributeName = attribute.getName().getLocalPart();
+
+            switch (attributeName) {
+                case "id":
+                    stateType.setId(attribute.getValue());
+                    break;
+                case "comment":
+                    stateType.setComment(attribute.getValue());
+                    break;
+            }
+        });
+
+        while (reader.hasNext()) {
+            XMLEvent nextEvent = reader.nextEvent();
+            if (nextEvent.isStartElement()) {
+                String elementName = nextEvent.asStartElement().getName().getLocalPart();
+                if (elementName.equals("arch")) {
+                    stateType.setPackageArch(parseArchStateEntity(nextEvent.asStartElement(), reader));
+                }
+                else if (elementName.equals("evr")) {
+                    stateType.setPackageEVR(parseEVRStateEntity(nextEvent.asStartElement(), reader));
+                }
+                else if (elementName.equals("version")) {
+                    stateType.setPackageVersion(parseVersionStateEntity(nextEvent.asStartElement(), reader));
+                }
+            }
+
+            if (nextEvent.isEndElement()) {
+                if (nextEvent.asEndElement().getName().getLocalPart().equals("rpminfo_state")) {
+                    return stateType;
+                }
+            }
+        }
+
+        throw new OvalParserException("Unable to find the closing tag for </rpminfo_state>");
+    }
+
+    private ArchType parseArchStateEntity(StartElement archElement, XMLEventReader reader) throws XMLStreamException {
+        ArchType archType = new ArchType();
+
+        archElement.getAttributes().forEachRemaining(attribute -> {
+            String attributeName = attribute.getName().getLocalPart();
+
+            if (attributeName.equals("operation")) {
+                archType.setOperation(OperationEnumeration.fromValue(attribute.getValue()));
+            }
+        });
+
+        archType.setValue(reader.getElementText());
+
+        return archType;
+    }
+
+    private EVRType parseEVRStateEntity(StartElement evrElement, XMLEventReader reader) throws XMLStreamException {
+        EVRType evrType = new EVRType();
+
+        evrElement.getAttributes().forEachRemaining(attribute -> {
+            String attributeName = attribute.getName().getLocalPart();
+
+            if (attributeName.equals("operation")) {
+                evrType.setOperation(OperationEnumeration.fromValue(attribute.getValue()));
+            }
+        });
+
+        evrType.setValue(reader.getElementText());
+
+        return evrType;
+    }
+
+    private VersionType parseVersionStateEntity(StartElement versionElement, XMLEventReader reader)
+            throws XMLStreamException {
+        VersionType versionType = new VersionType();
+
+        versionElement.getAttributes().forEachRemaining(attribute -> {
+            String attributeName = attribute.getName().getLocalPart();
+
+            if (attributeName.equals("operation")) {
+                versionType.setOperation(OperationEnumeration.fromValue(attribute.getValue()));
+            }
+        });
+
+        versionType.setValue(reader.getElementText());
+
+        return versionType;
+    }
+
+    private List<ObjectType> parseObjects(XMLEventReader reader) throws XMLStreamException {
+        List<ObjectType> objects = new ArrayList<>();
+
+        while (reader.hasNext()) {
+            XMLEvent nextEvent = reader.nextEvent();
+
+            if (nextEvent.isStartElement()) {
+                if (nextEvent.asStartElement().getName().getLocalPart().equals("rpminfo_object")) {
+                    ObjectType objectType = parseObjectType(nextEvent.asStartElement(), reader);
+                    objects.add(objectType);
+                }
+            }
+
+            if (nextEvent.isEndElement()) {
+                if (nextEvent.asEndElement().getName().getLocalPart().equals("objects")) {
+                    return objects;
+                }
+            }
+        }
+
+        throw new OvalParserException("Unable to find the closing tag for </objects>");
+    }
+
+    private ObjectType parseObjectType(StartElement rpmObjectElement, XMLEventReader reader) throws XMLStreamException {
+        ObjectType objectType = new ObjectType();
+
+        rpmObjectElement.getAttributes().forEachRemaining(attribute -> {
+            String attributeName = attribute.getName().getLocalPart();
+
+            switch (attributeName) {
+                case "id":
+                    objectType.setId(attribute.getValue());
+                    break;
+                case "comment":
+                    objectType.setComment(attribute.getValue());
+                    break;
+            }
+        });
+
+
+        while (reader.hasNext()) {
+            XMLEvent nextEvent = reader.nextEvent();
+            if (nextEvent.isStartElement()) {
+                if (nextEvent.asStartElement().getName().getLocalPart().equals("name")) {
+                    objectType.setPackageName(reader.getElementText());
+                }
+            }
+
+            if (nextEvent.isEndElement()) {
+                if (nextEvent.asEndElement().getName().getLocalPart().equals("rpminfo_object")) {
+                    return objectType;
+                }
+            }
+        }
+
+        throw new OvalParserException("Unable to find the closing tag for </rpminfo_object>");
     }
 
 }

--- a/java/core/src/main/java/com/suse/oval/OvalParser.java
+++ b/java/core/src/main/java/com/suse/oval/OvalParser.java
@@ -22,14 +22,20 @@ import com.suse.oval.ovaltypes.ObjectType;
 import com.suse.oval.ovaltypes.OperationEnumeration;
 import com.suse.oval.ovaltypes.OvalRootType;
 import com.suse.oval.ovaltypes.StateType;
+import com.suse.oval.ovaltypes.TestType;
 import com.suse.oval.ovaltypes.VersionType;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
+import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.Attribute;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 
@@ -45,6 +51,7 @@ import java.util.ArrayList;
  * The Oval Parser is responsible for parsing OVAL(Open Vulnerability and Assessment Language) documents
  */
 public class OvalParser {
+    private static final Logger LOG = LogManager.getLogger(OvalParser.class);
 
     /**
      * Parse the given OVAL file
@@ -96,14 +103,91 @@ public class OvalParser {
                     else if (elementName.equals("states")) {
                         ovalRoot.setStates(parseStates(reader));
                     }
+                    else if (elementName.equals("tests")) {
+                        ovalRoot.setTests(parseTests(reader));
+                    }
                 }
             }
 
             return ovalRoot;
 
-        } catch (XMLStreamException | FileNotFoundException e) {
+        }
+        catch (XMLStreamException | FileNotFoundException e) {
             throw new OvalParserException("Failed to parse the given OVAL file at: " + ovalFile.getAbsolutePath(), e);
         }
+    }
+
+    private List<TestType> parseTests(XMLEventReader reader) throws XMLStreamException {
+        List<TestType> tests = new ArrayList<>();
+
+        while (reader.hasNext()) {
+            XMLEvent nextEvent = reader.nextEvent();
+
+            if (nextEvent.isStartElement()) {
+                if (nextEvent.asStartElement().getName().getLocalPart().equals("rpminfo_test")) {
+                    TestType testType = parseTestType(nextEvent.asStartElement(), reader);
+                    tests.add(testType);
+                }
+            }
+
+            if (nextEvent.isEndElement()) {
+                if (nextEvent.asEndElement().getName().getLocalPart().equals("tests")) {
+                    return tests;
+                }
+            }
+        }
+
+        throw new OvalParserException("Unable to find the closing tag for </tests>");
+    }
+
+    private TestType parseTestType(StartElement testElement, XMLEventReader reader) throws XMLStreamException {
+        TestType testType = new TestType();
+
+        testElement.getAttributes().forEachRemaining(attribute -> {
+            String attributeName = attribute.getName().getLocalPart();
+
+            switch (attributeName) {
+                case "id":
+                    testType.setId(attribute.getValue());
+                    break;
+                case "comment":
+                    testType.setComment(attribute.getValue());
+                    break;
+            }
+        });
+
+        while (reader.hasNext()) {
+            XMLEvent nextEvent = reader.nextEvent();
+
+            if (nextEvent.isStartElement()) {
+                if (nextEvent.asStartElement().getName().getLocalPart().equals("object")) {
+                    Attribute objectRefAttribute = nextEvent.asStartElement().getAttributeByName(
+                            new QName("object_ref"));
+                    if (objectRefAttribute != null) {
+                        testType.setObjectRef(objectRefAttribute.getValue());
+                    } else {
+                        LOG.warn("objectRef property was not found");
+                    }
+                } else if (nextEvent.asStartElement().getName().getLocalPart().equals("state")) {
+                    Attribute stateRefAttribute = nextEvent.asStartElement().getAttributeByName(
+                            new QName("state_ref"));
+                    if (stateRefAttribute != null) {
+                        testType.setStateRef(stateRefAttribute.getValue());
+                    }
+                    else {
+                        LOG.warn("stateRef property was not found");
+                    }
+                }
+            }
+
+            if (nextEvent.isEndElement()) {
+                if (nextEvent.asEndElement().getName().getLocalPart().equals("rpminfo_test")) {
+                    return testType;
+                }
+            }
+        }
+
+        throw new OvalParserException("Unable to find the closing tag for </rpminfo_test>");
     }
 
     private List<StateType> parseStates(XMLEventReader reader) throws XMLStreamException {
@@ -141,6 +225,8 @@ public class OvalParser {
                     break;
                 case "comment":
                     stateType.setComment(attribute.getValue());
+                    break;
+                default:
                     break;
             }
         });
@@ -254,6 +340,8 @@ public class OvalParser {
                     break;
                 case "comment":
                     objectType.setComment(attribute.getValue());
+                    break;
+                default:
                     break;
             }
         });

--- a/java/core/src/main/java/com/suse/oval/exceptions/OvalParserException.java
+++ b/java/core/src/main/java/com/suse/oval/exceptions/OvalParserException.java
@@ -23,6 +23,15 @@ import com.suse.oval.parser.OvalParser;
 public class OvalParserException extends RuntimeException {
 
     /**
+     * Constructs a new parser exception with the specified cause.
+     *
+     * @param exception the cause (which is saved for later retrieval by the getCause() method).
+     * */
+    public OvalParserException(Exception exception) {
+        super(exception);
+    }
+
+    /**
      * Constructs a new parser exception with the specified detail message.
      *
      * @param message the detail message. The detail message is saved for later retrieval by the getMessage() method.

--- a/java/core/src/main/java/com/suse/oval/exceptions/OvalParserException.java
+++ b/java/core/src/main/java/com/suse/oval/exceptions/OvalParserException.java
@@ -15,8 +15,10 @@
 
 package com.suse.oval.exceptions;
 
+import com.suse.oval.parser.OvalParser;
+
 /**
- * A runtime exception thrown by {@link com.suse.oval.OvalParser} when it encounters errors while parsing an OVAL file.
+ * A runtime exception thrown by {@link OvalParser} when it encounters errors while parsing an OVAL file.
  * */
 public class OvalParserException extends RuntimeException {
 

--- a/java/core/src/main/java/com/suse/oval/manager/OVALResourcesCache.java
+++ b/java/core/src/main/java/com/suse/oval/manager/OVALResourcesCache.java
@@ -15,7 +15,6 @@
 
 package com.suse.oval.manager;
 
-import com.suse.oval.parser.OVALResourcesResult;
 import com.suse.oval.ovaltypes.ObjectType;
 import com.suse.oval.ovaltypes.OvalRootType;
 import com.suse.oval.ovaltypes.StateType;
@@ -41,12 +40,6 @@ public class OVALResourcesCache {
         this.stateManager = new OvalStateManager(rootType.getStates());
         this.testManager = new OvalTestManager(rootType.getTests());
         this.objectManager = new OvalObjectManager(rootType.getObjects());
-    }
-
-    public OVALResourcesCache(OVALResourcesResult resourcesResult) {
-        this.stateManager = new OvalStateManager(resourcesResult.getStates());
-        this.testManager = new OvalTestManager(resourcesResult.getTests());
-        this.objectManager = new OvalObjectManager(resourcesResult.getObjects());
     }
 
     /**

--- a/java/core/src/main/java/com/suse/oval/manager/OVALResourcesCache.java
+++ b/java/core/src/main/java/com/suse/oval/manager/OVALResourcesCache.java
@@ -15,6 +15,7 @@
 
 package com.suse.oval.manager;
 
+import com.suse.oval.parser.OVALResourcesResult;
 import com.suse.oval.ovaltypes.ObjectType;
 import com.suse.oval.ovaltypes.OvalRootType;
 import com.suse.oval.ovaltypes.StateType;
@@ -26,7 +27,7 @@ import java.util.Optional;
  * A cache for OVAL resources (objects, states and tests) to be able to efficiently look up OVAL resources
  * by their id.
  * */
-public class OVALLookupHelper {
+public class OVALResourcesCache {
     private final OvalStateManager stateManager;
     private final OvalTestManager testManager;
     private final OvalObjectManager objectManager;
@@ -36,10 +37,16 @@ public class OVALLookupHelper {
      *
      * @param rootType the root to get OVAL resources from
      */
-    public OVALLookupHelper(OvalRootType rootType) {
+    public OVALResourcesCache(OvalRootType rootType) {
         this.stateManager = new OvalStateManager(rootType.getStates());
         this.testManager = new OvalTestManager(rootType.getTests());
         this.objectManager = new OvalObjectManager(rootType.getObjects());
+    }
+
+    public OVALResourcesCache(OVALResourcesResult resourcesResult) {
+        this.stateManager = new OvalStateManager(resourcesResult.getStates());
+        this.testManager = new OvalTestManager(resourcesResult.getTests());
+        this.objectManager = new OvalObjectManager(resourcesResult.getObjects());
     }
 
     /**

--- a/java/core/src/main/java/com/suse/oval/ovaltypes/Advisory.java
+++ b/java/core/src/main/java/com/suse/oval/ovaltypes/Advisory.java
@@ -35,9 +35,14 @@ public class Advisory {
 
     @XmlElement(name = "affected", namespace = "http://oval.mitre.org/XMLSchema/oval-definitions-5")
     private AdvisoryAffectedType affected;
-
-    public void setAffectedCpeList(AffectedCpeList affectedCpeListIn) {
-        this.affectedCpeList = affectedCpeListIn;
+    /**
+     * Sets the list of affected CPEs.
+     *
+     * @param affectedCpeListIn the list of affected CPEs
+     * */
+    public void setAffectedCpeList(List<String> affectedCpeListIn) {
+        this.affectedCpeList = new AffectedCpeList();
+        this.affectedCpeList.setCpeList(affectedCpeListIn);
     }
 
     public List<String> getAffectedCpeList() {

--- a/java/core/src/main/java/com/suse/oval/ovaltypes/CriteriaType.java
+++ b/java/core/src/main/java/com/suse/oval/ovaltypes/CriteriaType.java
@@ -66,6 +66,15 @@ public class CriteriaType implements BaseCriteria {
     }
 
     /**
+     * Sets the contained criteria or criterion objects
+     *
+     * @param childrenIn the list of children {@link BaseCriteria}.
+     * */
+    public void setChildren(List<BaseCriteria> childrenIn) {
+        this.children = childrenIn;
+    }
+
+    /**
      * Gets the value of the operator property.
      *
      * @return the operator property or {@link LogicOperatorType#AND} if none is specified

--- a/java/core/src/main/java/com/suse/oval/ovaltypes/CriteriaType.java
+++ b/java/core/src/main/java/com/suse/oval/ovaltypes/CriteriaType.java
@@ -137,4 +137,14 @@ public class CriteriaType implements BaseCriteria {
     public void setComment(String value) {
         this.comment = value;
     }
+
+    @Override
+    public String toString() {
+        return "CriteriaType{" +
+               "children=" + children +
+               ", operator=" + operator +
+               ", negate=" + negate +
+               ", comment='" + comment + '\'' +
+               '}';
+    }
 }

--- a/java/core/src/main/java/com/suse/oval/ovaltypes/CriterionType.java
+++ b/java/core/src/main/java/com/suse/oval/ovaltypes/CriterionType.java
@@ -93,4 +93,13 @@ public class CriterionType implements BaseCriteria {
     public void setComment(String value) {
         this.comment = value;
     }
+
+    @Override
+    public String toString() {
+        return "CriterionType{" +
+               "testRef='" + testRef + '\'' +
+               ", negate=" + negate +
+               ", comment='" + comment + '\'' +
+               '}';
+    }
 }

--- a/java/core/src/main/java/com/suse/oval/ovaltypes/EVRType.java
+++ b/java/core/src/main/java/com/suse/oval/ovaltypes/EVRType.java
@@ -30,8 +30,6 @@ import jakarta.xml.bind.annotation.XmlValue;
 public class EVRType {
     @XmlValue
     private String value;
-    @XmlAttribute(name = "datatype")
-    private EVRDataTypeEnum datatype;
     @XmlAttribute(name = "operation", required = true)
     private OperationEnumeration operation;
 
@@ -41,14 +39,6 @@ public class EVRType {
 
     public void setValue(String valueIn) {
         this.value = valueIn;
-    }
-
-    public EVRDataTypeEnum getDatatype() {
-        return datatype;
-    }
-
-    public void setDatatype(EVRDataTypeEnum datatypeIn) {
-        this.datatype = datatypeIn;
     }
 
     public OperationEnumeration getOperation() {

--- a/java/core/src/main/java/com/suse/oval/ovaltypes/TestType.java
+++ b/java/core/src/main/java/com/suse/oval/ovaltypes/TestType.java
@@ -15,6 +15,7 @@
 
 package com.suse.oval.ovaltypes;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -147,6 +148,9 @@ public class TestType {
      * @param valueIn the state id to set
      * */
     public void setStateRef(String valueIn) {
+        if (states == null) {
+            states = new ArrayList<>();
+        }
         states.clear();
         StateRefType stateRef = new StateRefType();
         stateRef.setStateRef(valueIn);

--- a/java/core/src/main/java/com/suse/oval/parser/OVALDefinitionsBulkHandler.java
+++ b/java/core/src/main/java/com/suse/oval/parser/OVALDefinitionsBulkHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 SUSE LLC
+ * Copyright (c) 2024 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/java/core/src/main/java/com/suse/oval/parser/OVALDefinitionsBulkHandler.java
+++ b/java/core/src/main/java/com/suse/oval/parser/OVALDefinitionsBulkHandler.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.oval.parser;
+
+import com.suse.oval.ovaltypes.DefinitionType;
+
+import java.util.List;
+
+/**
+ * A handler class to apply an operation (.e.g. write them to database), on every bulk/list of parsed OVAL definitions.
+ * */
+@FunctionalInterface
+public interface OVALDefinitionsBulkHandler {
+    /**
+     * Handles the given bulk/list of OVAL definitions.
+     *
+     * @param bulk list of OVAL definitions.
+     * */
+    void handle(List<DefinitionType> bulk);
+}

--- a/java/core/src/main/java/com/suse/oval/parser/OVALResources.java
+++ b/java/core/src/main/java/com/suse/oval/parser/OVALResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 SUSE LLC
+ * Copyright (c) 2024 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/java/core/src/main/java/com/suse/oval/parser/OVALResources.java
+++ b/java/core/src/main/java/com/suse/oval/parser/OVALResources.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.oval.parser;
+
+import com.suse.oval.ovaltypes.ObjectType;
+import com.suse.oval.ovaltypes.StateType;
+import com.suse.oval.ovaltypes.TestType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class OVALResources {
+    private List<ObjectType> objects = new ArrayList<>();
+    private List<StateType> states = new ArrayList<>();
+    private List<TestType> tests = new ArrayList<>();
+
+    public List<ObjectType> getObjects() {
+        return objects;
+    }
+
+    public List<StateType> getStates() {
+        return states;
+    }
+
+    public List<TestType> getTests() {
+        return tests;
+    }
+
+    public void setObjects(List<ObjectType> objectsIn) {
+        this.objects = objectsIn;
+    }
+
+    public void setStates(List<StateType> statesIn) {
+        this.states = statesIn;
+    }
+
+    public void setTests(List<TestType> testsIn) {
+        this.tests = testsIn;
+    }
+}

--- a/java/core/src/main/java/com/suse/oval/parser/OvalParser.java
+++ b/java/core/src/main/java/com/suse/oval/parser/OvalParser.java
@@ -50,6 +50,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -81,18 +82,28 @@ public class OvalParser {
     /**
      * Parse the given OVAL file
      *
-     * @param ovalFile the OVAL file to parse
-     * @return the parsed OVAL encapulated in a {@link OvalRootType} object=
+     * @param ovalFileURL the OVAL file to parse
+     * @return the parsed OVAL encapsulated in an {@link OvalRootType} object.
      * */
-    public OvalRootType parse(URL ovalFile) throws OvalParserException {
+    public OvalRootType parse(URL ovalFileURL) throws OvalParserException {
+        File ovalFile;
         try {
-            JAXBContext jaxbContext = JAXBContext.newInstance(OvalRootType.class);
-            Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
-            return (OvalRootType) unmarshaller.unmarshal(ovalFile);
+            ovalFile = new File(ovalFileURL.toURI());
         }
-        catch (JAXBException e) {
-            throw new OvalParserException("Failed to parse the given OVAL file at: " + ovalFile, e);
+        catch (URISyntaxException e) {
+            throw new OvalParserException("Bad OVAL file path: " + ovalFileURL, e);
         }
+
+        List<DefinitionType> allDefinitions = parseAllDefinitions(ovalFile);
+        OVALResources ovalResources = parseResources(ovalFile);
+
+        OvalRootType ovalRootType = new OvalRootType();
+        ovalRootType.setDefinitions(allDefinitions);
+        ovalRootType.setObjects(ovalResources.getObjects());
+        ovalRootType.setStates(ovalResources.getStates());
+        ovalRootType.setTests(ovalResources.getTests());
+
+        return ovalRootType;
     }
 
     /**
@@ -105,6 +116,8 @@ public class OvalParser {
         XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
         try {
             XMLEventReader reader = xmlInputFactory.createXMLEventReader(new FileInputStream(ovalFile));
+            // Disable external entities processing as a protection measure against XXE.
+            xmlInputFactory.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
 
             List<DefinitionType> definitions = new ArrayList<>();
 
@@ -128,8 +141,8 @@ public class OvalParser {
                     if (nextEvent.asEndElement().getName().getLocalPart().equals("definitions")) {
                         if (!definitions.isEmpty()) {
                             bulkHandler.handle(definitions);
-                            definitions = new ArrayList<>();
                         }
+                        break;
                     }
                 }
             }
@@ -160,6 +173,9 @@ public class OvalParser {
      * */
     public OVALResources parseResources(File ovalFile) {
         XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+        // Disable external entities processing as a protection measure against XXE.
+        xmlInputFactory.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
+
         try {
             XMLEventReader reader = xmlInputFactory.createXMLEventReader(new FileInputStream(ovalFile));
 

--- a/java/core/src/main/java/com/suse/oval/parser/OvalParser.java
+++ b/java/core/src/main/java/com/suse/oval/parser/OvalParser.java
@@ -46,6 +46,9 @@ import com.suse.oval.ovaltypes.linux.RpminfoTest;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.codehaus.stax2.XMLEventReader2;
+import org.codehaus.stax2.XMLInputFactory2;
+import org.codehaus.stax2.evt.XMLEvent2;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -57,12 +60,9 @@ import java.util.List;
 import java.util.Objects;
 
 import javax.xml.namespace.QName;
-import javax.xml.stream.XMLEventReader;
-import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.Attribute;
 import javax.xml.stream.events.StartElement;
-import javax.xml.stream.events.XMLEvent;
 
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
@@ -113,19 +113,20 @@ public class OvalParser {
      * @param bulkHandler an operation to applied on every bulk of parsed OVAL definitions.
      * */
     public void parseDefinitionsInBulk(File ovalFile, OVALDefinitionsBulkHandler bulkHandler) {
-        XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+        XMLInputFactory2 xmlInputFactory = (XMLInputFactory2) XMLInputFactory2.newInstance();
         // Disable external entities processing as a protection measure against XXE.
         xmlInputFactory.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
 
         try {
-            XMLEventReader reader = xmlInputFactory.createXMLEventReader(new FileInputStream(ovalFile));
+            XMLEventReader2 reader =
+                (XMLEventReader2) xmlInputFactory.createXMLEventReader(new FileInputStream(ovalFile));
             // Disable external entities processing as a protection measure against XXE.
             xmlInputFactory.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
 
             List<DefinitionType> definitions = new ArrayList<>();
 
             while (reader.hasNext()) {
-                XMLEvent nextEvent = reader.nextEvent();
+                XMLEvent2 nextEvent = (XMLEvent2) reader.nextEvent();
 
                 if (nextEvent.isStartElement()) {
                     String elementName = nextEvent.asStartElement().getName().getLocalPart();
@@ -175,17 +176,18 @@ public class OvalParser {
      * @return an {@link OVALResources} object containing OVAL objects, states and tests.
      * */
     public OVALResources parseResources(File ovalFile) {
-        XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+        XMLInputFactory2 xmlInputFactory = (XMLInputFactory2) XMLInputFactory2.newInstance();
         // Disable external entities processing as a protection measure against XXE.
         xmlInputFactory.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
 
         try {
-            XMLEventReader reader = xmlInputFactory.createXMLEventReader(new FileInputStream(ovalFile));
+            XMLEventReader2 reader =
+                (XMLEventReader2) xmlInputFactory.createXMLEventReader(new FileInputStream(ovalFile));
 
             OVALResources resources = new OVALResources();
 
             while (reader.hasNext()) {
-                XMLEvent nextEvent = reader.nextEvent();
+                XMLEvent2 nextEvent = (XMLEvent2) reader.nextEvent();
 
                 if (nextEvent.isStartElement()) {
                     String elementName = nextEvent.asStartElement().getName().getLocalPart();
@@ -213,7 +215,7 @@ public class OvalParser {
         }
     }
 
-    private DefinitionType parseDefinitionType(StartElement definitionElement, XMLEventReader reader)
+    private DefinitionType parseDefinitionType(StartElement definitionElement, XMLEventReader2 reader)
             throws XMLStreamException {
         DefinitionType definitionType = new DefinitionType();
 
@@ -232,7 +234,7 @@ public class OvalParser {
         });
 
         while (reader.hasNext()) {
-            XMLEvent nextEvent = reader.nextEvent();
+            XMLEvent2 nextEvent = (XMLEvent2) reader.nextEvent();
 
             if (nextEvent.isStartElement()) {
                 if (nextEvent.asStartElement().getName().getLocalPart().equals("metadata")) {
@@ -253,7 +255,7 @@ public class OvalParser {
         throw new OvalParserException("Unable to find the closing tag for </definition>");
     }
 
-    private CriteriaType parseDefinitionCriteria(StartElement criteriaElement, XMLEventReader reader)
+    private CriteriaType parseDefinitionCriteria(StartElement criteriaElement, XMLEventReader2 reader)
             throws XMLStreamException {
         CriteriaType criteriaType = new CriteriaType();
 
@@ -276,7 +278,7 @@ public class OvalParser {
 
         List<BaseCriteria> children = new ArrayList<>();
         while (reader.hasNext()) {
-            XMLEvent nextEvent = reader.nextEvent();
+            XMLEvent2 nextEvent = (XMLEvent2) reader.nextEvent();
             if (nextEvent.isStartElement()) {
                 if (nextEvent.asStartElement().getName().getLocalPart().equals("criterion")) {
                     children.add(parseDefinitionCriterion(nextEvent.asStartElement()));
@@ -317,10 +319,10 @@ public class OvalParser {
         return criterionType;
     }
 
-    private MetadataType parseDefinitionMetadata(XMLEventReader reader) throws XMLStreamException {
+    private MetadataType parseDefinitionMetadata(XMLEventReader2 reader) throws XMLStreamException {
         MetadataType metadataType = new MetadataType();
         while (reader.hasNext()) {
-            XMLEvent nextEvent = reader.nextEvent();
+            XMLEvent2 nextEvent = (XMLEvent2) reader.nextEvent();
 
             if (nextEvent.isStartElement()) {
                 if (nextEvent.asStartElement().getName().getLocalPart().equals("title")) {
@@ -344,13 +346,13 @@ public class OvalParser {
         throw new OvalParserException("Unable to find the closing tag for </metadata>");
     }
 
-    private Advisory parseAdvisory(XMLEventReader reader) throws XMLStreamException {
+    private Advisory parseAdvisory(XMLEventReader2 reader) throws XMLStreamException {
         Advisory advisory = new Advisory();
 
         List<AdvisoryCveType> cveList = new ArrayList<>();
 
         while (reader.hasNext()) {
-            XMLEvent nextEvent = reader.nextEvent();
+            XMLEvent2 nextEvent = (XMLEvent2) reader.nextEvent();
 
             if (nextEvent.isStartElement()) {
                 if (nextEvent.asStartElement().getName().getLocalPart().equals("affected_cpe_list")) {
@@ -375,11 +377,11 @@ public class OvalParser {
         throw new OvalParserException("Unable to find the closing tag for </advisory>");
     }
 
-    private AdvisoryAffectedType parseAdvisoryAffectedType(XMLEventReader reader) throws XMLStreamException {
+    private AdvisoryAffectedType parseAdvisoryAffectedType(XMLEventReader2 reader) throws XMLStreamException {
         AdvisoryAffectedType advisoryAffectedType = new AdvisoryAffectedType();
 
         while (reader.hasNext()) {
-            XMLEvent nextEvent = reader.nextEvent();
+            XMLEvent2 nextEvent = (XMLEvent2) reader.nextEvent();
 
             if (nextEvent.isStartElement()) {
                 if (nextEvent.asStartElement().getName().getLocalPart().equals("resolution")) {
@@ -397,7 +399,7 @@ public class OvalParser {
         throw new OvalParserException("Unable to find the closing tag for </affected>");
     }
 
-    private AdvisoryResolutionType parseAdvisoryResolutionType(StartElement resolutionElement, XMLEventReader reader)
+    private AdvisoryResolutionType parseAdvisoryResolutionType(StartElement resolutionElement, XMLEventReader2 reader)
             throws XMLStreamException {
         AdvisoryResolutionType advisoryResolutionType = new AdvisoryResolutionType();
 
@@ -409,7 +411,7 @@ public class OvalParser {
         List<String> affectedComponents = new ArrayList<>();
 
         while (reader.hasNext()) {
-            XMLEvent nextEvent = reader.nextEvent();
+            XMLEvent2 nextEvent = (XMLEvent2) reader.nextEvent();
 
             if (nextEvent.isStartElement()) {
                 if (nextEvent.asStartElement().getName().getLocalPart().equals("component")) {
@@ -428,7 +430,7 @@ public class OvalParser {
         throw new OvalParserException("Unable to find the closing tag for </resolution>");
     }
 
-    private AdvisoryCveType parseAdvisoryCve(XMLEventReader reader) throws XMLStreamException {
+    private AdvisoryCveType parseAdvisoryCve(XMLEventReader2 reader) throws XMLStreamException {
         AdvisoryCveType cveType = new AdvisoryCveType();
 
         cveType.setCve(reader.getElementText());
@@ -436,11 +438,11 @@ public class OvalParser {
         return cveType;
     }
 
-    private List<String> parseAffectedCpeList(XMLEventReader reader) throws XMLStreamException {
+    private List<String> parseAffectedCpeList(XMLEventReader2 reader) throws XMLStreamException {
         List<String> cpes = new ArrayList<>();
 
         while (reader.hasNext()) {
-            XMLEvent nextEvent = reader.nextEvent();
+            XMLEvent2 nextEvent = (XMLEvent2) reader.nextEvent();
 
             if (nextEvent.isStartElement()) {
                 if (nextEvent.asStartElement().getName().getLocalPart().equals("cpe")) {
@@ -458,11 +460,11 @@ public class OvalParser {
         throw new OvalParserException("Unable to find the closing tag for </affected_cpe_list>");
     }
 
-    private List<TestType> parseTests(XMLEventReader reader) throws XMLStreamException {
+    private List<TestType> parseTests(XMLEventReader2 reader) throws XMLStreamException {
         List<TestType> tests = new ArrayList<>();
 
         while (reader.hasNext()) {
-            XMLEvent nextEvent = reader.nextEvent();
+            XMLEvent2 nextEvent = (XMLEvent2) reader.nextEvent();
 
             if (nextEvent.isStartElement()) {
                 String element = nextEvent.asStartElement().getName().getLocalPart();
@@ -484,7 +486,7 @@ public class OvalParser {
         throw new OvalParserException("Unable to find the closing tag for </tests>");
     }
 
-    private TestType parseTestType(StartElement testElement, XMLEventReader reader, PackageType packageType)
+    private TestType parseTestType(StartElement testElement, XMLEventReader2 reader, PackageType packageType)
             throws XMLStreamException {
 
         Objects.requireNonNull(packageType);
@@ -511,7 +513,7 @@ public class OvalParser {
         });
 
         while (reader.hasNext()) {
-            XMLEvent nextEvent = reader.nextEvent();
+            XMLEvent2 nextEvent = (XMLEvent2) reader.nextEvent();
 
             if (nextEvent.isStartElement()) {
                 if (nextEvent.asStartElement().getName().getLocalPart().equals("object")) {
@@ -547,11 +549,11 @@ public class OvalParser {
         throw new OvalParserException("Unable to find the closing tag for test type");
     }
 
-    private List<StateType> parseStates(XMLEventReader reader) throws XMLStreamException {
+    private List<StateType> parseStates(XMLEventReader2 reader) throws XMLStreamException {
         List<StateType> states = new ArrayList<>();
 
         while (reader.hasNext()) {
-            XMLEvent nextEvent = reader.nextEvent();
+            XMLEvent2 nextEvent = (XMLEvent2) reader.nextEvent();
 
             if (nextEvent.isStartElement()) {
                 String element = nextEvent.asStartElement().getName().getLocalPart();
@@ -573,7 +575,7 @@ public class OvalParser {
         throw new OvalParserException("Unable to find the closing tag for </states>");
     }
 
-    private StateType parseStateType(StartElement rpmStateElement, XMLEventReader reader, PackageType packageType)
+    private StateType parseStateType(StartElement rpmStateElement, XMLEventReader2 reader, PackageType packageType)
             throws XMLStreamException {
         Objects.requireNonNull(packageType);
         StateType stateType;
@@ -599,7 +601,7 @@ public class OvalParser {
         });
 
         while (reader.hasNext()) {
-            XMLEvent nextEvent = reader.nextEvent();
+            XMLEvent2 nextEvent = (XMLEvent2) reader.nextEvent();
             if (nextEvent.isStartElement()) {
                 String elementName = nextEvent.asStartElement().getName().getLocalPart();
                 if (elementName.equals("arch")) {
@@ -624,7 +626,7 @@ public class OvalParser {
         throw new OvalParserException("Unable to find the closing tag for state type");
     }
 
-    private ArchType parseArchStateEntity(StartElement archElement, XMLEventReader reader) throws XMLStreamException {
+    private ArchType parseArchStateEntity(StartElement archElement, XMLEventReader2 reader) throws XMLStreamException {
         ArchType archType = new ArchType();
 
         archElement.getAttributes().forEachRemaining(attribute -> {
@@ -640,7 +642,7 @@ public class OvalParser {
         return archType;
     }
 
-    private EVRType parseEVRStateEntity(StartElement evrElement, XMLEventReader reader) throws XMLStreamException {
+    private EVRType parseEVRStateEntity(StartElement evrElement, XMLEventReader2 reader) throws XMLStreamException {
         EVRType evrType = new EVRType();
 
         evrElement.getAttributes().forEachRemaining(attribute -> {
@@ -655,7 +657,7 @@ public class OvalParser {
         return evrType;
     }
 
-    private VersionType parseVersionStateEntity(StartElement versionElement, XMLEventReader reader)
+    private VersionType parseVersionStateEntity(StartElement versionElement, XMLEventReader2 reader)
             throws XMLStreamException {
         VersionType versionType = new VersionType();
 
@@ -672,11 +674,11 @@ public class OvalParser {
         return versionType;
     }
 
-    private List<ObjectType> parseObjects(XMLEventReader reader) throws XMLStreamException {
+    private List<ObjectType> parseObjects(XMLEventReader2 reader) throws XMLStreamException {
         List<ObjectType> objects = new ArrayList<>();
 
         while (reader.hasNext()) {
-            XMLEvent nextEvent = reader.nextEvent();
+            XMLEvent2 nextEvent = (XMLEvent2) reader.nextEvent();
 
             if (nextEvent.isStartElement()) {
                 String element = nextEvent.asStartElement().getName().getLocalPart();
@@ -698,7 +700,7 @@ public class OvalParser {
         throw new OvalParserException("Unable to find the closing tag for </objects>");
     }
 
-    private ObjectType parseObjectType(StartElement rpmObjectElement, XMLEventReader reader, PackageType packageType)
+    private ObjectType parseObjectType(StartElement rpmObjectElement, XMLEventReader2 reader, PackageType packageType)
             throws XMLStreamException {
         Objects.requireNonNull(packageType);
         ObjectType objectType;
@@ -725,7 +727,7 @@ public class OvalParser {
         });
 
         while (reader.hasNext()) {
-            XMLEvent nextEvent = reader.nextEvent();
+            XMLEvent2 nextEvent = (XMLEvent2) reader.nextEvent();
             if (nextEvent.isStartElement()) {
                 if (nextEvent.asStartElement().getName().getLocalPart().equals("name")) {
                     objectType.setPackageName(reader.getElementText());

--- a/java/core/src/main/java/com/suse/oval/parser/OvalParser.java
+++ b/java/core/src/main/java/com/suse/oval/parser/OvalParser.java
@@ -13,9 +13,10 @@
  * in this software or its documentation.
  */
 
-package com.suse.oval;
+package com.suse.oval.parser;
 
 import com.redhat.rhn.domain.rhnpackage.PackageType;
+
 import com.suse.oval.exceptions.OvalParserException;
 import com.suse.oval.ovaltypes.Advisory;
 import com.suse.oval.ovaltypes.AdvisoryAffectedType;
@@ -46,9 +47,14 @@ import com.suse.oval.ovaltypes.linux.RpminfoTest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.JAXBException;
-import jakarta.xml.bind.Unmarshaller;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
@@ -57,19 +63,16 @@ import javax.xml.stream.events.Attribute;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Objects;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 
 /**
  * The Oval Parser is responsible for parsing OVAL(Open Vulnerability and Assessment Language) documents
  */
 public class OvalParser {
+    public static final int DEFINITIONS_BULK_SIZE = 500;
+
     private static final Logger LOG = LogManager.getLogger(OvalParser.class);
     private static final List<String> TEST_TYPES = List.of("rpminfo_test", "dpkginfo_test");
     private static final List<String> OBJECT_TYPES = List.of("rpminfo_object", "dpkginfo_object");
@@ -81,38 +84,86 @@ public class OvalParser {
      * @param ovalFile the OVAL file to parse
      * @return the parsed OVAL encapulated in a {@link OvalRootType} object=
      * */
-    public OvalRootType parse(File ovalFile) throws OvalParserException {
+    public OvalRootType parse(URL ovalFile) throws OvalParserException {
         try {
             JAXBContext jaxbContext = JAXBContext.newInstance(OvalRootType.class);
             Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
             return (OvalRootType) unmarshaller.unmarshal(ovalFile);
         }
         catch (JAXBException e) {
-            throw new OvalParserException("Failed to parse the given OVAL file at: " + ovalFile.getAbsolutePath(), e);
+            throw new OvalParserException("Failed to parse the given OVAL file at: " + ovalFile, e);
         }
     }
 
     /**
-     * Parse the given OVAL file from a URL
+     * Parses the given OVAL file in bulks. For every bulk parsed, it calls {@link OVALDefinitionsBulkHandler#handle}.
      *
-     * @param url the URL to get the OVAL file from
-     * @return the parsed OVAL encapsulated in a {@link OvalRootType} object
+     * @param ovalFile an XML file containing OVAL definitions to be parsed.
+     * @param bulkHandler an operation to applied on every bulk of parsed OVAL definitions.
      * */
-    public OvalRootType parse(URL url) {
-        try {
-            return parseStax(new File(url.toURI()));
-        }
-        catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public OvalRootType parseStax(File ovalFile) {
+    public void parseDefinitionsInBulk(File ovalFile, OVALDefinitionsBulkHandler bulkHandler) {
         XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
         try {
             XMLEventReader reader = xmlInputFactory.createXMLEventReader(new FileInputStream(ovalFile));
 
-            OvalRootType ovalRoot = new OvalRootType();
+            List<DefinitionType> definitions = new ArrayList<>();
+
+            while (reader.hasNext()) {
+                XMLEvent nextEvent = reader.nextEvent();
+
+                if (nextEvent.isStartElement()) {
+                    String elementName = nextEvent.asStartElement().getName().getLocalPart();
+                    if (elementName.equals("definition")) {
+                        DefinitionType definitionType = parseDefinitionType(nextEvent.asStartElement(), reader);
+                        definitions.add(definitionType);
+
+                        if (definitions.size() == DEFINITIONS_BULK_SIZE) {
+                            bulkHandler.handle(definitions);
+                            definitions = new ArrayList<>();
+                        }
+                    }
+                }
+
+                if (nextEvent.isEndElement()) {
+                    if (nextEvent.asEndElement().getName().getLocalPart().equals("definitions")) {
+                        if (!definitions.isEmpty()) {
+                            bulkHandler.handle(definitions);
+                            definitions = new ArrayList<>();
+                        }
+                    }
+                }
+            }
+        }
+        catch (XMLStreamException | FileNotFoundException e) {
+            throw new OvalParserException("Failed to parse OVAL definitions from OVAL file at: " +
+                    ovalFile.getAbsolutePath(), e);
+        }
+    }
+    /**
+     * Utility method to parse all OVAL definitions at once instead of in bulks. To be used in testing.
+     *
+     * @param ovalFile an XML file containing OVAL definitions to be parsed.
+     * @return all OVAL definitions in {@code ovalFile}
+     * */
+    public List<DefinitionType> parseAllDefinitions(File ovalFile) {
+        List<DefinitionType> allDefinitions = new ArrayList<>();
+
+        parseDefinitionsInBulk(ovalFile, allDefinitions::addAll);
+
+        return allDefinitions;
+    }
+    /**
+     * Parses the list of objects, states and tests from the given {@code ovalFile}.
+     *
+     * @param ovalFile an XML file containing OVAL definitions to be parsed.
+     * @return an {@link OVALResources} object containing OVAL objects, states and tests.
+     * */
+    public OVALResources parseResources(File ovalFile) {
+        XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+        try {
+            XMLEventReader reader = xmlInputFactory.createXMLEventReader(new FileInputStream(ovalFile));
+
+            OVALResources resources = new OVALResources();
 
             while (reader.hasNext()) {
                 XMLEvent nextEvent = reader.nextEvent();
@@ -121,52 +172,26 @@ public class OvalParser {
                     String elementName = nextEvent.asStartElement().getName().getLocalPart();
                     switch (elementName) {
                         case "objects":
-                            ovalRoot.setObjects(parseObjects(reader));
+                            resources.setObjects(parseObjects(reader));
                             break;
                         case "states":
-                            ovalRoot.setStates(parseStates(reader));
+                            resources.setStates(parseStates(reader));
                             break;
                         case "tests":
-                            ovalRoot.setTests(parseTests(reader));
-                            break;
-                        case "definitions":
-                            ovalRoot.setDefinitions(parseDefinitions(reader));
+                            resources.setTests(parseTests(reader));
                             break;
                         default: // Do nothing
                     }
                 }
             }
 
-            return ovalRoot;
-
+            return resources;
         }
         catch (XMLStreamException | FileNotFoundException e) {
-            throw new OvalParserException("Failed to parse the given OVAL file at: " + ovalFile.getAbsolutePath(), e);
+            throw new OvalParserException(
+                    "Failed to parse the OVAL resources(tests, states and objects) from OVAL file at: " +
+                            ovalFile.getAbsolutePath(), e);
         }
-    }
-
-    private List<DefinitionType> parseDefinitions(XMLEventReader reader) throws XMLStreamException {
-        List<DefinitionType> definitions = new ArrayList<>();
-
-        while (reader.hasNext()) {
-            XMLEvent nextEvent = reader.nextEvent();
-
-            if (nextEvent.isStartElement()) {
-                if (nextEvent.asStartElement().getName().getLocalPart().equals("definition")) {
-                    DefinitionType definitionType = parseDefinitionType(nextEvent.asStartElement(), reader);
-                    definitions.add(definitionType);
-                }
-            }
-
-            if (nextEvent.isEndElement()) {
-                if (nextEvent.asEndElement().getName().getLocalPart().equals("definitions")) {
-                    return definitions;
-                }
-            }
-        }
-
-        throw new OvalParserException("Unable to find the closing tag for </definitions>");
-
     }
 
     private DefinitionType parseDefinitionType(StartElement definitionElement, XMLEventReader reader)
@@ -425,7 +450,7 @@ public class OvalParser {
                 if (element.equals("rpminfo_test")) {
                     tests.add(parseTestType(nextEvent.asStartElement(), reader, PackageType.RPM));
                 }
-                else if(element.equals("dpkginfo_test_test")) {
+                else if (element.equals("dpkginfo_test_test")) {
                     tests.add(parseTestType(nextEvent.asStartElement(), reader, PackageType.DEB));
                 }
             }
@@ -462,6 +487,7 @@ public class OvalParser {
                 case "comment":
                     testType.setComment(attribute.getValue());
                     break;
+                default:
             }
         });
 
@@ -541,7 +567,6 @@ public class OvalParser {
 
         rpmStateElement.getAttributes().forEachRemaining(attribute -> {
             String attributeName = attribute.getName().getLocalPart();
-
             switch (attributeName) {
                 case "id":
                     stateType.setId(attribute.getValue());
@@ -660,7 +685,8 @@ public class OvalParser {
         ObjectType objectType;
         if (packageType == PackageType.DEB) {
             objectType = new DpkginfoObject();
-        } else {
+        }
+        else {
             objectType = new RpminfoObject();
         }
 
@@ -678,7 +704,6 @@ public class OvalParser {
                     break;
             }
         });
-
 
         while (reader.hasNext()) {
             XMLEvent nextEvent = reader.nextEvent();

--- a/java/core/src/main/java/com/suse/oval/parser/OvalParser.java
+++ b/java/core/src/main/java/com/suse/oval/parser/OvalParser.java
@@ -114,6 +114,9 @@ public class OvalParser {
      * */
     public void parseDefinitionsInBulk(File ovalFile, OVALDefinitionsBulkHandler bulkHandler) {
         XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+        // Disable external entities processing as a protection measure against XXE.
+        xmlInputFactory.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
+
         try {
             XMLEventReader reader = xmlInputFactory.createXMLEventReader(new FileInputStream(ovalFile));
             // Disable external entities processing as a protection measure against XXE.

--- a/java/core/src/main/java/com/suse/oval/parser/OvalParser.java
+++ b/java/core/src/main/java/com/suse/oval/parser/OvalParser.java
@@ -15,6 +15,7 @@
 
 package com.suse.oval.parser;
 
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.rhnpackage.PackageType;
 
 import com.suse.oval.exceptions.OvalParserException;
@@ -65,7 +66,6 @@ import javax.xml.stream.events.StartElement;
  * The Oval Parser is responsible for parsing OVAL(Open Vulnerability and Assessment Language) documents
  */
 public class OvalParser {
-    public static final int DEFINITIONS_BULK_SIZE = 500;
 
     private static final Logger LOG = LogManager.getLogger(OvalParser.class);
     private static final List<String> TEST_TYPES = List.of("rpminfo_test", "dpkginfo_test");
@@ -99,7 +99,7 @@ public class OvalParser {
                     DefinitionType definitionType = parseDefinitionType(nextEvent.asStartElement(), reader);
                     definitions.add(definitionType);
 
-                    if (definitions.size() == DEFINITIONS_BULK_SIZE) {
+                    if (definitions.size() == ConfigDefaults.get().getOvalDefinitionsBulkSize()) {
                         bulkHandler.handle(definitions);
                         definitions = new ArrayList<>();
                     }

--- a/java/core/src/main/java/com/suse/oval/parser/OvalParser.java
+++ b/java/core/src/main/java/com/suse/oval/parser/OvalParser.java
@@ -33,7 +33,6 @@ import com.suse.oval.ovaltypes.LogicOperatorType;
 import com.suse.oval.ovaltypes.MetadataType;
 import com.suse.oval.ovaltypes.ObjectType;
 import com.suse.oval.ovaltypes.OperationEnumeration;
-import com.suse.oval.ovaltypes.OvalRootType;
 import com.suse.oval.ovaltypes.StateType;
 import com.suse.oval.ovaltypes.TestType;
 import com.suse.oval.ovaltypes.VersionType;
@@ -52,8 +51,6 @@ import org.codehaus.stax2.evt.XMLEvent2;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -74,33 +71,6 @@ public class OvalParser {
     private static final List<String> TEST_TYPES = List.of("rpminfo_test", "dpkginfo_test");
     private static final List<String> OBJECT_TYPES = List.of("rpminfo_object", "dpkginfo_object");
     private static final List<String> STATE_TYPES = List.of("rpminfo_state", "dpkginfo_state");
-
-    /**
-     * Parse the given OVAL file
-     *
-     * @param ovalFileURL the OVAL file to parse
-     * @return the parsed OVAL encapsulated in an {@link OvalRootType} object.
-     * */
-    public OvalRootType parse(URL ovalFileURL) throws OvalParserException {
-        File ovalFile;
-        try {
-            ovalFile = new File(ovalFileURL.toURI());
-        }
-        catch (URISyntaxException e) {
-            throw new OvalParserException("Bad OVAL file path: " + ovalFileURL, e);
-        }
-
-        List<DefinitionType> allDefinitions = parseAllDefinitions(ovalFile);
-        OVALResources ovalResources = parseResources(ovalFile);
-
-        OvalRootType ovalRootType = new OvalRootType();
-        ovalRootType.setDefinitions(allDefinitions);
-        ovalRootType.setObjects(ovalResources.getObjects());
-        ovalRootType.setStates(ovalResources.getStates());
-        ovalRootType.setTests(ovalResources.getTests());
-
-        return ovalRootType;
-    }
 
     /**
      * Parses the given OVAL file in bulks. For every bulk parsed, it calls {@link OVALDefinitionsBulkHandler#handle}.
@@ -149,19 +119,7 @@ public class OvalParser {
                     ovalFile.getAbsolutePath(), e);
         }
     }
-    /**
-     * Utility method to parse all OVAL definitions at once instead of in bulks. To be used in testing.
-     *
-     * @param ovalFile an XML file containing OVAL definitions to be parsed.
-     * @return all OVAL definitions in {@code ovalFile}
-     * */
-    public List<DefinitionType> parseAllDefinitions(File ovalFile) {
-        List<DefinitionType> allDefinitions = new ArrayList<>();
 
-        parseDefinitionsInBulk(ovalFile, allDefinitions::addAll);
-
-        return allDefinitions;
-    }
     /**
      * Parses the list of objects, states and tests from the given {@code ovalFile}.
      *

--- a/java/core/src/main/java/com/suse/oval/parser/OvalParser.java
+++ b/java/core/src/main/java/com/suse/oval/parser/OvalParser.java
@@ -47,7 +47,6 @@ import com.suse.oval.ovaltypes.linux.RpminfoTest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codehaus.stax2.XMLEventReader2;
-import org.codehaus.stax2.XMLInputFactory2;
 import org.codehaus.stax2.evt.XMLEvent2;
 
 import java.io.File;
@@ -60,13 +59,10 @@ import java.util.List;
 import java.util.Objects;
 
 import javax.xml.namespace.QName;
+import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.Attribute;
 import javax.xml.stream.events.StartElement;
-
-import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.JAXBException;
-import jakarta.xml.bind.Unmarshaller;
 
 /**
  * The Oval Parser is responsible for parsing OVAL(Open Vulnerability and Assessment Language) documents
@@ -113,13 +109,13 @@ public class OvalParser {
      * @param bulkHandler an operation to applied on every bulk of parsed OVAL definitions.
      * */
     public void parseDefinitionsInBulk(File ovalFile, OVALDefinitionsBulkHandler bulkHandler) {
-        XMLInputFactory2 xmlInputFactory = (XMLInputFactory2) XMLInputFactory2.newInstance();
+        XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
         // Disable external entities processing as a protection measure against XXE.
         xmlInputFactory.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
 
         try {
             XMLEventReader2 reader =
-                (XMLEventReader2) xmlInputFactory.createXMLEventReader(new FileInputStream(ovalFile));
+                    (XMLEventReader2) xmlInputFactory.createXMLEventReader(new FileInputStream(ovalFile));
             // Disable external entities processing as a protection measure against XXE.
             xmlInputFactory.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
 
@@ -128,26 +124,23 @@ public class OvalParser {
             while (reader.hasNext()) {
                 XMLEvent2 nextEvent = (XMLEvent2) reader.nextEvent();
 
-                if (nextEvent.isStartElement()) {
-                    String elementName = nextEvent.asStartElement().getName().getLocalPart();
-                    if (elementName.equals("definition")) {
-                        DefinitionType definitionType = parseDefinitionType(nextEvent.asStartElement(), reader);
-                        definitions.add(definitionType);
+                if (nextEvent.isStartElement() &&
+                        nextEvent.asStartElement().getName().getLocalPart().equals("definition")) {
+                    DefinitionType definitionType = parseDefinitionType(nextEvent.asStartElement(), reader);
+                    definitions.add(definitionType);
 
-                        if (definitions.size() == DEFINITIONS_BULK_SIZE) {
-                            bulkHandler.handle(definitions);
-                            definitions = new ArrayList<>();
-                        }
+                    if (definitions.size() == DEFINITIONS_BULK_SIZE) {
+                        bulkHandler.handle(definitions);
+                        definitions = new ArrayList<>();
                     }
                 }
 
-                if (nextEvent.isEndElement()) {
-                    if (nextEvent.asEndElement().getName().getLocalPart().equals("definitions")) {
-                        if (!definitions.isEmpty()) {
-                            bulkHandler.handle(definitions);
-                        }
-                        break;
+                if (nextEvent.isEndElement() &&
+                        nextEvent.asEndElement().getName().getLocalPart().equals("definitions")) {
+                    if (!definitions.isEmpty()) {
+                        bulkHandler.handle(definitions);
                     }
+                    break;
                 }
             }
         }
@@ -176,13 +169,13 @@ public class OvalParser {
      * @return an {@link OVALResources} object containing OVAL objects, states and tests.
      * */
     public OVALResources parseResources(File ovalFile) {
-        XMLInputFactory2 xmlInputFactory = (XMLInputFactory2) XMLInputFactory2.newInstance();
+        XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
         // Disable external entities processing as a protection measure against XXE.
         xmlInputFactory.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
 
         try {
             XMLEventReader2 reader =
-                (XMLEventReader2) xmlInputFactory.createXMLEventReader(new FileInputStream(ovalFile));
+                    (XMLEventReader2) xmlInputFactory.createXMLEventReader(new FileInputStream(ovalFile));
 
             OVALResources resources = new OVALResources();
 
@@ -245,10 +238,8 @@ public class OvalParser {
                 }
             }
 
-            if (nextEvent.isEndElement()) {
-                if (nextEvent.asEndElement().getName().getLocalPart().equals("definition")) {
-                    return definitionType;
-                }
+            if (nextEvent.isEndElement() && nextEvent.asEndElement().getName().getLocalPart().equals("definition")) {
+                return definitionType;
             }
         }
 
@@ -288,11 +279,9 @@ public class OvalParser {
                 }
             }
 
-            if (nextEvent.isEndElement()) {
-                if (nextEvent.asEndElement().getName().getLocalPart().equals("criteria")) {
-                    criteriaType.setChildren(children);
-                    return criteriaType;
-                }
+            if (nextEvent.isEndElement() && nextEvent.asEndElement().getName().getLocalPart().equals("criteria")) {
+                criteriaType.setChildren(children);
+                return criteriaType;
             }
         }
 
@@ -336,10 +325,8 @@ public class OvalParser {
                 }
             }
 
-            if (nextEvent.isEndElement()) {
-                if (nextEvent.asEndElement().getName().getLocalPart().equals("metadata")) {
-                    return metadataType;
-                }
+            if (nextEvent.isEndElement() && nextEvent.asEndElement().getName().getLocalPart().equals("metadata")) {
+                return metadataType;
             }
         }
 
@@ -366,11 +353,9 @@ public class OvalParser {
                 }
             }
 
-            if (nextEvent.isEndElement()) {
-                if (nextEvent.asEndElement().getName().getLocalPart().equals("advisory")) {
-                    advisory.setCveList(cveList);
-                    return advisory;
-                }
+            if (nextEvent.isEndElement() && nextEvent.asEndElement().getName().getLocalPart().equals("advisory")) {
+                advisory.setCveList(cveList);
+                return advisory;
             }
         }
 
@@ -383,16 +368,13 @@ public class OvalParser {
         while (reader.hasNext()) {
             XMLEvent2 nextEvent = (XMLEvent2) reader.nextEvent();
 
-            if (nextEvent.isStartElement()) {
-                if (nextEvent.asStartElement().getName().getLocalPart().equals("resolution")) {
-                    advisoryAffectedType.setResolution(parseAdvisoryResolutionType(nextEvent.asStartElement(), reader));
-                }
+            if (nextEvent.isStartElement() &&
+                    nextEvent.asStartElement().getName().getLocalPart().equals("resolution")) {
+                advisoryAffectedType.setResolution(parseAdvisoryResolutionType(nextEvent.asStartElement(), reader));
             }
 
-            if (nextEvent.isEndElement()) {
-                if (nextEvent.asEndElement().getName().getLocalPart().equals("affected")) {
-                    return advisoryAffectedType;
-                }
+            if (nextEvent.isEndElement() && nextEvent.asEndElement().getName().getLocalPart().equals("affected")) {
+                return advisoryAffectedType;
             }
         }
 
@@ -413,17 +395,14 @@ public class OvalParser {
         while (reader.hasNext()) {
             XMLEvent2 nextEvent = (XMLEvent2) reader.nextEvent();
 
-            if (nextEvent.isStartElement()) {
-                if (nextEvent.asStartElement().getName().getLocalPart().equals("component")) {
-                    affectedComponents.add(reader.getElementText());
-                }
+            if (nextEvent.isStartElement() &&
+                    nextEvent.asStartElement().getName().getLocalPart().equals("component")) {
+                affectedComponents.add(reader.getElementText());
             }
 
-            if (nextEvent.isEndElement()) {
-                if (nextEvent.asEndElement().getName().getLocalPart().equals("resolution")) {
-                    advisoryResolutionType.setAffectedComponents(affectedComponents);
-                    return advisoryResolutionType;
-                }
+            if (nextEvent.isEndElement() && nextEvent.asEndElement().getName().getLocalPart().equals("resolution")) {
+                advisoryResolutionType.setAffectedComponents(affectedComponents);
+                return advisoryResolutionType;
             }
         }
 
@@ -444,16 +423,13 @@ public class OvalParser {
         while (reader.hasNext()) {
             XMLEvent2 nextEvent = (XMLEvent2) reader.nextEvent();
 
-            if (nextEvent.isStartElement()) {
-                if (nextEvent.asStartElement().getName().getLocalPart().equals("cpe")) {
-                    cpes.add(reader.getElementText());
-                }
+            if (nextEvent.isStartElement() && nextEvent.asStartElement().getName().getLocalPart().equals("cpe")) {
+                cpes.add(reader.getElementText());
             }
 
-            if (nextEvent.isEndElement()) {
-                if (nextEvent.asEndElement().getName().getLocalPart().equals("affected_cpe_list")) {
-                    return cpes;
-                }
+            if (nextEvent.isEndElement() &&
+                    nextEvent.asEndElement().getName().getLocalPart().equals("affected_cpe_list")) {
+                return cpes;
             }
         }
 
@@ -476,10 +452,8 @@ public class OvalParser {
                 }
             }
 
-            if (nextEvent.isEndElement()) {
-                if (nextEvent.asEndElement().getName().getLocalPart().equals("tests")) {
-                    return tests;
-                }
+            if (nextEvent.isEndElement() && nextEvent.asEndElement().getName().getLocalPart().equals("tests")) {
+                return tests;
             }
         }
 
@@ -516,26 +490,7 @@ public class OvalParser {
             XMLEvent2 nextEvent = (XMLEvent2) reader.nextEvent();
 
             if (nextEvent.isStartElement()) {
-                if (nextEvent.asStartElement().getName().getLocalPart().equals("object")) {
-                    Attribute objectRefAttribute = nextEvent.asStartElement().getAttributeByName(
-                            new QName("object_ref"));
-                    if (objectRefAttribute != null) {
-                        testType.setObjectRef(objectRefAttribute.getValue());
-                    }
-                    else {
-                        LOG.warn("objectRef property was not found");
-                    }
-                }
-                else if (nextEvent.asStartElement().getName().getLocalPart().equals("state")) {
-                    Attribute stateRefAttribute = nextEvent.asStartElement().getAttributeByName(
-                            new QName("state_ref"));
-                    if (stateRefAttribute != null) {
-                        testType.setStateRef(stateRefAttribute.getValue());
-                    }
-                    else {
-                        LOG.warn("stateRef property was not found");
-                    }
-                }
+                processTestTypeStartElement(nextEvent, testType);
             }
 
             if (nextEvent.isEndElement()) {
@@ -547,6 +502,29 @@ public class OvalParser {
         }
 
         throw new OvalParserException("Unable to find the closing tag for test type");
+    }
+
+    private static void processTestTypeStartElement(XMLEvent2 nextEvent, TestType testType) {
+        if (nextEvent.asStartElement().getName().getLocalPart().equals("object")) {
+            Attribute objectRefAttribute = nextEvent.asStartElement().getAttributeByName(
+                    new QName("object_ref"));
+            if (objectRefAttribute != null) {
+                testType.setObjectRef(objectRefAttribute.getValue());
+            }
+            else {
+                LOG.warn("objectRef property was not found");
+            }
+        }
+        else if (nextEvent.asStartElement().getName().getLocalPart().equals("state")) {
+            Attribute stateRefAttribute = nextEvent.asStartElement().getAttributeByName(
+                    new QName("state_ref"));
+            if (stateRefAttribute != null) {
+                testType.setStateRef(stateRefAttribute.getValue());
+            }
+            else {
+                LOG.warn("stateRef property was not found");
+            }
+        }
     }
 
     private List<StateType> parseStates(XMLEventReader2 reader) throws XMLStreamException {
@@ -565,10 +543,8 @@ public class OvalParser {
                 }
             }
 
-            if (nextEvent.isEndElement()) {
-                if (nextEvent.asEndElement().getName().getLocalPart().equals("states")) {
-                    return states;
-                }
+            if (nextEvent.isEndElement() && nextEvent.asEndElement().getName().getLocalPart().equals("states")) {
+                return states;
             }
         }
 
@@ -600,6 +576,10 @@ public class OvalParser {
             }
         });
 
+        return processStateType(reader, stateType);
+    }
+
+    private StateType processStateType(XMLEventReader2 reader, StateType stateType) throws XMLStreamException {
         while (reader.hasNext()) {
             XMLEvent2 nextEvent = (XMLEvent2) reader.nextEvent();
             if (nextEvent.isStartElement()) {
@@ -690,10 +670,8 @@ public class OvalParser {
                 }
             }
 
-            if (nextEvent.isEndElement()) {
-                if (nextEvent.asEndElement().getName().getLocalPart().equals("objects")) {
-                    return objects;
-                }
+            if (nextEvent.isEndElement() && nextEvent.asEndElement().getName().getLocalPart().equals("objects")) {
+                return objects;
             }
         }
 
@@ -728,10 +706,8 @@ public class OvalParser {
 
         while (reader.hasNext()) {
             XMLEvent2 nextEvent = (XMLEvent2) reader.nextEvent();
-            if (nextEvent.isStartElement()) {
-                if (nextEvent.asStartElement().getName().getLocalPart().equals("name")) {
-                    objectType.setPackageName(reader.getElementText());
-                }
+            if (nextEvent.isStartElement() && nextEvent.asStartElement().getName().getLocalPart().equals("name")) {
+                objectType.setPackageName(reader.getElementText());
             }
 
             if (nextEvent.isEndElement()) {

--- a/java/core/src/main/java/com/suse/oval/vulnerablepkgextractor/SUSEVulnerablePackageExtractor.java
+++ b/java/core/src/main/java/com/suse/oval/vulnerablepkgextractor/SUSEVulnerablePackageExtractor.java
@@ -30,9 +30,6 @@ import com.suse.oval.ovaltypes.ObjectType;
 import com.suse.oval.ovaltypes.StateType;
 import com.suse.oval.ovaltypes.TestType;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -44,7 +41,6 @@ import java.util.regex.Pattern;
  * from: <a href="https://ftp.suse.com/pub/projects/security/oval/">SUSE OVAL</a>
  */
 public class SUSEVulnerablePackageExtractor extends CriteriaTreeBasedExtractor {
-    private static final Logger LOG = LogManager.getLogger(SUSEVulnerablePackageExtractor.class);
     private static final Pattern RELEASE_PACKAGE_REGEX = Pattern.compile(
             "^\\s*(?<releasePackage>[-a-zA-Z_0-9]+) is\\s*(==|>=)\\s*(?<releasePackageVersion>[0-9.]+)\\s*$");
     private final OVALResourcesCache ovalResourcesCache;

--- a/java/core/src/main/java/com/suse/oval/vulnerablepkgextractor/SUSEVulnerablePackageExtractor.java
+++ b/java/core/src/main/java/com/suse/oval/vulnerablepkgextractor/SUSEVulnerablePackageExtractor.java
@@ -30,6 +30,9 @@ import com.suse.oval.ovaltypes.ObjectType;
 import com.suse.oval.ovaltypes.StateType;
 import com.suse.oval.ovaltypes.TestType;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -41,6 +44,7 @@ import java.util.regex.Pattern;
  * from: <a href="https://ftp.suse.com/pub/projects/security/oval/">SUSE OVAL</a>
  */
 public class SUSEVulnerablePackageExtractor extends CriteriaTreeBasedExtractor {
+    private static final Logger LOG = LogManager.getLogger(SUSEVulnerablePackageExtractor.class);
     private static final Pattern RELEASE_PACKAGE_REGEX = Pattern.compile(
             "^\\s*(?<releasePackage>[-a-zA-Z_0-9]+) is\\s*(==|>=)\\s*(?<releasePackageVersion>[0-9.]+)\\s*$");
     private final OVALResourcesCache ovalResourcesCache;

--- a/java/core/src/main/java/com/suse/oval/vulnerablepkgextractor/SUSEVulnerablePackageExtractor.java
+++ b/java/core/src/main/java/com/suse/oval/vulnerablepkgextractor/SUSEVulnerablePackageExtractor.java
@@ -20,7 +20,7 @@ import com.redhat.rhn.domain.rhnpackage.PackageEvr;
 import com.suse.oval.OsFamily;
 import com.suse.oval.cpe.Cpe;
 import com.suse.oval.cpe.CpeBuilder;
-import com.suse.oval.manager.OVALLookupHelper;
+import com.suse.oval.manager.OVALResourcesCache;
 import com.suse.oval.ovaltypes.BaseCriteria;
 import com.suse.oval.ovaltypes.CriteriaType;
 import com.suse.oval.ovaltypes.CriterionType;
@@ -43,20 +43,20 @@ import java.util.regex.Pattern;
 public class SUSEVulnerablePackageExtractor extends CriteriaTreeBasedExtractor {
     private static final Pattern RELEASE_PACKAGE_REGEX = Pattern.compile(
             "^\\s*(?<releasePackage>[-a-zA-Z_0-9]+) is\\s*(==|>=)\\s*(?<releasePackageVersion>[0-9.]+)\\s*$");
-    private final OVALLookupHelper ovalLookupHelper;
+    private final OVALResourcesCache ovalResourcesCache;
 
     /**
      * Standard constructor
      *
      * @param vulnerabilityDefinitionIn the vulnerability definition to extract vulnerable packages from
-     * @param ovalLookupHelperIn        the oval lookup helper
-     */
+     * @param ovalResourcesCacheIn      the oval lookup helper
+     * */
     public SUSEVulnerablePackageExtractor(DefinitionType vulnerabilityDefinitionIn,
-                                          OVALLookupHelper ovalLookupHelperIn) {
+                                          OVALResourcesCache ovalResourcesCacheIn) {
         super(vulnerabilityDefinitionIn);
-        Objects.requireNonNull(ovalLookupHelperIn);
+        Objects.requireNonNull(ovalResourcesCacheIn);
 
-        this.ovalLookupHelper = ovalLookupHelperIn;
+        this.ovalResourcesCache = ovalResourcesCacheIn;
     }
 
     @Override
@@ -81,17 +81,17 @@ public class SUSEVulnerablePackageExtractor extends CriteriaTreeBasedExtractor {
             String comment = packageCriterion.getComment();
             String testId = packageCriterion.getTestRef();
 
-            TestType packageTest = ovalLookupHelper.lookupTestById(testId)
+            TestType packageTest = ovalResourcesCache.lookupTestById(testId)
                     .orElseThrow(() -> new IllegalStateException("Referenced package test is not found: " + testId));
 
             String objectId = packageTest.getObjectRef();
             String stateId = packageTest.getStateRef()
                     .orElseThrow(() -> new IllegalStateException("Unexpected empty package state in SUSE OVAL"));
 
-            ObjectType packageObject = ovalLookupHelper.lookupObjectById(objectId)
+            ObjectType packageObject = ovalResourcesCache.lookupObjectById(objectId)
                     .orElseThrow(() -> new IllegalStateException("Referenced package object not found: " + objectId));
 
-            StateType packageState = ovalLookupHelper.lookupStateById(stateId)
+            StateType packageState = ovalResourcesCache.lookupStateById(stateId)
                     .orElseThrow(() -> new IllegalStateException("Referenced package state not found: " + stateId));
 
             String packageName = packageObject.getPackageName();
@@ -122,7 +122,7 @@ public class SUSEVulnerablePackageExtractor extends CriteriaTreeBasedExtractor {
         for (CriterionType productCriterion : productCriterions) {
             String comment = productCriterion.getComment();
             String productUserFriendlyName = comment.replace(" is installed", "");
-            TestType productTest = ovalLookupHelper.lookupTestById(productCriterion.getTestRef()).orElseThrow();
+            TestType productTest = ovalResourcesCache.lookupTestById(productCriterion.getTestRef()).orElseThrow();
 
             ProductVulnerablePackages vulnerableProduct = new ProductVulnerablePackages();
             vulnerableProduct.setSingleCve(definition.getSingleCve().orElseThrow());

--- a/java/core/src/main/java/com/suse/oval/vulnerablepkgextractor/VulnerablePackagesExtractors.java
+++ b/java/core/src/main/java/com/suse/oval/vulnerablepkgextractor/VulnerablePackagesExtractors.java
@@ -16,7 +16,7 @@
 package com.suse.oval.vulnerablepkgextractor;
 
 import com.suse.oval.OsFamily;
-import com.suse.oval.manager.OVALLookupHelper;
+import com.suse.oval.manager.OVALResourcesCache;
 import com.suse.oval.ovaltypes.DefinitionClassEnum;
 import com.suse.oval.ovaltypes.DefinitionType;
 import com.suse.oval.vulnerablepkgextractor.redhat.RedHatVulnerablePackageExtractorFromPatchDefinition;
@@ -34,18 +34,18 @@ public class VulnerablePackagesExtractors {
      *
      * @param definition the definition to extract vulnerable packages from
      * @param osFamily the os family
-     * @param ovalLookupHelper a helper class to lookup OVAL resources efficiently
+     * @param ovalResourcesCache a helper class to lookup OVAL resources efficiently
      * @return a vulnerable package extractor instance
      * */
     public static VulnerablePackagesExtractor create(DefinitionType definition, OsFamily osFamily,
-                                                     OVALLookupHelper ovalLookupHelper) {
+                                                     OVALResourcesCache ovalResourcesCache) {
         switch (osFamily) {
             case LEAP:
             case LEAP_MICRO:
             case SUSE_LINUX_ENTERPRISE_SERVER:
             case SUSE_LINUX_ENTERPRISE_DESKTOP:
             case SUSE_LINUX_ENTERPRISE_MICRO:
-                return new SUSEVulnerablePackageExtractor(definition, ovalLookupHelper);
+                return new SUSEVulnerablePackageExtractor(definition, ovalResourcesCache);
             case DEBIAN:
                 return new DebianVulnerablePackagesExtractor(definition);
             case REDHAT_ENTERPRISE_LINUX:

--- a/java/core/src/main/resources/com/redhat/rhn/common/db/datasource/xml/oval_queries.xml
+++ b/java/core/src/main/resources/com/redhat/rhn/common/db/datasource/xml/oval_queries.xml
@@ -64,14 +64,7 @@
 
     <write-mode name="clear_oval_metadata_by_os_product">
         <query params="os_product_family, os_product_version">
-            DELETE
-            FROM suseOVALPlatformVulnerable pv
-            WHERE pv.platform_id = (SELECT id
-                                    FROM suseOVALOsProduct osProduct
-                                    WHERE osProduct.os_family = :os_product_family
-                                      AND osProduct.version = :os_product_version);
-            DELETE
-            FROM suseOVALOsProduct osProduct
+            DELETE FROM suseOVALOsProduct osProduct
             WHERE osProduct.os_family = :os_product_family
               AND osProduct.version = :os_product_version;
         </query>

--- a/java/core/src/main/resources/com/redhat/rhn/common/db/datasource/xml/oval_queries.xml
+++ b/java/core/src/main/resources/com/redhat/rhn/common/db/datasource/xml/oval_queries.xml
@@ -62,9 +62,19 @@
         </query>
     </mode>
 
-    <write-mode name="clear_oval_metadata_by_platform">
-        <query params="cpe">
-            DELETE FROM suseOVALPlatform plat where plat.cpe = :cpe;
+    <write-mode name="clear_oval_metadata_by_os_product">
+        <query params="os_product_family, os_product_version">
+            DELETE
+            FROM suseOVALPlatformVulnerable pv
+            WHERE pv.platform_id = (SELECT id
+                                    FROM suseOVALOsProduct osProduct
+                                    WHERE osProduct.os_family = :os_product_family
+                                      AND osProduct.version = :os_product_version);
+            DELETE
+            FROM suseOVALOsProduct osProduct
+            WHERE osProduct.os_family = :os_product_family
+              AND osProduct.version = :os_product_version;
         </query>
     </write-mode>
+
 </datasource_modes>

--- a/java/core/src/main/resources/com/redhat/rhn/common/db/datasource/xml/oval_queries.xml
+++ b/java/core/src/main/resources/com/redhat/rhn/common/db/datasource/xml/oval_queries.xml
@@ -1,7 +1,7 @@
 <datasource_modes>
     <callable-mode name="add_product_vulnerable_package">
-        <query params="package_name, fix_epoch, fix_version, fix_release, fix_type, product_name, cve_name">
-            call insert_product_vulnerable_packages(:package_name, :fix_epoch, :fix_version, :fix_release, :fix_type, :product_name, :cve_name)
+        <query params="package_name, fix_epoch, fix_version, fix_release, fix_type, product_name, os_product_family, os_product_version, cve_name">
+            call insert_product_vulnerable_packages(:package_name, :fix_epoch, :fix_version, :fix_release, :fix_type, :product_name, :os_product_family, :os_product_version, :cve_name)
         </query>
     </callable-mode>
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/audit/CVEAuditManagerOVALTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/audit/CVEAuditManagerOVALTest.java
@@ -564,7 +564,9 @@ public class CVEAuditManagerOVALTest extends RhnBaseTestCase {
     }
 
     private static void extractAndSaveVulnerablePackages(OvalRootType rootType) {
-        OVALCleaner.cleanup(rootType, OsFamily.LEAP, "15.4");
+        rootType.setOsFamily(OsFamily.LEAP);
+        rootType.setOsVersion("15.4");
+        OVALCleaner.cleanup(rootType);
         OVALCachingFactory.savePlatformsVulnerablePackages(rootType);
 
         TestUtils.flushSession();

--- a/java/core/src/test/java/com/redhat/rhn/manager/audit/CVEAuditManagerOVALTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/audit/CVEAuditManagerOVALTest.java
@@ -40,8 +40,8 @@ import com.redhat.rhn.testing.TestUtils;
 import com.suse.oval.OVALCachingFactory;
 import com.suse.oval.OVALCleaner;
 import com.suse.oval.OsFamily;
-import com.suse.oval.OvalParser;
 import com.suse.oval.ovaltypes.OvalRootType;
+import com.suse.oval.parser.OvalParser;
 
 import org.junit.jupiter.api.Test;
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/audit/CVEAuditManagerOVALTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/audit/CVEAuditManagerOVALTest.java
@@ -41,7 +41,7 @@ import com.suse.oval.OVALCachingFactory;
 import com.suse.oval.OVALCleaner;
 import com.suse.oval.OsFamily;
 import com.suse.oval.ovaltypes.OvalRootType;
-import com.suse.oval.parser.OvalParser;
+import com.suse.oval.parser.OvalTestUtils;
 
 import org.junit.jupiter.api.Test;
 
@@ -56,11 +56,10 @@ import java.util.stream.Collectors;
 // TODO: Test for when patch status is unknown
 public class CVEAuditManagerOVALTest extends RhnBaseTestCase {
     public static final String CPE_OPENSUSE_LEAP_15_4 = "cpe:/o:opensuse:leap:15.4";
-    private OvalParser ovalParser = new OvalParser();
 
     @Test
     void testDoAuditSystemNotAffected() throws Exception {
-        OvalRootType ovalRoot = ovalParser.parse(TestUtils
+        OvalRootType ovalRoot = OvalTestUtils.parse(TestUtils
                 .findTestData("/com/redhat/rhn/manager/audit/oval/oval-def-1.xml"));
 
         Cve cve = createTestCve("CVE-2022-2991");
@@ -95,7 +94,7 @@ public class CVEAuditManagerOVALTest extends RhnBaseTestCase {
      */
     @Test
     void testDoAuditSystemNotAffectedWhenOSIsAffected() throws Exception {
-        OvalRootType ovalRoot = ovalParser.parse(TestUtils
+        OvalRootType ovalRoot = OvalTestUtils.parse(TestUtils
                 .findTestData("/com/redhat/rhn/manager/audit/oval/oval-def-1.xml"));
 
         Cve cve = createTestCve("CVE-2022-2991");
@@ -124,7 +123,7 @@ public class CVEAuditManagerOVALTest extends RhnBaseTestCase {
 
     @Test
     void testDoAuditSystemPatched() throws Exception {
-        OvalRootType ovalRoot = ovalParser.parse(TestUtils
+        OvalRootType ovalRoot = OvalTestUtils.parse(TestUtils
                 .findTestData("/com/redhat/rhn/manager/audit/oval/oval-def-1.xml"));
 
         Cve cve = createTestCve("CVE-2022-2991");
@@ -158,7 +157,7 @@ public class CVEAuditManagerOVALTest extends RhnBaseTestCase {
 
     @Test
     void testDoAuditSystemAffectedFullPatchAvailable() throws Exception {
-        OvalRootType ovalRoot = ovalParser.parse(TestUtils
+        OvalRootType ovalRoot = OvalTestUtils.parse(TestUtils
                 .findTestData("/com/redhat/rhn/manager/audit/oval/oval-def-1.xml"));
 
         Cve cve = createTestCve("CVE-2022-2991");
@@ -197,7 +196,7 @@ public class CVEAuditManagerOVALTest extends RhnBaseTestCase {
 
     @Test
     void testDoAuditSystemAffectedPatchUnavailable() throws Exception {
-        OvalRootType ovalRoot = ovalParser.parse(TestUtils
+        OvalRootType ovalRoot = OvalTestUtils.parse(TestUtils
                 .findTestData("/com/redhat/rhn/manager/audit/oval/oval-def-2.xml"));
 
         Cve cve = createTestCve("CVE-2008-2934");
@@ -231,7 +230,7 @@ public class CVEAuditManagerOVALTest extends RhnBaseTestCase {
 
     @Test
     void testDoAuditSystemAffectedPartialPatchAvailable() throws Exception {
-        OvalRootType ovalRoot = ovalParser.parse(TestUtils
+        OvalRootType ovalRoot = OvalTestUtils.parse(TestUtils
                 .findTestData("/com/redhat/rhn/manager/audit/oval/oval-def-3.xml"));
 
         Cve cve = createTestCve("CVE-2008-2934");
@@ -274,7 +273,7 @@ public class CVEAuditManagerOVALTest extends RhnBaseTestCase {
 
     @Test
     void testDoAuditSystemAffectedPartialPatchAvailableFalsePositive() throws Exception {
-        OvalRootType ovalRoot = ovalParser.parse(TestUtils
+        OvalRootType ovalRoot = OvalTestUtils.parse(TestUtils
                 .findTestData("/com/redhat/rhn/manager/audit/oval/oval-def-3.xml"));
 
         Cve cve = createTestCve("CVE-2008-2934");
@@ -316,7 +315,7 @@ public class CVEAuditManagerOVALTest extends RhnBaseTestCase {
 
     @Test
     void testDoAuditSystemAffectedPatchInapplicable() throws Exception {
-        OvalRootType ovalRoot = ovalParser.parse(TestUtils
+        OvalRootType ovalRoot = OvalTestUtils.parse(TestUtils
                 .findTestData("/com/redhat/rhn/manager/audit/oval/oval-def-1.xml"));
 
         Cve cve = createTestCve("CVE-2022-2991");
@@ -363,7 +362,7 @@ public class CVEAuditManagerOVALTest extends RhnBaseTestCase {
 
     @Test
     void testDoAuditSystemAffectedPatchInapplicableSuccessorProduct() throws Exception {
-        OvalRootType ovalRoot = ovalParser.parse(TestUtils
+        OvalRootType ovalRoot = OvalTestUtils.parse(TestUtils
                 .findTestData("/com/redhat/rhn/manager/audit/oval/oval-def-1.xml"));
 
         Cve cve = createTestCve("CVE-2022-2991");
@@ -419,7 +418,7 @@ public class CVEAuditManagerOVALTest extends RhnBaseTestCase {
      */
     @Test
     public void testDoAuditSystemPatchedWithIrrelevantErrata() throws Exception {
-        OvalRootType ovalRoot = ovalParser.parse(TestUtils
+        OvalRootType ovalRoot = OvalTestUtils.parse(TestUtils
                 .findTestData("/com/redhat/rhn/manager/audit/oval/oval-def-1.xml"));
 
         Cve cve = createTestCve("CVE-2022-2991");
@@ -455,7 +454,7 @@ public class CVEAuditManagerOVALTest extends RhnBaseTestCase {
 
     @Test
     void testDoAuditSystemAffectedPatchUnavailableInUyuni() throws Exception {
-        OvalRootType ovalRoot = ovalParser.parse(TestUtils
+        OvalRootType ovalRoot = OvalTestUtils.parse(TestUtils
                 .findTestData("/com/redhat/rhn/manager/audit/oval/oval-def-1.xml"));
 
         Cve cve = createTestCve("CVE-2022-2991");
@@ -504,7 +503,7 @@ public class CVEAuditManagerOVALTest extends RhnBaseTestCase {
     public void testListSystemsByPatchStatusKnownCVE() throws IOException, ClassNotFoundException {
         User user = createTestUser();
 
-        OvalRootType ovalRoot = ovalParser.parse(TestUtils
+        OvalRootType ovalRoot = OvalTestUtils.parse(TestUtils
                 .findTestData("/com/redhat/rhn/manager/audit/oval/oval-def-1.xml"));
 
         Cve knownCve = createTestCve("CVE-2022-2991");
@@ -517,7 +516,7 @@ public class CVEAuditManagerOVALTest extends RhnBaseTestCase {
 
     @Test
     public void testListSystemsByPatchStatusAffectedPatchInapplicable() throws Exception {
-        OvalRootType ovalRoot = ovalParser.parse(TestUtils
+        OvalRootType ovalRoot = OvalTestUtils.parse(TestUtils
                 .findTestData("/com/redhat/rhn/manager/audit/oval/oval-def-1.xml"));
 
         Cve cve = createTestCve("CVE-2022-2991");

--- a/java/core/src/test/java/com/suse/oval/parser/OvalTestUtils.java
+++ b/java/core/src/test/java/com/suse/oval/parser/OvalTestUtils.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.oval.parser;
+
+import com.suse.oval.exceptions.OvalParserException;
+import com.suse.oval.ovaltypes.DefinitionType;
+import com.suse.oval.ovaltypes.OvalRootType;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility methods for OVAL parsing to be used in tests.
+ */
+public class OvalTestUtils {
+
+    private static final OvalParser PARSER = new OvalParser();
+
+    private OvalTestUtils() {
+    }
+
+    /**
+     * Parse the given OVAL file
+     *
+     * @param ovalFileURL the OVAL file to parse
+     * @return the parsed OVAL encapsulated in an {@link OvalRootType} object.
+     * */
+    public static OvalRootType parse(URL ovalFileURL) throws OvalParserException {
+        File ovalFile;
+        try {
+            ovalFile = new File(ovalFileURL.toURI());
+        }
+        catch (URISyntaxException e) {
+            throw new OvalParserException("Bad OVAL file path: " + ovalFileURL, e);
+        }
+
+        List<DefinitionType> allDefinitions = parseAllDefinitions(ovalFile);
+        OVALResources ovalResources = PARSER.parseResources(ovalFile);
+
+        OvalRootType ovalRootType = new OvalRootType();
+        ovalRootType.setDefinitions(allDefinitions);
+        ovalRootType.setObjects(ovalResources.getObjects());
+        ovalRootType.setStates(ovalResources.getStates());
+        ovalRootType.setTests(ovalResources.getTests());
+
+        return ovalRootType;
+    }
+
+    /**
+     * Utility method to parse all OVAL definitions at once instead of in bulks. To be used in testing.
+     *
+     * @param ovalFile an XML file containing OVAL definitions to be parsed.
+     * @return all OVAL definitions in {@code ovalFile}
+     * */
+    public static List<DefinitionType> parseAllDefinitions(File ovalFile) {
+        List<DefinitionType> allDefinitions = new ArrayList<>();
+
+        PARSER.parseDefinitionsInBulk(ovalFile, allDefinitions::addAll);
+
+        return allDefinitions;
+    }
+}

--- a/java/spacewalk-java.changes.HoussemNasri.oval-stax-parser
+++ b/java/spacewalk-java.changes.HoussemNasri.oval-stax-parser
@@ -1,0 +1,4 @@
+- Optimized memory usage by replacing DOM-based XML parsing with
+  a streaming StaX parser for OVAL metadata files.
+- Improved resilience of OVAL metadata synchronization to handle
+  invalid Criterion elements.

--- a/schema/spacewalk/common/tables/suseOVALOsProduct.sql
+++ b/schema/spacewalk/common/tables/suseOVALOsProduct.sql
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+CREATE TABLE suseOVALOsProduct
+(
+    id          NUMERIC NOT NULL
+                    CONSTRAINT suse_oval_os_product_id_pk PRIMARY KEY,
+    os_family   VARCHAR NOT NULL,
+    version     VARCHAR NOT NULL
+);
+
+CREATE SEQUENCE suse_oval_os_product_id_seq;
+
+CREATE UNIQUE INDEX suse_oval_os_family_version_uq
+    ON suseOVALOsProduct(os_family, version);

--- a/schema/spacewalk/common/tables/suseOVALOsProduct.sql
+++ b/schema/spacewalk/common/tables/suseOVALOsProduct.sql
@@ -1,17 +1,17 @@
-/*
- * Copyright (c) 2024 SUSE LLC
- *
- * This software is licensed to you under the GNU General Public License,
- * version 2 (GPLv2). There is NO WARRANTY for this software, express or
- * implied, including the implied warranties of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
- * along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
- */
+--
+-- Copyright (c) 2024 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
 
 CREATE TABLE suseOVALOsProduct
 (

--- a/schema/spacewalk/common/tables/suseOVALPlatformVulnerable.sql
+++ b/schema/spacewalk/common/tables/suseOVALPlatformVulnerable.sql
@@ -23,7 +23,8 @@ CREATE TABLE suseOVALPlatformVulnerable
                             REFERENCES suseOVALPlatform (id)
                             ON DELETE CASCADE,
     product_os_id        NUMERIC NOT NULL
-                            REFERENCES suseOVALOsProduct (id),
+                            REFERENCES suseOVALOsProduct (id)
+                            ON DELETE CASCADE,
     cve_id               NUMERIC NOT NULL
                             REFERENCES rhnCve (id),
                          CONSTRAINT platform_prod_cve_id_uq UNIQUE (platform_id, product_os_id, cve_id)

--- a/schema/spacewalk/common/tables/suseOVALPlatformVulnerable.sql
+++ b/schema/spacewalk/common/tables/suseOVALPlatformVulnerable.sql
@@ -22,9 +22,11 @@ CREATE TABLE suseOVALPlatformVulnerable
     platform_id          NUMERIC NOT NULL
                             REFERENCES suseOVALPlatform (id)
                             ON DELETE CASCADE,
+    product_os_id        NUMERIC NOT NULL
+                            REFERENCES suseOVALOsProduct (id),
     cve_id               NUMERIC NOT NULL
                             REFERENCES rhnCve (id),
-                         CONSTRAINT platform_cve_id_uq UNIQUE (platform_id, cve_id)
+                         CONSTRAINT platform_prod_cve_id_uq UNIQUE (platform_id, product_os_id, cve_id)
 );
 
 CREATE INDEX suse_oval_plat_vuln_plat_id_idx ON suseOVALPlatformVulnerable(platform_id);

--- a/schema/spacewalk/common/tables/tables.deps
+++ b/schema/spacewalk/common/tables/tables.deps
@@ -253,7 +253,8 @@ suseMinionInfo                     :: rhnServer
 suseInstalledProduct               :: rhnPackageArch
 suseMdData                         :: rhnChannel rhnPackage suseMdKeyword
 suseOVALPlatform                   ::
-suseOVALPlatformVulnerable         :: suseOVALPlatform rhnCVE
+suseOVALOsProduct                  ::
+suseOVALPlatformVulnerable         :: suseOVALOsProduct suseOVALPlatform rhnCVE
 suseOVALVulnerablePackage          :: suseOVALPlatformVulnerable
 susePackageEula                    :: rhnPackage suseEula
 susePackageProductFile             :: suseProductFile rhnPackage

--- a/schema/spacewalk/postgres/procs/insert_product_vulnerable_packages.sql
+++ b/schema/spacewalk/postgres/procs/insert_product_vulnerable_packages.sql
@@ -14,7 +14,7 @@
 --
 
 CREATE OR REPLACE PROCEDURE
-insert_product_vulnerable_packages(package_name_in varchar, fix_epoch_in varchar, fix_version_in varchar, fix_release_in varchar, fix_type_in varchar, product_cpe_in varchar, cve_name_in varchar)
+insert_product_vulnerable_packages(package_name_in varchar, fix_epoch_in varchar, fix_version_in varchar, fix_release_in varchar, fix_type_in varchar, product_cpe_in varchar, product_os_family_in varchar, product_os_version_in varchar, cve_name_in varchar)
 AS
 $$
 DECLARE
@@ -22,11 +22,27 @@ DECLARE
     product_cpe_id_val numeric;
     platform_vulnerable_id_val bigint;
     fix_version_evrt evr_t;
+    product_os_id_val numeric;
 begin
 
     cve_id_val := lookup_cve(cve_name_in);
 
     product_cpe_id_val := lookup_oval_platform(product_cpe_in);
+
+    -- Check if the suseOVALOsProduct exists, if not insert it.
+    IF NOT EXISTS (
+        SELECT 1
+        FROM suseOVALOsProduct
+        WHERE os_family = product_os_family_in
+          AND version = product_os_version_in
+    ) THEN
+        INSERT INTO suseOVALOsProduct(id, os_family, version)
+        VALUES (nextval('suse_oval_os_product_id_seq'), product_os_family_in, product_os_version_in);
+    END IF;
+
+    SELECT id INTO product_os_id_val
+    FROM suseOVALOsProduct
+    WHERE os_family = product_os_family_in AND version = product_os_version_in;
 
     IF fix_version_in IS NULL THEN
       fix_version_evrt := NULL;
@@ -34,9 +50,9 @@ begin
       fix_version_evrt := evr_t(fix_epoch_in, fix_version_in, fix_release_in, fix_type_in);
     END IF;
 
-    INSERT INTO suseOVALPlatformVulnerable(platform_id, cve_id)
-    VALUES (product_cpe_id_val, cve_id_val)
-    ON CONFLICT (platform_id, cve_id) DO
+    INSERT INTO suseOVALPlatformVulnerable(platform_id, product_os_id, cve_id)
+    VALUES (product_cpe_id_val, product_os_id_val, cve_id_val)
+    ON CONFLICT (platform_id, product_os_id, cve_id) DO
     UPDATE SET platform_id = suseOVALPlatformVulnerable.platform_id
     RETURNING id INTO platform_vulnerable_id_val;
 

--- a/schema/spacewalk/susemanager-schema.changes.HoussemNasri.oval-stax-parser
+++ b/schema/spacewalk/susemanager-schema.changes.HoussemNasri.oval-stax-parser
@@ -1,0 +1,3 @@
+- Added `os_product` column to `suseOVALPlatformVulnerablePackage`
+  table to map vulnerabilities to operating system products found 
+  in OVAL config.

--- a/schema/spacewalk/susemanager-schema.changes.HoussemNasri.oval-stax-parser
+++ b/schema/spacewalk/susemanager-schema.changes.HoussemNasri.oval-stax-parser
@@ -1,3 +1,3 @@
 - Added `os_product` column to `suseOVALPlatformVulnerablePackage`
-  table to map vulnerabilities to operating system products found 
+  table to map vulnerabilities to operating system products found
   in OVAL config.

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.1-to-susemanager-schema-5.1.2/003-map-oval-vulnerability-metadata-by-os-product.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.1-to-susemanager-schema-5.1.2/003-map-oval-vulnerability-metadata-by-os-product.sql
@@ -51,7 +51,9 @@ ALTER TABLE suseOVALPlatformVulnerable
     DROP CONSTRAINT IF EXISTS platform_prod_cve_id_uq;
 ALTER TABLE suseOVALPlatformVulnerable
     ADD CONSTRAINT platform_prod_cve_id_uq UNIQUE (platform_id, product_os_id, cve_id);
-ALTER TABLE suseOVALPlatformVulnerable ADD CONSTRAINT suse_oval_platform_vulnerable_pkg_os_product_id_fkey
+ALTER TABLE suseOVALPlatformVulnerable
+    DROP CONSTRAINT IF EXISTS suse_oval_platform_vulnerable_os_product_id_fkey;
+ALTER TABLE suseOVALPlatformVulnerable ADD CONSTRAINT suse_oval_platform_vulnerable_os_product_id_fkey
     FOREIGN KEY (product_os_id) REFERENCES suseOVALOsProduct(id) ON DELETE CASCADE;
 
 DROP PROCEDURE IF exists insert_product_vulnerable_packages(package_name_in varchar, fix_epoch_in varchar, fix_version_in varchar, fix_release_in varchar, fix_type_in varchar, product_cpe_in varchar, cve_name_in varchar);

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.1-to-susemanager-schema-5.1.2/003-map-oval-vulnerability-metadata-by-os-product.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.1-to-susemanager-schema-5.1.2/003-map-oval-vulnerability-metadata-by-os-product.sql
@@ -51,3 +51,53 @@ ALTER TABLE suseOVALPlatformVulnerable
     DROP CONSTRAINT IF EXISTS platform_prod_cve_id_uq;
 ALTER TABLE suseOVALPlatformVulnerable
     ADD CONSTRAINT platform_prod_cve_id_uq UNIQUE (platform_id, product_os_id, cve_id);
+
+CREATE OR REPLACE PROCEDURE
+insert_product_vulnerable_packages(package_name_in varchar, fix_epoch_in varchar, fix_version_in varchar, fix_release_in varchar, fix_type_in varchar, product_cpe_in varchar, product_os_family_in varchar, product_os_version_in varchar, cve_name_in varchar)
+AS
+$$
+DECLARE
+    cve_id_val numeric;
+    product_cpe_id_val numeric;
+    platform_vulnerable_id_val bigint;
+    fix_version_evrt evr_t;
+    product_os_id_val numeric;
+begin
+
+    cve_id_val := lookup_cve(cve_name_in);
+
+    product_cpe_id_val := lookup_oval_platform(product_cpe_in);
+
+    -- Check if the suseOVALOsProduct exists, if not insert it.
+    IF NOT EXISTS (
+        SELECT 1
+        FROM suseOVALOsProduct
+        WHERE os_family = product_os_family_in
+          AND version = product_os_version_in
+    ) THEN
+        INSERT INTO suseOVALOsProduct(id, os_family, version)
+        VALUES (nextval('suse_oval_os_product_id_seq'), product_os_family_in, product_os_version_in);
+    END IF;
+
+    SELECT id INTO product_os_id_val
+    FROM suseOVALOsProduct
+    WHERE os_family = product_os_family_in AND version = product_os_version_in;
+
+    IF fix_version_in IS NULL THEN
+      fix_version_evrt := NULL;
+    ELSE
+      fix_version_evrt := evr_t(fix_epoch_in, fix_version_in, fix_release_in, fix_type_in);
+    END IF;
+
+    INSERT INTO suseOVALPlatformVulnerable(platform_id, product_os_id, cve_id)
+    VALUES (product_cpe_id_val, product_os_id_val, cve_id_val)
+    ON CONFLICT (platform_id, product_os_id, cve_id) DO
+    UPDATE SET platform_id = suseOVALPlatformVulnerable.platform_id
+    RETURNING id INTO platform_vulnerable_id_val;
+
+    INSERT INTO suseOVALVulnerablePackage(plat_vuln_id, name, fix_version)
+    VALUES (platform_vulnerable_id_val, package_name_in, fix_version_evrt)
+    ON CONFLICT(plat_vuln_id, name) DO
+      UPDATE SET fix_version = EXCLUDED.fix_version;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.1-to-susemanager-schema-5.1.2/003-map-oval-vulnerability-metadata-by-os-product.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.1-to-susemanager-schema-5.1.2/003-map-oval-vulnerability-metadata-by-os-product.sql
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+CREATE TABLE IF NOT EXISTS suseOVALOsProduct
+(
+    id          NUMERIC NOT NULL
+        CONSTRAINT suse_oval_os_product_id_pk PRIMARY KEY,
+    os_family   VARCHAR NOT NULL,
+    version     VARCHAR NOT NULL
+);
+
+CREATE SEQUENCE IF NOT EXISTS suse_oval_os_product_id_seq;
+
+CREATE UNIQUE INDEX IF NOT EXISTS suse_oval_os_family_version_uq
+    ON suseOVALOsProduct(os_family, version);
+
+/*
+* This block checks if the 'product_os_id' column exists in the suseOVALPlatformVulnerable table.
+* If the column does not exist, it truncates the table, restarts the identity sequence,
+* and adds the product_os_id column as a NOT NULL type.
+*/
+DO $$
+    BEGIN
+        IF NOT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_name = 'suseovalplatformvulnerable' AND column_name = 'product_os_id'
+        ) THEN
+            TRUNCATE suseOVALPlatformVulnerable RESTART IDENTITY CASCADE;
+            -- noinspection SqlAddNotNullColumn
+            ALTER TABLE suseOVALPlatformVulnerable
+                ADD COLUMN product_os_id NUMERIC NOT NULL;
+        END IF;
+    END $$;
+
+ALTER TABLE suseOVALPlatformVulnerable
+    DROP CONSTRAINT IF EXISTS platform_cve_id_uq;
+ALTER TABLE suseOVALPlatformVulnerable
+    DROP CONSTRAINT IF EXISTS platform_prod_cve_id_uq;
+ALTER TABLE suseOVALPlatformVulnerable
+    ADD CONSTRAINT platform_prod_cve_id_uq UNIQUE (platform_id, product_os_id, cve_id);

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.1-to-susemanager-schema-5.1.2/003-map-oval-vulnerability-metadata-by-os-product.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.1-to-susemanager-schema-5.1.2/003-map-oval-vulnerability-metadata-by-os-product.sql
@@ -51,6 +51,10 @@ ALTER TABLE suseOVALPlatformVulnerable
     DROP CONSTRAINT IF EXISTS platform_prod_cve_id_uq;
 ALTER TABLE suseOVALPlatformVulnerable
     ADD CONSTRAINT platform_prod_cve_id_uq UNIQUE (platform_id, product_os_id, cve_id);
+ALTER TABLE suseOVALPlatformVulnerable ADD CONSTRAINT suse_oval_platform_vulnerable_pkg_os_product_id_fkey
+    FOREIGN KEY (product_os_id) REFERENCES suseOVALOsProduct(id) ON DELETE CASCADE;
+
+DROP PROCEDURE IF exists insert_product_vulnerable_packages(package_name_in varchar, fix_epoch_in varchar, fix_version_in varchar, fix_release_in varchar, fix_type_in varchar, product_cpe_in varchar, cve_name_in varchar);
 
 CREATE OR REPLACE PROCEDURE
 insert_product_vulnerable_packages(package_name_in varchar, fix_epoch_in varchar, fix_version_in varchar, fix_release_in varchar, fix_type_in varchar, product_cpe_in varchar, product_os_family_in varchar, product_os_version_in varchar, cve_name_in varchar)

--- a/schema/spacewalk/upgrade/susemanager-schema-5.2.4-to-susemanager-schema-5.2.5/100-map-oval-vulnerability-metadata-by-os-product.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.2.4-to-susemanager-schema-5.2.5/100-map-oval-vulnerability-metadata-by-os-product.sql
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SUSE LLC
+ * Copyright (c) 2026 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or


### PR DESCRIPTION
## What does this PR change?

Introduce a StAX parser (instead of the current JAXB parser) for OVAL files to increase memory efficiency when parsing large OVAL files.

### Useful Links
- [The RFC](https://github.com/uyuni-project/uyuni-rfc/pull/80)
## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **Only backend changes**
- [x] **DONE**

## Test coverage
- No tests: **test adapted**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/26814

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
