### PR TITLE
Notify users when updates are available to the Uyuni server

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/notification/NotificationMessage.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/NotificationMessage.java
@@ -25,6 +25,7 @@ import com.redhat.rhn.domain.notification.types.OnboardingFailed;
 import com.redhat.rhn.domain.notification.types.PaygAuthenticationUpdateFailed;
 import com.redhat.rhn.domain.notification.types.StateApplyFailed;
 import com.redhat.rhn.domain.notification.types.SubscriptionWarning;
+import com.redhat.rhn.domain.notification.types.UpdateAvailableNotification;
 
 import com.google.gson.Gson;
 
@@ -134,7 +135,9 @@ public class NotificationMessage implements Serializable {
                 return new Gson().fromJson(getData(), EndOfLifePeriod.class);
             case SubscriptionWarning:
                 return new Gson().fromJson(getData(), SubscriptionWarning.class);
-            default: throw new RuntimeException("should not happen!");
+            case UpdateAvailableNotification:
+                return new Gson().fromJson(getData(), UpdateAvailableNotification.class);
+            default: throw new RuntimeException("Notification type not found");
         }
     }
 
@@ -153,6 +156,7 @@ public class NotificationMessage implements Serializable {
             case PaygAuthenticationUpdateFailed: return "PAYG refresh failed";
             case EndOfLifePeriod: return "End of Life Period";
             case SubscriptionWarning: return "Subscription Warning";
+            case UpdateAvailableNotification: return "Updates are Available";
             default: return getType().name();
         }
     }

--- a/java/code/src/com/redhat/rhn/domain/notification/NotificationMessage.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/NotificationMessage.java
@@ -25,7 +25,7 @@ import com.redhat.rhn.domain.notification.types.OnboardingFailed;
 import com.redhat.rhn.domain.notification.types.PaygAuthenticationUpdateFailed;
 import com.redhat.rhn.domain.notification.types.StateApplyFailed;
 import com.redhat.rhn.domain.notification.types.SubscriptionWarning;
-import com.redhat.rhn.domain.notification.types.UpdateAvailableNotification;
+import com.redhat.rhn.domain.notification.types.UpdateAvailable;
 
 import com.google.gson.Gson;
 
@@ -135,8 +135,8 @@ public class NotificationMessage implements Serializable {
                 return new Gson().fromJson(getData(), EndOfLifePeriod.class);
             case SubscriptionWarning:
                 return new Gson().fromJson(getData(), SubscriptionWarning.class);
-            case UpdateAvailableNotification:
-                return new Gson().fromJson(getData(), UpdateAvailableNotification.class);
+            case UpdateAvailable:
+                return new Gson().fromJson(getData(), UpdateAvailable.class);
             default: throw new RuntimeException("Notification type not found");
         }
     }
@@ -156,7 +156,7 @@ public class NotificationMessage implements Serializable {
             case PaygAuthenticationUpdateFailed: return "PAYG refresh failed";
             case EndOfLifePeriod: return "End of Life Period";
             case SubscriptionWarning: return "Subscription Warning";
-            case UpdateAvailableNotification: return "Updates are Available";
+            case UpdateAvailable: return "Updates are Available";
             default: return getType().name();
         }
     }

--- a/java/code/src/com/redhat/rhn/domain/notification/types/NotificationType.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/NotificationType.java
@@ -26,4 +26,5 @@ public enum NotificationType {
     PaygAuthenticationUpdateFailed,
     EndOfLifePeriod,
     SubscriptionWarning,
+    UpdateAvailableNotification,
 }

--- a/java/code/src/com/redhat/rhn/domain/notification/types/NotificationType.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/NotificationType.java
@@ -26,5 +26,5 @@ public enum NotificationType {
     PaygAuthenticationUpdateFailed,
     EndOfLifePeriod,
     SubscriptionWarning,
-    UpdateAvailableNotification,
+    UpdateAvailable,
 }

--- a/java/code/src/com/redhat/rhn/domain/notification/types/UpdateAvailable.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/UpdateAvailable.java
@@ -57,14 +57,14 @@ public class UpdateAvailable implements NotificationData {
         String repo = mgr ? "SLE-Module-SUSE-Manager-Server-" + version + "-Updates" : UYUNI_PATCH_REPO;
 
         try {
-            Process patchProc = runtime.exec(new String[]{"bash", "-c",
+            Process patchProc = runtime.exec(new String[]{"/bin/bash", "-c",
                     "LC_ALL=C zypper lp -r " + repo + " | grep 'applicable patch'"});
             patchProc.waitFor();
             // 0 here means there are patches
             hasUpdates = (0 == patchProc.exitValue());
             if (!hasUpdates && !mgr) {
                 // Check for updates on uyuni when there are no patches
-                Process updateProc = runtime.exec(new String[]{"bash", "-c",
+                Process updateProc = runtime.exec(new String[]{"/bin/bash", "-c",
                         "LC_ALL=C zypper lu -r " + UYUNI_UPDATE_REPO + " | grep 'Available Version'"});
                 updateProc.waitFor();
                 hasUpdates = (0 == updateProc.exitValue());

--- a/java/code/src/com/redhat/rhn/domain/notification/types/UpdateAvailable.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/UpdateAvailable.java
@@ -14,7 +14,6 @@
  */
 package com.redhat.rhn.domain.notification.types;
 
-
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.notification.NotificationMessage;
@@ -25,10 +24,13 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 
-public class UpdateAvailableNotification implements NotificationData {
+/**
+ * Notification data for an update being available for the server.
+ */
+public class UpdateAvailable implements NotificationData {
 
     private static final LocalizationService LOCALIZATION_SERVICE = LocalizationService.getInstance();
-    private static final Logger LOG = LogManager.getLogger(UpdateAvailableNotification.class);
+    private static final Logger LOG = LogManager.getLogger(UpdateAvailable.class);
     private static final String UYUNI_PATCH_REPO = "systemsmanagement_Uyuni_Stable_Patches";
     private static final String UYUNI_UPDATE_REPO = "systemsmanagement_Uyuni_Stable";
 
@@ -41,7 +43,7 @@ public class UpdateAvailableNotification implements NotificationData {
      *
      * @param runtimeIn runtime object for command execution
      */
-    public UpdateAvailableNotification(Runtime runtimeIn) {
+    public UpdateAvailable(Runtime runtimeIn) {
         this.runtime = runtimeIn;
     }
 
@@ -85,7 +87,7 @@ public class UpdateAvailableNotification implements NotificationData {
 
     @Override
     public NotificationType getType() {
-        return NotificationType.UpdateAvailableNotification;
+        return NotificationType.UpdateAvailable;
     }
 
     @Override

--- a/java/code/src/com/redhat/rhn/domain/notification/types/UpdateAvailableNotification.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/UpdateAvailableNotification.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.domain.notification.types;
+
+
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.localization.LocalizationService;
+import com.redhat.rhn.domain.notification.NotificationMessage;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+
+public class UpdateAvailableNotification implements NotificationData {
+
+    private static final LocalizationService LOCALIZATION_SERVICE = LocalizationService.getInstance();
+    private static final Logger LOG = LogManager.getLogger(UpdateAvailableNotification.class);
+    private static final String UYUNI_PATCH_REPO = "systemsmanagement_Uyuni_Stable_Patches";
+    private static final String UYUNI_UPDATE_REPO = "systemsmanagement_Uyuni_Stable";
+
+    private final boolean mgr = !ConfigDefaults.get().isUyuni();
+    private final String version = StringUtils.substringBeforeLast(ConfigDefaults.get().getProductVersion(), ".");
+    private final Runtime runtime;
+
+    /**
+     * Constructor allowing to pass the runtime as argument.
+     *
+     * @param runtimeIn runtime object for command execution
+     */
+    public UpdateAvailableNotification(Runtime runtimeIn) {
+        this.runtime = runtimeIn;
+    }
+
+    /**
+     * returns true if there are updates available.
+     *
+     * @return boolean
+     **/
+    public boolean updateAvailable() {
+        boolean hasUpdates = false;
+        String repo = mgr ? "SLE-Module-SUSE-Manager-Server-" + version + "-Updates" : UYUNI_PATCH_REPO;
+
+        try {
+            Process patchProc = runtime.exec(new String[]{"bash", "-c",
+                    "LC_ALL=C zypper lp -r " + repo + " | grep 'applicable patch'"});
+            patchProc.waitFor();
+            // 0 here means there are patches
+            hasUpdates = (0 == patchProc.exitValue());
+            if (!hasUpdates && !mgr) {
+                // Check for updates on uyuni when there are no patches
+                Process updateProc = runtime.exec(new String[]{"bash", "-c",
+                        "LC_ALL=C zypper lu -r " + UYUNI_UPDATE_REPO + " | grep 'Available Version'"});
+                updateProc.waitFor();
+                hasUpdates = (0 == updateProc.exitValue());
+            }
+        }
+        catch (IOException e) {
+            LOG.warn("Unable to check for updates", e);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.warn("Wait for update check was interrupted", e);
+        }
+        return hasUpdates;
+    }
+
+    @Override
+    public NotificationMessage.NotificationMessageSeverity getSeverity() {
+        return NotificationMessage.NotificationMessageSeverity.warning;
+    }
+
+    @Override
+    public NotificationType getType() {
+        return NotificationType.UpdateAvailableNotification;
+    }
+
+    @Override
+    public String getSummary() {
+        return LOCALIZATION_SERVICE.getMessage("notification.updateavailable.summary");
+    }
+
+    @Override
+    public String getDetails() {
+        String url = mgr ?
+                "https://www.suse.com/releasenotes/x86_64/SUSE-MANAGER/" + version + "/index.html" :
+                "https://www.uyuni-project.org/pages/stable-version.html";
+        return LOCALIZATION_SERVICE.getMessage("notification.updateavailable.detail", url);
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/notification/types/test/UpdateAvailableTest.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/test/UpdateAvailableTest.java
@@ -14,9 +14,9 @@
  */
 package com.redhat.rhn.domain.notification.types.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.notification.NotificationMessage;
@@ -29,12 +29,10 @@ import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-
 class UpdateAvailableTest extends MockObjectTestCase {
 
-    private static Runtime runtimeMock;
-    private static Process processMock;
+    private Runtime runtimeMock;
+    private Process processMock;
 
     @BeforeEach
     public void setUp() {
@@ -62,40 +60,30 @@ class UpdateAvailableTest extends MockObjectTestCase {
     }
 
     @Test
-    public void testUpdatesAvailable() {
+    public void testUpdatesAvailable() throws Exception {
         // Return 0 on all invocations of exec() -> an update is available
-        try {
-            checking(new Expectations() {{
-                 allowing(runtimeMock).exec(with(any(String[].class)));
-                 will(returnValue(processMock));
-                 allowing(processMock).waitFor();
-                 allowing(processMock).exitValue();
-                 will(returnValue(0));
-            }});
-        }
-        catch (IOException | InterruptedException e) {
-            e.printStackTrace();
-        }
+        checking(new Expectations() {{
+             allowing(runtimeMock).exec(with(any(String[].class)));
+             will(returnValue(processMock));
+             allowing(processMock).waitFor();
+             allowing(processMock).exitValue();
+             will(returnValue(0));
+        }});
 
         UpdateAvailable notification = new UpdateAvailable(runtimeMock);
         assertTrue(notification.updateAvailable());
     }
 
     @Test
-    public void testNoUpdatesAvailable() {
+    public void testNoUpdatesAvailable() throws Exception {
         // Return 1 on all invocations of exec() -> no update is available
-        try {
-            checking(new Expectations() {{
-                 allowing(runtimeMock).exec(with(any(String[].class)));
-                 will(returnValue(processMock));
-                 allowing(processMock).waitFor();
-                 allowing(processMock).exitValue();
-                 will(returnValue(1));
-            }});
-        }
-        catch (IOException | InterruptedException e) {
-            e.printStackTrace();
-        }
+        checking(new Expectations() {{
+             allowing(runtimeMock).exec(with(any(String[].class)));
+             will(returnValue(processMock));
+             allowing(processMock).waitFor();
+             allowing(processMock).exitValue();
+             will(returnValue(1));
+        }});
 
         UpdateAvailable notification = new UpdateAvailable(runtimeMock);
         assertFalse(notification.updateAvailable());

--- a/java/code/src/com/redhat/rhn/domain/notification/types/test/UpdateAvailableTest.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/test/UpdateAvailableTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.domain.notification.types.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.domain.notification.NotificationMessage;
+import com.redhat.rhn.domain.notification.types.NotificationType;
+import com.redhat.rhn.domain.notification.types.UpdateAvailableNotification;
+import com.redhat.rhn.testing.MockObjectTestCase;
+
+import org.jmock.Expectations;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+class UpdateAvailableTest extends MockObjectTestCase {
+
+    private static Runtime runtimeMock;
+    private static Process processMock;
+
+    @BeforeEach
+    public void setUp() {
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+        runtimeMock = mock(Runtime.class);
+        processMock = mock(Process.class);
+    }
+
+    @Test
+    public void testPropertiesAndStrings() {
+        UpdateAvailableNotification notification = new UpdateAvailableNotification(runtimeMock);
+        assertEquals(NotificationType.UpdateAvailableNotification, notification.getType());
+        assertEquals(NotificationMessage.NotificationMessageSeverity.warning, notification.getSeverity());
+        assertEquals("Updates are available.", notification.getSummary());
+        if (ConfigDefaults.get().isUyuni()) {
+            assertEquals("A new update for Uyuni is now available. For further details, please refer to the " +
+                         "<a href=\"https://www.uyuni-project.org/pages/stable-version.html\">release notes<a>.",
+                         notification.getDetails());
+        }
+        else {
+            assertEquals("A new update for SUSE Manager is now available. For further details, please refer to the " +
+                         "<a href=\"https://www.suse.com/releasenotes/x86_64/SUSE-MANAGER/4.3/index.html\">release " +
+                         "notes<a>.", notification.getDetails());
+        }
+    }
+
+    @Test
+    public void testUpdatesAvailable() {
+        // Return 0 on all invocations of exec() -> an update is available
+        try {
+            checking(new Expectations() {{
+                 allowing(runtimeMock).exec(with(any(String[].class)));
+                 will(returnValue(processMock));
+                 allowing(processMock).waitFor();
+                 allowing(processMock).exitValue();
+                 will(returnValue(0));
+            }});
+        }
+        catch (IOException | InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        UpdateAvailableNotification notification = new UpdateAvailableNotification(runtimeMock);
+        assertTrue(notification.updateAvailable());
+    }
+
+    @Test
+    public void testNoUpdatesAvailable() {
+        // Return 1 on all invocations of exec() -> no update is available
+        try {
+            checking(new Expectations() {{
+                 allowing(runtimeMock).exec(with(any(String[].class)));
+                 will(returnValue(processMock));
+                 allowing(processMock).waitFor();
+                 allowing(processMock).exitValue();
+                 will(returnValue(1));
+            }});
+        }
+        catch (IOException | InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        UpdateAvailableNotification notification = new UpdateAvailableNotification(runtimeMock);
+        assertFalse(notification.updateAvailable());
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/notification/types/test/UpdateAvailableTest.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/test/UpdateAvailableTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertTrue;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.notification.NotificationMessage;
 import com.redhat.rhn.domain.notification.types.NotificationType;
-import com.redhat.rhn.domain.notification.types.UpdateAvailableNotification;
+import com.redhat.rhn.domain.notification.types.UpdateAvailable;
 import com.redhat.rhn.testing.MockObjectTestCase;
 
 import org.jmock.Expectations;
@@ -45,8 +45,8 @@ class UpdateAvailableTest extends MockObjectTestCase {
 
     @Test
     public void testPropertiesAndStrings() {
-        UpdateAvailableNotification notification = new UpdateAvailableNotification(runtimeMock);
-        assertEquals(NotificationType.UpdateAvailableNotification, notification.getType());
+        UpdateAvailable notification = new UpdateAvailable(runtimeMock);
+        assertEquals(NotificationType.UpdateAvailable, notification.getType());
         assertEquals(NotificationMessage.NotificationMessageSeverity.warning, notification.getSeverity());
         assertEquals("Updates are available.", notification.getSummary());
         if (ConfigDefaults.get().isUyuni()) {
@@ -77,7 +77,7 @@ class UpdateAvailableTest extends MockObjectTestCase {
             e.printStackTrace();
         }
 
-        UpdateAvailableNotification notification = new UpdateAvailableNotification(runtimeMock);
+        UpdateAvailable notification = new UpdateAvailable(runtimeMock);
         assertTrue(notification.updateAvailable());
     }
 
@@ -97,7 +97,7 @@ class UpdateAvailableTest extends MockObjectTestCase {
             e.printStackTrace();
         }
 
-        UpdateAvailableNotification notification = new UpdateAvailableNotification(runtimeMock);
+        UpdateAvailable notification = new UpdateAvailable(runtimeMock);
         assertFalse(notification.updateAvailable());
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -9424,6 +9424,12 @@ For a detailed analysis, please refer to the log files.</source>
       <trans-unit id="notification.subscriptionwarning.detail">
         <source>You have subscriptions that are expiring soon or already expired. Please check the &lt;a href="/rhn/manager/subscription-matching"&gt;Subscription Matching&lt;/a&gt; page.</source>
       </trans-unit>
+      <trans-unit id="notification.updateavailable.summary">
+        <source>Updates are available.</source>
+      </trans-unit>
+      <trans-unit id="notification.updateavailable.detail">
+        <source>A new update for @@PRODUCT_NAME@@ is now available. For further details, please refer to the &lt;a href="{0}"&gt;release notes&lt;a&gt;.</source>
+      </trans-unit>
       <trans-unit id="notification.endoflife.expired.summary">
         <source>@@PRODUCT_NAME@@ {0} has reached end of life</source>
       </trans-unit>

--- a/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
@@ -24,7 +24,7 @@ import com.redhat.rhn.domain.notification.NotificationMessage;
 import com.redhat.rhn.domain.notification.UserNotificationFactory;
 import com.redhat.rhn.domain.notification.types.EndOfLifePeriod;
 import com.redhat.rhn.domain.notification.types.SubscriptionWarning;
-import com.redhat.rhn.domain.notification.types.UpdateAvailableNotification;
+import com.redhat.rhn.domain.notification.types.UpdateAvailable;
 import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.frontend.dto.ActionMessage;
@@ -142,7 +142,7 @@ public class DailySummary extends RhnJavaJob {
     }
 
     private void  processUpdateAvailableNotification() {
-        UpdateAvailableNotification uan = new UpdateAvailableNotification(Runtime.getRuntime());
+        UpdateAvailable uan = new UpdateAvailable(Runtime.getRuntime());
         if (uan.updateAvailable()) {
             NotificationMessage notificationMessage =
                     UserNotificationFactory.createNotificationMessage(uan);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
@@ -24,6 +24,7 @@ import com.redhat.rhn.domain.notification.NotificationMessage;
 import com.redhat.rhn.domain.notification.UserNotificationFactory;
 import com.redhat.rhn.domain.notification.types.EndOfLifePeriod;
 import com.redhat.rhn.domain.notification.types.SubscriptionWarning;
+import com.redhat.rhn.domain.notification.types.UpdateAvailableNotification;
 import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.frontend.dto.ActionMessage;
@@ -85,6 +86,7 @@ public class DailySummary extends RhnJavaJob {
     @Override
     public void execute(JobExecutionContext ctxIn) {
 
+        processUpdateAvailableNotification();
         processEndOfLifeNotification();
         processSubscriptionWarningNotification();
 
@@ -136,6 +138,16 @@ public class DailySummary extends RhnJavaJob {
                     UserNotificationFactory.createNotificationMessage(new SubscriptionWarning());
             UserNotificationFactory.storeNotificationMessageFor(notificationMessage,
                     Collections.singleton(RoleFactory.ORG_ADMIN), Optional.empty());
+        }
+    }
+
+    private void  processUpdateAvailableNotification() {
+        UpdateAvailableNotification uan = new UpdateAvailableNotification(Runtime.getRuntime());
+        if (uan.updateAvailable()) {
+            NotificationMessage notificationMessage =
+                    UserNotificationFactory.createNotificationMessage(uan);
+            UserNotificationFactory.storeNotificationMessageFor(notificationMessage,
+                    Collections.singleton(RoleFactory.SAT_ADMIN), Optional.empty());
         }
     }
 

--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -217,7 +217,7 @@ java.kiwi_os_image_building_enabled = true
 java.notifications_lifetime = 30
 
 # Configure the disablement of notification messages by type - example disabling all notification types
-#java.notifications_type_disabled = OnboardingFailed,ChannelSyncFailed,ChannelSyncFinished,CreateBootstrapRepoFailed,StateApplyFailed,UpdateAvailableNotification,SubscriptionWarning
+#java.notifications_type_disabled = OnboardingFailed,ChannelSyncFailed,ChannelSyncFinished,CreateBootstrapRepoFailed,StateApplyFailed,UpdateAvailable,SubscriptionWarning
 java.notifications_type_disabled = ChannelSyncFinished
 
 # Maximal number of parallel connections to refresh from SCC

--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -217,7 +217,7 @@ java.kiwi_os_image_building_enabled = true
 java.notifications_lifetime = 30
 
 # Configure the disablement of notification messages by type - example disabling all notification types
-#java.notifications_type_disabled = OnboardingFailed,ChannelSyncFailed,ChannelSyncFinished,CreateBootstrapRepoFailed,StateApplyFailed
+#java.notifications_type_disabled = OnboardingFailed,ChannelSyncFailed,ChannelSyncFinished,CreateBootstrapRepoFailed,StateApplyFailed,UpdateAvailableNotification,SubscriptionWarning
 java.notifications_type_disabled = ChannelSyncFinished
 
 # Maximal number of parallel connections to refresh from SCC

--- a/java/spacewalk-java.changes.mseidl.update-notification
+++ b/java/spacewalk-java.changes.mseidl.update-notification
@@ -1,0 +1,1 @@
+- Shows a notification when an update for Uyuni is available

--- a/web/html/src/manager/notifications/notification-messages.tsx
+++ b/web/html/src/manager/notifications/notification-messages.tsx
@@ -56,8 +56,8 @@ const _MESSAGE_TYPE = {
     id: "SubscriptionWarning",
     text: t("Subscription Warning"),
   },
-  UpdateAvailableNotification: {
-    id: "UpdateAvailableNotification",
+  UpdateAvailable: {
+    id: "UpdateAvailable",
     text: t("Update Notification"),
   },
 };

--- a/web/html/src/manager/notifications/notification-messages.tsx
+++ b/web/html/src/manager/notifications/notification-messages.tsx
@@ -56,6 +56,10 @@ const _MESSAGE_TYPE = {
     id: "SubscriptionWarning",
     text: t("Subscription Warning"),
   },
+  UpdateAvailableNotification: {
+    id: "UpdateAvailableNotification",
+    text: t("Update Notification"),
+  },
 };
 
 function reloadData(dataUrlSlice: string) {

--- a/web/spacewalk-web.changes.mseidl.update-notification
+++ b/web/spacewalk-web.changes.mseidl.update-notification
@@ -1,0 +1,1 @@
+- Shows a notification when an update for Uyuni is available


### PR DESCRIPTION
## What does this PR change?

This patch contains code to check in the background for updates or critical security patches available from the official Uyuni channels on a daily basis (via the `daily summary` taskomatic job). Users are then notified in the UI with a reference to the latest release notes accordingly. The notification shown is currently rather generic and the patch relies on the repo names in order to work (), so this could be further improved in a number of ways. For example we could:

- Identify official channels via the URL instead of the repo name (to make it work even if an admin renamed the channels)
- Send email notifications or show a more prominent popup right after login
- Make the notification message more specific and show more details, for example distinguishing between security patch and new Uyuni version

## GUI diff

![image](https://github.com/uyuni-project/uyuni/assets/729454/a40b04d9-fa63-42da-b544-69d76139130a)

## Documentation

- No documentation needed, the feature is self-explanatory, at least in the current state.

## Test coverage

- Unit tests were added

## Links

Downstream Issue: https://github.com/SUSE/spacewalk/issues/17919
Downstream PR (originally created by @mseidl): https://github.com/SUSE/spacewalk/pull/21922

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository.

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
