### PR TITLE
Revert actions-checkout dependency to v1 in python2 compatibility check

### DIFF
--- a/.github/workflows/susemanager-sls-compatible-python26-syntax.yml
+++ b/.github/workflows/susemanager-sls-compatible-python26-syntax.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       # We need to use "checkout@v1" here as is the only version compatible with Python 2.6
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v1
 
       - name: Configure repos from CentOS vault
         run: |


### PR DESCRIPTION
This GH action is intended to run on python2, which is only supported by v1 of the checkout action.

Related failures after version bump: https://github.com/uyuni-project/uyuni/actions/workflows/susemanager-sls-compatible-python26-syntax.yml

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
