### PR TITLE
QE: Update test suite for using Leap 15.4

### DIFF
--- a/testsuite/features/secondary/allcli_software_channels.feature
+++ b/testsuite/features/secondary/allcli_software_channels.feature
@@ -9,6 +9,7 @@ Feature: Channel subscription via SSM
     Given I am authorized for the "Admin" section
 
 @sle_minion
+@susemanager
   Scenario: Change child channels for SLES minion subscribed to a base channel
     When I follow the left menu "Systems > System List > All"
     And I click on the clear SSM button
@@ -34,6 +35,33 @@ Feature: Channel subscription via SSM
     And a table line should contain system "sle_minion", "Scheduled"
 
 @sle_minion
+@uyuni
+  Scenario: Change child channels for openSUSE minion subscribed to a base channel
+    When I follow the left menu "Systems > System List > All"
+    And I click on the clear SSM button
+    And I check the "sle_minion" client
+    And I should see "1" systems selected for SSM
+    And I follow the left menu "Systems > System Set Manager > Overview"
+    And I follow "channel memberships" in the content area
+    Then I should see a "Base Channel" text
+    And I should see a "Next" text
+    When I select "Fake Base Channel" from drop-down in table line with "openSUSE Leap 15.4 (x86_64)"
+    And I click on "Next"
+    Then I should see a "Child Channels" text
+    And I should see a "Fake Base Channel" text
+    And I should see a "1 system(s) to subscribe" text
+    When I choose radio button "Subscribe" for child channel "Fake Child Channel"
+    And I click on "Next"
+    Then I should see a "Channel Changes Overview" text
+    And I should see a "1 system(s) to subscribe" text
+    When I schedule action to 3 minutes from now
+    And I click on "Confirm"
+    And I remember when I scheduled an action
+    Then I wait until I see "Channel Changes Actions" text
+    And a table line should contain system "sle_minion", "Scheduled"
+
+@sle_minion
+@susemanager
   Scenario: Check SLES minion is still subscribed to old channels before channel change completes
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
@@ -42,6 +70,17 @@ Feature: Channel subscription via SSM
     Then radio button "SLE-Product-SLES15-SP4-Pool for x86_64" should be checked
     And I wait until I do not see "Loading..." text
     And I should see "SLE15-SP4-Installer-Updates for x86_64" as unchecked
+
+@sle_minion
+@uyuni
+  Scenario: Check openSUSE minion is still subscribed to old channels before channel change completes
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    Then radio button "openSUSE Leap 15.4 (x86_64)" should be checked
+    And I wait until I do not see "Loading..." text
+    And I should see "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)" as unchecked
 
 @sle_minion
 @susemanager
@@ -54,8 +93,8 @@ Feature: Channel subscription via SSM
 @uyuni
   Scenario: Check old channels are still enabled on SLES minion before channel change completes
     When I refresh the metadata for "sle_minion"
-    Then "13" channels should be enabled on "sle_minion"
-    And channel "SLE-Product-SLES15-SP4-Pool for x86_64" should be enabled on "sle_minion"
+    Then "10" channels should be enabled on "sle_minion"
+    And channel "openSUSE Leap 15.4 (x86_64)" should be enabled on "sle_minion"
 
   Scenario: Wait 3 minutes for the scheduled action to be executed
     When I wait for "180" seconds
@@ -77,9 +116,17 @@ Feature: Channel subscription via SSM
     And I should see "Fake Child Channel" as checked
 
 @sle_minion
+@susemanager
   Scenario: Check the new channels are enabled on the SLES minion
     When I refresh the metadata for "sle_minion"
     Then "2" channels should be enabled on "sle_minion"
+    And channel "Fake Base Channel" should be enabled on "sle_minion"
+    And channel "Fake Child Channel" should be enabled on "sle_minion"
+
+@uyuni
+  Scenario: Check the new channels are enabled on the SLES minion
+    When I refresh the metadata for "sle_minion"
+    Then "4" channels should be enabled on "sle_minion"
     And channel "Fake Base Channel" should be enabled on "sle_minion"
     And channel "Fake Child Channel" should be enabled on "sle_minion"
 
@@ -144,6 +191,7 @@ Feature: Channel subscription via SSM
     Then radio button "Fake-Deb-AMD64-Channel" should be checked
 
 @sle_minion
+@susemanager
   Scenario: Cleanup: subscribe the SLES minion back to previous channels
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
@@ -168,6 +216,30 @@ Feature: Channel subscription via SSM
     When I follow "scheduled" in the content area
     And I wait until I see "1 system successfully completed this action." text, refreshing the page
     Then channel "SLE15-SP4-Installer-Updates for x86_64" should not be enabled on "sle_minion"
+
+@sle_minion
+@uyuni
+  Scenario: Cleanup: subscribe the openSUSE minion back to previous channels
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    And I check radio button "openSUSE Leap 15.4 (x86_64)"
+    And I wait until I do not see "Loading..." text
+    And I check "openSUSE 15.4 non oss (x86_64)"
+    And I check "openSUSE Leap 15.4 non oss Updates (x86_64)"
+    And I check "openSUSE Leap 15.4 Updates (x86_64)"
+    And I check "Update repository of openSUSE Leap 15.4 Backports (x86_64)"
+    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.4 (x86_64)"
+    And I check "Uyuni Client Tools for openSUSE Leap 15.4 (x86_64)"
+    And I check "Fake-RPM-SUSE-Channel"
+    And I click on "Next"
+    Then I should see a "Confirm Software Channel Change" text
+    When I click on "Confirm"
+    Then I should see a "Changing the channels has been scheduled." text
+    When I follow "scheduled" in the content area
+    And I wait until I see "1 system successfully completed this action." text, refreshing the page
+    Then channel "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)" should not be enabled on "sle_minion"
 
   Scenario: Cleanup: remove remaining systems from SSM after channel subscription tests
     When I click on the clear SSM button

--- a/testsuite/features/secondary/min_activationkey.feature
+++ b/testsuite/features/secondary/min_activationkey.feature
@@ -38,6 +38,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
     And I enter "e^i.pi=-1" in the editor
     And I click on "Create Configuration File"
 
+@susemanager
   Scenario: Create a complete minion activation key
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
@@ -49,6 +50,33 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
     And I wait for child channels to appear
     And I include the recommended child channels
     And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"
+    And I check "Fake-RPM-SUSE-Channel"
+    And I click on "Create Activation Key"
+    And I follow "Configuration" in the content area
+    And I follow first "Subscribe to Channels" in the content area
+    And I check "Key Channel" in the list
+    And I click on "Continue"
+    And I follow "Packages"
+    And I enter "orion-dummy perseus-dummy" as "packages"
+    And I click on "Update Activation Key"
+    Then I should see a "Activation key Minion testing has been modified" text
+
+@uyuni
+  Scenario: Create a complete minion activation key
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "Create Key"
+    And I wait for child channels to appear
+    And I enter "Minion testing" as "description"
+    And I enter "MINION-TEST" as "key"
+    And I enter "20" as "usageLimit"
+    And I select "openSUSE Leap 15.4 (x86_64)" from "selectedBaseChannel"
+    And I wait for child channels to appear
+    And I check "openSUSE 15.4 non oss (x86_64)"
+    And I check "openSUSE Leap 15.4 non oss Updates (x86_64)"
+    And I check "openSUSE Leap 15.4 Updates (x86_64)"
+    And I check "Update repository of openSUSE Leap 15.4 Backports (x86_64)"
+    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.4 (x86_64)"
+    And I check "Uyuni Client Tools for openSUSE Leap 15.4 (x86_64)"
     And I check "Fake-RPM-SUSE-Channel"
     And I click on "Create Activation Key"
     And I follow "Configuration" in the content area
@@ -86,9 +114,15 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
     Given I am on the Systems overview page of this "sle_minion"
     Then I run spacecmd listevents for "sle_minion"
 
+@susemanager
   Scenario: Verify that minion bootstrapped with base channel
     Given I am on the Systems page
     Then I should see a "SLE-Product-SLES15-SP4-Pool for x86_64" text
+
+@uyuni
+  Scenario: Verify that minion bootstrapped with base channel
+    Given I am on the Systems page
+    Then I should see a "openSUSE Leap 15.4 x86_64" text
 
   # bsc#1080807 - Assigning configuration channel in activation key doesn't work
   Scenario: Verify that minion bootstrapped with configuration channel

--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -11,8 +11,15 @@ Feature: Operate an Ansible control node in a normal minion
   Scenario: Pre-requisite: Deploy test playbooks and inventory file
     When I deploy testing playbooks and inventory files to "sle_minion"
 
+@susemanager
   Scenario: Pre-requisite: Enable client tools repositories
     When I enable the repositories "tools_update_repo tools_pool_repo" on this "sle_minion"
+    And I refresh the metadata for "sle_minion"
+
+# TODO: Check why tools_update_repo is not available on the openSUSE minion
+@uyuni
+  Scenario: Pre-requisite: Enable client tools repositories
+    When I enable the repositories "tools_pool_repo os_pool_repo" on this "sle_minion"
     And I refresh the metadata for "sle_minion"
 
   Scenario: Enable "Ansible control node" system type
@@ -83,7 +90,14 @@ Feature: Operate an Ansible control node in a normal minion
     And I remove package "orion-dummy" from this "sle_minion" without error control
     And I remove "/tmp/file.txt" from "sle_minion"
 
+@susemanager
   Scenario: Cleanup: Disable client tools repositories
     Given I am on the Systems overview page of this "sle_minion"
     When I disable the repositories "tools_update_repo tools_pool_repo" on this "sle_minion"
+    And I refresh the metadata for "sle_minion"
+
+@uyuni
+  Scenario: Cleanup: Disable client tools repositories
+    Given I am on the Systems overview page of this "sle_minion"
+    When I disable the repositories "tools_pool_repo os_pool_repo" on this "sle_minion"
     And I refresh the metadata for "sle_minion"

--- a/testsuite/features/secondary/min_bootstrap_api.feature
+++ b/testsuite/features/secondary/min_bootstrap_api.feature
@@ -47,6 +47,7 @@ Feature: Register a Salt minion via API
     Given I am on the Systems overview page of this "sle_minion"
     Then I run spacecmd listevents for "sle_minion"
 
+@susemanager
   Scenario: API bootstrap: subscribe to base channel
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
@@ -57,6 +58,27 @@ Feature: Register a Salt minion via API
     And I include the recommended child channels
     And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"
     And I check "Fake-RPM-SUSE-Channel" 
+    And I click on "Next"
+    Then I should see a "Confirm Software Channel Change" text
+    When I click on "Confirm"
+    Then I should see a "Changing the channels has been scheduled." text
+    And I wait until event "Subscribe channels scheduled by admin" is completed
+
+@uyuni
+  Scenario: API bootstrap: subscribe to base channel
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    And I check radio button "openSUSE Leap 15.4 (x86_64)"
+    And I wait until I do not see "Loading..." text
+    And I check "openSUSE 15.4 non oss (x86_64)"
+    And I check "openSUSE Leap 15.4 non oss Updates (x86_64)"
+    And I check "openSUSE Leap 15.4 Updates (x86_64)"
+    And I check "Update repository of openSUSE Leap 15.4 Backports (x86_64)"
+    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.4 (x86_64)"
+    And I check "Uyuni Client Tools for openSUSE Leap 15.4 (x86_64)"
+    And I check "Fake-RPM-SUSE-Channel"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"

--- a/testsuite/features/secondary/min_bootstrap_script.feature
+++ b/testsuite/features/secondary/min_bootstrap_script.feature
@@ -39,6 +39,7 @@ Feature: Register a Salt minion with a bootstrap script
   Scenario: Detect latest Salt changes on the script-bootstrapped SLES minion
     When I query latest Salt changes on "sle_minion"
 
+@susemanager
   Scenario: Subscribe the script-bootstrapped SLES minion to a base channel
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
@@ -48,6 +49,22 @@ Feature: Register a Salt minion with a bootstrap script
     And I wait until I do not see "Loading..." text
     And I include the recommended child channels
     And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"
+    And I check "Fake-RPM-SUSE-Channel"
+    And I click on "Next"
+    Then I should see a "Confirm Software Channel Change" text
+    When I click on "Confirm"
+    Then I should see a "Changing the channels has been scheduled." text
+    And I wait until event "Subscribe channels scheduled by admin" is completed
+
+@uyuni
+  Scenario: Subscribe the script-bootstrapped SLES minion to a base channel
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    And I check radio button "openSUSE Leap 15.4 (x86_64)"
+    And I wait until I do not see "Loading..." text
+    And I check "Uyuni Client Tools for openSUSE Leap 15.4 (x86_64)"
     And I check "Fake-RPM-SUSE-Channel"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text

--- a/testsuite/features/secondary/min_change_software_channel.feature
+++ b/testsuite/features/secondary/min_change_software_channel.feature
@@ -14,6 +14,7 @@ Feature: Assign child channel to a system
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
+@susemanager
   Scenario: Check the system is still subscribed to old channels before channel change completes
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
@@ -22,6 +23,16 @@ Feature: Assign child channel to a system
     Then radio button "SLE-Product-SLES15-SP4-Pool for x86_64" should be checked
     And I wait until I do not see "Loading..." text
     And I should see "SLE15-SP4-Installer-Updates for x86_64" as unchecked
+
+@uyuni
+  Scenario: Check the system is still subscribed to old channels before channel change completes
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    Then radio button "openSUSE Leap 15.4 (x86_64)" should be checked
+    And I wait until I do not see "Loading..." text
+    And I should see "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)" as unchecked
 
 # susemanager has the Client Tools channels more than uyuni. (+2)
 # in Head also Beta Client Tools Channels (+2)
@@ -34,9 +45,10 @@ Feature: Assign child channel to a system
 @uyuni
   Scenario: Check old channels are still enabled on the system before channel change completes
     When I refresh the metadata for "sle_minion"
-    Then "13" channels should be enabled on "sle_minion"
-    And channel "SLE-Product-SLES15-SP4-Pool for x86_64" should be enabled on "sle_minion"
+    Then "8" channels should be enabled on "sle_minion"
+    And channel "openSUSE Leap 15.4 (x86_64)" should be enabled on "sle_minion"
 
+@susemanager
   Scenario: Assign a child channel to the system
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
@@ -52,11 +64,28 @@ Feature: Assign child channel to a system
     And I wait until I see "1 system successfully completed this action." text, refreshing the page
     Then channel "SLE15-SP4-Installer-Updates for x86_64" should be enabled on "sle_minion"
 
+@uyuni
+  Scenario: Assign a child channel to the system
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    Then radio button "openSUSE Leap 15.4 (x86_64)" should be checked
+    And I wait until I do not see "Loading..." text
+    And I check "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)"
+    And I click on "Next"
+    Then I should see a "Confirm Software Channel Change" text
+    And I click on "Confirm"
+    Then I should see a "Changing the channels has been scheduled." text
+    When I follow "scheduled" in the content area
+    And I wait until I see "1 system successfully completed this action." text, refreshing the page
+    Then channel "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)" should be enabled on "sle_minion"
+
   Scenario: Check channel change has completed for the system
     Given I am on the Systems overview page of this "sle_minion"
     When I wait until event "Subscribe channels scheduled by admin" is completed
     Then I should see a "The client completed this action on" text
 
+@susemanager
   Scenario: Check the system is subscribed to the new channels
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
@@ -64,6 +93,15 @@ Feature: Assign child channel to a system
     Then radio button "SLE-Product-SLES15-SP4-Pool for x86_64" should be checked
     And I wait until I do not see "Loading..." text
     And I should see "SLE15-SP4-Installer-Updates for x86_64" as checked
+
+@uyuni
+  Scenario: Check the system is subscribed to the new channels
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    Then radio button "openSUSE Leap 15.4 (x86_64)" should be checked
+    And I wait until I do not see "Loading..." text
+    And I should see "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)" as checked
 
 @susemanager
   Scenario: Check the new channels are enabled on the system
@@ -75,10 +113,11 @@ Feature: Assign child channel to a system
 @uyuni
   Scenario: Check the new channels are enabled on the system
     When I refresh the metadata for "sle_minion"
-    Then "14" channels should be enabled on "sle_minion"
-    And channel "SLE-Product-SLES15-SP4-Pool for x86_64" should be enabled on "sle_minion"
-    And channel "SLE15-SP4-Installer-Updates for x86_64" should be enabled on "sle_minion"
+    Then "9" channels should be enabled on "sle_minion"
+    And channel "openSUSE Leap 15.4 (x86_64)" should be enabled on "sle_minion"
+    And channel "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)" should be enabled on "sle_minion"
 
+@susemanager
   Scenario: Cleanup: subscribe the system back to previous channels
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
@@ -97,3 +136,27 @@ Feature: Assign child channel to a system
     When I follow "scheduled" in the content area
     And I wait until I see "1 system successfully completed this action." text, refreshing the page
     Then channel "SLE15-SP4-Installer-Updates for x86_64" should not be enabled on "sle_minion"
+
+@uyuni
+  Scenario: Cleanup: subscribe the system back to previous channels
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    Then radio button "openSUSE Leap 15.4 (x86_64)" should be checked
+    And I wait until I do not see "Loading..." text
+    And I wait until I see "openSUSE Leap 15.4 Updates (x86_64)" text
+    And I check "openSUSE 15.4 non oss (x86_64)"
+    And I check "openSUSE Leap 15.4 non oss Updates (x86_64)"
+    And I check "openSUSE Leap 15.4 Updates (x86_64)"
+    And I check "Update repository of openSUSE Leap 15.4 Backports (x86_64)"
+    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.4 (x86_64)"
+    And I check "Uyuni Client Tools for openSUSE Leap 15.4 (x86_64)"
+    And I check "Fake-RPM-SUSE-Channel"
+    And I uncheck "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)"
+    And I click on "Next"
+    Then I should see a "Confirm Software Channel Change" text
+    When I click on "Confirm"
+    Then I should see a "Changing the channels has been scheduled." text
+    When I follow "scheduled" in the content area
+    And I wait until I see "1 system successfully completed this action." text, refreshing the page
+    Then channel "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)" should not be enabled on "sle_minion"

--- a/testsuite/features/secondary/min_custom_pkg_download_endpoint.feature
+++ b/testsuite/features/secondary/min_custom_pkg_download_endpoint.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022 SUSE LLC
+# Copyright (c) 2019-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # In order to use different end-point to download rpms other than the manager instance itself, one can do so with
@@ -11,6 +11,7 @@ Feature: Repos file generation based on custom pillar data
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
+@susemanager
   Scenario: Subscribe the SLES minion to a channel
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
@@ -19,6 +20,21 @@ Feature: Repos file generation based on custom pillar data
     And I check radio button "SLE-Product-SLES15-SP4-Pool for x86_64"
     And I wait until I see "SLE-Module-Basesystem15-SP4-Pool for x86_64" text
     And I uncheck "SLE-Module-Basesystem15-SP4-Pool for x86_64"
+    And I click on "Next"
+    Then I should see a "Confirm Software Channel Change" text
+    When I click on "Confirm"
+    Then I should see a "Changing the channels has been scheduled." text
+    When I follow "scheduled" in the content area
+    And I wait until I see "1 system successfully completed this action." text, refreshing the page
+
+@uyuni
+  Scenario: Subscribe the openSUSE minion to a channel
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    And I check radio button "openSUSE Leap 15.4 (x86_64)"
+    And I wait until I see "openSUSE 15.4 non oss (x86_64)" text
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
@@ -38,6 +54,7 @@ Feature: Repos file generation based on custom pillar data
     And I install the package download endpoint pillar file on the server
     And I refresh the pillar data
 
+@susemanager
   Scenario: Subscribe the SLES minion to a channel again so new RPM end-point will be taken into account
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
@@ -45,6 +62,22 @@ Feature: Repos file generation based on custom pillar data
     And I check radio button "SLE-Product-SLES15-SP4-Pool for x86_64"
     And I wait until I see "SLE-Module-Basesystem15-SP4-Pool for x86_64" text
     And I uncheck "SLE-Module-Basesystem15-SP4-Pool for x86_64"
+    And I click on "Next"
+    Then I should see a "Confirm Software Channel Change" text
+    When I click on "Confirm"
+    Then I should see a "Changing the channels has been scheduled." text
+    When I follow "scheduled" in the content area
+    And I wait until I see "1 system successfully completed this action." text, refreshing the page
+
+
+@uyuni
+  Scenario: Subscribe the openSUSE minion to a channel again so new RPM end-point will be taken into account
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    And I check radio button "openSUSE Leap 15.4 (x86_64)"
+    And I wait until I see "openSUSE 15.4 non oss (x86_64)" text
+    And I check "openSUSE 15.4 non oss (x86_64)"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
@@ -62,6 +95,7 @@ Feature: Repos file generation based on custom pillar data
     And I install a salt pillar top file for "disable_local_repos_off, salt_bundle_config" with target "*" on the server
     And I refresh the pillar data
 
+@susemanager
   Scenario: Cleanup: subscribe the SLES minion to a channel
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
@@ -70,6 +104,26 @@ Feature: Repos file generation based on custom pillar data
     And I wait until I see "SLE15-SP4-Installer-Updates for x86_64" text
     And I include the recommended child channels
     And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"
+    And I check "Fake-RPM-SUSE-Channel"
+    And I click on "Next"
+    Then I should see a "Confirm Software Channel Change" text
+    When I click on "Confirm"
+    Then I should see a "Changing the channels has been scheduled." text
+    When I follow "scheduled" in the content area
+    And I wait until I see "1 system successfully completed this action." text, refreshing the page
+
+@uyuni
+  Scenario: Cleanup: subscribe the SLES minion to a channel
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    And I check radio button "openSUSE Leap 15.4 (x86_64)"
+    And I wait until I see "openSUSE 15.4 non oss (x86_64)" text
+    And I check "openSUSE Leap 15.4 non oss Updates (x86_64)"
+    And I check "openSUSE Leap 15.4 Updates (x86_64)"
+    And I check "Update repository of openSUSE Leap 15.4 Backports (x86_64)"
+    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.4 (x86_64)"
+    And I check "Uyuni Client Tools for openSUSE Leap 15.4 (x86_64)"
     And I check "Fake-RPM-SUSE-Channel"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text

--- a/testsuite/features/secondary/min_salt_openscap_audit.feature
+++ b/testsuite/features/secondary/min_salt_openscap_audit.feature
@@ -12,6 +12,10 @@ Feature: OpenSCAP audit of Salt minion
     Given I am authorized for the "Admin" section
     And I am on the Systems overview page of this "sle_minion"
 
+@Uyuni
+  Scenario: Enable required repositories
+    When I enable repository "os_pool_repo" on this "sle_minion" without error control
+
   Scenario: Install the OpenSCAP packages on the SLE minion
     When I refresh the metadata for "sle_minion"
     And I install OpenSCAP dependencies on "sle_minion"
@@ -84,3 +88,7 @@ Feature: OpenSCAP audit of Salt minion
 
   Scenario: Cleanup: remove the OpenSCAP packages from the SLE minion
     When I remove OpenSCAP dependencies from "sle_minion"
+
+@Uyuni
+  Scenario: Cleanup: Disable required repositories
+    When I disable repository "os_pool_repo" on this "sle_minion" without error control

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -320,9 +320,17 @@ Feature: Manage KVM virtual machines via the GUI
     And I should see a "test-net2" virtual network on "kvm_server"
     And "test-net2" virtual network on "kvm_server" should have "192.168.128.1" IPv4 address with 24 prefix
 
+@susemanager
   Scenario: Install TFTP boot package on the server
     When I install package tftpboot-installation on the server
     And I wait for "tftpboot-installation-SLE-15-SP4-x86_64" to be installed on "server"
+
+# TODO: Not available in any Leap repository, yet
+# See https://suse.slack.com/archives/C02CKHR76Q2/p1694189245268889
+#@uyuni
+#  Scenario: Install TFTP boot package on the server
+#    And I install package tftpboot-installation on the server
+#    And I wait for "tftpboot-installation-openSUSE-Leap-15.4-x86_64" to be installed on "server"
 
 @virthost_kvm
   Scenario: Edit a virtual network

--- a/testsuite/features/secondary/minssh_ansible_control_node.feature
+++ b/testsuite/features/secondary/minssh_ansible_control_node.feature
@@ -13,8 +13,15 @@ Feature: Operate an Ansible control node in SSH minion
   Scenario: Pre-requisite: Deploy test playbooks and inventory file
     When I deploy testing playbooks and inventory files to "ssh_minion"
 
+@susemanager
   Scenario: Pre-requisite: Enable client tools repositories
     When I enable the repositories "tools_update_repo tools_pool_repo" on this "ssh_minion"
+    And I refresh the metadata for "ssh_minion"
+
+# TODO: Check why tools_update_repo is not available on the openSUSE minion
+@uyuni
+  Scenario: Pre-requisite: Enable client tools repositories
+    When I enable the repositories "tools_pool_repo os_pool_repo" on this "ssh_minion"
     And I refresh the metadata for "ssh_minion"
 
   Scenario: Enable "Ansible control node" system type
@@ -82,11 +89,17 @@ Feature: Operate an Ansible control node in SSH minion
     And I uncheck "ansible_control_node"
     And I click on "Update Properties"
     Then I should see a "System properties changed" text
-    And I disable the repositories "tools_update_repo tools_pool_repo" on this "ssh_minion"
     And I remove package "orion-dummy" from this "ssh_minion" without error control
     And I remove "/tmp/file.txt" from "ssh_minion"
 
+@susemanager
   Scenario: Cleanup: Disable client tools repositories
     Given I am on the Systems overview page of this "ssh_minion"
     When I disable the repositories "tools_update_repo tools_pool_repo" on this "ssh_minion"
+    And I refresh the metadata for "ssh_minion"
+
+@uyuni
+  Scenario: Cleanup: Disable client tools repositories
+    Given I am on the Systems overview page of this "ssh_minion"
+    When I disable the repositories "tools_pool_repo os_pool_repo" on this "ssh_minion"
     And I refresh the metadata for "ssh_minion"

--- a/testsuite/features/secondary/minssh_bootstrap_api.feature
+++ b/testsuite/features/secondary/minssh_bootstrap_api.feature
@@ -57,6 +57,7 @@ Feature: Register a salt-ssh system via API
     Given I am on the Systems overview page of this "ssh_minion"
     Then I check for failed events on history event page
 
+@susemanager
   Scenario: API bootstrap: subscribe SSH minion to base channel
     Given I am on the Systems overview page of this "ssh_minion"
     When I follow "Software" in the content area
@@ -66,6 +67,22 @@ Feature: Register a salt-ssh system via API
     And I wait until I do not see "Loading..." text
     And I include the recommended child channels
     And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"
+    And I check "Fake-RPM-SUSE-Channel"
+    And I click on "Next"
+    Then I should see a "Confirm Software Channel Change" text
+    When I click on "Confirm"
+    Then I should see a "Changing the channels has been scheduled." text
+    And I wait until event "Subscribe channels scheduled by admin" is completed
+
+@uyuni
+  Scenario: API bootstrap: subscribe SSH minion to base channel
+    Given I am on the Systems overview page of this "ssh_minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    And I check radio button "openSUSE Leap 15.4 (x86_64)"
+    And I wait until I do not see "Loading..." text
+    And I check "Uyuni Client Tools for openSUSE Leap 15.4 (x86_64)"
     And I check "Fake-RPM-SUSE-Channel"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text

--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -35,9 +35,17 @@ Feature: PXE boot a terminal with Cobbler
     And I click on "Apply Highstate"
     And I wait until event "Apply highstate scheduled by admin" is completed
 
+@susemanager
   Scenario: Install TFTP boot package on the server
     When I install package tftpboot-installation on the server
     And I wait for "tftpboot-installation-SLE-15-SP4-x86_64" to be installed on "server"
+
+# TODO: Not available in any Leap repository, yet
+# See https://suse.slack.com/archives/C02CKHR76Q2/p1694189245268889
+#@uyuni
+# Scenario: Install TFTP boot package on the server
+#   When I install package tftpboot-installation on the server
+#   And I wait for "tftpboot-installation-openSUSE-Leap-15.4-x86_64" to be installed on "server"
 
   Scenario: Create auto installation distribution
     When I follow the left menu "Systems > Autoinstallation > Distributions"

--- a/testsuite/features/secondary/srv_content_lifecycle.feature
+++ b/testsuite/features/secondary/srv_content_lifecycle.feature
@@ -30,6 +30,7 @@ Feature: Content lifecycle
     And I should see a "Filters" text
     And I should see a "Environment Lifecycle" text
 
+@susemanager
   Scenario: Add a source to the project
     When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
@@ -40,11 +41,29 @@ Feature: Content lifecycle
     And I wait until I see "SLE-Product-SLES15-SP4-Pool for x86_64" text
     Then I should see a "Version 1: (draft - not built) - Check the changes below" text
 
+@uyuni
+  Scenario: Add a source to the project
+    When I follow the left menu "Content Lifecycle > Projects"
+    And I follow "clp_name"
+    And I click on "Attach/Detach Sources"
+    And I select "openSUSE Leap 15.4 (x86_64)" from "selectedBaseChannel"
+    And I click on "Save"
+    And I wait until I see "openSUSE Leap 15.4 (x86_64)" text
+    Then I should see a "Version 1: (draft - not built) - Check the changes below" text
+
+@susemanager
   Scenario: Verify added sources
     When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
     Then I should see a "SLE-Product-SLES15-SP4-Updates for x86_64" text
     And I should see a "Build (2)" text
+
+@uyuni
+  Scenario: Verify added sources
+    When I follow the left menu "Content Lifecycle > Projects"
+    And I follow "clp_name"
+    Then I should see a "openSUSE Leap 15.4 (x86_64)" text
+    And I should see a "Build (1)" text
 
   Scenario: Add environments to the project
     When I follow the left menu "Content Lifecycle > Projects"
@@ -73,11 +92,24 @@ Feature: Content lifecycle
     Then I wait until I see "qa_name" text
     And I should see a "qa_desc" text
 
+@susemanager
   Scenario: Build the sources in the project
     When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
     Then I should see a "not built" text in the environment "qa_name"
     When I click on "Build (2)"
+    Then I should see a "Version 1 history" text
+    When I enter "test version message 1" as "message"
+    And I click the environment build button
+    And I wait until I see "Version 1: test version message 1" text in the environment "dev_name"
+    And I wait at most 600 seconds until I see "Built" text in the environment "dev_name"
+
+@uyuni
+  Scenario: Build the sources in the project
+    When I follow the left menu "Content Lifecycle > Projects"
+    And I follow "clp_name"
+    Then I should see a "not built" text in the environment "qa_name"
+    When I click on "Build (1)"
     Then I should see a "Version 1 history" text
     When I enter "test version message 1" as "message"
     And I click the environment build button
@@ -136,6 +168,7 @@ Feature: Content lifecycle
     And I click on "Delete" in "Delete Project" modal
     Then I should not see a "clp_name" text
 
+@susemanager
   Scenario: Cleanup: remove the created channels
     When I delete these channels with spacewalk-remove-channel:
       |clp_label-prod_label-fake_base_channel|
@@ -148,5 +181,17 @@ Feature: Content lifecycle
       |clp_label-prod_label-sle-product-sles15-sp4-pool-x86_64|
       |clp_label-qa_label-sle-product-sles15-sp4-pool-x86_64|
       |clp_label-dev_label-sle-product-sles15-sp4-pool-x86_64|
+    And I list channels with spacewalk-remove-channel
+    Then I shouldn't get "clp_label"
+
+@uyuni
+  Scenario: Cleanup: remove the created channels
+    When I delete these channels with spacewalk-remove-channel:
+      |clp_label-prod_label-fake_base_channel|
+      |clp_label-prod_label-opensuse_leap15_4-x86_64|
+      |clp_label-qa_label-fake_base_channel|
+      |clp_label-qa_label-opensuse_leap15_4-x86_64|
+      |clp_label-dev_label-fake_base_channel|
+      |clp_label-dev_label-opensuse_leap15_4-x86_64|
     And I list channels with spacewalk-remove-channel
     Then I shouldn't get "clp_label"

--- a/testsuite/features/secondary/srv_dist_channel_mapping.feature
+++ b/testsuite/features/secondary/srv_dist_channel_mapping.feature
@@ -1,6 +1,7 @@
-# Copyright (c) 2022 SUSE LLC
+# Copyright (c) 2022-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@skip_if_github_validation
 Feature: Distribution Channel Mapping
 
   Scenario: Log in as admin user
@@ -17,6 +18,7 @@ Feature: Distribution Channel Mapping
     And I should see a "No distribution channel mappings currently exist." text in the content area
 
 @scc_credentials
+@susemanager
   Scenario: Create new map for x86_64 SUSE clients
     When I follow the left menu "Software > Distribution Channel Mapping"
     And I follow "Create Distribution Channel Mapping"
@@ -27,6 +29,18 @@ Feature: Distribution Channel Mapping
     And I select "SLE-Product-SLES15-SP4-Pool for x86_64" from "channel_label" dropdown
     And I click on "Create Mapping"
     Then I should see a "SUSE Linux Enterprise Server 15 SP 4" link in the content area
+
+@uyuni
+  Scenario: Create new map for x86_64 openSUSE clients
+    When I follow the left menu "Software > Distribution Channel Mapping"
+    And I follow "Create Distribution Channel Mapping"
+    Then I should see a "Create Distribution Channel Map" text
+    When I enter "openSUSE Leap 15.4" as "os"
+    And I enter "15.4" as "release"
+    And I select "x86_64" from "architecture" dropdown
+    And I select "openSUSE Leap 15.4 (x86_64)" from "channel_label" dropdown
+    And I click on "Create Mapping"
+    Then I should see a "openSUSE Leap 15.4" link in the content area
 
   Scenario: Create new map for x86_64 Ubuntu clients with test base channel
     When I follow the left menu "Software > Distribution Channel Mapping"
@@ -52,6 +66,7 @@ Feature: Distribution Channel Mapping
     Then I should see a "SUSE Linux Enterprise Server 15 SP 4 iSeries" link in the content area
 
 @scc_credentials
+@susemanager
   Scenario: Update map for x86_64 SUSE clients using test-x86_64 channel
     When I follow the left menu "Software > Distribution Channel Mapping"
     Then I should see the text "SUSE Linux Enterprise Server 15 SP 4" in the Operating System field
@@ -64,6 +79,20 @@ Feature: Distribution Channel Mapping
     And I click on "Update Mapping"
     Then I should see the text "SUSE Linux Enterprise Server 15 SP 4 modified" in the Operating System field
     And I should see the text "sle-product-sles15-sp4-pool-x86_64" in the Channel Label field
+
+@uyuni
+  Scenario: Update map for x86_64 openSUSE clients using test-x86_64 channel
+    When I follow the left menu "Software > Distribution Channel Mapping"
+    Then I should see the text "openSUSE Leap 15.4" in the Operating System field
+    And I should see the text "x86_64" in the Architecture field
+    And I should see the text "opensuse_leap15_4-x86_64" in the Channel Label field
+    When I follow "openSUSE Leap 15.4"
+    Then I should see a "Update Distribution Channel Map" text
+    When I enter "openSUSE Leap 15.4 modified" as "os"
+    And I select "openSUSE Leap 15.4 (x86_64)" from "channel_label" dropdown
+    And I click on "Update Mapping"
+    Then I should see the text "openSUSE Leap 15.4 modified" in the Operating System field
+    And I should see the text "opensuse_leap15_4-x86_64" in the Channel Label field
 
   Scenario: Update map for x86_64 Ubuntu clients using test base channel
     When I follow the left menu "Software > Distribution Channel Mapping"
@@ -91,6 +120,7 @@ Feature: Distribution Channel Mapping
     And I should see the text "fake-deb-amd64-channel" in the Channel Label field
 
 @scc_credentials
+@susemanager
   Scenario: Cleanup: delete the map created for x68_64 SUSE clients
     When I follow the left menu "Software > Distribution Channel Mapping"
     Then I should see the text "SUSE Linux Enterprise Server 15 SP 4 modified" in the Operating System field
@@ -102,6 +132,19 @@ Feature: Distribution Channel Mapping
     Then I should see a "Delete Distribution Channel Map" text
     When I click on "Delete Mapping"
     Then I should not see a "SUSE Linux Enterprise Server 15 SP 4 modified" link
+
+@uyuni
+  Scenario: Cleanup: delete the map created for x68_64 openSUSE clients
+    When I follow the left menu "Software > Distribution Channel Mapping"
+    Then I should see the text "openSUSE Leap 15.4 modified" in the Operating System field
+    And I should see the text "x86_64" in the Architecture field
+    When I follow "openSUSE Leap 15.4 modified"
+    Then I should see a "Update Distribution Channel Map" text
+    And I should see a "Delete Distribution Channel" link
+    When I follow "Delete Distribution Channel Mapping"
+    Then I should see a "Delete Distribution Channel Map" text
+    When I click on "Delete Mapping"
+    Then I should not see a "openSUSE Leap 15.4 modified" link
     
   Scenario: Cleanup: delete the map created for x68_64 Ubuntu clients
     When I follow the left menu "Software > Distribution Channel Mapping"

--- a/testsuite/features/secondary/srv_maintenance_windows.feature
+++ b/testsuite/features/secondary/srv_maintenance_windows.feature
@@ -80,6 +80,7 @@ Feature: Maintenance windows
     And I click on "Confirm"
     Then I should see a "Maintenance schedule has been assigned" text
 
+@susemanager
   Scenario: Schedule channel change action
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area

--- a/testsuite/features/secondary/srv_manage_activationkey.feature
+++ b/testsuite/features/secondary/srv_manage_activationkey.feature
@@ -1,6 +1,7 @@
 # Copyright (c) 2010-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@skip_if_github_validation
 Feature: Manipulate activation keys
   In order to register systems to the spacewalk server
   As the testing user
@@ -66,6 +67,7 @@ Feature: Manipulate activation keys
     Then I should see a "Activation key SUSE Test PKG Key i586 has been deleted." text
 
 @scc_credentials
+@susemanager
   Scenario: Create an activation key with a channel and a package list for x86_64
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
@@ -74,6 +76,21 @@ Feature: Manipulate activation keys
     And I enter "SUSE-TEST-x86_64" as "key"
     And I enter "20" as "usageLimit"
     And I select "SLE-Product-SLES15-SP4-Pool for x86_64" from "selectedBaseChannel"
+    And I click on "Create Activation Key"
+    And I follow "Packages"
+    And I enter "sed" as "packages"
+    And I click on "Update Activation Key"
+    Then I should see a "Activation key SUSE Test PKG Key x86_64 has been modified." text
+
+@uyuni
+  Scenario: Create an activation key with a channel and a package list for x86_64
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "Create Key"
+    And I wait until I do not see "Loading..." text
+    And I enter "SUSE Test PKG Key x86_64" as "description"
+    And I enter "SUSE-TEST-x86_64" as "key"
+    And I enter "20" as "usageLimit"
+    And I select "openSUSE Leap 15.4 (x86_64)" from "selectedBaseChannel"
     And I click on "Create Activation Key"
     And I follow "Packages"
     And I enter "sed" as "packages"

--- a/testsuite/features/secondary/srv_task_status_engine.feature
+++ b/testsuite/features/secondary/srv_task_status_engine.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 SUSE LLC
+# Copyright (c) 2022-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Task Engine Status
@@ -41,6 +41,7 @@ Feature: Task Engine Status
     And I should see a "FINISHED" text
 
 @scc_credentials
+@susemanager
   Scenario: Resync a product to trigger a new task and check if it is visible on the Runtime Status page
     When I follow the left menu "Admin > Task Engine Status > Runtime Status"
     And I follow the left menu "Admin > Setup Wizard > Products"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -509,8 +509,7 @@ end
 
 When(/^I extract the log files from all our active nodes$/) do
   $node_by_host.each do |_host, node|
-    # the salt_migration_minion is not available anymore
-    next if node.nil? || node == get_target('salt_migration_minion')
+    next if node.nil?
 
     STDOUT.puts "Node: #{node.full_hostname}"
     extract_logs_from_node(node)

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1170,10 +1170,11 @@ When(/^I (enable|disable) the necessary repositories before installing Prometheu
   node = get_target(host)
   os_version = node.os_version.gsub('-SP', '.')
   os_family = node.os_family
-  repositories = 'tools_pool_repo tools_update_repo'
+  # TODO: Check why tools_update_repo is not available on the openSUSE minion
+  repositories = 'tools_pool_repo'
   if os_family =~ /^opensuse/ || os_family =~ /^sles/
     if product != 'Uyuni'
-      repositories.concat(' tools_additional_repo')
+      repositories.concat('  tools_update_repo tools_additional_repo')
       # Needed because in SLES15SP3 and openSUSE 15.3 and higher, firewalld will replace this package.
       # But the tools_update_repo's priority doesn't allow to cope with the obsoletes option from firewalld.
       if os_version.to_f >= 15.3


### PR DESCRIPTION
## What does this PR change?

This includes some more adjustments for using openSUSE Leap 15.4 in our Uyuni CI. KVM + Cobbler tests will still fail because of the missing TFTP package I was not able to find (see e.g. https://suse.slack.com/archives/C02CKHR76Q2/p1694189245268889).
I ran all tests manually on the Uyuni CI controller. Some of the tests look a little bit different in Uyuni than in SUMA because of e.g. no child channels were selected by default due to the missing reposync.

Furthermore, I also fixed an issue in the finishing stage where we could not extract the log files due to taking special care of the nested VM. This works now again:

```bash
uyuni-master-ctl:~/spacewalk/testsuite # cucumber features/dom.feature
Capybara APP Host: https://uyuni-master-srv.mgr.suse.de:8888
Initializing a twopence node for 'server'.
Host 'server' is alive with determined hostname uyuni-master-srv and FQDN uyuni-master-srv.mgr.suse.de
Node: uyuni-master-srv, OS Version: 15.4, Family: opensuse-leap
Activating HTTP API
Using the default profile...
Feature: doms tests

  Scenario: doms tests                                     # features/dom.feature:3
      This scenario ran at: 2023-09-08 18:29:19 +0200
Node: uyuni-master-srv.mgr.suse.de
    When I extract the log files from all our active nodes # features/step_definitions/command_steps.rb:510
      This scenario took: 255 seconds

1 scenario (1 passed)
1 step (1 passed)
4m15.035s
```

## GUI diff

No difference.


- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were added

- [x] **DONE**

## Links

- Fixes https://github.com/SUSE/spacewalk/issues/22421
- Manager 4.3: 
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
