### PR TITLE
Change list endpoints in saltkey namespace to accept GET requests instead of POST (bsc#1214463)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandler.java
@@ -20,6 +20,7 @@ import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
 import com.redhat.rhn.frontend.xmlrpc.PermissionCheckFailureException;
 import com.redhat.rhn.frontend.xmlrpc.UnsupportedOperationException;
 
+import com.suse.manager.api.ReadOnly;
 import com.suse.manager.utils.SaltKeyUtils;
 
 import java.util.List;
@@ -49,6 +50,7 @@ public class SaltKeyHandler extends BaseHandler {
      * @apidoc.param #session_key()
      * @apidoc.returntype #array_single("string", "Accepted salt key list")
      */
+    @ReadOnly
     public List<String> acceptedList(User loggedInUser) {
         ensureOrgAdmin(loggedInUser);
         return saltKeyUtils.acceptedSaltKeyList(loggedInUser);
@@ -63,6 +65,7 @@ public class SaltKeyHandler extends BaseHandler {
      * @apidoc.param #session_key()
      * @apidoc.returntype #array_single("string", "Pending salt key list")
      */
+    @ReadOnly
     public List<String> pendingList(User loggedInUser) {
         ensureOrgAdmin(loggedInUser);
         return saltKeyUtils.unacceptedSaltKeyList(loggedInUser);
@@ -77,6 +80,7 @@ public class SaltKeyHandler extends BaseHandler {
      * @apidoc.param #session_key()
      * @apidoc.returntype #array_single("string", "Rejected salt key list")
      */
+    @ReadOnly
     public List<String> rejectedList(User loggedInUser) {
         ensureOrgAdmin(loggedInUser);
         return saltKeyUtils.rejectedSaltKeyList(loggedInUser);
@@ -91,6 +95,7 @@ public class SaltKeyHandler extends BaseHandler {
      * @apidoc.param #session_key()
      * @apidoc.returntype #array_single("string", "Denied salt key list")
      */
+    @ReadOnly
     public List<String> deniedList(User loggedInUser) {
         ensureOrgAdmin(loggedInUser);
         return saltKeyUtils.deniedSaltKeyList(loggedInUser);

--- a/java/spacewalk-java.changes.cbbayburt.bsc1214463
+++ b/java/spacewalk-java.changes.cbbayburt.bsc1214463
@@ -1,0 +1,2 @@
+- Change list endpoints in saltkey namespace to accept GET
+  requests instead of POST (bsc#1214463)


### PR DESCRIPTION
Updates the following endpoints in the 'saltkey' namespace to accept GET requests instead of POST:

- acceptedList
- pendingList
- rejectedList
- deniedList

Port of: https://github.com/SUSE/spacewalk/pull/22493

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
