### PR TITLE
QE: more test suite adjustment for Leap 15.4

### DIFF
--- a/testsuite/features/secondary/allcli_software_channels.feature
+++ b/testsuite/features/secondary/allcli_software_channels.feature
@@ -93,7 +93,7 @@ Feature: Channel subscription via SSM
 @uyuni
   Scenario: Check old channels are still enabled on SLES minion before channel change completes
     When I refresh the metadata for "sle_minion"
-    Then "10" channels should be enabled on "sle_minion"
+    Then "8" channels should be enabled on "sle_minion"
     And channel "openSUSE Leap 15.4 (x86_64)" should be enabled on "sle_minion"
 
   Scenario: Wait 3 minutes for the scheduled action to be executed
@@ -126,7 +126,7 @@ Feature: Channel subscription via SSM
 @uyuni
   Scenario: Check the new channels are enabled on the SLES minion
     When I refresh the metadata for "sle_minion"
-    Then "4" channels should be enabled on "sle_minion"
+    Then "2" channels should be enabled on "sle_minion"
     And channel "Fake Base Channel" should be enabled on "sle_minion"
     And channel "Fake Child Channel" should be enabled on "sle_minion"
 

--- a/testsuite/features/secondary/allcli_software_channels_dependencies.feature
+++ b/testsuite/features/secondary/allcli_software_channels_dependencies.feature
@@ -8,6 +8,7 @@ Feature: Channel subscription with recommended or required dependencies
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
+@susemanager
   Scenario: Play with recommended and required child channels selection for a single system
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
@@ -28,6 +29,23 @@ Feature: Channel subscription with recommended or required dependencies
     When I click on the "disabled" toggler
     Then I should see the child channel "SLE-Module-Server-Applications15-SP4-Pool for x86_64" "selected"
 
+# These tests do not test if recommended channesl are shown correctly due to the fact that we kill the reposync
+# for openSUSE Leap. With this caveat, no child channels are selected when selection openSUSE as parent.
+@uyuni
+  Scenario: Play with recommended and required child channels selection for a single system
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait for child channels to appear
+    And I check radio button "(none, disable service)"
+    And I wait for child channels to appear
+    And I check radio button "openSUSE Leap 15.4 (x86_64)"
+    Then I should see the child channel "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)" "unselected" and "disabled"
+    Then I should see the child channel "openSUSE 15.4 non oss (x86_64)" "selected"
+    When I select the child channel "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)"
+    Then I should see the child channel "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)" "selected"
+
+@susemanager
   Scenario: Play with recommended and required child channels selection in SSM
     When I follow the left menu "Systems > System List > All"
     And I check the "sle_minion" client
@@ -45,6 +63,24 @@ Feature: Channel subscription with recommended or required dependencies
     When I click on the "disabled" toggler
     Then I should see "Subscribe" "selected" for the "SLE-Module-Basesystem15-SP4-Pool for x86_64" channel
     And I should see "No change" "unselected" for the "SLE-Module-Basesystem15-SP4-Pool for x86_64" channel
+
+# These tests do not test if recommended channesl are shown correctly due to the fact that we kill the reposync
+# for openSUSE Leap. With this caveat, no child channels are selected when selection openSUSE as parent.
+@uyuni
+  Scenario: Play with recommended and required child channels selection in SSM
+    When I follow the left menu "Systems > System List > All"
+    And I check the "sle_minion" client
+    Then I should see "1" systems selected for SSM
+    When I follow the left menu "Systems > System Set Manager > Overview"
+    And I follow "channel memberships" in the content area
+    Then I should see a "Base Channel" text
+    And I should see a "Next" text
+    And I should see a table line with "openSUSE Leap 15.4 (x86_64)", "1"
+    When I select "No Change" from drop-down in table line with "openSUSE Leap 15.4 (x86_64)"
+    And I click on "Next"
+    Then I should see the toggler "disabled"
+    And I should see a "openSUSE 15.4 non oss (x86_64)" text
+    And I should see "No change" "selected" for the "openSUSE 15.4 non oss (x86_64)" channel
 
   Scenario: Cleanup: remove remaining systems from SSM after software channel tests
     When I click on the clear SSM button

--- a/testsuite/features/secondary/min_activationkey.feature
+++ b/testsuite/features/secondary/min_activationkey.feature
@@ -122,7 +122,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
 @uyuni
   Scenario: Verify that minion bootstrapped with base channel
     Given I am on the Systems page
-    Then I should see a "openSUSE Leap 15.4 x86_64" text
+    Then I should see a "openSUSE Leap 15.4 (x86_64)" text
 
   # bsc#1080807 - Assigning configuration channel in activation key doesn't work
   Scenario: Verify that minion bootstrapped with configuration channel

--- a/testsuite/features/secondary/min_salt_openscap_audit.feature
+++ b/testsuite/features/secondary/min_salt_openscap_audit.feature
@@ -23,6 +23,7 @@ Feature: OpenSCAP audit of Salt minion
     And I click on "Update Package List"
     And I wait until event "Package List Refresh" is completed
 
+@susemanager
   Scenario: Schedule an OpenSCAP audit job on the SLE minion
     When I follow "Audit" in the content area
     And I follow "Schedule" in the content area
@@ -33,6 +34,18 @@ Feature: OpenSCAP audit of Salt minion
     Then I should see a "XCCDF scan has been scheduled" text
     And I wait at most 500 seconds until event "OpenSCAP xccdf scanning" is completed
 
+@uyuni
+  Scenario: Schedule an OpenSCAP audit job on the SLE minion
+    When I follow "Audit" in the content area
+    And I follow "Schedule" in the content area
+    And I wait at most 30 seconds until I do not see "This system does not yet have OpenSCAP scan capability." text, refreshing the page
+    And I enter "--profile standard" as "params"
+    And I enter "/usr/share/xml/scap/ssg/content/ssg-opensuse-ds-1.2.xml" as "path"
+    And I click on "Schedule"
+    Then I should see a "XCCDF scan has been scheduled" text
+    And I wait at most 500 seconds until event "OpenSCAP xccdf scanning" is completed
+
+@susemanager
   Scenario: Check results of the audit job on the minion
     When I follow "Audit" in the content area
     And I follow "xccdf_org.open-scap_testresult"
@@ -43,12 +56,35 @@ Feature: OpenSCAP audit of Salt minion
     And I click on the filter button
     Then I should see a "xccdf_org.ssgproject.content_rule_service_httpd_disabled" link
 
+@uyuni
+  Scenario: Check results of the audit job on the minion
+    When I follow "Audit" in the content area
+    And I follow "xccdf_org.open-scap_testresult"
+    Then I should see a "Details of XCCDF Scan" text
+    And I should see a "profile standard" text
+    And I should see a "XCCDF Rule Results" text
+    When I enter "pass" as the filtered XCCDF result type
+    And I click on the filter button
+    Then I should see a "xccdf_org.ssgproject.content_rule_file_permissions_etc_passwd" link
+
+@susemanager
   Scenario: Create a second, almost identical, audit job
     When I follow "Audit" in the content area
     And I follow "Schedule" in the content area
     And I wait at most 30 seconds until I do not see "This system does not yet have OpenSCAP scan capability." text, refreshing the page
     And I enter "--profile standard" as "params"
     And I enter "/usr/share/xml/scap/ssg/content/ssg-sle15-ds-1.2.xml" as "path"
+    And I click on "Schedule"
+    Then I should see a "XCCDF scan has been scheduled" text
+    When I wait for the OpenSCAP audit to finish
+
+@uyuni
+  Scenario: Create a second, almost identical, audit job
+    When I follow "Audit" in the content area
+    And I follow "Schedule" in the content area
+    And I wait at most 30 seconds until I do not see "This system does not yet have OpenSCAP scan capability." text, refreshing the page
+    And I enter "--profile standard" as "params"
+    And I enter "/usr/share/xml/scap/ssg/content/ssg-opensuse-ds-1.2.xml" as "path"
     And I click on "Schedule"
     Then I should see a "XCCDF scan has been scheduled" text
     When I wait for the OpenSCAP audit to finish


### PR DESCRIPTION
## What does this PR change?

This PR adjusts more things in the test suite code for using Leap 15.4. in Uyuni.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were added

- [x] **DONE**

## Links

- Manager 4.3:
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
