### PR TITLE
Remove all tasks for the processed system in the system update

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/task/TaskFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/task/TaskFactory.java
@@ -130,6 +130,24 @@ public class TaskFactory extends HibernateFactory {
     }
 
     /**
+     * Delete tasks matching a name and a data, ignoring priority and organization.
+     *
+     * @param name the tasks name
+     * @param data the tasks data
+     */
+    public static void deleteByNameData(String name, Long data) {
+        Session session = HibernateFactory.getSession();
+        CriteriaBuilder builder = session.getCriteriaBuilder();
+        CriteriaDelete<Task> criteriaDelete = builder.createCriteriaDelete(Task.class);
+        Root<Task> root = criteriaDelete.from(Task.class);
+        criteriaDelete.where(builder.and(
+                builder.equal(root.get("name"), name),
+                builder.equal(root.get("data"), data)
+        ));
+        session.createQuery(criteriaDelete).executeUpdate();
+    }
+
+    /**
      * Gets the list of "update errata cache for channel" tasks.
      * @param org The org containing the tasks
      * @return Returns a list of task objects

--- a/java/code/src/com/redhat/rhn/taskomatic/task/systems/SystemsOverviewUpdateWorker.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/systems/SystemsOverviewUpdateWorker.java
@@ -17,7 +17,6 @@ package com.redhat.rhn.taskomatic.task.systems;
 import com.redhat.rhn.common.db.datasource.CallableMode;
 import com.redhat.rhn.common.db.datasource.ModeFactory;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
-import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.task.TaskFactory;
 import com.redhat.rhn.taskomatic.task.threaded.QueueWorker;
 import com.redhat.rhn.taskomatic.task.threaded.TaskQueue;
@@ -91,7 +90,6 @@ public class SystemsOverviewUpdateWorker implements QueueWorker {
      * @param sid the System id to remove the tasks from
      */
     public static void removeTask(Long sid) {
-        TaskFactory.deleteByOrgNameDataPriority(OrgFactory.getSatelliteOrg(), SystemsOverviewUpdateDriver.TASK_NAME,
-                sid, 0);
+        TaskFactory.deleteByNameData(SystemsOverviewUpdateDriver.TASK_NAME, sid);
     }
 }

--- a/java/spacewalk-java.changes.cbosdo.system-update-fix
+++ b/java/spacewalk-java.changes.cbosdo.system-update-fix
@@ -1,0 +1,2 @@
+- Remove all systems tasks for all organizations after updating 
+  systems


### PR DESCRIPTION
## What does this PR change?

Fix for https://github.com/uyuni-project/uyuni/issues/7313 where only the system update tasks for systems of organization 1 where cleaned up.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: requires multiple orgs

- [X] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/7313

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
