### PR TITLE
QE: Fix test suite issues for build validation

### DIFF
--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -415,7 +415,11 @@ Note that the text area variant handles the new lines characters while the other
   Then service "bind" is enabled on "proxy"
   And service "dhcpd" is running on "proxy"
   When I restart the "bind" service on "sle_minion"
+  And I start the "apache2" service on "proxy"
+  And I stop the "apache2" service on "proxy"
   And I reload the "apache2" service on "proxy"
+  And I enable the "apache2" service on "proxy"
+  And I disable the "apache2" service on "proxy"
 ```
 
 * File removal

--- a/testsuite/features/build_validation/add_non_MU_repositories/oracle9_minion_build_clm.feature
+++ b/testsuite/features/build_validation/add_non_MU_repositories/oracle9_minion_build_clm.feature
@@ -27,7 +27,8 @@ Feature: Add the Oracle 9 distribution custom repositories
     And I wait until I do not see "Loading" text
     And I select "oraclelinux9 for x86_64" from "selectedBaseChannel"
     # "oraclelinux9-appstream for x86_64" is already checked
-    And I check "Uyuni Client Tools for Oracle Linux 9 (x86_64)"
+    And I check "EL9-Manager-Tools-Pool for x86_64 OL9"
+    And I check "EL9-Manager-Tools-Updates for x86_64 OL9"
     And I check "Custom Channel for oracle9_minion"
     And I click on "Save"
     Then I should see a "EL9-Manager-Tools-Pool for x86_64 OL9" text

--- a/testsuite/features/build_validation/containerization/proxy_as_pod_basic_tests.feature
+++ b/testsuite/features/build_validation/containerization/proxy_as_pod_basic_tests.feature
@@ -31,7 +31,7 @@ Feature: Register and test a Containerized Proxy
     When I stop salt-minion on "proxy"
     And I run "spacewalk-proxy stop" on "proxy"
     # workaround for bsc#1205976
-    And I stop "tftp" service on "proxy"
+    And I stop the "tftp" service on "proxy"
     And I wait until "squid" service is inactive on "proxy"
     And I wait until "apache2" service is inactive on "proxy"
     And I wait until "tftp" service is inactive on "proxy"
@@ -45,7 +45,7 @@ Feature: Register and test a Containerized Proxy
     And I add avahi hosts in Containerized Proxy configuration
 
   Scenario: Start Containerized Proxy services
-    When I start "uyuni-proxy-pod" service on "proxy"
+    When I start the "uyuni-proxy-pod" service on "proxy"
     And I wait until "uyuni-proxy-pod" service is active on "proxy"
     And I wait until "uyuni-proxy-httpd" service is active on "proxy"
     And I wait until "uyuni-proxy-salt-broker" service is active on "proxy"
@@ -227,7 +227,7 @@ Feature: Register and test a Containerized Proxy
     Then "containerized_proxy" should not be registered
 
   Scenario: Cleanup: Stop Containerized Proxy services
-    When I stop "uyuni-proxy-pod" service on "proxy"
+    When I stop the "uyuni-proxy-pod" service on "proxy"
 
   Scenario: Cleanup: Remove Containerized Proxy configuration
     When I ensure folder "/etc/uyuni/proxy/*" doesn't exist on "proxy"
@@ -245,7 +245,7 @@ Feature: Register and test a Containerized Proxy
     When I start salt-minion on "proxy"
     And I run "spacewalk-proxy start" on "proxy"
     # workaround for bsc#1205976
-    And I start "tftp" service on "proxy"
+    And I start the "tftp" service on "proxy"
     And I wait until "squid" service is active on "proxy"
     And I wait until "apache2" service is active on "proxy"
     And I wait until "tftp" service is active on "proxy"

--- a/testsuite/features/build_validation/init_clients/proxy.feature
+++ b/testsuite/features/build_validation/init_clients/proxy.feature
@@ -52,7 +52,6 @@ Feature: Setup SUSE Manager proxy
     And file "/etc/sysconfig/apache2" should contain "rewrite" on "proxy"
     And file "/etc/sysconfig/apache2" should contain "version" on "proxy"
     And file "/etc/sysconfig/apache2" should contain "ssl" on "proxy"
-    And file "/etc/sysconfig/apache2" should contain "access_compat" on "proxy"
     And file "/etc/sysconfig/apache2" should contain "wsgi" on "proxy"
     Then I should see "proxy" via spacecmd
     And service "salt-broker" is active on "proxy"

--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -48,6 +48,7 @@ Feature: Smoke tests for <client>
     And I wait until event "Patch Update:" is completed
     And I reboot the "<client>" if it is a SLE Micro
 
+@skip_for_sle_micro_ssh_minion
   Scenario: Install a package on the <client>
     When I follow "Software" in the content area
     And I follow "Install"
@@ -60,6 +61,7 @@ Feature: Smoke tests for <client>
     And I wait until event "Package Install/Upgrade scheduled by admin" is completed
     And I reboot the "<client>" if it is a SLE Micro
 
+@skip_for_sle_micro_ssh_minion
   Scenario: Remove package from <client>
     When I follow "Software" in the content area
     And I follow "List / Remove"
@@ -148,7 +150,8 @@ Feature: Smoke tests for <client>
     And I wait until event "Package Install/Upgrade scheduled by admin" is completed
     And I reboot the "<client>" if it is a SLE Micro
 
-  Scenario: Test Prometheus exporter formula on the <client>
+@skip_for_sle_micro_ssh_minion
+  Scenario: Enable Prometheus Node exporter formula on the <client>
     Given I am on the Systems overview page of this "<client>"
     When I follow "Formulas" in the content area
     And I check the "prometheus-exporters" formula
@@ -159,24 +162,49 @@ Feature: Smoke tests for <client>
     And I click on "Expand All Sections"
     And I should see a "Enable and configure Prometheus exporters for managed systems." text
     And I check "node" exporter
+    And I click on "Save"
+    Then I should see a "Formula saved" text
+
+@skip_for_sle_micro
+  Scenario: Enable Prometheus Apache and Postgres exporter formula on the <client>
+    Given I am on the Systems overview page of this "<client>"
+    When I follow "Formulas" in the content area
+    When I follow "Prometheus Exporters" in the content area
+    And I click on "Expand All Sections"
+    And I should see a "Enable and configure Prometheus exporters for managed systems." text
     And I check "apache" exporter
     And I check "postgres" exporter
     And I click on "Save"
     Then I should see a "Formula saved" text
-    # Apply highstate for Prometheus exporters
+
+@skip_for_sle_micro_ssh_minion
+  Scenario: Apply highstate for the Prometheus exporters on the <client>
+    Given I am on the Systems overview page of this "<client>"
     When I follow "States" in the content area
     And I click on "Apply Highstate"
     Then I should see a "Applying the highstate has been scheduled." text
     And I wait until event "Apply highstate scheduled by admin" is completed
-    # Visit monitoring endpoints on the minion
+
+@skip_for_sle_micro_ssh_minion
+@sle_micro_minion
+  # workaround for SLE Micro minion issue bsc#1209374
+  Scenario: Enable and start Prometheus Node Exporter service
+    And I start the "prometheus-node_exporter.service" service on "<client>"
+    And I enable the "prometheus-node_exporter.service" service on "<client>"
+
+@skip_for_sle_micro_ssh_minion
+  Scenario: Visit Node monitoring endpoint on the <client>
     When I wait until "node" exporter service is active on "<client>"
     And I visit "Prometheus node exporter" endpoint of this "<client>"
-    And I wait until "apache" exporter service is active on "<client>"
+
+@skip_for_sle_micro
+  Scenario: Visit Apache and Postgres monitoring endpoint on the <client>
+    When I wait until "apache" exporter service is active on "<client>"
     And I visit "Prometheus apache exporter" endpoint of this "<client>"
     And I wait until "postgres" exporter service is active on "<client>"
     And I visit "Prometheus postgres exporter" endpoint of this "<client>"
-    And I reboot the "<client>" if it is a SLE Micro
 
+@skip_for_sle_micro_ssh_minion
 @monitoring_server
   Scenario: Test <client> on Grafana
     When I visit the grafana dashboards of this "monitoring_server"

--- a/testsuite/features/init_clients/proxy_register_as_pod.feature
+++ b/testsuite/features/init_clients/proxy_register_as_pod.feature
@@ -21,7 +21,7 @@ Feature: Setup Containerized Proxy
     When I stop salt-minion on "proxy"
     And I run "spacewalk-proxy stop" on "proxy"
     # workaround for bsc#1205976
-    And I stop "tftp" service on "proxy"
+    And I stop the "tftp" service on "proxy"
     And I wait until "squid" service is inactive on "proxy"
     And I wait until "apache2" service is inactive on "proxy"
     And I wait until "tftp" service is inactive on "proxy"
@@ -35,7 +35,7 @@ Feature: Setup Containerized Proxy
     And I add avahi hosts in Containerized Proxy configuration
 
   Scenario: Start Containerized Proxy services
-    When I start "uyuni-proxy-pod" service on "proxy"
+    When I start the "uyuni-proxy-pod" service on "proxy"
     And I wait until "uyuni-proxy-pod" service is active on "proxy"
     And I wait until "uyuni-proxy-httpd" service is active on "proxy"
     And I wait until "uyuni-proxy-salt-broker" service is active on "proxy"

--- a/testsuite/features/secondary/proxy_as_pod_basic_tests.feature
+++ b/testsuite/features/secondary/proxy_as_pod_basic_tests.feature
@@ -43,7 +43,7 @@ Feature: Register and test a Containerized Proxy
     When I stop salt-minion on "proxy"
     And I run "spacewalk-proxy stop" on "proxy"
     # workaround for bsc#1205976
-    And I stop "tftp" service on "proxy"
+    And I stop the "tftp" service on "proxy"
     And I wait until "squid" service is inactive on "proxy"
     And I wait until "apache2" service is inactive on "proxy"
     And I wait until "tftp" service is inactive on "proxy"
@@ -57,7 +57,7 @@ Feature: Register and test a Containerized Proxy
     And I add avahi hosts in Containerized Proxy configuration
 
   Scenario: Start Containerized Proxy services
-    When I start "uyuni-proxy-pod" service on "proxy"
+    When I start the "uyuni-proxy-pod" service on "proxy"
     And I wait until "uyuni-proxy-pod" service is active on "proxy"
     And I wait until "uyuni-proxy-httpd" service is active on "proxy"
     And I wait until "uyuni-proxy-salt-broker" service is active on "proxy"
@@ -239,7 +239,7 @@ Feature: Register and test a Containerized Proxy
     Then "containerized_proxy" should not be registered
 
   Scenario: Cleanup: Stop Containerized Proxy services
-    When I stop "uyuni-proxy-pod" service on "proxy"
+    When I stop the "uyuni-proxy-pod" service on "proxy"
 
   Scenario: Cleanup: Remove Containerized Proxy configuration
     When I ensure folder "/etc/uyuni/proxy/*" doesn't exist on "proxy"
@@ -257,7 +257,7 @@ Feature: Register and test a Containerized Proxy
     When I start salt-minion on "proxy"
     And I run "spacewalk-proxy start" on "proxy"
     # workaround for bsc#1205976
-    And I start "tftp" service on "proxy"
+    And I start the "tftp" service on "proxy"
     And I wait until "squid" service is active on "proxy"
     And I wait until "apache2" service is active on "proxy"
     And I wait until "tftp" service is active on "proxy"

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -433,5 +433,5 @@ Feature: PXE boot a Retail terminal
     And I wait until event "Apply highstate scheduled by admin" is completed
 
   Scenario: Reset TFTP defaults
-    When I stop tftp on the proxy
+    When I stop the "tftp" service on "proxy"
     And I reset tftp defaults on the proxy

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -690,9 +690,9 @@ Then(/^I should see "(.*?)" in the output$/) do |arg1|
   raise "Command Output #{@command_output} don't include #{arg1}" unless @command_output.include? arg1
 end
 
-When(/^I (start|stop) "([^"]*)" service on "([^"]*)"$/) do |action, service, host|
+When(/^I (start|stop|restart|reload|enable|disable) the "([^"]*)" service on "([^"]*)"$/) do |action, service, host|
   node = get_target(host)
-  node.run("systemctl #{action} #{service}")
+  node.run("systemctl #{action} #{service}", check_errors: true, verbose: true)
 end
 
 Then(/^service "([^"]*)" is enabled on "([^"]*)"$/) do |service, host|
@@ -1516,16 +1516,6 @@ When(/^I enable firewall ports for monitoring on this "([^"]*)"$/) do |host|
   output, _code = node.run('firewall-cmd --list-ports')
   raise StandardError, "Couldn't successfully enable all ports needed for monitoring. Opened ports: #{output}" unless
     output.include? '9100/tcp 9117/tcp 9187/tcp'
-end
-
-When(/^I restart the "([^"]*)" service on "([^"]*)"$/) do |service, minion|
-  node = get_target(minion)
-  node.run("systemctl restart #{service}", check_errors: true, verbose: true)
-end
-
-When(/^I reload the "([^"]*)" service on "([^"]*)"$/) do |service, minion|
-  node = get_target(minion)
-  node.run("systemctl reload #{service}", check_errors: true, verbose: true)
 end
 
 When(/^I delete the system "([^"]*)" via spacecmd$/) do |minion|

--- a/testsuite/features/step_definitions/retail_steps.rb
+++ b/testsuite/features/step_definitions/retail_steps.rb
@@ -129,10 +129,6 @@ When(/^I start tftp on the proxy$/) do
   end
 end
 
-When(/^I stop tftp on the proxy$/) do
-  get_target('proxy').run('systemctl stop tftp.service')
-end
-
 When(/^I set up the private network on the terminals$/) do
   proxy = net_prefix + ADDRESSES['proxy']
   # /etc/sysconfig/network/ifcfg-eth1 and /etc/resolv.conf

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -453,6 +453,10 @@ Before('@suse_minion') do |scenario|
   skip_this_scenario unless (filename.include? 'sle') || (filename.include? 'suse')
 end
 
+Before('@sle_micro_minion') do |scenario|
+  skip_this_scenario unless scenario.location.file.include? 'slemicro'
+end
+
 Before('@skip_for_debianlike') do |scenario|
   filename = scenario.location.file
   skip_this_scenario if (filename.include? 'ubuntu') || (filename.include? 'debian')
@@ -473,6 +477,12 @@ end
 
 Before('@skip_for_sle_micro') do |scenario|
   skip_this_scenario if scenario.location.file.include? 'slemicro'
+end
+
+Before('@skip_for_sle_micro_ssh_minion') do |scenario|
+  sle_micro_ssh_nodes = %w[slemicro51_ssh_minion slemicro52_ssh_minion slemicro53_ssh_minion slemicro54_ssh_minion]
+  current_feature_node = scenario.location.file.split(%r{(\_smoke_tests.feature|\/)})[-2]
+  skip_this_scenario if sle_micro_ssh_nodes.include? current_feature_node
 end
 
 # do some tests only if we have SCC credentials


### PR DESCRIPTION
## What does this PR change?

### TODO

- [x] wait for feedback from mc on the `access_compat` removal. mc confirmed that we do not use access_compat anymore. This was something for Apache 2.2 which we do not support since a long time anymore. So it is fine to remove the line from the test.


This will fix test suite issues I found during the 4.3.8 BV

- [x] It seems we do not have the `access_compat` apache module loaded on SUMA 4.3. On Uyuni this module is present.
- [x] Oracle 9 CLM fixes
- [x] Adapt SLE Micro monitoring tests since not all exporters are available, only the node exporter is available: https://bugzilla.suse.com/show_bug.cgi?id=1212248
```salt
----------
          ID: node_exporter
    Function: pkg.installed
        Name: golang-github-prometheus-node_exporter
      Result: true
     Comment: 1 targeted package was installed/updated.
     Started: 03:21:31.704386
    Duration: 4529.007
         SLS: prometheus-exporters
     Changed: golang-github-prometheus-node_exporter:
                  old: ''
                  new: 1.5.0-150100.3.26.1
              
----------
          ID: node_exporter
    Function: file.managed
        Name: /etc/sysconfig/prometheus-node_exporter
      Result: true
     Comment: File /etc/sysconfig/prometheus-node_exporter updated
     Started: 03:21:36.236282
    Duration: 76.993
         SLS: prometheus-exporters
     Changed: diff: "--- 
              +++ 
              @@ -1,11 +1,9 @@
              -## Path:        Network/Monitors/Prometheus/node_exporter
              -## Description: Prometheus node exporter startup parameters
              \
                  -## Type:        string
              -## Default:     ''
              +## Path:           Applications/NodeExporter
              +## Description:    Prometheus exporter for machine metrics
              \
                  +## Type:           string()
              +## Default:        \"\"
              +## ServiceRestart: prometheus-node_exporter
               #
              -# Additional arguments for the node_exporter.
              \
                  -# Please call: /usr/bin/node_exporter --help
              -# for a full list of possible options. 
              -# Note: Please keep the list on one line, of possible.
              +#\
                  \ Arguments for running prometheus-node_exporter
               #
              -ARGS=''
              +ARGS=--collector.systemd --web.listen-address=:9100
              "
              
----------
          ID: node_exporter
    Function: service.running
        Name: prometheus-node_exporter
      Result: true
     Comment: Service restarted
     Started: 03:21:36.987878
    Duration: 14.805
         SLS: prometheus-exporters
     Changed: prometheus-node_exporter: true
              
----------
          ID: apache_exporter
    Function: pkg.installed
        Name: golang-github-lusitaniae-apache_exporter
      Result: false
     Comment: An error was encountered while installing package(s): Zypper command failure: Package 'golang-github-lusitaniae-apache_exporter' not found.Loading repository data...
Reading installed packages...
     Started: 03:21:37.003766
    Duration: 1470.762
         SLS: prometheus-exporters
     Changed: {}
----------
          ID: apache_exporter
    Function: file.managed
        Name: /etc/sysconfig/prometheus-apache_exporter
      Result: false
     Comment: One or more requisite failed: prometheus-exporters.apache_exporter
     Started: 03:21:38.475034
    Duration: 0.003
         SLS: prometheus-exporters
     Changed: {}
----------
          ID: apache_exporter
    Function: service.running
        Name: prometheus-apache_exporter
      Result: false
     Comment: One or more requisite failed: prometheus-exporters.apache_exporter
     Started: 03:21:38.475319
    Duration: 0.002
         SLS: prometheus-exporters
     Changed: {}
----------
          ID: postgres_exporter
    Function: pkg.installed
        Name: prometheus-postgres_exporter
      Result: false
     Comment: An error was encountered while installing package(s): Zypper command failure: Package 'prometheus-postgres_exporter' not found.Loading repository data...
Reading installed packages...
     Started: 03:21:38.475376
    Duration: 1365.875
         SLS: prometheus-exporters
     Changed: {}
----------
          ID: postgres_exporter
    Function: file.managed
        Name: /etc/sysconfig/prometheus-postgres_exporter
      Result: false
     Comment: One or more requisite failed: prometheus-exporters.postgres_exporter
     Started: 03:21:39.841766
    Duration: 0.003
         SLS: prometheus-exporters
     Changed: {}
----------
          ID: postgres_exporter
    Function: service.running
        Name: prometheus-postgres_exporter
      Result: false
     Comment: One or more requisite failed: prometheus-exporters.postgres_exporter
     Started: 03:21:39.842069
    Duration: 0.003
         SLS: prometheus-exporters
     Changed: {}
----------
```
- [x] Exclude SLE Micro SSH minions from package installation/removal tests since it is not supported: https://bugzilla.suse.com/show_bug.cgi?id=1208045


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**
## Links

- Manager 4.3: 
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
