### PR TITLE
Extend unique index for rhnpackagechangelogdata table

### DIFF
--- a/python/spacewalk/satellite_tools/reposync.py
+++ b/python/spacewalk/satellite_tools/reposync.py
@@ -1366,10 +1366,6 @@ class RepoSync(object):
                     raise
                 except Exception as e:
                     e_message = f'Exception: {e}'
-                    if importer:
-                        e_message += f'\nPackage: {repr(importer)}'
-                    if src_importer:
-                        e_message += f'\nSource package: {repr(src_importer)}'
                     log2(0, 1, e_message, stream=sys.stderr)
                     if self.fail:
                         raise

--- a/python/spacewalk/server/importlib/packageImport.py
+++ b/python/spacewalk/server/importlib/packageImport.py
@@ -285,16 +285,20 @@ class PackageImport(ChannelPackageSubscription):
                 self.checksums[fchecksumTuple] = None
 
         # Uniquify changelog entries
-        unique_package_changelog_hash = {}
+        unique_package_changelog_hash = set()
         unique_package_changelog = []
         for changelog in package['changelog']:
-            key = (self._fix_encoding(changelog['name'][:128]), self._fix_encoding(changelog['time']), self._fix_encoding(changelog['text'])[:3000])
+            changelog_name = self._fix_encoding(changelog['name'][:128])
+            changelog_time = self._fix_encoding(changelog['time'])
+            changelog_text = self._fix_encoding(changelog['text'])[:3000]
+            key = (changelog_name, changelog_time, changelog_text)
             if key not in unique_package_changelog_hash:
                 self.changelog_data[key] = None
-                changelog['name'] = changelog['name'][:128]
-                changelog['text'] = changelog['text'][:3000]
+                changelog['name'] = changelog_name
+                changelog['text'] = changelog_text
+                changelog['time'] = changelog_time
                 unique_package_changelog.append(changelog)
-                unique_package_changelog_hash[key] = 1
+                unique_package_changelog_hash.add(key)
         package['changelog'] = unique_package_changelog
 
         # fix encoding issues in package summary and description

--- a/python/spacewalk/spacewalk-backend.changes.witek.add-unique-index
+++ b/python/spacewalk/spacewalk-backend.changes.witek.add-unique-index
@@ -1,0 +1,1 @@
+- Add unique index for rhnpackagechangelogdata table

--- a/schema/spacewalk/common/tables/rhnPackageChangeLogData.sql
+++ b/schema/spacewalk/common/tables/rhnPackageChangeLogData.sql
@@ -28,8 +28,9 @@ CREATE TABLE rhnPackageChangeLogData
 
 ;
 
-CREATE INDEX rhn_pkg_cld_nt_idx
-    ON rhnPackageChangeLogData (name, time)
+CREATE UNIQUE INDEX CONCURRENTLY rhn_pkg_cld_ntt_idx
+    ON rhnPackageChangeLogData
+    USING btree(name, digest("text", 'sha512'::text), time)
     
     ;
 

--- a/schema/spacewalk/common/tables/rhnPackageChangeLogData.sql
+++ b/schema/spacewalk/common/tables/rhnPackageChangeLogData.sql
@@ -28,7 +28,7 @@ CREATE TABLE rhnPackageChangeLogData
 
 ;
 
-CREATE UNIQUE INDEX CONCURRENTLY rhn_pkg_cld_ntt_idx
+CREATE UNIQUE INDEX rhn_pkg_cld_ntt_idx
     ON rhnPackageChangeLogData
     USING btree(name, digest("text", 'sha512'::text), time)
     

--- a/schema/spacewalk/common/tables/rhnPackageChangeLogData.sql
+++ b/schema/spacewalk/common/tables/rhnPackageChangeLogData.sql
@@ -13,8 +13,6 @@
 -- in this software or its documentation.
 --
 
-CREATE EXTENSION IF NOT EXISTS pgcrypto;
-
 CREATE TABLE rhnPackageChangeLogData
 (
     id          NUMERIC NOT NULL

--- a/schema/spacewalk/common/tables/rhnPackageChangeLogData.sql
+++ b/schema/spacewalk/common/tables/rhnPackageChangeLogData.sql
@@ -13,6 +13,7 @@
 -- in this software or its documentation.
 --
 
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 CREATE TABLE rhnPackageChangeLogData
 (

--- a/schema/spacewalk/postgres/start.sql
+++ b/schema/spacewalk/postgres/start.sql
@@ -21,3 +21,5 @@ create temporary table store_searchpath as select setting from pg_settings where
 
 update pg_settings set setting = (select setting from store_searchpath) where name = 'search_path';
 drop table store_searchpath;
+
+CREATE EXTENSION pgcrypto;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.6-to-susemanager-schema-4.4.7/203-add-changelogdata-index.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.6-to-susemanager-schema-4.4.7/203-add-changelogdata-index.sql
@@ -29,6 +29,7 @@ select remove_duplicate_changelogdata();
 drop function remove_duplicate_changelogdata();
 
 drop index if exists rhn_pkg_cld_nt_idx;
+drop index if exists rhn_pkg_cld_ntt_idx;
 
 create extension if not exists pgcrypto;
 create unique index concurrently rhn_pkg_cld_ntt_idx

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.6-to-susemanager-schema-4.4.7/203-add-changelogdata-index.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.6-to-susemanager-schema-4.4.7/203-add-changelogdata-index.sql
@@ -30,8 +30,8 @@ drop function remove_duplicate_changelogdata();
 
 drop index if exists rhn_pkg_cld_nt_idx;
 
-create extension pgcrypto;
+create extension if not exists pgcrypto;
 create unique index concurrently rhn_pkg_cld_ntt_idx
     on "rhnpackagechangelogdata"
-    using btree(name, digest("text", 'md5'::text), "time");
+    using btree(name, digest("text", 'sha512'::text), "time");
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.6-to-susemanager-schema-4.4.7/203-add-changelogdata-index.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.6-to-susemanager-schema-4.4.7/203-add-changelogdata-index.sql
@@ -1,0 +1,37 @@
+create or replace function remove_duplicate_changelogdata()
+returns void as
+$$
+declare original record;
+declare duplicate record;
+begin
+    for original in select min(id) as id
+            from rhnpackagechangelogdata
+            group by name, text, time
+            having count(*) > 1 loop
+        for duplicate in select data2.id
+                from rhnpackagechangelogdata data1, rhnpackagechangelogdata data2
+                where data1.name = data2.name
+                and data1.text = data2.text
+                and data1.time = data2.time
+                and data1.id != data2.id
+                and data1.id = original.id loop
+            update rhnpackagechangelogrec
+                set changelog_data_id = original.id
+                where changelog_data_id = duplicate.id;
+            delete from rhnpackagechangelogdata
+                where id = duplicate.id;
+        end loop;
+    end loop;
+end;
+$$ language plpgsql;
+
+select remove_duplicate_changelogdata();
+drop function remove_duplicate_changelogdata();
+
+drop index if exists rhn_pkg_cld_nt_idx;
+
+create extension pgcrypto;
+create unique index concurrently rhn_pkg_cld_ntt_idx
+    on "rhnpackagechangelogdata"
+    using btree(name, digest("text", 'md5'::text), "time");
+


### PR DESCRIPTION
## What does this PR change?

In spite of client code trying to avoid duplicate records for changelog
data such records are observed in the database.
The change enforces unique combination of `name`, `time` and `text`
fields by updating the definition of the unique index on the database
level.

Additionally:

- Add logging package details during failed import.
- Clean up the logic for removing duplicate changelog entries.

## Links

Tracks suse/spacewalk#22470

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
