### PR TITLE
Fix leap_15_5 common_channel in testsuite

### DIFF
--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -64,7 +64,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
 
 @uyuni
   Scenario: Add openSUSE Leap 15.5 product, including Uyuni Client Tools
-    When I use spacewalk-common-channel to add channel "opensuse_leap15.5 opensuse_leap15.5-non-oss opensuse_leap15.5-non-oss-updates opensuse_leap15.5-updates opensuse_leap15.5-backports-updates opensuse_leap15.5-sle-updates uyuni-proxy-devel-leap opensuse_leap15.5-uyuni-client" with arch "x86_64"
+    When I use spacewalk-common-channel to add channel "opensuse_leap15_5 opensuse_leap15_5-non-oss opensuse_leap15_5-non-oss-updates opensuse_leap15_5-updates opensuse_leap15_5-backports-updates opensuse_leap15_5-sle-updates uyuni-proxy-devel-leap opensuse_leap15_5-uyuni-client" with arch "x86_64"
 
 @proxy
 @susemanager


### PR DESCRIPTION
## What does this PR change?

I did the mistake of using opensuse_15.5 instead of opensuse_15_5 ( . instead of _ ).
This PR fixes it.

## GUI diff

No difference.



- [x] **DONE**

## Documentation
- No documentation needed
- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
