### PR TITLE
Precreate system users to always have well known UID and GID

### DIFF
--- a/containers/init-image/Dockerfile
+++ b/containers/init-image/Dockerfile
@@ -16,6 +16,21 @@ LABEL org.opencontainers.image.vendor="Uyuni project"
 LABEL org.opencontainers.image.url="https://www.uyuni-project.org/"
 # endlabelprefix
 
+# Create stable static UID and GID for salt, tomcat, apache (wwwrun), postgres, ...
+RUN groupadd -r --gid 10550 susemanager && \
+  groupadd -r --gid 10551 tomcat && \
+  groupadd -r --gid 10552 www && \
+  groupadd -r --gid 10553 wwwrun && \
+  groupadd -r --gid 10554 salt && \
+  groupadd -r --gid 10555 tftp && \
+  groupadd -r --gid 10556 postgres
+
+RUN useradd -r -s /usr/sbin/nologin -G susemanager,www -g tomcat -d /usr/share/tomcat --uid 10551 tomcat && \
+  useradd -r -s /usr/sbin/nologin -G susemanager,www -g wwwrun -d /var/lib/wwwrun --uid 10552 wwwrun && \
+  useradd -r -s /usr/sbin/nologin -G susemanager -g salt -d /var/lib/salt --uid 10554 salt && \
+  useradd -r -s /usr/sbin/nologin -g tftp -d /srv/tftpboot --uid 10555 tftp && \
+  useradd -r -s /usr/bin/bash -g postgres -d /var/lib/pgsql --uid 10556 postgres
+
 # Fill the image with content and clean the cache(s)
 RUN set -euo pipefail; zypper -n in --no-recommends systemd gzip; zypper -n clean; rm -rf /var/log/*
 CMD ["/usr/lib/systemd/systemd"]

--- a/containers/init-image/init-image.changes.oholecek.static_users
+++ b/containers/init-image/init-image.changes.oholecek.static_users
@@ -1,0 +1,1 @@
+- Add static and well known users for server containers


### PR DESCRIPTION
## What does this PR change?

For various maintenance tasks and migrations, it is beneficial to have a stable and well known user and group ids for data in the container. This PR creates needed users and groups before anything is installed. Packages themselves during installation check for user/group existence and at most assign supplemental groups if needed.

UIDs and GIDs are starting at 10550 to limit potential conflict with host system and also avoid conflict with host's system users and groups.

DB's postgres user has to have login shell because we list it's envs during configuration which does not work with nologin.

## GUI diff

No difference.


- [X] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/21400

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
