### PR TITLE
Fix common stable and devel channels for proxy and server testing

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -2351,7 +2351,7 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 [uyuni-server-devel-leap]
 name     = Uyuni Server Devel for %(base_channel_name)s (Development)
 archs    = x86_64
-base_channels = opensuse_leap15_4-%(arch)s
+base_channels = opensuse_leap15_5-%(arch)s
 checksum = sha256
 gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s
@@ -2398,10 +2398,20 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/
 
+[uyuni-proxy-stable-leap-155]
+name     = Uyuni Proxy Stable for %(base_channel_name)s
+archs    = x86_64, aarch64
+base_channels = opensuse_leap15_5-%(arch)s
+checksum = sha256
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/
+
 [uyuni-proxy-devel-leap]
 name     = Uyuni Proxy Devel for %(base_channel_name)s (Development)
 archs    = x86_64
-base_channels = opensuse_leap15_4-%(arch)s
+base_channels = opensuse_leap15_5-%(arch)s
 checksum = sha256
 gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s


### PR DESCRIPTION
## What does this PR change?

Fix common stable and devel channels for proxy and server testing, in the context of leap 15.5 migration.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed

- [ ] **DONE**

## Test coverage
- No tests
- [ ] **DONE**

## Links
related to epic https://github.com/SUSE/spacewalk/issues/21515
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
