### PR TITLE
Adapt containers to openSUSE Leap 15.5

### DIFF
--- a/containers/proxy-httpd-image/Dockerfile
+++ b/containers/proxy-httpd-image/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 #!BuildTag: uyuni/proxy-httpd:latest uyuni/proxy-httpd:4.4.0 uyuni/proxy-httpd:4.4.0.%RELEASE%
 
-ARG BASE=registry.suse.com/bci/bci-base:15.4
+ARG BASE=registry.suse.com/bci/bci-base:15.5
 FROM $BASE AS base
 
 
@@ -32,7 +32,7 @@ COPY uyuni-configure.py /usr/bin/uyuni-configure.py
 RUN chmod +x /usr/bin/uyuni-configure.py
 
 # Define slim image
-ARG BASE=registry.suse.com/bci/bci-base:15.4
+ARG BASE=registry.suse.com/bci/bci-base:15.5
 FROM $BASE AS slim
 
 ARG PRODUCT=Uyuni

--- a/containers/proxy-httpd-image/proxy-httpd-image.changes.raul.change-leap-version-in-containers
+++ b/containers/proxy-httpd-image/proxy-httpd-image.changes.raul.change-leap-version-in-containers
@@ -1,0 +1,1 @@
+- Adapt to openSUSE Leap 15.5

--- a/containers/proxy-salt-broker-image/Dockerfile
+++ b/containers/proxy-salt-broker-image/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 #!BuildTag: uyuni/proxy-salt-broker:latest uyuni/proxy-salt-broker:4.4.0 uyuni/proxy-salt-broker:4.4.0.%RELEASE%
 
-ARG BASE=registry.suse.com/bci/bci-base:15.4
+ARG BASE=registry.suse.com/bci/bci-base:15.5
 FROM $BASE AS fat
 
 ARG PRODUCT_REPO
@@ -22,7 +22,7 @@ COPY prepare_target.sh .
 RUN sh prepare_target.sh
 
 # Define slim image
-ARG BASE=registry.suse.com/bci/bci-base:15.4
+ARG BASE=registry.suse.com/bci/bci-base:15.5
 FROM $BASE AS slim
 
 ARG PRODUCT=Uyuni

--- a/containers/proxy-salt-broker-image/proxy-salt-broker-image.changes.raul.change-leap-version-in-containers
+++ b/containers/proxy-salt-broker-image/proxy-salt-broker-image.changes.raul.change-leap-version-in-containers
@@ -1,0 +1,1 @@
+- Adapt to openSUSE Leap 15.5

--- a/containers/proxy-squid-image/Dockerfile
+++ b/containers/proxy-squid-image/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 #!BuildTag: uyuni/proxy-squid:latest uyuni/proxy-squid:4.4.0 uyuni/proxy-squid:4.4.0.%RELEASE%
 
-ARG BASE=registry.suse.com/bci/bci-base:15.4
+ARG BASE=registry.suse.com/bci/bci-base:15.5
 FROM $BASE AS base
 
 ARG PRODUCT_REPO
@@ -35,7 +35,7 @@ RUN chown squid:squid /var/cache/squid
 RUN chmod a+x /var/log
 
 # Define slim image
-ARG BASE=registry.suse.com/bci/bci-base:15.4
+ARG BASE=registry.suse.com/bci/bci-base:15.5
 FROM $BASE AS slim
 
 USER squid

--- a/containers/proxy-squid-image/proxy-squid-image.changes.raul.change-leap-version-in-containers
+++ b/containers/proxy-squid-image/proxy-squid-image.changes.raul.change-leap-version-in-containers
@@ -1,0 +1,1 @@
+- Adapt to openSUSE Leap 15.5

--- a/containers/proxy-ssh-image/Dockerfile
+++ b/containers/proxy-ssh-image/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 #!BuildTag: uyuni/proxy-ssh:latest uyuni/proxy-ssh:4.4.0 uyuni/proxy-ssh:4.4.0.%RELEASE%
 
-ARG BASE=registry.suse.com/bci/bci-base:15.4
+ARG BASE=registry.suse.com/bci/bci-base:15.5
 FROM $BASE AS base
 
 ARG PRODUCT_REPO
@@ -28,7 +28,7 @@ COPY uyuni-configure.py /usr/bin/uyuni-configure.py
 RUN chmod +x /usr/bin/uyuni-configure.py
 
 # Define slim image
-ARG BASE=registry.suse.com/bci/bci-base:15.4
+ARG BASE=registry.suse.com/bci/bci-base:15.5
 FROM $BASE AS slim
 
 ARG PRODUCT=Uyuni

--- a/containers/proxy-ssh-image/proxy-ssh-image.changes.raul.change-leap-version-in-containers
+++ b/containers/proxy-ssh-image/proxy-ssh-image.changes.raul.change-leap-version-in-containers
@@ -1,0 +1,1 @@
+- Adapt to openSUSE Leap 15.5

--- a/containers/proxy-tftpd-image/Dockerfile
+++ b/containers/proxy-tftpd-image/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 #!BuildTag: uyuni/proxy-tftpd:latest uyuni/proxy-tftpd:4.4.0 uyuni/proxy-tftpd:4.4.0.%RELEASE%
 
-ARG BASE=registry.suse.com/bci/bci-base:15.4
+ARG BASE=registry.suse.com/bci/bci-base:15.5
 FROM $BASE AS base
 
 ARG PRODUCT_REPO
@@ -27,7 +27,7 @@ COPY tftp_wrapper.py /usr/bin/tftp_wrapper.py
 RUN chmod +x /usr/bin/tftp_wrapper.py
 
 # Define slim image
-ARG BASE=registry.suse.com/bci/bci-base:15.4
+ARG BASE=registry.suse.com/bci/bci-base:15.5
 FROM $BASE AS slim
 
 ARG PRODUCT=Uyuni

--- a/containers/proxy-tftpd-image/proxy-tftpd-image.changes.raul.change-leap-version-in-containers
+++ b/containers/proxy-tftpd-image/proxy-tftpd-image.changes.raul.change-leap-version-in-containers
@@ -1,0 +1,1 @@
+- Adapt to openSUSE Leap 15.5


### PR DESCRIPTION
## What does this PR change?

**Adapt containers to openSUSE Leap 15.5**

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: **To be mentioned in the release notes**

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/22510

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
