### PR TITLE
Update spacewalk-utils.changes with leap 15.5

### DIFF
--- a/utils/spacewalk-utils.changes.jmassaguerpla@suse.com.fix_common_stable_and_devel_channels
+++ b/utils/spacewalk-utils.changes.jmassaguerpla@suse.com.fix_common_stable_and_devel_channels
@@ -1,0 +1,1 @@
+- Add openSUSE Leap 15.5 common channels


### PR DESCRIPTION
## What does this PR change?

Update spacewake-utils.changes with changes from https://github.com/uyuni-project/uyuni/pull/7540

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests
- [X] **DONE**

## Links

related to https://github.com/SUSE/spacewalk/issues/21515

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
