### PR TITLE
Migrate testsuite to 15.5

### DIFF
--- a/testsuite/features/secondary/allcli_software_channels.feature
+++ b/testsuite/features/secondary/allcli_software_channels.feature
@@ -45,7 +45,7 @@ Feature: Channel subscription via SSM
     And I follow "channel memberships" in the content area
     Then I should see a "Base Channel" text
     And I should see a "Next" text
-    When I select "Fake Base Channel" from drop-down in table line with "openSUSE Leap 15.4 (x86_64)"
+    When I select "Fake Base Channel" from drop-down in table line with "openSUSE Leap 15.5 (x86_64)"
     And I click on "Next"
     Then I should see a "Child Channels" text
     And I should see a "Fake Base Channel" text
@@ -78,9 +78,9 @@ Feature: Channel subscription via SSM
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    Then radio button "openSUSE Leap 15.4 (x86_64)" should be checked
+    Then radio button "openSUSE Leap 15.5 (x86_64)" should be checked
     And I wait until I do not see "Loading..." text
-    And I should see "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)" as unchecked
+    And I should see "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)" as unchecked
 
 @sle_minion
 @susemanager
@@ -94,7 +94,7 @@ Feature: Channel subscription via SSM
   Scenario: Check old channels are still enabled on SLES minion before channel change completes
     When I refresh the metadata for "sle_minion"
     Then "8" channels should be enabled on "sle_minion"
-    And channel "openSUSE Leap 15.4 (x86_64)" should be enabled on "sle_minion"
+    And channel "openSUSE Leap 15.5 (x86_64)" should be enabled on "sle_minion"
 
   Scenario: Wait 3 minutes for the scheduled action to be executed
     When I wait for "180" seconds
@@ -224,14 +224,14 @@ Feature: Channel subscription via SSM
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "openSUSE Leap 15.4 (x86_64)"
+    And I check radio button "openSUSE Leap 15.5 (x86_64)"
     And I wait until I do not see "Loading..." text
-    And I check "openSUSE 15.4 non oss (x86_64)"
-    And I check "openSUSE Leap 15.4 non oss Updates (x86_64)"
-    And I check "openSUSE Leap 15.4 Updates (x86_64)"
-    And I check "Update repository of openSUSE Leap 15.4 Backports (x86_64)"
-    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.4 (x86_64)"
-    And I check "Uyuni Client Tools for openSUSE Leap 15.4 (x86_64)"
+    And I check "openSUSE 15.5 non oss (x86_64)"
+    And I check "openSUSE Leap 15.5 non oss Updates (x86_64)"
+    And I check "openSUSE Leap 15.5 Updates (x86_64)"
+    And I check "Update repository of openSUSE Leap 15.5 Backports (x86_64)"
+    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
+    And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)"
     And I check "Fake-RPM-SUSE-Channel"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
@@ -239,7 +239,7 @@ Feature: Channel subscription via SSM
     Then I should see a "Changing the channels has been scheduled." text
     When I follow "scheduled" in the content area
     And I wait until I see "1 system successfully completed this action." text, refreshing the page
-    Then channel "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)" should not be enabled on "sle_minion"
+    Then channel "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)" should not be enabled on "sle_minion"
 
   Scenario: Cleanup: remove remaining systems from SSM after channel subscription tests
     When I click on the clear SSM button

--- a/testsuite/features/secondary/allcli_software_channels_dependencies.feature
+++ b/testsuite/features/secondary/allcli_software_channels_dependencies.feature
@@ -39,11 +39,11 @@ Feature: Channel subscription with recommended or required dependencies
     And I wait for child channels to appear
     And I check radio button "(none, disable service)"
     And I wait for child channels to appear
-    And I check radio button "openSUSE Leap 15.4 (x86_64)"
-    Then I should see the child channel "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)" "unselected" and "disabled"
-    Then I should see the child channel "openSUSE 15.4 non oss (x86_64)" "selected"
-    When I select the child channel "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)"
-    Then I should see the child channel "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)" "selected"
+    And I check radio button "openSUSE Leap 15.5 (x86_64)"
+    Then I should see the child channel "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)" "unselected" and "disabled"
+    Then I should see the child channel "openSUSE 15.5 non oss (x86_64)" "selected"
+    When I select the child channel "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)"
+    Then I should see the child channel "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)" "selected"
 
 @susemanager
   Scenario: Play with recommended and required child channels selection in SSM
@@ -75,12 +75,12 @@ Feature: Channel subscription with recommended or required dependencies
     And I follow "channel memberships" in the content area
     Then I should see a "Base Channel" text
     And I should see a "Next" text
-    And I should see a table line with "openSUSE Leap 15.4 (x86_64)", "1"
-    When I select "No Change" from drop-down in table line with "openSUSE Leap 15.4 (x86_64)"
+    And I should see a table line with "openSUSE Leap 15.5 (x86_64)", "1"
+    When I select "No Change" from drop-down in table line with "openSUSE Leap 15.5 (x86_64)"
     And I click on "Next"
     Then I should see the toggler "disabled"
-    And I should see a "openSUSE 15.4 non oss (x86_64)" text
-    And I should see "No change" "selected" for the "openSUSE 15.4 non oss (x86_64)" channel
+    And I should see a "openSUSE 15.5 non oss (x86_64)" text
+    And I should see "No change" "selected" for the "openSUSE 15.5 non oss (x86_64)" channel
 
   Scenario: Cleanup: remove remaining systems from SSM after software channel tests
     When I click on the clear SSM button

--- a/testsuite/features/secondary/min_activationkey.feature
+++ b/testsuite/features/secondary/min_activationkey.feature
@@ -69,14 +69,14 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
     And I enter "Minion testing" as "description"
     And I enter "MINION-TEST" as "key"
     And I enter "20" as "usageLimit"
-    And I select "openSUSE Leap 15.4 (x86_64)" from "selectedBaseChannel"
+    And I select "openSUSE Leap 15.5 (x86_64)" from "selectedBaseChannel"
     And I wait for child channels to appear
-    And I check "openSUSE 15.4 non oss (x86_64)"
-    And I check "openSUSE Leap 15.4 non oss Updates (x86_64)"
-    And I check "openSUSE Leap 15.4 Updates (x86_64)"
-    And I check "Update repository of openSUSE Leap 15.4 Backports (x86_64)"
-    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.4 (x86_64)"
-    And I check "Uyuni Client Tools for openSUSE Leap 15.4 (x86_64)"
+    And I check "openSUSE 15.5 non oss (x86_64)"
+    And I check "openSUSE Leap 15.5 non oss Updates (x86_64)"
+    And I check "openSUSE Leap 15.5 Updates (x86_64)"
+    And I check "Update repository of openSUSE Leap 15.5 Backports (x86_64)"
+    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
+    And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)"
     And I check "Fake-RPM-SUSE-Channel"
     And I click on "Create Activation Key"
     And I follow "Configuration" in the content area
@@ -122,7 +122,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
 @uyuni
   Scenario: Verify that minion bootstrapped with base channel
     Given I am on the Systems page
-    Then I should see a "openSUSE Leap 15.4 (x86_64)" text
+    Then I should see a "openSUSE Leap 15.5 (x86_64)" text
 
   # bsc#1080807 - Assigning configuration channel in activation key doesn't work
   Scenario: Verify that minion bootstrapped with configuration channel

--- a/testsuite/features/secondary/min_bootstrap_api.feature
+++ b/testsuite/features/secondary/min_bootstrap_api.feature
@@ -70,14 +70,14 @@ Feature: Register a Salt minion via API
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "openSUSE Leap 15.4 (x86_64)"
+    And I check radio button "openSUSE Leap 15.5 (x86_64)"
     And I wait until I do not see "Loading..." text
-    And I check "openSUSE 15.4 non oss (x86_64)"
-    And I check "openSUSE Leap 15.4 non oss Updates (x86_64)"
-    And I check "openSUSE Leap 15.4 Updates (x86_64)"
-    And I check "Update repository of openSUSE Leap 15.4 Backports (x86_64)"
-    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.4 (x86_64)"
-    And I check "Uyuni Client Tools for openSUSE Leap 15.4 (x86_64)"
+    And I check "openSUSE 15.5 non oss (x86_64)"
+    And I check "openSUSE Leap 15.5 non oss Updates (x86_64)"
+    And I check "openSUSE Leap 15.5 Updates (x86_64)"
+    And I check "Update repository of openSUSE Leap 15.5 Backports (x86_64)"
+    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
+    And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)"
     And I check "Fake-RPM-SUSE-Channel"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text

--- a/testsuite/features/secondary/min_bootstrap_script.feature
+++ b/testsuite/features/secondary/min_bootstrap_script.feature
@@ -62,9 +62,9 @@ Feature: Register a Salt minion with a bootstrap script
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "openSUSE Leap 15.4 (x86_64)"
+    And I check radio button "openSUSE Leap 15.5 (x86_64)"
     And I wait until I do not see "Loading..." text
-    And I check "Uyuni Client Tools for openSUSE Leap 15.4 (x86_64)"
+    And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)"
     And I check "Fake-RPM-SUSE-Channel"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text

--- a/testsuite/features/secondary/min_change_software_channel.feature
+++ b/testsuite/features/secondary/min_change_software_channel.feature
@@ -30,9 +30,9 @@ Feature: Assign child channel to a system
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    Then radio button "openSUSE Leap 15.4 (x86_64)" should be checked
+    Then radio button "openSUSE Leap 15.5 (x86_64)" should be checked
     And I wait until I do not see "Loading..." text
-    And I should see "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)" as unchecked
+    And I should see "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)" as unchecked
 
 # susemanager has the Client Tools channels more than uyuni. (+2)
 # in Head also Beta Client Tools Channels (+2)
@@ -46,7 +46,7 @@ Feature: Assign child channel to a system
   Scenario: Check old channels are still enabled on the system before channel change completes
     When I refresh the metadata for "sle_minion"
     Then "8" channels should be enabled on "sle_minion"
-    And channel "openSUSE Leap 15.4 (x86_64)" should be enabled on "sle_minion"
+    And channel "openSUSE Leap 15.5 (x86_64)" should be enabled on "sle_minion"
 
 @susemanager
   Scenario: Assign a child channel to the system
@@ -69,16 +69,16 @@ Feature: Assign child channel to a system
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    Then radio button "openSUSE Leap 15.4 (x86_64)" should be checked
+    Then radio button "openSUSE Leap 15.5 (x86_64)" should be checked
     And I wait until I do not see "Loading..." text
-    And I check "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)"
+    And I check "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     And I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
     When I follow "scheduled" in the content area
     And I wait until I see "1 system successfully completed this action." text, refreshing the page
-    Then channel "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)" should be enabled on "sle_minion"
+    Then channel "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)" should be enabled on "sle_minion"
 
   Scenario: Check channel change has completed for the system
     Given I am on the Systems overview page of this "sle_minion"
@@ -99,9 +99,9 @@ Feature: Assign child channel to a system
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    Then radio button "openSUSE Leap 15.4 (x86_64)" should be checked
+    Then radio button "openSUSE Leap 15.5 (x86_64)" should be checked
     And I wait until I do not see "Loading..." text
-    And I should see "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)" as checked
+    And I should see "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)" as checked
 
 @susemanager
   Scenario: Check the new channels are enabled on the system
@@ -114,8 +114,8 @@ Feature: Assign child channel to a system
   Scenario: Check the new channels are enabled on the system
     When I refresh the metadata for "sle_minion"
     Then "9" channels should be enabled on "sle_minion"
-    And channel "openSUSE Leap 15.4 (x86_64)" should be enabled on "sle_minion"
-    And channel "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)" should be enabled on "sle_minion"
+    And channel "openSUSE Leap 15.5 (x86_64)" should be enabled on "sle_minion"
+    And channel "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)" should be enabled on "sle_minion"
 
 @susemanager
   Scenario: Cleanup: subscribe the system back to previous channels
@@ -142,21 +142,21 @@ Feature: Assign child channel to a system
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    Then radio button "openSUSE Leap 15.4 (x86_64)" should be checked
+    Then radio button "openSUSE Leap 15.5 (x86_64)" should be checked
     And I wait until I do not see "Loading..." text
-    And I wait until I see "openSUSE Leap 15.4 Updates (x86_64)" text
-    And I check "openSUSE 15.4 non oss (x86_64)"
-    And I check "openSUSE Leap 15.4 non oss Updates (x86_64)"
-    And I check "openSUSE Leap 15.4 Updates (x86_64)"
-    And I check "Update repository of openSUSE Leap 15.4 Backports (x86_64)"
-    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.4 (x86_64)"
-    And I check "Uyuni Client Tools for openSUSE Leap 15.4 (x86_64)"
+    And I wait until I see "openSUSE Leap 15.5 Updates (x86_64)" text
+    And I check "openSUSE 15.5 non oss (x86_64)"
+    And I check "openSUSE Leap 15.5 non oss Updates (x86_64)"
+    And I check "openSUSE Leap 15.5 Updates (x86_64)"
+    And I check "Update repository of openSUSE Leap 15.5 Backports (x86_64)"
+    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
+    And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)"
     And I check "Fake-RPM-SUSE-Channel"
-    And I uncheck "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)"
+    And I uncheck "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
     When I follow "scheduled" in the content area
     And I wait until I see "1 system successfully completed this action." text, refreshing the page
-    Then channel "Uyuni Proxy Devel for openSUSE Leap 15.4 (x86_64) (Development)" should not be enabled on "sle_minion"
+    Then channel "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)" should not be enabled on "sle_minion"

--- a/testsuite/features/secondary/min_custom_pkg_download_endpoint.feature
+++ b/testsuite/features/secondary/min_custom_pkg_download_endpoint.feature
@@ -33,8 +33,8 @@ Feature: Repos file generation based on custom pillar data
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "openSUSE Leap 15.4 (x86_64)"
-    And I wait until I see "openSUSE 15.4 non oss (x86_64)" text
+    And I check radio button "openSUSE Leap 15.5 (x86_64)"
+    And I wait until I see "openSUSE 15.5 non oss (x86_64)" text
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
@@ -75,9 +75,9 @@ Feature: Repos file generation based on custom pillar data
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "openSUSE Leap 15.4 (x86_64)"
-    And I wait until I see "openSUSE 15.4 non oss (x86_64)" text
-    And I check "openSUSE 15.4 non oss (x86_64)"
+    And I check radio button "openSUSE Leap 15.5 (x86_64)"
+    And I wait until I see "openSUSE 15.5 non oss (x86_64)" text
+    And I check "openSUSE 15.5 non oss (x86_64)"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
@@ -117,13 +117,13 @@ Feature: Repos file generation based on custom pillar data
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "openSUSE Leap 15.4 (x86_64)"
-    And I wait until I see "openSUSE 15.4 non oss (x86_64)" text
-    And I check "openSUSE Leap 15.4 non oss Updates (x86_64)"
-    And I check "openSUSE Leap 15.4 Updates (x86_64)"
-    And I check "Update repository of openSUSE Leap 15.4 Backports (x86_64)"
-    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.4 (x86_64)"
-    And I check "Uyuni Client Tools for openSUSE Leap 15.4 (x86_64)"
+    And I check radio button "openSUSE Leap 15.5 (x86_64)"
+    And I wait until I see "openSUSE 15.5 non oss (x86_64)" text
+    And I check "openSUSE Leap 15.5 non oss Updates (x86_64)"
+    And I check "openSUSE Leap 15.5 Updates (x86_64)"
+    And I check "Update repository of openSUSE Leap 15.5 Backports (x86_64)"
+    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
+    And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)"
     And I check "Fake-RPM-SUSE-Channel"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text

--- a/testsuite/features/secondary/minssh_bootstrap_api.feature
+++ b/testsuite/features/secondary/minssh_bootstrap_api.feature
@@ -80,9 +80,9 @@ Feature: Register a salt-ssh system via API
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "openSUSE Leap 15.4 (x86_64)"
+    And I check radio button "openSUSE Leap 15.5 (x86_64)"
     And I wait until I do not see "Loading..." text
-    And I check "Uyuni Client Tools for openSUSE Leap 15.4 (x86_64)"
+    And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)"
     And I check "Fake-RPM-SUSE-Channel"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text

--- a/testsuite/features/secondary/srv_content_lifecycle.feature
+++ b/testsuite/features/secondary/srv_content_lifecycle.feature
@@ -46,9 +46,9 @@ Feature: Content lifecycle
     When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
     And I click on "Attach/Detach Sources"
-    And I select "openSUSE Leap 15.4 (x86_64)" from "selectedBaseChannel"
+    And I select "openSUSE Leap 15.5 (x86_64)" from "selectedBaseChannel"
     And I click on "Save"
-    And I wait until I see "openSUSE Leap 15.4 (x86_64)" text
+    And I wait until I see "openSUSE Leap 15.5 (x86_64)" text
     Then I should see a "Version 1: (draft - not built) - Check the changes below" text
 
 @susemanager
@@ -62,7 +62,7 @@ Feature: Content lifecycle
   Scenario: Verify added sources
     When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
-    Then I should see a "openSUSE Leap 15.4 (x86_64)" text
+    Then I should see a "openSUSE Leap 15.5 (x86_64)" text
     And I should see a "Build (1)" text
 
   Scenario: Add environments to the project

--- a/testsuite/features/secondary/srv_dist_channel_mapping.feature
+++ b/testsuite/features/secondary/srv_dist_channel_mapping.feature
@@ -35,12 +35,12 @@ Feature: Distribution Channel Mapping
     When I follow the left menu "Software > Distribution Channel Mapping"
     And I follow "Create Distribution Channel Mapping"
     Then I should see a "Create Distribution Channel Map" text
-    When I enter "openSUSE Leap 15.4" as "os"
-    And I enter "15.4" as "release"
+    When I enter "openSUSE Leap 15.5" as "os"
+    And I enter "15.5" as "release"
     And I select "x86_64" from "architecture" dropdown
-    And I select "openSUSE Leap 15.4 (x86_64)" from "channel_label" dropdown
+    And I select "openSUSE Leap 15.5 (x86_64)" from "channel_label" dropdown
     And I click on "Create Mapping"
-    Then I should see a "openSUSE Leap 15.4" link in the content area
+    Then I should see a "openSUSE Leap 15.5" link in the content area
 
   Scenario: Create new map for x86_64 Ubuntu clients with test base channel
     When I follow the left menu "Software > Distribution Channel Mapping"
@@ -83,15 +83,15 @@ Feature: Distribution Channel Mapping
 @uyuni
   Scenario: Update map for x86_64 openSUSE clients using test-x86_64 channel
     When I follow the left menu "Software > Distribution Channel Mapping"
-    Then I should see the text "openSUSE Leap 15.4" in the Operating System field
+    Then I should see the text "openSUSE Leap 15.5" in the Operating System field
     And I should see the text "x86_64" in the Architecture field
     And I should see the text "opensuse_leap15_4-x86_64" in the Channel Label field
-    When I follow "openSUSE Leap 15.4"
+    When I follow "openSUSE Leap 15.5"
     Then I should see a "Update Distribution Channel Map" text
-    When I enter "openSUSE Leap 15.4 modified" as "os"
-    And I select "openSUSE Leap 15.4 (x86_64)" from "channel_label" dropdown
+    When I enter "openSUSE Leap 15.5 modified" as "os"
+    And I select "openSUSE Leap 15.5 (x86_64)" from "channel_label" dropdown
     And I click on "Update Mapping"
-    Then I should see the text "openSUSE Leap 15.4 modified" in the Operating System field
+    Then I should see the text "openSUSE Leap 15.5 modified" in the Operating System field
     And I should see the text "opensuse_leap15_4-x86_64" in the Channel Label field
 
   Scenario: Update map for x86_64 Ubuntu clients using test base channel
@@ -136,15 +136,15 @@ Feature: Distribution Channel Mapping
 @uyuni
   Scenario: Cleanup: delete the map created for x68_64 openSUSE clients
     When I follow the left menu "Software > Distribution Channel Mapping"
-    Then I should see the text "openSUSE Leap 15.4 modified" in the Operating System field
+    Then I should see the text "openSUSE Leap 15.5 modified" in the Operating System field
     And I should see the text "x86_64" in the Architecture field
-    When I follow "openSUSE Leap 15.4 modified"
+    When I follow "openSUSE Leap 15.5 modified"
     Then I should see a "Update Distribution Channel Map" text
     And I should see a "Delete Distribution Channel" link
     When I follow "Delete Distribution Channel Mapping"
     Then I should see a "Delete Distribution Channel Map" text
     When I click on "Delete Mapping"
-    Then I should not see a "openSUSE Leap 15.4 modified" link
+    Then I should not see a "openSUSE Leap 15.5 modified" link
     
   Scenario: Cleanup: delete the map created for x68_64 Ubuntu clients
     When I follow the left menu "Software > Distribution Channel Mapping"

--- a/testsuite/features/secondary/srv_manage_activationkey.feature
+++ b/testsuite/features/secondary/srv_manage_activationkey.feature
@@ -90,7 +90,7 @@ Feature: Manipulate activation keys
     And I enter "SUSE Test PKG Key x86_64" as "description"
     And I enter "SUSE-TEST-x86_64" as "key"
     And I enter "20" as "usageLimit"
-    And I select "openSUSE Leap 15.4 (x86_64)" from "selectedBaseChannel"
+    And I select "openSUSE Leap 15.5 (x86_64)" from "selectedBaseChannel"
     And I click on "Create Activation Key"
     And I follow "Packages"
     And I enter "sed" as "packages"


### PR DESCRIPTION
## What does this PR change?

Adapt secondary tests to 15.5

## GUI diff

No difference.


- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/21562

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
