### PR TITLE
Fix tests to check for 15.5 and not 15.4

### DIFF
--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -330,7 +330,7 @@ Feature: Manage KVM virtual machines via the GUI
 #@uyuni
 #  Scenario: Install TFTP boot package on the server
 #    And I install package tftpboot-installation on the server
-#    And I wait for "tftpboot-installation-openSUSE-Leap-15.4-x86_64" to be installed on "server"
+#    And I wait for "tftpboot-installation-openSUSE-Leap-15.5-x86_64" to be installed on "server"
 
 @virthost_kvm
   Scenario: Edit a virtual network

--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -45,7 +45,7 @@ Feature: PXE boot a terminal with Cobbler
 #@uyuni
 # Scenario: Install TFTP boot package on the server
 #   When I install package tftpboot-installation on the server
-#   And I wait for "tftpboot-installation-openSUSE-Leap-15.4-x86_64" to be installed on "server"
+#   And I wait for "tftpboot-installation-openSUSE-Leap-15.5-x86_64" to be installed on "server"
 
   Scenario: Create auto installation distribution
     When I follow the left menu "Systems > Autoinstallation > Distributions"

--- a/testsuite/features/secondary/srv_content_lifecycle.feature
+++ b/testsuite/features/secondary/srv_content_lifecycle.feature
@@ -188,10 +188,10 @@ Feature: Content lifecycle
   Scenario: Cleanup: remove the created channels
     When I delete these channels with spacewalk-remove-channel:
       |clp_label-prod_label-fake_base_channel|
-      |clp_label-prod_label-opensuse_leap15_4-x86_64|
+      |clp_label-prod_label-opensuse_leap15_5-x86_64|
       |clp_label-qa_label-fake_base_channel|
-      |clp_label-qa_label-opensuse_leap15_4-x86_64|
+      |clp_label-qa_label-opensuse_leap15_5-x86_64|
       |clp_label-dev_label-fake_base_channel|
-      |clp_label-dev_label-opensuse_leap15_4-x86_64|
+      |clp_label-dev_label-opensuse_leap15_5-x86_64|
     And I list channels with spacewalk-remove-channel
     Then I shouldn't get "clp_label"

--- a/testsuite/features/secondary/srv_dist_channel_mapping.feature
+++ b/testsuite/features/secondary/srv_dist_channel_mapping.feature
@@ -85,14 +85,14 @@ Feature: Distribution Channel Mapping
     When I follow the left menu "Software > Distribution Channel Mapping"
     Then I should see the text "openSUSE Leap 15.5" in the Operating System field
     And I should see the text "x86_64" in the Architecture field
-    And I should see the text "opensuse_leap15_4-x86_64" in the Channel Label field
+    And I should see the text "opensuse_leap15_5-x86_64" in the Channel Label field
     When I follow "openSUSE Leap 15.5"
     Then I should see a "Update Distribution Channel Map" text
     When I enter "openSUSE Leap 15.5 modified" as "os"
     And I select "openSUSE Leap 15.5 (x86_64)" from "channel_label" dropdown
     And I click on "Update Mapping"
     Then I should see the text "openSUSE Leap 15.5 modified" in the Operating System field
-    And I should see the text "opensuse_leap15_4-x86_64" in the Channel Label field
+    And I should see the text "opensuse_leap15_5-x86_64" in the Channel Label field
 
   Scenario: Update map for x86_64 Ubuntu clients using test base channel
     When I follow the left menu "Software > Distribution Channel Mapping"


### PR DESCRIPTION
## What does this PR change?

Fix some tests that I forgot in a previous PR.

## GUI diff

No difference.


- [ ] **DONE**

## Documentation
- No documentation needed
- [ ] **DONE**

## Test coverage
- No tests
- [ ] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/21562

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
