### PR TITLE
Use call() instead of run() to maintain Python 3.4 compatibility

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/payg/script/payg_extract_repo_data.py
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/payg/script/payg_extract_repo_data.py
@@ -50,12 +50,12 @@ def is_payg_instance():
                         "For a correct PAYG detection please install the 'python-instance-billing-flavor-check' package"])
 
     try:
-        result = subprocess.run(flavor_check, check=False, stdout=subprocess.PIPE, universal_newlines=True).stdout.strip()
+        result = subprocess.call(flavor_check, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     except subprocess.CalledProcessError as e:
         system_exit(1, ["Failed to execute instance-flavor-check tool.", e])
 
-    return result == "PAYG"
-
+    # instance-flavor-check return 10 for PAYG. Other possible values are 11 -> BYOS and 12 -> Unknown
+    return result == 10
 
 
 SuseCloudInfo = namedtuple('SuseCloudInfo', ['header_auth', 'hostname'])

--- a/java/spacewalk-java.changes.mackdk.4.3-fix-credential-extraction-sles-12
+++ b/java/spacewalk-java.changes.mackdk.4.3-fix-credential-extraction-sles-12
@@ -1,0 +1,1 @@
+- Fix PAYG credentials extraction for SLES 12 clients (bsc#1215352)


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue with extracting PAYG credentials from a SLES 12 client. In this os the default python 3 version is 3.4 and currently the script is using the subprocess.run() to run instance-flavor-check, which is not available for that version. This PR changes the script to use subprocess.call() instead. With this change, the way the PAYG instance is identified is also changed. Before we were relying on the text "PAYG" on the standard output, now we check the return code of the command.

Port of https://github.com/SUSE/spacewalk/pull/22523

**Wait for the 4.3 PR to be reviewed to merge this**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/22522
Tracks https://github.com/SUSE/spacewalk/pull/22523

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
