### PR TITLE
Do not warn about missing Client Tools Channel subscription

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -351,7 +351,7 @@ public class ContentSyncManager {
      * @return list of all available products
      */
     public List<MgrSyncProductDto> listProducts() {
-        if (!(ConfigDefaults.get().isUyuni() || hasToolsChannelSubscription())) {
+        if (!(ConfigDefaults.get().isUyuni() || hasToolsChannelSubscription() || canSyncToolsChannelViaCloudRMT())) {
             LOG.warn("No SUSE Manager Server Subscription available. " +
                      "Products requiring Client Tools Channel will not be shown.");
         }

--- a/java/spacewalk-java.changes.mackdk.remove-warning-in-payg-scenario
+++ b/java/spacewalk-java.changes.mackdk.remove-warning-in-payg-scenario
@@ -1,0 +1,2 @@
+- Do not warn about missing Client Tools Channel subscription in a 
+  PAYG environment


### PR DESCRIPTION
## What does this PR change?

This PR removes a warning in the logs about missing Tools Channels subscription when the the tools channels are synced with PAYG credentials, as reported in https://github.com/SUSE/spacewalk/issues/22500#issuecomment-1720329031

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: only change in logging

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
