### PR TITLE
Fix NoClassDefFoundError when opening notifications

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/notification/UserNotificationFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/UserNotificationFactory.java
@@ -78,7 +78,7 @@ public class UserNotificationFactory extends HibernateFactory {
             mailer = cobj.getDeclaredConstructor().newInstance();
         }
         catch (Throwable e) {
-            log.warn("An exception was thrown while configuring Mailer", e);
+            log.error("An exception was thrown while initializing custom mailer class", e);
             mailer = new SmtpMail();
         }
     }

--- a/java/code/src/com/redhat/rhn/domain/notification/UserNotificationFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/UserNotificationFactory.java
@@ -77,7 +77,8 @@ public class UserNotificationFactory extends HibernateFactory {
             Class<? extends Mail> cobj = Class.forName(clazz).asSubclass(Mail.class);
             mailer = cobj.getDeclaredConstructor().newInstance();
         }
-        catch (Exception e) {
+        catch (Throwable e) {
+            log.warn("An exception was thrown while configuring Mailer", e);
             mailer = new SmtpMail();
         }
     }

--- a/java/code/src/com/redhat/rhn/domain/notification/UserNotificationFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/UserNotificationFactory.java
@@ -77,7 +77,7 @@ public class UserNotificationFactory extends HibernateFactory {
             Class<? extends Mail> cobj = Class.forName(clazz).asSubclass(Mail.class);
             mailer = cobj.getDeclaredConstructor().newInstance();
         }
-        catch (Throwable e) {
+        catch (Exception | LinkageError e) {
             log.error("An exception was thrown while initializing custom mailer class", e);
             mailer = new SmtpMail();
         }

--- a/java/code/src/com/redhat/rhn/frontend/events/BaseMailAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/BaseMailAction.java
@@ -60,7 +60,7 @@ public abstract class BaseMailAction {
             Class<? extends Mail> cobj = Class.forName(clazz).asSubclass(Mail.class);
             return cobj.getDeclaredConstructor().newInstance();
         }
-        catch (Throwable e) {
+        catch (Exception | LinkageError e) {
             getLogger().error("An exception was thrown while initializing custom mailer class", e);
             return new SmtpMail();
         }

--- a/java/code/src/com/redhat/rhn/frontend/events/BaseMailAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/BaseMailAction.java
@@ -52,16 +52,16 @@ public abstract class BaseMailAction {
      * @return the mailer associated with this class
      */
     protected Mail getMail() {
-        String clazz = Config.get().getString(
-                "web.mailer_class");
+        String clazz = Config.get().getString("web.mailer_class");
         if (clazz == null) {
             return new SmtpMail();
         }
         try {
-            Class cobj = Class.forName(clazz);
-            return (Mail) cobj.newInstance();
+            Class<? extends Mail> cobj = Class.forName(clazz).asSubclass(Mail.class);
+            return cobj.getDeclaredConstructor().newInstance();
         }
-        catch (Exception e) {
+        catch (Throwable e) {
+            getLogger().error("An exception was thrown while initializing custom mailer class", e);
             return new SmtpMail();
         }
     }

--- a/java/spacewalk-java.changes.houssemnasri.fix-notification-error
+++ b/java/spacewalk-java.changes.houssemnasri.fix-notification-error
@@ -1,0 +1,1 @@
+- Fix server error when visiting the notifications page


### PR DESCRIPTION
## What does this PR change?

The problem is that `Class#forName` can throw a `LinkageError` or `ExceptionInInitializerError` which wouldn't be caught by the current catch statement. Eventually, since `configureMailer()` is called during class initialization, the exception will be caught by the classloader and translated into `NoClassDefFoundError`. However, I still don't know why exactly an Error was thrown in the first place nor I can reproduce the other behaviors reported like the WebUI not responding. 

To reproduce, replace the content of `configureMailer()` with `throw new LinkageError();`, and then try to visit the notifications page. In the logs, you'll get a similar exception to what was reported in the linked issue. One difference is that the exception starts from `prepareUserNotifications` not `dataUnread`.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed.

- [x] **DONE**

## Test coverage
- No tests.

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/6918

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
