### PR TITLE
do not install instance-flavor-check on opensuse

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/packages/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/init.sls
@@ -15,7 +15,7 @@ mgr_install_products:
 {%- endif %}
 {%- endif %}
 
-{%- if grains['os_family'] == 'Suse' and grains['instance_id'] is defined %}
+{%- if grains['os_family'] == 'Suse' and grains['instance_id'] is defined and "opensuse" not in grains['oscodename']|lower%}
 {# install flavor check tool in cloud instances to be able to detect payg instances #}
 mgr_install_flavor_check:
   pkg.installed:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.fix-uyuni-in-cloud
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.fix-uyuni-in-cloud
@@ -1,0 +1,1 @@
+- do not install instance-flavor-check tool on openSUSE


### PR DESCRIPTION
## What does this PR change?

Fix uyuni testsuite in cloud

- do not require instance-flavor-check tool on opensuse

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes #
Tracks https://github.com/SUSE/spacewalk/pull/22536

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
