### PR TITLE
QE: Fix event history check by shortening event name

### DIFF
--- a/testsuite/features/init_clients/proxy_branch_network.feature
+++ b/testsuite/features/init_clients/proxy_branch_network.feature
@@ -203,7 +203,7 @@ Feature: Setup Uyuni for Retail branch network
   Scenario: Disable repositories after installing branch services
     When I disable repositories after installing branch server
     # WORKAROUND: the following event fails because the proxy needs 10 minutes to become responsive again
-    # And I wait until event "Package List Refresh scheduled by (system)" is completed
+    # And I wait until event "Package List Refresh" is completed
     And I wait for "700" seconds
 
 @proxy

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -197,11 +197,11 @@ Feature: PXE boot a Retail terminal
     When I wait until I see the name of "pxeboot_minion", refreshing the page
     And I follow this "pxeboot_minion" link
     # Workaround: Increase timeout temporarily get rid of timeout issues
-    And I wait at most 350 seconds until event "Apply states [saltboot] scheduled by (system)" is completed
+    And I wait at most 350 seconds until event "Apply states [saltboot]" is completed
     And I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until radio button "SLE-Product-SLES15-SP4-Pool for x86_64" is checked, refreshing the page
-    And I wait until event "Package List Refresh scheduled by (system)" is completed
+    And I wait until event "Package List Refresh" is completed
     Then "pxeboot_minion" should have been reformatted
 
   Scenario: Check connection from terminal to branch server


### PR DESCRIPTION
## What does this PR change?
The name of the event in the event history and event summary doesn't exactly match, as the event summary doesn't have "scheduled by (system)". As such, we removed that part of the event check.

## Links

Fixes https://github.com/SUSE/spacewalk/issues/22555
- 4.3 https://github.com/SUSE/spacewalk/pull/22556

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
