### PR TITLE
No fixed wait until proxy becomes responsive again

### DIFF
--- a/testsuite/features/init_clients/proxy_branch_network.feature
+++ b/testsuite/features/init_clients/proxy_branch_network.feature
@@ -202,9 +202,7 @@ Feature: Setup Uyuni for Retail branch network
 @private_net
   Scenario: Disable repositories after installing branch services
     When I disable repositories after installing branch server
-    # WORKAROUND: the following event fails because the proxy needs 10 minutes to become responsive again
-    # And I wait until event "Package List Refresh" is completed
-    And I wait for "700" seconds
+    And I wait at most 700 seconds until event "Package List Refresh" is completed
 
 @proxy
 @private_net


### PR DESCRIPTION
## What does this PR change?

Use new step introduced in September 2022 to wait for an event that takes a long time.


## Links

Ports:
* 4.3: https://github.com/SUSE/spacewalk/pull/22563


## Changelogs

- [x] No changelog needed
