### PR TITLE
Sync GPG properties on each build in CLM (bsc#1213689)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -775,6 +775,13 @@ public class ContentManager {
         }
     }
 
+    private static void syncGpgKeyInfo(Channel source, Channel target) {
+        target.setGPGCheck(source.isGPGCheck());
+        target.setGPGKeyFp(source.getGPGKeyFp());
+        target.setGPGKeyId(source.getGPGKeyId());
+        target.setGPGKeyUrl(source.getGPGKeyUrl());
+    }
+
     /**
      * Clone {@link Channel}s to given {@link ContentEnvironment}
      *
@@ -850,6 +857,9 @@ public class ContentManager {
         else {
             tgt.cloneModulesFrom(newSource);
         }
+
+        // Sync GPG key info to target in case it's updated since last build
+        syncGpgKeyInfo(newSource, tgt);
 
         return swTgt;
     }

--- a/java/spacewalk-java.changes.cbbayburt.bsc1213689
+++ b/java/spacewalk-java.changes.cbbayburt.bsc1213689
@@ -1,0 +1,1 @@
+- Sync GPG properties on each build in CLM (bsc#1213689)


### PR DESCRIPTION
Sync GPG fields on target repositories on build/promote in case the values have changed in the source after the last build.

Port of: https://github.com/SUSE/spacewalk/pull/22537

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
