### PR TITLE
Fix db migration in podman setup

### DIFF
--- a/testsuite/podman_runner/07_manager_setup.sh
+++ b/testsuite/podman_runner/07_manager_setup.sh
@@ -12,7 +12,8 @@ for schema in ${available_schemas[@]}; do
     specfile=$(find ${src_dir}/schema/${schema}/ -name *.spec)
     # Use Perl extended regexp and look-around assertions to extract only the values from the spec properties
     schema_name=$(grep -oP "Name:\s+\K(.*)$" ${specfile})
-    schema_version=$(grep -oP "Version:\s+\K(.*)$" ${specfile})
+    # Get the installed version
+    schema_version=$(sudo -i podman exec uyuni-server-all-in-one-test bash -c "rpm -q ${schema_name} | rev | cut -d - -f2   | rev")
 
     sudo -i podman exec uyuni-server-all-in-one-test bash -c "/testsuite/podman_runner/run_db_migrations.sh ${schema_name} ${schema_version}"
 done


### PR DESCRIPTION
## What does this PR change?

CI: fix the database migration. We need to look at the versions of the installed schema. Otherwise, when preparing for a release, the version in the specfile does not match.


## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links
N/A
- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
