### PR TITLE
Run the updates based on the installed version

### DIFF
--- a/testsuite/podman_runner/07_manager_setup.sh
+++ b/testsuite/podman_runner/07_manager_setup.sh
@@ -8,12 +8,13 @@ sudo -i podman exec uyuni-server-all-in-one-test bash -c "/usr/bin/spacewalk-sch
 
 # Make sure latest sql migration scripts have been executed for both the main and the reporting database
 available_schemas=("spacewalk" "reportdb")
-for schema in ${available_schemas[@]}; do
-    specfile=$(find ${src_dir}/schema/${schema}/ -name *.spec)
-    # Use Perl extended regexp and look-around assertions to extract only the values from the spec properties
-    schema_name=$(grep -oP "Name:\s+\K(.*)$" ${specfile})
-    schema_version=$(grep -oP "Version:\s+\K(.*)$" ${specfile})
+for schema in "${available_schemas[@]}"; do
+    specfile=$(find "${src_dir}/schema/${schema}/" -name '*.spec')
+    # Get the package name from the spec using Perl extended regexp and look-around assertions to extract only its value
+    schema_name=$(grep -oP "Name:\s+\K(.*)$" "${specfile}")
+    # Check the version of the package installed in the podman container
+    schema_version=$(sudo -i podman exec uyuni-server-all-in-one-test rpm -q --queryformat '%{version}' "${schema_name}")
 
+    # Run the missing migrations and only those, to ensure no script is out of place
     sudo -i podman exec uyuni-server-all-in-one-test bash -c "/testsuite/podman_runner/run_db_migrations.sh ${schema_name} ${schema_version}"
 done
-

--- a/testsuite/podman_runner/run_db_migrations.sh
+++ b/testsuite/podman_runner/run_db_migrations.sh
@@ -22,7 +22,10 @@ else
     exit 1
 fi
 
-for i in $(find ${upgrade_dir} -name "$1-$2-to-*"); do
+# Including all sub-folders of the upgrade dir that comes after the one called "${schema_name}-${schema_version}-to-..."
+# This should make sure we apply all the scripts meant to be executed on top of the current schema version.
+# It probably won't happen often that we have multiple pending directories, but it could happen in case of re-tagging
+for i in $(find ${upgrade_dir} -name "$1-*-to-*" | sed -n "/$1-$2-to-.*$/,$ p"); do
     echo $(basename $i)
     for j in $(find $i -name *.sql); do
         echo -e "\t$(basename $j)"; spacewalk-sql ${additional_params} $j | sed 's/^/\t\t/';


### PR DESCRIPTION
## What does this PR change?

Currently in the acceptance test we upgrade the database based on the version of the spec files. This breaks the tests when we create the new tag but the packages are not yet released and the podman container still has the old version installed. 

This PR changes this behaviour and uses the version of the schema package installed on the podman container to detect which scripts to run

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: change in the test scripts

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
