### PR TITLE
No fixed delay until proxy gets responsive again

### DIFF
--- a/testsuite/features/init_clients/proxy_branch_network.feature
+++ b/testsuite/features/init_clients/proxy_branch_network.feature
@@ -191,6 +191,8 @@ Feature: Setup Uyuni for Retail branch network
     When I follow "States" in the content area
     And I click on "Apply Highstate"
     And I wait until event "Apply highstate scheduled by admin" is completed
+    # This also triggers a "Package List Refresh" event that will fail
+    # because the Salt connexion is disoriented after those changes
     Then service "dhcpd" is enabled on "proxy"
     And service "dhcpd" is active on "proxy"
     And service "named" is enabled on "proxy"
@@ -201,10 +203,8 @@ Feature: Setup Uyuni for Retail branch network
 @proxy
 @private_net
   Scenario: Disable repositories after installing branch services
+    Given the Salt master can reach "proxy"
     When I disable repositories after installing branch server
-    # WORKAROUND: the following event fails because the proxy needs 10 minutes to become responsive again
-    # And I wait until event "Package List Refresh" is completed
-    And I wait for "700" seconds
 
 @proxy
 @private_net

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -10,14 +10,15 @@ require 'tempfile'
 
 Given(/^the Salt master can reach "(.*?)"$/) do |minion|
   system_name = get_system_name(minion)
+  server = get_target('server')
   start = Time.now
-  # 300 is the default 1st keepalive interval for the minion
-  # where it realizes the connection is stuck
-  repeat_until_timeout(timeout: 300, retries: 3, message: "Master can not communicate with #{minion}", report_result: true) do
-    out, _code = get_target('server').run("salt #{system_name} test.ping")
+  # 700 seconds is the maximum time it takes the proxy to recover after being redefined for Retail
+  # 300 seconds would be the default first keepalive interval for the minion before it realizes the connection is stuck
+  repeat_until_timeout(timeout: 700, message: "Master can not communicate with #{minion}", report_result: true) do
+    out, _code = server.run("salt #{system_name} test.ping", check_errors: false)
     if out.include?(system_name) && out.include?('True')
       finished = Time.now
-      log "Took #{finished.to_i - start.to_i} seconds to contact the minion"
+      log "It took #{finished.to_i - start.to_i} seconds to contact the minion"
       break
     end
     sleep 1


### PR DESCRIPTION
## What does this PR change?

This PR removes a fixed wait of 700 seconds.

2nd attempt - this time it has been tested properly, e.g. redeploying from scratch at each test.

We win between 6 to 8 minutes per test suite run in NUE and PRV.


## Links

Ports:
* 4.3: https://github.com/SUSE/spacewalk/pull/22568


## Changelogs

- [x] No changelog needed
