### PR TITLE
Add option to filter packages by build time in CLM

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
@@ -37,6 +37,7 @@ import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.MATCHES_P
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.MODULE_NONE;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.PROVIDES_NAME;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.PTF_ALL;
+import static com.redhat.rhn.domain.contentmgmt.PackageFilter.BUILD_DATE;
 import static com.redhat.rhn.domain.contentmgmt.PtfFilter.FIELD_PTF_ALL;
 import static com.redhat.rhn.domain.contentmgmt.PtfFilter.FIELD_PTF_NUMBER;
 import static com.redhat.rhn.domain.contentmgmt.PtfFilter.FIELD_PTF_PACKAGE;
@@ -86,6 +87,10 @@ public class FilterCriteria {
         Triple.of(PACKAGE, GREATEREQ, "nevra"),
         Triple.of(PACKAGE, GREATER, "nevra"),
         Triple.of(PACKAGE, MATCHES, "name"),
+        Triple.of(PACKAGE, LOWER, BUILD_DATE),
+        Triple.of(PACKAGE, LOWEREQ, BUILD_DATE),
+        Triple.of(PACKAGE, GREATER, BUILD_DATE),
+        Triple.of(PACKAGE, GREATEREQ, BUILD_DATE),
         Triple.of(ERRATUM, EQUALS, "advisory_name"),
         Triple.of(ERRATUM, EQUALS, "advisory_type"),
         Triple.of(ERRATUM, EQUALS, "synopsis"),

--- a/java/spacewalk-java.changes.welder.clm-filter-packages-by-build-time
+++ b/java/spacewalk-java.changes.welder.clm-filter-packages-by-build-time
@@ -1,0 +1,1 @@
+- Add option to filter packages by build time in CLM (jsc#SUMA-282)

--- a/web/html/src/manager/content-management/list-filters/filter-form.tsx
+++ b/web/html/src/manager/content-management/list-filters/filter-form.tsx
@@ -46,6 +46,9 @@ const FilterForm = (props: Props) => {
           if (clmFilterOptions.ISSUE_DATE.key === filter.type) {
             draft[clmFilterOptions.ISSUE_DATE.key] = localizedMoment();
           }
+          if (clmFilterOptions.PACKAGE_BUILD_DATE.key === filter.type) {
+            draft[clmFilterOptions.PACKAGE_BUILD_DATE.key] = localizedMoment();
+          }
         })
       );
     }
@@ -195,6 +198,16 @@ const FilterForm = (props: Props) => {
               <DateTime
                 name={clmFilterOptions.ISSUE_DATE.key}
                 label={t("Issued")}
+                labelClass="col-md-3"
+                divClass="col-md-8"
+                required
+              />
+            )}
+
+            {clmFilterOptions.PACKAGE_BUILD_DATE.key === filterType && (
+              <DateTime
+                name={clmFilterOptions.PACKAGE_BUILD_DATE.key}
+                label={t("Build")}
                 labelClass="col-md-3"
                 divClass="col-md-8"
                 required

--- a/web/html/src/manager/content-management/shared/business/filters.enum.ts
+++ b/web/html/src/manager/content-management/shared/business/filters.enum.ts
@@ -157,6 +157,12 @@ export const clmFilterOptions: ClmFilterOptionsEnumType = {
     entityType: filterEntity.PACKAGE,
     matchers: [filterMatchers.PROVIDES_NAME],
   },
+  PACKAGE_BUILD_DATE: {
+    key: "build_date",
+    text: t("Build date"),
+    entityType: filterEntity.PACKAGE,
+    matchers: [filterMatchers.LOWER, filterMatchers.LOWEREQ, filterMatchers.GREATER, filterMatchers.GREATEREQ],
+  },
   ADVISORY_NAME: {
     key: "advisory_name",
     text: t("Advisory Name"),

--- a/web/spacewalk-web.changes.welder.clm-filter-packages-by-build-time
+++ b/web/spacewalk-web.changes.welder.clm-filter-packages-by-build-time
@@ -1,0 +1,1 @@
+- Add option to filter packages by build time in CLM (jsc#SUMA-282)


### PR DESCRIPTION
## What does this PR change?

It adds a new option to CLM, allowing users to filter packages by build date.

## GUI diff

Before:

After:

![image](https://github.com/uyuni-project/uyuni/assets/17532261/ee699aee-d576-4441-a8a8-cc23c6355233)


- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links
Fixes https://github.com/SUSE/spacewalk/issues/13350

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
