### PR TITLE
testsuite: fix container proxy test cleanup

### DIFF
--- a/testsuite/features/secondary/proxy_as_pod_basic_tests.feature
+++ b/testsuite/features/secondary/proxy_as_pod_basic_tests.feature
@@ -243,8 +243,8 @@ Feature: Register and test a Containerized Proxy
 
   Scenario: Cleanup: Remove Containerized Proxy configuration
     When I ensure folder "/etc/uyuni/proxy/*" doesn't exist on "proxy"
-    And I remove "/tmp/proxy_container_config.zip" from "proxy"
-    And I remove "/tmp/proxy_container_config.zip" from "server"
+    And I remove "/tmp/proxy_container_config.tar.gz" from "proxy"
+    And I remove "/tmp/proxy_container_config.tar.gz" from "server"
 
   Scenario: Cleanup: Remove "Pod Proxy Channel" configuration channel
     When I follow the left menu "Configuration > Channels"


### PR DESCRIPTION
## What does this PR change?

The config file to clean is no longer a `zip`, but a `tar.gz`. The missing file test fails in container server CI, but is ignored in master:

![Screenshot from 2023-09-26 13-38-58](https://github.com/uyuni-project/uyuni/assets/397931/50649a54-323d-4812-a3e3-02070fbc9cc4)


## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Cucumber tests were fixed

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
