### PR TITLE
Add JAVA_OPTS option for rhn-search

### DIFF
--- a/search-server/spacewalk-search/spacewalk-search.changes.cbosdo.search_javaopts
+++ b/search-server/spacewalk-search/spacewalk-search.changes.cbosdo.search_javaopts
@@ -1,0 +1,1 @@
+- Add JAVA_OPTS configuration for rhn-search

--- a/search-server/spacewalk-search/src/config/rhn-search
+++ b/search-server/spacewalk-search/src/config/rhn-search
@@ -10,7 +10,7 @@ fi
 SEARCH_CLASSPATH="${SEARCH_JARS}:${SEARCH_RHN_CLASSPATH}:${SEARCH_RHN_JARS}"
 SEARCH_PARAMS="-Dfile.encoding=UTF-8 -Xms${SEARCH_INIT_MEMORY}m -Xmx${SEARCH_MAX_MEMORY}m"
 
-JAVACMD="/usr/bin/java -Djava.library.path=${SEARCH_LIBRARY_PATH} -classpath ${SEARCH_CLASSPATH} ${SEARCH_PARAMS}"
+JAVACMD="/usr/bin/java ${JAVA_OPTS} -Djava.library.path=${SEARCH_LIBRARY_PATH} -classpath ${SEARCH_CLASSPATH} ${SEARCH_PARAMS}"
 
 if [[ $# -eq 0 ]]; then
     $JAVACMD -Dlog4j2.configurationFile=/usr/share/rhn/search/classes/log4j2.xml com.redhat.satellite.search.Main

--- a/search-server/spacewalk-search/src/config/search/rhn_search_daemon.conf
+++ b/search-server/spacewalk-search/src/config/search/rhn_search_daemon.conf
@@ -9,3 +9,4 @@ SEARCH_RHN_JARS="/usr/share/rhn/lib/spacewalk-asm.jar:/usr/share/rhn/lib/rhn.jar
 SEARCH_JARS="/usr/share/rhn/search/lib/*"
 SEARCH_INIT_MEMORY=32
 SEARCH_MAX_MEMORY=512
+JAVA_OPTS=""


### PR DESCRIPTION
## What does this PR change?

Since the tanuki wrapper removal we cannot enable Java remote debugging on the search server. A JAVA_OPTS option will now help this.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: empty option

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
