### PR TITLE
mgr-inter-sync command fix config clear cache

### DIFF
--- a/python/spacewalk/common/rhnConfig.py
+++ b/python/spacewalk/common/rhnConfig.py
@@ -129,16 +129,17 @@ class RHNOptions:
         the configuration cache self.__configs
         """
         # Speed up the most common case
-        timeDiff = self.modifiedYN()
-        if not timeDiff and self.is_initialized():
-            # Nothing to do: the config file did not change and we already
-            # have the config cached
-            return
-        else:
-            # if the timestamp changed, clear the list of cached configs
-            # and retain the new timestamp
-            self.updateLastModified(timeDiff)
-            self.__configs.clear()  # cache cleared
+        if self.is_initialized():
+            timeDiff = self.modifiedYN()
+            if not timeDiff:
+                # Nothing to do: the config file did not change and we already
+                # have the config cached
+                return
+            else:
+                # if the timestamp changed, clear the list of cached configs
+                # and retain the new timestamp
+                self.updateLastModified(timeDiff)
+                self.__configs.clear()  # cache cleared
 
         # parse the defaults.
         self._parseDefaults(allCompsYN=0)

--- a/python/spacewalk/spacewalk-backend.changes.tanganellilore.fix_clear_cache_config
+++ b/python/spacewalk/spacewalk-backend.changes.tanganellilore.fix_clear_cache_config
@@ -1,0 +1,1 @@
+- fix clear of self.__config cache on rhnConfig.py only when timeDiff change


### PR DESCRIPTION
## What does this PR change?

In `mgr-inter-sync` if we use `--iss-parent` or if we missing to add `iss_parent` on `rhn.conf`, configuration passed or retrived from DB will be used only for some functions, not for whole run of the script.
A issue that highlight this is this one:
https://github.com/uyuni-project/uyuni/issues/7565

This PR will fix this behavior, that is generated by calculation of initialized component and `timeDiff `in same line.

Actually, `self.__config` will be cleared everytime `self.__component` is `None` and `timeDiff` is not `0`, so everytime we have new component, we simply delete all config already loaded.
This probably was introduced with the new method `with cfg_component(component=None)` that for example is used internally. Calling this we simply define new component=None and `parse` function clear everything in the `self.__config`  creating a "sort of loop", because net time that arrive with new component, this will clear everything.

This explain why we have this error on linked issue, because in that case we simply reload the `rhn.conf` for component `server.satellite`, defined by `mgr-inter-sync` command, instead use what was extracted from DB or passed by command line.

This PR simply move out the `self.is_initialized()` in a dedicated `if`, that wrap the check of `timeDiff`.
So:

1. in case of component not initialized (like component=None or any other component), we simply to load the config from disk
2. in case of component already initialized, we check if file was changed
   a. if not, we `return`
   b. if yes, we clear `self.__config `

I have some doubpts related clear everything, becase this can broke something that is setted by OPTIONS or command line, but I don't know the logic behind this code, so I leave it as is (I have in mind some method to "merge" what is cached with what is changed in a file, but I prefer for now maintain as is)


I also evaluated some differents approach but this is the simplest with less code changed

## GUI diff

No difference.



## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
