### PR TITLE
Fix owner after smdba execution in the DB migration script (bsc#1214746)

### DIFF
--- a/susemanager/bin/pg-migrate-x-to-y.sh
+++ b/susemanager/bin/pg-migrate-x-to-y.sh
@@ -194,11 +194,11 @@ fi
 
 cp /var/lib/pgsql/data-pg$OLD_VERSION/pg_hba.conf /var/lib/pgsql/data
 cp /var/lib/pgsql/data-pg${OLD_VERSION}/postgresql.conf /var/lib/pgsql/data/
-chown postgres:postgres /var/lib/pgsql/data/*
 
 echo "$(timestamp)   Tune new postgresql configuration..."
 smdba system-check autotuning
 if [ $? -eq 0 ]; then
+    chown postgres:postgres /var/lib/pgsql/data/*
     echo "$(timestamp)   Successfully tuned new postgresql configuration."
 else
     echo "$(timestamp)   Tuning of new postgresql configuration failed!"

--- a/susemanager/susemanager.changes.vzhestkov.fix-owner-after-smdba
+++ b/susemanager/susemanager.changes.vzhestkov.fix-owner-after-smdba
@@ -1,0 +1,1 @@
+- Fix possible permission issues with database migration script (bsc#1214746)


### PR DESCRIPTION
## What does this PR change?

Running `smdba system-check autotuning` can produce the files in `/var/lib/pgsql/data/` with `root` user permission what can cause issues on running Postgres afterwards.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Links

Fixes https://github.com/SUSE/spacewalk/issues/22437

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
