### PR TITLE
fix RHUI support for RHEL 7 clients

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/payg/script/rhui7_extract_repo_data.py
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/payg/script/rhui7_extract_repo_data.py
@@ -117,7 +117,7 @@ def get_rhui_url(url):
     global cloud_vendor
     surl = url.strip().replace(',', "")
     urlparams = urlparse.urlparse(url.strip())
-    if urlparams.hostname.startswith("rhui.") and urlparams.hostname.endswith(".redhat.com"):
+    if urlparams.hostname.startswith("rhui") and urlparams.hostname.endswith(".redhat.com"):
         cloud_vendor = "aws"
         return surl
     elif urlparams.hostname.startswith("rhui") and urlparams.hostname.endswith(".microsoft.com"):

--- a/java/code/src/com/redhat/rhn/taskomatic/task/payg/script/rhui_extract_repo_data.py
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/payg/script/rhui_extract_repo_data.py
@@ -96,7 +96,7 @@ def get_rhui_url(url):
     global cloud_vendor
     surl = url.strip().replace(',', "")
     urlparams = urlparse.urlparse(surl)
-    if urlparams.hostname.startswith("rhui.") and urlparams.hostname.endswith(".redhat.com"):
+    if urlparams.hostname.startswith("rhui") and urlparams.hostname.endswith(".redhat.com"):
         cloud_vendor = "aws"
         return surl
     elif urlparams.hostname.startswith("rhui") and urlparams.hostname.endswith(".microsoft.com"):

--- a/java/spacewalk-java.changes.mc.Manager-4.3-fix-RHUI7
+++ b/java/spacewalk-java.changes.mc.Manager-4.3-fix-RHUI7
@@ -1,0 +1,1 @@
+- fix RHUI support for RHEL 7 clients (bsc#1215756)


### PR DESCRIPTION
## What does this PR change?

Fix RHUI support for RHEL 7 client. As 8 and 9 may see the same in future, applied the same change also to the other script.
RedHat changed the hostnames of the RHUI repository server to include numbers in the name.

rhui.x.y.z => rhui3.x.y.z

## Links

Port of https://github.com/SUSE/spacewalk/pull/22598

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
