### PR TITLE
Wrong SCC credentials not marked as invalid

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/renderers/setupwizard/MirrorCredentialsRenderer.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/renderers/setupwizard/MirrorCredentialsRenderer.java
@@ -14,8 +14,10 @@
  */
 package com.redhat.rhn.frontend.action.renderers.setupwizard;
 
+import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.frontend.action.renderers.RendererHelper;
 import com.redhat.rhn.manager.content.ContentSyncException;
+import com.redhat.rhn.manager.content.ContentSyncManager;
 import com.redhat.rhn.manager.setup.MirrorCredentialsDto;
 import com.redhat.rhn.manager.setup.MirrorCredentialsManager;
 import com.redhat.rhn.manager.setup.MirrorCredentialsNotUniqueException;
@@ -44,6 +46,7 @@ public class MirrorCredentialsRenderer {
     private static final String ATTRIB_MIRRCREDS = "credentials";
     private static final String ATTRIB_CREDS_ID = "credentialsId";
     private static final String ATTRIB_SUCCESS = "success";
+    private static final String ATTRIB_FROM_DIR = "fromDir";
     private static final String ATTRIB_SUBSCRIPTIONS = "subscriptions";
 
     // Save credentials return codes
@@ -191,7 +194,11 @@ public class MirrorCredentialsRenderer {
         // Download if forced refresh or status unknown
         subs = credsManager.getSubscriptions(creds, request, refresh);
 
+        // Check if `fromDir` var is set to avoid checking credentials
+        String localPath = Config.get().getString(ContentSyncManager.RESOURCE_PATH, null);
+
         request.setAttribute(ATTRIB_SUCCESS, subs != null);
+        request.setAttribute(ATTRIB_FROM_DIR, localPath != null);
         request.setAttribute(ATTRIB_CREDS_ID, id);
         return RendererHelper.renderRequest(CREDS_VERIFY_URL, request, response);
     }

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -25076,6 +25076,9 @@ given channel.</source>
       <trans-unit id="mirror-credentials.jsp.failed" xml:space="preserve">
         <source>verification failed (click to refresh)</source>
       </trans-unit>
+      <trans-unit id="mirror-credentials.jsp.fromDir" xml:space="preserve">
+        <source>cannot verify credentials because `server.susemanager.fromdir` property is set in rhn.conf</source>
+      </trans-unit>
       <trans-unit id="mirror-credentials.jsp.modal-edit.title" xml:space="preserve">
         <source>Edit credentials</source>
       </trans-unit>

--- a/java/code/webapp/WEB-INF/pages/admin/setup/mirror-credentials-verify.jsp
+++ b/java/code/webapp/WEB-INF/pages/admin/setup/mirror-credentials-verify.jsp
@@ -1,11 +1,18 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://rhn.redhat.com/rhn" prefix="rhn" %>
 
+
+<c:if test="${fromDir}">
+    <rhn:icon type="system-warn" title="mirror-credentials.jsp.fromDir" />
+</c:if>
+
 <a href="javascript:void(0);" onClick="verifyCredentials('${credentialsId}', true);">
-    <c:if test="${success}">
-        <rhn:icon type="setup-wizard-creds-verified" title="mirror-credentials.jsp.success" />
-    </c:if>
-    <c:if test="${! success}">
-        <rhn:icon type="setup-wizard-creds-failed" title="mirror-credentials.jsp.failed" />
+    <c:if test="${! fromDir}">
+        <c:if test="${success}">
+            <rhn:icon type="setup-wizard-creds-verified" title="mirror-credentials.jsp.success" />
+        </c:if>
+        <c:if test="${! success}">
+            <rhn:icon type="setup-wizard-creds-failed" title="mirror-credentials.jsp.failed" />
+        </c:if>
     </c:if>
 </a>

--- a/java/spacewalk-java.changes.1211270.mikeletux
+++ b/java/spacewalk-java.changes.1211270.mikeletux
@@ -1,0 +1,1 @@
+- Avoid SCC credentials check if `server.susemanager.fromdir` is set (bsc#1211270)


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/22540

## GUI diff

No difference.

- [x] **DONE**

## Documentation
PR in docs repo -> https://github.com/uyuni-project/uyuni-docs/pull/2469

- [x] **DONE**

## Test coverage
- No tests: already covered
Require testsuite change https://github.com/uyuni-project/uyuni/pull/7593

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/21688

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
