### PR TITLE
Prevent reposync tracebacks on packages with empty release

### DIFF
--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -1180,6 +1180,10 @@ password={passwd}
         for pack in pkglist:
             new_pack = ContentPackage()
             epoch, version, release = RawSolvablePackage._parse_solvable_evr(pack.evr)
+            # Prevent repeating to download the package with empty release on each run.
+            # Release should be specified in the package. Assuming empty release as 0.
+            if release == "":
+                release = "0"
             new_pack.setNVREA(pack.name, version, release, epoch, pack.arch)
             new_pack.unique_id = RawSolvablePackage(pack)
             checksum = pack.lookup_checksum(solv.SOLVABLE_CHECKSUM)

--- a/python/spacewalk/spacewalk-backend.changes.vzhestkov.fix-reposync-with-no-release
+++ b/python/spacewalk/spacewalk-backend.changes.vzhestkov.fix-reposync-with-no-release
@@ -1,0 +1,1 @@
+- Prevent reposync tracebacks on packages with empty release (bsc#1213738)

--- a/python/uyuni/uyuni-common-libs.changes.vzhestkov.fix-reposync-with-no-release
+++ b/python/uyuni/uyuni-common-libs.changes.vzhestkov.fix-reposync-with-no-release
@@ -1,0 +1,1 @@
+- Prevent reposync tracebacks on packages with empty release (bsc#1213738)


### PR DESCRIPTION
## What does this PR change?

In case if repo contains the package with empty release specified in the header it could lead to the traceback while running `spacewalk-repo-sync` for such repo.

The only example found was `microsoft-identity-diagnostics-1.0.0-.x86_64.rpm` in `https://packages.microsoft.com/rhel/8/prod/` but it was fixed after.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: no tests for the modified packages and the fix is for very specific corner case.

## Links

Fixes https://github.com/SUSE/spacewalk/issues/22135

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
