### PR TITLE
fix low contrast in homepage

### DIFF
--- a/web/html/src/branding/css/uyuni/legacy-theme.less
+++ b/web/html/src/branding/css/uyuni/legacy-theme.less
@@ -430,7 +430,7 @@ header, nav.navbar-pf {
       // nodeLink and leafLink
       div.nodeLink,
       div.leafLink {
-        color: @gray-light;
+        color: @white;
         border-left: 3px solid transparent;
         a {
           display: block;

--- a/web/html/src/branding/css/uyuni/legacy-variables.less
+++ b/web/html/src/branding/css/uyuni/legacy-variables.less
@@ -1,6 +1,7 @@
 // TODO: This should be merged with variables.less
 
 /* Main tags colours */
+@green-dark-1:           #008558;
 @green-dark:             #02A49C;
 @green:                  #00C081;
 @green-light:            #02D35F;
@@ -29,7 +30,7 @@
 @aside:                        @blue;
 @aside-border:                 lighten(@aside, 8%);
 @aside-menu-hyperlink:         @white;
-@aside-menu-active:            @green;
+@aside-menu-active:            @green-dark-1;
 
 /* aside menu search box */
 @aside-menu-search-clear:          fade(@gray, 60%);


### PR DESCRIPTION
## What does this PR change?

**This PR fixes the low contrast between the menu items and the background color, as identified by WAVE**

## GUI diff

Before:

![1](https://github.com/uyuni-project/uyuni/assets/48498778/41ae4508-a5e3-4be6-8b9c-0b49825d9edc)

After:

![2](https://github.com/uyuni-project/uyuni/assets/48498778/e29e663a-0e14-49d6-8f14-e7d2e0798246)

- [X] **DONE**

## Documentation
- No documentation needed: **This changes improves the contrast color of the texts and the background to enhance accessibility, no additional documentation is needed.**

- [X] **DONE**

## Test coverage

- No tests: already covered

- [X] **DONE**

## Links

Fixes #7101 

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
