### PR TITLE
Master bug 1213132 ansible inventory

### DIFF
--- a/java/buildconf/LICENSE.txt
+++ b/java/buildconf/LICENSE.txt
@@ -1,5 +1,5 @@
 ^/\*$
-^ \* Copyright \(c\) (20([01]\d|20)--)?20(1\d|2[0123]) (Red Hat, Inc.|SUSE LLC)$
+^ \* Copyright \(c\) (20([012]\d|20)--)?20(1\d|2[0123]) (Red Hat, Inc.|SUSE LLC)$
 ^ \*$
 ^ \* This software is licensed to you under the GNU General Public License,$
 ^ \* version 2 \(GPLv2\). There is NO WARRANTY for this software, express or$

--- a/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
@@ -383,15 +383,9 @@ public class AnsibleController {
     public static Set<String> parseInventoryAndGetHostnames(Map<String, Map<String, Object>> inventoryMap) {
         HashSet<String> hostnames = new HashSet<>();
 
-        Optional<List<String>> ungrouped = Optional.ofNullable((List<String>)inventoryMap.get("ungrouped").get("hosts"));
-        if (ungrouped.isPresent()) {
-            ungrouped.get().stream().forEach(host -> hostnames.add(host));
-        }
-
         for (Map.Entry<String, Map<String, Object>> entry : inventoryMap.entrySet()) {
             String ansibleGroupName = entry.getKey();
-            if (!ansibleGroupName.equals("ungrouped") && !ansibleGroupName.equals("all") &&
-                    !ansibleGroupName.equals("_meta")) {
+            if (!ansibleGroupName.equals("_meta")) {
                 Optional<List<String>> list = Optional.ofNullable((List<String>)entry.getValue().get("hosts"));
                 if (list.isPresent()) {
                     list.get().stream().forEach(host -> hostnames.add(host));

--- a/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
@@ -60,6 +60,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -380,13 +381,25 @@ public class AnsibleController {
      * @return the Set of hostnames
      */
     public static Set<String> parseInventoryAndGetHostnames(Map<String, Map<String, Object>> inventoryMap) {
-        // Assumption: "_meta" and the nested "hostvars" keys always present in the map to contains all hostnames
-        if (inventoryMap.containsKey("_meta") &&
-                inventoryMap.get("_meta").containsKey("hostvars") &&
-                inventoryMap.get("_meta").get("hostvars") instanceof Map) {
-            return ((Map<String, Object>) inventoryMap.get("_meta").get("hostvars")).keySet();
+        HashSet<String> hostnames = new HashSet<>();
+
+        Optional<List<String>> ungrouped = Optional.ofNullable((List<String>)inventoryMap.get("ungrouped").get("hosts"));
+        if (ungrouped.isPresent()) {
+            ungrouped.get().stream().forEach(host -> hostnames.add(host));
         }
-        return new HashSet<>();
+
+        for (Map.Entry<String, Map<String, Object>> entry : inventoryMap.entrySet()) {
+            String ansibleGroupName = entry.getKey();
+            if (!ansibleGroupName.equals("ungrouped") && !ansibleGroupName.equals("all") &&
+                    !ansibleGroupName.equals("_meta")) {
+                Optional<List<String>> list = Optional.ofNullable((List<String>)entry.getValue().get("hosts"));
+                if (list.isPresent()) {
+                    list.get().stream().forEach(host -> hostnames.add(host));
+                }
+            }
+        }
+
+        return hostnames;
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 SUSE LLC
+ * Copyright (c) 2021--2023 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package com.suse.manager.webui.controllers;
 
 import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
@@ -47,6 +46,7 @@ import com.suse.utils.Json;
 
 import com.google.gson.Gson;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.yaml.snakeyaml.Yaml;
@@ -60,7 +60,6 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -386,9 +385,10 @@ public class AnsibleController {
         for (Map.Entry<String, Map<String, Object>> entry : inventoryMap.entrySet()) {
             String ansibleGroupName = entry.getKey();
             if (!ansibleGroupName.equals("_meta")) {
-                Optional<List<String>> list = Optional.ofNullable((List<String>)entry.getValue().get("hosts"));
-                if (list.isPresent()) {
-                    list.get().stream().forEach(host -> hostnames.add(host));
+                @SuppressWarnings("unchecked")
+                List<String> hostList = (List<String>)entry.getValue().get("hosts");
+                if (CollectionUtils.isNotEmpty(hostList)) {
+                    hostnames.addAll(hostList);
                 }
             }
         }

--- a/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 SUSE LLC
+ * Copyright (c) 2023 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/java/code/src/com/suse/manager/webui/controllers/test/AnsibleControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/AnsibleControllerTest.java
@@ -32,17 +32,9 @@ import java.util.Map;
 import java.util.Set;
 
 public class AnsibleControllerTest extends BaseTestCaseWithUser {
-    @BeforeAll
-    public static void beforeAll() {}
-
-    @Override
-    @BeforeEach
-    public void setUp() throws Exception {}
-
-    @Override
-    @AfterEach
-    public void tearDown() throws Exception {}
-
+    /**
+     * Class used for test `testParseInventoryAndGetHostnames`
+     */
     private class InventoryTestCase {
         private String TestName;
         private Map<String, Map<String, Object>> Inventory;
@@ -67,7 +59,12 @@ public class AnsibleControllerTest extends BaseTestCaseWithUser {
             return ExpectedResult;
         }
     }
-    public List<InventoryTestCase> getTestInventories() {
+
+    /**
+     *
+     * @return some testing Ansible inventories to test `AnsibleController.parseInventoryAndGetHostnames`
+     */
+    private List<InventoryTestCase> getTestInventories() {
         return new LinkedList<>() {{
             add(new InventoryTestCase(
                     "1_empty_inventory",
@@ -160,6 +157,9 @@ public class AnsibleControllerTest extends BaseTestCaseWithUser {
         }};
     }
 
+    /**
+     * Tests `AnsibleController.parseInventoryAndGetHostnames`
+     */
     @Test
     public void testParseInventoryAndGetHostnames() {
         List<InventoryTestCase> testCases = getTestInventories();

--- a/java/code/src/com/suse/manager/webui/controllers/test/AnsibleControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/AnsibleControllerTest.java
@@ -18,10 +18,9 @@ package com.suse.manager.webui.controllers.test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
+
 import com.suse.manager.webui.controllers.AnsibleController;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
@@ -36,27 +35,27 @@ public class AnsibleControllerTest extends BaseTestCaseWithUser {
      * Class used for test `testParseInventoryAndGetHostnames`
      */
     private class InventoryTestCase {
-        private String TestName;
-        private Map<String, Map<String, Object>> Inventory;
-        private Set<String> ExpectedResult;
+        private String testName;
+        private Map<String, Map<String, Object>> inventory;
+        private Set<String> expectedResult;
 
-        public InventoryTestCase(String TestName, Map<String, Map<String, Object>> Inventory, Set<String> ExpectedResult) {
-            this.TestName = TestName;
-            this.Inventory = Inventory;
-            this.ExpectedResult = ExpectedResult;
+        InventoryTestCase(String testNameIn, Map<String, Map<String, Object>> inventoryIn,
+                                 Set<String> expectedResultIn) {
+            testName = testNameIn;
+            inventory = inventoryIn;
+            expectedResult = expectedResultIn;
         }
 
-
         public String getTestName() {
-            return TestName;
+            return testName;
         }
 
         public Map<String, Map<String, Object>> getInventory() {
-            return Inventory;
+            return inventory;
         }
 
         public Set<String> getExpectedResult() {
-            return ExpectedResult;
+            return expectedResult;
         }
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/test/AnsibleControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/AnsibleControllerTest.java
@@ -24,7 +24,6 @@ import com.suse.manager.webui.controllers.AnsibleController;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -64,96 +63,88 @@ public class AnsibleControllerTest extends BaseTestCaseWithUser {
      * @return some testing Ansible inventories to test `AnsibleController.parseInventoryAndGetHostnames`
      */
     private List<InventoryTestCase> getTestInventories() {
-        return new LinkedList<>() {{
-            add(new InventoryTestCase(
-                    "1_empty_inventory",
-                    new LinkedHashMap<>() {{
-                        put("_meta", new LinkedHashMap<>() {{
-                            put("hostvars", new LinkedList<String>());
-                        }});
-                    }},
-                    new HashSet<>()
-            ));
-
-            add(new InventoryTestCase(
-                    "2_inventory_with_ungrouped_hosts",
-                    new LinkedHashMap<>() {{
-                        put("_meta", new LinkedHashMap<>() {{
-                            put("hostvars", new LinkedList<String>());
-                        }});
-                        put("all", new LinkedHashMap<>() {{
-                            put("children", new LinkedList<String>() {{
-                                add("ungrouped");
-                            }});
-                        }});
-                        put("ungrouped", new LinkedHashMap<>() {{
-                            put("hosts", new LinkedList<String>() {{
-                                add("gray-fox.shadow-moses.island");
-                                add("meryl.shadow-moses.island");
-                                add("otacon.shadow-moses.island");
-                            }});
-                        }});
-                    }},
-                    new HashSet<>() {{
-                        add("gray-fox.shadow-moses.island");
-                        add("meryl.shadow-moses.island");
-                        add("otacon.shadow-moses.island");
-                    }}
-            ));
-
-            add(new InventoryTestCase(
-                            "3_inventory_with_ungrouped_servers_grouped_servers_and_nested_groups",
-                            new LinkedHashMap<>() {
-                                {
-                                    put("_meta", new LinkedHashMap<>() {{
-                                        put("hostvars", new LinkedList<String>());
-                                    }});
-                                    put("all", new LinkedHashMap<>() {{
-                                        put("children", new LinkedList<String>() {{
-                                            add("ungrouped");
-                                            add("government");
-                                            add("fox-hound");
-                                        }});
-                                    }});
-                                    put("ungrouped", new LinkedHashMap<>() {{
-                                        put("hosts", new LinkedList<String>() {{
-                                            add("gray-fox.shadow-moses.island");
-                                            add("meryl.shadow-moses.island");
-                                            add("otacon.shadow-moses.island");
-                                        }});
-                                    }});
-                                    put("government", new LinkedHashMap<>() {{
-                                        put("hosts", new LinkedList<String>() {{
-                                            add("solid-snake.shadow-moses.island");
-                                            add("cambell.shadow-moses.island");
-                                        }});
-                                    }});
-                                    put("fox-hound", new LinkedHashMap<>() {{
-                                        put("hosts", new LinkedList<String>() {{
-                                            add("liquid-snake.shadow-moses.island");
-                                            add("ocelot.shadow-moses.island");
-                                        }});
-                                    }});
-                                    put("characters", new LinkedHashMap<>() {{
-                                        put("children", new LinkedList<String>() {{
-                                            add("government");
-                                            add("fox-hound");
-                                        }});
-                                    }});
-                                }
-                            },
-                            new HashSet<>() {{
-                                add("gray-fox.shadow-moses.island");
-                                add("meryl.shadow-moses.island");
-                                add("otacon.shadow-moses.island");
-                                add("solid-snake.shadow-moses.island");
-                                add("cambell.shadow-moses.island");
-                                add("liquid-snake.shadow-moses.island");
-                                add("ocelot.shadow-moses.island");
-                            }}
+        return List.of(
+            new InventoryTestCase(
+                "1_empty_inventory",
+                Map.of("_meta", Map.of(
+                        "hostvars", new LinkedList<String>()
+                        )
+                    ),
+                new HashSet<>()
+            ),
+            new InventoryTestCase(
+                "2_inventory_with_ungrouped_hosts",
+                Map.of(
+                    "_meta", Map.of(
+                        "hostvars", new LinkedList<String>()
+                    ),
+                    "all", Map.of(
+                        "children", List.of(
+                            "ungrouped"
+                        )
+                    ),
+                    "ungrouped", Map.of(
+                        "hosts", List.of(
+                                "gray-fox.shadow-moses.island",
+                                "meryl.shadow-moses.island",
+                                "otacon.shadow-moses.island"
+                        )
                     )
-            );
-        }};
+                ),
+                Set.of(
+                    "gray-fox.shadow-moses.island",
+                    "meryl.shadow-moses.island",
+                    "otacon.shadow-moses.island"
+                )
+            ),
+            new InventoryTestCase(
+                "3_inventory_with_ungrouped_servers_grouped_servers_and_nested_groups",
+                Map.of(
+                    "_meta", Map.of("hostvars", new LinkedList<String>()),
+                    "all", Map.of(
+                        "children", List.of(
+                                "ungrouped",
+                                "government",
+                                "fox-hound"
+                        )
+                    ),
+                    "ungrouped", Map.of(
+                        "hosts", List.of(
+                            "gray-fox.shadow-moses.island",
+                            "meryl.shadow-moses.island",
+                            "otacon.shadow-moses.island"
+                        )
+                    ),
+                    "government", Map.of(
+                        "hosts", List.of(
+                            "solid-snake.shadow-moses.island",
+                            "cambell.shadow-moses.island"
+                        )
+                    ),
+                    "fox-hound", Map.of(
+                        "hosts", List.of(
+                                "liquid-snake.shadow-moses.island",
+                                "ocelot.shadow-moses.island"
+                        )
+                    ),
+                    "characters", Map.of(
+                        "children", List.of(
+                            "government",
+                            "fox-hound"
+                        )
+                    )
+                ),
+                Set.of(
+                    "gray-fox.shadow-moses.island",
+                    "meryl.shadow-moses.island",
+                    "otacon.shadow-moses.island",
+                    "solid-snake.shadow-moses.island",
+                    "cambell.shadow-moses.island",
+                    "liquid-snake.shadow-moses.island",
+                    "ocelot.shadow-moses.island"
+                )
+            )
+        );
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/test/AnsibleControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/AnsibleControllerTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.webui.controllers.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
+import com.suse.manager.webui.controllers.AnsibleController;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class AnsibleControllerTest extends BaseTestCaseWithUser {
+    @BeforeAll
+    public static void beforeAll() {}
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {}
+
+    @Override
+    @AfterEach
+    public void tearDown() throws Exception {}
+
+    private class InventoryTestCase {
+        private String TestName;
+        private Map<String, Map<String, Object>> Inventory;
+        private Set<String> ExpectedResult;
+
+        public InventoryTestCase(String TestName, Map<String, Map<String, Object>> Inventory, Set<String> ExpectedResult) {
+            this.TestName = TestName;
+            this.Inventory = Inventory;
+            this.ExpectedResult = ExpectedResult;
+        }
+
+
+        public String getTestName() {
+            return TestName;
+        }
+
+        public Map<String, Map<String, Object>> getInventory() {
+            return Inventory;
+        }
+
+        public Set<String> getExpectedResult() {
+            return ExpectedResult;
+        }
+    }
+    public List<InventoryTestCase> getTestInventories() {
+        return new LinkedList<>() {{
+            add(new InventoryTestCase(
+                    "1_empty_inventory",
+                    new LinkedHashMap<>() {{
+                        put("_meta", new LinkedHashMap<>() {{
+                            put("hostvars", new LinkedList<String>());
+                        }});
+                    }},
+                    new HashSet<>()
+            ));
+
+            add(new InventoryTestCase(
+                    "2_inventory_with_ungrouped_hosts",
+                    new LinkedHashMap<>() {{
+                        put("_meta", new LinkedHashMap<>() {{
+                            put("hostvars", new LinkedList<String>());
+                        }});
+                        put("all", new LinkedHashMap<>() {{
+                            put("children", new LinkedList<String>() {{
+                                add("ungrouped");
+                            }});
+                        }});
+                        put("ungrouped", new LinkedHashMap<>() {{
+                            put("hosts", new LinkedList<String>() {{
+                                add("gray-fox.shadow-moses.island");
+                                add("meryl.shadow-moses.island");
+                                add("otacon.shadow-moses.island");
+                            }});
+                        }});
+                    }},
+                    new HashSet<>() {{
+                        add("gray-fox.shadow-moses.island");
+                        add("meryl.shadow-moses.island");
+                        add("otacon.shadow-moses.island");
+                    }}
+            ));
+
+            add(new InventoryTestCase(
+                            "3_inventory_with_ungrouped_servers_grouped_servers_and_nested_groups",
+                            new LinkedHashMap<>() {
+                                {
+                                    put("_meta", new LinkedHashMap<>() {{
+                                        put("hostvars", new LinkedList<String>());
+                                    }});
+                                    put("all", new LinkedHashMap<>() {{
+                                        put("children", new LinkedList<String>() {{
+                                            add("ungrouped");
+                                            add("government");
+                                            add("fox-hound");
+                                        }});
+                                    }});
+                                    put("ungrouped", new LinkedHashMap<>() {{
+                                        put("hosts", new LinkedList<String>() {{
+                                            add("gray-fox.shadow-moses.island");
+                                            add("meryl.shadow-moses.island");
+                                            add("otacon.shadow-moses.island");
+                                        }});
+                                    }});
+                                    put("government", new LinkedHashMap<>() {{
+                                        put("hosts", new LinkedList<String>() {{
+                                            add("solid-snake.shadow-moses.island");
+                                            add("cambell.shadow-moses.island");
+                                        }});
+                                    }});
+                                    put("fox-hound", new LinkedHashMap<>() {{
+                                        put("hosts", new LinkedList<String>() {{
+                                            add("liquid-snake.shadow-moses.island");
+                                            add("ocelot.shadow-moses.island");
+                                        }});
+                                    }});
+                                    put("characters", new LinkedHashMap<>() {{
+                                        put("children", new LinkedList<String>() {{
+                                            add("government");
+                                            add("fox-hound");
+                                        }});
+                                    }});
+                                }
+                            },
+                            new HashSet<>() {{
+                                add("gray-fox.shadow-moses.island");
+                                add("meryl.shadow-moses.island");
+                                add("otacon.shadow-moses.island");
+                                add("solid-snake.shadow-moses.island");
+                                add("cambell.shadow-moses.island");
+                                add("liquid-snake.shadow-moses.island");
+                                add("ocelot.shadow-moses.island");
+                            }}
+                    )
+            );
+        }};
+    }
+
+    @Test
+    public void testParseInventoryAndGetHostnames() {
+        List<InventoryTestCase> testCases = getTestInventories();
+        testCases.stream().forEach((testCase) -> {
+            Set<String> gotHostnames = AnsibleController.parseInventoryAndGetHostnames(testCase.getInventory());
+            assertEquals(gotHostnames, testCase.getExpectedResult());
+        });
+    }
+}

--- a/java/code/src/com/suse/manager/webui/controllers/test/AnsibleControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/AnsibleControllerTest.java
@@ -23,8 +23,6 @@ import com.suse.manager.webui.controllers.AnsibleController;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/java/code/src/com/suse/manager/webui/controllers/test/AnsibleControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/AnsibleControllerTest.java
@@ -67,17 +67,15 @@ public class AnsibleControllerTest extends BaseTestCaseWithUser {
             new InventoryTestCase(
                 "1_empty_inventory",
                 Map.of("_meta", Map.of(
-                        "hostvars", new LinkedList<String>()
-                        )
+                        "hostvars", List.of())
                     ),
-                new HashSet<>()
+                Set.of()
             ),
             new InventoryTestCase(
                 "2_inventory_with_ungrouped_hosts",
                 Map.of(
                     "_meta", Map.of(
-                        "hostvars", new LinkedList<String>()
-                    ),
+                        "hostvars", List.of()),
                     "all", Map.of(
                         "children", List.of(
                             "ungrouped"
@@ -100,7 +98,7 @@ public class AnsibleControllerTest extends BaseTestCaseWithUser {
             new InventoryTestCase(
                 "3_inventory_with_ungrouped_servers_grouped_servers_and_nested_groups",
                 Map.of(
-                    "_meta", Map.of("hostvars", new LinkedList<String>()),
+                    "_meta", Map.of("hostvars", List.of()),
                     "all", Map.of(
                         "children", List.of(
                                 "ungrouped",

--- a/java/spacewalk-java.changes.mikeletux.bsc1213132
+++ b/java/spacewalk-java.changes.mikeletux.bsc1213132
@@ -1,0 +1,1 @@
+- Fix bug about listing Ansible inventories (bsc#1213132)


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/22566

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: it is a bugfix for something it should've worked earlier.

- [x] **DONE**

## Test coverage
- Unit tests were added: `AnsibleControllerTest.testParseInventoryAndGetHostnames`

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/22065

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
