### PR TITLE
Make `Loggerhead` log include error logs from third-party code

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/login/templates/login.jade
+++ b/java/code/src/com/suse/manager/webui/controllers/login/templates/login.jade
@@ -15,6 +15,9 @@ html(lang=window.preferredLocale.replace("_", "-"))
         // import styles
         link(rel='stylesheet', href='/css/#{webTheme}.css?cb=#{webBuildtimestamp}', id='web-theme')
         link(rel='stylesheet', href='/css/updated-#{webTheme}.css?cb=#{webBuildtimestamp}', id='updated-web-theme', disabled="disabled")
+        script(type='text/javascript').
+            window.preferredLocale = "#{preferredLocale}";
+            window.docsLocale = "#{docsLocale}";
         script(src='/javascript/jquery.js?cb=#{webBuildtimestamp}')
         script(src='/javascript/login.js?cb=#{webBuildtimestamp}')
         script(src='/javascript/bootstrap.js?cb=#{webBuildtimestamp}')
@@ -38,8 +41,6 @@ html(lang=window.preferredLocale.replace("_", "-"))
             | #{request_method}
 
         script(type='text/javascript').
-            window.preferredLocale = "#{preferredLocale}";
-            window.docsLocale = "#{docsLocale}";
             spaImportReactPage('login/login')
                 .then(function (module) {
                     module.renderer(

--- a/java/spacewalk-java.changes.eth.network-debug
+++ b/java/spacewalk-java.changes.eth.network-debug
@@ -1,0 +1,1 @@
+- Improved logging to better capture third-party library issues

--- a/web/html/src/build/webpack.config.js
+++ b/web/html/src/build/webpack.config.js
@@ -216,6 +216,7 @@ module.exports = (env, argv) => {
           // Hardcode this so it always matches
           pathname: DEVSERVER_WEBSOCKET_PATHNAME,
         },
+        logging: "error",
       },
       // Override CORS headers for `yarn storybook`, these are not required otherwise
       headers: {

--- a/web/html/src/core/log/loggerhead.ts
+++ b/web/html/src/core/log/loggerhead.ts
@@ -21,6 +21,7 @@ export default class Loggerhead {
     if (this.console.info) {
       console.info(message);
     }
+    window.performance.mark(message);
   }
 
   debug(message: string) {
@@ -30,6 +31,7 @@ export default class Loggerhead {
     if (this.console.debug) {
       console.debug(message);
     }
+    this.mark({ level: "debug", message });
   }
 
   warn(message: string) {
@@ -39,6 +41,7 @@ export default class Loggerhead {
     if (this.console.warning) {
       console.warn(message);
     }
+    this.mark({ level: "warning", message });
   }
 
   error(message: string) {
@@ -48,6 +51,19 @@ export default class Loggerhead {
     if (this.console.error) {
       console.error(message);
     }
+    this.mark({ level: "error", message });
+  }
+
+  /**
+   * Debugging information that's stored only if the user is creating a performance recording for debugging purposes.
+   * NB! This is NOT sent to the server logs as it may contain sensitive data.
+   */
+  debugRecordingOnly(message: unknown) {
+    this.mark({ level: "trace", message });
+  }
+
+  private mark<T extends { level: string; message: unknown }>(input: T) {
+    window.performance.mark(JSON.stringify(input));
   }
 
   private postData(data: { level: Level; message: string }) {

--- a/web/html/src/core/log/loggerhead.ts
+++ b/web/html/src/core/log/loggerhead.ts
@@ -1,7 +1,7 @@
-// This file is allowed to use console, everyone else is not
-/* eslint-disable no-console */
 type Headers = Record<string, string>;
 type Level = "info" | "debug" | "warning" | "error";
+
+// TODO: Why does ESLint's no-console not work?
 
 export default class Loggerhead {
   private _log = console.log.bind(console);
@@ -35,32 +35,37 @@ export default class Loggerhead {
   ) => {
     // Use level "info" for our own logs, console.log() for the browser
     this._log(...args);
-    this.postData({ level: "info", message: args.toString() });
-    this.mark({ level: "info", message: args.toString() });
+    const message = args.toString();
+    this.postData({ level: "info", message });
+    this.mark({ level: "info", message });
   };
 
   info = (...args: Parameters<typeof console["info"]>) => {
     this._info(...args);
-    this.postData({ level: "info", message: args.toString() });
-    this.mark({ level: "info", message: args.toString() });
+    const message = args.toString();
+    this.postData({ level: "info", message });
+    this.mark({ level: "info", message });
   };
 
   debug = (...args: Parameters<typeof console["debug"]>) => {
     this._debug(...args);
-    this.postData({ level: "debug", message: args.toString() });
-    this.mark({ level: "debug", message: args.toString() });
+    const message = args.toString();
+    this.postData({ level: "debug", message });
+    this.mark({ level: "debug", message });
   };
 
   warn = (...args: Parameters<typeof console["warn"]>) => {
     this._warn(...args);
-    this.postData({ level: "warning", message: args.toString() });
-    this.mark({ level: "warning", message: args.toString() });
+    const message = args.toString();
+    this.postData({ level: "warning", message });
+    this.mark({ level: "warning", message });
   };
 
   error = (...args: Parameters<typeof console["error"]>) => {
     this._error(...args);
-    this.postData({ level: "error", message: args.toString() });
-    this.mark({ level: "error", message: args.toString() });
+    const message = args.toString();
+    this.postData({ level: "error", message });
+    this.mark({ level: "error", message });
   };
 
   private mark(input: { level: Level; message: string }) {

--- a/web/html/src/core/log/loggerhead.ts
+++ b/web/html/src/core/log/loggerhead.ts
@@ -1,3 +1,6 @@
+// This file is allowed to use console, everyone else is not
+/* eslint-disable no-console */
+
 type Headers = Record<string, string>;
 type Level = "info" | "debug" | "trace" | "warning" | "error";
 type LogParams = Parameters<typeof console["log"]>;

--- a/web/html/src/core/log/loggerhead.ts
+++ b/web/html/src/core/log/loggerhead.ts
@@ -2,8 +2,6 @@ type Headers = Record<string, string>;
 type Level = "info" | "debug" | "trace" | "warning" | "error";
 type LogParams = Parameters<typeof console["log"]>;
 
-// TODO: Why does ESLint's no-console not work?
-
 export default class Loggerhead {
   private _log = console.log.bind(console);
   private _info = console.info.bind(console);
@@ -80,7 +78,7 @@ export default class Loggerhead {
   };
 
   private mark(input: { level: Level; message: string }) {
-    // Older Node doesn't have this method, this check should be safe once we upgrade to Node 20
+    // Older Node doesn't have this method, this check should be safe to remove once we upgrade to Node 20
     if (typeof performance !== "undefined" && "mark" in performance) {
       performance.mark(JSON.stringify(input));
     }

--- a/web/html/src/utils/network.ts
+++ b/web/html/src/utils/network.ts
@@ -50,12 +50,26 @@ function request<Returns>(
     // Setting the contentType to false lets the browser define the header with the boundary.
     contentType: contentType === "multipart/form-data" ? false : `${contentType}; charset=UTF-8`,
     processData: processData,
-    beforeSend: (xhr) => {
+    beforeSend: (jqXHR) => {
+      Loggerhead.debugRecordingOnly({
+        type: "network",
+        event: "beforeSend",
+        url,
+        data,
+      });
       if (headers !== undefined) {
         Object.keys(headers).forEach((header) => {
-          xhr.setRequestHeader(header, headers[header]);
+          jqXHR.setRequestHeader(header, headers[header]);
         });
       }
+    },
+    complete: (jqXHR) => {
+      Loggerhead.debugRecordingOnly({
+        type: "network",
+        event: "complete",
+        url,
+        responseText: jqXHR.responseText,
+      });
     },
   });
   return Utils.cancelable(Promise.resolve(a), () => a.abort());

--- a/web/html/src/utils/network.ts
+++ b/web/html/src/utils/network.ts
@@ -50,26 +50,12 @@ function request<Returns>(
     // Setting the contentType to false lets the browser define the header with the boundary.
     contentType: contentType === "multipart/form-data" ? false : `${contentType}; charset=UTF-8`,
     processData: processData,
-    beforeSend: (jqXHR) => {
-      Loggerhead.debugRecordingOnly({
-        type: "network",
-        event: "beforeSend",
-        url,
-        data,
-      });
+    beforeSend: (xhr) => {
       if (headers !== undefined) {
         Object.keys(headers).forEach((header) => {
-          jqXHR.setRequestHeader(header, headers[header]);
+          xhr.setRequestHeader(header, headers[header]);
         });
       }
-    },
-    complete: (jqXHR) => {
-      Loggerhead.debugRecordingOnly({
-        type: "network",
-        event: "complete",
-        url,
-        responseText: jqXHR.responseText,
-      });
     },
   });
   return Utils.cancelable(Promise.resolve(a), () => a.abort());

--- a/web/spacewalk-web.changes.eth.network-debug
+++ b/web/spacewalk-web.changes.eth.network-debug
@@ -1,0 +1,1 @@
+- Improved logging to better capture third-party library issues


### PR DESCRIPTION
## What does this PR change?

Currently our global logger only logs errors and warns from our own code which means we crucially miss errors thrown from React etc. This PR binds our logger to the global console so we should see more information from debug logs.  

Additionally I've added [performance marks](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark) so it's easier to line up events if the client makes a performance recording for us. Otherwise you need to jump between our own logs and the recording to get the full picture.  

(As a side effect, thanks to these changes I found a small bug in our login page where the locale was set too late so it was undefined for some scripts.)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/22609

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
