### PR TITLE
Handle PKCS8 format for server keys in setup script

### DIFF
--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes.cbosdo.pkcs8-key
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes.cbosdo.pkcs8-key
@@ -1,0 +1,1 @@
+- Handle server keys in PKCS8 format in mgr-ssl-cert-setup


### PR DESCRIPTION
## What does this PR change?

Newer versions of openssl generate the keys in PKCS8 format with the `BEGIN PRIVATE KEY` instead of `BEGIN (RSA|EC) PRIVATE KEY`.

The mgr-ssl-cert-setup tool now fails only if it cannot read the key or if the key is encrypted.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: manual tests

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
