### PR TITLE
QE: Disable Advanced Search tests for Uyuni

### DIFF
--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -8,7 +8,8 @@
 
 # IDEMPOTENT
 
-- features/secondary/srv_advanced_search.feature
+# Workaround for bug in search server, as mentioned here - https://github.com/SUSE/spacewalk/issues/22594
+# - features/secondary/srv_advanced_search.feature
 - features/secondary/srv_check_sync_source_packages.feature
 - features/secondary/srv_change_password.feature
 - features/secondary/srv_clone_channel_npn.feature


### PR DESCRIPTION
## What does this PR change?

As mentioned in https://github.com/SUSE/spacewalk/issues/22594, the advanced search tests will be disabled in Uyuni until the search server can be reworked.

## Links

Fixes https://github.com/SUSE/spacewalk/issues/22594

No ports necessary

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
