### PR TITLE
Fix podman sql scripts selection

### DIFF
--- a/testsuite/podman_runner/run_db_migrations.sh
+++ b/testsuite/podman_runner/run_db_migrations.sh
@@ -22,12 +22,26 @@ else
     exit 1
 fi
 
-# Including all sub-folders of the upgrade dir that comes after the one called "${schema_name}-${schema_version}-to-..."
-# This should make sure we apply all the scripts meant to be executed on top of the current schema version.
-# It probably won't happen often that we have multiple pending directories, but it could happen in case of re-tagging
-for i in $(find ${upgrade_dir} -name "$1-*-to-*" | sed -n "/$1-$2-to-.*$/,$ p"); do
-    echo $(basename $i)
-    for j in $(find $i -name *.sql); do
-        echo -e "\t$(basename $j)"; spacewalk-sql ${additional_params} $j | sed 's/^/\t\t/';
-    done;
+# Start with the given schema name and version
+schema="$1"
+version="$2"
+
+# Get the upgrade dir for the current schema and version
+current_dir="$(find ${upgrade_dir} -name "$schema-$version-to-*")"
+until [ -z "${current_dir}" ]
+do
+    basename "${current_dir}"
+
+    # Apply all the sql scripts from this directory
+    while IFS= read -r -d '' file
+    do
+        echo -e "\t$(basename "${file}")"; spacewalk-sql ${additional_params} "${file}" | sed 's/^/\t\t/';
+    done < <(find "${current_dir}" -name '*.sql' -print0)
+
+    # Set the next schema and version from the directory name
+    schema=$(basename "${current_dir}" | sed -e 's/.*-to-\([a-z-]\+\)-.*$/\1/')
+    version=$(basename "${current_dir}" | sed -e 's/.*-\([0-9.]\+\)$/\1/')
+
+    # Check if another upgrade directory exists
+    current_dir=$(find ${upgrade_dir} -name "$schema-$version-to-*")
 done


### PR DESCRIPTION
## What does this PR change?

This PR changes the logic of how the sql scripts are applied in the podman testsuite runner. Instead of listing just listing the directories with a `find` and relying on the list to be correctly sorted (which was not the case and cause the linked issue), it now starts from the directory `<schema name>-<current version>-to-*` and moves to the next one specified after the `-to-` part, looping until there are no further directories to pick up.

This should ensure the correct application of all the required sql scripts starting from the current schema version installed inside the podman container.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: only changes to the test infrastracture

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/22617

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
