### PR TITLE
Fix SLES 15 for SAP entries in mgr-create-bootstrap-repo (bsc#1215120)

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -942,6 +942,14 @@ DATA = {
         'PDID' : [1772, 1908], 'BETAPDID' : [], 'PKGLIST' :  ONLYSLE15 + PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/sle/15/1/bootstrap/'
     },
+    'SLES4SAP-15-SP1-x86_64' : {
+        'PDID' : [1772, 1712, 1766], 'BETAPDID' : [1928], 'PKGLIST' :  ONLYSLE15 + PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/sle/15/1/bootstrap/'
+    },
+    'SLES4SAP-15-SP1-ppc64le' : {
+        'PDID' : [1770, 1710, 1765], 'BETAPDID' : [1926], 'PKGLIST' :  ONLYSLE15 + PKGLIST15_SALT + PKGLIST15_PPC,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/sle/15/1/bootstrap/'
+    },
     'SLE-15-SP2-aarch64' : {
         'PDID' : [1943, 1709, 2372], 'BETAPDID' : [1925], 'PKGLIST' :  ONLYSLE15 + PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/sle/15/2/bootstrap/'
@@ -962,6 +970,14 @@ DATA = {
         'PDID' : [1946, 2015], 'BETAPDID' : [], 'PKGLIST' :  ONLYSLE15 + PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/sle/15/2/bootstrap/'
     },
+    'SLES4SAP-15-SP2-x86_64' : {
+        'PDID' : [1946, 1712, 1941], 'BETAPDID' : [1928], 'PKGLIST' :  ONLYSLE15 + PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/sle/15/2/bootstrap/'
+    },
+    'SLES4SAP-15-SP2-ppc64le' : {
+        'PDID' : [1944, 1710, 1940], 'BETAPDID' : [1926], 'PKGLIST' :  ONLYSLE15 + PKGLIST15_SALT + PKGLIST15_PPC,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/sle/15/2/bootstrap/'
+    },
     'SLE-15-SP3-aarch64' : {
         'PDID' : [2142, 1709, 2567], 'BETAPDID' : [1925], 'PKGLIST' :  ONLYSLE15 + PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/sle/15/3/bootstrap/'
@@ -980,6 +996,14 @@ DATA = {
     },
     'SUMA-42-PROXY-x86_64' : {
         'PDID' : [2145, 2225, 2223], 'BETAPDID' : [], 'PKGLIST' :  ONLYSLE15 + PKGLIST15_SALT_OPT_BUNDLE + PKGLIST15_X86_ARM,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/sle/15/3/bootstrap/'
+    },
+    'SLES4SAP-15-SP3-x86_64' : {
+        'PDID' : [2145, 1712, 2136], 'BETAPDID' : [1928], 'PKGLIST' :  ONLYSLE15 + PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/sle/15/3/bootstrap/'
+    },
+    'SLES4SAP-15-SP3-ppc64le' : {
+        'PDID' : [2143, 1710, 2135], 'BETAPDID' : [1926], 'PKGLIST' :  ONLYSLE15 + PKGLIST15_SALT + PKGLIST15_PPC,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/sle/15/3/bootstrap/'
     },
     'SLE-15-SP4-aarch64' : {

--- a/susemanager/susemanager.changes.rjpmestre.bsc1215120
+++ b/susemanager/susemanager.changes.rjpmestre.bsc1215120
@@ -1,0 +1,1 @@
+- fix SLES 15 for SAP not being listed in mgr-create-bootstrap-repo (bsc#1215120)


### PR DESCRIPTION
## What does this PR change?

adds the bootstrap data so SLES 15 for SAP SP1/2/3 entries are listed in mgr-create-bootstrap-repo (bsc#1215120)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/pull/22604

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
