### PR TITLE
alternative to copy system package updates to reportdb

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/SystemReport_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/SystemReport_queries.xml
@@ -323,33 +323,38 @@
     </query>
 </mode>
 
-<mode name="SystemPackageUpdate" class="">
-    <query params="offset, limit">
-          WITH latest AS (
-            SELECT rhnserverneededcache.server_id
-                      , rhnPackage.name_id
-                      , MAX(rhnPackageEvr.evr) AS evr
-              FROM rhnserverneededcache
-                      INNER JOIN rhnPackage ON rhnserverneededcache.package_id = rhnPackage.id
-                      INNER JOIN rhnPackageEvr on rhnPackage.evr_id = rhnPackageEvr.id
-              GROUP BY rhnserverneededcache.server_id
-                      , rhnPackage.name_id
-          )
-          SELECT DISTINCT rhnserverneededcache.server_id AS system_id
-                    , rhnserverneededcache.package_id
-                    , rhnpackagename.name
-                    , rhnpackageevr.epoch
-                    , rhnpackageevr.version
-                    , rhnpackageevr.release
-                    , rhnpackagearch.label AS arch
-                    , rhnpackageevr.type
-                    , rhnpackageevr.evr = latest.evr AS is_latest
-            FROM rhnserverneededcache
-                    INNER JOIN rhnpackage ON rhnserverneededcache.package_id = rhnpackage.id
-                    INNER JOIN rhnpackageevr ON rhnpackage.evr_id = rhnpackageevr.id
-                    INNER JOIN rhnpackagename ON rhnpackage.name_id = rhnpackagename.id
-                    INNER JOIN rhnpackagearch ON rhnpackage.package_arch_id = rhnpackagearch.id
-                    INNER JOIN latest ON (latest.server_id = rhnserverneededcache.server_id AND latest.name_id = rhnpackage.name_id)
+<mode name="SystemPackageUpdateIDs" class="">
+    <query>
+        SELECT DISTINCT server_id AS id FROM rhnserverneededcache
+    </query>
+</mode>
+
+<mode name="SystemPackageUpdate_byId" class="">
+    <query params="id, offset, limit">
+        WITH latest AS (
+          SELECT rhnserverneededcache.server_id, rhnPackage.name_id, MAX(rhnPackageEvr.evr) AS evr
+          FROM rhnserverneededcache
+          INNER JOIN rhnPackage ON rhnserverneededcache.package_id = rhnPackage.id
+          INNER JOIN rhnPackageEvr on rhnPackage.evr_id = rhnPackageEvr.id
+          WHERE rhnserverneededcache.server_id = :id
+          GROUP BY rhnserverneededcache.server_id, rhnPackage.name_id
+        )
+        SELECT DISTINCT rhnserverneededcache.server_id AS system_id
+                      , rhnserverneededcache.package_id
+                      , rhnpackagename.name
+                      , rhnpackageevr.epoch
+                      , rhnpackageevr.version
+                      , rhnpackageevr.release
+                      , rhnpackagearch.label AS arch
+                      , rhnpackageevr.type
+                      , rhnpackageevr.evr = latest.evr AS is_latest
+        FROM rhnserverneededcache
+        INNER JOIN rhnpackage ON rhnserverneededcache.package_id = rhnpackage.id
+        INNER JOIN rhnpackageevr ON rhnpackage.evr_id = rhnpackageevr.id
+        INNER JOIN rhnpackagename ON rhnpackage.name_id = rhnpackagename.id
+        INNER JOIN rhnpackagearch ON rhnpackage.package_arch_id = rhnpackagearch.id
+        INNER JOIN latest ON (latest.server_id = rhnserverneededcache.server_id AND latest.name_id = rhnpackage.name_id)
+        WHERE rhnserverneededcache.server_id = :id
         ORDER BY system_id, name, package_id OFFSET :offset LIMIT :limit
     </query>
 </mode>

--- a/java/spacewalk-java.changes.mc.Manager-4.3-alt-reportdb-copy-sys_pkg_updates
+++ b/java/spacewalk-java.changes.mc.Manager-4.3-alt-reportdb-copy-sys_pkg_updates
@@ -1,0 +1,1 @@
+- implement different way to copy data for SystemPackageUpdate report database table (bsc#1211912)


### PR DESCRIPTION
## What does this PR change?

Copying available package updates for systems into report db may take for some customers with extreme amount of data "endless" (multiple days).
This is an alternative approach to copy the data system by system.

Interestingly this is also faster when normal amount of data

```
# Refreshing table SystemPackageUpdate took 3.722286264 seconds. (OLD)
# Refreshing table SystemPackageUpdate took 1.911311917 seconds. (NEW)
``` 

The query explain in our case went down as well (factor 10)

 Execution Time: 314.961 ms (OLD)
to
 Execution Time: 29.757 ms (NEW)

## Links

Port of https://github.com/SUSE/spacewalk/pull/22611

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
