### PR TITLE
add index on rhnserverneededcache server/errata id to speed up certain queries (bsc#1211912)

### DIFF
--- a/schema/spacewalk/common/tables/rhnServerNeededCache.sql
+++ b/schema/spacewalk/common/tables/rhnServerNeededCache.sql
@@ -53,6 +53,9 @@ CREATE INDEX rhn_snc_cid_idx
     
     ;
 
+CREATE INDEX rhn_snc_seid_idx
+    ON rhnServerNeededCache (server_id, errata_id);
+
 CREATE INDEX rhn_snc_speid_idx
     ON rhnServerNeededCache (server_id, package_id, errata_id)
     

--- a/schema/spacewalk/susemanager-schema.changes.kwalter.serverneededcache-index
+++ b/schema/spacewalk/susemanager-schema.changes.kwalter.serverneededcache-index
@@ -1,0 +1,1 @@
+- add index on server needed cache to improve performance for some queries (bsc#1211912)

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.6-to-susemanager-schema-4.4.7/002-add-serverneededcache-index.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.6-to-susemanager-schema-4.4.7/002-add-serverneededcache-index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS rhn_snc_seid_idx
+    ON rhnServerNeededCache (server_id, errata_id);


### PR DESCRIPTION
## What does this PR change?

adds an additional index to rhnserverneededcache to speed up certain types of queries.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links


Tracks https://github.com/SUSE/spacewalk/issues/21708

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
