### PR TITLE
Respect user email preferences when sending 'user creation' emails (bsc#1214553)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/events/NewUserAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/NewUserAction.java
@@ -28,7 +28,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -94,14 +93,11 @@ public class NewUserAction extends BaseMailAction implements MessageAction {
 
 
     private String[] getEmails(NewUserEvent evt) {
-        List adminList = evt.getAdmins();
-        String[] adminEmails = new String[adminList.size()];
-        int index = 0;
-        for (Object oIn : adminList) {
-            adminEmails[index] = ((User) oIn).getEmail();
-            index++;
-        }
-        return adminEmails;
+        return evt.getAdmins().stream()
+                .filter(u -> !u.isDisabled())
+                .filter(u -> u.getEmailNotify() == 1)
+                .map(User::getEmail)
+                .toArray(String[]::new);
     }
 
 

--- a/java/code/src/com/redhat/rhn/frontend/events/NewUserEvent.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/NewUserEvent.java
@@ -33,7 +33,7 @@ public class NewUserEvent extends BaseEvent implements EventMessage  {
     private User accountCreator;
     private String link;
     private String domain;
-    private List adminList;
+    private List<User> adminList;
 
     /**
      * format this message as a string
@@ -142,13 +142,13 @@ public class NewUserEvent extends BaseEvent implements EventMessage  {
     /**
      * @return Returns the link.
      */
-    public List getAdmins() {
+    public List<User> getAdmins() {
         return adminList;
     }
     /**
      * @param admins Admins to set.
      */
-    public void setAdmins(List admins) {
+    public void setAdmins(List<User> admins) {
         this.adminList = admins;
     }
 

--- a/java/code/src/com/redhat/rhn/manager/user/CreateUserCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/user/CreateUserCommand.java
@@ -102,7 +102,7 @@ public class CreateUserCommand {
      * might be encrypted, thus useless for this method
      */
     public void publishNewUserEvent(User accountCreator,
-                                    List admins,
+                                    List<User> admins,
                                     String domain,
                                     String password) {
         NewUserEvent userevt = new NewUserEvent();

--- a/java/spacewalk-java.changes.cbbayburt.bsc1214553
+++ b/java/spacewalk-java.changes.cbbayburt.bsc1214553
@@ -1,0 +1,1 @@
+- Respect user email preferences when sending 'user creation' emails (bsc#1214553)


### PR DESCRIPTION
"Create user" action uses a different, older logic than all the other events to send emails and it doesn't respect users' email preferences. This patch removes users that have email notifications off from the recipient list when sending "user creation" emails.

Port of: https://github.com/SUSE/spacewalk/pull/22550

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
