### PR TITLE
Fix datetimepicker erroneously updating the date field (bsc#1210253, bsc#1215820)

### DIFF
--- a/web/html/src/branding/css/susemanager/components/buttons.less
+++ b/web/html/src/branding/css/susemanager/components/buttons.less
@@ -196,6 +196,7 @@ button.is-plain {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  background: none;
   border: none;
   border-radius: 0;
   box-sizing: border-box;

--- a/web/html/src/branding/css/uyuni/buttons.less
+++ b/web/html/src/branding/css/uyuni/buttons.less
@@ -2,6 +2,7 @@ button.is-plain {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  background: none;
   border: none;
   border-radius: 0;
   box-sizing: border-box;

--- a/web/html/src/components/datetime/DateTimePicker.test.tsx
+++ b/web/html/src/components/datetime/DateTimePicker.test.tsx
@@ -1,0 +1,92 @@
+import * as React from "react";
+import { useState } from "react";
+
+import { localizedMoment } from "utils";
+import { render, screen, type } from "utils/test-utils";
+
+import { DateTimePicker } from "./DateTimePicker";
+
+describe("DateTimePicker", () => {
+  const getInputs = () => {
+    const datePicker = screen.getByTestId<HTMLInputElement>("date-picker");
+    const timePicker = screen.getByTestId<HTMLInputElement>("time-picker");
+    return { datePicker, timePicker };
+  };
+
+  test("prop value is rendered in the user's timezone", () => {
+    const validISOString = "2020-02-01T04:00:00.000Z";
+    const Setup = () => {
+      const [value, setValue] = useState(localizedMoment(validISOString));
+      return <DateTimePicker value={value} onChange={setValue} />;
+    };
+    render(<Setup />);
+
+    const { datePicker, timePicker } = getInputs();
+    // These values need to be offset by the user's timezone
+    expect(datePicker.value).toEqual("2020-01-31");
+    expect(timePicker.value).toEqual("20:00");
+  });
+
+  test("picking a date and time uses the user's timezone", (done) => {
+    const validISOString = "2020-02-01T04:00:00.000Z";
+    let changeEventCount = 0;
+
+    const Setup = () => {
+      const [value, setValue] = useState(localizedMoment(validISOString));
+      return (
+        <DateTimePicker
+          value={value}
+          onChange={(newValue) => {
+            changeEventCount += 1;
+            setValue(newValue);
+
+            if (changeEventCount === 2) {
+              // Note that this value should be in a different day due to the timezone offset
+              expect(newValue.toISOString()).toEqual("2020-01-17T07:30:00.000Z");
+              done();
+            }
+          }}
+        />
+      );
+    };
+    render(<Setup />);
+
+    const { datePicker, timePicker } = getInputs();
+    datePicker.click();
+    screen.getByText("16").click();
+    timePicker.click();
+    screen.getByText("23:30").click();
+
+    expect(datePicker.value).toEqual("2020-01-16");
+    expect(timePicker.value).toEqual("23:30");
+  });
+
+  test("clearing the time input doesn't change the date (bsc#1210253)", (done) => {
+    const validISOString = "2020-01-30T15:00:00.000Z";
+    let changeEventCount = 0;
+
+    const Setup = () => {
+      const [value, setValue] = useState(localizedMoment(validISOString));
+      return (
+        <DateTimePicker
+          value={value}
+          onChange={(newValue) => {
+            changeEventCount += 1;
+            setValue(newValue);
+
+            if (changeEventCount === 2) {
+              expect(newValue.toUserDateTimeString()).toEqual("2020-01-16 00:00");
+              done();
+            }
+          }}
+        />
+      );
+    };
+    render(<Setup />);
+
+    const { datePicker, timePicker } = getInputs();
+    datePicker.click();
+    screen.getByText("16").click();
+    type(timePicker, "0", false);
+  });
+});

--- a/web/html/src/utils/test-utils/mock.tsx
+++ b/web/html/src/utils/test-utils/mock.tsx
@@ -1,13 +1,3 @@
-// Mock the datetime picker to avoid it causing issues due to missing jQuery/Bootstrap parts
-jest.mock("components/datetime/DateTimePicker", () => {
-  return {
-    __esModule: true,
-    DateTimePicker: () => {
-      return <div>DateTimePicker mockup</div>;
-    },
-  };
-});
-
 // Mock the ACE Editor to avoid it causing issues due to the missing proper library import
 jest.mock("components/ace-editor", () => {
   return {

--- a/web/spacewalk-web.changes.eth.Manager-4.3-MU-4.3.8-bsc-1215820
+++ b/web/spacewalk-web.changes.eth.Manager-4.3-MU-4.3.8-bsc-1215820
@@ -1,0 +1,1 @@
+- Fix datetimepicker erroneously updating the date field (bsc#1210253, bsc#1215820)


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/22630

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
