### PR TITLE
Fix typo in repo name in server-migrator script

### DIFF
--- a/susemanager/bin/server-migrator.sh
+++ b/susemanager/bin/server-migrator.sh
@@ -37,7 +37,7 @@ zypper ar -n "Main Update Repository" http://download.opensuse.org/update/leap/$
 zypper ar -n "Non-OSS Repository" http://download.opensuse.org/distribution/leap/${NEW_VERSION_ID}/repo/non-oss repo-non-oss
 zypper ar -n "Update Repository (Non-Oss)" http://download.opensuse.org/update/leap/${NEW_VERSION_ID}/non-oss/ repo-update-non-oss
 zypper ar -n "Uyuni Server Stable" https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/ uyuni-server-stable
-zypper ar -n "Update repository wiht updates from SUSE Linux Enterprise" http://download.opensuse.org/update/leap/${NEW_VERSION_ID}/sle repo-sle-update
+zypper ar -n "Update repository with updates from SUSE Linux Enterprise" http://download.opensuse.org/update/leap/${NEW_VERSION_ID}/sle repo-sle-update
 zypper ar -n "Update repository of openSUSE Backports" http://download.opensuse.org/update/leap/${NEW_VERSION_ID}/backports/ repo-backports-update
 zypper ref
 zypper -n dup --allow-vendor-change


### PR DESCRIPTION
## What does this PR change?

There is a typo in the repo name when [migrating to a new OS version](https://www.uyuni-project.org/uyuni-docs/en/uyuni/installation-and-upgrade/db-migration-xy.html):
`Update repository wiht updates from SUSE Linux Enterprise`

This was annoying me a bit, so here is the fix for that!

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: this only changes the displayname of one of the OS repos after a major upgrade

- [x] **DONE**

## Test coverage
- No tests: didn't see that checked in any of the tests

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

I don't think this is worth a changelog entry.

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
