### PR TITLE
Disallow Google GSON 2.10 or higher due to removed methods

### DIFF
--- a/java/spacewalk-java.changes.sbluhm.googlegson
+++ b/java/spacewalk-java.changes.sbluhm.googlegson
@@ -1,0 +1,1 @@
+- Disallow Google GSON 2.10 or higher due to removed methods.

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -96,7 +96,7 @@ BuildRequires:  dom4j
 BuildRequires:  dwr >= 3
 BuildRequires:  glassfish-jaxb-runtime
 BuildRequires:  glassfish-jaxb-txw2
-BuildRequires:  google-gson >= 2.2.4
+BuildRequires:  google-gson < 2.10.0
 BuildRequires:  hibernate-commons-annotations
 BuildRequires:  hibernate-types
 BuildRequires:  httpcomponents-asyncclient
@@ -186,7 +186,7 @@ Requires:       glassfish-activation-api
 Requires:       glassfish-jaxb-api
 Requires:       glassfish-jaxb-runtime
 Requires:       glassfish-jaxb-txw2
-Requires:       google-gson >= 2.2.4
+Requires:       google-gson < 2.10.0
 Requires:       hibernate-commons-annotations
 Requires:       hibernate-types
 Requires:       httpcomponents-client

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -96,7 +96,7 @@ BuildRequires:  dom4j
 BuildRequires:  dwr >= 3
 BuildRequires:  glassfish-jaxb-runtime
 BuildRequires:  glassfish-jaxb-txw2
-BuildRequires:  google-gson < 2.10.0
+BuildRequires:  (google-gson >= 2.2.4 with google-gson < 2.10.0)
 BuildRequires:  hibernate-commons-annotations
 BuildRequires:  hibernate-types
 BuildRequires:  httpcomponents-asyncclient

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -186,7 +186,7 @@ Requires:       glassfish-activation-api
 Requires:       glassfish-jaxb-api
 Requires:       glassfish-jaxb-runtime
 Requires:       glassfish-jaxb-txw2
-Requires:       google-gson < 2.10.0
+Requires:       (google-gson >= 2.2.4 with google-gson < 2.10.0)
 Requires:       hibernate-commons-annotations
 Requires:       hibernate-types
 Requires:       httpcomponents-client


### PR DESCRIPTION
## What does this PR change?

1. Disallow Google GSON 2.10 or higher due to removed methods.
Salt communication fails otherwise with a class not found exception when accessing the Salt keys page.
(GSON 2.10 is available in the Enteprise Linux 9 repos)

2. Remove minimum GSON requirement. What would install a lower version?

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

Package build tested on Copr for  epel-9-x86_64 


- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
