### PR TITLE
Update package source to meet tito requirement

### DIFF
--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes.stefan.titofix
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes.stefan.titofix
@@ -1,0 +1,1 @@
+- Tito requires to list the package source as %{name}-%{version}.tar.gz

--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.spec
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.spec
@@ -78,7 +78,7 @@ Group:          admin
 Group:          System Environment/Base
 %endif
 Version:        4.4.5
-Source0:        https://github.com/uyuni-project/uyuni/archive/%{name}-%{version}-1.tar.gz
+Source0:        %{name}-%{version}.tar.gz
 Source1:        https://raw.githubusercontent.com/uyuni-project/uyuni/%{name}-%{version}-1/client/rhel/%{name}/%{name}-rpmlintrc
 URL:            https://github.com/uyuni-project/uyuni
 Release:        1

--- a/java/spacewalk-java.changes.stefan.titofix
+++ b/java/spacewalk-java.changes.stefan.titofix
@@ -1,0 +1,1 @@
+- Tito requires to list the source as %{name}-%{version}.tar.gz

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -62,7 +62,7 @@ Group:          Applications/Internet
 Version:        4.4.20
 Release:        1
 URL:            https://github.com/uyuni-project/uyuni
-Source0:        https://github.com/uyuni-project/uyuni/archive/%{name}-%{version}-1.tar.gz
+Source0:        %{name}-%{version}.tar.gz
 Source1:        https://raw.githubusercontent.com/uyuni-project/uyuni/%{name}-%{version}-1/java/%{name}-rpmlintrc
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch

--- a/projects/ssl-cert-check/spacewalk-ssl-cert-check.changes.stefan.titofix
+++ b/projects/ssl-cert-check/spacewalk-ssl-cert-check.changes.stefan.titofix
@@ -1,0 +1,1 @@
+- Tito requires to list the package source as %{name}-%{version}.tar.gz

--- a/projects/ssl-cert-check/spacewalk-ssl-cert-check.spec
+++ b/projects/ssl-cert-check/spacewalk-ssl-cert-check.spec
@@ -28,7 +28,7 @@ Summary:        Check ssl certs for impending expiration
 License:        GPL-2.0-only
 Group:          Applications/System
 URL:            https://github.com/uyuni-project/uyuni
-Source0:        https://github.com/uyuni-project/uyuni/archive/%{name}-%{version}-1.tar.gz
+Source0:        %{name}-%{version}.tar.gz
 Source1:        https://raw.githubusercontent.com/uyuni-project/uyuni/%{name}-%{version}-1/projects/ssl-cert-check/%{name}-rpmlintrc
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch

--- a/python/spacewalk/spacewalk-backend.changes.stefan.titofix
+++ b/python/spacewalk/spacewalk-backend.changes.stefan.titofix
@@ -1,0 +1,1 @@
+- Tito requires to list the package source as %{name}-%{version}.tar.gz

--- a/python/spacewalk/spacewalk-backend.spec
+++ b/python/spacewalk/spacewalk-backend.spec
@@ -53,7 +53,7 @@ Group:          System/Management
 Version:        4.4.11
 Release:        1
 URL:            https://github.com/uyuni-project/uyuni
-Source0:        https://github.com/uyuni-project/uyuni/archive/%{name}-%{version}-1.tar.gz
+Source0:        %{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 %if !0%{?suse_version} || 0%{?suse_version} >= 1120
 BuildArch:      noarch

--- a/schema/reportdb/uyuni-reportdb-schema.changes.stefan.titofix
+++ b/schema/reportdb/uyuni-reportdb-schema.changes.stefan.titofix
@@ -1,0 +1,1 @@
+- Tito requires to list the package source as %{name}-%{version}.tar.gz

--- a/schema/reportdb/uyuni-reportdb-schema.spec
+++ b/schema/reportdb/uyuni-reportdb-schema.spec
@@ -26,7 +26,7 @@ Group:          Applications/Internet
 
 Version:        4.4.4
 Release:        1
-Source0:        https://github.com/uyuni-project/uyuni/archive/%{name}-%{version}-1.tar.gz
+Source0:        %{name}-%{version}.tar.gz
 Source1:        https://raw.githubusercontent.com/uyuni-project/uyuni/%{name}-%{version}-1/schema/reportdb/%{name}-rpmlintrc
 
 URL:            https://github.com/uyuni-project/uyuni

--- a/schema/spacewalk/susemanager-schema.changes.stefan.titofix
+++ b/schema/spacewalk/susemanager-schema.changes.stefan.titofix
@@ -1,0 +1,1 @@
+- Tito requires to list the package source as %{name}-%{version}.tar.gz

--- a/schema/spacewalk/susemanager-schema.spec
+++ b/schema/spacewalk/susemanager-schema.spec
@@ -26,7 +26,7 @@ Group:          Applications/Internet
 
 Version:        4.4.7
 Release:        1
-Source0:        https://github.com/uyuni-project/uyuni/archive/%{name}-%{version}-1.tar.gz
+Source0:        %{name}-%{version}.tar.gz
 Source1:        https://raw.githubusercontent.com/uyuni-project/uyuni/%{name}-%{version}-1/schema/spacewalk/%{name}-rpmlintrc
 
 URL:            https://github.com/uyuni-project/uyuni


### PR DESCRIPTION
## What does this PR change?

Tito requires to list the package source as %{name}-%{version}.tar.gz
If an existing source is set, tito downloads the package instead of using the git structure. This stops the package from building on Fedora Copr (the download has a different folder structure).

(see Tito man page at https://github.com/rpm-software-management/tito/blob/9fd0c5a2c7c801f3186a0d7c836ed7278fdcff0c/tito.8.asciidoc?plain=1#L55)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

Build manually tested on copr  epel-9-x86_64.

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
