### PR TITLE
Make navigation steps use 24-hour time, not 12-hour time

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -249,7 +249,7 @@ end
 
 When(/^I enter (\d+) minutes from now as "([^"]*)"$/) do |minutes_to_add, field|
   future_time = Time.now + 60 * minutes_to_add.to_i
-  future_time.strftime('%l:%M %P').to_s.strip
+  future_time.strftime('%H:%M').to_s.strip
   fill_in(field, with: future_time, fill_options: { clear: :backspace })
 end
 


### PR DESCRIPTION
## What does this PR change?

Currently the Cucumber step for selecting times uses 12-hour time which can lead to odd issues. Since our picker expects 24-hour time anyway, use that format instead.

```perl
use POSIX qw(strftime);

print strftime("%l:%M %P\n", localtime(5143213912312740)); # 9:59 pm
print strftime("%H:%M\n", localtime(5143213912312740)); # 21:59
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
