### PR TITLE
We are constrained to sync SLES on Uyuni

### DIFF
--- a/testsuite/features/core/srv_create_activationkey.feature
+++ b/testsuite/features/core/srv_create_activationkey.feature
@@ -105,14 +105,23 @@ Feature: Create activation keys
     And I click on "Create Activation Key"
     Then I should see a "Activation key Proxy Key x86_64 has been created" text
 
+@buildhost
   Scenario: Create an activation key for the build host
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
     And I wait for child channels to appear
     And I enter "Build host Key x86_64" as "description"
     And I enter "BUILD-HOST-KEY-x86_64" as "key"
-    And I enter "20" as "usageLimit"
     And I check "Container Build Host"
     And I check "OS Image Build Host"
     And I click on "Create Activation Key"
     Then I should see a "Activation key Build host Key x86_64 has been created" text
+
+  Scenario: Create an activation key for the terminal
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "Create Key"
+    And I wait for child channels to appear
+    And I enter "Terminal Key x86_64" as "description"
+    And I enter "TERMINAL-KEY-x86_64" as "key"
+    And I click on "Create Activation Key"
+    Then I should see a "Activation key Terminal Key x86_64 has been created" text

--- a/testsuite/features/core/srv_create_activationkey.feature
+++ b/testsuite/features/core/srv_create_activationkey.feature
@@ -116,8 +116,3 @@ Feature: Create activation keys
     And I check "OS Image Build Host"
     And I click on "Create Activation Key"
     Then I should see a "Activation key Build host Key x86_64 has been created" text
-    And I should see a "Details" link
-    And I should see a "Packages" link
-    And I should see a "Configuration" link in the content area
-    And I should see a "Groups" link
-    And I should see a "Activated Systems" link

--- a/testsuite/features/init_clients/allcli_update_activationkeys.feature
+++ b/testsuite/features/init_clients/allcli_update_activationkeys.feature
@@ -191,7 +191,6 @@ Feature: Update activation keys
 
 @skip_if_github_validation
 @scc_credentials
-@susemanager
   Scenario: Update build host key with synced base product
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Build host Key x86_64" in the content area
@@ -209,6 +208,21 @@ Feature: Update activation keys
     And I wait until "SLE-Module-Desktop-Applications15-SP4-Updates for x86_64" has been checked
     And I check "SLE-Module-Containers15-SP4-Pool for x86_64"
     And I wait until "SLE-Module-Containers15-SP4-Updates for x86_64" has been checked
-    And I check "Fake-RPM-SUSE-Channel"
     And I click on "Update Activation Key"
     Then I should see a "Activation key Build host Key x86_64 has been modified" text
+
+@skip_if_github_validation
+@scc_credentials
+  Scenario: Update terminal key with synced base product
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "Terminal Key x86_64" in the content area
+    And I wait for child channels to appear
+    And I select "SLE-Product-SLES15-SP4-Pool for x86_64" from "selectedBaseChannel"
+    And I wait for child channels to appear
+    And I include the recommended child channels
+    And I wait until "SLE-Module-Basesystem15-SP4-Pool for x86_64" has been checked
+    And I wait until "SLE-Module-Basesystem15-SP4-Updates for x86_64" has been checked
+    And I wait until "SLE-Module-Server-Applications15-SP4-Pool for x86_64" has been checked
+    And I wait until "SLE-Module-Server-Applications15-SP4-Updates for x86_64" has been checked
+    And I click on "Update Activation Key"
+    Then I should see a "Activation key Terminal Key x86_64 has been modified" text

--- a/testsuite/features/init_clients/allcli_update_activationkeys.feature
+++ b/testsuite/features/init_clients/allcli_update_activationkeys.feature
@@ -65,7 +65,7 @@ Feature: Update activation keys
     And I check "SLE-Module-Containers15-SP4-Pool for x86_64"
     And I wait until "SLE-Module-Containers15-SP4-Updates for x86_64" has been checked
     And I check "Fake-RPM-SUSE-Channel"
-    When I click on "Update Activation Key"
+    And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE Test Key x86_64 has been modified" text
 
 @skip_if_github_validation
@@ -83,7 +83,7 @@ Feature: Update activation keys
     And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
     And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)"
     And I check "Fake-RPM-SUSE-Channel"
-    When I click on "Update Activation Key"
+    And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE Test Key x86_64 has been modified" text
 
 @skip_if_github_validation
@@ -168,7 +168,7 @@ Feature: Update activation keys
     And I wait until "SLE-Module-Server-Applications15-SP4-Updates for x86_64 Proxy 4.3" has been checked
     And I wait until "SLE-Module-SUSE-Manager-Proxy-4.3-Pool for x86_64" has been checked
     And I wait until "SLE-Module-SUSE-Manager-Proxy-4.3-Updates for x86_64" has been checked
-    When I click on "Update Activation Key"
+    And I click on "Update Activation Key"
     Then I should see a "Activation key Proxy Key x86_64 has been modified" text
 
 @skip_if_github_validation
@@ -186,7 +186,7 @@ Feature: Update activation keys
     And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
     And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)"
     And I check "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64)"
-    When I click on "Update Activation Key"
+    And I click on "Update Activation Key"
     Then I should see a "Activation key Proxy Key x86_64 has been modified" text
 
 @skip_if_github_validation
@@ -210,5 +210,5 @@ Feature: Update activation keys
     And I check "SLE-Module-Containers15-SP4-Pool for x86_64"
     And I wait until "SLE-Module-Containers15-SP4-Updates for x86_64" has been checked
     And I check "Fake-RPM-SUSE-Channel"
-    When I click on "Update Activation Key"
+    And I click on "Update Activation Key"
     Then I should see a "Activation key Build host Key x86_64 has been modified" text

--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -62,6 +62,32 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I see "SUSE Linux Enterprise Server 15 SP4 x86_64" product has been added
     Then the SLE15 SP4 product should be added
 
+@scc_credentials
+@uyuni
+  Scenario: Add SLES 15 SP4 product with recommended sub-products for the build host and the terminal
+    When I follow the left menu "Admin > Setup Wizard > Products"
+    And I wait until I do not see "Loading" text
+    And I enter "SUSE Linux Enterprise Server 15 SP4" as the filtered product description
+    And I wait until I see "SUSE Linux Enterprise Server 15 SP4 x86_64" text
+    And I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP4 x86_64"
+    And I open the sub-list of the product "Basesystem Module 15 SP4 x86_64"
+    And I open the sub-list of the product "Desktop Applications Module 15 SP4 x86_64"
+    Then I should see that the "Basesystem Module 15 SP4 x86_64" product is "recommended"
+    And I should see that the "Server Applications Module 15 SP4 x86_64" product is "recommended"
+    When I select "SUSE Linux Enterprise Server 15 SP4 x86_64" as a product
+    Then I should see the "SUSE Linux Enterprise Server 15 SP4 x86_64" selected
+    And I should see the "Basesystem Module 15 SP4 x86_64" selected
+    And I should see the "Server Applications Module 15 SP4 x86_64" selected
+    When I select "Desktop Applications Module 15 SP4 x86_64" as a product
+    And I select "Development Tools Module 15 SP4 x86_64" as a product
+    Then I should see the "Desktop Applications Module 15 SP4 x86_64" selected
+    And I should see the "Development Tools Module 15 SP4 x86_64" selected
+    When I select "Containers Module 15 SP4 x86_64" as a product
+    Then I should see the "Containers Module 15 SP4 x86_64" selected
+    When I click the Add Product button
+    And I wait until I see "SUSE Linux Enterprise Server 15 SP4 x86_64" product has been added
+    Then the SLE15 SP4 product should be added
+
 @uyuni
   Scenario: Add openSUSE Leap 15.5 product, including Uyuni Client Tools
     When I use spacewalk-common-channel to add channel "opensuse_leap15_5 opensuse_leap15_5-non-oss opensuse_leap15_5-non-oss-updates opensuse_leap15_5-updates opensuse_leap15_5-backports-updates opensuse_leap15_5-sle-updates uyuni-proxy-devel-leap opensuse_leap15_5-uyuni-client" with arch "x86_64"

--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -26,7 +26,7 @@ Feature: Build OS images
     And I follow "Create"
     And I enter "suse_os_image" as "label"
     And I select "Kiwi" from "imageType"
-    And I select "1-SUSE-KEY-x86_64" from "activationKey"
+    And I select "1-TERMINAL-KEY-x86_64" from "activationKey"
     And I enter the image filename for "pxeboot_minion" relative to profiles as "path"
     And I click on "create-btn"
     And I wait until no Salt job is running on "build_host"

--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -35,13 +35,12 @@ Feature: PXE boot a terminal with Cobbler
     And I click on "Apply Highstate"
     And I wait until event "Apply highstate scheduled by admin" is completed
 
-@susemanager
+  # We currently test Cobbler with SLES 15 SP4, even on Uyuni
   Scenario: Install TFTP boot package on the server
     When I install package tftpboot-installation on the server
     And I wait for "tftpboot-installation-SLE-15-SP4-x86_64" to be installed on "server"
 
-# TODO: Not available in any Leap repository, yet
-# See https://suse.slack.com/archives/C02CKHR76Q2/p1694189245268889
+# TODO: use this code when we start testing Cobbler with Leap
 #@uyuni
 # Scenario: Install TFTP boot package on the server
 #   When I install package tftpboot-installation on the server
@@ -81,7 +80,7 @@ Feature: PXE boot a terminal with Cobbler
     When I enter "self_update=0" as "kernel_options"
     And I click on "Update"
     And I follow "Variables"
-    And I enter "distrotree=SLE-15-SP4-TFTP\nregistration_key=1-SUSE-KEY-x86_64\nredhat_management_server=proxy.example.org" as "variables" text area
+    And I enter "distrotree=SLE-15-SP4-TFTP\nregistration_key=1-TERMINAL-KEY-x86_64\nredhat_management_server=proxy.example.org" as "variables" text area
     And I click on "Update Variables"
     And I follow "Autoinstallation File"
     Then I should see a "SLE-15-SP4-TFTP" text
@@ -124,9 +123,9 @@ Feature: PXE boot a terminal with Cobbler
     When I install the GPG key of the test packages repository on the PXE boot minion
     And I follow "Software" in the content area
     And I follow "Install"
-    And I enter "virgo-dummy-2.0-1.1" as the filtered package name
+    And I enter "bison-3.0.4" as the filtered package name
     And I click on the filter button 
-    And I check "virgo-dummy-2.0-1.1" in the list
+    And I check "bison-3.0.4" in the list
     And I click on "Install Selected Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled" text

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -215,9 +215,9 @@ Feature: PXE boot a Retail terminal
     When I install the GPG key of the test packages repository on the PXE boot minion
     And I follow "Software" in the content area
     And I follow "Install"
-    And I enter "virgo" as the filtered package name
+    And I enter "bison" as the filtered package name
     And I click on the filter button
-    And I check "virgo-dummy-2.0-1.1" in the list
+    And I check "bison-3.0.4" in the list
     And I click on "Install Selected Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled" text
@@ -227,9 +227,9 @@ Feature: PXE boot a Retail terminal
     Given I navigate to the Systems overview page of this "pxeboot_minion"
     When I follow "Software" in the content area
     And I follow "List / Remove"
-    And I enter "virgo" as the filtered package name
+    And I enter "bison" as the filtered package name
     And I click on the filter button
-    And I check "virgo-dummy-2.0-1.1" in the list
+    And I check "bison-3.0.4" in the list
     And I click on "Remove Packages"
     And I click on "Confirm"
     Then I should see a "1 package removal has been scheduled" text
@@ -320,7 +320,7 @@ Feature: PXE boot a Retail terminal
     And I disable repositories after installing branch server
 
   Scenario: Bootstrap the PXE boot minion
-    When I create bootstrap script for "proxy.example.org" hostname and set the activation key "1-SUSE-KEY-x86_64" in the bootstrap script on the proxy
+    When I create bootstrap script for "proxy.example.org" hostname and set the activation key "1-TERMINAL-KEY-x86_64" in the bootstrap script on the proxy
     And I bootstrap pxeboot minion via bootstrap script on the proxy
     # Workaround: Increase timeout temporarily get rid of timeout issues
     And I wait at most 350 seconds until Salt master sees "pxeboot_minion" as "unaccepted"
@@ -340,9 +340,9 @@ Feature: PXE boot a Retail terminal
     When I follow "pxeboot" terminal
     And I follow "Software" in the content area
     And I follow "Install"
-    And I enter "virgo-dummy-2.0-1.1" as the filtered package name
+    And I enter "bison" as the filtered package name
     And I click on the filter button
-    And I check "virgo-dummy-2.0-1.1" in the list
+    And I check "bison-3.0.4" in the list
     And I click on "Install Selected Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled" text
@@ -353,9 +353,9 @@ Feature: PXE boot a Retail terminal
     When I follow "pxeboot" terminal
     And I follow "Software" in the content area
     And I follow "List / Remove"
-    And I enter "virgo" as the filtered package name
+    And I enter "bison" as the filtered package name
     And I click on the filter button
-    And I check "virgo-dummy-2.0-1.1" in the list
+    And I check "bison-3.0.4" in the list
     And I click on "Remove Packages"
     And I click on "Confirm"
     Then I should see a "1 package removal has been scheduled" text


### PR DESCRIPTION
## What does this PR change?

The first commit is about cleanup:
* a few duplicated test lines removed
* When/And

The second commit does the real stuff:
* synchronizes SLES 15 SP 4 on Uyuni (it will go to build host and PXE booted hosts)
* makes sure to add a base channel to build host activation key
* create new activation key for terminal, with SLES 15 SP4 as base channel
* makes sure the PXE-bootstrapped hosts (both Cobbler and Retail) use the terminal activation key

The terminal and build host activation keys do not contain the fake channel because it is already on the minion, and the parent channel is different: Leap for the minion, and SLES for the build host and the terminal. If we want the fake packages like virgo-dummy, we need to create yet another fake channel (which I do in a second draft PR #7640).

It looks like it already works in a similar way in Build Validation - nothing changed there.


## Links

Ports:
* 4.3:


## Changelogs

- [x] No changelog needed
