### PR TITLE
Improve datetimepicker time input

### DIFF
--- a/web/html/src/components/datetime/DateTimePicker.test.tsx
+++ b/web/html/src/components/datetime/DateTimePicker.test.tsx
@@ -61,7 +61,7 @@ describe("DateTimePicker", () => {
     expect(timePicker.value).toEqual("23:30");
   });
 
-  test("clearing the time input doesn't change the date (bsc#1210253)", (done) => {
+  test("clearing or manually editing the time input doesn't change the date (bsc#1210253, bsc#1215820)", (done) => {
     const validISOString = "2020-01-30T15:00:00.000Z";
     let changeEventCount = 0;
 
@@ -88,5 +88,52 @@ describe("DateTimePicker", () => {
     datePicker.click();
     screen.getByText("16").click();
     type(timePicker, "0", false);
+  });
+
+  test("picking a time from the dropdown works", (done) => {
+    const validISOString = "2020-02-01T04:00:00.000Z";
+
+    const Setup = () => {
+      const [value, setValue] = useState(localizedMoment(validISOString));
+      return (
+        <DateTimePicker
+          value={value}
+          onChange={(newValue) => {
+            setValue(newValue);
+
+            expect(newValue.toUserDateTimeString()).toEqual("2020-01-31 14:30");
+            done();
+          }}
+        />
+      );
+    };
+    render(<Setup />);
+
+    const { timePicker } = getInputs();
+    timePicker.click();
+    screen.getByText("14:30").click();
+  });
+
+  test("manually entering a time value works", (done) => {
+    const validISOString = "2020-02-01T04:00:00.000Z";
+
+    const Setup = () => {
+      const [value, setValue] = useState(localizedMoment(validISOString));
+      return (
+        <DateTimePicker
+          value={value}
+          onChange={(newValue) => {
+            setValue(newValue);
+
+            expect(newValue.toUserDateTimeString()).toEqual("2020-01-31 23:45");
+            done();
+          }}
+        />
+      );
+    };
+    render(<Setup />);
+
+    const { timePicker } = getInputs();
+    type(timePicker, "23:45");
   });
 });

--- a/web/html/src/components/datetime/DateTimePicker.tsx
+++ b/web/html/src/components/datetime/DateTimePicker.tsx
@@ -7,7 +7,7 @@ import ReactDatePicker from "react-datepicker";
 import { localizedMoment, parseTimeString } from "utils";
 
 // Turn this on to view internal state under the picker in the UI
-const SHOW_DEBUG_VALUES = true;
+const SHOW_DEBUG_VALUES = false;
 
 type InputPassthroughProps = {
   "data-id": string | undefined;

--- a/web/html/src/components/datetime/DateTimePicker.tsx
+++ b/web/html/src/components/datetime/DateTimePicker.tsx
@@ -188,12 +188,14 @@ export const DateTimePicker = (props: Props) => {
                 onChange(mergedDate);
               }}
               onChangeRaw={(event) => {
-                const rawValue = event.target.value.trim();
-                // TODO: Alternatively remove everything that isn't a number and a ":"?
-                // If the user pastes in a value or doesn't type a ":", only keep the first four numbers
-                // TODO: Implement
+                // In case the user pastes a value, clean it up and cut it to max length
+                const rawValue = event.target.value.replaceAll(/[^\d:]/g, "");
+                const cutValue = rawValue.includes(":") ? rawValue.substring(0, 5) : rawValue.substring(0, 4);
+                if (cutValue !== event.target.value) {
+                  event.target.value = cutValue;
+                }
 
-                const parsed = parseTimeString(rawValue);
+                const parsed = parseTimeString(cutValue);
                 if (!parsed) {
                   return;
                 }
@@ -216,7 +218,6 @@ export const DateTimePicker = (props: Props) => {
                   className="form-control"
                   // This is used by Cucumber to interact with the component
                   data-testid="time-picker"
-                  maxLength={5}
                 />
               }
             />

--- a/web/html/src/components/datetime/DateTimePicker.tsx
+++ b/web/html/src/components/datetime/DateTimePicker.tsx
@@ -4,10 +4,10 @@ import { forwardRef, useRef } from "react";
 
 import ReactDatePicker from "react-datepicker";
 
-import { localizedMoment } from "utils";
+import { localizedMoment, parseTimeString } from "utils";
 
 // Turn this on to view internal state under the picker in the UI
-const SHOW_DEBUG_VALUES = false;
+const SHOW_DEBUG_VALUES = true;
 
 type InputPassthroughProps = {
   "data-id": string | undefined;
@@ -173,8 +173,10 @@ export const DateTimePicker = (props: Props) => {
               portalId="time-picker-portal"
               ref={timePickerRef}
               selected={browserTimezoneValue.toDate()}
-              onChange={(date) => {
-                if (date === null) {
+              onChange={(date, event) => {
+                // If this fires without an event, it means the user picked a time from the dropdown
+                // This handler is only used the dropdown selection, onChangeRaw() handles regular user input
+                if (date === null || event) {
                   return;
                 }
                 /**
@@ -183,6 +185,20 @@ export const DateTimePicker = (props: Props) => {
                  */
                 const mergedDate = browserTimezoneValue.toDate();
                 mergedDate.setHours(date.getHours(), date.getMinutes());
+                onChange(mergedDate);
+              }}
+              onChangeRaw={(event) => {
+                const rawValue = event.target.value.trim();
+                // TODO: Alternatively remove everything that isn't a number and a ":"?
+                // If the user pastes in a value or doesn't type a ":", only keep the first four numbers
+                // TODO: Implement
+
+                const parsed = parseTimeString(rawValue);
+                if (!parsed) {
+                  return;
+                }
+                const mergedDate = browserTimezoneValue.toDate();
+                mergedDate.setHours(parsed.hours, parsed.minutes);
                 onChange(mergedDate);
               }}
               showTimeSelect

--- a/web/html/src/utils/datetime/localizedMoment.test.ts
+++ b/web/html/src/utils/datetime/localizedMoment.test.ts
@@ -1,4 +1,4 @@
-import { localizedMoment } from "./localizedMoment";
+import { localizedMoment, parseTimeString } from "./localizedMoment";
 
 describe("localizedMoment", () => {
   const validISOString = "2020-01-30T23:00:00.000Z";
@@ -81,5 +81,13 @@ describe("localizedMoment", () => {
 
     const nextWeek = localizedMoment().add(1, "week");
     expect(nextWeek.calendar()).toEqual(nextWeek.format("YYYY-MM-DD"));
+  });
+
+  // This function is a thin wrapper around moment so we only add basic test coverage
+  test("parseTimeString", () => {
+    expect(parseTimeString("")).toEqual(null);
+    expect(parseTimeString("2345")).toEqual({ hours: 23, minutes: 45 });
+    expect(parseTimeString("23:45")).toEqual({ hours: 23, minutes: 45 });
+    expect(parseTimeString(" 23 45 67 ")).toEqual({ hours: 23, minutes: 45 });
   });
 });

--- a/web/html/src/utils/datetime/localizedMoment.ts
+++ b/web/html/src/utils/datetime/localizedMoment.ts
@@ -200,7 +200,7 @@ Object.defineProperties(moment, {
 });
 
 const parseTimeString = function (input: string): { hours: number; minutes: number } | null {
-  const parsed = moment(input, ["H:m"]);
+  const parsed = moment(input.trim(), ["H:m", "Hm"]);
   if (parsed.isValid()) {
     return {
       hours: parsed.hours(),

--- a/web/html/src/utils/datetime/localizedMoment.ts
+++ b/web/html/src/utils/datetime/localizedMoment.ts
@@ -199,6 +199,17 @@ Object.defineProperties(moment, {
   },
 });
 
+const parseTimeString = function (input: string): { hours: number; minutes: number } | null {
+  const parsed = moment(input, ["H:m"]);
+  if (parsed.isValid()) {
+    return {
+      hours: parsed.hours(),
+      minutes: parsed.minutes(),
+    };
+  }
+  return null;
+};
+
 function localizedMomentConstructor(input?: moment.MomentInput) {
   // We make all inputs UTC internally and only format them for output
   const utcMoment =
@@ -214,4 +225,4 @@ function localizedMomentConstructor(input?: moment.MomentInput) {
 }
 
 const localizedMoment: typeof moment = Object.setPrototypeOf(localizedMomentConstructor, moment);
-export { localizedMoment };
+export { localizedMoment, parseTimeString };

--- a/web/spacewalk-web.changes.eth.date-improve
+++ b/web/spacewalk-web.changes.eth.date-improve
@@ -1,0 +1,1 @@
+- Improve datetimepicker input formatting


### PR DESCRIPTION
## What does this PR change?

Currently, the picker works somewhat counterintuitively when you omit a ":" or leave off a trailing number, sometimes producing odd values which are not instantly clear why they happened. This PR moves the time parsing over to moment, adds test coverage, and other small improvements.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
