### PR TITLE
Only bail out if we modify existing changes file

### DIFF
--- a/.github/workflows/changelogs.yml
+++ b/.github/workflows/changelogs.yml
@@ -56,11 +56,11 @@ jobs:
       with:
         filter: '*.changes'
     - name: Fail if the master changelog files are modified
-      if: steps.master.outputs.all
+      if: steps.master.outputs.modified
       run: |
         echo "Master changelog files cannot be modified directly."
         echo "Please revert your changes on the following master changelog file(s):"
-        for file in ${{steps.master.outputs.all}}
+        for file in ${{steps.master.outputs.modified}}
         do
           echo "  - $file"
         done


### PR DESCRIPTION
## What does this PR change?

The changelog test should not fail on new, deleted or moved changes files.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: workflow change

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
