### PR TITLE
Fix failed actions rescheduling

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionExecutor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionExecutor.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.taskomatic.task;
 
 import com.redhat.rhn.GlobalInstanceHolder;
+import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
@@ -121,7 +122,16 @@ public class MinionActionExecutor extends RhnJavaJob {
         // COMMITted in the database. Wait for some minutes checking if it appears
         int waitedTime = 0;
         while (countQueuedServerActions(action) == 0 && waitedTime < ACTION_DATABASE_GRACE_TIME) {
+            if (action != null) {
+                HibernateFactory.getSession().flush();
+                HibernateFactory.getSession().evict(action);
+            }
+
             action = ActionFactory.lookupById(actionId);
+
+            if (log.isDebugEnabled()) {
+                log.debug("Number of Queued Server Actions for {}: {}", actionId, countQueuedServerActions(action));
+            }
             try {
                 Thread.sleep(ACTION_DATABASE_POLL_TIME);
             }

--- a/java/spacewalk-java.changes.welder.fix-failed-actions-reschedule
+++ b/java/spacewalk-java.changes.welder.fix-failed-actions-reschedule
@@ -1,0 +1,1 @@
+- Fix failed actions rescheduling (bsc#1214121)


### PR DESCRIPTION
## What does this PR change?

This patch modifies the minion action executor to remove the action object from the Hibernate cache before attempting to retrieve it again, addressing the issue of getting stuck in the loop because of information never changes in Hibernate cache.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: legacy code

- [x] **DONE**

## Links

Related to https://github.com/SUSE/spacewalk/issues/22292

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
