### PR TITLE
Fix unscheduling actions when the trigger name changed after retry

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoQuartzHelper.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoQuartzHelper.java
@@ -180,12 +180,21 @@ public class TaskoQuartzHelper {
      * @param jobLabel job name
      */
     public static void destroyJob(Integer orgId, String jobLabel) {
+        destroyJob(triggerKey(jobLabel, getGroupName(orgId)));
+    }
+
+    /**
+     * unschedules job
+     *
+     * @param key trigger key
+     */
+    public static void destroyJob(TriggerKey key) {
         try {
-            SchedulerKernel.getScheduler().unscheduleJob(triggerKey(jobLabel, getGroupName(orgId)));
-            log.info("Job {} unscheduled successfully.", jobLabel);
+            SchedulerKernel.getScheduler().unscheduleJob(key);
+            log.info("Job {} unscheduled successfully.", key.getName());
         }
         catch (SchedulerException e) {
-            log.error("Unable to unschedule job {} of organization # {}", jobLabel, orgId, e);
+            log.error("Unable to unschedule job {} of organization # {}", key.getName(), key.getGroup(), e);
         }
     }
 

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoXmlRpcHandler.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoXmlRpcHandler.java
@@ -30,6 +30,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.quartz.SchedulerException;
 import org.quartz.Trigger;
+import org.quartz.TriggerKey;
+import org.quartz.impl.matchers.GroupMatcher;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -213,13 +215,24 @@ public class TaskoXmlRpcHandler {
     public Integer unscheduleBunch(Integer orgId, String jobLabel) {
         // one or none shall be returned
         List<TaskoSchedule> scheduleList = TaskoFactory.listActiveSchedulesByOrgAndLabel(orgId, jobLabel);
+        TriggerKey triggerKey;
         Trigger trigger;
         try {
-            trigger = SchedulerKernel.getScheduler().getTrigger(triggerKey(jobLabel,
-                    TaskoQuartzHelper.getGroupName(orgId)));
+            triggerKey = triggerKey(jobLabel, TaskoQuartzHelper.getGroupName(orgId));
+            trigger = SchedulerKernel.getScheduler().getTrigger(triggerKey);
+
+            // Try to find retry triggers as fallback
+            if (trigger == null) {
+                triggerKey = SchedulerKernel.getScheduler()
+                    .getTriggerKeys(GroupMatcher.anyGroup()).stream()
+                    .filter(it -> it.getName().startsWith(jobLabel + "-retry"))
+                    .findFirst().orElse(null);
+                trigger = SchedulerKernel.getScheduler().getTrigger(triggerKey);
+            }
         }
         catch (SchedulerException e) {
             trigger = null;
+            triggerKey = null;
         }
         // check for inconsistencies
         // quartz unschedules job after trigger end time
@@ -232,7 +245,7 @@ public class TaskoXmlRpcHandler {
             schedule.unschedule();
         }
         if (trigger != null) {
-            TaskoQuartzHelper.destroyJob(orgId, jobLabel);
+            TaskoQuartzHelper.destroyJob(triggerKey);
         }
         return 1;
     }

--- a/java/spacewalk-java.changes.welder.fix-unscheduling-retry-trigger
+++ b/java/spacewalk-java.changes.welder.fix-unscheduling-retry-trigger
@@ -1,0 +1,1 @@
+- Fix unscheduling actions when the trigger name changed after retry (bsc#1214121)


### PR DESCRIPTION
## What does this PR change?

When a quartz triggers is rescheduled due to thread unavailability in Taskomatic, we change its name to include a suffix (-retry-{timestamp}) - see `TaskoQuartzHelper.rescheduleJob`. If we then try to unschedule the action linked to this trigger, the action will be deleted and the trigger will keep scheduled.

Keeping the retry trigger scheduled has a harmful side effect of blocking Taskomatic thread for 10 minutes waiting for the action (that was already deleted) to appear in the database.

This PR address this issue.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: legacy code

- [x] **DONE**

## Links

Related to https://github.com/SUSE/spacewalk/issues/22292

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
