### PR TITLE
States fail to apply to openEuler 22.03 client

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/certs/openeuler.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/openeuler.sls
@@ -1,1 +1,24 @@
-redhat.sls
+{%- if grains['osrelease']|int == 6 %}
+enable_ca_store:
+  cmd.run:
+    - name: /usr/bin/update-ca-trust enable
+    - runas: root
+    - unless: "/usr/bin/update-ca-trust check | grep \"PEM/JAVA Status: ENABLED\""
+{%- endif %}
+
+mgr_ca_cert:
+  file.managed:
+    - name: /etc/pki/ca-trust/source/anchors/RHN-ORG-TRUSTED-SSL-CERT
+    - source:
+      - salt://certs/RHN-ORG-TRUSTED-SSL-CERT
+{%- if grains['osrelease']|int == 6 %}
+    - require:
+      - cmd: enable_ca_store
+{%- endif %}
+
+update-ca-certificates:
+  cmd.run:
+    - name: /usr/bin/update-ca-trust extract
+    - runas: root
+    - onchanges:
+      - file: mgr_ca_cert

--- a/susemanager-utils/susemanager-sls/salt/certs/openeuler.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/openeuler.sls
@@ -1,20 +1,8 @@
-{%- if grains['osrelease']|int == 6 %}
-enable_ca_store:
-  cmd.run:
-    - name: /usr/bin/update-ca-trust enable
-    - runas: root
-    - unless: "/usr/bin/update-ca-trust check | grep \"PEM/JAVA Status: ENABLED\""
-{%- endif %}
-
 mgr_ca_cert:
   file.managed:
     - name: /etc/pki/ca-trust/source/anchors/RHN-ORG-TRUSTED-SSL-CERT
     - source:
       - salt://certs/RHN-ORG-TRUSTED-SSL-CERT
-{%- if grains['osrelease']|int == 6 %}
-    - require:
-      - cmd: enable_ca_store
-{%- endif %}
 
 update-ca-certificates:
   cmd.run:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.raul.fix_7635
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.raul.fix_7635
@@ -1,1 +1,1 @@
-- Fix file susemanager-utils/susemanager-sls/salt/certs/openeuler.sls
+- Fix the certificate management for openEuler

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.raul.fix_7635
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.raul.fix_7635
@@ -1,0 +1,1 @@
+- Fix file susemanager-utils/susemanager-sls/salt/certs/openeuler.sls


### PR DESCRIPTION
## What does this PR change?

This PR fixes a wrong certificate for openEuler clients. Making the file be a symlink to redhat.sls was not working, and the original content of the name of the file did not work either. I think this was working in the first tests of the past though.
I'll be glad to hear about any other proposals.

## GUI diff

Before: Registration failed with the step called "Apply states [certs, channels, packages, services.salt-minion]"
After: Registration won't fail any more.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #7635

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
