### PR TITLE
Sync sles too on uyuni 2

### DIFF
--- a/testsuite/features/core/srv_create_activationkey.feature
+++ b/testsuite/features/core/srv_create_activationkey.feature
@@ -111,8 +111,16 @@ Feature: Create activation keys
     And I wait for child channels to appear
     And I enter "Build host Key x86_64" as "description"
     And I enter "BUILD-HOST-KEY-x86_64" as "key"
-    And I enter "20" as "usageLimit"
     And I check "Container Build Host"
     And I check "OS Image Build Host"
     And I click on "Create Activation Key"
     Then I should see a "Activation key Build host Key x86_64 has been created" text
+
+  Scenario: Create an activation key for the terminal
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "Create Key"
+    And I wait for child channels to appear
+    And I enter "Terminal Key x86_64" as "description"
+    And I enter "TERMINAL-KEY-x86_64" as "key"
+    And I click on "Create Activation Key"
+    Then I should see a "Activation key Terminal Key x86_64 has been created" text

--- a/testsuite/features/core/srv_create_activationkey.feature
+++ b/testsuite/features/core/srv_create_activationkey.feature
@@ -116,8 +116,3 @@ Feature: Create activation keys
     And I check "OS Image Build Host"
     And I click on "Create Activation Key"
     Then I should see a "Activation key Build host Key x86_64 has been created" text
-    And I should see a "Details" link
-    And I should see a "Packages" link
-    And I should see a "Configuration" link in the content area
-    And I should see a "Groups" link
-    And I should see a "Activated Systems" link

--- a/testsuite/features/init_clients/allcli_update_activationkeys.feature
+++ b/testsuite/features/init_clients/allcli_update_activationkeys.feature
@@ -148,7 +148,6 @@ Feature: Update activation keys
     Then I should see a "Activation key Proxy Key x86_64 has been modified" text
 
 @scc_credentials
-@susemanager
   Scenario: Update build host key with synced base product
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Build host Key x86_64" in the content area
@@ -166,6 +165,44 @@ Feature: Update activation keys
     And I wait until "SLE-Module-Desktop-Applications15-SP4-Updates for x86_64" has been checked
     And I check "SLE-Module-Containers15-SP4-Pool for x86_64"
     And I wait until "SLE-Module-Containers15-SP4-Updates for x86_64" has been checked
-    And I check "Fake-RPM-SUSE-Channel"
     And I click on "Update Activation Key"
     Then I should see a "Activation key Build host Key x86_64 has been modified" text
+
+@scc_credentials
+  Scenario: Update terminal key with synced base product
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "Terminal Key x86_64" in the content area
+    And I wait for child channels to appear
+    And I select "SLE-Product-SLES15-SP4-Pool for x86_64" from "selectedBaseChannel"
+    And I wait for child channels to appear
+    And I include the recommended child channels
+    And I wait until "SLE-Module-Basesystem15-SP4-Pool for x86_64" has been checked
+    And I wait until "SLE-Module-Basesystem15-SP4-Updates for x86_64" has been checked
+    And I wait until "SLE-Module-Server-Applications15-SP4-Pool for x86_64" has been checked
+    And I wait until "SLE-Module-Server-Applications15-SP4-Updates for x86_64" has been checked
+    And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"
+    And I wait until "SLE-Module-DevTools15-SP4-Updates for x86_64" has been checked
+    And I wait until "SLE-Module-Desktop-Applications15-SP4-Pool for x86_64" has been checked
+    And I wait until "SLE-Module-Desktop-Applications15-SP4-Updates for x86_64" has been checked
+    And I check "SLE-Module-Containers15-SP4-Pool for x86_64"
+    And I wait until "SLE-Module-Containers15-SP4-Updates for x86_64" has been checked
+    And I click on "Update Activation Key"
+    Then I should see a "Activation key Terminal Key x86_64 has been modified" text
+
+@susemanager
+  Scenario: Update terminal key with normal SUSE fake channel
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "Terminal Key x86_64" in the content area
+    And I wait for child channels to appear
+    And I check "Fake-RPM-SUSE-Channel"
+    And I click on "Update Activation Key"
+    Then I should see a "Activation key Terminal Key x86_64 has been modified" text
+
+@uyuni
+  Scenario: Update terminal key with specific fake channel
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "Terminal Key x86_64" in the content area
+    And I wait for child channels to appear
+    And I check "Fake-RPM-Terminal-Channel"
+    And I click on "Update Activation Key"
+    Then I should see a "Activation key Terminal Key x86_64 has been modified" text

--- a/testsuite/features/init_clients/allcli_update_activationkeys.feature
+++ b/testsuite/features/init_clients/allcli_update_activationkeys.feature
@@ -65,7 +65,7 @@ Feature: Update activation keys
     And I check "SLE-Module-Containers15-SP4-Pool for x86_64"
     And I wait until "SLE-Module-Containers15-SP4-Updates for x86_64" has been checked
     And I check "Fake-RPM-SUSE-Channel"
-    When I click on "Update Activation Key"
+    And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE Test Key x86_64 has been modified" text
 
 @skip_if_github_validation
@@ -83,13 +83,13 @@ Feature: Update activation keys
     And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
     And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)"
     And I check "Fake-RPM-SUSE-Channel"
-    When I click on "Update Activation Key"
+    And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE Test Key x86_64 has been modified" text
 
 @skip_if_github_validation
 @scc_credentials
 @susemanager
-  Scenario: Update SSH key with synced base product
+  Scenario: Update SLE SSH key with synced base product
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE SSH Test Key x86_64" in the content area
     And I wait for child channels to appear
@@ -103,7 +103,7 @@ Feature: Update activation keys
 
 @skip_if_github_validation
 @uyuni
-  Scenario: Update SSH key with synced base product
+  Scenario: Update openSUSE Leap SSH key with synced base product
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE SSH Test Key x86_64" in the content area
     And I wait until I do not see "Loading..." text
@@ -122,7 +122,7 @@ Feature: Update activation keys
 @skip_if_github_validation
 @scc_credentials
 @susemanager
-  Scenario: Update SSH tunnel key with synced base product
+  Scenario: Update SLE SSH tunnel key with synced base product
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE SSH Tunnel Test Key x86_64" in the content area
     And I wait for child channels to appear
@@ -136,7 +136,7 @@ Feature: Update activation keys
 
 @skip_if_github_validation
 @uyuni
-  Scenario: Update SSH tunnel key with synced base product
+  Scenario: Update openSUSE Leap SSH tunnel key with synced base product
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE SSH Tunnel Test Key x86_64" in the content area
     And I wait until I do not see "Loading..." text
@@ -155,7 +155,7 @@ Feature: Update activation keys
 @skip_if_github_validation
 @scc_credentials
 @susemanager
-  Scenario: Update the Proxy key with synced base product
+  Scenario: Update the SLE Proxy key with synced base product
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Proxy Key x86_64" in the content area
     And I wait for child channels to appear
@@ -168,12 +168,12 @@ Feature: Update activation keys
     And I wait until "SLE-Module-Server-Applications15-SP4-Updates for x86_64 Proxy 4.3" has been checked
     And I wait until "SLE-Module-SUSE-Manager-Proxy-4.3-Pool for x86_64" has been checked
     And I wait until "SLE-Module-SUSE-Manager-Proxy-4.3-Updates for x86_64" has been checked
-    When I click on "Update Activation Key"
+    And I click on "Update Activation Key"
     Then I should see a "Activation key Proxy Key x86_64 has been modified" text
 
 @skip_if_github_validation
 @uyuni
-  Scenario: Update the Proxy key with synced base product
+  Scenario: Update the openSUSE Leap Proxy key with synced base product
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Proxy Key x86_64" in the content area
     And I wait for child channels to appear
@@ -186,7 +186,7 @@ Feature: Update activation keys
     And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
     And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)"
     And I check "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64)"
-    When I click on "Update Activation Key"
+    And I click on "Update Activation Key"
     Then I should see a "Activation key Proxy Key x86_64 has been modified" text
 
 @skip_if_github_validation
@@ -210,5 +210,5 @@ Feature: Update activation keys
     And I check "SLE-Module-Containers15-SP4-Pool for x86_64"
     And I wait until "SLE-Module-Containers15-SP4-Updates for x86_64" has been checked
     And I check "Fake-RPM-SUSE-Channel"
-    When I click on "Update Activation Key"
+    And I click on "Update Activation Key"
     Then I should see a "Activation key Build host Key x86_64 has been modified" text

--- a/testsuite/features/init_clients/allcli_update_activationkeys.feature
+++ b/testsuite/features/init_clients/allcli_update_activationkeys.feature
@@ -1,6 +1,7 @@
 # Copyright (c) 2022-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@skip_if_github_validation
 Feature: Update activation keys
   In order to register systems to the spacewalk server
   As admin
@@ -9,42 +10,6 @@ Feature: Update activation keys
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  Scenario: Add a child channel to the base product channel
-    When I follow the left menu "Software > Manage > Channels"
-    And I follow "Create Channel"
-    And I enter "Fake-RPM-SUSE-Channel" as "Channel Name"
-    And I enter "fake-rpm-suse-channel" as "Channel Label"
-    And I select the parent channel for the "sle_minion" from "Parent Channel"
-    And I select "x86_64" from "Architecture:"
-    And I enter "Fake-RPM-SUSE-Channel for testing" as "Channel Summary"
-    And I enter "Description for Fake-RPM-SUSE-Channel Child Channel." as "Channel Description"
-    And I click on "Create Channel"
-    Then I should see a "Channel Fake-RPM-SUSE-Channel created." text
-
-  Scenario: Add the repository to the x86_64 child channel
-    When I follow the left menu "Software > Manage > Channels"
-    And I follow "Fake-RPM-SUSE-Channel"
-    And I enter "file:///etc/pki/rpm-gpg/uyuni-tools-gpg-pubkey-0d20833e.key" as "GPG key URL"
-    And I click on "Update Channel"
-    Then I should see a "Channel Fake-RPM-SUSE-Channel updated" text
-    When I follow "Repositories" in the content area
-    And I select the "fake-rpm-repo" repo
-    And I click on "Save Repositories"
-    Then I should see a "Fake-RPM-SUSE-Channel repository information was successfully updated" text
-
-  Scenario: Synchronize the repository in the x86_64 channel
-    When I enable source package syncing
-    And I follow the left menu "Software > Manage > Channels"
-    And I follow "Fake-RPM-SUSE-Channel"
-    And I follow "Repositories" in the content area
-    And I follow "Sync"
-    And I wait at most 60 seconds until I do not see "Repository sync is running." text, refreshing the page
-    And I click on "Sync Now"
-    Then I should see a "Repository sync scheduled for Fake-RPM-SUSE-Channel." text
-    And I wait until the channel "fake-rpm-suse-channel" has been synced
-    And I disable source package syncing
-
-@skip_if_github_validation
 @scc_credentials
 @susemanager
   Scenario: Update SLE key with synced base product
@@ -68,7 +33,6 @@ Feature: Update activation keys
     And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE Test Key x86_64 has been modified" text
 
-@skip_if_github_validation
 @uyuni
   Scenario: Update openSUSE Leap key with synced base product
     When I follow the left menu "Systems > Activation Keys"
@@ -86,7 +50,6 @@ Feature: Update activation keys
     And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE Test Key x86_64 has been modified" text
 
-@skip_if_github_validation
 @scc_credentials
 @susemanager
   Scenario: Update SLE SSH key with synced base product
@@ -101,7 +64,6 @@ Feature: Update activation keys
     And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE SSH Test Key x86_64 has been modified" text
 
-@skip_if_github_validation
 @uyuni
   Scenario: Update openSUSE Leap SSH key with synced base product
     When I follow the left menu "Systems > Activation Keys"
@@ -119,7 +81,6 @@ Feature: Update activation keys
     And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE SSH Test Key x86_64 has been modified" text
 
-@skip_if_github_validation
 @scc_credentials
 @susemanager
   Scenario: Update SLE SSH tunnel key with synced base product
@@ -134,7 +95,6 @@ Feature: Update activation keys
     And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE SSH Tunnel Test Key x86_64 has been modified" text
 
-@skip_if_github_validation
 @uyuni
   Scenario: Update openSUSE Leap SSH tunnel key with synced base product
     When I follow the left menu "Systems > Activation Keys"
@@ -152,7 +112,6 @@ Feature: Update activation keys
     And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE SSH Tunnel Test Key x86_64 has been modified" text
 
-@skip_if_github_validation
 @scc_credentials
 @susemanager
   Scenario: Update the SLE Proxy key with synced base product
@@ -171,7 +130,6 @@ Feature: Update activation keys
     And I click on "Update Activation Key"
     Then I should see a "Activation key Proxy Key x86_64 has been modified" text
 
-@skip_if_github_validation
 @uyuni
   Scenario: Update the openSUSE Leap Proxy key with synced base product
     When I follow the left menu "Systems > Activation Keys"
@@ -189,7 +147,6 @@ Feature: Update activation keys
     And I click on "Update Activation Key"
     Then I should see a "Activation key Proxy Key x86_64 has been modified" text
 
-@skip_if_github_validation
 @scc_credentials
 @susemanager
   Scenario: Update build host key with synced base product

--- a/testsuite/features/reposync/srv_create_repository.feature
+++ b/testsuite/features/reposync/srv_create_repository.feature
@@ -3,7 +3,7 @@
 #
 # This feature can cause failures in:
 # If the fake-rpm-repo fails to be created:
-# - features/init_client/allcli_update_activationkeys.feature
+# - features/reposync/srv_sync_fake_channels.feature
 # If Fake-Deb-AMD64-Channel fails to be updated with the repository:
 # - features/secondary/min_deblike_salt_install_package.feature
 # - features/secondary/min_deblike_salt_install_with_staging.feature

--- a/testsuite/features/reposync/srv_sync_fake_channels.feature
+++ b/testsuite/features/reposync/srv_sync_fake_channels.feature
@@ -47,3 +47,46 @@ Feature: Prepare fake SUSE channels
   Scenario: Verify state of Fake-RPM-SUSE-Channel custom channel
     Then "orion-dummy-1.1-1.1.x86_64.rpm" package should have been stored
     And solver file for "fake-rpm-suse-channel" should reference "orion-dummy-1.1-1.1.x86_64.rpm"
+
+@uyuni
+  Scenario: Add the terminal child channel to the base product channel
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Create Channel"
+    And I enter "Fake-RPM-Terminal-Channel" as "Channel Name"
+    And I enter "fake-rpm-terminal-channel" as "Channel Label"
+    And I select "SLE-Product-SLES15-SP4-Pool for x86_64" from "Parent Channel"
+    And I select "x86_64" from "Architecture:"
+    And I enter "Fake-RPM-Terminal-Channel for testing" as "Channel Summary"
+    And I enter "Description for Fake-RPM-Terminal-Channel Child Channel." as "Channel Description"
+    And I click on "Create Channel"
+    Then I should see a "Channel Fake-RPM-Terminal-Channel created." text
+
+@uyuni
+  Scenario: Add the repository to the terminal child channel
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Fake-RPM-Terminal-Channel"
+    And I enter "file:///etc/pki/rpm-gpg/uyuni-tools-gpg-pubkey-0d20833e.key" as "GPG key URL"
+    And I click on "Update Channel"
+    Then I should see a "Channel Fake-RPM-Terminal-Channel updated" text
+    When I follow "Repositories" in the content area
+    And I select the "fake-rpm-repo" repo
+    And I click on "Save Repositories"
+    Then I should see a "Fake-RPM-Terminal-Channel repository information was successfully updated" text
+
+@uyuni
+  Scenario: Synchronize the repository in the terminal channel
+    When I enable source package syncing
+    And I follow the left menu "Software > Manage > Channels"
+    And I follow "Fake-RPM-Terminal-Channel"
+    And I follow "Repositories" in the content area
+    And I follow "Sync"
+    And I wait at most 60 seconds until I do not see "Repository sync is running." text, refreshing the page
+    And I click on "Sync Now"
+    Then I should see a "Repository sync scheduled for Fake-RPM-Terminal-Channel." text
+    And I wait until the channel "fake-rpm-terminal-channel" has been synced
+    And I disable source package syncing
+
+@uyuni
+  Scenario: Verify state of Fake-RPM-Terminal-Channel custom channel
+    Then "orion-dummy-1.1-1.1.x86_64.rpm" package should have been stored
+    And solver file for "fake-rpm-terminal-channel" should reference "orion-dummy-1.1-1.1.x86_64.rpm"

--- a/testsuite/features/reposync/srv_sync_fake_channels.feature
+++ b/testsuite/features/reposync/srv_sync_fake_channels.feature
@@ -1,0 +1,49 @@
+# Copyright (c) 2022-2023 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Prepare fake SUSE channels
+  In order to have patches and packages to install on clients
+  As admin
+  I want to prepare the channels containing those patches and packages
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Add the fake packages child channel to the base product channel
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Create Channel"
+    And I enter "Fake-RPM-SUSE-Channel" as "Channel Name"
+    And I enter "fake-rpm-suse-channel" as "Channel Label"
+    And I select the parent channel for the "sle_minion" from "Parent Channel"
+    And I select "x86_64" from "Architecture:"
+    And I enter "Fake-RPM-SUSE-Channel for testing" as "Channel Summary"
+    And I enter "Description for Fake-RPM-SUSE-Channel Child Channel." as "Channel Description"
+    And I click on "Create Channel"
+    Then I should see a "Channel Fake-RPM-SUSE-Channel created." text
+
+  Scenario: Add the repository to the fake packages child channel
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Fake-RPM-SUSE-Channel"
+    And I enter "file:///etc/pki/rpm-gpg/uyuni-tools-gpg-pubkey-0d20833e.key" as "GPG key URL"
+    And I click on "Update Channel"
+    Then I should see a "Channel Fake-RPM-SUSE-Channel updated" text
+    When I follow "Repositories" in the content area
+    And I select the "fake-rpm-repo" repo
+    And I click on "Save Repositories"
+    Then I should see a "Fake-RPM-SUSE-Channel repository information was successfully updated" text
+
+  Scenario: Synchronize the repository in the fake packages channel
+    When I enable source package syncing
+    And I follow the left menu "Software > Manage > Channels"
+    And I follow "Fake-RPM-SUSE-Channel"
+    And I follow "Repositories" in the content area
+    And I follow "Sync"
+    And I wait at most 60 seconds until I do not see "Repository sync is running." text, refreshing the page
+    And I click on "Sync Now"
+    Then I should see a "Repository sync scheduled for Fake-RPM-SUSE-Channel." text
+    And I wait until the channel "fake-rpm-suse-channel" has been synced
+    And I disable source package syncing
+
+  Scenario: Verify state of Fake-RPM-SUSE-Channel custom channel
+    Then "orion-dummy-1.1-1.1.x86_64.rpm" package should have been stored
+    And solver file for "fake-rpm-suse-channel" should reference "orion-dummy-1.1-1.1.x86_64.rpm"

--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -62,6 +62,32 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I see "SUSE Linux Enterprise Server 15 SP4 x86_64" product has been added
     Then the SLE15 SP4 product should be added
 
+@scc_credentials
+@uyuni
+  Scenario: Add SLES 15 SP4 product with recommended sub-products for the build host and the terminal
+    When I follow the left menu "Admin > Setup Wizard > Products"
+    And I wait until I do not see "Loading" text
+    And I enter "SUSE Linux Enterprise Server 15 SP4" as the filtered product description
+    And I wait until I see "SUSE Linux Enterprise Server 15 SP4 x86_64" text
+    And I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP4 x86_64"
+    And I open the sub-list of the product "Basesystem Module 15 SP4 x86_64"
+    And I open the sub-list of the product "Desktop Applications Module 15 SP4 x86_64"
+    Then I should see that the "Basesystem Module 15 SP4 x86_64" product is "recommended"
+    And I should see that the "Server Applications Module 15 SP4 x86_64" product is "recommended"
+    When I select "SUSE Linux Enterprise Server 15 SP4 x86_64" as a product
+    Then I should see the "SUSE Linux Enterprise Server 15 SP4 x86_64" selected
+    And I should see the "Basesystem Module 15 SP4 x86_64" selected
+    And I should see the "Server Applications Module 15 SP4 x86_64" selected
+    When I select "Desktop Applications Module 15 SP4 x86_64" as a product
+    And I select "Development Tools Module 15 SP4 x86_64" as a product
+    Then I should see the "Desktop Applications Module 15 SP4 x86_64" selected
+    And I should see the "Development Tools Module 15 SP4 x86_64" selected
+    When I select "Containers Module 15 SP4 x86_64" as a product
+    Then I should see the "Containers Module 15 SP4 x86_64" selected
+    When I click the Add Product button
+    And I wait until I see "SUSE Linux Enterprise Server 15 SP4 x86_64" product has been added
+    Then the SLE15 SP4 product should be added
+
 @uyuni
   Scenario: Add openSUSE Leap 15.5 product, including Uyuni Client Tools
     When I use spacewalk-common-channel to add channel "opensuse_leap15_5 opensuse_leap15_5-non-oss opensuse_leap15_5-non-oss-updates opensuse_leap15_5-updates opensuse_leap15_5-backports-updates opensuse_leap15_5-sle-updates uyuni-proxy-devel-leap opensuse_leap15_5-uyuni-client" with arch "x86_64"

--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -26,7 +26,7 @@ Feature: Build OS images
     And I follow "Create"
     And I enter "suse_os_image" as "label"
     And I select "Kiwi" from "imageType"
-    And I select "1-SUSE-KEY-x86_64" from "activationKey"
+    And I select "1-TERMINAL-KEY-x86_64" from "activationKey"
     And I enter the image filename for "pxeboot_minion" relative to profiles as "path"
     And I click on "create-btn"
     And I wait until no Salt job is running on "build_host"

--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -35,13 +35,12 @@ Feature: PXE boot a terminal with Cobbler
     And I click on "Apply Highstate"
     And I wait until event "Apply highstate scheduled by admin" is completed
 
-@susemanager
+  # We currently test Cobbler with SLES 15 SP4, even on Uyuni
   Scenario: Install TFTP boot package on the server
     When I install package tftpboot-installation on the server
     And I wait for "tftpboot-installation-SLE-15-SP4-x86_64" to be installed on "server"
 
-# TODO: Not available in any Leap repository, yet
-# See https://suse.slack.com/archives/C02CKHR76Q2/p1694189245268889
+# TODO: use this code when we start testing Cobbler with Leap
 #@uyuni
 # Scenario: Install TFTP boot package on the server
 #   When I install package tftpboot-installation on the server
@@ -81,7 +80,7 @@ Feature: PXE boot a terminal with Cobbler
     When I enter "self_update=0" as "kernel_options"
     And I click on "Update"
     And I follow "Variables"
-    And I enter "distrotree=SLE-15-SP4-TFTP\nregistration_key=1-SUSE-KEY-x86_64\nredhat_management_server=proxy.example.org" as "variables" text area
+    And I enter "distrotree=SLE-15-SP4-TFTP\nregistration_key=1-TERMINAL-KEY-x86_64\nredhat_management_server=proxy.example.org" as "variables" text area
     And I click on "Update Variables"
     And I follow "Autoinstallation File"
     Then I should see a "SLE-15-SP4-TFTP" text

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -340,7 +340,7 @@ Feature: PXE boot a Retail terminal
     When I follow "pxeboot" terminal
     And I follow "Software" in the content area
     And I follow "Install"
-    And I enter "virgo-dummy-2.0-1.1" as the filtered package name
+    And I enter "virgo" as the filtered package name
     And I click on the filter button
     And I check "virgo-dummy-2.0-1.1" in the list
     And I click on "Install Selected Packages"

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -320,7 +320,7 @@ Feature: PXE boot a Retail terminal
     And I disable repositories after installing branch server
 
   Scenario: Bootstrap the PXE boot minion
-    When I create bootstrap script for "proxy.example.org" hostname and set the activation key "1-SUSE-KEY-x86_64" in the bootstrap script on the proxy
+    When I create bootstrap script for "proxy.example.org" hostname and set the activation key "1-TERMINAL-KEY-x86_64" in the bootstrap script on the proxy
     And I bootstrap pxeboot minion via bootstrap script on the proxy
     # Workaround: Increase timeout temporarily get rid of timeout issues
     And I wait at most 350 seconds until Salt master sees "pxeboot_minion" as "unaccepted"

--- a/testsuite/run_sets/github_validation/github_validation_core.yml
+++ b/testsuite/run_sets/github_validation/github_validation_core.yml
@@ -11,4 +11,5 @@
 - features/core/srv_create_activationkey.feature
 - features/core/srv_osimage.feature
 - features/core/srv_docker.feature
+- features/reposync/srv_sync_fake_channels.feature
 ## Container features END ###

--- a/testsuite/run_sets/reposync.yml
+++ b/testsuite/run_sets/reposync.yml
@@ -14,5 +14,6 @@
 - features/reposync/srv_enable_sync_products.feature
 - features/reposync/srv_wait_for_reposync.feature
 - features/reposync/srv_create_repository.feature
+- features/reposync/srv_sync_fake_channels.feature
 
 ## Channels and Product synchronization features END ###


### PR DESCRIPTION
## What does this PR change?

First commit is about cleanup and nitpicks:

* remove a few duplicated test lines removed
* When/And
* unique scenario names
* homogeneous filtering of packages

Second commit is a refactor done independantly by Oscar and me:

* isolate the reposync of fake channels

Third commit does the real stuff:

* synchronize SLES 15 SP 4 on Uyuni (it will go to build host and PXE booted hosts)
* add a base channel to build host activation key
* create new channel and activation key for terminal, with SLES 15 SP4 as base channel
* make sure the PXE-bootstrapped hosts (both Cobbler and Retail) use the build host activation key

**It should be followed by a new PR that kills SLES 15 SP4 reposync right after beginning and tests Cobbler on Leap.**


## Links

Ports:
* 4.3: https://github.com/SUSE/spacewalk/pull/22720


## Changelogs

- [x] No changelog needed
