### PR TITLE
Change openEuler url's for the Uyuni tools

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -4203,16 +4203,16 @@ repo_url = https://repo.openeuler.org/openEuler-22.03-LTS/EPOL/main/%(arch)s
 archs	= x86_64, aarch64
 name	= Uyuni client tools for %(base_channel_name)s
 base_channels = openeuler2203-%(arch)s
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/repodata/repomd.xml.key
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/next:/openEuler2203/openEuler_22.03/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/next:/openEuler2203/openEuler_22.03/
 
 [openeuler2203-uyuni-client-devel]
 archs	= x86_64, aarch64
 name	= Uyuni client tools for %(base_channel_name)s (Development)
 base_channels = openeuler2203-%(arch)s
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL8-Uyuni-Client-Tools/EL_8/repodata/repomd.xml.key
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/next:/openEuler2203/openEuler_22.03/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL8-Uyuni-Client-Tools/EL_8/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/next:/openEuler2203/openEuler_22.03/

--- a/utils/spacewalk-utils.changes.raul.fix_openeuler_url
+++ b/utils/spacewalk-utils.changes.raul.fix_openeuler_url
@@ -1,0 +1,1 @@
+- Change openEuler url's for the Uyuni tools


### PR DESCRIPTION
## What does this PR change?

Fixes the url for the Uyuni tools as Almalinux 8 bundle stopped being used and openEuler got its own bundle.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #7642

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
