### PR TITLE
QE: Fix Recurring Actions test

### DIFF
--- a/testsuite/features/secondary/min_recurring_action.feature
+++ b/testsuite/features/secondary/min_recurring_action.feature
@@ -195,13 +195,47 @@ Feature: Recurring Actions
     When I am on the Systems overview page of this "sle_minion"
     Then I wait until I see "System is up to date" text, refreshing the page
 
+@susemanager
   Scenario: Cleanup: subscribe system back to default base channel
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
     And I check default base channel radio button of this "sle_minion"
+    And I wait for child channels to appear
+    And I include the recommended child channels
+    And I wait until "SLE-Module-Basesystem15-SP4-Pool for x86_64" has been checked
+    And I wait until "SLE-Module-Basesystem15-SP4-Updates for x86_64" has been checked
+    And I wait until "SLE-Module-Server-Applications15-SP4-Pool for x86_64" has been checked
+    And I wait until "SLE-Module-Server-Applications15-SP4-Updates for x86_64" has been checked
+    And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"
+    And I wait until "SLE-Module-DevTools15-SP4-Updates for x86_64" has been checked
+    And I wait until "SLE-Module-Desktop-Applications15-SP4-Pool for x86_64" has been checked
+    And I wait until "SLE-Module-Desktop-Applications15-SP4-Updates for x86_64" has been checked
+    And I check "SLE-Module-Containers15-SP4-Pool for x86_64"
+    And I wait until "SLE-Module-Containers15-SP4-Updates for x86_64" has been checked
+    And I check "Fake-RPM-SUSE-Channel"
+    And I click on "Next"
+    Then I should see a "Confirm Software Channel Change" text
+    When I click on "Confirm"
+    Then I should see a "Changing the channels has been scheduled." text
+    And I wait until event "Subscribe channels scheduled by admin" is completed
+
+@uyuni
+  Scenario: Cleanup: subscribe system back to default base channel
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
+    And I check default base channel radio button of this "sle_minion"
+    And I wait for child channels to appear
+    And I check "openSUSE 15.5 non oss (x86_64)"
+    And I check "openSUSE Leap 15.5 non oss Updates (x86_64)"
+    And I check "openSUSE Leap 15.5 Updates (x86_64)"
+    And I check "Update repository of openSUSE Leap 15.5 Backports (x86_64)"
+    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
+    And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)"
+    And I check "Fake-RPM-SUSE-Channel"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"

--- a/testsuite/features/step_definitions/datepicker_steps.rb
+++ b/testsuite/features/step_definitions/datepicker_steps.rb
@@ -12,7 +12,7 @@ require 'date'
 def get_future_time(minutes_to_add)
   now = Time.new
   future_time = now + 60 * minutes_to_add.to_i
-  future_time.strftime('%k:%M').to_s.strip
+  future_time.strftime('%H:%M').to_s.strip
 end
 
 Given(/^I pick "([^"]*)" as date$/) do |desired_date|

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -248,9 +248,9 @@ When(/^I enter "([^"]*)" as "([^"]*)"$/) do |text, field|
 end
 
 When(/^I enter (\d+) minutes from now as "([^"]*)"$/) do |minutes_to_add, field|
-  future_time = Time.now + 60 * minutes_to_add.to_i
-  future_time.strftime('%H:%M').to_s.strip
+  future_time = get_future_time(minutes_to_add)
   fill_in(field, with: future_time, fill_options: { clear: :backspace })
+  log "Execution time: #{future_time}"
 end
 
 When(/^I enter "([^"]*)" as "([^"]*)" text area$/) do |arg1, arg2|


### PR DESCRIPTION
## What does this PR change?

This will

- restore idempotency regarding SUSE minion child channels
- fix the issue with the event not showing up
The screenshot below shows e.g. the output of

```cucumber
And I check radio button "schedule-daily"
And I enter 2 minutes from now as "time-daily_time"
```
scheduled at around 11:21 am, but this is definitely not nearly around Europe/Berlin.

  ![Image](https://github.com/SUSE/spacewalk/assets/12104291/99ca039c-f516-4c85-9b69-cf34de915a0d)

I adjusted the `get_future_time()` method according to the following:

https://ruby-doc.org/stdlib-2.5.8/libdoc/date/rdoc/DateTime.html#method-i-strftime
>Time (Hour, Minute, Second, Subsecond):
  %H - Hour of the day, 24-hour clock, zero-padded (00..23)
  %k - Hour of the day, 24-hour clock, blank-padded ( 0..23)


This method was only used in package installation tests, which I tested with my new changes. I also make use of this method in one of the steps used in our Recurring Actions tests to prevent code duplication. I tested this on HEAD.

### Package installation step that uses `get_future_time()` with the new change
```bash
  Scenario: Install package in the future and check for staging                             # features/dom.feature:6
      This scenario ran at: 2023-10-05 13:26:50 +0200
Initializing a twopence node for 'sle_minion'.
Host 'sle_minion' is alive with determined hostname suma-head-min-sles15 and FQDN suma-head-min-sles15.mgr.suse.de
Node: suma-head-min-sles15, OS Version: 15-SP4, Family: sles
    Given I am on the Systems overview page of this "sle_minion"                            # features/step_definitions/navigation_steps.rb:429
    And I follow "Software" in the content area                                             # features/step_definitions/navigation_steps.rb:325
      WARN: Step ends with an ajax transition not finished, let's wait a bit!
    And I follow "Packages" in the content area                                             # features/step_definitions/navigation_steps.rb:325
      WARN: Step ends with an ajax transition not finished, let's wait a bit!
    And I follow "Install" in the content area                                              # features/step_definitions/navigation_steps.rb:325
      WARN: Step ends with an ajax transition not finished, let's wait a bit!
    And I enter "orion-dummy-1.1-1.1" as the filtered package name                          # features/step_definitions/navigation_steps.rb:830
    And I click on the filter button                                                        # features/step_definitions/navigation_steps.rb:804
    When I check row with "orion-dummy-1.1-1.1" and arch of "sle_minion"                    # features/step_definitions/navigation_steps.rb:866
    And I click on "Install Selected Packages"                                              # features/step_definitions/navigation_steps.rb:282
    And I pick 3 minutes from now as schedule time                                          # features/step_definitions/datepicker_steps.rb:72
    And I click on "Confirm"                                                                # features/step_definitions/navigation_steps.rb:282
    Then I should see a "1 package install has been scheduled for" text                     # features/step_definitions/navigation_steps.rb:600
    And I wait until the package "orion-dummy-1.1-1.1" has been cached on this "sle_minion" # features/step_definitions/command_steps.rb:954
    And I wait for "orion-dummy-1.1-1.1" to be installed on "sle_minion"                    # features/step_definitions/command_steps.rb:171
      This scenario took: 146 seconds

2 scenarios (2 passed)
14 steps (14 passed)
2m28.823s
```

### Recurring Actions

```bash
suma-head-ctl:~/spacewalk/testsuite # cucumber features/secondary/min_recurring_action.feature
Capybara APP Host: https://suma-head-srv.mgr.suse.de:8888
Initializing a twopence node for 'server'.
Host 'server' is alive with determined hostname suma-head-srv and FQDN suma-head-srv.mgr.suse.de
Node: suma-head-srv, OS Version: 15-SP4, Family: sles
Activating XML-RPC API
Using the default profile...
# Copyright (c) 2020-2023 SUSE LLC
# Licensed under the terms of the MIT license.
@skip_if_github_validation @scope_recurring_actions
Feature: Recurring Actions
(...)
31 scenarios (31 passed)
338 steps (338 passed)
8m54.327s
```

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were adjusted

- [x] **DONE**

## Links

- Manager 4.3: 
- Fixes https://github.com/SUSE/spacewalk/issues/22654
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
