### PR TITLE
testsuite: update reposync to leap 15.5

### DIFF
--- a/testsuite/features/reposync/reference_srv_check_reposync.feature
+++ b/testsuite/features/reposync/reference_srv_check_reposync.feature
@@ -38,13 +38,13 @@ Feature: Reposync works as expected
     And I wait until the channel "sle-module-containers15-sp4-pool-x86_64" has been synced with packages
 
 @uyuni
-  Scenario: Check reposync of openSUSE Leap 15.4 channels being finished
-    Then I wait until the channel "opensuse_leap15_4" has been synced with packages
-    And I wait until the channel "opensuse_leap15_4-non-oss" has been synced with packages
-    And I wait until the channel "opensuse_leap15_4-non-oss-updates" has been synced with packages
-    And I wait until the channel "opensuse_leap15_4-updates" has been synced with packages
-    And I wait until the channel "opensuse_leap15_4-backports-updates" has been synced with packages
-    And I wait until the channel "opensuse_leap15_4-sle-updates" has been synced with packages
+  Scenario: Check reposync of openSUSE Leap 15.5 channels being finished
+    Then I wait until the channel "opensuse_leap15_5" has been synced with packages
+    And I wait until the channel "opensuse_leap15_5-non-oss" has been synced with packages
+    And I wait until the channel "opensuse_leap15_5-non-oss-updates" has been synced with packages
+    And I wait until the channel "opensuse_leap15_5-updates" has been synced with packages
+    And I wait until the channel "opensuse_leap15_5-backports-updates" has been synced with packages
+    And I wait until the channel "opensuse_leap15_5-sle-updates" has been synced with packages
     And I wait until the channel "uyuni-proxy-devel-leap" has been synced with packages
 
 @scc_credentials
@@ -58,6 +58,6 @@ Feature: Reposync works as expected
 
 @uyuni
   Scenario: Check reposync of Client Tools being finished
-    And I wait until the channel "opensuse_leap15_4-uyuni-client" has been synced with packages
+    And I wait until the channel "opensuse_leap15_5-uyuni-client" has been synced with packages
     And I wait until the channel "rockylinux8-uyuni-client-x86_64" has been synced with packages
     And I wait until the channel "ubuntu-2204-amd64-uyuni-client" has been synced with packages

--- a/testsuite/features/reposync/reference_srv_sync_products_extra.feature
+++ b/testsuite/features/reposync/reference_srv_sync_products_extra.feature
@@ -16,8 +16,8 @@ Feature: Synchronize extra products in the products page of the Setup Wizard
     When I use spacewalk-common-channel to add channel "sle-product-sles15-sp4-pool-x86_64 sles15-sp4-uyuni-client" with arch "x86_64"
 
 @uyuni
-  Scenario: Add openSUSE Leap 15.4 product, including Uyuni Client Tools
-    When I use spacewalk-common-channel to add channel "opensuse_leap15_4 opensuse_leap15_4-non-oss opensuse_leap15_4-non-oss-updates opensuse_leap15_4-updates opensuse_leap15_4-backports-updates opensuse_leap15_4-sle-updates uyuni-proxy-devel-leap opensuse_leap15_4-uyuni-client" with arch "x86_64"
+  Scenario: Add openSUSE Leap 15.5 product, including Uyuni Client Tools
+    When I use spacewalk-common-channel to add channel "opensuse_leap15_5 opensuse_leap15_5-non-oss opensuse_leap15_5-non-oss-updates opensuse_leap15_5-updates opensuse_leap15_5-backports-updates opensuse_leap15_5-sle-updates uyuni-proxy-devel-leap opensuse_leap15_5-uyuni-client" with arch "x86_64"
 
 @scc_credentials
 @susemanager


### PR DESCRIPTION
## What does this PR change?

This updates the reposync tests to leap 15.5

## GUI diff

No difference.


- [ ] **DONE**

## Documentation
- No documentation needed

- [ ] **DONE**

## Test coverage
- This is a test

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/22688


- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
