### PR TITLE
Testsuite: update test containers to leap 15.5

### DIFF
--- a/testsuite/dockerfiles/controller-dev/Dockerfile
+++ b/testsuite/dockerfiles/controller-dev/Dockerfile
@@ -1,6 +1,6 @@
-FROM opensuse/leap:15.4
+FROM opensuse/leap:15.5
 RUN zypper ref -f && \ 
-    zypper -n ar --no-gpgcheck http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.4/ tools && \
+    zypper -n ar --no-gpgcheck http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.5/ tools && \
     zypper -n install nmap tar gzip iputils \
       gcc \
       make \
@@ -18,7 +18,7 @@ RUN zypper ref -f && \
       zlib-devel \
       libxslt-devel \
       mozilla-nss-tools \
-      postgresql-devel \
+      postgresql14-devel \
       ruby2.5-rubygem-bundler \
       twopence \
       python-twopence \
@@ -28,7 +28,7 @@ RUN zypper ref -f && \
       rubygem-twopence \
       chromium \
       chromedriver \
-      npm8 \
+      npm \
       openssh-server \
       openssh-clients \
       hostname \

--- a/testsuite/dockerfiles/opensuse-minion/Dockerfile
+++ b/testsuite/dockerfiles/opensuse-minion/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/leap:15.4
+FROM opensuse/leap:15.5
 RUN zypper -n ar --no-gpgcheck https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/ Uyuni-Server-POOL-x86_64 && \
     zypper -n ar --no-gpgcheck https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm/systemsmanagement:Uyuni:Test-Packages:Pool.repo && \
     zypper ref -f && \ 

--- a/testsuite/dockerfiles/server-all-in-one/Dockerfile
+++ b/testsuite/dockerfiles/server-all-in-one/Dockerfile
@@ -1,11 +1,11 @@
-FROM registry.suse.com/bci/bci-init:15.4
+FROM registry.suse.com/bci/bci-init:15.5
 # from https://raw.githubusercontent.com/rjmateus/uyuni-container/main/uyuni/Dockerfile
 
-RUN zypper ar -G http://download.opensuse.org/update/leap/15.4/backports/ backports_update_repo
-RUN zypper ar -G http://download.opensuse.org/distribution/leap/15.4/repo/oss/ os_pool_repo
-RUN zypper ar -G http://download.opensuse.org/update/leap/15.4/oss/ os_update_repo
+RUN zypper ar -G http://download.opensuse.org/update/leap/15.5/backports/ backports_update_repo
+RUN zypper ar -G http://download.opensuse.org/distribution/leap/15.5/repo/oss/ os_pool_repo
+RUN zypper ar -G http://download.opensuse.org/update/leap/15.5/oss/ os_update_repo
 RUN zypper ar -G http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/ server_pool_repo
-RUN zypper ar -G http://download.opensuse.org/update/leap/15.4/sle/ sle_update_repo
+RUN zypper ar -G http://download.opensuse.org/update/leap/15.5/sle/ sle_update_repo
 RUN zypper ar -G http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Testing-Overlay-POOL-x86_64-Media1/ testing_overlay_devel_repo
 
 copy setup_env.sh /root/setup_env.sh


### PR DESCRIPTION
## What does this PR change?

Testsuite: update test containers to leap 15.5

## GUI diff

No difference.



- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests
- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/22694


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
