### PR TITLE
fix token check of image build repositories

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
@@ -71,8 +71,7 @@ public class DownloadController {
 
     private static final Key KEY = TokenBuilder.getKeyForSecret(
             TokenBuilder.getServerSecret().orElseThrow(
-                        () -> new IllegalArgumentException(
-                                "Server has no key configured")));
+                        () -> new IllegalArgumentException("Server has no key configured")));
     private static final JwtConsumer JWT_CONSUMER = new JwtConsumerBuilder()
             .setVerificationKey(KEY)
             .build();
@@ -385,8 +384,7 @@ public class DownloadController {
         }
         catch (URISyntaxException e) {
             LOG.error("Unable to parse: {}", request.url());
-            halt(HttpStatus.SC_INTERNAL_SERVER_ERROR,
-                    String.format("url '%s' is malformed", request.url()));
+            halt(HttpStatus.SC_INTERNAL_SERVER_ERROR, String.format("url '%s' is malformed", request.url()));
         }
 
         String basename = FilenameUtils.getBaseName(path);
@@ -404,8 +402,7 @@ public class DownloadController {
             if (LOG.isDebugEnabled()) {
                 LOG.error("{}: Package not found in channel: {}", path, StringUtil.sanitizeLogInput(channel));
             }
-            halt(HttpStatus.SC_NOT_FOUND,
-                 String.format("%s not found in %s", basename, channel));
+            halt(HttpStatus.SC_NOT_FOUND, String.format("%s not found in %s", basename, channel));
         }
 
         File file = new File(mountPoint, pkg.getPath()).getAbsoluteFile();
@@ -469,8 +466,7 @@ public class DownloadController {
             if (LOG.isInfoEnabled()) {
                 LOG.info("Forbidden: You need a token to access {}", request.pathInfo().replaceAll("[\n\r\t]", "_"));
             }
-            halt(HttpStatus.SC_FORBIDDEN,
-                 String.format("You need a token to access %s", request.pathInfo()));
+            halt(HttpStatus.SC_FORBIDDEN, String.format("You need a token to access %s", request.pathInfo()));
         }
         if ((queryParams.size() > 1 && header == null) ||
                 (!queryParams.isEmpty() && header != null)) {
@@ -511,14 +507,12 @@ public class DownloadController {
         AccessTokenFactory.lookupByToken(token).ifPresentOrElse(obj -> {
             Instant now = Instant.now();
             if (!obj.getValid() || now.isAfter(obj.getExpiration().toInstant())) {
-                LOG.info(String.format("Forbidden: invalid token %s to access %s", token, filename));
+                LOG.info("Forbidden: invalid token {} to access {}", token, filename);
                 halt(HttpStatus.SC_FORBIDDEN, "This token is not valid");
             }
-        }, () -> {
-            LOG.debug(String.format(
-                    "Token %s to access %s doesn't exists in the database - could be an image build token",
-                    token, filename));
-        });
+        }, () -> LOG.debug("Token {} to access {} doesn't exists in the database - could be an image build token",
+                token, filename)
+        );
         try {
             JwtClaims claims = JWT_CONSUMER.processToClaims(token);
 
@@ -534,13 +528,11 @@ public class DownloadController {
                     // new versions of getStringListClaimValue() return an empty list instead of null
                     .filter(l -> !l.isEmpty());
             Opt.consume(channelClaim,
-                    () -> LOG.info(String.format("Token %s does provide access to any channel", token)),
+                    () -> LOG.info("Token {} does provide access to any channel", token),
                     channels -> {
                 if (!channels.contains(channel)) {
-                    LOG.info(String.format("Forbidden: Token %s does not provide access to channel %s",
-                                           token, channel));
-                    LOG.info(String.format("Token allow access only to the following channels: %s",
-                                           String.join(",", channels)));
+                    LOG.info("Forbidden: Token {} does not provide access to channel {}", token, channel);
+                    LOG.info("Token allow access only to the following channels: {}", String.join(",", channels));
                     halt(HttpStatus.SC_FORBIDDEN, "Token " + token + " does not provide access to channel " + channel);
                 }
             });
@@ -552,14 +544,14 @@ public class DownloadController {
                 halt(HttpStatus.SC_BAD_REQUEST, "Token does not specify the organization");
             }, orgId -> {
                 if (!ChannelFactory.isAccessibleBy(channel, orgId)) {
-                    LOG.info(String.format("Forbidden: Token does not provide access to channel %s", channel));
+                    LOG.info("Forbidden: Token does not provide access to channel {}", channel);
                     halt(HttpStatus.SC_FORBIDDEN, "Token does not provide access to channel " + channel);
                 }
             });
         }
         catch (InvalidJwtException | MalformedClaimException e) {
-            LOG.info(String.format("Forbidden: Token %s is not valid to access %s in %s: %s",
-                    token, filename, channel, e.getMessage()));
+            LOG.info("Forbidden: Token %s is not valid to access {} in {}: {}", token, filename, channel,
+                    e.getMessage());
             halt(HttpStatus.SC_FORBIDDEN,
                  String.format("Token is not valid to access %s in %s: %s", filename, channel, e.getMessage()));
         }

--- a/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
@@ -515,8 +515,9 @@ public class DownloadController {
                 halt(HttpStatus.SC_FORBIDDEN, "This token is not valid");
             }
         }, () -> {
-            LOG.info(String.format("Forbidden: token %s to access %s doesn't exists in the database", token, filename));
-            halt(HttpStatus.SC_FORBIDDEN, "This token is not valid");
+            LOG.debug(String.format(
+                    "Token %s to access %s doesn't exists in the database - could be an image build token",
+                    token, filename));
         });
         try {
             JwtClaims claims = JWT_CONSUMER.processToClaims(token);


### PR DESCRIPTION
## What does this PR change?

Download Tokens of image build repositories are not stored in DB.
The valid check needs to pass if they are not found.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/22727

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
