### PR TITLE
Use checkout@v1 in susemanager-sls-compatible-python26-syntax workflow

### DIFF
--- a/.github/workflows/susemanager-sls-compatible-python26-syntax.yml
+++ b/.github/workflows/susemanager-sls-compatible-python26-syntax.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       # We need to use "checkout@v1" here as is the only version compatible with Python 2.6
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v1
 
       - name: Configure repos from CentOS vault
         run: |


### PR DESCRIPTION
## What does this PR change?

Checkout@v1 is the only version compatible with python 2.6. Using a higher version leads to workflows failing when checking out the repo, see https://github.com/uyuni-project/uyuni/actions/runs/6427883155/job/17454183064?pr=7466

Refs https://github.com/uyuni-project/uyuni/pull/7498
## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
