### PR TITLE
Skip sync SLE channels in github actions

### DIFF
--- a/testsuite/features/core/srv_create_activationkey.feature
+++ b/testsuite/features/core/srv_create_activationkey.feature
@@ -116,6 +116,7 @@ Feature: Create activation keys
     And I click on "Create Activation Key"
     Then I should see a "Activation key Build host Key x86_64 has been created" text
 
+@scc_credentials
   Scenario: Create an activation key for the terminal
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"

--- a/testsuite/features/init_clients/allcli_update_activationkeys.feature
+++ b/testsuite/features/init_clients/allcli_update_activationkeys.feature
@@ -190,6 +190,7 @@ Feature: Update activation keys
     Then I should see a "Activation key Terminal Key x86_64 has been modified" text
 
 @susemanager
+@scc_credentials
   Scenario: Update terminal key with normal SUSE fake channel
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Terminal Key x86_64" in the content area
@@ -199,6 +200,7 @@ Feature: Update activation keys
     Then I should see a "Activation key Terminal Key x86_64 has been modified" text
 
 @uyuni
+@scc_credentials
   Scenario: Update terminal key with specific fake channel
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Terminal Key x86_64" in the content area

--- a/testsuite/features/reposync/srv_sync_fake_channels.feature
+++ b/testsuite/features/reposync/srv_sync_fake_channels.feature
@@ -49,6 +49,7 @@ Feature: Prepare fake SUSE channels
     And solver file for "fake-rpm-suse-channel" should reference "orion-dummy-1.1-1.1.x86_64.rpm"
 
 @uyuni
+@scc_credentials
   Scenario: Add the terminal child channel to the base product channel
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
@@ -62,6 +63,7 @@ Feature: Prepare fake SUSE channels
     Then I should see a "Channel Fake-RPM-Terminal-Channel created." text
 
 @uyuni
+@scc_credentials
   Scenario: Add the repository to the terminal child channel
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Fake-RPM-Terminal-Channel"
@@ -74,6 +76,7 @@ Feature: Prepare fake SUSE channels
     Then I should see a "Fake-RPM-Terminal-Channel repository information was successfully updated" text
 
 @uyuni
+@scc_credentials
   Scenario: Synchronize the repository in the terminal channel
     When I enable source package syncing
     And I follow the left menu "Software > Manage > Channels"
@@ -87,6 +90,7 @@ Feature: Prepare fake SUSE channels
     And I disable source package syncing
 
 @uyuni
+@scc_credentials
   Scenario: Verify state of Fake-RPM-Terminal-Channel custom channel
     Then "orion-dummy-1.1-1.1.x86_64.rpm" package should have been stored
     And solver file for "fake-rpm-terminal-channel" should reference "orion-dummy-1.1-1.1.x86_64.rpm"


### PR DESCRIPTION
## What does this PR change?

Test suite change:

We do not have SCC credentials to sync SLE channels. In any case, this was needed for the build host, for the retail use case, which is not tested in gh actions anyway.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

N/A
- [X]  **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
