### PR TITLE
Consider server id when removing invalid erratas from rhnSet

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Errata_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Errata_queries.xml
@@ -848,11 +848,11 @@ ORDER BY E.update_date, E.id
 </mode>
 
 <write-mode name="delete_invalid_erratas_from_set">
-  <query params="label">
+  <query params="label,server_id">
     DELETE FROM rhnSet
       WHERE label = :label
         AND element not in (
-          select errata_id from rhnServerNeededErrataCache where errata_id is not null
+          select errata_id from rhnServerNeededErrataCache where errata_id is not null and server_id = :server_id
         )
     </query>
 </write-mode>

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -2218,6 +2218,7 @@ public class ErrataManager extends BaseManager {
         String errataLabel = RhnSetDecl.generateCustomSetName(RhnSetDecl.ERRATA, serverId);
         Map<String, Object> params = new HashMap<>();
         params.put("label", errataLabel);
+        params.put("server_id", serverId);
         WriteMode m = ModeFactory.getWriteMode(ERRATA_QUERIES, "delete_invalid_erratas_from_set");
         m.executeUpdate(params);
     }

--- a/java/spacewalk-java.changes.welder.improve-invalid-errata-delete
+++ b/java/spacewalk-java.changes.welder.improve-invalid-errata-delete
@@ -1,0 +1,1 @@
+- Consider server id when removing invalid erratas from rhnSet (bsc#1204235,bsc#1207012,bsc#1211560)


### PR DESCRIPTION
## What does this PR change?

**Context**
After a successful patch installation, an update to the server needed cache is scheduled to run, but it takes up to a minute to effectively run and reflect on the WebUI. In this interval, an already installed patch is available for selection, and selecting it at this moment marks it to be installed again. After some seconds, the patch disappear from the screen and there is no chance to remove the it after that, only running a database script.

**Changes in this PR:**
This PR takes the server id into consideration when removing invalid erratas from `rhnSet`. With that we avoid the situation where the errata is invalid for a server but is in the `rhnServerNeededErrataCache` because of it is valid for other server.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: legacy code

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
