### PR TITLE
fix(4746): Do not link and sync pkgs that fail to download

### DIFF
--- a/python/spacewalk/satellite_tools/download.py
+++ b/python/spacewalk/satellite_tools/download.py
@@ -284,9 +284,8 @@ class DownloadThread(Thread):
                 self.parent.log_obj.log(success, os.path.basename(params['relative_path']))
             self.queue.task_done()
             if not success:
-                package = os.path.basename(params['relative_path'])
-                # append package name without extension
-                self.failed_pkgs.add(package.rsplit('.', maxsplit=1)[0])
+                package = os.path.basename(params['target_file'])
+                self.failed_pkgs.add(package)
         self.curl.close()
 
 

--- a/python/spacewalk/satellite_tools/reposync.py
+++ b/python/spacewalk/satellite_tools/reposync.py
@@ -1152,6 +1152,9 @@ class RepoSync(object):
         downloader.set_log_obj(logger)
         downloader.run()
 
+        log(0, 'Filtering packages that failed to download')
+        to_process = [i for i in to_process if i[0].getNVREA() not in downloader.failed_pkgs]
+
         log2background(0, "Importing packages started.")
         log(0, '')
         log(0, '  Importing packages to DB:')

--- a/python/spacewalk/satellite_tools/reposync.py
+++ b/python/spacewalk/satellite_tools/reposync.py
@@ -1153,7 +1153,7 @@ class RepoSync(object):
         downloader.run()
 
         log(0, 'Filtering packages that failed to download')
-        to_process = [i for i in to_process if i[0].getNVREA() not in downloader.failed_pkgs]
+        to_process = [i for i in to_process if os.path.basename(i[0].path) not in downloader.failed_pkgs]
 
         log2background(0, "Importing packages started.")
         log(0, '')

--- a/python/spacewalk/satellite_tools/spacewalk-repo-sync
+++ b/python/spacewalk/satellite_tools/spacewalk-repo-sync
@@ -23,7 +23,6 @@ except ImportError:
     #  python3
     import io as StringIO
 import json
-import shutil
 import sys
 import os
 from optparse import OptionParser

--- a/python/spacewalk/satellite_tools/spacewalk-repo-sync
+++ b/python/spacewalk/satellite_tools/spacewalk-repo-sync
@@ -23,6 +23,7 @@ except ImportError:
     #  python3
     import io as StringIO
 import json
+import shutil
 import sys
 import os
 from optparse import OptionParser

--- a/python/spacewalk/spacewalk-backend.changes.mczernek.4746
+++ b/python/spacewalk/spacewalk-backend.changes.mczernek.4746
@@ -1,0 +1,1 @@
+- prevent reposync from processing failed packages

--- a/python/test/unit/spacewalk/satellite_tools/test_download.py
+++ b/python/test/unit/spacewalk/satellite_tools/test_download.py
@@ -58,6 +58,34 @@ def test_reposync_timeout_minrate_are_passed_to_curl():
 
 @patch("uyuni.common.context_managers.initCFG", Mock())
 @patch("spacewalk.satellite_tools.download.log", Mock())  # no logging
+@patch("spacewalk.satellite_tools.download.log2", Mock())  # no logging
+@patch("spacewalk.satellite_tools.download.PyCurlFileObjectThread", Mock(return_value=None)) # fail download 
+def test_reposync_sets_failed_pkgs():
+    fail_pkg_name = "fail.rpm"
+    params = NoKeyErrorsDict({
+        "http_headers": dict(), 
+        "urls": ["http://example.com"], 
+        "target_file": fail_pkg_name})
+
+    CFG = Mock()
+    CFG.REPOSYNC_TIMEOUT = 1
+    CFG.REPOSYNC_MINRATE = 1
+    CFG.REPOSYNC_DOWNLOAD_THREADS = 1
+
+    curl_spy = Mock()
+
+    with patch(
+        "spacewalk.satellite_tools.download.pycurl.Curl", Mock(return_value=curl_spy)
+    ), patch("uyuni.common.context_managers.CFG", CFG):
+        td = ThreadedDownloader(retries=0, force=True)
+        td.add(params)
+        td.run()
+        assert len(td.failed_pkgs) == 1
+        assert fail_pkg_name in td.failed_pkgs
+
+
+@patch("uyuni.common.context_managers.initCFG", Mock())
+@patch("spacewalk.satellite_tools.download.log", Mock())  # no logging
 @patch("urlgrabber.grabber.PyCurlFileObject._do_grab", Mock())  # no downloads
 @patch("urlgrabber.grabber.PyCurlFileObject.close", Mock())  # no need to close files
 @patch("spacewalk.satellite_tools.download.os.path.isfile", Mock(return_value=False))
@@ -117,3 +145,34 @@ def test_reposync_download_thread_fetch_url_proxy_pass():
         assert "proxy" not in url_grabber_opts_mock.mock_calls[1].kwargs
         assert "username" not in url_grabber_opts_mock.mock_calls[1].kwargs
         assert "password" not in url_grabber_opts_mock.mock_calls[1].kwargs
+
+
+def test_reposync_download_thread_sets_failed_pkg():
+    failed_pkg_name = "failed.rpm"
+    queue = Queue()
+    queue.put(
+        {
+            "ssl_ca_cert": None,
+            "ssl_client_cert": None,
+            "ssl_client_key": None,
+            "bytes_range": None,
+            "http_headers": {},
+            "timeout": None,
+            "minrate": None,
+            "urls": ["http://example.com:8080"],
+            "relative_path": failed_pkg_name,
+            "urlgrabber_logspec": None,
+            "proxies": [],
+            "target_file": failed_pkg_name
+        }
+    )
+    parent_mock = Mock()
+    parent_mock.retries = 0
+    url_grabber_opts_mock = Mock()
+    url_grabber_opts_mock.return_value.retrycodes = [-1]
+    with patch(
+        "spacewalk.satellite_tools.download.URLGrabberOptions", url_grabber_opts_mock
+    ):
+        thread = DownloadThread(parent_mock, queue)
+        thread.run()
+        assert failed_pkg_name in thread.failed_pkgs

--- a/python/test/unit/spacewalk/satellite_tools/test_download.py
+++ b/python/test/unit/spacewalk/satellite_tools/test_download.py
@@ -59,8 +59,8 @@ def test_reposync_timeout_minrate_are_passed_to_curl():
 @patch("uyuni.common.context_managers.initCFG", Mock())
 @patch("spacewalk.satellite_tools.download.log", Mock())  # no logging
 @patch("spacewalk.satellite_tools.download.log2", Mock())  # no logging
-@patch("spacewalk.satellite_tools.download.PyCurlFileObjectThread", Mock(return_value=None)) # fail download 
-def test_reposync_sets_failed_pkgs():
+@patch("spacewalk.satellite_tools.download.PyCurlFileObjectThread", Mock(return_value=None))  # fail download
+def test_reposync_threaded_downloader_sets_failed_pkgs():
     fail_pkg_name = "fail.rpm"
     params = NoKeyErrorsDict({
         "http_headers": dict(), 

--- a/python/test/unit/spacewalk/satellite_tools/test_reposync.py
+++ b/python/test/unit/spacewalk/satellite_tools/test_reposync.py
@@ -233,7 +233,7 @@ class RepoSyncTest(unittest.TestCase):
     @patch("spacewalk.satellite_tools.reposync.os", os)
     @patch("spacewalk.satellite_tools.reposync.ThreadedDownloader")
     @patch("spacewalk.satellite_tools.reposync.multiprocessing.Pool")
-    def test_sync_excludes_failed_pkgs(self, pool, downloader):
+    def test_import_packages_excludes_failed_pkgs(self, pool, downloader):
         """
         When downloader fails to download a subset of packages
         Then the RepoSync.import_packages function should not process the failed packages


### PR DESCRIPTION
## What does this PR change?

When a package fails to download, `reposync.py` still tries to process and link it internally. This PR fixes https://github.com/uyuni-project/uyuni/issues/4746

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
