### PR TITLE
Fix payg cert import

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygAuthDataProcessor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygAuthDataProcessor.java
@@ -230,6 +230,11 @@ public class PaygAuthDataProcessor {
 
         instance.setRmtHosts(rmtHost);
         PaygSshDataFactory.savePaygSshData(instance);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("CloudRmtHost Hostname: {}", rmtHost.getHost());
+            LOG.debug("CloudRmtHost IP: {}", rmtHost.getIp());
+            LOG.debug("CloudRmtHost SSL Cert: {}", rmtHost.getSslCert());
+        }
     }
 
     private Credentials processAndGetCredentials(PaygSshData instance, PaygInstanceInfo paygData)

--- a/java/code/src/com/redhat/rhn/taskomatic/task/payg/script/payg_extract_repo_data.py
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/payg/script/payg_extract_repo_data.py
@@ -115,9 +115,9 @@ def _extract_rmt_server_info(netloc):
         system_exit(4, ["unable to get ip for repository server (error {}):".format(e)])
 
     server_ip = host_ip_output.split(" ")[0].strip()
-    ca_cert_path = "/usr/share/pki/trust/anchors/registration_server_%s.pem" % server_ip.replace('.','_')
+    ca_cert_path = "/etc/pki/trust/anchors/registration_server_%s.pem" % server_ip.replace('.','_')
     if not Path(ca_cert_path).exists():
-        ca_cert_path = "/etc/pki/trust/anchors/registration_server_%s.pem" % server_ip.replace('.','_')
+        ca_cert_path = "/usr/share/pki/trust/anchors/registration_server_%s.pem" % server_ip.replace('.','_')
         if not Path(ca_cert_path).exists():
             system_exit(6, ["CA file for server {} not found (location '/etc/pki/trust/anchors/' or '/usr/share/pki/trust/anchors/')".format( server_ip)])
     with open(ca_cert_path) as f:

--- a/java/spacewalk-java.changes.mc.Manager-4.3-fix-payg-cert-import
+++ b/java/spacewalk-java.changes.mc.Manager-4.3-fix-payg-cert-import
@@ -1,0 +1,2 @@
+- look for the PAYG CA certificate location in different order to
+  find and import the correct one (bsc#1214759)


### PR DESCRIPTION
## What does this PR change?

The payg import script look for the RMT CA certificate in the following order:

1. /usr/share/pki/trust/anchors/
2. /etc/pki/trust/anchors/

This order seems to be wrong as updates to certificates are applied to /etc/ only.
This cause old certificates are still available in /usr/... and gets imported (first match win)
while the new certificates in /etc/ are ignored.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/22695

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
