### PR TITLE
Fix modify kickstart profile when using "Always newest tree" option

### DIFF
--- a/java/code/webapp/WEB-INF/pages/kickstart/softwareedit.jsp
+++ b/java/code/webapp/WEB-INF/pages/kickstart/softwareedit.jsp
@@ -19,25 +19,31 @@
     }
 
     function toggleKSTree(what) {
-        var form = document.getElementsByName("kickstartSoftwareForm")[0];
+        var form = jQuery("form[name='kickstartSoftwareForm']");
+        var select = form.find("select[id='kstree']");
+
         if(what.checked) {
-            form.tree.disabled=1;
+            select.prop("disabled", "disabled");
         } else {
-            form.tree.disabled=0;
+            select.prop("disabled", false);
         }
     }
 
     function clickNewestRHTree() {
-        var form = document.getElementsByName("kickstartSoftwareForm")[0];
-        if(form.useNewestRHTree.checked) {
-            form.useNewestTree.checked = false;
+        var form = jQuery("form[name='kickstartSoftwareForm']");
+        var treeCheckbox = form.find("input[name='useNewestTree']")
+        var rhTreeCheckbox = form.find("input[name='useNewestRHTree']")
+        if(rhTreeCheckbox.is(':checked')) {
+            treeCheckbox.attr('checked', false);
         }
     }
 
     function clickNewestTree() {
-        var form = document.getElementsByName("kickstartSoftwareForm")[0];
-        if(form.useNewestTree.checked) {
-            form.useNewestRHTree.checked = false;
+        var form = jQuery("form[name='kickstartSoftwareForm']");
+        var treeCheckbox = form.find("input[name='useNewestTree']")
+        var rhTreeCheckbox = form.find("input[name='useNewestRHTree']")
+        if(treeCheckbox.is(':checked')) {
+            rhTreeCheckbox.attr('checked', false);
         }
     }
     //-->
@@ -113,63 +119,37 @@
                                                   labelProperty="label" />
                                 </html:select>
                             </c:if>
-                        </c:when>
-                        <c:otherwise>
-                            <div class="alert alert-warning"><bean:message key="kickstart.edit.software.notrees.jsp" /></div>
-                        </c:otherwise>
-                    </c:choose>
-                </div>
-            </div>
-            <c:choose>
-                <c:when test="${notrees == null}">
-                    <c:if test="${usingNewest == true or usingNewestRH == true}">
-                        <div class="form-group">
-                            <div class="col-lg-offset-3 col-lg-6">
-                                <html:select styleClass="form-control"
-                                             property="tree"
-                                             onchange="reloadForm(this);"
-                                             styleId="kstree"
-                                             disabled="true">
-                                    <html:options collection="trees"
-                                                  property="id"
-                                                  labelProperty="label" />
-                                </html:select>
-                            </div>
-                        </div>
-                    </c:if>
-                    <c:if test="${not (usingNewest == true or usingNewestRH == true)}">
-                        <div class="form-group">
-                            <div class="col-lg-offset-3 col-lg-6">
-                                <html:select styleClass="form-control"
-                                             property="tree"
-                                             onchange="reloadForm(this);"
-                                             styleId="kstree">
-                                    <html:options collection="trees"
-                                                  property="id"
-                                                  labelProperty="label" />
-                                </html:select>
-                            </div>
-                        </div>
-                    </c:if>
-                    <c:if test="${redHatTreesAvailable != null}">
-                        <div class="form-group">
-                            <div class="col-lg-offset-3 col-lg-6">
-                                <div class="checkbox">
-                                    <label>
-                                        <input type="checkbox" name="useNewestRHTree" value="0"
-                                               onclick="toggleKSTree(this); clickNewestRHTree()"
-                                               <c:if test="${usingNewestRH == true}">checked=1</c:if> />
-                                        <bean:message key="kickstart.jsp.create.wizard.kstree.always_new.label"/>
-                                    </label>
-                                </div>
-                                    <div class="help-block">
-                                        <bean:message key="kickstart.jsp.create.wizard.kstree.always_new_RH"/>                                
+                            <c:if test="${not (usingNewest == true or usingNewestRH == true)}">
+                                <div class="form-group">
+                                    <div class="col-lg-6">
+                                        <html:select styleClass="form-control"
+                                                     property="tree"
+                                                     onchange="reloadForm(this);"
+                                                     styleId="kstree">
+                                            <html:options collection="trees"
+                                                          property="id"
+                                                          labelProperty="label" />
+                                        </html:select>
                                     </div>
-                            </div>
-                        </div>
-                    </c:if>
-                    <div class="form-group">
-                        <div class="col-lg-offset-3 col-lg-6">
+                                </div>
+                            </c:if>
+                            <c:if test="${redHatTreesAvailable != null}">
+                                <div class="form-group">
+                                    <div class="col-lg-6">
+                                        <div class="checkbox">
+                                            <label>
+                                                <input type="checkbox" name="useNewestRHTree" value="0"
+                                                       onclick="toggleKSTree(this); clickNewestRHTree()"
+                                                       <c:if test="${usingNewestRH == true}">checked=1</c:if> />
+                                                <bean:message key="kickstart.jsp.create.wizard.kstree.always_new.label"/>
+                                            </label>
+                                        </div>
+                                            <div class="help-block">
+                                                <bean:message key="kickstart.jsp.create.wizard.kstree.always_new_RH"/>
+                                            </div>
+                                    </div>
+                                </div>
+                            </c:if>
                             <div class="checkbox">
                                 <label>
                                     <input type="checkbox"
@@ -183,13 +163,13 @@
                             <div class="help-block">
                                 <bean:message key="kickstart.jsp.create.wizard.kstree.always_new"/>
                             </div>
-                        </div>
-                    </div>
-                </c:when>
-                <c:otherwise>
-                    <div class="alert alert-warning"><bean:message key="kickstart.edit.software.notrees.jsp" /></div>
-                </c:otherwise>
-            </c:choose>
+                        </c:when>
+                        <c:otherwise>
+                            <div class="alert alert-warning"><bean:message key="kickstart.edit.software.notrees.jsp" /></div>
+                        </c:otherwise>
+                    </c:choose>
+                </div>
+            </div>
 
             <div class="form-group">
                 <label class="col-lg-3 control-label">

--- a/java/spacewalk-java.changes.welder.bsc1215813
+++ b/java/spacewalk-java.changes.welder.bsc1215813
@@ -1,0 +1,1 @@
+- Fix modify kickstart profile when using "Always newest tree" option (bsc#1215813)


### PR DESCRIPTION
## What does this PR change?

This PR does basically 2 changes:

 1. It removes a duplicated code that was causing the option for selecting the kickstart tree to be wrongly displayed twice.
 2. It changes the code to use jQuery when manipulating the DOM. Before the change we were facing unexpected errors when clicking on "Always newest tree" and the field for selecting was keeping always disabled. See Bugzilla for reference.

## GUI diff

Before:
![image](https://github.com/uyuni-project/uyuni/assets/17532261/b8dd8a82-f9a5-4a73-b982-6abfc507f57c)

After:
![image](https://github.com/uyuni-project/uyuni/assets/17532261/9a23e4a6-7e8c-42ef-bcf3-df0f5df128f6)

- [x] **DONE**

## Documentation
- No documentation needed: bug fix

- [x] **DONE**

## Test coverage
- No tests: legacy code

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/22655

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
