### PR TITLE
Fix issue where bad scc creds were preventing scc refreshing

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -521,8 +521,7 @@ public class ContentSyncManager {
      */
     private void refreshRepositoriesAuthentication(String mirrorUrl, boolean excludeSCC) throws ContentSyncException {
         List<Credentials> credentials = filterCredentials();
-        // ContentSyncException flag
-        boolean cse = false;
+        Exception syncException = null;
         ChannelFactory.cleanupOrphanVendorContentSource();
 
         // Query repos for all mirror credentials and consolidate

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -541,8 +541,7 @@ public class ContentSyncManager {
                     // test for OES credentials
                     if (c == null || !accessibleUrl(OES_URL, c.getUsername(), c.getPassword())) {
                         LOG.info("Credential is not an OES credentials");
-                        // ContentSyncException flag
-                        cse = true;
+                        syncException = e;
                     }
                 }
                 catch (URISyntaxException e) {

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -521,7 +521,8 @@ public class ContentSyncManager {
      */
     private void refreshRepositoriesAuthentication(String mirrorUrl, boolean excludeSCC) throws ContentSyncException {
         List<Credentials> credentials = filterCredentials();
-
+        // ContentSyncException flag
+        boolean cse = false;
         ChannelFactory.cleanupOrphanVendorContentSource();
 
         // Query repos for all mirror credentials and consolidate
@@ -540,7 +541,8 @@ public class ContentSyncManager {
                     // test for OES credentials
                     if (c == null || !accessibleUrl(OES_URL, c.getUsername(), c.getPassword())) {
                         LOG.info("Credential is not an OES credentials");
-                        throw new ContentSyncException(e);
+                        // ContentSyncException flag
+                        cse = true;
                     }
                 }
                 catch (URISyntaxException e) {
@@ -564,6 +566,10 @@ public class ContentSyncManager {
         ensureSUSEProductChannelData();
         linkAndRefreshContentSource(mirrorUrl);
         ManagerInfoFactory.setLastMgrSyncRefresh();
+
+        if (cse) {
+            throw new ContentSyncException("Invalid credentials");
+        }
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -544,7 +544,7 @@ public class ContentSyncManager {
                     }
                 }
                 catch (URISyntaxException e) {
-                    throw new ContentSyncException(e);
+                    syncException = e;
                 }
             }
             else if (c.isTypeOf(Credentials.TYPE_CLOUD_RMT)) {
@@ -565,8 +565,8 @@ public class ContentSyncManager {
         linkAndRefreshContentSource(mirrorUrl);
         ManagerInfoFactory.setLastMgrSyncRefresh();
 
-        if (cse) {
-            throw new ContentSyncException("Invalid credentials");
+        if (syncException != null) {
+            throw new ContentSyncException(syncException);
         }
     }
 

--- a/java/spacewalk-java.changes.mseidl.Manager-4.3-fix-scc-badcred
+++ b/java/spacewalk-java.changes.mseidl.Manager-4.3-fix-scc-badcred
@@ -1,0 +1,1 @@
+- Fix issue where bad scc creds were preventing other credentials to refresh (bsc#1211355)


### PR DESCRIPTION
## What does this PR change?
Port already merged in 4.3


Fixes issue when with one bad credential would prevent the other good credential from refreshing. 
#21473 
https://bugzilla.suse.com/show_bug.cgi?id=1211355
## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
