### PR TITLE
QE: Fix `update_ca()` for hostname rename tests

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1543,7 +1543,8 @@ When(/^I run spacewalk-hostname-rename command on the server$/) do
   end
 
   # Update the server CA certificate since it changed, otherwise all API and browser uses will fail
-  update_ca
+  update_ca('controller')
+  update_ca('proxy')
 
   # Reset the API client to take the new CA into account
   reset_api_client


### PR DESCRIPTION
## What does this PR change?

It seems we need to update and copy the CA certificate not only to the controller, but also to the proxy.

```bash
❯ rubocop _0.83.0_ features/support/commonlib.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
```

```bash
suma-head-ctl:~/spacewalk/testsuite # cucumber features/secondary/srv_rename_hostname.feature 
Capybara APP Host: https://suma-head-srv.mgr.suse.de:8888
Initializing a twopence node for 'server'.
Host 'server' is alive with determined hostname suma-head-srv and FQDN suma-head-srv.mgr.suse.de
Node: suma-head-srv, OS Version: 15-SP4, Family: sles
Activating XML-RPC API
Using the default profile...
(...)
4 scenarios (4 passed)
15 steps (15 passed)
1m40.624s
```



## GUI diff

No difference.


- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were added
- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
