### PR TITLE
Remove uyuni-build-keys dependency from susemanager rpm

### DIFF
--- a/susemanager/susemanager.changes.mbussolotto.remove_uyuni-build-keys
+++ b/susemanager/susemanager.changes.mbussolotto.remove_uyuni-build-keys
@@ -1,0 +1,1 @@
+- Remove uyuni-build-keys dependency

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -156,7 +156,6 @@ Requires:       spacewalk-backend-sql
 Requires:       spacewalk-common
 Requires:       susemanager-build-keys
 Requires:       susemanager-sync-data
-Requires:       uyuni-build-keys
 BuildRequires:  docbook-utils
 
 %description tools


### PR DESCRIPTION
## What does this PR change?
ERROR:
```
=========== Test SUSE-Manager-Server x86_64 ===========
can't install patterns-suma_server-4.3-150550.10.1.develHead.x86_64:
  package patterns-suma_server-4.3-150550.10.1.develHead.x86_64 requires susemanager-tools, but none of the providers can be installed
  nothing provides uyuni-build-keys needed by susemanager-tools-4.4.8-150550.6.1.develHead.x86_64
```
Remove uyuni-build-keys dependency from susemanager rpm (susemanager-build-keys already priovides it)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed
- 
- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
