### PR TITLE
Add database table stats and configs to the support configs

### DIFF
--- a/python/spacewalk/satellite_tools/spacewalk-debug
+++ b/python/spacewalk/satellite_tools/spacewalk-debug
@@ -328,11 +328,19 @@ fi
 echo "    * get diskspace available"
 df -h > $DIR/diskinfo
 
-echo "    * get database statistics"
-/usr/bin/rhn-db-stats $DIR/database/db-stats.log
+echo "    * get database settings"
+/usr/bin/rhn-db-stats $DIR/database/db-settings.log
 
 echo "    * get schema statistics"
 /usr/bin/rhn-schema-stats $DIR/database/schema-stats.log
+
+echo "    * get tables statistics"
+QUERY="SELECT * FROM pg_stat_user_tables;"
+echo "$QUERY" | /usr/bin/spacewalk-sql --select-mode - > "${DIR}/database/table_stats.log"
+
+echo "    * get per table configuration options"
+QUERY="SELECT relname, reloptions FROM pg_class JOIN pg_namespace ON  pg_namespace.oid = pg_class.relnamespace WHERE pg_namespace.nspname = 'public' AND pg_class.relkind = 'r';"
+echo "$QUERY" | /usr/bin/spacewalk-sql --select-mode - > "${DIR}/database/table_options.log"
 
 # alert.log
 if [ -f /rhnsat/admin/rhnsat/bdump/alert_rhnsat.log ] ; then

--- a/python/spacewalk/spacewalk-backend.changes.oholecek.support-config-db-stats
+++ b/python/spacewalk/spacewalk-backend.changes.oholecek.support-config-db-stats
@@ -1,0 +1,1 @@
+- add table statistics and options to the support config database output


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/22390

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: As far as I know we don't have support config features documented

- [X] **DONE**

## Test coverage
- No tests: **add explanation**

- [X] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/22390

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
