### PR TITLE
Recognize squashfs build results from kiwi

### DIFF
--- a/susemanager-utils/susemanager-sls/src/modules/kiwi_info.py
+++ b/susemanager-utils/susemanager-sls/src/modules/kiwi_info.py
@@ -198,6 +198,7 @@ _compression_types = [
     {"suffix": ".gz", "compression": "gzip"},
     {"suffix": ".bz", "compression": "bzip"},
     {"suffix": ".xz", "compression": "xz"},
+    {"suffix": ".tar.xz", "compression": "xz"},
     {"suffix": ".install.iso", "compression": None},
     {"suffix": ".iso", "compression": None},
     {"suffix": ".qcow2", "compression": None},
@@ -208,6 +209,7 @@ _compression_types = [
     {"suffix": ".vhdx", "compression": None},
     {"suffix": ".vdi", "compression": None},
     {"suffix": ".raw", "compression": None},
+    {"suffix": ".squashfs", "compression": None},
     {"suffix": "", "compression": None},
 ]
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.oholecek.add_squash_fs
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.oholecek.add_squash_fs
@@ -1,0 +1,1 @@
+- Recognize squashfs and tbz build results from kiwi (bsc#1216085)


### PR DESCRIPTION
## What does this PR change?

Our kiwi build inspection was missing squashfs output format. This PR adds recognition of it.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: integration tests cover for regressions, no unit tests are present

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/22772
Tracks https://github.com/SUSE/spacewalk/pull/22743

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
