### PR TITLE
fix opensuse channel names

### DIFF
--- a/testsuite/features/reposync/reference_srv_check_reposync.feature
+++ b/testsuite/features/reposync/reference_srv_check_reposync.feature
@@ -39,13 +39,13 @@ Feature: Reposync works as expected
 
 @uyuni
   Scenario: Check reposync of openSUSE Leap 15.5 channels being finished
-    Then I wait until the channel "opensuse_leap15_5" has been synced with packages
-    And I wait until the channel "opensuse_leap15_5-non-oss" has been synced with packages
-    And I wait until the channel "opensuse_leap15_5-non-oss-updates" has been synced with packages
-    And I wait until the channel "opensuse_leap15_5-updates" has been synced with packages
-    And I wait until the channel "opensuse_leap15_5-backports-updates" has been synced with packages
-    And I wait until the channel "opensuse_leap15_5-sle-updates" has been synced with packages
-    And I wait until the channel "uyuni-proxy-devel-leap" has been synced with packages
+    Then I wait until the channel "opensuse_leap15_5-x86_64" has been synced with packages
+    And I wait until the channel "opensuse_leap15_5-non-oss-x86_64" has been synced with packages
+    And I wait until the channel "opensuse_leap15_5-non-oss-updates-x86_64" has been synced with packages
+    And I wait until the channel "opensuse_leap15_5-updates-x86_64" has been synced with packages
+    And I wait until the channel "opensuse_leap15_5-backports-updates-x86_64" has been synced with packages
+    And I wait until the channel "opensuse_leap15_5-sle-updates-x86_64" has been synced with packages
+    And I wait until the channel "uyuni-proxy-devel-leap-x86_64" has been synced with packages
 
 @scc_credentials
 @susemanager
@@ -58,6 +58,6 @@ Feature: Reposync works as expected
 
 @uyuni
   Scenario: Check reposync of Client Tools being finished
-    And I wait until the channel "opensuse_leap15_5-uyuni-client" has been synced with packages
+    And I wait until the channel "opensuse_leap15_5-uyuni-client-x86_64" has been synced with packages
     And I wait until the channel "rockylinux8-uyuni-client-x86_64" has been synced with packages
     And I wait until the channel "ubuntu-2204-amd64-uyuni-client" has been synced with packages


### PR DESCRIPTION
## What does this PR change?

fix endless

` I am still waiting for 'opensuse_leap15_5' channel to be synchronized.`

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
