### PR TITLE
K3S debug ports and doc update

### DIFF
--- a/containers/doc/server-kubernetes/README.md
+++ b/containers/doc/server-kubernetes/README.md
@@ -39,9 +39,9 @@ for image in cert-manager-cainjector cert-manager-controller cert-manager-ctl ce
   podman save --output $image.tar quay.io/jetstack/$image:latest
 done
 
-podman pull registry.opensuse.org/systemsmanagement/uyuni/master/servercontainer/containers/uyuni/server:latest
+podman pull registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni/server:latest
 
-podman save --output server.tar registry.opensuse.org/systemsmanagement/uyuni/master/servercontainer/containers/uyuni/server:latest
+podman save --output server.tar registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni/server:latest
 ```
 
 or
@@ -52,7 +52,7 @@ for image in cert-manager-cainjector cert-manager-controller cert-manager-ctl ce
     skopeo copy docker://quay.io/jetstack/$image:latest docker-archive:$image.tar:quay.io/jetstack/$image:latest
 done
 
-skopeo copy docker://registry.opensuse.org/systemsmanagement/uyuni/master/servercontainer/containers/uyuni/server:latest docker-archive:server.tar:registry.opensuse.org/systemsmanagement/uyuni/master/servercontainer/containers/uyuni/server:latest
+skopeo copy docker://registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni/server:latest docker-archive:server.tar:registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni/server:latest
 ```
 
 Copy the `cert-manager` and `uyuni/server` helm charts locally:
@@ -123,19 +123,19 @@ helm pull --destination . oci://registry.opensuse.org/uyuni/server
 
 ## For Podman
 
-With K3s it is possible to preload the container images and avoid it to be fetched from a registry.
+With Podman it is possible to preload the container images and avoid it to be fetched from a registry.
 For this, on a machine with internet access, pull the image using `podman`, `docker` or `skopeo` and save it as a `tar` archive.
 For example:
 
 ```
-podman pull registry.opensuse.org/systemsmanagement/uyuni/master/servercontainer/containers/uyuni/server:latest
-podman save --output server-image.tar registry.opensuse.org/systemsmanagement/uyuni/master/servercontainer/containers/uyuni/server:latest
+podman pull registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni/server:latest
+podman save --output server-image.tar registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni/server:latest
 ```
 
 or
 
 ```
-skopeo copy docker://registry.opensuse.org/systemsmanagement/uyuni/master/servercontainer/containers/uyuni/server:latest docker-archive:server-image.tar:registry.opensuse.org/systemsmanagement/uyuni/master/servercontainer/containers/uyuni/server:latest
+skopeo copy docker://registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni/server:latest docker-archive:server-image.tar:registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni/server:latest
 ```
 
 Transfer the resulting `server-image.tar` to the server and load it using the following command:

--- a/containers/server-helm/templates/k3s-ingress-routes.yaml
+++ b/containers/server-helm/templates/k3s-ingress-routes.yaml
@@ -122,6 +122,20 @@ spec:
     - match: HostSNI(`*`)
       services:
       - name: uyuni-tcp
+        port: 8003
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: search-debug-router
+  namespace: "{{ .Release.Namespace }}"
+spec:
+  entryPoints:
+    - search-debug
+  routes:
+    - match: HostSNI(`*`)
+      services:
+      - name: uyuni-tcp
         port: 8002
 ---
 apiVersion: traefik.containo.us/v1alpha1


### PR DESCRIPTION
## What does this PR change?

Update the traefik routes forJDWP debug port changes for tomcat and search server
Also update the K3S documentation for offline installation after verification of the instructions.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
