### PR TITLE
Wait for filelock

### DIFF
--- a/java/code/src/com/redhat/rhn/common/util/FileLocks.java
+++ b/java/code/src/com/redhat/rhn/common/util/FileLocks.java
@@ -40,7 +40,7 @@ import java.util.function.Supplier;
 public class FileLocks {
 
     // Logger instance
-    private static Logger log = LogManager.getLogger(FileLocks.class);
+    private static final Logger LOG = LogManager.getLogger(FileLocks.class);
 
     /**
      * Lock for the scc refresh process
@@ -99,7 +99,7 @@ public class FileLocks {
         ) {
             if (fileLock != null) {
                 try {
-                    log.info("File lock {} acquired.", filePath);
+                    LOG.info("File lock {} acquired.", filePath);
                     try {
                         // Set the user to tomcat so both taskomatic (root) and tomcat (tomcat) can use it.
                         FileSystem fileSystem = FileSystems.getDefault();
@@ -110,7 +110,7 @@ public class FileLocks {
                         }
                     }
                     catch (IOException e) {
-                        log.error("Error adjusting lock file user.", e);
+                        LOG.error("Error adjusting lock file user.", e);
                     }
                     return fn.get();
                 }
@@ -120,12 +120,12 @@ public class FileLocks {
                 }
             }
             else {
-                log.warn("File lock {} already in use.", filePath);
+                LOG.warn("File lock {} already in use.", filePath);
                 throw new OverlappingFileLockException();
             }
         }
         catch (IOException e) {
-            log.error("File lock {} error", filePath, e);
+            LOG.error("File lock {} error", filePath, e);
             throw new RuntimeException(e);
         }
     }
@@ -161,17 +161,17 @@ public class FileLocks {
             }
             catch (OverlappingFileLockException e) {
                 try {
-                    log.debug("waiting to get lock");
+                    LOG.debug("waiting to get lock");
                     TimeUnit.SECONDS.sleep(5);
                 }
                 catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();
-                    log.warn("Interrupted", ie);
+                    LOG.warn("Interrupted", ie);
                     throw new OverlappingFileLockException();
                 }
             }
         } while (Instant.now().isBefore(i));
-        log.warn("TIMEOUT: Lock could not be acquired in time");
+        LOG.warn("TIMEOUT: Lock could not be acquired in time");
         throw new OverlappingFileLockException();
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MgrSyncRefresh.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MgrSyncRefresh.java
@@ -97,7 +97,7 @@ public class MgrSyncRefresh extends RhnJavaJob {
             }
 
             // Perform the refresh
-            FileLocks.SCC_REFRESH_LOCK.withFileLock(() -> {
+            FileLocks.SCC_REFRESH_LOCK.withTimeoutFileLock(() -> {
                 try {
                     ContentSyncManager csm = new ContentSyncManager();
                     csm.updateChannelFamilies(csm.readChannelFamilies());
@@ -116,7 +116,7 @@ public class MgrSyncRefresh extends RhnJavaJob {
                 catch (ContentSyncException e) {
                     log.error("Error during mgr-sync refresh", e);
                 }
-            });
+            }, 600);
 
             try {
                 // Schedule sync of all vendor channels

--- a/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygUpdateAuthTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygUpdateAuthTask.java
@@ -101,7 +101,7 @@ public class PaygUpdateAuthTask extends RhnJavaJob {
         }
 
         if (CollectionUtils.isNotEmpty(paygSshData)) {
-            sccRefreshLock.withFileLock(() -> {
+            sccRefreshLock.withTimeoutFileLock(() -> {
                 paygSshData.forEach(this::updateInstanceData);
 
                 // Call the content sync manager to refresh all repositories content sources and the authorizations
@@ -111,7 +111,7 @@ public class PaygUpdateAuthTask extends RhnJavaJob {
                 catch (ContentSyncException ex) {
                     log.error("Unable to refresh repositories", ex);
                 }
-            });
+            }, 60);
         }
     }
 

--- a/java/spacewalk-java.changes.mc.Manager-4.3-wait-for-filelock
+++ b/java/spacewalk-java.changes.mc.Manager-4.3-wait-for-filelock
@@ -1,0 +1,1 @@
+- wait for lock to execute scc sync task (bsc#1216030)


### PR DESCRIPTION
## What does this PR change?

To prevent conflicting scc sync tasks to fight for the lock, wait some time for it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **manual tried**

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/22790

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
