### PR TITLE
Ensure PAYG refresh process does not call SCC

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -2488,7 +2488,7 @@ public class ContentSyncManager {
      * @throws SCCClientException when access is not possible
      * @return {@link SCCWebClient}
      */
-    private SCCClient getSCCClient(Credentials credentials)
+    protected SCCClient getSCCClient(Credentials credentials)
             throws URISyntaxException, SCCClientException {
         // check that URL is valid
         URI url = new URI(Config.get().getString(ConfigDefaults.SCC_URL));

--- a/java/code/src/com/redhat/rhn/testing/MockObjectTestCase.java
+++ b/java/code/src/com/redhat/rhn/testing/MockObjectTestCase.java
@@ -15,6 +15,8 @@
 
 package com.redhat.rhn.testing;
 
+import com.suse.utils.Exceptions;
+
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.States;
@@ -23,8 +25,6 @@ import org.jmock.internal.ExpectationBuilder;
 import org.jmock.junit5.JUnit5Mockery;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
-
-import java.util.function.Consumer;
 
 /**
  * jMock boilerplate.
@@ -59,10 +59,12 @@ public class MockObjectTestCase {
     /**
      * @param expectationsConsumer consumer to build the expectations
      */
-    public void checking(Consumer<Expectations> expectationsConsumer) {
-        Expectations expectations = new Expectations();
-        expectationsConsumer.accept(expectations);
-        context.checking(expectations);
+    public void checking(Exceptions.ThrowingConsumer<Expectations, Exception> expectationsConsumer) {
+        Exceptions.handleByWrapping(() -> {
+            Expectations expectations = new Expectations();
+            expectationsConsumer.accept(expectations);
+            context.checking(expectations);
+        });
     }
 
     /**

--- a/java/code/src/com/suse/utils/Exceptions.java
+++ b/java/code/src/com/suse/utils/Exceptions.java
@@ -20,28 +20,45 @@ public final class Exceptions {
 
     /**
      * Represents an operation that does not accept inputs and returns no result, but may throw an exception.
+     * @param <E> type of exception
      */
     @FunctionalInterface
-    public interface ThrowingOperation {
+    public interface ThrowingRunnable<E extends Exception> {
         /**
          * Performs this operation.
-         * @throws Exception when an error occurs during the execution
+         * @throws E when an error occurs during the execution
          */
-        void execute() throws Exception;
+        void run() throws E;
     }
 
     /**
      * Represents an operation that does not accept inputs and returns a value, but may throw an exception.
      * @param <T> the type of the return value
+     * @param <E> type of exception
      */
     @FunctionalInterface
-    public interface ThrowingSupplier<T> {
+    public interface ThrowingSupplier<T, E extends Exception>  {
         /**
          * Performs this operation.
          * @return the result of the operation
-         * @throws Exception when an error occurs during the execution
+         * @throws E when an error occurs during the execution
          */
-        T execute() throws Exception;
+        T get() throws E;
+    }
+
+    /**
+     * Represents an operation that accepts a single input argument and returns no result, but may throw an exception.
+     * @param <T> the type of the return value
+     * @param <E> type of exception
+     */
+    @FunctionalInterface
+    public interface ThrowingConsumer<T, E extends Exception>  {
+        /**
+         * Performs this operation.
+         * @param value the value to consume
+         * @throws E when an error occurs during the execution
+         */
+        void accept(T value) throws E;
     }
 
     private Exceptions() {
@@ -51,11 +68,12 @@ public final class Exceptions {
     /**
      * Executes an operation and returns the exception if occurred during the execution.
      * @param operation the operation to perform
+     * @param <E> type of exception
      * @return an optional wrapping the exception, or empty if the operation completes successfully.
      */
-    public static Optional<? extends Exception> handleByReturning(ThrowingOperation operation) {
+    public static <E extends Exception> Optional<Exception> handleByReturning(ThrowingRunnable<E> operation) {
         try {
-            operation.execute();
+            operation.run();
             return Optional.empty();
         }
         catch (Exception ex) {
@@ -66,11 +84,12 @@ public final class Exceptions {
     /**
      * Executes an operation and wraps any exception into a runtime exception.
      * @param operation the operation to perform
+     * @param <E> type of exception
      * @throws RuntimeException if an exception occurs during the operation.
      */
-    public static void handleByWrapping(ThrowingOperation operation) {
+    public static <E extends Exception> void handleByWrapping(ThrowingRunnable<E> operation) {
         handleByWrapping(() -> {
-            operation.execute();
+            operation.run();
             return null;
         });
     }
@@ -79,12 +98,13 @@ public final class Exceptions {
      * Executes an operation and wraps any exception into a runtime exception.
      * @param operation the operation to perform
      * @param <T> the type of the return value of the operation
+     * @param <E> type of exception
      * @return the result value of the operation
      * @throws RuntimeException if an exception occurs during the operation.
      */
-    public static <T> T handleByWrapping(ThrowingSupplier<T> operation) {
+    public static <T, E extends Exception> T handleByWrapping(ThrowingSupplier<T, E> operation) {
         try {
-            return operation.execute();
+            return operation.get();
         }
         catch (Exception ex) {
             throw new RuntimeException("Unable to execute operation", ex);


### PR DESCRIPTION
## What does this PR change?

This PR adds an additional unit test to verify we are not calling SCC with the logic used to refresh PAYG authorizations.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/22676

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
