### PR TITLE
QE: Fix and improve the server hostname rename test

### DIFF
--- a/testsuite/.rubocop_todo.yml
+++ b/testsuite/.rubocop_todo.yml
@@ -342,6 +342,7 @@ Style/AndOr:
     - 'features/step_definitions/common_steps.rb'
     - 'features/step_definitions/file_management_steps.rb'
     - 'features/step_definitions/retail_steps.rb'
+    - 'features/step_definitions/salt_steps.rb'
     - 'features/step_definitions/setup_steps.rb'
 
 # Offense count: 1

--- a/testsuite/features/secondary/srv_rename_hostname.feature
+++ b/testsuite/features/secondary/srv_rename_hostname.feature
@@ -21,6 +21,51 @@ Feature: Reconfigure the server's hostname
     When I change the server's short hostname from hosts and hostname files
     And I run spacewalk-hostname-rename command on the server
 
+@proxy
+  Scenario: Copy the new server keys and configure the proxy
+    When I copy server's keys to the proxy
+    And I configure the proxy
+    Then I should see "proxy" via spacecmd
+    When I restart the "salt-minion" service on "proxy"
+    Then service "salt-minion" is active on "proxy"
+    When I restart the "salt-broker" service on "proxy"
+    Then service "salt-broker" is active on "proxy"
+
+@proxy
+  Scenario: Apply high state on the proxy to populate new server CA
+    When I apply highstate on "proxy"
+
+@sle_minion
+  Scenario: Apply high state on the SUSE Minion to populate new server CA
+    When I apply highstate on "sle_minion"
+
+@ssh_minion
+  Scenario: Apply high state on the SUSE SSH Minion to populate new server CA
+    When I apply highstate on "ssh_minion"
+
+@rhlike_minion
+  Scenario: Apply high state on the Red Hat-like Minion to populate new server CA
+    When I apply highstate on "rhlike_minion"
+
+@deblike_minion
+  Scenario: Apply high state on the Debian-like Minion to populate new server CA
+    When I apply highstate on "deblike_minion"
+
+@buildhost
+  Scenario: Apply high state on the build host to populate new server CA
+    When I apply highstate on "build_host"
+
+@virthost_kvm
+  Scenario: Apply high state on the virthost to populate new server CA
+    When I apply highstate on "kvm_server"
+
+@pxeboot_minion
+  Scenario: Apply high state on the PXE boot minion to populate new server CA
+    When I apply highstate on "pxeboot_minion"
+
+  Scenario: Check all new server certificates on the minions
+    When I check all certificates after renaming the server hostname
+
   Scenario: Do some minimal smoke test on the renamed server
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Details" in the content area
@@ -40,3 +85,48 @@ Feature: Reconfigure the server's hostname
   Scenario: Change hostname back and reboot server
     When I change back the server's hostname
     And I run spacewalk-hostname-rename command on the server
+
+@proxy
+  Scenario: Copy the new server keys and configure the proxy
+    When I copy server's keys to the proxy
+    And I configure the proxy
+    Then I should see "proxy" via spacecmd
+    When I restart the "salt-minion" service on "proxy"
+    Then service "salt-minion" is active on "proxy"
+    When I restart the "salt-broker" service on "proxy"
+    Then service "salt-broker" is active on "proxy"
+
+@proxy
+  Scenario: Apply high state on the proxy to populate new server CA
+    When I apply highstate on "proxy"
+
+@sle_minion
+  Scenario: Apply high state on the SUSE Minion to populate new server CA
+    When I apply highstate on "sle_minion"
+
+@ssh_minion
+  Scenario: Apply high state on the SUSE SSH Minion to populate new server CA
+    When I apply highstate on "ssh_minion"
+
+@rhlike_minion
+  Scenario: Apply high state on the Red Hat-like Minion to populate new server CA
+    When I apply highstate on "rhlike_minion"
+
+@deblike_minion
+  Scenario: Apply high state on the Debian-like Minion to populate new server CA
+    When I apply highstate on "deblike_minion"
+
+@buildhost
+  Scenario: Apply high state on the build host to populate new server CA
+    When I apply highstate on "build_host"
+
+@virthost_kvm
+  Scenario: Apply high state on the virthost to populate new server CA
+    When I apply highstate on "kvm_server"
+
+@pxeboot_minion
+  Scenario: Apply high state on the PXE boot minion to populate new server CA
+    When I apply highstate on "pxeboot_minion"
+
+  Scenario: Check all new server certificates on the minions
+    When I check all certificates after renaming the server hostname

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -237,16 +237,6 @@ When(/^vendor change should be enabled for [^"]* on "([^"]*)"$/) do |host|
   raise 'Vendor change option not found in logs' unless return_code.zero?
 end
 
-When(/^I apply highstate on "([^"]*)"$/) do |host|
-  system_name = get_system_name(host)
-  if host.include? 'ssh_minion'
-    cmd = 'mgr-salt-ssh'
-  elsif host.include? 'minion' or host.include? 'build'
-    cmd = 'salt'
-  end
-  get_target('server').run_until_ok("#{cmd} #{system_name} state.highstate")
-end
-
 When(/^I wait until "([^"]*)" service is active on "([^"]*)"$/) do |service, host|
   node = get_target(host)
   cmd = "systemctl is-active #{service}"

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -578,3 +578,14 @@ When(/^I purge salt-minion on "([^"]*)" after a migration$/) do |host|
   cleanup = %(salt #{system_name} state.apply util.mgr_switch_to_venv_minion pillar='{"mgr_purge_non_venv_salt_files": True, "mgr_purge_non_venv_salt": True}')
   get_target('server').run(cleanup, check_errors: true, verbose: true)
 end
+
+When(/^I apply highstate on "([^"]*)"$/) do |host|
+  system_name = get_system_name(host)
+  if host.include? 'ssh_minion'
+    cmd = 'mgr-salt-ssh'
+  elsif host.include? 'minion' or host.include? 'build' or host.include? 'proxy'
+    cmd = 'salt'
+  end
+  log "#{cmd} #{system_name} state.highstate"
+  get_target('server').run_until_ok("#{cmd} #{system_name} state.highstate")
+end

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -418,23 +418,14 @@ def file_inject(node, local_file, remote_file)
 end
 
 # This function updates the server certificate on the controller node
-def update_ca(node)
+def update_controller_ca
   server_ip = get_target('server').public_ip
   server_name = get_target('server').full_hostname
 
-  case node
-  when 'proxy'
-    command = "wget http://#{server_ip}/pub/RHN-ORG-TRUSTED-SSL-CERT -O /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT; " \
-      'update-ca-certificates;'
-    get_target('proxy').run('rm /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT', verbose: true)
-    get_target('proxy').run(command, verbose: true)
-  else
-    # controller
-    puts `rm /etc/pki/trust/anchors/*;
-    wget http://#{server_ip}/pub/RHN-ORG-TRUSTED-SSL-CERT -O /etc/pki/trust/anchors/#{server_name}.cert &&
-    update-ca-certificates &&
-    certutil -d sql:/root/.pki/nssdb -A -t TC -n "susemanager" -i  /etc/pki/trust/anchors/#{server_name}.cert`
-  end
+  puts `rm /etc/pki/trust/anchors/*;
+  wget http://#{server_ip}/pub/RHN-ORG-TRUSTED-SSL-CERT -O /etc/pki/trust/anchors/#{server_name}.cert &&
+  update-ca-certificates &&
+  certutil -d sql:/root/.pki/nssdb -A -t TC -n "susemanager" -i  /etc/pki/trust/anchors/#{server_name}.cert`
 end
 
 # This functions checks if the channel has been synced


### PR DESCRIPTION
## What does this PR change?

This 
- fixes the server hostname rename test
- added some basic hostname and certificate check after each rename
- moves the step `When(/^I apply highstate on "([^"]*)"$/) do |host|` to `salt_steps.rb` since it belongs there
- reverts the `update_ca` method to its original form because we only need it on the controller

### Fixed test
```bash
dominik-ctl:~/spacewalk/testsuite # cucumber features/secondary/srv_rename_hostname.feature
(...)
22 scenarios (10 skipped, 12 passed)
45 steps (10 skipped, 35 passed)
5m39.206s
dominik-ctl:~/spacewalk/testsuite #
```

### Improvements
I implemented some basic certificate and hostname checks which did work:

```bash
(...)
  Scenario: Check all new server certificates on the minions         # features/secondary/srv_rename_hostname.feature:131
      This scenario ran at: 2023-10-19 14:42:12 +0200
    When I check all certificates after renaming the server hostname # features/step_definitions/command_steps.rb:1626
      Server certificate serial: 0a:cb:26:d4:e6:56:6a:0d:24:a9:52:d1:01:af:ab:a6:ce:36:81:f5
      proxy certificate serial: 0a:cb:26:d4:e6:56:6a:0d:24:a9:52:d1:01:af:ab:a6:ce:36:81:f5
      sle_minion certificate serial: 0a:cb:26:d4:e6:56:6a:0d:24:a9:52:d1:01:af:ab:a6:ce:36:81:f5
      ssh_minion certificate serial: 0a:cb:26:d4:e6:56:6a:0d:24:a9:52:d1:01:af:ab:a6:ce:36:81:f5
      This scenario took: 1 seconds

24 scenarios (10 skipped, 14 passed)
47 steps (10 skipped, 37 passed)
5m42.736s
```

## GUI diff

No difference.


- [x] **DONE**
## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were added

- [x] **DONE**

## Links

- https://gitlab.suse.de/galaxy/infrastructure/-/merge_requests/818
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
