### PR TITLE
Add missing button classes

### DIFF
--- a/java/code/webapp/WEB-INF/pages/kickstart/ssm/schedule.jsp
+++ b/java/code/webapp/WEB-INF/pages/kickstart/ssm/schedule.jsp
@@ -56,7 +56,7 @@
 <h2><rhn:icon type="header-kickstart" /><bean:message key="kickstart.schedule.heading4.jsp" /></h2>
     <div class="spacewalk-section-toolbar">
         <div class="action-button-wrapper">
-            <input type="submit" name="dispatch" value="${rhn:localize('ssm.kickstart.schedule.create.records.button.jsp')}" />
+            <input class="btn btn-default" type="submit" name="dispatch" value="${rhn:localize('ssm.kickstart.schedule.create.records.button.jsp')}" />
             <input class="btn btn-default" type="submit" name="dispatch" value="${rhn:localize('kickstart.schedule.button2.jsp')}"/>
         </div>
     </div>


### PR DESCRIPTION
## What does this PR change?

Don's video highlighted a UI bug, this button doesn't have the regular button classes.

<img width="610" alt="Screenshot 2023-10-18 at 11 28 33" src="https://github.com/uyuni-project/uyuni/assets/3171718/05070622-03a4-434f-967f-a042b65e3903">


## GUI diff

Bugfix.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfix.

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
