### PR TITLE
disable dnf_rhui_plugin and fix header handling of susemanagerplugin

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/dnf-susemanager-plugin/susemanagerplugin.py
+++ b/susemanager-utils/susemanager-sls/salt/channels/dnf-susemanager-plugin/susemanagerplugin.py
@@ -11,6 +11,8 @@ class Susemanager(dnf.Plugin):
         for repo in self.base.repos.get_matching("susemanager:*"):
             try:
                 susemanager_token = repo.cfg.getValue(section=repo.id, key="susemanager_token")
-                repo.set_http_headers(["X-Mgr-Auth: %s" % susemanager_token])
+                hdr = list(repo.get_http_headers())
+                hdr.append("X-Mgr-Auth: %s" % susemanager_token)
+                repo.set_http_headers(hdr)
             except:
                 pass

--- a/susemanager-utils/susemanager-sls/salt/channels/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/init.sls
@@ -44,6 +44,15 @@ mgrchannels_enable_dnf_plugins:
 {#- default is '1' when option is not specififed #}
     - onlyif: grep -e 'plugins=0' -e 'plugins=False' -e 'plugins=no' /etc/dnf/dnf.conf
 {%- endif %}
+
+{# this break the susemanagerplugin as it overwrite HTTP headers (bsc#1214601) #}
+mgrchannels_disable_dnf_rhui_plugin:
+  file.replace:
+    - name: /etc/yum/pluginconf.d/dnf_rhui_plugin.conf
+    - pattern: enabled=.*
+    - repl: enabled=0
+    - onlyif: grep -e 'enabled=1' -e 'enabled=True' -e 'enabled=yes' /etc/yum/pluginconf.d/dnf_rhui_plugin.conf
+
 {%- endif %}
 
 {%- if is_yum %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mc.Manager-4.3-fix-azure-rhui-plugin-issues
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mc.Manager-4.3-fix-azure-rhui-plugin-issues
@@ -1,0 +1,2 @@
+- disable dnf_rhui_plugin as it break our susemanagerplugin (bsc#1214601)
+- fix susemanagerplugin to not overwrite header fields set by other plugins


### PR DESCRIPTION
## What does this PR change?

- disable dnf_rhui_plugin as it break our susemanagerplugin. This plugin overwrite our X-Mgr-Auth header field
- fix susemanagerplugin to not overwrite header fields set by other plugins

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **manual - happens only in Azure**

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/22800

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
