### PR TITLE
QE: fix SLE Micro client tools sync in Uyuni BV

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -209,7 +209,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @uyuni
 @slemicro51_minion
   Scenario: Add SUSE Linux Enterprise Micro 5.1 Uyuni Client tools
-    When I use spacewalk-common-channel to add channel "suse-microos-5.1-pool-x86_64 suse-microos-5.1-devel-uyuni-client" with arch "x86_64"
+    When I use spacewalk-common-channel to add channel "suse-microos-5.1-devel-uyuni-client" with arch "x86_64"
 
 @susemanager
 @slemicro52_minion
@@ -241,7 +241,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @uyuni
 @slemicro52_minion
   Scenario: Add SUSE Linux Enterprise Micro 5.2 Uyuni Client tools
-    When I use spacewalk-common-channel to add channel "suse-microos-5.2-pool-x86_64 suse-microos-5.2-devel-uyuni-client" with arch "x86_64"
+    When I use spacewalk-common-channel to add channel "suse-microos-5.2-devel-uyuni-client" with arch "x86_64"
 
 @susemanager
 @slemicro53_minion
@@ -273,7 +273,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @uyuni
 @slemicro53_minion
   Scenario: Add SUSE Linux Enterprise Micro 5.3 Uyuni Client tools
-    When I use spacewalk-common-channel to add channel "sle-micro-5.3-pool-x86_64 sle-micro-5.3-devel-uyuni-client" with arch "x86_64"
+    When I use spacewalk-common-channel to add channel "sle-micro-5.3-devel-uyuni-client" with arch "x86_64"
 
 @susemanager
 @slemicro54_minion
@@ -305,7 +305,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @uyuni
 @slemicro54_minion
   Scenario: Add SUSE Linux Enterprise Micro 5.4 Uyuni Client tools
-    When I use spacewalk-common-channel to add channel "sle-micro-5.4-pool-x86_64 sle-micro-5.4-devel-uyuni-client" with arch "x86_64"
+    When I use spacewalk-common-channel to add channel "sle-micro-5.4-devel-uyuni-client" with arch "x86_64"
 
 @susemanager
 @opensuse154arm_minion


### PR DESCRIPTION
## What does this PR change?

We only need to add the client tools channel name when using `spacewalk-common-channels`. The base channel is not necessarily needed.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links

- Manager-4.3: https://github.com/SUSE/spacewalk/pull/22802
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
