### PR TITLE
Fix recurring action test

### DIFF
--- a/testsuite/features/secondary/min_recurring_action.feature
+++ b/testsuite/features/secondary/min_recurring_action.feature
@@ -167,7 +167,7 @@ Feature: Recurring Actions
 
   Scenario: Pre-requisite: check that there are updates available
     Given I am on the Systems overview page of this "sle_minion"
-    And I wait until I see "Software Updates Available" text
+    And I wait until I see "Software Updates Available" text, refreshing the page
 
   Scenario: Create a recurring action to apply "uptodate" state to a system group
     When I follow the left menu "Systems > System Groups"

--- a/testsuite/features/secondary/min_recurring_action.feature
+++ b/testsuite/features/secondary/min_recurring_action.feature
@@ -167,7 +167,7 @@ Feature: Recurring Actions
 
   Scenario: Pre-requisite: check that there are updates available
     Given I am on the Systems overview page of this "sle_minion"
-    Then I should see a "Software Updates Available" text
+    And I wait until I see "Software Updates Available" text
 
   Scenario: Create a recurring action to apply "uptodate" state to a system group
     When I follow the left menu "Systems > System Groups"


### PR DESCRIPTION
## What does this PR change?

The software update text is taking few seconds to show up. Because we are using should and not wait, we are expecting the text to be immediately visible. Change the should see to wait for text.

## Links
https://github.com/SUSE/spacewalk/issues/22735
- [x] **DONE**

## Changelogs

- [x] No changelog needed


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
