### PR TITLE
Update tomcat jars to version greater than 9.0.75

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -112,12 +112,12 @@
         <dependency org="suse" name="stax-ex" rev="1.8" />
 
         <!-- Tomcat jars -->
-        <dependency org="suse" name="jasper" rev="9.0.75" />
-        <dependency org="suse" name="jasper-el" rev="9.0.75" />
-        <dependency org="suse" name="tomcat-el-3.0-api" rev="9.0.75" />
-        <dependency org="suse" name="tomcat-jsp-2.3-api" rev="9.0.75" />
-        <dependency org="suse" name="tomcat-juli" rev="9.0.75" />
-        <dependency org="suse" name="tomcat-servlet-4.0-api" rev="9.0.75" />
+        <dependency org="suse" name="jasper" rev="[9.0.75,10.0.0[" />
+        <dependency org="suse" name="jasper-el" rev="[9.0.75,10.0.0["/>
+        <dependency org="suse" name="tomcat-el-3.0-api" rev="[9.0.75,10.0.0[" />
+        <dependency org="suse" name="tomcat-jsp-2.3-api" rev="[9.0.75,10.0.0[" />
+        <dependency org="suse" name="tomcat-juli" rev="[9.0.75,10.0.0[" />
+        <dependency org="suse" name="tomcat-servlet-4.0-api" rev="[9.0.75,10.0.0[" />
 
         <!-- Compilation and testing -->
         <dependency org="suse" name="velocity-engine-core" rev="2.3"/>

--- a/java/spacewalk-java.changes.mbussolotto.tomcat_rev
+++ b/java/spacewalk-java.changes.mbussolotto.tomcat_rev
@@ -1,0 +1,1 @@
+- Update tomcat jars to version greater than 9.0.75


### PR DESCRIPTION
## What does this PR change?

According to https://ant.apache.org/ivy/history/2.5.2/ivyfile/dependency.html update tomcat jars to version greater than 9.0.75 (but lower than 10.0.0).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
