### PR TITLE
Fix "system.provisionSystem" xmlrpc endpoint to calculate kickstart host properly (bsc#1215209)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/RhnXmlRpcServer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/RhnXmlRpcServer.java
@@ -16,6 +16,7 @@ package com.redhat.rhn.frontend.xmlrpc;
 
 import java.io.InputStream;
 import java.io.Writer;
+
 import javax.servlet.http.HttpServletRequest;
 
 import redstone.xmlrpc.XmlRpcDispatcher;
@@ -41,6 +42,7 @@ public class RhnXmlRpcServer extends XmlRpcServer {
      * @param serverHost the hostname/ipaddress that the client used in
      *      reference to the server
      * @param protoc the protocol the client used in connection to the server
+     * @param rawRequest the raw request representing the client connection to the server
      * available  to  custom processors.
      */
     public void execute(InputStream xmlInput, Writer output, String callerIp,

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/RhnXmlRpcServer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/RhnXmlRpcServer.java
@@ -16,6 +16,7 @@ package com.redhat.rhn.frontend.xmlrpc;
 
 import java.io.InputStream;
 import java.io.Writer;
+import javax.servlet.http.HttpServletRequest;
 
 import redstone.xmlrpc.XmlRpcDispatcher;
 import redstone.xmlrpc.XmlRpcServer;
@@ -28,6 +29,7 @@ public class RhnXmlRpcServer extends XmlRpcServer {
     private static ThreadLocal<String> server = new ThreadLocal<>();
     private static ThreadLocal<String> proto = new ThreadLocal<>();
     private static ThreadLocal<String> caller = new ThreadLocal<>();
+    private static ThreadLocal<HttpServletRequest> request = new ThreadLocal<>();
 
     /**
      * Adding a method to get the callerIp into the XmlRpc for logging.
@@ -42,10 +44,11 @@ public class RhnXmlRpcServer extends XmlRpcServer {
      * available  to  custom processors.
      */
     public void execute(InputStream xmlInput, Writer output, String callerIp,
-            String serverHost, String protoc) {
+            String serverHost, String protoc, HttpServletRequest rawRequest) {
         server.set(serverHost);
         proto.set(protoc);
         caller.set(callerIp);
+        request.set(rawRequest);
         XmlRpcDispatcher dispatcher = new XmlRpcDispatcher(this, callerIp);
         dispatcher.dispatch(xmlInput, output);
     }
@@ -72,5 +75,13 @@ public class RhnXmlRpcServer extends XmlRpcServer {
      */
     public static String getCallerIp() {
         return caller.get();
+    }
+
+    /**
+     * Retrieve the the raw request of the current xmlrpc call.
+     * @return HttpServletRequest object
+     */
+    public static HttpServletRequest getRequest() {
+        return request.get();
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/RhnXmlRpcServer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/RhnXmlRpcServer.java
@@ -53,6 +53,10 @@ public class RhnXmlRpcServer extends XmlRpcServer {
         request.set(rawRequest);
         XmlRpcDispatcher dispatcher = new XmlRpcDispatcher(this, callerIp);
         dispatcher.dispatch(xmlInput, output);
+        server.remove();
+        proto.remove();
+        caller.remove();
+        request.remove();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/XmlRpcServlet.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/XmlRpcServlet.java
@@ -149,7 +149,8 @@ public class XmlRpcServlet extends HttpServlet {
                            response.getWriter(),
                            request.getRemoteAddr(),
                            request.getLocalName(),
-                           request.getProtocol());
+                           request.getProtocol(),
+                           request);
 
             /*
              * jesusr - 2007.09.14

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -98,6 +98,7 @@ import com.redhat.rhn.domain.state.VersionConstraints;
 import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.domain.token.ActivationKeyFactory;
 import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.action.kickstart.KickstartHelper;
 import com.redhat.rhn.frontend.context.Context;
 import com.redhat.rhn.frontend.dto.ActivationKeyDto;
 import com.redhat.rhn.frontend.dto.ErrataOverview;
@@ -2928,7 +2929,8 @@ public class SystemHandler extends BaseHandler {
                     "No Kickstart Profile found with label: " + profileName);
         }
 
-        String host = RhnXmlRpcServer.getServerName();
+        KickstartHelper helper = new KickstartHelper(RhnXmlRpcServer.getRequest());
+        String host = helper.getKickstartHost();
 
 
         KickstartScheduleCommand cmd = new KickstartScheduleCommand(
@@ -2981,7 +2983,8 @@ public class SystemHandler extends BaseHandler {
                     "No Kickstart Profile found with label: " + profileName);
         }
 
-        String host = RhnXmlRpcServer.getServerName();
+        KickstartHelper helper = new KickstartHelper(RhnXmlRpcServer.getRequest());
+        String host = helper.getKickstartHost();
 
         KickstartScheduleCommand cmd = new KickstartScheduleCommand(
                 Long.valueOf(sid),

--- a/java/spacewalk-java.changes.meaksh.Manager-4.3-fix-xmlrpc-provision-server-endpoint
+++ b/java/spacewalk-java.changes.meaksh.Manager-4.3-fix-xmlrpc-provision-server-endpoint
@@ -1,0 +1,1 @@
+Fix system.provisionSystem xmlrpc endpoint to calculate host properly (bsc#1215209)


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue with `system.provisionSystem` endpoint, where the kickstart host that is used to generate tftpboot tree is calculated based on the hostname of the request, leading to wrongly assume `localhost` (and therefore generating wrong files) when connected to Uyuni XMLRPC API via `localhost`.

This PR makes this endpoint to use the same mechanism that the UI uses to calculate the kickstart host:

- If request is done via an Uyuni Proxy -> use the first proxy address in the chain of Uyuni proxies.
- Otherwise use default Cobbler host (Uyuni Server)

You can see the above mechanism implemented here: https://github.com/SUSE/spacewalk/blob/d4787b8757f0f5d2bbc56c5b325258349d56df09/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartHelper.java#L258-L282

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/22528

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
