### PR TITLE
Ci add feedback from gh actions acceptance tests fix

### DIFF
--- a/.github/workflows/acceptance_tests_secondary.yml
+++ b/.github/workflows/acceptance_tests_secondary.yml
@@ -14,6 +14,7 @@ jobs:
   pre-comment:
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       pull-requests: write
     steps:
       - uses: peter-evans/create-or-update-comment@v2
@@ -30,6 +31,7 @@ jobs:
   post-comment:
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       pull-requests: write
     steps:
       - uses: peter-evans/create-or-update-comment@v2

--- a/.github/workflows/acceptance_tests_secondary.yml
+++ b/.github/workflows/acceptance_tests_secondary.yml
@@ -21,9 +21,22 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             :wave: Hello! Thanks for contributing to our project :smile:
+            :coffe: Acceptance tests will take same time (aprox. 1h)
   test-uyuni:
     uses: ./.github/workflows/acceptance_tests_common.yml
     with:
       secondary_tests: "17_run_secondary_tests.sh" 
       server_id: "secondary"
+  post-comment:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            :dance: Test have finish
+            You can check the results
+            Happy hacking!
 


### PR DESCRIPTION
## What does this PR change?

fix permissions in github actions.

## GUI diff

No difference.


- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links
N/A
- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
