### PR TITLE
Ci add feedback as separate workflow

### DIFF
--- a/.github/workflows/acceptance_tests_feedback.yml
+++ b/.github/workflows/acceptance_tests_feedback.yml
@@ -1,0 +1,28 @@
+name: acceptance-tests-feedback
+on:
+  pull_request_target:
+    paths:
+      - 'java/**'
+      - 'web/html/src/**'
+      - 'testsuite/**'
+      - '.github/workflows/acceptance_tests_secondary.yml'
+      - '.github/workflows/acceptance_tests_common.yml'
+      - '!java/*.changes*'
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            :wave: Hello! Thanks for contributing to our project :smile:
+            :coffe: Acceptance tests will take same time (aprox. 1h)
+            :eyes: Once tests finish, you can check the cucumber report.
+            See the [troubleshooting guide](https://github.com/uyuni-project/uyuni/wiki/Running-Acceptance-Tests-at-PR#troubleshooting) if you need any help.
+            :warning: You should not merge if acceptance tests fail to pass
+            Happy hacking
+

--- a/.github/workflows/acceptance_tests_secondary.yml
+++ b/.github/workflows/acceptance_tests_secondary.yml
@@ -11,34 +11,9 @@ on:
   schedule:
     - cron: '0 6 * * *'
 jobs:
-  pre-comment:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: peter-evans/create-or-update-comment@v2
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            :wave: Hello! Thanks for contributing to our project :smile:
-            :coffe: Acceptance tests will take same time (aprox. 1h)
   test-uyuni:
     uses: ./.github/workflows/acceptance_tests_common.yml
     with:
       secondary_tests: "17_run_secondary_tests.sh" 
       server_id: "secondary"
-  post-comment:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: peter-evans/create-or-update-comment@v2
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            :dance: Test have finish
-            You can check the results
-            Happy hacking!
 


### PR DESCRIPTION
## What does this PR change?

I am getting all the time permission problems if I try to add a comment from the same workflow we run the tests. Let's do it differently and add a comment from a separate workflow.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests
- [X] **DONE**

## Links

N/A

- [A] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [A] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
