### PR TITLE
server container: fix the documentation for podman offline installation

### DIFF
--- a/containers/doc/server-kubernetes/README.md
+++ b/containers/doc/server-kubernetes/README.md
@@ -77,15 +77,7 @@ done
 ```
 
 In order to tell K3s to not pull the images, set the image pull policy needs to be set to `Never`.
-This needs to be done for both Uyuni and cert-manager helm charts.
-
-For the Uyuni helm chart, set the `pullPolicy` chart value to `Never` by passing a `--helm-uyuni-values=uyuni-values.yaml` parameter to `uyuniadm install` with the following `uyuni-values.yaml` file content:
-
-```
-pullPolicy: Never
-```
-
-For the cert-manager helm chart, create a `cert-values.yaml` file with the following content and pass `--helm-certmanager-values=values.yaml` parameter to `uyuniadm install`:
+Add the `--image-pullPolicy=Never` parameter to `uyuniadm` command or add the following to the configuration file:
 
 ```
 image:
@@ -138,19 +130,19 @@ For example:
 
 ```
 podman pull registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni/server:latest
-podman save --output server-image.tar registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni/server:latest
+podman save --output server.tar registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni/server:latest
 ```
 
 or
 
 ```
-skopeo copy docker://registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni/server:latest docker-archive:server-image.tar:registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni/server:latest
+skopeo copy docker://registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni/server:latest docker-archive:server.tar:registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni/server:latest
 ```
 
 Transfer the resulting `server-image.tar` to the server and load it using the following command:
 
 ```
-podman load -i server-image.tar
+podman load -i server.tar
 ```
 
 # Migrating from a regular server


### PR DESCRIPTION
## What does this PR change?

Fix the tarball names in the podman offline container documentation.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: documentation notes change
- [X] **DONE**

## Test coverage
- No tests: doc
- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
