### PR TITLE
Add changelogs for translations in spacewalk-client-tools and spacecmd

### DIFF
--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes.raul.changelogs_spacewalk-client-tools_spacecmd
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes.raul.changelogs_spacewalk-client-tools_spacecmd
@@ -1,0 +1,2 @@
+- version 4.4.6-1
+  * Update translation strings

--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes.raul.changelogs_spacewalk-client-tools_spacecmd
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes.raul.changelogs_spacewalk-client-tools_spacecmd
@@ -1,2 +1,1 @@
-- version 4.4.6-1
-  * Update translation strings
+- Update translation strings

--- a/spacecmd/spacecmd.changes.raul.changelogs_spacewalk-client-tools_spacecmd
+++ b/spacecmd/spacecmd.changes.raul.changelogs_spacewalk-client-tools_spacecmd
@@ -1,0 +1,2 @@
+- version 4.4.9-1
+  * Update translation strings

--- a/spacecmd/spacecmd.changes.raul.changelogs_spacewalk-client-tools_spacecmd
+++ b/spacecmd/spacecmd.changes.raul.changelogs_spacewalk-client-tools_spacecmd
@@ -1,2 +1,1 @@
-- version 4.4.9-1
-  * Update translation strings
+- Update translation strings


### PR DESCRIPTION
## What does this PR change?

Adds changelogs regarding the translations in the two mentioned packages, spacewalk-client-tools and spacecmd

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only changelogs additions

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Related: https://github.com/SUSE/spacewalk/issues/22583

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
