### PR TITLE
Enable setting system reboot delay via rhn.conf

### DIFF
--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -370,6 +370,11 @@ public class ConfigDefaults {
     public static final String UNIFY_CUSTOM_CHANNEL_MANAGEMENT = "java.unify_custom_channel_management";
 
     /**
+     * Specify the number of minutes to wait before performing a system reboot
+     * */
+    public static final String REBOOT_DELAY = "java.reboot_delay";
+
+    /**
      * Disable SSL redirection
      */
     public static final String NO_SSL = "server.no_ssl";
@@ -1146,5 +1151,21 @@ public class ConfigDefaults {
      */
     public long getRhuiDefaultOrgId() {
         return Config.get().getInt(RHUI_DEFAULT_ORG_ID, 1);
+    }
+
+    /**
+     * Returns the number of minutes to wait before performing a system reboot
+     *
+     * @return the minutes to wait before a system reboot
+     * */
+    public int getRebootDelay() {
+        int rebootDelay = Config.get().getInt(REBOOT_DELAY, 3);
+        // A value of 0 would cause a direct shutdown which makes it impossible for salt to return
+        // the result back, resulting in a failed action.
+        if (rebootDelay < 1) {
+            rebootDelay = 1;
+        }
+
+        return rebootDelay;
     }
 }

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -1280,10 +1280,11 @@ public class SaltServerActionService {
     }
 
     private Map<LocalCall<?>, List<MinionSummary>> rebootAction(List<MinionSummary> minionSummaries) {
+        int rebootDelay = ConfigDefaults.get().getRebootDelay();
         return minionSummaries.stream().collect(
             Collectors.groupingBy(
                 m -> m.isTransactionalUpdate() ? TransactionalUpdate.reboot() :
-                        com.suse.salt.netapi.calls.modules.System.reboot(Optional.of(3))
+                        com.suse.salt.netapi.calls.modules.System.reboot(Optional.of(rebootDelay))
             )
         );
     }

--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -256,3 +256,8 @@ java.min_report_schema_version = 4.3.5
 
 # Disable the update status
 java.disable_update_status = 0
+
+# Number of minutes to wait before performing a system reboot. It should be >= 1 because a value of 0 would
+# cause a direct shutdown which makes it impossible for salt to return the result back, resulting in a failed
+# action
+java.reboot_delay = 3

--- a/java/spacewalk-java.changes.HoussemNasri.minutes-before-reboot
+++ b/java/spacewalk-java.changes.HoussemNasri.minutes-before-reboot
@@ -1,0 +1,2 @@
+- Add a config to specify the number of minutes to wait before
+ performing a system reboot


### PR DESCRIPTION
## What does this PR change?

This PR adds a new config entry to `rhn.conf` named `java.reboot_delay` that is used to specify the number of minutes Uyuni has to wait before performing a system reboot.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
No documentation needed: **Description of the new config was added to `rhn_java.conf`. It should be enough as the default 3 minutes reboot delay was not mentioned in Uyuni docs nor in the XML-RPC API.**

- [x] **DONE**

## Test coverage

No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/7707

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
