### PR TITLE
QE: Fixup for server hostname rename test

### DIFF
--- a/testsuite/features/secondary/srv_rename_hostname.feature
+++ b/testsuite/features/secondary/srv_rename_hostname.feature
@@ -26,8 +26,8 @@ Feature: Reconfigure the server's hostname
     When I copy server's keys to the proxy
     And I configure the proxy
     Then I should see "proxy" via spacecmd
-    When I restart the "salt-minion" service on "proxy"
-    Then service "salt-minion" is active on "proxy"
+    When I restart the "venv-salt-minion" service on "proxy"
+    Then service "venv-salt-minion" is active on "proxy"
     When I restart the "salt-broker" service on "proxy"
     Then service "salt-broker" is active on "proxy"
 
@@ -56,12 +56,14 @@ Feature: Reconfigure the server's hostname
     When I apply highstate on "build_host"
 
 @virthost_kvm
+  # WORKAROUND: Use the webUI instead of Salt like with the other minions above
+  # The Salt call always failed for unknown reasons
   Scenario: Apply high state on the virthost to populate new server CA
-    When I apply highstate on "kvm_server"
-
-@pxeboot_minion
-  Scenario: Apply high state on the PXE boot minion to populate new server CA
-    When I apply highstate on "pxeboot_minion"
+    Given I am on the Systems overview page of this "kvm_server"
+    When I follow "States" in the content area
+    And I click on "Apply Highstate"
+    Then I should see a "Applying the highstate has been scheduled." text
+    And I wait until event "Apply highstate scheduled by admin" is completed
 
   Scenario: Check all new server certificates on the minions
     When I check all certificates after renaming the server hostname
@@ -91,8 +93,8 @@ Feature: Reconfigure the server's hostname
     When I copy server's keys to the proxy
     And I configure the proxy
     Then I should see "proxy" via spacecmd
-    When I restart the "salt-minion" service on "proxy"
-    Then service "salt-minion" is active on "proxy"
+    When I restart the "venv-salt-minion" service on "proxy"
+    Then service "venv-salt-minion" is active on "proxy"
     When I restart the "salt-broker" service on "proxy"
     Then service "salt-broker" is active on "proxy"
 
@@ -121,12 +123,14 @@ Feature: Reconfigure the server's hostname
     When I apply highstate on "build_host"
 
 @virthost_kvm
+  # WORKAROUND: Use the webUI instead of Salt like with the other minions above
+  # The Salt call always failed for unknown reasons
   Scenario: Apply high state on the virthost to populate new server CA
-    When I apply highstate on "kvm_server"
-
-@pxeboot_minion
-  Scenario: Apply high state on the PXE boot minion to populate new server CA
-    When I apply highstate on "pxeboot_minion"
+    Given I am on the Systems overview page of this "kvm_server"
+    When I follow "States" in the content area
+    And I click on "Apply Highstate"
+    Then I should see a "Applying the highstate has been scheduled." text
+    And I wait until event "Apply highstate scheduled by admin" is completed
 
   Scenario: Check all new server certificates on the minions
     When I check all certificates after renaming the server hostname

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1499,9 +1499,11 @@ When(/^I run spacewalk-hostname-rename command on the server$/) do
   end
 
   # Update the server CA certificate since it changed, otherwise all API and browser uses will fail
+  log 'Update controller CA certificates'
   update_controller_ca
 
   # Reset the API client to take the new CA into account
+  log 'Resetting the API client'
   reset_api_client
 
   raise 'Error while running spacewalk-hostname-rename command - see logs above' unless result_code.zero?
@@ -1517,17 +1519,30 @@ When(/^I check all certificates after renaming the server hostname$/) do
 
   raise 'Error getting server certificate serial!' unless result_code.zero?
 
-  command_minion = "openssl x509 --noout --text -in /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT | grep -A1 'Serial' | grep -v 'Serial'"
   targets = %w[proxy sle_minion ssh_minion rhlike_minion deblike_minion build_host kvm_server]
   targets.each do |target|
+    os_family = get_target(target).os_family
     # get all defined minions from the environment variables and check their certificate serial
     next unless ENV.key? ENV_VAR_BY_HOST[target]
+    # Red Hat-like and Debian-like minions store their certificates in a different location
+    certificate = if os_family =~ /^centos/ || os_family =~ /^rocky/
+                    '/etc/pki/ca-trust/source/anchors/RHN-ORG-TRUSTED-SSL-CERT'
+                  elsif os_family =~ /^ubuntu/ || os_family =~ /^debian/
+                    '/usr/local/share/ca-certificates/susemanager/RHN-ORG-TRUSTED-SSL-CERT.crt'
+                  else
+                    '/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT'
+                  end
+    get_target(target).run("test -s #{certificate}", successcodes: [0], check_errors: true)
+
+    command_minion = "openssl x509 --noout --text -in #{certificate} | grep -A1 'Serial' | grep -v 'Serial'"
     minion_cert_serial, result_code = get_target(target).run(command_minion)
+
+    raise "#{target}: Error getting server certificate serial!" unless result_code.zero?
+
     minion_cert_serial.strip!
     log "#{target} certificate serial: #{minion_cert_serial}"
 
-    raise 'Error getting server certificate serial!' unless result_code.zero?
-    raise "Error comparing #{target} certificate with server!" unless minion_cert_serial == server_cert_serial
+    raise "#{target}: Error, certificate does not match with server one" unless minion_cert_serial == server_cert_serial
   end
 end
 

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -586,6 +586,6 @@ When(/^I apply highstate on "([^"]*)"$/) do |host|
   elsif host.include? 'minion' or host.include? 'build' or host.include? 'proxy'
     cmd = 'salt'
   end
-  log "#{cmd} #{system_name} state.highstate"
+  log "Salt command: #{cmd} #{system_name} state.highstate"
   get_target('server').run_until_ok("#{cmd} #{system_name} state.highstate")
 end

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -417,12 +417,15 @@ def file_inject(node, local_file, remote_file)
   node.inject(local_file, remote_file, 'root', false)
 end
 
-# This function updates the server certificate on the controller node
+# This function updates the server certificate on the controller node by
+# - deleting the old one from the nss database
+# - importing the new one from the server
 def update_controller_ca
   server_ip = get_target('server').public_ip
   server_name = get_target('server').full_hostname
 
-  puts `rm /etc/pki/trust/anchors/*;
+  puts `certutil -d sql:/root/.pki/nssdb -t TC -n "susemanager" -D;
+  rm /etc/pki/trust/anchors/*;
   wget http://#{server_ip}/pub/RHN-ORG-TRUSTED-SSL-CERT -O /etc/pki/trust/anchors/#{server_name}.cert &&
   update-ca-certificates &&
   certutil -d sql:/root/.pki/nssdb -A -t TC -n "susemanager" -i  /etc/pki/trust/anchors/#{server_name}.cert`


### PR DESCRIPTION
## What does this PR change?

- the proxy uses `venv-salt-minion` instead of `salt-minion`
- Red Hat-like minion has a different location for certificates: `/etc/pki/ca-trust/source/anchors/`
- Debian-like minion has a different location for certificates: `/usr/local/share/ca-certificates/susemanager/`
- no `pxeboot-minion` available at this point
- fix `certutil` issue in `update_controller_ca`

The test suite somehow can not apply high state on the KVM host via Salt. When running it manually, however, it works fine.
```bash
  @virthost_kvm
  Scenario: Apply high state on the virthost to populate new server CA # features/secondary/srv_rename_hostname.feature:120
      This scenario ran at: 2023-10-24 09:21:24 +0200
Timeout after 250 seconds (Timeout.timeout), last result was: bash: dominik-min-kvm.mgr.suse.de: command not found
    When I apply highstate on "kvm_server"                             # features/step_definitions/salt_steps.rb:582
       dominik-min-kvm.mgr.suse.de state.highstate
      execution expired (Timeout::Error)
      ./features/support/lavanda.rb:196:in `sleep'
      ./features/support/lavanda.rb:196:in `block in run_until_ok'
      ./features/support/commonlib.rb:94:in `block in repeat_until_timeout'
      ./features/support/commonlib.rb:83:in `repeat_until_timeout'
      ./features/support/lavanda.rb:193:in `run_until_ok'
      ./features/step_definitions/salt_steps.rb:590:in `/^I apply highstate on "([^"]*)"$/'
      features/secondary/srv_rename_hostname.feature:121:in `I apply highstate on "kvm_server"'
=> /var/log/rhn/rhn_web_ui.log
```
I switched the highstate for that minion from Salt to the webUI, which also only takes ~30s to complete.


### TODO

- [x] `certutil: could not add certificate to token or database: SEC_ERROR_ADDING_CERT: Error adding certificate to database.`
- [x] fix second webUI highstate for `kmv_server` (follow-up issue for chromedriver from point above)
```bash
  @virthost_kvm
  Scenario: Apply high state on the virthost to populate new server CA       # features/secondary/srv_rename_hostname.feature:124
      This scenario ran at: 2023-10-24 09:55:29 +0200
#<Thread:0x0000562bfb2dbf68@/root/spacewalk/testsuite/features/support/api_test.rb:64 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
        11: from /root/spacewalk/testsuite/features/support/api_test.rb:65:in `block in call'
        10: from /root/spacewalk/testsuite/features/support/api_test.rb:65:in `synchronize'
         9: from /root/spacewalk/testsuite/features/support/api_test.rb:66:in `block (2 levels) in call'
         8: from /root/spacewalk/testsuite/features/support/xmlrpc_client.rb:28:in `call'
         7: from /usr/lib64/ruby/gems/2.5.0/gems/xmlrpc-0.3.3/lib/xmlrpc/client.rb:268:in `call'
         6: from /usr/lib64/ruby/gems/2.5.0/gems/xmlrpc-0.3.3/lib/xmlrpc/client.rb:287:in `call2'
         5: from /usr/lib64/ruby/gems/2.5.0/gems/xmlrpc-0.3.3/lib/xmlrpc/client.rb:495:in `do_rpc'
         4: from /usr/lib64/ruby/2.5.0/net/http.rb:915:in `start'
         3: from /usr/lib64/ruby/2.5.0/net/http.rb:920:in `do_start'
         2: from /usr/lib64/ruby/2.5.0/net/http.rb:985:in `connect'
         1: from /usr/lib64/ruby/2.5.0/net/protocol.rb:44:in `ssl_socket_connect'
/usr/lib64/ruby/2.5.0/net/protocol.rb:44:in `connect_nonblock': SSL_connect returned=1 errno=0 state=error: certificate verify failed (unable to get local issuer certificate) (OpenSSL::SSL::SSLError)
    Given I am on the Systems overview page of this "kvm_server"             # features/step_definitions/navigation_steps.rb:437
      SSL_connect returned=1 errno=0 state=error: certificate verify failed (unable to get local issuer certificate) (OpenSSL::SSL::SSLError)
      ./features/support/xmlrpc_client.rb:28:in `call'
      ./features/support/api_test.rb:66:in `block (2 levels) in call'
      ./features/support/api_test.rb:65:in `synchronize'
      ./features/support/api_test.rb:65:in `block in call'
      features/secondary/srv_rename_hostname.feature:125:in `I am on the Systems overview page of this "kvm_server"'
    When I follow "States" in the content area                               # features/step_definitions/navigation_steps.rb:326
    And I click on "Apply Highstate"                                         # features/step_definitions/navigation_steps.rb:283
    Then I should see a "Applying the highstate has been scheduled." text    # features/step_definitions/navigation_steps.rb:613
    And I wait until event "Apply highstate scheduled by admin" is completed # features/step_definitions/common_steps.rb:135
=> /var/log/rhn/rhn_web_ui.log
```

See
- https://stackoverflow.com/questions/63178715/sec-error-adding-cert-error-adding-certificate-to-database and
- https://serverfault.com/questions/414578/certutil-function-failed-security-library-bad-database

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links

- fixes: https://github.com/SUSE/spacewalk/issues/22770
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
