### PR TITLE
QE: Fix GH validation core stage

### DIFF
--- a/testsuite/features/reposync/srv_create_fake_channels.feature
+++ b/testsuite/features/reposync/srv_create_fake_channels.feature
@@ -128,6 +128,7 @@ Feature: Create fake channels
     And I click on "Create Channel"
     Then I should see a "Channel Fake-RPM-Terminal-Channel created." text
 
+@deblike_minion
   Scenario: Add Debian-like AMD64 base channel
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
@@ -145,6 +146,7 @@ Feature: Create fake channels
     And I click on "Create Channel"
     Then I should see a "Channel Fake-Base-Channel-Debian-like created." text
 
+@rhlike_minion
   Scenario: Add a RedHat-like base channel
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"

--- a/testsuite/features/reposync/srv_create_fake_repositories.feature
+++ b/testsuite/features/reposync/srv_create_fake_repositories.feature
@@ -41,6 +41,7 @@ Feature: Create fake repositories for each fake child channel
     And I click on "Save Repositories"
     Then I should see a "Fake-Base-Channel repository information was successfully updated" text
 
+@sle_minion
   Scenario: Add the fake RPM repository to the SUSE fake child channel
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Fake-RPM-SUSE-Channel"
@@ -63,7 +64,7 @@ Feature: Create fake repositories for each fake child channel
     And I click on "Save Repositories"
     Then I should see a "Test-Base-Channel-x86_64 repository information was successfully updated" text
 
-  @rhlike_minion
+@rhlike_minion
   Scenario: Add the fake RPM repository to the RedHat-like base channel
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Fake-Base-Channel-RH-like"
@@ -114,6 +115,7 @@ Feature: Create fake repositories for each fake child channel
     And I click on "Save Repositories"
     Then I should see a "Fake-Base-Channel-Debian-like repository information was successfully updated" text
 
+@pxeboot_minion
 @uyuni
 @scc_credentials
   Scenario: Add the repository to the terminal child channel

--- a/testsuite/features/reposync/srv_sync_fake_channels.feature
+++ b/testsuite/features/reposync/srv_sync_fake_channels.feature
@@ -29,6 +29,7 @@ Feature: Synchronize fake channels
     Then I should see a "Repository sync scheduled for Fake-Base-Channel." text
     And I wait until the channel "fake-base-channel" has been synced
 
+@sle_minion
   Scenario: Synchronize Fake-RPM-SUSE-Channel channel
     Given I am authorized for the "Admin" section
     When I follow the left menu "Software > Manage > Channels"
@@ -40,6 +41,7 @@ Feature: Synchronize fake channels
     Then I should see a "Repository sync scheduled for Fake-RPM-SUSE-Channel." text
     And I wait until the channel "fake-rpm-suse-channel" has been synced
 
+@sle_minion
   Scenario: Verify state of Fake-RPM-SUSE-Channel channel
     Then "orion-dummy-1.1-1.1.x86_64.rpm" package should have been stored
     And solver file for "fake-rpm-suse-channel" should reference "orion-dummy-1.1-1.1.x86_64.rpm"
@@ -90,6 +92,7 @@ Feature: Synchronize fake channels
     Then I should see a "Repository sync scheduled for Fake-Base-Channel-RH-like." text
     And I wait until the channel "fake-base-channel-rh-like" has been synced
 
+@pxeboot_minion
 @uyuni
 @scc_credentials
   Scenario: Synchronize the repository in the terminal channel
@@ -103,7 +106,7 @@ Feature: Synchronize fake channels
     Then I should see a "Repository sync scheduled for Fake-RPM-Terminal-Channel." text
     And I wait until the channel "fake-rpm-terminal-channel" has been synced
 
-
+@pxeboot_minion
 @uyuni
 @scc_credentials
   Scenario: Verify state of Fake-RPM-Terminal-Channel custom channel

--- a/testsuite/podman_runner/11_run_core_tests.sh
+++ b/testsuite/podman_runner/11_run_core_tests.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 set -xe
-sudo -i podman exec controller-test bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=uyuni-server-all-in-one-test && export HOSTNAME=controller-test && cd /testsuite && rake cucumber:github_validation_core"
-
+sudo -i podman exec controller-test bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=uyuni-server-all-in-one-test && export HOSTNAME=controller-test && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && cd /testsuite && rake cucumber:github_validation_core"

--- a/testsuite/podman_runner/16_run_init_clients_tests.sh
+++ b/testsuite/podman_runner/16_run_init_clients_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -xe
-sudo -i podman exec controller-test bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=uyuni-server-all-in-one-test && export HOSTNAME=controller-test && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && export DEBLIKE_MINION=deblike_minion && cd /testsuite && rake cucumber:github_validation_init_clients"
+sudo -i podman exec controller-test bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=uyuni-server-all-in-one-test && export HOSTNAME=controller-test && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && cd /testsuite && rake cucumber:github_validation_init_clients"

--- a/testsuite/podman_runner/17_run_secondary_tests.sh
+++ b/testsuite/podman_runner/17_run_secondary_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -xe
-sudo -i podman exec controller-test bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=uyuni-server-all-in-one-test && export HOSTNAME=controller-test && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && export DEBLIKE_MINION=deblike_minion && cd /testsuite && rake cucumber:secondary"
+sudo -i podman exec controller-test bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=uyuni-server-all-in-one-test && export HOSTNAME=controller-test && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && cd /testsuite && rake cucumber:secondary"

--- a/testsuite/podman_runner/18_run_secondary_parallelizable_tests.sh
+++ b/testsuite/podman_runner/18_run_secondary_parallelizable_tests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -xe
 sudo -i podman exec controller-test bash -c "zypper ref && zypper -n install expect"
-sudo -i podman exec controller-test bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=uyuni-server-all-in-one-test && export HOSTNAME=controller-test && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && export DEBLIKE_MINION=deblike_minion && cd /testsuite && rake cucumber:secondary_parallelizable"
+sudo -i podman exec controller-test bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=uyuni-server-all-in-one-test && export HOSTNAME=controller-test && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && cd /testsuite && rake cucumber:secondary_parallelizable"

--- a/testsuite/podman_runner/18_run_secondary_parallelizable_tests_subset.sh
+++ b/testsuite/podman_runner/18_run_secondary_parallelizable_tests_subset.sh
@@ -7,4 +7,4 @@ then
     exit 1
 fi
 
-sudo -i podman exec controller-test bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=uyuni-server-all-in-one-test && export HOSTNAME=controller-test && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && export DEBLIKE_MINION=deblike_minion && cd /testsuite && rake cucumber:secondary_parallelizable_${1}"
+sudo -i podman exec controller-test bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=uyuni-server-all-in-one-test && export HOSTNAME=controller-test && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && cd /testsuite && rake cucumber:secondary_parallelizable_${1}"

--- a/testsuite/run_sets/github_validation/github_validation_core.yml
+++ b/testsuite/run_sets/github_validation/github_validation_core.yml
@@ -7,9 +7,9 @@
 - features/github_validation/core/first_settings.feature
 - features/core/srv_user_preferences.feature
 - features/reposync/srv_create_fake_channels.feature
-- features/github_validation/core/create_repository.feature
+- features/reposync/srv_create_fake_repositories.feature
+- features/reposync/srv_sync_fake_channels.feature
 - features/reposync/srv_create_activationkey.feature
 - features/core/srv_osimage.feature
 - features/core/srv_docker.feature
-- features/reposync/srv_sync_fake_channels.feature
 ## Container features END ###


### PR DESCRIPTION
## What does this PR change?

Having refactored in a previous PR how we handle synchronization of channels, we missed the fact that we don't need a different Cucumber feature on the GH Validation in order to create the fake repositories, therefore we can delete it and re-use the same Cucumber feature that we use in our CI test suite.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were adapted

- [x] **DONE**

## Links

No Ports:
- Manager-4.3 (For now, we did not port GH Validations to Spacewalk)

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
