### PR TITLE
CI: only update comment, or we create spam

### DIFF
--- a/.github/workflows/acceptance_tests_feedback.yml
+++ b/.github/workflows/acceptance_tests_feedback.yml
@@ -17,12 +17,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: peter-evans/create-or-update-comment@v2
+      - uses: actions-cool/maintain-one-comment@v3
         with:
-          issue-number: ${{ github.event.pull_request.number }}
           body: |
             :wave: Hello! Thanks for contributing to our project.
-            Acceptance tests will take same time (aprox. 1h), please be patient :coffee:
+            Acceptance tests will take some time (aprox. 1h), please be patient :coffee:
             You can see the progress at the end of this page and at https://github.com/uyuni-project/uyuni/pull/${{ github.event.pull_request.number  }}/checks
             Once tests finish, if they fail, you can check :eyes: the cucumber report. See the link at the output of the action.
             You can also check the artifacts section, which contains the logs at https://github.com/uyuni-project/uyuni/pull/${{ github.event.pull_request.number }}/checks.
@@ -31,4 +30,5 @@ jobs:
             :warning: You should not merge if acceptance tests fail to pass. :warning:
 
             Happy hacking!
+          body-include: 'Running-Acceptance-Tests-at-PR#troubleshooting'
 


### PR DESCRIPTION
## What does this PR change?

Only update comment in github, do not add a new one.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed
- [ ] **DONE**

## Test coverage
- No tests

- [ ] **DONE**

## Links

N/A

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
