### PR TITLE
Fix feedback message for github

### DIFF
--- a/.github/workflows/acceptance_tests_feedback.yml
+++ b/.github/workflows/acceptance_tests_feedback.yml
@@ -30,5 +30,5 @@ jobs:
             :warning: You should not merge if acceptance tests fail to pass. :warning:
 
             Happy hacking!
-          body-include: 'Running-Acceptance-Tests-at-PR#troubleshooting'
+          body-include: "<acceptance_tests_at_pr>" 
 


### PR DESCRIPTION
## What does this PR change?

fixes the message from github actions acceptance tests at PR feedback.

## GUI diff

No difference.



- [ ] **DONE**

## Documentation
- No documentation needed
- [ ] **DONE**

## Test coverage
- No tests
- [ ] **DONE**

## Links
N/A

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
