### PR TITLE
Test patches on all clients excepted Debian

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -32,9 +32,6 @@ Feature: Smoke tests for <client>
     And the system name for "<client>" should be correct
     And I should see several text fields
 
-# TODO: remove the "skip" tags when Rocky and Alma have patches available.
-@skip_for_rocky9
-@skip_for_alma9
 @skip_for_debianlike
   Scenario: Install a patch on the <client>
     When I follow "Software" in the content area

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -480,15 +480,6 @@ Before('@skip_for_minion') do |scenario|
   skip_this_scenario if scenario.location.file.include? 'minion'
 end
 
-# TODO: remove these 2 "skip" tags when Rocky and Alma have patches available.
-Before('@skip_for_alma9') do
-  skip_this_scenario if ENV.key?(ENV_VAR_BY_HOST['alma9_minion']) || ENV.key?(ENV_VAR_BY_HOST['alma9_ssh_minion'])
-end
-
-Before('@skip_for_rocky9') do
-  skip_this_scenario if ENV.key?(ENV_VAR_BY_HOST['rocky9_minion']) || ENV.key?(ENV_VAR_BY_HOST['rocky_ssh_minion'])
-end
-
 Before('@skip_for_sle_micro') do |scenario|
   skip_this_scenario if scenario.location.file.include? 'slemicro'
 end


### PR DESCRIPTION
## What does this PR change?

This PR removes the `@skip_for_alma9`  and `@skip_for_rocky9` tags, now that Alma 9 and Rocky 9 have patches.

The implementation of these tags was wrong anyway.

Note: Alma 9 has no "Non-Critical" patches as of now. This should be fixed by 4.3.10. If it's not, we will work around it again, but this time with a working implementation.


## Links

Ports:
* 4.3: https://github.com/SUSE/spacewalk/pull/22853


## Changelogs

- [x] No changelog needed
