### PR TITLE
CI: also sync deb repos

### DIFF
--- a/testsuite/dockerfiles/server-all-in-one-dev/Dockerfile
+++ b/testsuite/dockerfiles/server-all-in-one-dev/Dockerfile
@@ -25,8 +25,9 @@ RUN mkdir /tmp/minima && \
     tar zxvf minima-linux-amd64.tar.gz && \
     cp minima /usr/bin/minima
 RUN /usr/bin/minima sync -c /etc/minima.yaml && \
-    mv /srv/www/htdocs/pub/TestRepoRpmUpdates/repositories/systemsmanagement\:/Uyuni\:/Test-Packages\:/Updates/rpm/* /srv/www/htdocs/pub/TestRepoRpmUpdates/ && \
-   rm -rf /srv/www/htdocs/pub/TestRepoRpmUpdates/repositories/
+    mv /srv/www/htdocs/pub/TestRepoRpmUpdates/repositories/systemsmanagement\:/Uyuni\:/Test-Packages\:/Updates/rpm /srv/www/htdocs/pub/TestRepoRpmUpdates/ && \
+    rm -rf /srv/www/htdocs/pub/TestRepoRpmUpdates/repositories/ \
+    mv /srv/www/htdocs/pub/TestRepoDebUpdates/repositories/systemsmanagement\:/Uyuni\:/Test-Packages\:/Updates/deb /srv/www/htdocs/pub/TestRepoDebUpdates/ && \
+    rm -rf /srv/www/htdocs/pub/TestRepoDebUpdates/repositories/
 RUN cd /srv/www/htdocs/pub && ln -s TestRepoRpmUpdates AnotherRepo
 RUN mkdir /etc/pki/rpm-gpg && wget -c http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm/repodata/repomd.xml.key -O  /etc/pki/rpm-gpg/uyuni-tools-gpg-pubkey-0d20833e.key
-

--- a/testsuite/dockerfiles/server-all-in-one-dev/minima.yaml
+++ b/testsuite/dockerfiles/server-all-in-one-dev/minima.yaml
@@ -1,6 +1,7 @@
 storage:
   type: file
-  path: /srv/www/htdocs/pub/TestRepoRpmUpdates
+  path: /srv/www/htdocs/pub/
 
 http:
   - url: http://downloadcontent.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/rpm
+  - url: http://downloadcontent.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/deb


### PR DESCRIPTION
## What does this PR change?

This PR add the synchronization of Deb Test Packages repository, in order to be able to test Debian-like clients in the GitHub Validation

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

No ports.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
