### PR TITLE
Enable repository to have glibc-locale available

### DIFF
--- a/testsuite/features/secondary/min_salt_formulas.feature
+++ b/testsuite/features/secondary/min_salt_formulas.feature
@@ -67,6 +67,7 @@ Feature: Use salt formulas
      And I wait at most 300 seconds until event "Apply highstate in test-mode scheduled" is completed
 
   Scenario: Apply the parametrized formula via the highstate
+     When I enable repository "sle_update_repo" on this "sle_minion" without error control
      And I follow "States" in the content area
      And I click on "Apply Highstate"
      Then I should see a "Applying the highstate has been scheduled." text
@@ -74,6 +75,7 @@ Feature: Use salt formulas
      Then the timezone on "sle_minion" should be "+05"
      And the keymap on "sle_minion" should be "ca"
      And the language on "sle_minion" should be "fr_FR.UTF-8"
+     And I disable repository "sle_update_repo" on this "sle_minion" without error control
 
   Scenario: Reset the formula on the minion
      When I follow "Formulas" in the content area


### PR DESCRIPTION
## What does this PR change?

Enable sle_update_repo repository to have glibc-locale available needed for the parametrized formula

## Links
Fixes : https://github.com/SUSE/spacewalk/issues/22595

- [x] **DONE**

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
