### PR TITLE
Fix migration salt nested minion

### DIFF
--- a/testsuite/features/secondary/min_salt_migration.feature
+++ b/testsuite/features/secondary/min_salt_migration.feature
@@ -97,6 +97,8 @@ Feature: Migrate Salt to bundled Salt on a nested Minion VM
 
   Scenario: Migrate the nested VM to the Salt bundle
     Given the Salt master can reach "salt_migration_minion"
+    When I install packages "venv-salt-minion" on this "salt_migration_minion"
+    Then "venv-salt-minion" should be installed on "salt_migration_minion"
     When I migrate "salt_migration_minion" from salt-minion to venv-salt-minion
 
   Scenario: Purge the Minion from the old salt-minion leftovers

--- a/testsuite/features/secondary/min_salt_migration.feature
+++ b/testsuite/features/secondary/min_salt_migration.feature
@@ -46,7 +46,7 @@ Feature: Migrate Salt to bundled Salt on a nested Minion VM
     And I wait until onboarding is completed for "salt_migration_minion"
 
   Scenario: Create the bootstrap repository for the SLES 15 KVM VM in the Salt migration context
-    When I create the bootstrap repository for "sle_minion" on the server
+    When I create the bootstrap repository for "sle15sp4_minion" on the server
 
 @susemanager
   Scenario: Subscribe the SLES 15 KVM VM to the SLES 15 SP4 channel and enable client tools in the Salt migration context

--- a/testsuite/features/secondary/min_salt_migration.feature
+++ b/testsuite/features/secondary/min_salt_migration.feature
@@ -82,8 +82,6 @@ Feature: Migrate Salt to bundled Salt on a nested Minion VM
     And I wait until I see "1 system successfully completed this action." text, refreshing the page
 
   Scenario: Do some basic testing on the nested VM without Salt bundle
-    When I install packages "venv-salt-minion" on this "salt_migration_minion"
-    Then "venv-salt-minion" should be installed on "salt_migration_minion"
     When I follow the left menu "Salt > Remote Commands"
     Then I should see a "Remote Commands" text in the content area
     When I enter command "file /etc/salt"


### PR DESCRIPTION
## What does this PR change?

Create the boostrap repository for the correct product.
Don't install venv-salt before the migration. It seems to interfere with the migration script.


## Links

Fix : https://github.com/SUSE/spacewalk/issues/22812

- [x] **DONE**

## Changelogs

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
