### PR TITLE
relax dependency to csp-billing-adapter-service

### DIFF
--- a/python/billingdataservice/billing-data-service.changes.mc.Manager-4.3-relax-dependency
+++ b/python/billingdataservice/billing-data-service.changes.mc.Manager-4.3-relax-dependency
@@ -1,0 +1,1 @@
+- relax dependency to csp-billing-adapter-service

--- a/python/billingdataservice/billing-data-service.spec
+++ b/python/billingdataservice/billing-data-service.spec
@@ -27,7 +27,7 @@ Source:         %{name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Requires:       apache2
-Requires:       csp-billing-adapter-service
+Recommends:     csp-billing-adapter-service
 Requires:       python3-Flask
 Requires:       spacewalk-backend-sql
 Requires:       spacewalk-taskomatic


### PR DESCRIPTION
## What does this PR change?

This makes the install check pass  when the public cloud module is not available.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/22854

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
