### PR TITLE
QE: Improve KVM test

### DIFF
--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -325,12 +325,10 @@ Feature: Manage KVM virtual machines via the GUI
     When I install package tftpboot-installation on the server
     And I wait for "tftpboot-installation-SLE-15-SP4-x86_64" to be installed on "server"
 
-# TODO: Not available in any Leap repository, yet
-# See https://suse.slack.com/archives/C02CKHR76Q2/p1694189245268889
-#@uyuni
-#  Scenario: Install TFTP boot package on the server
-#    And I install package tftpboot-installation on the server
-#    And I wait for "tftpboot-installation-openSUSE-Leap-15.5-x86_64" to be installed on "server"
+@uyuni
+ Scenario: Install TFTP boot package on the server
+   When I install package tftpboot-installation on the server
+   And I wait for "tftpboot-installation-openSUSE-Leap-15.5-x86_64" to be installed on "server"
 
 @virthost_kvm
   Scenario: Edit a virtual network
@@ -439,6 +437,22 @@ Feature: Manage KVM virtual machines via the GUI
   Scenario: Cleanup: Remove the TFTP boot package from the server
     When I remove package "tftpboot-installation-SLE-15-SP4-x86_64" from this "server" without error control
     And I wait for "tftpboot-installation-SLE-15-SP4-x86_64" to be uninstalled on "server"
+
+@uyuni
+  Scenario: Cleanup: Remove the TFTP boot package from the server
+    When I remove package "tftpboot-installation-openSUSE-Leap-15.5-x86_64" from this "server" without error control
+    And I wait for "tftpboot-installation-openSUSE-Leap-15.5-x86_64" to be uninstalled on "server"
+
+  Scenario: Cleanup: Stop virtual network
+    Given I am on the "Virtualization" page of this "kvm_server"
+    And I follow "Virtualization" in the content area
+    And I follow "Networks" in the content area
+    And I wait until I do not see "Loading..." text
+    Then table row for "test-net0" should contain "running"
+    When I click on "Stop" in row "test-net0"
+    And I click on "Stop" in "Stop Network" modal
+    Then I wait until table row for "test-net0" contains button "Start"
+    And table row for "test-net0" should contain "stopped"
 
   Scenario: Check for errors in Cobbler monitoring
     Then the local logs for Cobbler should not contain errors

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -904,12 +904,18 @@ When(/^I remove packages? "([^"]*)" from this "([^"]*)"((?: without error contro
 end
 
 When(/^I install package tftpboot-installation on the server$/) do
-  output, _code = get_target('server').run('find /var/spacewalk/packages -name tftpboot-installation-SLE-15-SP4-x86_64-*.noarch.rpm')
-  packages = output.split("\n")
-  pattern = '/tftpboot-installation-([^/]+)*.noarch.rpm'
-  # Reverse sort the package name to get the latest version first and install it
-  package = packages.min { |a, b| b.match(pattern)[0] <=> a.match(pattern)[0] }
-  get_target('server').run("rpm -i #{package}", check_errors: false)
+  server = get_target('server')
+  os_version = server.os_version
+  if product == 'Uyuni'
+    server.run("zypper --non-interactive install tftpboot-installation-openSUSE-Leap-#{os_version}-x86_64", check_errors: false, verbose: true)
+  else
+    output, _code = server.run('find /var/spacewalk/packages -name tftpboot-installation-SLE-15-SP4-x86_64-*.noarch.rpm')
+    packages = output.split("\n")
+    pattern = '/tftpboot-installation-([^/]+)*.noarch.rpm'
+    # Reverse sort the package name to get the latest version first and install it
+    package = packages.min { |a, b| b.match(pattern)[0] <=> a.match(pattern)[0] }
+    server.run("rpm -i #{package}", check_errors: false)
+  end
 end
 
 When(/^I reset tftp defaults on the proxy$/) do


### PR DESCRIPTION
## What does this PR change?

- The package `tftpboot-installation-openSUSE-Leap-15` is now available with the switch to openSUSE Leap 15.5
- the network interface `test-net0` was never stopped, which caused a failed highstate in the latter server hostname rename test
## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
