### PR TITLE
add SLES15 SP4 LTSS and ESPOS and LTSS for HPC 15 SP5

### DIFF
--- a/susemanager-sync-data/channel_families.json
+++ b/susemanager-sync-data/channel_families.json
@@ -80,6 +80,14 @@
     "name" : "SUSE Linux Enterprise High Performance Computing LTSS 15 SP4 x86_64"
   },
   {
+    "label" : "HPC15-SP5-LTSS-ARM64",
+    "name" : "SUSE Linux Enterprise High Performance Computing LTSS 15 SP5 ARM64"
+  },
+  {
+    "label" : "HPC15-SP5-LTSS-X86",
+    "name" : "SUSE Linux Enterprise High Performance Computing LTSS 15 SP5 x86_64"
+  },
+  {
     "label" : "HPE-HELION-OPENSTACK-X86",
     "name" : "HPE Helion Openstack (x86)"
   },
@@ -330,6 +338,22 @@
   {
     "label" : "SLES15-SP3-LTSS-Z",
     "name" : "SUSE Linux Enterprise Server LTSS 15 SP3 Z-Series"
+  },
+  {
+    "label" : "SLES15-SP4-LTSS-ARM64",
+    "name" : "SUSE Linux Enterprise Server LTSS 15 SP4 ARM64"
+  },
+  {
+    "label" : "SLES15-SP4-LTSS-PPC",
+    "name" : "SUSE Linux Enterprise Server LTSS 15 SP4 PPC"
+  },
+  {
+    "label" : "SLES15-SP4-LTSS-X86",
+    "name" : "SUSE Linux Enterprise Server LTSS 15 SP4 x86_64"
+  },
+  {
+    "label" : "SLES15-SP4-LTSS-Z",
+    "name" : "SUSE Linux Enterprise Server LTSS 15 SP4 Z-Series"
   },
   {
     "label" : "SLESMT",

--- a/susemanager-sync-data/susemanager-sync-data.changes.mc.Manager-4.3
+++ b/susemanager-sync-data/susemanager-sync-data.changes.mc.Manager-4.3
@@ -1,0 +1,3 @@
+- add SLES15 SP4 LTSS
+- add ESPOS and LTSS for HPC 15 SP5
+


### PR DESCRIPTION
## What does this PR change?

- add SLES15 SP4 LTSS
- add ESPOS and LTSS for HPC 15 SP5

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/22859

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
