### PR TITLE
QE: Fix switch from sha256 to sha512

### DIFF
--- a/testsuite/features/secondary/min_check_patches_install.feature
+++ b/testsuite/features/secondary/min_check_patches_install.feature
@@ -38,7 +38,7 @@ Feature: Display patches
     And I follow "andromeda-dummy-6789"
     And I follow "Packages"
     Then I should see a "Fake-RPM-SUSE-Channel" link
-    And I should see a "sha256:ba3f6d939fce43b60f4d20a09887e211f11024b61defb246dd62705bf4f4ced0" text
+    And I should see a "sha512:6bc584eb0af1bc04705c78e59ca0e4154ea86c46cd75abee57c82bfc4ebb57f3660ed21e9aceceae03855264e163853acbcde88005609d773c20f185587f70cc" text
     And I should see a "andromeda-dummy-2.0-1.1-noarch" link
 
   Scenario: Check relevant patches for this client

--- a/testsuite/features/secondary/srv_check_channels_page.feature
+++ b/testsuite/features/secondary/srv_check_channels_page.feature
@@ -52,8 +52,8 @@ Feature: The channels page
     Then I should see a "This is the andromeda dummy package used for testing SUSE Manager" text
     And I should see a "Fake-RPM-SUSE-Channel" link
     And I should see a "build.opensuse.org" text
-    And I should see a "SHA256sum:" text
-    And I should see a "packages/1/ba3/andromeda-dummy/2.0-1.1/noarch/ba3f6d939fce43b60f4d20a09887e211f11024b61defb246dd62705bf4f4ced0/andromeda-dummy-2.0-1.1.noarch.rpm" text
+    And I should see a "SHA512sum:" text
+    And I should see a "packages/1/6bc/andromeda-dummy/2.0-1.1/noarch/6bc584eb0af1bc04705c78e59ca0e4154ea86c46cd75abee57c82bfc4ebb57f3660ed21e9aceceae03855264e163853acbcde88005609d773c20f185587f70cc/andromeda-dummy-2.0-1.1.noarch.rpm" text
 
   Scenario: Check package dependencies page
     When I follow the left menu "Software > Channel List > All"


### PR DESCRIPTION
## What does this PR change?

We had some changes to the checksums recently and switched from SHA256 to SHA512.
Fixes https://github.com/SUSE/spacewalk/issues/22845

![image](https://github.com/uyuni-project/uyuni/assets/12104291/b1517723-20f4-4879-a213-683d1f6e3ccb)
![image](https://github.com/uyuni-project/uyuni/assets/12104291/bcf6f745-409b-46ee-8aad-a512b96d6cc4)
![image](https://github.com/uyuni-project/uyuni/assets/12104291/0418a504-6732-43d5-aa7b-08588cc610d9)

Tested on HEAD.
```bash
(...)
  Scenario: Check packages of SLES release 6789 patches                                                                                                               # features/secondary/min_check_patches_install.feature:36
      This scenario ran at: 2023-10-24 14:35:53 +0200
    When I follow the left menu "Patches > Patch List > Relevant"                                                                                                     # features/step_definitions/navigation_steps.rb:364
    And I follow "andromeda-dummy-6789"                                                                                                                               # features/step_definitions/navigation_steps.rb:311
    And I follow "Packages"                                                                                                                                           # features/step_definitions/navigation_steps.rb:311
    Then I should see a "Fake-RPM-SUSE-Channel" link                                                                                                                  # features/step_definitions/navigation_steps.rb:668
    And I should see a "sha512:6bc584eb0af1bc04705c78e59ca0e4154ea86c46cd75abee57c82bfc4ebb57f3660ed21e9aceceae03855264e163853acbcde88005609d773c20f185587f70cc" text # features/step_definitions/navigation_steps.rb:613
    And I should see a "andromeda-dummy-2.0-1.1-noarch" link                                                                                                          # features/step_definitions/navigation_steps.rb:668
      This scenario took: 1 seconds
(...)
  Scenario: Check package metadata                                                                                                                                                                                                              # features/secondary/srv_check_channels_page.feature:46
      This scenario ran at: 2023-10-24 14:37:36 +0200
    When I follow the left menu "Software > Channel List > All"                                                                                                                                                                                 # features/step_definitions/navigation_steps.rb:364
    And I follow "Show All Child Channels"                                                                                                                                                                                                      # features/step_definitions/navigation_steps.rb:311
    And I follow "Fake-RPM-SUSE-Channel"                                                                                                                                                                                                        # features/step_definitions/navigation_steps.rb:311
    And I follow "Packages"                                                                                                                                                                                                                     # features/step_definitions/navigation_steps.rb:311
    And I follow "andromeda-dummy-2.0-1.1.noarch"                                                                                                                                                                                               # features/step_definitions/navigation_steps.rb:311
    Then I should see a "This is the andromeda dummy package used for testing SUSE Manager" text                                                                                                                                                # features/step_definitions/navigation_steps.rb:613
    And I should see a "Fake-RPM-SUSE-Channel" link                                                                                                                                                                                             # features/step_definitions/navigation_steps.rb:668
    And I should see a "build.opensuse.org" text                                                                                                                                                                                                # features/step_definitions/navigation_steps.rb:613
    And I should see a "SHA512sum:" text                                                                                                                                                                                                        # features/step_definitions/navigation_steps.rb:613
    And I should see a "packages/1/6bc/andromeda-dummy/2.0-1.1/noarch/6bc584eb0af1bc04705c78e59ca0e4154ea86c46cd75abee57c82bfc4ebb57f3660ed21e9aceceae03855264e163853acbcde88005609d773c20f185587f70cc/andromeda-dummy-2.0-1.1.noarch.rpm" text # features/step_definitions/navigation_steps.rb:613
      This scenario took: 2 seconds
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
