### PR TITLE
add bootstrap repository data X micro 5.5

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1224,6 +1224,14 @@ DATA = {
         'BASECHANNEL' : 'opensuse_micro5_4-aarch64', 'PKGLIST' :  PKGLISTMICRO_BUNDLE_ONLY,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensusemicro/5/4/bootstrap/'
     },
+    'openSUSE-Leap-Micro-5.5-x86_64-uyuni' : {
+        'BASECHANNEL' : 'opensuse_micro5_5-x86_64', 'PKGLIST' :  PKGLISTMICRO_BUNDLE_ONLY,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensusemicro/5/5/bootstrap/'
+    },
+    'openSUSE-Leap-Micro-5.5-aarch64-uyuni' : {
+        'BASECHANNEL' : 'opensuse_micro5_5-aarch64', 'PKGLIST' :  PKGLISTMICRO_BUNDLE_ONLY,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensusemicro/5/5/bootstrap/'
+    },
     'openSUSE-MicroOS-x86_64-uyuni' : {
         'BASECHANNEL' : 'opensuse_microos-x86_64', 'PKGLIST' : PKGLISTUMBLEWEED_SALT_NO_BUNDLE,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensusemicroos/latest/0/bootstrap/'

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1120,6 +1120,18 @@ DATA = {
         'PDID' : [2574, 2551], 'BETAPDID' : [2554], 'PKGLIST' : PKGLISTMICRO_BUNDLE_ONLY,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/slemicro/5/4/bootstrap/'
     },
+    'SLE-MICRO-5.5-aarch64' : {
+        'PDID' : [2603, 2549], 'BETAPDID' : [2552], 'PKGLIST' : PKGLISTMICRO_BUNDLE_ONLY,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/slemicro/5/5/bootstrap/'
+    },
+    'SLE-MICRO-5.5-s390x' : {
+        'PDID' : [2604, 2550], 'BETAPDID' : [2553], 'PKGLIST' : PKGLISTMICRO_BUNDLE_ONLY,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/slemicro/5/5/bootstrap/'
+    },
+    'SLE-MICRO-5.5-x86_64' : {
+        'PDID' : [2605, 2551], 'BETAPDID' : [2554], 'PKGLIST' : PKGLISTMICRO_BUNDLE_ONLY,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/slemicro/5/5/bootstrap/'
+    },
     'openSUSE-Leap-15-x86_64' : {
         'BASECHANNEL' : 'opensuse_leap15_0-x86_64', 'PKGLIST' :  PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/opensuse/15/0/bootstrap/'

--- a/susemanager/susemanager.changes.mc.Manager-4.3-bsrepo-def-slemicro55
+++ b/susemanager/susemanager.changes.mc.Manager-4.3-bsrepo-def-slemicro55
@@ -1,0 +1,1 @@
+- add bootstrap repository data for SLE-Micro 5.5

--- a/susemanager/susemanager.changes.mc.bsrepo-def-slemicro55
+++ b/susemanager/susemanager.changes.mc.bsrepo-def-slemicro55
@@ -1,0 +1,1 @@
+- add bootstrap repository definition for openSUSE Leap Micro 5.5

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1336,6 +1336,46 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
 
+[opensuse_micro5_5]
+checksum = sha256
+archs    = x86_64, aarch64
+name     = openSUSE Leap Micro 5.5 (%(arch)s)
+gpgkey_url = https://download.opensuse.org/distribution/leap-micro/5.5/product/repo/Leap-Micro-5.5-x86_64-Media1/gpg-pubkey-3dbdc284-53674dd4.asc
+gpgkey_id = 3DBDC284
+gpgkey_fingerprint = 22C0 7BA5 3417 8CD0 2EFE  22AA B88B 2FD4 3DBD C284
+repo_url = https://download.opensuse.org/distribution/leap-micro/5.5/product/repo/Leap-Micro-5.5-%(arch)s-Media1/
+dist_map_release = 5.5
+
+[opensuse_micro5_5-sle-updates]
+label    = %(base_channel)s-sle-updates
+name     = SLE Micro 5.5 Update Repository (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_micro5_5-%(arch)s
+repo_url = https://download.opensuse.org/update/leap-micro/5.5/sle/
+
+# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap Micro 5.X releases
+[opensuse_micro5_5-uyuni-client]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = x86_64, aarch64
+base_channels = opensuse_micro5_5-%(arch)s
+checksum = sha256
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+
+# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap Micro 5.X release
+[opensuse_micro5_5-uyuni-client-devel]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = x86_64, aarch64
+base_channels = opensuse_micro5_5-%(arch)s
+checksum = sha256
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+
 [opensuse_tumbleweed]
 checksum = sha256
 archs    = x86_64, aarch64

--- a/utils/spacewalk-utils.changes.mc.bsrepo-def-slemicro55
+++ b/utils/spacewalk-utils.changes.mc.bsrepo-def-slemicro55
@@ -1,0 +1,1 @@
+- add openSUSE Leap Micro 5.5 to spacewalk-commons-channels


### PR DESCRIPTION
## What does this PR change?

- Add bootstrap repository data for SLE-Micro 5.5 and openSUSE Leap Micro 5.5
- add repository definitions for openSUSE Leap Micro 5.5 to spacewalk-common-channels

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

A port of https://github.com/SUSE/spacewalk/pull/22860 + openSUSE Leap

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
