### PR TITLE
QE: Fix the channel to check on the CVE Audit test

### DIFF
--- a/testsuite/features/secondary/min_cve_audit.feature
+++ b/testsuite/features/secondary/min_cve_audit.feature
@@ -82,7 +82,7 @@ Feature: CVE Audit on SLE Salt Minions
     Then I should get status "NOT_AFFECTED" for "sle_minion"
     When I call audit.list_systems_by_patch_status() with CVE identifier "CVE-1999-9999"
     Then I should get status "AFFECTED_PATCH_APPLICABLE" for "sle_minion"
-    And I should get the test channel
+    And I should get the test base channel
     And I should get the "milkyway-dummy-2345" patch
 
   Scenario: Apply patches

--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -500,13 +500,13 @@ Then(/^I should get status "([^"]+)" for "([^"]+)"$/) do |status, host|
   step %(I should get status "#{status}" for system "#{get_system_id(node)}")
 end
 
-Then(/^I should get the test channel$/) do
-  arch = `uname -m`
+Then(/^I should get the test base channel$/) do
+  arch, _code = get_target('server').run('uname -m')
   arch.chomp!
   channel = if arch != 'x86_64'
               'fake-base-channel-i586'
             else
-              'fake-rpm-suse-channel'
+              'fake-base-channel'
             end
   log "result: #{@result}"
   assert(@result['channel_labels'].include?(channel))


### PR DESCRIPTION
## What does this PR change?

Fix the channel to check on the CVE Audit test

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
