### PR TITLE
We check the restart of the host, not of the SUMA server

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1433,7 +1433,7 @@ When(/^I reboot the "([^"]*)" minion through SSH$/) do |host|
   node.run('reboot > /dev/null 2> /dev/null &')
   reboot_timeout = 120
   check_shutdown(node.public_ip, reboot_timeout)
-  check_restart(get_target('server').public_ip, node, reboot_timeout)
+  check_restart(node.public_ip, node, reboot_timeout)
 end
 
 When(/^I reboot the "([^"]*)" minion through the web UI$/) do |host|


### PR DESCRIPTION
## What does this PR change?

This PR tries to call `check_restart` with the correct arguments.


## Links

Ports:
* 4.3: https://github.com/SUSE/spacewalk/pull/22865


## Changelogs

- [x] No changelog needed
