### PR TITLE
QE: Fix grafana radio button check

### DIFF
--- a/testsuite/features/build_validation/init_clients/monitoring_server.feature
+++ b/testsuite/features/build_validation/init_clients/monitoring_server.feature
@@ -88,7 +88,7 @@ Feature: Bootstrap the monitoring server
   Scenario: Test Grafana dashboards of monitoring server
     When I visit the grafana dashboards of this "monitoring_server"
     And I wait until I do not see "Loading Grafana" text
-    And I check radio button "View as list"
+    And I check radio button "View as list", if not checked
     # These are the 4 dashboards created by default when enabling the Grafana formula
     Then I should see a "Apache2" text
     And I should see a "PostgreSQL database insights" text

--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -207,7 +207,7 @@ Feature: Smoke tests for <client>
     When I visit the grafana dashboards of this "monitoring_server"
     And I wait until I do not see "Loading Grafana" text
     And I wait until I see "General" text
-    And I check radio button "View as list"
+    And I check radio button "View as list", if not checked
     When I follow "Client Systems"
     Then I should see "<client>" hostname
     When I enter "<client>" hostname on grafana's host field

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -201,6 +201,10 @@ When(/^I check radio button "(.*?)"$/) do |arg1|
   raise "#{arg1} can't be checked" unless choose(arg1)
 end
 
+When(/^I check radio button "(.*?)", if not checked$/) do |arg1|
+  choose(arg1) unless has_checked_field?(arg1)
+end
+
 When(/^I check default base channel radio button of this "([^"]*)"$/) do |host|
   default_base_channel = BASE_CHANNEL_BY_CLIENT[product][host]
   raise "#{default_base_channel} can't be checked" unless choose(default_base_channel)


### PR DESCRIPTION
## What does this PR change?
There were errors when, in Grafana, we were trying to check a radio button when it was already checked. This makes it so we don't double check the button, and the rest of the tests can continue as normal. Tested with @Bischoff on the 4.3.9 BV.

## Links

- 4.3 https://github.com/SUSE/spacewalk/pull/22857

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
