### PR TITLE
A reboot is not needed to deploy a file in /etc on a SLE micro

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -119,7 +119,6 @@ Feature: Smoke tests for <client>
     When I click on "Deploy Files to Selected Systems"
     Then I should see a "1 revision-deploy is being scheduled." text
     And I should see a "0 revision-deploys overridden." text
-    And I reboot the "<client>" if it is a SLE Micro
     And I wait until file "/etc/s-mgr/config" exists on "<client>"
     Then file "/etc/s-mgr/config" should contain "COLOR=white" on "<client>"
 


### PR DESCRIPTION
## What does this PR change?

According to my tests, the deployment of `/etc/s-mgr/config` works even if we don't reboot afterwards.

This PR does not make stability any better, it just helps speed.


## Links

Ports:
* 4.3: https://github.com/SUSE/spacewalk/pull/22868


## Changelogs

- [x] No changelog needed
