### PR TITLE
specify http timeouts for salt-api connections

### DIFF
--- a/java/code/src/com/redhat/rhn/common/util/http/HttpClientAdapter.java
+++ b/java/code/src/com/redhat/rhn/common/util/http/HttpClientAdapter.java
@@ -77,6 +77,7 @@ public class HttpClientAdapter {
     public static final String MAX_CONNCECTIONS = "java.mgr_sync_max_connections";
     public static final String HTTP_CONNECTION_TIMEOUT = "java.http_connection_timeout";
     public static final String HTTP_SOCKET_TIMEOUT = "java.http_socket_timeout";
+    public static final String SALT_API_HTTP_SOCKET_TIMEOUT = "java.salt_api_http_socket_timeout";
     private static final int TO_MILLISECONDS = 1000;
 
     /** The log. */
@@ -122,8 +123,8 @@ public class HttpClientAdapter {
 
         clientBuilder.setDefaultCredentialsProvider(credentialsProvider);
         Builder requestConfigBuilder = RequestConfig.custom()
-                .setConnectTimeout(Config.get().getInt(HTTP_CONNECTION_TIMEOUT, 5) * TO_MILLISECONDS)
-                .setSocketTimeout(Config.get().getInt(HTTP_SOCKET_TIMEOUT, 5 * 60) * TO_MILLISECONDS)
+                .setConnectTimeout(HttpClientAdapter.getHTTPConnectionTimeout(5))
+                .setSocketTimeout(HttpClientAdapter.getHTTPSocketTimeout(5 * 60))
                 .setCookieSpec(CookieSpecs.IGNORE_COOKIES);
 
         // Store the proxy settings
@@ -146,8 +147,8 @@ public class HttpClientAdapter {
             }
 
             // Explicitly exclude the NTLM authentication scheme
-            requestConfigBuilder =  requestConfigBuilder.setProxyPreferredAuthSchemes(
-                                    Arrays.asList(AuthSchemes.DIGEST, AuthSchemes.BASIC));
+            requestConfigBuilder = requestConfigBuilder.setProxyPreferredAuthSchemes(
+                    Arrays.asList(AuthSchemes.DIGEST, AuthSchemes.BASIC));
 
             clientBuilder.setProxyAuthenticationStrategy(new ProxyAuthenticationStrategy());
 
@@ -190,7 +191,7 @@ public class HttpClientAdapter {
          */
         @Override
         public HttpRoute determineRoute(final HttpHost host, final HttpRequest request,
-                final HttpContext context) throws HttpException {
+                                        final HttpContext context) throws HttpException {
 
             Boolean ignoreNoProxy = (Boolean) context.getAttribute(IGNORE_NO_PROXY);
             URI requestUri = (URI) context.getAttribute(REQUEST_URI);
@@ -323,5 +324,29 @@ public class HttpClientAdapter {
             }
         }
         return true;
+    }
+
+    /**
+     * @param defaultTimeout default timeout in seconds
+     * @return return the HTTP Connection Timeout in milliseconds
+     */
+    public static int getHTTPConnectionTimeout(int defaultTimeout) {
+        return Config.get().getInt(HTTP_CONNECTION_TIMEOUT, defaultTimeout) * TO_MILLISECONDS;
+    }
+
+    /**
+     * @param defaultTimeout default timeout in seconds
+     * @return return the HTTP Socket Timeout in milliseconds
+     */
+    public static int getHTTPSocketTimeout(int defaultTimeout) {
+        return Config.get().getInt(HTTP_SOCKET_TIMEOUT, defaultTimeout) * TO_MILLISECONDS;
+    }
+
+    /**
+     * @param defaultTimeout default timeout in seconds
+     * @return return the HTTP Socket Timeout in milliseconds for salt api connections
+     */
+    public static int getSaltApiHTTPSocketTimeout(int defaultTimeout) {
+        return Config.get().getInt(SALT_API_HTTP_SOCKET_TIMEOUT, defaultTimeout) * TO_MILLISECONDS;
     }
 }

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -18,6 +18,7 @@ import com.redhat.rhn.common.RhnRuntimeException;
 import com.redhat.rhn.common.client.ClientCertificate;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.messaging.JavaMailException;
+import com.redhat.rhn.common.util.http.HttpClientAdapter;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.server.ServerFactory;
@@ -188,9 +189,9 @@ public class SaltService implements SystemQuery, SaltApi {
      */
     public SaltService() {
         RequestConfig requestConfig = RequestConfig.custom()
-                .setConnectTimeout(0)
-                .setSocketTimeout(0)
-                .setConnectionRequestTimeout(0)
+                .setConnectTimeout(HttpClientAdapter.getHTTPConnectionTimeout(5))
+                .setSocketTimeout(HttpClientAdapter.getSaltApiHTTPSocketTimeout(12 * 60 * 60))
+                .setConnectionRequestTimeout(5 * 60 * 1000)
                 .setCookieSpec(CookieSpecs.STANDARD)
                 .build();
         HttpAsyncClientBuilder httpClientBuilder = HttpAsyncClients.custom();

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -585,8 +585,8 @@ public class SaltService implements SystemQuery, SaltApi {
             }
             catch (SaltException e) {
                 try {
-                    LOG.error("Unable to connect: {}, retrying in " + DELAY_TIME_SECONDS + " seconds.", e);
-                    Thread.sleep(1000 * DELAY_TIME_SECONDS);
+                    LOG.error("Unable to connect: {}, retrying in {} seconds.", e, DELAY_TIME_SECONDS);
+                    Thread.sleep(1000L * DELAY_TIME_SECONDS);
                     if (retries == 1) {
                         MailHelper.withSmtp().sendAdminEmail("Cannot connect to salt event bus",
                                 "salt-api daemon is not responding. Check the status of " +
@@ -599,6 +599,7 @@ public class SaltService implements SystemQuery, SaltApi {
                 }
                 catch (InterruptedException e1) {
                     LOG.error("Interrupted during sleep", e1);
+                    Thread.currentThread().interrupt();
                 }
             }
         }
@@ -1091,7 +1092,7 @@ public class SaltService implements SystemQuery, SaltApi {
     public Optional<SystemInfo> getSystemInfoFull(String minionId) {
         return rawJsonCall(State.apply(Collections.singletonList(ApplyStatesEventMessage.SYSTEM_INFO_FULL),
                Optional.empty()), minionId)
-               .flatMap(result -> result.result())
+               .flatMap(Result::result)
                .map(result -> Json.GSON.fromJson(result, SystemInfo.class));
     }
 

--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -240,6 +240,9 @@ java.http_connection_timeout = 5
 # HTTP Socket Timeout in seconds
 java.http_socket_timeout = 300
 
+# HTTP Socket Timeout in seconds for salt-api connections (12 hours)
+java.salt_api_http_socket_timeout = 43200
+
 # Allow adding patch (errata) information via the API for the specified vendor channels. This is provided as convenience
 # option to allow third-party scripts to change vendor information, but please note any channel in this list, once this
 # option is enabled, cannot be supported by the vendor. Please check the documentation for more information.

--- a/java/spacewalk-java.changes.mc.Manager-4.3-salt-api-connection
+++ b/java/spacewalk-java.changes.mc.Manager-4.3-salt-api-connection
@@ -1,0 +1,1 @@
+- add salt-api socket timeout to abort stuck taskomatic jobs (bsc#1211649)


### PR DESCRIPTION
## What does this PR change?

It seems that sometimes (with high load) HTTP connections from taskomatic to salt-api for salt-ssh calls gets stuck,
while the ssh connection from the server to the client does not exist (anymore?), the http connection is still up and waiting for a result. Such connections can stay open for days.

To prevent keeping these connections open forever, this PR introduce a socket timeout which will kill the connection after a time of inactivity.
This time is by default very long (12 hours) as during a salt-ssh connection a full state.apply needs to be finished before a result is send back. If this state.apply contain for example a distribution upgrade with thousand of packages, it could take hours to complete.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/22834

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
