### PR TITLE
Reboot SLE micros through the web UI

### DIFF
--- a/testsuite/features/build_validation/init_clients/slemicro51_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro51_minion.feature
@@ -23,7 +23,7 @@ Feature: Bootstrap a SLE Micro 5.1 Salt minion
     And I wait until I see "Bootstrap process initiated." text
 
   Scenario: Reboot the SLE Micro 5.1 minion and wait until reboot is completed
-    When I reboot the "slemicro51_minion" minion through SSH
+    When I reboot the "slemicro51_minion" minion through the web UI
 
   Scenario: Check the new bootstrapped SLE Micro 5.1 minion in System Overview page
     When I wait until onboarding is completed for "slemicro51_minion"

--- a/testsuite/features/build_validation/init_clients/slemicro52_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro52_minion.feature
@@ -23,7 +23,7 @@ Feature: Bootstrap a SLE Micro 5.2 Salt minion
     And I wait until I see "Bootstrap process initiated." text
 
   Scenario: Reboot the SLE Micro 5.2 minion and wait until reboot is completed
-    When I reboot the "slemicro52_minion" minion through SSH
+    When I reboot the "slemicro52_minion" minion through the web UI
 
   Scenario: Check the new bootstrapped SLE Micro 5.2 minion in System Overview page
     When I wait until onboarding is completed for "slemicro52_minion"

--- a/testsuite/features/build_validation/init_clients/slemicro53_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro53_minion.feature
@@ -23,7 +23,7 @@ Feature: Bootstrap a SLE Micro 5.3 Salt minion
     And I wait until I see "Bootstrap process initiated." text
 
   Scenario: Reboot the SLE Micro 5.3 minion and wait until reboot is completed
-    When I reboot the "slemicro53_minion" minion through SSH
+    When I reboot the "slemicro53_minion" minion through the web UI
 
   Scenario: Check the new bootstrapped SLE Micro 5.3 minion in System Overview page
     When I wait until onboarding is completed for "slemicro53_minion"

--- a/testsuite/features/build_validation/init_clients/slemicro54_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro54_minion.feature
@@ -23,7 +23,7 @@ Feature: Bootstrap a SLE Micro 5.4 Salt minion
     And I wait until I see "Bootstrap process initiated." text
 
   Scenario: Reboot the SLE Micro 5.4 minion and wait until reboot is completed
-    When I reboot the "slemicro54_minion" minion through SSH
+    When I reboot the "slemicro54_minion" minion through the web UI
 
   Scenario: Check the new bootstrapped SLE Micro 5.4 minion in System Overview page
     When I wait until onboarding is completed for "slemicro54_minion"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1434,14 +1434,6 @@ When(/^I reboot the server through SSH$/) do
   end
 end
 
-When(/^I reboot the "([^"]*)" minion through SSH$/) do |host|
-  node = get_target(host)
-  node.run('reboot > /dev/null 2> /dev/null &')
-  reboot_timeout = 120
-  check_shutdown(node.public_ip, reboot_timeout)
-  check_restart(node.public_ip, node, reboot_timeout)
-end
-
 When(/^I reboot the "([^"]*)" minion through the web UI$/) do |host|
   steps %(
     Given I am on the Systems overview page of this "#{host}"
@@ -1457,7 +1449,7 @@ end
 
 When(/^I reboot the "([^"]*)" if it is a SLE Micro$/) do |host|
   if slemicro_host?(host)
-    step %(I reboot the "#{host}" minion through SSH)
+    step %(I reboot the "#{host}" minion through the web UI)
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

It looks like SSH reboots on SLE micro minions provoke `Minion is down or could not be contacted` failures.

Switching back to plain old UI reboots.


## Links

Ports:
* 4.3: https://github.com/SUSE/spacewalk/pull/22873


## Changelogs

- [x] No changelog needed
