### PR TITLE
Use INIT_BASE bci for images push in ibs

### DIFF
--- a/rel-eng/push-packages-to-obs.sh
+++ b/rel-eng/push-packages-to-obs.sh
@@ -271,6 +271,7 @@ while read PKG_NAME; do
       if [ "${OSCAPI}" == "https://api.suse.de" ]; then
           # SUSE Manager settings
           VERSION=$(sed 's/^\([0-9]\+\.[0-9]\+\).*$/\1/' ${BASE_DIR}/packages/uyuni-base)
+          sed "s/^ARG INIT_BASE=.*$/ARG INIT_BASE=bci/bci-init:15.4/" -i $SRPM_PKG_DIR/Dockerfile
           sed "/^#\!BuildTag:/s/uyuni/suse\/manager\/${VERSION}/g" -i $SRPM_PKG_DIR/Dockerfile
           sed "/^# labelprefix=/s/org\.opensuse\.uyuni/com.suse.manager/" -i $SRPM_PKG_DIR/Dockerfile
           sed "s/^ARG VENDOR=.*$/ARG VENDOR=\"SUSE LLC\"/" -i $SRPM_PKG_DIR/Dockerfile


### PR DESCRIPTION
## What does this PR change?

IBS is failing building two images:

- `init-image` -> `unresolvable: nothing provides container:opensuse/leap:15.4`
- `server-image` -> `unresolvable: nothing provides container:uyuni/init:latest`

The issue can be fix in  `push-packages-to-obs.sh` (as explained here https://github.com/uyuni-project/uyuni/commit/ae1a97c2f530387e3dde697d3d142e6eb21eebed ) :
- `init-image` is not required in IBS, so it shouldn't be pushed
- `server-image`  should use `bci/bci-init:15.4` instead of `container:uyuni/init:latest`

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests
- [x] **DONE**

## Links
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
