### PR TITLE
Enhance hardware data sent to SCC by memory

### DIFF
--- a/java/code/src/com/suse/scc/SCCSystemRegistration.java
+++ b/java/code/src/com/suse/scc/SCCSystemRegistration.java
@@ -216,6 +216,7 @@ public class SCCSystemRegistration {
             ofNullable(srv.getVirtualInstance().getUuid())
                     .ifPresent(u -> hwinfo.put("uuid", u.replaceAll("(\\w{8})(\\w{4})(\\w{4})(\\w{4})(\\w{12})",
                             "$1-$2-$3-$4-$5")));
+            hwinfo.put("mem_total", srv.getVirtualInstance().getTotalMemory().toString());
         }
         else {
             // null == physical instance

--- a/java/spacewalk-java.changes.rjpmestre.enhance-hardware-data-sent-to-scc-by-memory
+++ b/java/spacewalk-java.changes.rjpmestre.enhance-hardware-data-sent-to-scc-by-memory
@@ -1,0 +1,1 @@
+- Enhance hardware data sent to SCC by memory


### PR DESCRIPTION
## What does this PR change?

As SCC API can now collect systems memory (RAM).  
This enhances hardware data sent to SCC by adding total memory in MiB

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/22758

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
