### PR TITLE
use init-image based on bci-base 15.4 in IBS

### DIFF
--- a/rel-eng/push-packages-to-obs.sh
+++ b/rel-eng/push-packages-to-obs.sh
@@ -263,7 +263,7 @@ while read PKG_NAME; do
       if [ "${OSCAPI}" == "https://api.suse.de" ]; then
           # SUSE Manager settings
           VERSION=$(sed 's/^\([0-9]\+\.[0-9]\+\).*$/\1/' ${BASE_DIR}/packages/uyuni-base)
-          sed "s/^ARG INIT_BASE=.*$/ARG INIT_BASE=bci\/bci-base:15.4/" -i $SRPM_PKG_DIR/Dockerfile
+          sed "s/^ARG INIT_BASE=.*$/ARG INIT_BASE=bci\/bci-init:15.4/" -i $SRPM_PKG_DIR/Dockerfile
           sed "/^#\!BuildTag:/s/uyuni/suse\/manager\/${VERSION}/g" -i $SRPM_PKG_DIR/Dockerfile
           sed "/^# labelprefix=/s/org\.opensuse\.uyuni/com.suse.manager/" -i $SRPM_PKG_DIR/Dockerfile
           sed "s/^ARG VENDOR=.*$/ARG VENDOR=\"SUSE LLC\"/" -i $SRPM_PKG_DIR/Dockerfile

--- a/rel-eng/push-packages-to-obs.sh
+++ b/rel-eng/push-packages-to-obs.sh
@@ -54,15 +54,7 @@ function srpm_package_defs() {
   #        ...
   #      done < <(srpm_package_defs)
   #
-  test -n "$PACKAGE" || {
-    if test "$OSCAPI" == "https://api.suse.de"; then
-        # The init-image is not needed for SUMA: BCI:Init will be used instead
-        PACKAGE=$(find "$SRPM_DIR" -mindepth 1 -maxdepth 1 -type d -printf "%P\n" \
-                  | grep -v -x -e init-image)
-    else
-        PACKAGE=$(find "$SRPM_DIR" -mindepth 1 -maxdepth 1 -type d -printf "%P\n")
-    fi
-  }
+  PACKAGE=$(find "$SRPM_DIR" -mindepth 1 -maxdepth 1 -type d -printf "%P\n")
   for N in $PACKAGE; do
     test -d "$SRPM_DIR/$N" || {
       echo "No package dir '$SRPM_DIR/$N'" >&2
@@ -271,7 +263,7 @@ while read PKG_NAME; do
       if [ "${OSCAPI}" == "https://api.suse.de" ]; then
           # SUSE Manager settings
           VERSION=$(sed 's/^\([0-9]\+\.[0-9]\+\).*$/\1/' ${BASE_DIR}/packages/uyuni-base)
-          sed "s/^ARG INIT_BASE=.*$/ARG INIT_BASE=bci\/bci-init:15.4/" -i $SRPM_PKG_DIR/Dockerfile
+          sed "s/^ARG INIT_BASE=.*$/ARG INIT_BASE=bci\/bci-base:15.4/" -i $SRPM_PKG_DIR/Dockerfile
           sed "/^#\!BuildTag:/s/uyuni/suse\/manager\/${VERSION}/g" -i $SRPM_PKG_DIR/Dockerfile
           sed "/^# labelprefix=/s/org\.opensuse\.uyuni/com.suse.manager/" -i $SRPM_PKG_DIR/Dockerfile
           sed "s/^ARG VENDOR=.*$/ARG VENDOR=\"SUSE LLC\"/" -i $SRPM_PKG_DIR/Dockerfile


### PR DESCRIPTION
## What does this PR change?

use init-image based on bci-base 15.4 in IBS

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed
- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
