### PR TITLE
Fix creating unique index

### DIFF
--- a/schema/spacewalk/common/tables/rhnPackageChangeLogData.sql
+++ b/schema/spacewalk/common/tables/rhnPackageChangeLogData.sql
@@ -29,7 +29,7 @@ CREATE TABLE rhnPackageChangeLogData
 
 CREATE UNIQUE INDEX rhn_pkg_cld_ntt_idx
     ON rhnPackageChangeLogData
-    USING btree(name, digest("text", 'sha512'::text), time)
+    USING btree(name, digest(text, 'sha512'::text), time)
     
     ;
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.6-to-susemanager-schema-4.4.7/203-add-changelogdata-index.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.6-to-susemanager-schema-4.4.7/203-add-changelogdata-index.sql
@@ -29,10 +29,9 @@ select remove_duplicate_changelogdata();
 drop function remove_duplicate_changelogdata();
 
 drop index if exists rhn_pkg_cld_nt_idx;
-drop index if exists rhn_pkg_cld_ntt_idx;
 
 create extension if not exists pgcrypto;
-create unique index concurrently rhn_pkg_cld_ntt_idx
-    on "rhnpackagechangelogdata"
-    using btree(name, digest("text", 'sha512'::text), "time");
+create unique index if not exists rhn_pkg_cld_ntt_idx
+    on rhnpackagechangelogdata
+    using btree(name, digest(text, 'sha512'::text), time);
 


### PR DESCRIPTION
Fix schema migration script for creating unique index.

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [x] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
