### PR TITLE
Fake tagging for separate changelogs as well

### DIFF
--- a/rel-eng/build-packages-for-obs.sh
+++ b/rel-eng/build-packages-for-obs.sh
@@ -140,6 +140,26 @@ while read PKG_NAME PKG_VER PKG_DIR; do
   ${VERBOSE:+cat "$T_LOG"}
 
   eval $(awk '/^Wrote:.*src.rpm/{srpm=$2}/^Wrote:.*.changes/{changes=$2}END{ printf "SRPM=\"%s\"\n",srpm; printf "CHANGES=\"%s\"\n",changes; }' "$T_LOG")
+  EXTRA_CHANGELOGS=0
+  if [ "$(head -n1 ${CHANGES}|grep '^- ')" == "" ]; then
+    PREVIOUS_CHANGELOGS=0
+  else
+    PREVIOUS_CHANGELOGS=1
+  fi
+  FILELIST="$(ls ${GIT_DIR}/${PKG_DIR}${PKG_NAME}.changes.* 2> /dev/null; true)"
+  for FILE in $FILELIST; do
+    if [ ${PREVIOUS_CHANGELOGS} -eq 0 -a ${EXTRA_CHANGELOGS} -eq 0 ]; then
+      sed -i '1i\\' ${CHANGES}
+    fi
+    EXTRA_CHANGELOGS=1
+    LINENUMBER=1
+    while IFS= read -r LINE; do
+      if [ "${LINE}" != "" ]; then
+        sed -i "${LINENUMBER}i\\${LINE}" ${CHANGES}
+	LINENUMBER=$((LINENUMBER+1))
+      fi
+    done < ${FILE}
+  done
   if [ "$(head -n1 ${CHANGES}|grep '^- ')" != "" ]; then
     echo "*** Untagged package, adding fake header..."
     sed -i "1i Fri Jan 01 00:00:00 CEST 2038 - faketagger@suse.inet\n" ${CHANGES}


### PR DESCRIPTION
## What does this PR change?

Fake tagging for separate changelogs as well.

As otherwise if no changes are present in the main changelog, no fake tagging was performed, and therefore checking the changes on the package on a live instance for development was tricky.

## CLI diff

### If the package has no changes in any changelog file

It still builds as expected:

```
$ rel-eng/build-packages-for-obs.sh spacewalk
spacewalk
Going to build new obs packages in /tmp/push-packages-to-obs/SRPMS...
=== Building package [spacewalk-4.4.4-1] from spacewalk/package/ (Try 1)
66 bloques
======================================================================
Built obs packages:  1
======================================================================
```

### If the package has entries on the main changelog file and extra changelog files

To test it I added an entry `-blah` at `spacewalk-java.changes`

Then the entries from the extra changelog files get added on top:
```
-------------------------------------------------------------------
Fri Jan 01 00:00:00 CEST 2038 - faketagger@suse.inet

- Revert action executor fix that was intended to prevent blocking of Taskomatic threads (bsc#1214121)
- Improve Taskomatic by removing invalid triggers before starting and enhancing logs
- Consider server id when removing invalid erratas from rhnSet (bsc#1204235,bsc#1207012,bsc#1211560)
- Fix unscheduling actions when the trigger name changed after retry (bsc#1214121)
- Fix failed actions rescheduling (bsc#1214121)
- Token cleanup process removing invalid tokens using sql query (bsc#1213376)
- fix FQDN machine name mapping on proxy configuration
- Fix token validation for shared (public) child channels (bsc#1216128)
- Handle spaces in /ks/dist/ file names (bsc#1213680)
- Fix issue where bad scc creds were preventing other credentials to refresh (bsc#1211355)
- Fix bug about listing Ansible inventories (bsc#1213132)
- Add payg info to UI and rest API
Fix system.provisionSystem xmlrpc endpoint to calculate host properly (bsc#1215209)
- wait for lock to execute scc sync task (bsc#1216030)
- add salt-api socket timeout to abort stuck taskomatic jobs (bsc#1211649)
- look for the PAYG CA certificate location in different order to
  find and import the correct one (bsc#1214759)
- fix notification messages email content (bsc#1216041)
- implement different way to copy data for SystemPackageUpdate report database table (bsc#1211912)
- Update tomcat jars to version greater than 9.0.75
- add detection of Debian 12
- Do not warn about missing Client Tools Channel subscription in a 
  PAYG environment
- Improved detection of the best authentication for accessing a 
  repository in case of PAYG credentials (bsc#1215362)
- Combine the PAYG credentials and the repository paths when they 
  collide (bsc#1215413)
- Do not call SCC when updating the repositories authentication 
  for PAYG (bsc#1215857)
- Restart the bunch from where it was interrupted when rescheduling
- Moved the Ubuntu errata processing in its own separate taskomatic
  task (bsc#1211145)
- Stop the taskomatic bunch execution if it was not possible to
  execute one of the tasks
- Fixed detection in case RHEL-based products (bsc#1214280)
- fix token issue with cloned deb channels (bsc#1214982)
- Add a config to specify the number of minutes to wait before
 performing a system reboot
- Fix server error when visiting the notifications page
- Include reboot_suggested and restart_suggested booleans in 
  errata.getDetails API response
- Improved logging to better capture third-party library issues
- Fix the use of page size preference in systems and packages lists
- Respect user email preferences when sending 'user creation' emails (bsc#1214553)
- Change list endpoints in saltkey namespace to accept GET
  requests instead of POST (bsc#1214463)
- Sync GPG properties on each build in CLM (bsc#1213689)
- Blah

-------------------------------------------------------------------
Wed Sep 27 17:44:34 CEST 2023 - rosuna@suse.com

- version 4.4.20-1
  * Fix RHUI support for RHEL 7 clients (bsc#1215756)
```

### If the package there are only entries on extra changelog files

Then the entries get added to the main changelog:
```
-------------------------------------------------------------------
Fri Jan 01 00:00:00 CEST 2038 - faketagger@suse.inet

- Revert action executor fix that was intended to prevent blocking of Taskomatic threads (bsc#1214121)
- Improve Taskomatic by removing invalid triggers before starting and enhancing logs
- Consider server id when removing invalid erratas from rhnSet (bsc#1204235,bsc#1207012,bsc#1211560)
- Fix unscheduling actions when the trigger name changed after retry (bsc#1214121)
- Fix failed actions rescheduling (bsc#1214121)
- Token cleanup process removing invalid tokens using sql query (bsc#1213376)
- fix FQDN machine name mapping on proxy configuration
- Fix token validation for shared (public) child channels (bsc#1216128)
- Handle spaces in /ks/dist/ file names (bsc#1213680)
- Fix issue where bad scc creds were preventing other credentials to refresh (bsc#1211355)
- Fix bug about listing Ansible inventories (bsc#1213132)
- Add payg info to UI and rest API
Fix system.provisionSystem xmlrpc endpoint to calculate host properly (bsc#1215209)
- wait for lock to execute scc sync task (bsc#1216030)
- add salt-api socket timeout to abort stuck taskomatic jobs (bsc#1211649)
- look for the PAYG CA certificate location in different order to
  find and import the correct one (bsc#1214759)
- fix notification messages email content (bsc#1216041)
- implement different way to copy data for SystemPackageUpdate report database table (bsc#1211912)
- Update tomcat jars to version greater than 9.0.75
- add detection of Debian 12
- Do not warn about missing Client Tools Channel subscription in a 
  PAYG environment
- Improved detection of the best authentication for accessing a 
  repository in case of PAYG credentials (bsc#1215362)
- Combine the PAYG credentials and the repository paths when they 
  collide (bsc#1215413)
- Do not call SCC when updating the repositories authentication 
  for PAYG (bsc#1215857)
- Restart the bunch from where it was interrupted when rescheduling
- Moved the Ubuntu errata processing in its own separate taskomatic
  task (bsc#1211145)
- Stop the taskomatic bunch execution if it was not possible to
  execute one of the tasks
- Fixed detection in case RHEL-based products (bsc#1214280)
- fix token issue with cloned deb channels (bsc#1214982)
- Add a config to specify the number of minutes to wait before
 performing a system reboot
- Fix server error when visiting the notifications page
- Include reboot_suggested and restart_suggested booleans in 
  errata.getDetails API response
- Improved logging to better capture third-party library issues
- Fix the use of page size preference in systems and packages lists
- Respect user email preferences when sending 'user creation' emails (bsc#1214553)
- Change list endpoints in saltkey namespace to accept GET
  requests instead of POST (bsc#1214463)
- Sync GPG properties on each build in CLM (bsc#1213689)

-------------------------------------------------------------------
Wed Sep 27 17:44:34 CEST 2023 - rosuna@suse.com

- version 4.4.20-1
  * Fix RHUI support for RHEL 7 clients (bsc#1215756)
```

- [ ] **DONE**

## Documentation
- No documentation needed: No doc, this is not for users, and we don't have it in any internal doc. It's just a goodie.

- [x] **DONE**

## Test coverage
- No tests: We don't have tests for this.

- [x] **DONE**

## Links

None, and IIUC @cbbayburt can confirm that the extra changelogs was not backported to 4.3. Otherwise I can backport this PR.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
