### PR TITLE
Fix QE script to not throw traceback

### DIFF
--- a/testsuite/features/upload_files/salt_event_parser.py
+++ b/testsuite/features/upload_files/salt_event_parser.py
@@ -20,13 +20,17 @@ f.close()
 failure_count = 0
 for error in errors:
     try:
-        j = json.loads("".join(error))
+        joined_error = "".join(error)
+        j = json.loads(joined_error)
         if not "return" in j:
             continue
+        if not isinstance(j["return"], dict):
+            continue
+        for k, v in j["return"].items():
+            if isinstance(v, dict) and not v.get("result", True):
+                failure_count += 1
+                print("\n# Failure", failure_count, ", _stamp:", j['_stamp'], json.dumps(v, sort_keys=True, indent=4))
     except ValueError as e:
         print("JSON cannot be parsed due to {0}".format(e))
         continue
-    for k in j["return"]:
-        if not j["return"][k]["result"]:
-            failure_count += 1
-            print("\n# Failure", failure_count, ", _stamp:", j['_stamp'], json.dumps(j["return"][k], sort_keys=True, indent=4))
+


### PR DESCRIPTION
## What does this PR change?

In the latest BV I had this failure:

```
15:04:10  Then the salt event log on server should contain no failures # features/step_definitions/salt_steps.rb:448
15:04:10        FAIL: python3 /tmp/salt_event_parser.py returned status code = 1.
15:04:10        Output:
15:04:10        Traceback (most recent call last):
15:04:10          File "/tmp/salt_event_parser.py", line 30, in <module>
15:04:10            if not j["return"][k]["result"]:
15:04:10        TypeError: string indices must be integers
15:04:10         (RuntimeError)
15:04:10        ./features/support/lavanda.rb:154:in `run'
15:04:10        ./features/step_definitions/salt_steps.rb:456:in `/^the salt event log on server should contain no failures$/'
15:04:10        features/build_validation/finishing/srv_debug.feature:13:in `the salt event log on server should contain no failures'
```

So I fixed it by refactoring the script to:

First check if j["return"] is a dictionary (isinstance(j["return"], dict)) to ensure it's iterable.

Then use a for loop to iterate over the keys and values in the j["return"] dictionary with for k, v in j["return"].items().

For each key-value pair, I check if v (the value) is a dictionary and if the "result" key within that dictionary is False. If these conditions are met, I increment the failure_count and print the failure information.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes no issue directly from testsuite review
Tracks https://github.com/SUSE/spacewalk/pull/22904

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
