### PR TITLE
Added new subscription-matcher message

### DIFF
--- a/web/html/src/manager/audit/subscription-matching/subscription-matching-messages.tsx
+++ b/web/html/src/manager/audit/subscription-matching/subscription-matching-messages.tsx
@@ -59,6 +59,10 @@ class Messages extends React.Component<Props> {
             ": " +
             systems[data["system_id"]].name;
           break;
+        case "no_products_associated":
+          message = t("Subscription with unsupported part number and no associated product has been ignored.");
+          additionalInformation = data["part_number"];
+          break;
         default:
           message = rawMessage["type"]; // we do not know the shape of the data, it could even be a complex nested object (bsc#1125600)
 

--- a/web/spacewalk-web.changes.mackdk.add-new-subscription-matcher-message
+++ b/web/spacewalk-web.changes.mackdk.add-new-subscription-matcher-message
@@ -1,0 +1,1 @@
+- Handle new message from subscription-matcher (bsc#1216506)


### PR DESCRIPTION
## What does this PR change?

This PR adds the handling of the new message introduced by https://github.com/uyuni-project/subscription-matcher/pull/48

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- Documentation issue was created: https://github.com/SUSE/spacewalk/issues/22893

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/22862

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
