### PR TITLE
Bing back dropped use for proxy method

### DIFF
--- a/java/code/src/com/redhat/rhn/common/util/http/HttpClientAdapter.java
+++ b/java/code/src/com/redhat/rhn/common/util/http/HttpClientAdapter.java
@@ -209,41 +209,6 @@ public class HttpClientAdapter {
             // Return direct route
             return new HttpRoute(host);
         }
-
-        /**
-         * Check for a given {@link URI} if a proxy should be used or not.
-         *
-         * @param uri the URI to check
-         * @return true if proxy should be used, else false
-         */
-        private boolean useProxyFor(URI uri) {
-            if (uri.getScheme().equals("file")) {
-                return false;
-            }
-            String host = uri.getHost();
-            if (host.equals("localhost") || host.equals("127.0.0.1") || host.equals("::1")) {
-                return false;
-            }
-
-            if (noProxyDomains.isEmpty()) {
-                return true;
-            }
-            else if (noProxyDomains.contains("*")) {
-                return false;
-            }
-
-            // Check for either an exact match or the previous character is a '.',
-            // so that host is within the same domain.
-            for (String domain : noProxyDomains) {
-                if (domain.startsWith(".")) {
-                    domain = domain.substring(1);
-                }
-                if (domain.equals(host) || host.endsWith("." + domain)) {
-                    return false;
-                }
-            }
-            return true;
-        }
     }
 
     /**
@@ -324,6 +289,41 @@ public class HttpClientAdapter {
         }
 
         return executeRequest(request, ignoreNoProxy);
+    }
+
+    /**
+     * Check for a given {@link URI} if a proxy should be used or not.
+     *
+     * @param uri the URI to check
+     * @return true if proxy should be used, else false
+     */
+    private boolean useProxyFor(URI uri) {
+        if (uri.getScheme().equals("file")) {
+            return false;
+        }
+        String host = uri.getHost();
+        if (host.equals("localhost") || host.equals("127.0.0.1") || host.equals("::1")) {
+            return false;
+        }
+
+        if (noProxyDomains.isEmpty()) {
+            return true;
+        }
+        else if (noProxyDomains.contains("*")) {
+            return false;
+        }
+
+        // Check for either an exact match or the previous character is a '.',
+        // so that host is within the same domain.
+        for (String domain : noProxyDomains) {
+            if (domain.startsWith(".")) {
+                domain = domain.substring(1);
+            }
+            if (domain.equals(host) || host.endsWith("." + domain)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**


### PR DESCRIPTION
## What does this PR change?

We moved a function into an inner class.
But it was used in Test cases in a special way which require it to be external.
This PR reset everything back

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

No backport to 4.3 required

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
