### PR TITLE
Change base image format and PRODUCT_PATTERN_PREFIX, to match regex in push-to-obs

### DIFF
--- a/containers/init-image/Dockerfile
+++ b/containers/init-image/Dockerfile
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: MIT
 #!BuildTag: uyuni/init:latest
 
-FROM opensuse/leap:15.5
+ARG INIT_BASE=opensuse/leap:15.5
+FROM $INIT_BASE
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=org.opensuse.uyuni.init

--- a/containers/server-image/Dockerfile
+++ b/containers/server-image/Dockerfile
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: MIT
 #!BuildTag: uyuni/server:latest
 
-ARG INIT_BASE=uyuni/init:latest
-FROM $INIT_BASE
+ARG INIT_IMAGE=uyuni/init:latest
+FROM $INIT_IMAGE
 
 ARG PRODUCT_PATTERN_PREFIX="patterns-uyuni"
 

--- a/rel-eng/push-packages-to-obs.sh
+++ b/rel-eng/push-packages-to-obs.sh
@@ -272,6 +272,7 @@ while read PKG_NAME; do
           # SUSE Manager settings
           VERSION=$(sed 's/^\([0-9]\+\.[0-9]\+\).*$/\1/' ${BASE_DIR}/packages/uyuni-base)
           sed "s/^ARG INIT_BASE=.*$/ARG INIT_BASE=bci\/bci-init:15.4/" -i $SRPM_PKG_DIR/Dockerfile
+          sed "s/^ARG PRODUCT_PATTERN_PREFIX=.*$/ARG PRODUCT_PATTERN_PREFIX=patterns-suma/" -i $SRPM_PKG_DIR/Dockerfile
           sed "/^#\!BuildTag:/s/uyuni/suse\/manager\/${VERSION}/g" -i $SRPM_PKG_DIR/Dockerfile
           sed "/^# labelprefix=/s/org\.opensuse\.uyuni/com.suse.manager/" -i $SRPM_PKG_DIR/Dockerfile
           sed "s/^ARG VENDOR=.*$/ARG VENDOR=\"SUSE LLC\"/" -i $SRPM_PKG_DIR/Dockerfile


### PR DESCRIPTION
## What does this PR change?

Change base image format and PRODUCT_PATTERN_PREFIX, to match regex in push-to-obs

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests
- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
