### PR TITLE
Use the full debian base channel name to avoid Ambiguous match

### DIFF
--- a/testsuite/features/secondary/srv_dist_channel_mapping.feature
+++ b/testsuite/features/secondary/srv_dist_channel_mapping.feature
@@ -49,7 +49,7 @@ Feature: Distribution Channel Mapping
     When I enter "Ubuntu 22.04.01 LTS" as "os"
     And I enter "22.04" as "release"
     And I select "x86_64" from "architecture" dropdown
-    And I select "Fake-Base-Channel" from "channel_label" dropdown
+    And I select "Fake-Base-Channel-Debian-like" from "channel_label" dropdown
     And I click on "Create Mapping"
     Then I should see a "Ubuntu 22.04.01 LTS" link in the content area
 
@@ -101,7 +101,7 @@ Feature: Distribution Channel Mapping
     And I should see the text "sle-product-sles15-sp4-pool-x86_64" in the Channel Label field
     When I follow "Ubuntu 22.04.01 LTS"
     And I enter "Ubuntu 22.04.01 LTS modified" as "os"
-    And I select "Fake-Base-Channel" from "channel_label" dropdown
+    And I select "Fake-Base-Channel-Debian-like" from "channel_label" dropdown
     And I click on "Update Mapping"
     Then I should see the text "Ubuntu 22.04.01 LTS modified" in the Operating System field
     And I should see the text "fake-base-channel" in the Channel Label field


### PR DESCRIPTION
## What does this PR change?
Use full debian base channel name to avoid ambiguous map.
Indeed base channel is matching more than one element in the channel drop box.
We are lucky to have this issue only in this feature. Our fake base channel should never have only Fake-Base-Channel name because it is share by more than one channel. I think we should rename the fake base channel for suse as for rh and debian like channel ( Fake-Base-Channel-Suse-like )

![base_channel_list](https://github.com/uyuni-project/uyuni/assets/55169628/06b66607-5403-406d-9eca-59d18f898bb4)


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
