### PR TITLE
Prevent losing Remote Command action result if returned JSON cannot be parsed

### DIFF
--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -568,6 +568,13 @@ public class SaltUtils {
             handleStateApplyData(serverAction, jsonResult, retcode, success);
         }
         else if (action.getActionType().equals(ActionFactory.TYPE_SCRIPT_RUN)) {
+            if (serverAction.getStatus().equals(ActionFactory.STATUS_FAILED)) {
+                serverAction.setResultMsg("Failed to execute script. [jid=" + jid + "]");
+            }
+            else {
+                serverAction.setResultMsg("Script executed successfully. [jid=" +
+                        jid + "]");
+            }
             Map<String, StateApplyResult<CmdResult>> stateApplyResult = Json.GSON.fromJson(jsonResult,
                     new TypeToken<Map<String, StateApplyResult<CmdResult>>>() { }.getType());
             CmdResult result = stateApplyResult.entrySet().stream()
@@ -594,13 +601,6 @@ public class SaltUtils {
             scriptResult.setStopDate(serverAction.getCompletionTime());
 
             // Depending on the status show stdout or stderr in the output
-            if (serverAction.getStatus().equals(ActionFactory.STATUS_FAILED)) {
-                serverAction.setResultMsg("Failed to execute script. [jid=" + jid + "]");
-            }
-            else {
-                serverAction.setResultMsg("Script executed successfully. [jid=" +
-                        jid + "]");
-            }
             scriptResult.setOutput(printStdMessages(result.getStderr(), result.getStdout()).getBytes());
         }
         else if (action.getActionType().equals(ActionFactory.TYPE_IMAGE_BUILD)) {

--- a/java/spacewalk-java.changes.meaksh.master-fix-traceback-remote-commands
+++ b/java/spacewalk-java.changes.meaksh.master-fix-traceback-remote-commands
@@ -1,0 +1,1 @@
+- Prevent losing Remote Command action result if returned JSON cannot be parsed


### PR DESCRIPTION
## What does this PR change?

This PR makes that action result for a Remote Command action to be set even if there are unexpected issues parsing the expected JSON from the action execution.

For example, before this PR, in cases of broken SSH connection while running a Remote Command action, the action will appears as stuck forever, as the traceback produced at parsing JSON is preventing the action result to be set.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
