### PR TITLE
Fix validation of lists with empty defaults in formulas (bsc#1216555)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/formula/FormulaManager.java
+++ b/java/code/src/com/redhat/rhn/manager/formula/FormulaManager.java
@@ -223,15 +223,17 @@ public class FormulaManager {
      */
     private void validateListContents(String key, List<Object> actualList, List<Object> expectedListFormat,
                                       Map<String, Object> def) throws InvalidFormulaException {
-        Class<?> expectedClass = expectedListFormat.iterator().next().getClass();
-        if (Map.class.isAssignableFrom(expectedClass)) {
-            for (Object item: actualList) {
-                validateDictionary((Map) item, def);
+        if (!expectedListFormat.isEmpty()) {
+            Class<?> expectedClass = expectedListFormat.iterator().next().getClass();
+            if (Map.class.isAssignableFrom(expectedClass)) {
+                for (Object item : actualList) {
+                    validateDictionary((Map) item, def);
+                }
             }
-        }
-        else {
-            for (Object item:actualList) {
-                validateTypes(key, expectedClass, item.getClass());
+            else {
+                for (Object item : actualList) {
+                    validateTypes(key, expectedClass, item.getClass());
+                }
             }
         }
     }

--- a/java/code/src/com/redhat/rhn/manager/formula/test/dhcpd-formula-data.json
+++ b/java/code/src/com/redhat/rhn/manager/formula/test/dhcpd-formula-data.json
@@ -24,6 +24,10 @@
   },
   "list_of_things":{
     "name":"aoeu",
+    "list_of_strings_empty_default": [
+      "foo",
+      "bar"
+    ],
     "partitions_as_primitive_list":[
       "fst",
       "snd",

--- a/java/code/src/com/redhat/rhn/manager/formula/test/dhcpd-formula-form.json
+++ b/java/code/src/com/redhat/rhn/manager/formula/test/dhcpd-formula-form.json
@@ -70,6 +70,14 @@
       "$type": "text",
       "$default": "aoeu"
     },
+    "list_of_strings_empty_default": {
+      "$name": "List of strings",
+      "$type": "edit-group",
+      "$prototype": {
+        "$type":"text"
+      },
+      "$default": []
+    },
     "partitions_as_primitive_list": {
       "$name": "HD Partitions as primitive list",
       "$type": "edit-group",

--- a/java/spacewalk-java.changes.cbbayburt.bsc1216555
+++ b/java/spacewalk-java.changes.cbbayburt.bsc1216555
@@ -1,0 +1,1 @@
+- Fix validation of lists with empty defaults in formulas (bsc#1216555)


### PR DESCRIPTION
Formula validation checks lists against the first element of the default values in the definition. When the default has no elements, it throws an OOB exception.

This patch disables the check when the default is an empty list.

Port of: https://github.com/SUSE/spacewalk/pull/22920

Fixes https://github.com/SUSE/spacewalk/issues/22903

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
