### PR TITLE
Parametrize info in init image

### DIFF
--- a/containers/init-image/Dockerfile
+++ b/containers/init-image/Dockerfile
@@ -3,18 +3,23 @@
 #!BuildTag: uyuni/init:latest
 
 ARG INIT_BASE=opensuse/leap:15.5
+ARG PRODUCT=Uyuni
+ARG VENDOR="Uyuni project"
+ARG URL="https://www.uyuni-project.org/"
+ARG REFERENCE_PREFIX="registry.opensuse.org/uyuni"
+
 FROM $INIT_BASE
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=org.opensuse.uyuni.init
-LABEL org.opencontainers.image.title="Systemd image"
-LABEL org.opencontainers.image.description="This container runs systemd"
+LABEL org.opencontainers.image.title="${PRODUCT} Init Image"
+LABEL org.opencontainers.image.description="This image initialize users, groups and software for ${PRODUCT} Container"
 LABEL org.opencontainers.image.version="4.4.0"
-LABEL org.opensuse.reference="registry.opensuse.org/uyuni/init:4.4.0.%RELEASE%"
+LABEL org.opensuse.reference="${REFERENCE_PREFIX}/init:4.4.0.%RELEASE%"
 LABEL org.openbuildservice.disturl="%DISTURL%"
 LABEL org.opencontainers.image.created="%BUILDTIME%"
-LABEL org.opencontainers.image.vendor="Uyuni project"
-LABEL org.opencontainers.image.url="https://www.uyuni-project.org/"
+LABEL org.opencontainers.image.vendor="${VENDOR}"
+LABEL org.opencontainers.image.url="${URL}"
 # endlabelprefix
 
 # Create stable static UID and GID for salt, tomcat, apache (wwwrun), postgres, ...


### PR DESCRIPTION
## What does this PR change?

Parametrize info in init image, in this way `push-packages-to-obs.sh` can set the correct values for IBS.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
