### PR TITLE
QE: Fix the channel label to compare in CVE Audit test

### DIFF
--- a/testsuite/features/secondary/min_cve_audit.feature
+++ b/testsuite/features/secondary/min_cve_audit.feature
@@ -82,7 +82,7 @@ Feature: CVE Audit on SLE Salt Minions
     Then I should get status "NOT_AFFECTED" for "sle_minion"
     When I call audit.list_systems_by_patch_status() with CVE identifier "CVE-1999-9999"
     Then I should get status "AFFECTED_PATCH_APPLICABLE" for "sle_minion"
-    And I should get the test base channel
+    And I should get the "fake-base-channel" channel label
     And I should get the "milkyway-dummy-2345" patch
 
   Scenario: Apply patches

--- a/testsuite/features/secondary/srv_activationkey_api.feature
+++ b/testsuite/features/secondary/srv_activationkey_api.feature
@@ -9,11 +9,11 @@ Feature: API "activationkey" namespace
 
   Scenario: Create activation key
     When I create an activation key with id "testkey", description "Key for testing" and limit of 10
-    Then I should get the new activation key
+    Then I should get the new activation key "1-testkey"
 
   Scenario: Activation key details
-    When I set the description of activation key to "Key description"
-    Then I get the description "Key description" for the activation key
+    When I set the description of the activation key "1-testkey" to "Key description"
+    Then I get the description "Key description" for the activation key "1-testkey"
 
   Scenario: Cleanup: delete activation key
-    When I delete the activation key
+    When I delete the activation key "1-testkey"


### PR DESCRIPTION
## What does this PR change?

Fix the channel label to compare in CVE Audit test, and take advantage of that to improve some other steps to have a more concise input.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage

- Cucumber tests were improved

- [x] **DONE**

## Links

Ports:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
