### PR TITLE
Bump WebUI version

### DIFF
--- a/web/conf/rhn_web.conf
+++ b/web/conf/rhn_web.conf
@@ -63,7 +63,7 @@ web.version = 4.4.0 Alpha1
 # the version of Uyuni to show at the WebUI, it will be prepended
 # to web.version as version for the SPECs, when building them
 # for Uyuni
-web.version.uyuni =  2023.09
+web.version.uyuni =  2023.10
 
 web.buildtimestamp = _OBS_BUILD_TIMESTAMP_
 

--- a/web/spacewalk-web.changes.deneb-alpha.Bump_WebUI_Version
+++ b/web/spacewalk-web.changes.deneb-alpha.Bump_WebUI_Version
@@ -1,0 +1,1 @@
+- Update the version for the WebUI


### PR DESCRIPTION
## What does this PR change?

**Update the WebUI version to 2023.10**

## GUI diff

Before: 2023.09

After: 2023.10

- [x] **DONE**

## Documentation
- No documentation needed: **this is only a bump of the WebUI version**

- [x] **DONE**

## Test coverage
- No tests: **Update the WebUI version to 2023.10**

- [x] **DONE**

## Links

Relates https://github.com/SUSE/spacewalk/issues/22583

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
