### PR TITLE
Revert cobbler changes

### DIFF
--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -35,15 +35,11 @@ Feature: PXE boot a terminal with Cobbler
     And I click on "Apply Highstate"
     And I wait until event "Apply highstate scheduled by admin" is completed
 
+  # We currently test Cobbler with SLES 15 SP4, even on Uyuni
   @susemanager
   Scenario: Install TFTP boot package on the server
     When I install package tftpboot-installation on the server
     And I wait for "tftpboot-installation-SLE-15-SP4-x86_64" to be installed on "server"
-
-  @uyuni
-  Scenario: Install TFTP boot package on the server
-    When I install package tftpboot-installation on the server
-    And I wait for "tftpboot-installation-openSUSE-Leap-15.5-x86_64" to be installed on "server"
 
 # TODO: use this code when we start testing Cobbler with Leap
 #@uyuni
@@ -150,15 +146,9 @@ Feature: PXE boot a terminal with Cobbler
     And I click on "Delete Distribution"
     Then I should not see a "SLE-15-SP4-TFTP" text
 
-  @susemanager
-  Scenario: Cleanup: Remove the TFTP boot package from the server
-    When I remove package "tftpboot-installation-SLE-15-SP4-x86_64" from this "server" without error control
+  Scenario: Cleanup: remove TFTP boot package from the server
+    And I remove package "tftpboot-installation-SLE-15-SP4-x86_64" from this "server" without error control
     And I wait for "tftpboot-installation-SLE-15-SP4-x86_64" to be uninstalled on "server"
-
-  @uyuni
-  Scenario: Cleanup: Remove the TFTP boot package from the server
-    When I remove package "tftpboot-installation-openSUSE-Leap-15.5-x86_64" from this "server" without error control
-    And I wait for "tftpboot-installation-openSUSE-Leap-15.5-x86_64" to be uninstalled on "server"
 
   Scenario: Cleanup: delete the PXE boot minion
     Given I navigate to the Systems overview page of this "pxeboot_minion"


### PR DESCRIPTION
## What does this PR change?

Revert change for the tftpd package for cobbler.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- 
- [x] **DONE**

## Test coverage
- No tests: already covered


- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
