### PR TITLE
Use the new apache2-mod_wsgi package name

### DIFF
--- a/python/spacewalk/spacewalk-backend.changes.deneb-alpha.fix-wsgi-requires
+++ b/python/spacewalk/spacewalk-backend.changes.deneb-alpha.fix-wsgi-requires
@@ -1,0 +1,1 @@
+- Use the new apache2-mod_wsgi package name

--- a/python/spacewalk/spacewalk-backend.spec
+++ b/python/spacewalk/spacewalk-backend.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package spacewalk-backend
 #
-# Copyright (c) 2022 SUSE LLC
+# Copyright (c) 2023 SUSE LLC
 # Copyright (c) 2008-2018 Red Hat, Inc.
 #
 # All modifications and additions to the file contributed by third parties
@@ -116,7 +116,7 @@ Group:          System/Management
 Requires(pre):  %{name}-sql = %{version}-%{release}
 Requires:       %{name}-sql = %{version}-%{release}
 Requires:       spacewalk-config
-Requires:       (apache2-mod_wsgi-python3 or python3-mod_wsgi)
+Requires:       (apache2-mod_wsgi or python3-mod_wsgi)
 Requires:       (python3-pam or python3-python-pam)
 
 # cobbler-web is known to break our configuration

--- a/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes.deneb-alpha.fix-wsgi-requires_tftpsync-recv
+++ b/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes.deneb-alpha.fix-wsgi-requires_tftpsync-recv
@@ -1,0 +1,2 @@
+- Use the new apache2-mod_wsgi package name
+- Build with Python 3 and clean up references to Python 2

--- a/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.spec
+++ b/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package susemanager-tftpsync-recv
 #
-# Copyright (c) 2022 SUSE LLC
+# Copyright (c) 2023 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -14,12 +14,6 @@
 
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
-
-
-%if 0%{?suse_version} > 1320 || 0%{?rhel}
-# SLE15 builds on Python 3
-%global build_py3   1
-%endif
 
 Name:           susemanager-tftpsync-recv
 Version:        4.4.1
@@ -37,13 +31,8 @@ Requires(pre):  apache2
 Requires(pre):  httpd
 %endif
 Requires(pre):  tftp
-%if 0%{?build_py3}
 Requires:       python3
-Requires:       (apache2-mod_wsgi-python3 or python3-mod_wsgi)
-%else
-Requires:       apache2-mod_wsgi
-Requires:       python
-%endif
+Requires:       (apache2-mod_wsgi or python3-mod_wsgi)
 Requires:       spacewalk-backend
 Requires:       spacewalk-proxy-common
 Requires(pre):  coreutils


### PR DESCRIPTION
## What does this PR change?

**Use the new apache2-mod_wsgi package name**

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **no test added but built locally on OBS**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/22574

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
