### PR TITLE
Fix the problem with the full package name of the proxy helm chart when tagging with tito

### DIFF
--- a/containers/proxy-helm/Chart.yaml
+++ b/containers/proxy-helm/Chart.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
-#!BuildTag: uyuni/proxy:latest
+#!BuildTag: uyuni/proxy-helm:latest
 apiVersion: v2
-name: proxy
+name: proxy-helm
 description: Uyuni proxy containers.
 type: application
 home: https://www.uyuni-project.org/

--- a/rel-eng/push-packages-to-obs.sh
+++ b/rel-eng/push-packages-to-obs.sh
@@ -282,7 +282,7 @@ while read PKG_NAME; do
   fi
 
   if [ -f "$SRPM_PKG_DIR/Chart.yaml" ]; then
-      NAME="${PKG_NAME%%-helm}"
+      NAME="${PKG_NAME}"
       if [ "${OSCAPI}" == "https://api.suse.de" ]; then
           # SUSE Manager settings
           VERSION=$(sed 's/^\([0-9]\+\.[0-9]\+\).*$/\1/' ${BASE_DIR}/packages/uyuni-base)


### PR DESCRIPTION
## What does this PR change?

In the following PR https://github.com/uyuni-project/uyuni/pull/7620 the name of the proxy helm chart was changed from `proxy-helm` to `proxy`. While the change is logical in itself, it creates errors when tagging the package with tito. In general, there're several things relevant for tito when tagging a package:

* its name in the `.spec` file (Chart.yml in case of a helm chart)
* the name of the `.changes` file in the package's dir
* the name on the `rel-eng/pacakges/`
* previous tags for this package

So the solution would be to either change all four parameters to `proxy` instead of `proxy-helm` here in git and only add the suffix when pushing to obs, or revert back to `proxy-helm`.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage
- Not tested

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
