### PR TITLE
Fix filter ID comparison when attaching filters to a CLM project (bsc#1215949)

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/FilterApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/FilterApiController.java
@@ -111,7 +111,7 @@ public class FilterApiController {
 
         List<Long> filterIdsToDetach = dbContentProject.getProjectFilters()
                 .stream()
-                .map(filter -> filter.getFilter().getId())
+                .map(pf -> pf.getFilter().getId())
                 .filter(filterId -> !filtersIdToUpdate.contains(filterId))
                 .collect(Collectors.toList());
         filterIdsToDetach.forEach(filterId -> CONTENT_MGR.detachFilter(
@@ -123,11 +123,9 @@ public class FilterApiController {
         List<Long> filterIdsToAttach = filtersIdToUpdate
                 .stream()
                 .filter(filterId ->
-                        !dbContentProject.getProjectFilters()
+                        dbContentProject.getProjectFilters()
                                 .stream()
-                                .filter(filter -> filter.getId().equals(filterId))
-                                .findFirst()
-                                .isPresent()
+                                .noneMatch(pf -> pf.getFilter().getId().equals(filterId))
                 )
                 .collect(Collectors.toList());
         filterIdsToAttach

--- a/java/spacewalk-java.changes.cbbayburt.bsc1215949
+++ b/java/spacewalk-java.changes.cbbayburt.bsc1215949
@@ -1,0 +1,1 @@
+- Fix filter ID comparison when attaching filters to a CLM project (bsc#1215949)


### PR DESCRIPTION
When attaching filters to a CLM project, the Java method wrongly compares a "project-filter ID" to a "filter ID", which prevents some filters from being properly attached. This patch fixes the code to compare two "filter IDs" correctly.

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
