### PR TITLE
QE: Don't print the full dumpsolv, but only the repo size.

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -434,17 +434,18 @@ end
 # This functions checks if the channel has been synced
 def channel_is_synced(channel)
   # solv is the last file to be written when the server synchronizes a channel, therefore we wait until it exist
-  result, code = get_target('server').run("dumpsolv /var/cache/rhn/repodata/#{channel}/solv", verbose: true, check_errors: false)
+  result, code = get_target('server').run("dumpsolv /var/cache/rhn/repodata/#{channel}/solv", verbose: false, check_errors: false)
+  STDOUT.puts "#{channel} -> #{result.match(/^repo size:.*/)}"
   if code.zero? && !result.include?('repo size: 0')
     STDOUT.puts "Channel #{channel} is synced."
     # We want to check if no .new files exists. On a re-sync, the old files stay, the new one have this suffix until it's ready.
-    _result, new_code = get_target('server').run("dumpsolv /var/cache/rhn/repodata/#{channel}/solv.new", verbose: true, check_errors: false)
+    _result, new_code = get_target('server').run("dumpsolv /var/cache/rhn/repodata/#{channel}/solv.new", verbose: false, check_errors: false)
     # Channel synced if no .new files exist
     !new_code.zero?
   else
     # If the solv file doesn't exist, we check if we are under a Debian-like repository
     command = "test -s /var/cache/rhn/repodata/#{channel}/Release && test -s /var/cache/rhn/repodata/#{channel}/Packages"
-    _result, new_code = get_target('server').run(command, verbose: true, check_errors: false)
+    _result, new_code = get_target('server').run(command, verbose: false, check_errors: false)
     # Channel synced if Release and Packages files exist
     new_code.zero?
   end


### PR DESCRIPTION
## What does this PR change?

The current code is generating too much overhead printing the dumpsolv. So these code changes are refactoring it, only to print the current repo size to understand if the solvables are already processed and so the channel is synchronized.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage

- Cucumber tests were refactored

- [x] **DONE**

## Links

Ports:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
