### PR TITLE
Fix build regression in FileUtils.java

### DIFF
--- a/java/code/src/com/redhat/rhn/common/util/FileUtils.java
+++ b/java/code/src/com/redhat/rhn/common/util/FileUtils.java
@@ -225,6 +225,10 @@ public class FileUtils {
             log.error("File not found: {}", pathToFile);
             throw new RuntimeException(e);
         }
+        catch (IOException e) {
+            log.error("Could not read from: {}", pathToFile);
+            throw new RuntimeException(e);
+        }
         finally {
             org.apache.commons.io.IOUtils.closeQuietly(fileStream);
         }

--- a/java/spacewalk-java.changes.stefan.fixes-spacewalk-java-4.4.21-1
+++ b/java/spacewalk-java.changes.stefan.fixes-spacewalk-java-4.4.21-1
@@ -1,0 +1,1 @@
+- Fix compile error "unreported IOException" in FileUtils.java.


### PR DESCRIPTION
## What does this PR change?

This change adds back a previously removed error catching clause.
Without it, the java build can fail with:
```
    [javac] /builddir/build/BUILD/spacewalk-java-git-69657.b67eaf5/code/src/com/redhat/rhn/common/util/FileUtils.java:216: error: unreported exception IOException; must be caught or declared to be thrown
    [javac]             LineIterator it = org.apache.commons.io.IOUtils.lineIterator(fileStream,
    [javac]                                                                         ^
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered
Additional build has been tested successfully on copr for
`epel-9-x86_64`
`opensuse-leap-15.5-x86_64`

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
