### PR TITLE
fix(7594): Skip syncing packages with incorrect metadata (bsc#1213738)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,10 +79,11 @@ reports/
 *.mypy*
 
 # VS Code
-java/.vscode
+.vscode/
 
 # Python
 venv/
+.venv/
 
 # Schema
 

--- a/.gitignore
+++ b/.gitignore
@@ -79,7 +79,8 @@ reports/
 *.mypy*
 
 # VS Code
-.vscode/
+java/.vscode
+python/.vscode
 
 # Python
 venv/

--- a/python/spacewalk/satellite_tools/repo_plugins/__init__.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/__init__.py
@@ -115,6 +115,14 @@ class ContentPackage:
             if not((checksum_type_in in self.checksums) and (self.checksums[checksum_type_in] == checksum_in)):
                 self.checksums[checksum_type_in] = checksum_in
 
+    def get_nvra_tuple(self) -> tuple:
+        """returns a tuple of name, version, release, arch"""
+        return (self.name, self.version, self.release, self.arch)
+
+    def is_metadata_valid(self) -> bool:
+        """Returns True if the package NVREA is set"""
+        return all(self.get_nvra_tuple())
+
     def __str__(self):
         return f'ContentPackage: name = {self.name}, epoch = {self.epoch}, version = {self.version}, release = {self.release}, arch = {self.arch}, checksum_type = {self.checksum_type}, checksum = {self.checksum}, checksums = {self.checksums}, path = {self.path}, a_pkg = {self.a_pkg}, unique_id = <{self.unique_id}>'
 

--- a/python/spacewalk/satellite_tools/repo_plugins/__init__.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/__init__.py
@@ -66,6 +66,12 @@ class ContentPackage:
         return nra
 
     def setNVREA(self, name, version, release, epoch, arch):
+        if not all((name, version, release, arch)):
+            raise ValueError(
+                (
+                    "Incorrect package NVRA values: "
+                    f"N: {name}, V: {version}, R: {release}, A: {arch}"
+                ))
         self.name = name
         self.version = version
         self.release = release
@@ -114,14 +120,6 @@ class ContentPackage:
             self.checksum = checksum_in
             if not((checksum_type_in in self.checksums) and (self.checksums[checksum_type_in] == checksum_in)):
                 self.checksums[checksum_type_in] = checksum_in
-
-    def get_nvra_tuple(self) -> tuple:
-        """returns a tuple of name, version, release, arch"""
-        return (self.name, self.version, self.release, self.arch)
-
-    def is_metadata_valid(self) -> bool:
-        """Returns True if the package NVREA is set"""
-        return all(self.get_nvra_tuple())
 
     def __str__(self):
         return f'ContentPackage: name = {self.name}, epoch = {self.epoch}, version = {self.version}, release = {self.release}, arch = {self.arch}, checksum_type = {self.checksum_type}, checksum = {self.checksum}, checksums = {self.checksums}, path = {self.path}, a_pkg = {self.a_pkg}, unique_id = <{self.unique_id}>'

--- a/python/spacewalk/satellite_tools/repo_plugins/deb_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/deb_src.py
@@ -21,6 +21,7 @@ import time
 import re
 import fnmatch
 import requests
+import logging
 from functools import cmp_to_key
 from salt.utils.versions import LooseVersion
 from uyuni.common import fileutils
@@ -44,7 +45,7 @@ except ImportError:
 RETRIES = 10
 RETRY_DELAY = 1
 FORMAT_PRIORITY = ['.xz', '.gz', '']
-
+log = logging.getLogger(__name__)
 
 class DebPackage:
     def __init__(self):
@@ -402,8 +403,13 @@ class ContentSource:
         to_return = []
         for pack in pkglist:
             new_pack = ContentPackage()
-            new_pack.setNVREA(pack.name, pack.version, pack.release,
-                              pack.epoch, pack.arch)
+            try:
+                new_pack.setNVREA(pack.name, pack.version, pack.release,
+                                pack.epoch, pack.arch)
+            except ValueError as e:
+                log(0, "WARNING: package contains incorrect metadata. SKIPPING!")
+                log(0, e)
+                continue
             new_pack.unique_id = pack
             new_pack.checksum_type = pack.checksum_type
             new_pack.checksum = pack.checksum

--- a/python/spacewalk/satellite_tools/repo_plugins/yum_dnf_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_dnf_src.py
@@ -317,19 +317,18 @@ class ContentSource(zypper_ContentSource):
             if pack.arch == 'src':
                 continue
             new_pack = ContentPackage()
-            new_pack.setNVREA(pack.name, pack.version, pack.release,
-                              pack.epoch, pack.arch)
+            try:
+                new_pack.setNVREA(pack.name, pack.version, pack.release,
+                                  pack.epoch, pack.arch)
+            except ValueError as e:
+                log(0, "WARNING: package contains incorrect metadata. SKIPPING!")
+                log(0, e)
+                continue
             new_pack.unique_id = RawSolvablePackage(pack)
-#            new_pack.hawkey_id = pack
             new_pack.checksum_type = pack.returnIdSum()[0]
             if new_pack.checksum_type == 'sha':
                 new_pack.checksum_type = 'sha1'
             new_pack.checksum = pack.returnIdSum()[1]
-            if new_pack.is_metadata_valid():
-                to_return.append(new_pack)
-            else:
-                log(0, f"WARNING: package {new_pack.getNVREA()} contains" \
-                    + "incorrect metadata. SKIPPING!")
             to_return.append(new_pack)
         return to_return
 

--- a/python/spacewalk/satellite_tools/repo_plugins/yum_dnf_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_dnf_src.py
@@ -325,6 +325,11 @@ class ContentSource(zypper_ContentSource):
             if new_pack.checksum_type == 'sha':
                 new_pack.checksum_type = 'sha1'
             new_pack.checksum = pack.returnIdSum()[1]
+            if new_pack.is_metadata_valid():
+                to_return.append(new_pack)
+            else:
+                log(0, f"WARNING: package {new_pack.getNVREA()} contains" \
+                    + "incorrect metadata. SKIPPING!")
             to_return.append(new_pack)
         return to_return
 

--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -1195,16 +1195,17 @@ password={passwd}
         for pack in pkglist:
             new_pack = ContentPackage()
             epoch, version, release = RawSolvablePackage._parse_solvable_evr(pack.evr)
-            new_pack.setNVREA(pack.name, version, release, epoch, pack.arch)
+            try:
+                new_pack.setNVREA(pack.name, version, release, epoch, pack.arch)
+            except ValueError as e:
+                log(0, "WARNING: package contains incorrect metadata. SKIPPING!")
+                log(0, e)
+                continue
             new_pack.unique_id = RawSolvablePackage(pack)
             checksum = pack.lookup_checksum(solv.SOLVABLE_CHECKSUM)
             new_pack.checksum_type = checksum.typestr()
             new_pack.checksum = checksum.hex()
-            if new_pack.is_metadata_valid():
-                to_return.append(new_pack)
-            else:
-                log(0, f"WARNING: package {new_pack.getNVREA()} contains" \
-                    + "incorrect metadata. SKIPPING!")
+            to_return.append(new_pack)
         return to_return
 
     @staticmethod

--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -1200,7 +1200,11 @@ password={passwd}
             checksum = pack.lookup_checksum(solv.SOLVABLE_CHECKSUM)
             new_pack.checksum_type = checksum.typestr()
             new_pack.checksum = checksum.hex()
-            to_return.append(new_pack)
+            if new_pack.is_metadata_valid():
+                to_return.append(new_pack)
+            else:
+                log(0, f"WARNING: package {new_pack.getNVREA()} contains" \
+                    + "incorrect metadata. SKIPPING!")
         return to_return
 
     @staticmethod

--- a/python/spacewalk/spacewalk-backend.changes.mczernek.7594-fix
+++ b/python/spacewalk/spacewalk-backend.changes.mczernek.7594-fix
@@ -1,1 +1,1 @@
-- Skip syncing packages with incorrect metadata (bsc#1213738)
+- Skip syncing packages with incorrect metadata

--- a/python/spacewalk/spacewalk-backend.changes.mczernek.7594-fix
+++ b/python/spacewalk/spacewalk-backend.changes.mczernek.7594-fix
@@ -1,0 +1,1 @@
+- Skip syncing packages with incorrect metadata (bsc#1213738)


### PR DESCRIPTION
## What does this PR change?

When an RPM package does not set required metadata headers, reposync throws errors for that repository.

In this change, we enforce that the metadata is set before the repository plugin includes the package in the `list_packages` function for further processing.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: no tests seem necessary (though I can add one for each modified plugin repository if you think it necessary)

## Links

Closes https://github.com/SUSE/spacewalk/issues/22135

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
