### PR TITLE
Don't fail but cancel the Acceptance Tests GH workflow

### DIFF
--- a/.github/workflows/acceptance_tests_common.yml
+++ b/.github/workflows/acceptance_tests_common.yml
@@ -21,6 +21,7 @@ jobs:
           echo "Workflow disabled. Sorry for that. We are working on fixing it"
           gh run cancel ${{ github.run_id }}
           gh run watch ${{ github.run_id }}
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: fix podman

--- a/.github/workflows/acceptance_tests_common.yml
+++ b/.github/workflows/acceptance_tests_common.yml
@@ -17,7 +17,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Disable workflow
-        run: echo "Workflow disabled. Sorry for that. We are working on fixing it" && exit -1
+        run: |
+          echo "Workflow disabled. Sorry for that. We are working on fixing it"
+          gh run cancel ${{ github.run_id }}
+          gh run watch ${{ github.run_id }}
       - name: fix podman
         run: sudo apt install podman=3.4.4+ds1-1ubuntu1 --allow-downgrades
       - name: welcome_message

--- a/.github/workflows/acceptance_tests_common.yml
+++ b/.github/workflows/acceptance_tests_common.yml
@@ -21,6 +21,8 @@ jobs:
           echo "Workflow disabled. Sorry for that. We are working on fixing it"
           gh run cancel ${{ github.run_id }}
           gh run watch ${{ github.run_id }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: fix podman
         run: sudo apt install podman=3.4.4+ds1-1ubuntu1 --allow-downgrades
       - name: welcome_message


### PR DESCRIPTION
## What does this PR change?

Proposal to don't fail the acceptance tests GH action when we have it disabled.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

No ports.

Idea extracted from this post: https://stackoverflow.com/questions/60589373/how-to-force-job-to-exit-in-github-actions-step

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
