### PR TITLE
Enforce minimum build version for apache-commons-io

### DIFF
--- a/java/spacewalk-java.changes.sbluhm.apache-commons-io
+++ b/java/spacewalk-java.changes.sbluhm.apache-commons-io
@@ -1,0 +1,1 @@
+- Enforce minimum build version for apache-commons-io to ensure successful build of FileUtils.java.

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -82,7 +82,7 @@ BuildRequires:  apache-commons-cli
 BuildRequires:  apache-commons-codec
 BuildRequires:  apache-commons-collections
 BuildRequires:  apache-commons-el
-BuildRequires:  apache-commons-io
+BuildRequires:  apache-commons-io >= 2.11.0
 BuildRequires:  apache-commons-jexl
 BuildRequires:  apache-commons-lang3 >= 3.4
 BuildRequires:  apache-commons-logging


### PR DESCRIPTION
## What does this PR change?

Build of FileUtils fails with apache-commons-io bundles lower than 2.11.0. This change ensures the minimum version to build.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

Build tested on copr for
`epel-9-x86_64 `
` opensuse-leap-15.5-x86_64 `

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
