### PR TITLE
try to download compressed ubuntu usn database and skip errata without packages

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManager.java
@@ -126,7 +126,7 @@ public class UbuntuErrataManager {
             try (
                 InputStream responseStream = httpResponse.getEntity().getContent();
                 BZip2CompressorInputStream bzIn = new BZip2CompressorInputStream(responseStream);
-                Reader responseReader = new InputStreamReader(bzIn);
+                Reader responseReader = new InputStreamReader(bzIn)
             ) {
                 Map<String, UbuntuErrataInfo> errataInfo = GSON.fromJson(responseReader, ERRATA_INFO_TYPE);
                 LOG.info("download ubuntu errata end");
@@ -141,7 +141,7 @@ public class UbuntuErrataManager {
             if (statusCode == HttpStatus.SC_OK) {
                 try (
                         InputStream responseStream = httpResponse.getEntity().getContent();
-                        Reader responseReader = new InputStreamReader(responseStream);
+                        Reader responseReader = new InputStreamReader(responseStream)
                 ) {
                     Map<String, UbuntuErrataInfo> errataInfo = GSON.fromJson(responseReader, ERRATA_INFO_TYPE);
                     LOG.info("download ubuntu errata end");
@@ -154,8 +154,8 @@ public class UbuntuErrataManager {
         }
     }
 
-    private static Stream<Entry> parseUbuntuErrata(Map<String, UbuntuErrataInfo> errataInfo) {
-        return errataInfo.values().stream().map(ubuntuErrataInfo -> {
+    private static Stream<Entry> parseUbuntuErrata(Map<String, UbuntuErrataInfo> errataInfo, Set<String> packageNames) {
+        return errataInfo.values().stream().flatMap(ubuntuErrataInfo -> {
             String description = ubuntuErrataInfo.getDescription().length() > 4000 ?
                     ubuntuErrataInfo.getDescription().substring(0, 4000) :
                     ubuntuErrataInfo.getDescription();
@@ -164,6 +164,9 @@ public class UbuntuErrataManager {
                     .flatMap(release ->
                             release.getValue().getBinaries().entrySet().stream().flatMap(binary -> {
                                 String name = binary.getKey();
+                                if (!packageNames.contains(name)) {
+                                    return Stream.empty();
+                                }
                                 String version = binary.getValue().getVersion();
 
                                 List<String> archs = release.getValue().getArchs()
@@ -188,7 +191,12 @@ public class UbuntuErrataManager {
                             })
                     ).collect(Collectors.toList());
 
-            return new Entry(
+            if (packageData.isEmpty()) {
+                // Skip Errata when we have no matching packages
+                LOG.debug("Skipping errata without matching packages: {}", ubuntuErrataInfo.getId());
+                return Stream.empty();
+            }
+            return Stream.of(new Entry(
                     ubuntuErrataInfo.getId(),
                     ubuntuErrataInfo.getCves(),
                     ubuntuErrataInfo.getSummary(),
@@ -196,7 +204,7 @@ public class UbuntuErrataManager {
                     ubuntuErrataInfo.getTimestamp(),
                     description,
                     reboot,
-                    packageData);
+                    packageData));
         });
     }
 
@@ -206,7 +214,7 @@ public class UbuntuErrataManager {
             URI uri = MgrSyncUtils.urlToFSPath(jsonDBUrl, "");
             try (
                 InputStream inputStream = Files.newInputStream(Paths.get(uri));
-                Reader fileReader = new InputStreamReader(inputStream);
+                Reader fileReader = new InputStreamReader(inputStream)
             ) {
                 return GSON.fromJson(fileReader, ERRATA_INFO_TYPE);
             }
@@ -237,9 +245,13 @@ public class UbuntuErrataManager {
                 Runtime.getRuntime().totalMemory(), Runtime.getRuntime().freeMemory());
             return;
         }
+        Set<String> packageNames = packagesByChannelMap.entrySet().stream()
+                .flatMap(entry -> entry.getValue().stream())
+                .map(p -> p.getPackageName().getName())
+                .collect(Collectors.toSet());
 
         LOG.debug("check deb packages in channels finished - get and parse errata");
-        Stream<Entry> ubuntuErrataInfo = parseUbuntuErrata(getUbuntuErrataInfo());
+        Stream<Entry> ubuntuErrataInfo = parseUbuntuErrata(getUbuntuErrataInfo(), packageNames);
         LOG.debug("get and parse errata finished - process Ubuntu Errata");
         processUbuntuErrata(packagesByChannelMap, ubuntuErrataInfo);
         LOG.debug("process Ubuntu Errata finished - done, totalMemory:{}, freeMemory:{}",
@@ -355,8 +367,8 @@ public class UbuntuErrataManager {
         // add changed errata to notification queue
         Map<Long, List<Long>> errataToChannels = changedErrata.stream().collect(
                 Collectors.toMap(
-                        e -> e.getId(),
-                        e -> e.getChannels().stream().map(c -> c.getId()).collect(Collectors.toList())
+                        Errata::getId,
+                        e -> e.getChannels().stream().map(Channel::getId).collect(Collectors.toList())
                         )
                 );
         changedErrata.stream().flatMap(e -> e.getChannels().stream()).distinct()

--- a/java/spacewalk-java.changes.mc.ubuntu-errata-compressed-db
+++ b/java/spacewalk-java.changes.mc.ubuntu-errata-compressed-db
@@ -1,0 +1,1 @@
+- try to download compressed ubuntu usn database


### PR DESCRIPTION
## What does this PR change?

Ubuntu provide the USN database also Bzip2 compressed.
Try to download the compressed first. In case this is not working fallback to raw json file.

In terms of time it does not give a big difference if the network bandwidth is high.
Maybe is makes a difference with less bandwitdth.

Download and decompress in case of bzip compressed file it takes ~ 15 seconds.
Same number when you download the uncompressed file.

The second commit skip all errata which does not have matching package names in the channel we look at.
This seems to bring down the time by 50% on the update channel i tested with.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Two points of https://github.com/SUSE/spacewalk/issues/20604
Ports: https://github.com/SUSE/spacewalk/pull/22994

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
