### PR TITLE
Fix Debian 12 wrong repo url for Uyuni client tools (stable)

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -3673,7 +3673,7 @@ archs    = amd64-deb
 repo_type = deb
 checksum = sha256
 base_channels = debian-12-pool-amd64-uyuni
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Debian11-Uyuni-Client-Tools/Debian_12/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Debian12-Uyuni-Client-Tools/Debian_12/
 
 [astralinux-orel-pool-amd64]
 label    = astralinux-orel-pool-amd64

--- a/utils/spacewalk-utils.changes.raul.fix_debian_12_uyuni_client_tools_stable
+++ b/utils/spacewalk-utils.changes.raul.fix_debian_12_uyuni_client_tools_stable
@@ -1,0 +1,1 @@
+- Fix Debian 12 wrong repo url for Uyuni client tools (stable)


### PR DESCRIPTION
## What does this PR change?

URL for Debian 12  repo  for Uyuni client tools (stable) was wrong, at some point of it, it contained a "11" instead of a "12".

## GUI diff

Nothing to be seen in the GUI, maybe in the console when using spacewalk-common-channels, but no GUI.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #7830

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
