### PR TITLE
GH validation client logs

### DIFF
--- a/.github/workflows/acceptance_tests_common.yml
+++ b/.github/workflows/acceptance_tests_common.yml
@@ -90,10 +90,19 @@ jobs:
       - name: get_server_logs
         if: ${{ failure() }}
         run: ./testsuite/podman_runner/19_get_server_logs.sh ${{ inputs.server_id }}
+      - name: get_client_logs
+        if: ${{ failure() }}
+        run: ./testsuite/podman_runner/20_get_client_logs.sh ${{ inputs.server_id }}
       - name: upload_server_log_artifacts
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3
         with:
           name: server_rhn_logs_${{ inputs.server_id }}
           path: /tmp/test-all-in-one/server-logs/${{ inputs.server_id }}
+      - name: upload_client_log_artifacts
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: client_logs_${{ inputs.server_id }}
+          path: ./testsuite/logs
 

--- a/testsuite/podman_runner/19_get_server_logs.sh
+++ b/testsuite/podman_runner/19_get_server_logs.sh
@@ -5,7 +5,7 @@ if [ $# -ne 1 ];
 then
 	echo "Usage: ${0} server_id"
 	echo "server_id is used for creating a unique folder"
-	exit -1
+	exit 1
 fi
 
 src_dir=$(cd $(dirname "$0")/../.. && pwd -P)

--- a/testsuite/podman_runner/20_get_client_logs.sh
+++ b/testsuite/podman_runner/20_get_client_logs.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -xe
+sudo -i podman exec controller-test bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=uyuni-server-all-in-one-test && export HOSTNAME=controller-test && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && cd /testsuite && cucumber features/finishing/allcli_debug.feature"


### PR DESCRIPTION
## What does this PR change?

Collect log files from clients, when the GH Validation fails

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage

- No tests

- [x] **DONE**

## Links

No ports

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
