### PR TITLE
QE: Disable verbose run method calling dumpsolv

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -367,7 +367,7 @@ end
 
 Then(/^solver file for "([^"]*)" should reference "([^"]*)"$/) do |channel, pkg|
   repeat_until_timeout(timeout: 600, message: "Reference #{pkg} not found in file.") do
-    _result, code = get_target('server').run("dumpsolv /var/cache/rhn/repodata/#{channel}/solv | grep #{pkg}", verbose: true, check_errors: false)
+    _result, code = get_target('server').run("dumpsolv /var/cache/rhn/repodata/#{channel}/solv | grep #{pkg}", verbose: false, check_errors: false)
     break if code.zero?
   end
 end


### PR DESCRIPTION
## What does this PR change?

Disable verbose run method calling dumpsolv

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were tweak

- [x] **DONE**

## Links

Ports:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
