### PR TITLE
add required steps about activation keys

### DIFF
--- a/testsuite/run_sets/reference_reposync.yml
+++ b/testsuite/run_sets/reference_reposync.yml
@@ -13,6 +13,8 @@
 - features/reposync/reference_srv_sync_products_extra.feature
 - features/reposync/reference_srv_check_reposync.feature
 
+- features/reposync/srv_create_activationkey.feature
+- features/reposync/allcli_update_activationkeys.feature
 
 #- features/reposync/srv_disable_scheduled_reposync.feature
 

--- a/testsuite/run_sets/reference_reposync.yml
+++ b/testsuite/run_sets/reference_reposync.yml
@@ -9,13 +9,17 @@
 # IMMUTABLE ORDER
 
 # these features sync real channels (last core features)
+#- features/reposync/srv_disable_scheduled_reposync.feature
+#- features/reposync/srv_sync_channels.feature
 - features/reposync/srv_sync_products.feature
+#- features/reposync/srv_enable_sync_products.feature
 - features/reposync/reference_srv_sync_products_extra.feature
 - features/reposync/reference_srv_check_reposync.feature
 
+- features/reposync/srv_create_fake_channels.feature
+- features/reposync/srv_create_fake_repositories.feature
+- features/reposync/srv_sync_fake_channels.feature
+# Activation keys can only be created after products and channels are synced
 - features/reposync/srv_create_activationkey.feature
 - features/reposync/allcli_update_activationkeys.feature
-
-#- features/reposync/srv_disable_scheduled_reposync.feature
-
 ## Channels and Product synchronization features END ###


### PR DESCRIPTION
## What does this PR change?

Fix reference setup and add steps which add and update activation keys.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

Ports https://github.com/SUSE/spacewalk/pull/23057

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
