### PR TITLE
Remove jcommon dependency in favor of modern java

### DIFF
--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -141,7 +141,7 @@
              commons-el commons-fileupload commons-io ${commons-lang} commons-logging ${commons-validator} ${hibernate5deps}
              ${commons-compress} ${javamail} smtp jdom ${jmock-jars}
              ${log4j-jars} oro redstone-xmlrpc-client redstone-xmlrpc ${struts-jars} ${tomcat-jars}
-             bcprov bcpg jcommon stringtree-json postgresql-jdbc ongres-scram/client ongres-scram/common
+             bcprov bcpg stringtree-json postgresql-jdbc ongres-scram/client ongres-scram/common
              ${stringprep-jars} taglibs-standard-impl taglibs-standard-jstlel
              taglibs-standard-spec logdriver quartz slf4j-api log4j/log4j-slf4j-impl
              concurrent velocity-engine-core simple-core  mockobjects mockobjects-core mockobjects-jdk1.4-j2ee1.3 strutstest" />
@@ -197,7 +197,7 @@
              commons-el commons-fileupload commons-io ${commons-lang} commons-logging ${commons-validator} ${hibernate5deps}
              ${commons-compress} ${tomcat-jars} ${javamail} jdom jsch
              ${log4j-jars} oro redstone-xmlrpc-client redstone-xmlrpc ${struts-jars}
-             jcommon stringtree-json postgresql-jdbc ongres-scram/client ongres-scram/common
+             stringtree-json postgresql-jdbc ongres-scram/client ongres-scram/common
              ${stringprep-jars} taglibs-standard-impl taglibs-standard-jstlel
              taglibs-standard-spec quartz ${suse-common-jars} velocity-engine-core
              concurrent simple-core snakeyaml simple-xml ${commons-jexl}" />
@@ -208,7 +208,7 @@
              commons-digester commons-discovery commons-el commons-fileupload commons-io
              ${commons-lang} commons-logging ${commons-compress}
              ${commons-validator} concurrent dom4j ${hibernate5deps} ${jta11-jars}
-             ${jaf} ${jasper-jars} ${javamail} ${jaxb} jcommon jdom ${other-jars}
+             ${jaf} ${jasper-jars} ${javamail} ${jaxb} jdom ${other-jars}
              ${tomcat-jars} ${log4j-jars} redstone-xmlrpc-client redstone-xmlrpc
              oro quartz stringtree-json sitemesh ${struts-jars}
              taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -53,7 +53,6 @@
         <dependency org="suse" name="java-saml-core" rev="2.4.0" />
         <dependency org="suse" name="javassist" rev="3.29.2" />
         <dependency org="suse" name="jboss-logging" rev="3.4.1" />
-        <dependency org="suse" name="jcommon" rev="1.0.16" />
         <dependency org="suse" name="jdom" rev="1.1.3" />
         <dependency org="suse" name="joda-time" rev="2.10.1" />
         <dependency org="suse" name="jose4j" rev="0.9.5" />

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -142,8 +142,6 @@ artifacts:
     repository: Leap_sle
   - artifact: jboss-logging
     repository: Leap
-  - artifact: jcommon
-    repository: Uyuni_Other
   - artifact: jctools-core
     package: jctools
     repository: Leap

--- a/java/code/src/com/redhat/rhn/common/util/FileUtils.java
+++ b/java/code/src/com/redhat/rhn/common/util/FileUtils.java
@@ -20,19 +20,15 @@ import org.apache.commons.collections.buffer.CircularFifoBuffer;
 import org.apache.commons.io.LineIterator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jfree.io.IOUtils;
 
-import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.StringWriter;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -134,23 +130,15 @@ public class FileUtils {
             log.debug("readStringFromFile: {}", StringUtil.sanitizeLogInput(path));
         }
 
-        File f = new File(path);
-        BufferedReader input;
         try {
-            input = new BufferedReader(new FileReader(f));
-            StringWriter writer = new StringWriter();
-            IOUtils.getInstance().copyWriter(input, writer);
-            String contents = writer.toString();
+            String contents = Files.readString(Path.of(path));
             if (noLog && log.isDebugEnabled()) {
                 log.debug("contents: {}", contents);
             }
             return contents;
         }
-        catch (FileNotFoundException e) {
-            throw new RhnRuntimeException("File not found: " + path);
-        }
         catch (IOException e) {
-            throw new RhnRuntimeException(e);
+            throw new RhnRuntimeException("Unable to load file content", e);
         }
     }
 

--- a/java/code/src/com/redhat/rhn/common/util/FileUtils.java
+++ b/java/code/src/com/redhat/rhn/common/util/FileUtils.java
@@ -17,28 +17,23 @@ package com.redhat.rhn.common.util;
 import com.redhat.rhn.common.RhnRuntimeException;
 
 import org.apache.commons.collections.buffer.CircularFifoBuffer;
-import org.apache.commons.io.LineIterator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.FileWriter;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.FileSystem;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.UserPrincipalLookupService;
 import java.util.Set;
-
+import java.util.stream.Stream;
 
 
 /**
@@ -47,7 +42,7 @@ import java.util.Set;
  */
 public class FileUtils {
 
-    private static Logger log = LogManager.getLogger(FileUtils.class);
+    private static final Logger LOGGER = LogManager.getLogger(FileUtils.class);
 
     private FileUtils() {
     }
@@ -58,27 +53,18 @@ public class FileUtils {
      * WARNING:  This deletes the original file before it writes.
      *
      * @param contents to save to file on disk
-     * @param path to save file to.
+     * @param location to save file to.
      */
-    public static void writeStringToFile(String contents, String path) {
+    public static void writeStringToFile(String contents, String location) {
+        Path path = Path.of(location);
+
         try {
-            File file = new File(path);
-            if (file.exists()) {
-                Files.delete(file.toPath());
-            }
-            file.createNewFile();
-            try (FileOutputStream fos = new FileOutputStream(file);
-                 FileWriter fw = new FileWriter(fos.getFD());
-                 BufferedWriter output = new BufferedWriter(fw)) {
-                output.write(contents);
-                output.flush();
-                fw.flush();
-                fos.getFD().sync();
-            }
+            Files.deleteIfExists(path);
+            Files.writeString(path, contents);
         }
         catch (Exception e) {
-            log.error("Error trying to write file to disk: [{}]", path, e);
-            throw new RhnRuntimeException(e);
+            LOGGER.error("Error trying to write file to disk: [{}]", location, e);
+            throw new RhnRuntimeException("Error trying to write file to disk", e);
         }
     }
 
@@ -93,10 +79,11 @@ public class FileUtils {
      */
     public static void setAttributes(Path path, String user, String group, Set<PosixFilePermission> permissions)
             throws IOException {
-        FileSystem fileSystem = FileSystems.getDefault();
-        UserPrincipalLookupService service = fileSystem.getUserPrincipalLookupService();
-        PosixFileAttributeView view  = Files.getFileAttributeView(
-                path, PosixFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
+        PosixFileAttributeView view = Files.getFileAttributeView(
+            path, PosixFileAttributeView.class, LinkOption.NOFOLLOW_LINKS
+        );
+        UserPrincipalLookupService service = FileSystems.getDefault().getUserPrincipalLookupService();
+
         view.setOwner(service.lookupPrincipalByName(user));
         view.setGroup(service.lookupPrincipalByGroupName(group));
         view.setPermissions(permissions);
@@ -126,14 +113,14 @@ public class FileUtils {
      * @return String containing file.
      */
     public static String readStringFromFile(String path, boolean noLog) {
-        if (log.isDebugEnabled()) {
-            log.debug("readStringFromFile: {}", StringUtil.sanitizeLogInput(path));
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("readStringFromFile: {}", StringUtil.sanitizeLogInput(path));
         }
 
         try {
             String contents = Files.readString(Path.of(path));
-            if (noLog && log.isDebugEnabled()) {
-                log.debug("contents: {}", contents);
+            if (noLog && LOGGER.isDebugEnabled()) {
+                LOGGER.debug("contents: {}", contents);
             }
             return contents;
         }
@@ -153,31 +140,25 @@ public class FileUtils {
      * @return byte[] array from file.
      */
     public static byte[] readByteArrayFromFile(File fileToRead, long start, long end) {
-        log.debug("readByteArrayFromFile: {} start: {} end: {}", fileToRead.getAbsolutePath(), start, end);
+        LOGGER.debug("readByteArrayFromFile: {} start: {} end: {}", fileToRead.getAbsolutePath(), start, end);
 
         int size = (int) (end - start);
-        log.debug("size of array: {}", size);
-        // Create the byte array to hold the data
-        byte[] bytes = new byte[size];
-        try (InputStream is = new FileInputStream(fileToRead)) {
-            // Read in the bytes
-            int offset = 0;
-            int numRead = 0;
+        LOGGER.debug("size of array: {}", size);
+
+        try (SeekableByteChannel byteChannel = Files.newByteChannel(fileToRead.toPath(), StandardOpenOption.READ)) {
             // Skip ahead
-            is.skip(start);
-            // start reading
-            while (offset < bytes.length &&
-                    (numRead) >= 0) {
-                numRead = is.read(bytes, offset,
-                        bytes.length - offset);
-                offset += numRead;
-            }
+            byteChannel.position(start);
+
+            // Create the byte array to hold the data
+            ByteBuffer byteBuffer = ByteBuffer.allocate(size);
+            byteChannel.read(byteBuffer);
+
+            return byteBuffer.array();
         }
-        catch (IOException fnf) {
-            log.error("Could not read from: {}", fileToRead.getAbsolutePath());
-            throw new RhnRuntimeException(fnf);
+        catch (IOException e) {
+            LOGGER.error("Could not read from: {}", fileToRead.getAbsolutePath());
+            throw new RhnRuntimeException("Could not read bytes from file", e);
         }
-        return bytes;
     }
 
     /**
@@ -188,27 +169,22 @@ public class FileUtils {
      */
     public static String getTailOfFile(String pathToFile, Integer lines) {
         CircularFifoBuffer buffer = new CircularFifoBuffer(lines);
-        try (InputStream fileStream = new FileInputStream(pathToFile)) {
-            LineIterator it = org.apache.commons.io.IOUtils.lineIterator(fileStream,
-                                                                         (String) null);
-            while (it.hasNext()) {
-                buffer.add(it.nextLine());
-            }
-        }
-        catch (FileNotFoundException e) {
-            log.error("File not found: {}", pathToFile);
-            throw new RhnRuntimeException(e);
+
+        try (Stream<String> linesStream = Files.lines(Path.of(pathToFile))) {
+            linesStream.forEach(line -> buffer.add(line));
         }
         catch (IOException e) {
-            log.error(String.format("Failed to close file %s", pathToFile));
+            LOGGER.error("File not found: {}", pathToFile);
             throw new RhnRuntimeException(e);
         }
+
         // Construct a string from the buffered lines
         StringBuilder sb = new StringBuilder();
         for (Object s : buffer) {
             sb.append(s);
             sb.append(System.getProperty("line.separator"));
         }
+
         return sb.toString();
     }
 
@@ -221,7 +197,7 @@ public class FileUtils {
             Files.deleteIfExists(path);
         }
         catch (IOException e) {
-            log.warn("Could not delete file: {}", path, e);
+            LOGGER.warn("Could not delete file: {}", path, e);
         }
     }
 }

--- a/java/code/src/com/redhat/rhn/common/util/download/DownloadUtils.java
+++ b/java/code/src/com/redhat/rhn/common/util/download/DownloadUtils.java
@@ -14,10 +14,6 @@
  */
 package com.redhat.rhn.common.util.download;
 
-
-
-import org.jfree.io.IOUtils;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -62,8 +58,7 @@ public class DownloadUtils {
 
     private static String toString(InputStream stream) throws IOException {
         StringWriter writer = new StringWriter();
-        IOUtils.getInstance().copyWriter(
-                new BufferedReader(new InputStreamReader(stream)), writer);
+        new BufferedReader(new InputStreamReader(stream)).transferTo(writer);
         return writer.toString();
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartFactory.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.domain.kickstart;
 
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.util.FileUtils;
 import com.redhat.rhn.domain.action.Action;
@@ -432,7 +433,7 @@ public class KickstartFactory extends HibernateFactory {
         }
         String path = ksdataIn.buildCobblerFileName();
         log.debug("writing ks file to : {}", path);
-        FileUtils.writeStringToFile(fileData, path);
+        FileUtils.writeStringToFile(fileData, ConfigDefaults.get().getKickstartConfigDir(), path);
     }
 
     private static String getKickstartTemplatePath(KickstartData ksdata, Profile p) {

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartRawData.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartRawData.java
@@ -46,14 +46,12 @@ public class KickstartRawData extends KickstartData {
     public String getData() {
         if (this.data == null) {
             Profile prof = Profile.lookupById(
-                    CobblerXMLRPCHelper.getConnection(
-                            ConfigDefaults.get().getCobblerAutomatedUser()),
+                    CobblerXMLRPCHelper.getConnection(ConfigDefaults.get().getCobblerAutomatedUser()),
                     this.getCobblerId());
             if (prof == null) {
                 return "";
             }
-            this.data = FileUtils.
-                readStringFromFile(prof.getKickstart());
+            this.data = FileUtils.readStringFromFile(ConfigDefaults.get().getKickstartConfigDir(), prof.getKickstart());
         }
         return this.data;
     }

--- a/java/code/src/com/redhat/rhn/domain/kickstart/cobbler/CobblerSnippet.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/cobbler/CobblerSnippet.java
@@ -193,7 +193,7 @@ public class CobblerSnippet implements Comparable<CobblerSnippet> {
     */
     public String getContents() {
         if (path.exists()) {
-            return FileUtils.readStringFromFile(path.getAbsolutePath());
+            return FileUtils.readStringFromFile(getPrefixFor(org), path.getAbsolutePath());
         }
         return null;
     }
@@ -212,8 +212,7 @@ public class CobblerSnippet implements Comparable<CobblerSnippet> {
         if (!path.exists()) {
             path.getParentFile().mkdirs();
         }
-        FileUtils.writeStringToFile(StringUtil.webToLinux(contents),
-                path.getAbsolutePath());
+        FileUtils.writeStringToFile(StringUtil.webToLinux(contents), getPrefixFor(org), path.getAbsolutePath());
     }
 
 

--- a/java/spacewalk-java.changes.mackdk.drop-jcommon
+++ b/java/spacewalk-java.changes.mackdk.drop-jcommon
@@ -1,0 +1,1 @@
+- Removed jcommon dependency

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -113,7 +113,6 @@ BuildRequires:  javamail
 BuildRequires:  javapackages-tools
 BuildRequires:  javassist
 BuildRequires:  jboss-logging
-BuildRequires:  jcommon
 BuildRequires:  jdom
 BuildRequires:  joda-time
 BuildRequires:  jose4j
@@ -200,7 +199,6 @@ Requires:       javamail
 Requires:       javapackages-tools
 Requires:       javassist
 Requires:       jboss-logging
-Requires:       jcommon
 Requires:       jdom
 Requires:       joda-time
 Requires:       jose4j
@@ -364,7 +362,6 @@ Requires:       httpcomponents-core
 Requires:       java-%{java_version}-openjdk
 Requires:       javassist
 Requires:       jboss-logging
-Requires:       jcommon
 Requires:       jpa-api
 Requires:       jsch
 Requires:       log4j


### PR DESCRIPTION
## What does this PR change?

This PR drops the dependency on jcommon. It was only used to copy from a `Reader` to a `Writer`. This operation is part of the java  API since version 10.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
