### PR TITLE
QE: Improve our raise exception avoiding a Rubocop warning

### DIFF
--- a/testsuite/.rubocop.yml
+++ b/testsuite/.rubocop.yml
@@ -2,6 +2,7 @@ inherit_from: .rubocop_todo.yml
 
 AllCops:
   EnabledByDefault: true
+  TargetRubyVersion: 2.5
 
 Metrics/CyclomaticComplexity:
   Max: 20

--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -186,26 +186,26 @@ end
 ## activationkey namespace
 
 Then(/^I should get some activation keys$/) do
-  raise if $api_test.activationkey.get_activation_keys_count < 1
+  raise ScriptError if $api_test.activationkey.get_activation_keys_count < 1
 end
 
 When(/^I create an activation key with id "([^"]*)", description "([^"]*)" and limit of (\d+)$/) do |id, dscr, limit|
   key = $api_test.activationkey.create(id, dscr, '', limit.to_i)
-  raise 'Key creation failed' if key.nil?
-  raise 'Bad key name' if key != "1-#{id}"
+  raise ScriptError, 'Key creation failed' if key.nil?
+  raise ScriptError, 'Bad key name' if key != "1-#{id}"
 end
 
 Then(/^I should get the new activation key "([^"]*)"$/) do |activation_key|
-  raise unless $api_test.activationkey.verify(activation_key)
+  raise ScriptError unless $api_test.activationkey.verify(activation_key)
 end
 
 When(/^I delete the activation key "([^"]*)"$/) do |activation_key|
-  raise unless $api_test.activationkey.delete(activation_key)
-  raise if $api_test.activationkey.verify(activation_key)
+  raise ScriptError unless $api_test.activationkey.delete(activation_key)
+  raise ScriptError if $api_test.activationkey.verify(activation_key)
 end
 
 When(/^I set the description of the activation key "([^"]*)" to "([^"]*)"$/) do |activation_key, description|
-  raise unless $api_test.activationkey.set_details(activation_key, description, '', 10, 'default')
+  raise RuntimeError unless $api_test.activationkey.set_details(activation_key, description, '', 10, 'default')
 end
 
 Then(/^I get the description "([^"]*)" for the activation key "([^"]*)"$/) do |description, activation_key|
@@ -215,7 +215,7 @@ Then(/^I get the description "([^"]*)" for the activation key "([^"]*)"$/) do |d
     log "  #{k}: #{v}"
   end
   log
-  raise unless details['description'] == description
+  raise ScriptError unless details['description'] == description
 end
 
 When(/^I create an activation key including custom channels for "([^"]*)" via API$/) do |client|
@@ -529,11 +529,9 @@ When(/^I deploy all systems registered to channel "([^"]*)"$/) do |channel|
 end
 
 When(/^I delete channel "([^"]*)" via API((?: without error control)?)$/) do |channel, error_control|
-  begin
-    $api_test.configchannel.delete_channels([channel])
-  rescue
-    raise 'Error deleting channel' if error_control.empty?
-  end
+  $api_test.configchannel.delete_channels([channel])
+rescue
+  raise SystemCallError, 'Error deleting channel' if error_control.empty?
 end
 
 When(/^I call system.create_system_profile\(\) with name "([^"]*)" and HW address "([^"]*)"$/) do |name, hw_address|

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -19,9 +19,9 @@ Then(/^"([^"]*)" should have a FQDN$/) do |host|
   result = lines[1]
   end_time = lines[2]
   resolution_time = end_time.to_i - initial_time.to_i
-  raise 'cannot determine hostname' unless return_code.zero?
-  raise "name resolution for #{node.full_hostname} took too long (#{resolution_time} seconds)" unless resolution_time <= 2
-  raise 'hostname is not fully qualified' unless result == node.full_hostname
+  raise ScriptError, 'cannot determine hostname' unless return_code.zero?
+  raise ScriptError, "name resolution for #{node.full_hostname} took too long (#{resolution_time} seconds)" unless resolution_time <= 2
+  raise ScriptError, 'hostname is not fully qualified' unless result == node.full_hostname
 end
 
 Then(/^reverse resolution should work for "([^"]*)"$/) do |host|
@@ -32,9 +32,9 @@ Then(/^reverse resolution should work for "([^"]*)"$/) do |host|
   result = lines[1]
   end_time = lines[2]
   resolution_time = end_time.to_i - initial_time.to_i
-  raise 'cannot do reverse resolution' unless return_code.zero?
-  raise "reverse resolution for #{node.full_hostname} took too long (#{resolution_time} seconds)" unless resolution_time <= 2
-  raise "reverse resolution for #{node.full_hostname} returned #{result}, expected to see #{node.full_hostname}" unless result.include? node.full_hostname
+  raise ScriptError, 'cannot do reverse resolution' unless return_code.zero?
+  raise ScriptError, "reverse resolution for #{node.full_hostname} took too long (#{resolution_time} seconds)" unless resolution_time <= 2
+  raise ScriptError, "reverse resolution for #{node.full_hostname} returned #{result}, expected to see #{node.full_hostname}" unless result.include? node.full_hostname
 end
 
 Then(/^I turn off disable_local_repos for all clients/) do
@@ -65,7 +65,7 @@ Then(/^the clock from "([^"]*)" should be exact$/) do |host|
   clock_node, _rc = node.run('date +\'%s\'')
   clock_controller = `date +'%s'`
   difference = clock_node.to_i - clock_controller.to_i
-  raise "clocks differ by #{difference} seconds" unless difference.abs < 2
+  raise StandardError, "clocks differ by #{difference} seconds" unless difference.abs < 2
 end
 
 Then(/^it should be possible to reach the test packages$/) do
@@ -126,7 +126,7 @@ end
 
 When(/^I list channels with spacewalk-remove-channel$/) do
   $command_output, return_code = get_target('server').run('spacewalk-remove-channel -l')
-  raise 'Unable to run spacewalk-remove-channel -l command on server' unless return_code.zero?
+  raise SystemCallError, 'Unable to run spacewalk-remove-channel -l command on server' unless return_code.zero?
 end
 
 When(/^I add "([^"]*)" channel$/) do |channel|
@@ -143,11 +143,11 @@ When(/^I use spacewalk-repo-sync to sync channel "([^"]*)"$/) do |channel|
 end
 
 Then(/^I should get "([^"]*)"$/) do |value|
-  raise "'#{value}' not found in output '#{$command_output}'" unless $command_output.include? value
+  raise ScriptError, "'#{value}' not found in output '#{$command_output}'" unless $command_output.include? value
 end
 
 Then(/^I shouldn't get "([^"]*)"$/) do |value|
-  raise "'#{value}' found in output '#{$command_output}'" if $command_output.include? value
+  raise ScriptError, "'#{value}' found in output '#{$command_output}'" if $command_output.include? value
 end
 
 # Packages
@@ -231,10 +231,10 @@ When(/^vendor change should be enabled for [^"]* on "([^"]*)"$/) do |host|
   next_day_rotated_log = "#{current_log}-#{day_after}.xz"
   begin
     _, return_code = node.run("xzdec #{next_day_rotated_log} | grep -- #{pattern}")
-  rescue RuntimeError
+  rescue Scr
     _, return_code = node.run("grep -- #{pattern} #{current_log} || xzdec #{rotated_log} | grep -- #{pattern}")
   end
-  raise 'Vendor change option not found in logs' unless return_code.zero?
+  raise ScriptError, 'Vendor change option not found in logs' unless return_code.zero?
 end
 
 When(/^I wait until "([^"]*)" service is active on "([^"]*)"$/) do |service, host|
@@ -347,7 +347,7 @@ end
 
 Then(/^the reposync logs should not report errors$/) do
   result, code = get_target('server').run('grep -i "ERROR:" /var/log/rhn/reposync/*.log', check_errors: false)
-  raise "Errors during reposync:\n#{result}" if code.zero?
+  raise ScriptError, "Errors during reposync:\n#{result}" if code.zero?
 end
 
 Then(/^the "([^"]*)" reposync logs should not report errors$/) do |list|
@@ -356,7 +356,7 @@ Then(/^the "([^"]*)" reposync logs should not report errors$/) do |list|
     _result, code = get_target('server').run("test -f /var/log/rhn/reposync/#{logs}.log", check_errors: false)
     if code.zero?
       result, code = get_target('server').run("grep -i 'ERROR:' /var/log/rhn/reposync/#{logs}.log", check_errors: false)
-      raise "Errors during #{logs} reposync:\n#{result}" if code.zero?
+      raise ScriptError, "Errors during #{logs} reposync:\n#{result}" if code.zero?
     end
   end
 end
@@ -420,7 +420,7 @@ end
 
 Then(/^file "([^"]*)" should contain "([^"]*)" on server$/) do |file, content|
   output, _code = get_target('server').run("grep -F '#{content}' #{file}", check_errors: false)
-  raise "'#{content}' not found in file #{file}" if output !~ /#{content}/
+  raise ScriptError, "'#{content}' not found in file #{file}" if output !~ /#{content}/
   "\n-----\n#{output}\n-----\n"
 end
 
@@ -428,7 +428,7 @@ Then(/^the tomcat logs should not contain errors$/) do
   output, _code = get_target('server').run('cat /var/log/tomcat/*')
   msgs = %w[ERROR NullPointer]
   msgs.each do |msg|
-    raise "-#{msg}-  msg found on tomcat logs" if output.include? msg
+    raise ScriptError, "-#{msg}-  msg found on tomcat logs" if output.include? msg
   end
 end
 
@@ -436,13 +436,13 @@ Then(/^the taskomatic logs should not contain errors$/) do
   output, _code = get_target('server').run('cat /var/log/rhn/rhn_taskomatic_daemon.log')
   msgs = %w[NullPointer]
   msgs.each do |msg|
-    raise "-#{msg}-  msg found on taskomatic logs" if output.include? msg
+    raise ScriptError, "-#{msg}-  msg found on taskomatic logs" if output.include? msg
   end
 end
 
 Then(/^the log messages should not contain out of memory errors$/) do
   output, code = get_target('server').run('grep -i "Out of memory: Killed process" /var/log/messages', check_errors: false)
-  raise "Out of memory errors in /var/log/messages:\n#{output}" if code.zero?
+  raise ScriptError, "Out of memory errors in /var/log/messages:\n#{output}" if code.zero?
 end
 
 When(/^I restart the spacewalk service$/) do
@@ -456,16 +456,14 @@ end
 When(/^I execute spacewalk-debug on the server$/) do
   get_target('server').run('spacewalk-debug')
   code = file_extract(get_target('server'), '/tmp/spacewalk-debug.tar.bz2', 'spacewalk-debug.tar.bz2')
-  raise 'Download debug file failed' unless code.zero?
+  raise ScriptError, 'Download debug file failed' unless code.zero?
 end
 
 When(/^I extract the log files from all our active nodes$/) do
   ENV_VAR_BY_HOST.each do |host, _env_var|
-    begin
-      get_target(host)
-    rescue StandardError
-      # Catch exceptions silently
-    end
+    get_target(host)
+  rescue StandardError
+    # Catch exceptions silently
   end
   $node_by_host.each do |_host, node|
     next if node.nil?
@@ -488,22 +486,22 @@ Then(/^the repo file should contain the (custom|normal) download endpoint on the
   normal_download_endpoint = "https://#{get_target('proxy').full_hostname}:443"
   expected_uri = URI.parse(type == 'custom' ? $custom_download_endpoint : normal_download_endpoint)
   log 'Expected protocol: ' + expected_uri.scheme + '  host: ' + expected_uri.host + '  port: ' + expected_uri.port.to_s
-  raise 'Some parameters are not as expected' unless real_uri.scheme == expected_uri.scheme && real_uri.host == expected_uri.host && real_uri.port == expected_uri.port
+  raise ScriptError, 'Some parameters are not as expected' unless real_uri.scheme == expected_uri.scheme && real_uri.host == expected_uri.host && real_uri.port == expected_uri.port
 end
 
 When(/^I copy "([^"]*)" to "([^"]*)"$/) do |file, host|
   node = get_target(host)
   return_code = file_inject(node, file, File.basename(file))
-  raise 'File injection failed' unless return_code.zero?
+  raise ScriptError, 'File injection failed' unless return_code.zero?
 end
 
 When(/^I copy "([^"]*)" file from "([^"]*)" to "([^"]*)"$/) do |file_path, from_host, to_host|
   from_node = get_target(from_host)
   to_node = get_target(to_host)
   return_code = file_extract(from_node, file_path, file_path)
-  raise 'File extraction failed' unless return_code.zero?
+  raise ScriptError, 'File extraction failed' unless return_code.zero?
   return_code = file_inject(to_node, file_path, file_path)
-  raise 'File injection failed' unless return_code.zero?
+  raise ScriptError, 'File injection failed' unless return_code.zero?
 end
 
 Then(/^the PXE default profile should be enabled$/) do
@@ -519,7 +517,7 @@ When(/^the server starts mocking an IPMI host$/) do
     source = File.dirname(__FILE__) + '/../upload_files/' + file
     dest = '/etc/ipmi/' + file
     return_code = file_inject(get_target('server'), source, dest)
-    raise 'File injection failed' unless return_code.zero?
+    raise ScriptError, 'File injection failed' unless return_code.zero?
   end
   get_target('server').run('chmod +x /etc/ipmi/fake_ipmi_host.sh')
   get_target('server').run('ipmi_sim -n < /dev/null > /dev/null &')
@@ -570,14 +568,14 @@ When(/^I install a user-defined state for "([^"]*)" on the server$/) do |host|
   source = File.dirname(__FILE__) + '/../upload_files/' + file
   dest = '/srv/salt/' + file
   return_code = file_inject(get_target('server'), source, dest)
-  raise 'File injection failed' unless return_code.zero?
+  raise ScriptError, 'File injection failed' unless return_code.zero?
   # generate top file and copy it to server
   script = "base:\n" \
            "  '#{system_name}':\n" \
            "    - user_defined_state\n"
   path = generate_temp_file('top.sls', script)
   return_code = file_inject(get_target('server'), path, '/srv/salt/top.sls')
-  raise 'File injection failed' unless return_code.zero?
+  raise ScriptError, 'File injection failed' unless return_code.zero?
   `rm #{path}`
   # make both files readeable by salt
   get_target('server').run('chgrp salt /srv/salt/*')
@@ -593,7 +591,7 @@ When(/^I uninstall the managed file from "([^"]*)"$/) do |host|
 end
 
 When(/^I configure tftp on the "([^"]*)"$/) do |host|
-  raise "This step doesn't support #{host}" unless %w[server proxy].include? host
+  raise ScriptError, "This step doesn't support #{host}" unless %w[server proxy].include? host
 
   case host
   when 'server'
@@ -609,7 +607,7 @@ When(/^I configure tftp on the "([^"]*)"$/) do |host|
 end
 
 When(/^I set the default PXE menu entry to the (target profile|local boot) on the "([^"]*)"$/) do |entry, host|
-  raise "This step doesn't support #{host}" unless %w[server proxy].include? host
+  raise ScriptError, "This step doesn't support #{host}" unless %w[server proxy].include? host
 
   node = get_target(host)
   target = '/srv/tftpboot/pxelinux.cfg/default'
@@ -627,22 +625,20 @@ end
 When(/^I clean the search index on the server$/) do
   output, _code = get_target('server').run('/usr/sbin/rhn-search cleanindex', check_errors: false)
   log 'Search reindex finished.' if output.include?('Index files have been deleted and database has been cleaned up, ready to reindex')
-  raise 'The output includes an error log' if output.include?('ERROR')
+  raise ScriptError, 'The output includes an error log' if output.include?('ERROR')
   step 'I wait until rhn-search is responding'
 end
 
 When(/^I wait until rhn-search is responding$/) do
   step 'I wait until "rhn-search" service is active on "server"'
   repeat_until_timeout(timeout: 60, message: 'rhn-search is not responding properly.') do
-    begin
-      log "Search by hostname: #{get_target('sle_minion').hostname}"
-      result = $api_test.system.search.hostname(get_target('sle_minion').hostname)
-      log result
-      break if get_target('sle_minion').full_hostname.include? result.first['hostname']
-    rescue StandardError => e
-      log "rhn-search still not responding.\nError message: #{e.message}"
-      sleep 3
-    end
+    log "Search by hostname: #{get_target('sle_minion').hostname}"
+    result = $api_test.system.search.hostname(get_target('sle_minion').hostname)
+    log result
+    break if get_target('sle_minion').full_hostname.include? result.first['hostname']
+  rescue StandardError => e
+    log "rhn-search still not responding.\nError message: #{e.message}"
+    sleep 3
   end
 end
 
@@ -657,7 +653,7 @@ Then(/^I wait until mgr-sync refresh is finished$/) do
 end
 
 Then(/^I should see "(.*?)" in the output$/) do |arg1|
-  raise "Command Output #{@command_output} don't include #{arg1}" unless @command_output.include? arg1
+  raise ScriptError, "Command Output #{@command_output} don't include #{arg1}" unless @command_output.include? arg1
 end
 
 When(/^I (start|stop|restart|reload|enable|disable) the "([^"]*)" service on "([^"]*)"$/) do |action, service, host|
@@ -669,28 +665,28 @@ Then(/^service "([^"]*)" is enabled on "([^"]*)"$/) do |service, host|
   node = get_target(host)
   output, _code = node.run("systemctl is-enabled '#{service}'", check_errors: false)
   output = output.split(/\n+/)[-1]
-  raise "Service #{service} not enabled" if output != 'enabled'
+  raise ScriptError, "Service #{service} not enabled" if output != 'enabled'
 end
 
 Then(/^service "([^"]*)" is active on "([^"]*)"$/) do |service, host|
   node = get_target(host)
   output, _code = node.run("systemctl is-active '#{service}'", check_errors: false)
   output = output.split(/\n+/)[-1]
-  raise "Service #{service} not active" if output != 'active'
+  raise ScriptError, "Service #{service} not active" if output != 'active'
 end
 
 Then(/^socket "([^"]*)" is enabled on "([^"]*)"$/) do |service, host|
   node = get_target(host)
   output, _code = node.run("systemctl is-enabled '#{service}.socket'", check_errors: false)
   output = output.split(/\n+/)[-1]
-  raise "Service #{service} not enabled" if output != 'enabled'
+  raise ScriptError, "Service #{service} not enabled" if output != 'enabled'
 end
 
 Then(/^socket "([^"]*)" is active on "([^"]*)"$/) do |service, host|
   node = get_target(host)
   output, _code = node.run("systemctl is-active '#{service}.socket'", check_errors: false)
   output = output.split(/\n+/)[-1]
-  raise "Service #{service} not active" if output != 'active'
+  raise ScriptError, "Service #{service} not active" if output != 'active'
 end
 
 When(/^I run "([^"]*)" on "([^"]*)"$/) do |cmd, host|
@@ -710,7 +706,7 @@ When(/^I run "([^"]*)" on "([^"]*)" without error control$/) do |cmd, host|
 end
 
 Then(/^the command should fail$/) do
-  raise 'Previous command must fail, but has NOT failed!' if $fail_code.zero?
+  raise ScriptError, 'Previous command must fail, but has NOT failed!' if $fail_code.zero?
 end
 
 When(/^I wait until file "([^"]*)" exists on "([^"]*)"$/) do |file, host|
@@ -770,7 +766,7 @@ end
 
 When(/^I (enable|disable) Debian-like "([^"]*)" repository on "([^"]*)"$/) do |action, repo, host|
   node = get_target(host)
-  raise "#{node.hostname} is not a Debian-like host." unless deb_host?(host)
+  raise ScriptError, "#{node.hostname} is not a Debian-like host." unless deb_host?(host)
 
   source_repo = "deb http://archive.ubuntu.com/ubuntu/ $(lsb_release -sc) #{repo}"
   node.run("sudo add-apt-repository -y -u #{action == 'disable' ? '--remove' : ''} \"#{source_repo}\"")
@@ -848,7 +844,7 @@ When(/^I (install|remove) OpenSCAP dependencies (on|from) "([^"]*)"$/) do |actio
   elsif os_family =~ /^ubuntu/
     pkgs = 'libopenscap8 scap-security-guide-ubuntu'
   else
-    raise "The node #{node.hostname} has not a supported OS Family (#{os_family})"
+    raise ScriptError, "The node #{node.hostname} has not a supported OS Family (#{os_family})"
   end
   step %(I #{action} packages "#{pkgs}" #{where} this "#{host}")
 end
@@ -873,7 +869,7 @@ When(/^I install packages? "([^"]*)" on this "([^"]*)"((?: without error control
     not_found_msg = 'not found in package names'
   end
   output, _code = node.run(cmd, check_errors: error_control.empty?, successcodes: successcodes)
-  raise "A package was not found. Output:\n #{output}" if output.include? not_found_msg
+  raise ScriptError, "A package was not found. Output:\n #{output}" if output.include? not_found_msg
 end
 
 When(/^I install old packages? "([^"]*)" on this "([^"]*)"((?: without error control)?)$/) do |package, host, error_control|
@@ -892,7 +888,7 @@ When(/^I install old packages? "([^"]*)" on this "([^"]*)"((?: without error con
     not_found_msg = 'not found in package names'
   end
   output, _code = node.run(cmd, check_errors: error_control.empty?, successcodes: successcodes)
-  raise "A package was not found. Output:\n #{output}" if output.include? not_found_msg
+  raise ScriptError, "A package was not found. Output:\n #{output}" if output.include? not_found_msg
 end
 
 When(/^I remove packages? "([^"]*)" from this "([^"]*)"((?: without error control)?)$/) do |package, host, error_control|
@@ -989,17 +985,17 @@ When(/^I copy server\'s keys to the proxy$/) do
 
     %w[proxy.crt proxy.key ca.crt].each do |file|
       return_code, = get_target('server').extract_file("/tmp/#{file}", "/tmp/#{file}")
-      raise 'File extraction failed' unless return_code.zero?
+      raise ScriptError, 'File extraction failed' unless return_code.zero?
       return_code = file_inject(get_target('proxy'), "/tmp/#{file}", "/tmp/#{file}")
-      raise 'File injection failed' unless return_code.zero?
+      raise ScriptError, 'File injection failed' unless return_code.zero?
     end
   else
     %w[RHN-ORG-PRIVATE-SSL-KEY RHN-ORG-TRUSTED-SSL-CERT rhn-ca-openssl.cnf].each do |file|
       return_code = file_extract(get_target('server'), '/root/ssl-build/' + file, '/tmp/' + file)
-      raise 'File extraction failed' unless return_code.zero?
+      raise ScriptError, 'File extraction failed' unless return_code.zero?
       get_target('proxy').run('mkdir -p /root/ssl-build')
       return_code = file_inject(get_target('proxy'), '/tmp/' + file, '/root/ssl-build/' + file)
-      raise 'File injection failed' unless return_code.zero?
+      raise ScriptError, 'File injection failed' unless return_code.zero?
     end
   end
 end
@@ -1127,7 +1123,7 @@ Then(/^I wait until refresh package list on "(.*?)" is finished$/) do |client|
     sleep 1
     next if result.include? '0    0    1'
     break if result.include? '1    0    0'
-    raise 'refresh package list failed' if result.include? '0    1    0'
+    raise ScriptError, 'refresh package list failed' if result.include? '0    1    0'
   end
 end
 
@@ -1138,7 +1134,7 @@ When(/^spacecmd should show packages "([^"]*)" installed on "([^"]*)"$/) do |pac
   result, _code = get_target('server').run(command, check_errors: false)
   packages.split(' ').each do |package|
     pkg = package.strip
-    raise "package #{pkg} is not installed" unless result.include? pkg
+    raise ScriptError, "package #{pkg} is not installed" unless result.include? pkg
   end
 end
 
@@ -1192,20 +1188,20 @@ When(/^I apply "([^"]*)" local salt state on "([^"]*)"$/) do |state, host|
   source = File.dirname(__FILE__) + '/../upload_files/salt/' + state + '.sls'
   remote_file = '/usr/share/susemanager/salt/' + state + '.sls'
   return_code = file_inject(node, source, remote_file)
-  raise 'File injection failed' unless return_code.zero?
+  raise ScriptError, 'File injection failed' unless return_code.zero?
   node.run("#{salt_call} --local --file-root=/usr/share/susemanager/salt --module-dirs=/usr/share/susemanager/salt/ --log-level=info --retcode-passthrough state.apply " + state)
 end
 
 When(/^I copy unset package file on server$/) do
   base_dir = File.dirname(__FILE__) + '/../upload_files/unset_package/'
   return_code = file_inject(get_target('server'), base_dir + 'subscription-tools-1.0-0.noarch.rpm', '/root/subscription-tools-1.0-0.noarch.rpm')
-  raise 'File injection failed' unless return_code.zero?
+  raise ScriptError, 'File injection failed' unless return_code.zero?
 end
 
 When(/^I copy vCenter configuration file on server$/) do
   base_dir = File.dirname(__FILE__) + '/../upload_files/virtualization/'
   return_code = file_inject(get_target('server'), base_dir + 'vCenter.json', '/var/tmp/vCenter.json')
-  raise 'File injection failed' unless return_code.zero?
+  raise ScriptError, 'File injection failed' unless return_code.zero?
 end
 
 When(/^I export software channels "([^"]*)" with ISS v2 to "([^"]*)"$/) do |channel, path|
@@ -1221,12 +1217,12 @@ When(/^I import data with ISS v2 from "([^"]*)"$/) do |path|
 end
 
 Then(/^"(.*?)" folder on server is ISS v2 export directory$/) do |folder|
-  raise "Folder #{folder} not found" unless file_exists?(get_target('server'), folder + '/sql_statements.sql.gz')
+  raise ScriptError, "Folder #{folder} not found" unless file_exists?(get_target('server'), folder + '/sql_statements.sql.gz')
 end
 
 Then(/^export folder "(.*?)" shouldn't exist on "(.*?)"$/) do |folder, host|
   node = get_target(host)
-  raise 'Folder exists' if folder_exists?(node, folder)
+  raise ScriptError, 'Folder exists' if folder_exists?(node, folder)
 end
 
 When(/^I ensure folder "(.*?)" doesn't exist on "(.*?)"$/) do |folder, host|
@@ -1239,15 +1235,15 @@ end
 Given(/^I can connect to the ReportDB on the Server$/) do
   # connect and quit database
   _result, return_code = get_target('server').run(reportdb_server_query('\\q'))
-  raise 'Couldn\'t connect to the ReportDB on the server' unless return_code.zero?
+  raise SystemCallError, 'Couldn\'t connect to the ReportDB on the server' unless return_code.zero?
 end
 
 Given(/^I have a user with admin access to the ReportDB$/) do
   users_and_permissions, return_code = get_target('server').run(reportdb_server_query('\\du'))
-  raise 'Couldn\'t connect to the ReportDB on the server' unless return_code.zero?
+  raise SystemCallError, 'Couldn\'t connect to the ReportDB on the server' unless return_code.zero?
   # extract only the line for the suma user
   suma_user_permissions = users_and_permissions[/pythia_susemanager(.*)}/]
-  raise 'ReportDB admin user pythia_susemanager doesn\'t have the required permissions' unless
+  raise ScriptError, 'ReportDB admin user pythia_susemanager doesn\'t have the required permissions' unless
     ['Superuser', 'Create role', 'Create DB'].all? { |permission| suma_user_permissions.include? permission }
 end
 
@@ -1257,13 +1253,13 @@ When(/^I create a read-only user for the ReportDB$/) do
   source = "#{File.dirname(__FILE__)}/../upload_files/#{file}"
   dest = "/tmp/#{file}"
   return_code = file_inject(get_target('server'), source, dest)
-  raise 'File injection in server failed' unless return_code.zero?
+  raise ScriptError, 'File injection in server failed' unless return_code.zero?
   get_target('server').run("expect -f /tmp/#{file} #{$reportdb_ro_user}")
 end
 
 Then(/^I should see the read-only user listed on the ReportDB user accounts$/) do
   users_and_permissions, _code = get_target('server').run(reportdb_server_query('\\du'))
-  raise 'Couldn\'t find the newly created user on the ReportDB' unless users_and_permissions.include? $reportdb_ro_user
+  raise ScriptError, 'Couldn\'t find the newly created user on the ReportDB' unless users_and_permissions.include? $reportdb_ro_user
 end
 
 When(/^I delete the read-only user for the ReportDB$/) do
@@ -1271,13 +1267,13 @@ When(/^I delete the read-only user for the ReportDB$/) do
   source = "#{File.dirname(__FILE__)}/../upload_files/#{file}"
   dest = "/tmp/#{file}"
   return_code = file_inject(get_target('server'), source, dest)
-  raise 'File injection in server failed' unless return_code.zero?
+  raise ScriptError, 'File injection in server failed' unless return_code.zero?
   get_target('server').run("expect -f /tmp/#{file} #{$reportdb_ro_user}")
 end
 
 Then(/^I shouldn't see the read-only user listed on the ReportDB user accounts$/) do
   users_and_permissions, _code = get_target('server').run(reportdb_server_query('\\du'))
-  raise 'Created read-only user on the ReportDB remains listed' if users_and_permissions.include? $reportdb_ro_user
+  raise ScriptError, 'Created read-only user on the ReportDB remains listed' if users_and_permissions.include? $reportdb_ro_user
 end
 
 When(/^I connect to the ReportDB with read-only user from external machine$/) do
@@ -1289,12 +1285,13 @@ Then(/^I should be able to query the ReportDB$/) do
   query_result = $reportdb_ro_conn.exec('select * from system;')
   # raises exception if the query wasn't successful
   query_result.check
-  raise 'ReportDB System table is unexpectedly empty after query' unless query_result.ntuples.positive?
+  raise SystemCallError, 'ReportDB System table is unexpectedly empty after query' unless query_result.ntuples.positive?
 end
 
 Then(/^I should find the systems from the UI in the ReportDB$/) do
   reportdb_listed_systems = $reportdb_ro_conn.exec('select hostname from system;').values.flatten
-  raise "Listed systems from the UI #{$systems_list} don't match the ones from the ReportDB System table #{reportdb_listed_systems}" unless $systems_list.all? { |ui_system| reportdb_listed_systems.include? ui_system }
+  match = $systems_list.all? { |ui_system| reportdb_listed_systems.include? ui_system }
+  raise ScriptError, "Listed systems from the UI #{$systems_list} don't match the ones from the ReportDB System table #{reportdb_listed_systems}" unless match
 end
 
 Then(/^I should not be able to "([^"]*)" data in a ReportDB "([^"]*)" as a read-only user$/) do |db_action, table_type|
@@ -1308,7 +1305,7 @@ Then(/^I should not be able to "([^"]*)" data in a ReportDB "([^"]*)" as a read-
     when 'delete'
       $reportdb_ro_conn.exec("delete from #{table_and_views[table_type]} where mgm_id = 1")
     else
-      raise 'Couldn\'t find command to manipulate the database'
+      raise ScriptError, 'Couldn\'t find command to manipulate the database'
     end
   end
 end
@@ -1321,7 +1318,7 @@ end
 Then(/^I should be able to connect to the ReportDB with the ReportDB admin user$/) do
   # connection from the controller to the reportdb in the server
   reportdb_admin_conn = PG.connect(host: get_target('server').public_ip, port: 5432, dbname: 'reportdb', user: $reportdb_admin_user, password: $reportdb_admin_password)
-  raise 'Couldn\'t connect to ReportDB with admin from external machine' unless reportdb_admin_conn.status.zero?
+  raise SystemCallError, 'Couldn\'t connect to ReportDB with admin from external machine' unless reportdb_admin_conn.status.zero?
 end
 
 Then(/^I should not be able to connect to product database with the ReportDB admin user$/) do
@@ -1343,10 +1340,10 @@ Then(/^I should find the updated "([^"]*)" property as "([^"]*)" on the "([^"]*)
   query_result = $reportdb_ro_conn.exec("select #{property}, synced_date from system where hostname = '#{system_hostname}'")
 
   reportdb_property_value = query_result.tuple(0)[0]
-  raise "#{property_name}'s value not updated - database still presents #{reportdb_property_value} instead of #{property_value}" unless reportdb_property_value == property_value
+  raise ScriptError, "#{property_name}'s value not updated - database still presents #{reportdb_property_value} instead of #{property_value}" unless reportdb_property_value == property_value
 
   final_synced_date = Time.parse(query_result.tuple(0)[1])
-  raise "Column synced_date not updated. Inital synced_date was #{$initial_synced_date} while current synced_date is #{final_synced_date}" unless final_synced_date > $initial_synced_date
+  raise ScriptError, "Column synced_date not updated. Inital synced_date was #{$initial_synced_date} while current synced_date is #{final_synced_date}" unless final_synced_date > $initial_synced_date
 end
 
 Given(/^I block connections from "([^"]*)" on "([^"]*)"$/) do |blockhost, target|
@@ -1416,9 +1413,9 @@ Then(/^port "([^"]*)" should be (open|closed)$/) do |port, selection|
   _output, code = get_target('server').run("ss --listening --numeric | grep :#{port}", check_errors: false, verbose: true)
   port_opened = code.zero?
   if selection == 'closed'
-    raise "Port '#{port}' open although it should not be!" if port_opened
+    raise ScriptError, "Port '#{port}' open although it should not be!" if port_opened
   else
-    raise "Port '#{port}' not open although it should be!" unless port_opened
+    raise ScriptError, "Port '#{port}' not open although it should be!" unless port_opened
   end
 end
 
@@ -1475,7 +1472,7 @@ When(/^I change the server's short hostname from hosts and hostname files$/) do
   hostname, _result = get_target('server').run('hostname')
   hostname.strip!
 
-  raise "Wrong hostname after changing it. Is: #{hostname}, should be: #{new_hostname}" unless hostname == new_hostname
+  raise ScriptError, "Wrong hostname after changing it. Is: #{hostname}, should be: #{new_hostname}" unless hostname == new_hostname
 
   # Add the new hostname on controller's /etc/hosts to resolve in smoke tests
   `echo '#{server_node.public_ip} #{new_hostname}#{server_node.full_hostname.delete_prefix(server_node.hostname)} #{new_hostname}' >> /etc/hosts`
@@ -1511,8 +1508,8 @@ When(/^I run spacewalk-hostname-rename command on the server$/) do
   log 'Resetting the API client'
   reset_api_client
 
-  raise 'Error while running spacewalk-hostname-rename command - see logs above' unless result_code.zero?
-  raise 'Error in the output logs - see logs above' if out_spacewalk.include? 'No such file or directory'
+  raise SystemCallError, 'Error while running spacewalk-hostname-rename command - see logs above' unless result_code.zero?
+  raise ScriptError, 'Error in the output logs - see logs above' if out_spacewalk.include? 'No such file or directory'
 end
 
 When(/^I check all certificates after renaming the server hostname$/) do
@@ -1522,7 +1519,7 @@ When(/^I check all certificates after renaming the server hostname$/) do
   server_cert_serial.strip!
   log "Server certificate serial: #{server_cert_serial}"
 
-  raise 'Error getting server certificate serial!' unless result_code.zero?
+  raise SystemCallError, 'Error getting server certificate serial!' unless result_code.zero?
 
   targets = %w[proxy sle_minion ssh_minion rhlike_minion deblike_minion build_host kvm_server]
   targets.each do |target|
@@ -1542,12 +1539,12 @@ When(/^I check all certificates after renaming the server hostname$/) do
     command_minion = "openssl x509 --noout --text -in #{certificate} | grep -A1 'Serial' | grep -v 'Serial'"
     minion_cert_serial, result_code = get_target(target).run(command_minion)
 
-    raise "#{target}: Error getting server certificate serial!" unless result_code.zero?
+    raise ScriptError, "#{target}: Error getting server certificate serial!" unless result_code.zero?
 
     minion_cert_serial.strip!
     log "#{target} certificate serial: #{minion_cert_serial}"
 
-    raise "#{target}: Error, certificate does not match with server one" unless minion_cert_serial == server_cert_serial
+    raise ScriptError, "#{target}: Error, certificate does not match with server one" unless minion_cert_serial == server_cert_serial
   end
 end
 
@@ -1564,7 +1561,7 @@ When(/^I change back the server's hostname$/) do
   hostname, _result = get_target('server').run('hostname')
   hostname.strip!
 
-  raise "Wrong hostname after changing it. Is: #{hostname}, should be: #{new_hostname}" unless hostname == new_hostname
+  raise ScriptError, "Wrong hostname after changing it. Is: #{hostname}, should be: #{new_hostname}" unless hostname == new_hostname
 
   # Cleanup the temporary entry in /etc/hosts on the controller
   `sed -i \'$d\' /etc/hosts`
@@ -1613,13 +1610,13 @@ When(/^I do a late hostname initialization of host "([^"]*)"$/) do |host|
   node = get_target(host)
 
   hostname, local, remote, code = node.test_and_store_results_together('hostname', 'root', 500)
-  raise "Cannot connect to get hostname for '#{$named_nodes[node.hash]}'. Response code: #{code}, local: #{local}, remote: #{remote}" if code.nonzero? || remote.nonzero? || local.nonzero?
-  raise "No hostname for '#{$named_nodes[node.hash]}'. Response code: #{code}" if hostname.empty?
+  raise ScriptError, "Cannot connect to get hostname for '#{$named_nodes[node.hash]}'. Response code: #{code}, local: #{local}, remote: #{remote}" if code.nonzero? || remote.nonzero? || local.nonzero?
+  raise ScriptError, "No hostname for '#{$named_nodes[node.hash]}'. Response code: #{code}" if hostname.empty?
   node.init_hostname(hostname)
 
   fqdn, local, remote, code = node.test_and_store_results_together('hostname -f', 'root', 500)
-  raise "Cannot connect to get FQDN for '#{$named_nodes[node.hash]}'. Response code: #{code}, local: #{local}, remote: #{remote}" if code.nonzero? || remote.nonzero? || local.nonzero?
-  raise "No FQDN for '#{$named_nodes[node.hash]}'. Response code: #{code}" if fqdn.empty?
+  raise ScriptError, "Cannot connect to get FQDN for '#{$named_nodes[node.hash]}'. Response code: #{code}, local: #{local}, remote: #{remote}" if code.nonzero? || remote.nonzero? || local.nonzero?
+  raise ScriptError, "No FQDN for '#{$named_nodes[node.hash]}'. Response code: #{code}" if fqdn.empty?
   node.init_full_hostname(fqdn)
 
   STDOUT.puts "Host '#{$named_nodes[node.hash]}' is alive with determined hostname #{hostname.strip} and FQDN #{fqdn.strip}"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -64,7 +64,7 @@ end
 Then(/^the IPv6 address for "([^"]*)" should be correct$/) do |host|
   node = get_target(host)
   interface, code = node.run("ip -6 address show #{node.public_interface}")
-  raise unless code.zero?
+  raise RuntimeError unless code.zero?
 
   lines = interface.lines
   # selects only lines with IPv6 addresses and proceeds to form an array with only those addresses
@@ -74,7 +74,7 @@ Then(/^the IPv6 address for "([^"]*)" should be correct$/) do |host|
   # confirms that the IPv6 address shown on the page is part of that list and, therefore, valid
   ipv6_address = find(:xpath, '//td[text()=\'IPv6 Address:\']/following-sibling::td[1]').text
   log "IPv6 address: #{ipv6_address}"
-  raise "List of IPv6 addresses: #{ipv6_addresses_list} doesn't include #{ipv6_address}" unless ipv6_addresses_list.include? ipv6_address
+  raise ScriptError, "List of IPv6 addresses: #{ipv6_addresses_list} doesn't include #{ipv6_address}" unless ipv6_addresses_list.include? ipv6_address
 end
 
 Then(/^the system ID for "([^"]*)" should be correct$/) do |host|
@@ -193,12 +193,12 @@ Then(/^the up2date logs on "([^"]*)" should contain no Traceback error$/) do |ho
   node = get_target(host)
   cmd = 'if grep "Traceback" /var/log/up2date ; then exit 1; else exit 0; fi'
   _out, code = node.run(cmd)
-  raise 'error found, check the client up2date logs' if code.nonzero?
+  raise ScriptError, 'error found, check the client up2date logs' if code.nonzero?
 end
 
 # action chains
 When(/^I check radio button "(.*?)"$/) do |arg1|
-  raise "#{arg1} can't be checked" unless choose(arg1)
+  raise ScriptError, "#{arg1} can't be checked" unless choose(arg1)
 end
 
 When(/^I check radio button "(.*?)", if not checked$/) do |arg1|
@@ -207,7 +207,7 @@ end
 
 When(/^I check default base channel radio button of this "([^"]*)"$/) do |host|
   default_base_channel = BASE_CHANNEL_BY_CLIENT[product][host]
-  raise "#{default_base_channel} can't be checked" unless choose(default_base_channel)
+  raise ScriptError, "#{default_base_channel} can't be checked" unless choose(default_base_channel)
 end
 
 When(/^I enter as remote command this script in$/) do |multiline|
@@ -249,7 +249,7 @@ Then(/^I should see the power is "([^"]*)"$/) do |status|
       break if check_text_and_catch_request_timeout_popup?(status)
       find(:xpath, '//button[@value="Get status"]').click
     end
-    raise "Power status #{status} not found" unless check_text_and_catch_request_timeout_popup?(status)
+    raise ScriptError, "Power status #{status} not found" unless check_text_and_catch_request_timeout_popup?(status)
   end
 end
 
@@ -280,7 +280,7 @@ When(/^I refresh the metadata for "([^"]*)"$/) do |host|
   elsif os_family =~ /^ubuntu/
     node.run('apt-get update')
   else
-    raise "The host #{host} has not yet a implementation for that step"
+    raise ScriptError, "The host #{host} has not yet a implementation for that step"
   end
 end
 
@@ -479,21 +479,21 @@ end
 Then(/^channel "([^"]*)" should not be enabled on "([^"]*)"$/) do |channel, host|
   node = get_target(host)
   _out, code = node.run("zypper lr -E | grep '#{channel}'", check_errors: false)
-  raise "'#{channel}' was not expected but was found." if code.to_i.zero?
+  raise ScriptError, "'#{channel}' was not expected but was found." if code.to_i.zero?
 end
 
 Then(/^"(\d+)" channels should be enabled on "([^"]*)"$/) do |count, host|
   node = get_target(host)
   node.run('zypper lr -E | tail -n +5', verbose: true)
   out, _code = node.run('zypper lr -E | tail -n +5 | wc -l')
-  raise "Expected #{count} channels enabled but found #{out}." unless count.to_i == out.to_i
+  raise ScriptError, "Expected #{count} channels enabled but found #{out}." unless count.to_i == out.to_i
 end
 
 Then(/^"(\d+)" channels with prefix "([^"]*)" should be enabled on "([^"]*)"$/) do |count, prefix, host|
   node = get_target(host)
   node.run("zypper lr -E | tail -n +5 | grep '#{prefix}'", verbose: true)
   out, _code = node.run("zypper lr -E | tail -n +5 | grep '#{prefix}' | wc -l")
-  raise "Expected #{count} channels enabled but found #{out}." unless count.to_i == out.to_i
+  raise ScriptError, "Expected #{count} channels enabled but found #{out}." unless count.to_i == out.to_i
 end
 
 # metadata steps

--- a/testsuite/features/step_definitions/datepicker_steps.rb
+++ b/testsuite/features/step_definitions/datepicker_steps.rb
@@ -24,10 +24,10 @@ Then(/^the date field should be set to "([^"]*)"$/) do |expected_date|
   month_compat = find('input#date_month', visible: false)
   year_compat = find('input#date_year', visible: false)
 
-  raise if day_compat.value.to_i != value.day
+  raise ScriptError if day_compat.value.to_i != value.day
   # month field is 0-11, ruby 1-12
-  raise if month_compat.value.to_i + 1 != value.month
-  raise if year_compat.value.to_i != value.year
+  raise ScriptError if month_compat.value.to_i + 1 != value.month
+  raise ScriptError if year_compat.value.to_i != value.year
 end
 
 Given(/^I open the date picker$/) do
@@ -35,7 +35,7 @@ Given(/^I open the date picker$/) do
 end
 
 Then(/^the date picker should be closed$/) do
-  raise unless has_no_css?('.date-time-picker-popup')
+  raise ScriptError, 'The date picker is not closed' unless has_no_css?('.date-time-picker-popup')
 end
 
 Then(/^the date picker title should be the current month and year$/) do
@@ -46,7 +46,7 @@ end
 Then(/^the date picker title should be "([^"]*)"$/) do |arg1|
   step 'I open the date picker' if has_no_css?('.date-time-picker-popup')
   switch = find('.date-time-picker-popup .react-datepicker__current-month')
-  raise unless switch.has_content?(arg1)
+  raise ScriptError, 'The date picker title has a different value or it cant be found' unless switch.has_content?(arg1)
 end
 
 Given(/^I pick "([^"]*)" as time$/) do |desired_time|
@@ -65,7 +65,7 @@ end
 
 When(/^I pick (\d+) minutes from now as schedule time$/) do |arg1|
   action_time = get_future_time(arg1)
-  raise unless find(:xpath, '//*[@id=\'date_timepicker_widget_input\']', wait: 2)
+  raise ScriptError unless find(:xpath, '//*[@id=\'date_timepicker_widget_input\']', wait: 2)
 
   step %(I enter "#{action_time}" as "date_timepicker_widget_input")
 end

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -31,13 +31,13 @@ When(/^I wait at most (\d+) seconds until image "([^"]*)" with version "([^"]*)"
       break
     end
   end
-  raise 'unable to find the image id' if image_id.zero?
+  raise KeyError, 'unable to find the image id' if image_id.zero?
 
   repeat_until_timeout(timeout: timeout.to_i, message: 'image build did not complete') do
     image_details = $api_test.image.get_details(image_id)
     log "Image Details: #{image_details}"
     break if image_details['buildStatus'] == 'completed'
-    raise 'image build failed.' if image_details['buildStatus'] == 'failed'
+    raise SystemCallError, 'image build failed.' if image_details['buildStatus'] == 'failed'
     sleep 5
   end
 end
@@ -52,13 +52,13 @@ When(/^I wait at most (\d+) seconds until image "([^"]*)" with version "([^"]*)"
       break
     end
   end
-  raise 'unable to find the image id' if image_id.zero?
+  raise SystemCallError, 'unable to find the image id' if image_id.zero?
 
   repeat_until_timeout(timeout: timeout.to_i, message: 'image inspection did not complete') do
     image_details = $api_test.image.get_details(image_id)
     log "Image Details: #{image_details}"
     break if image_details['inspectStatus'] == 'completed'
-    raise 'image inspect failed.' if image_details['inspectStatus'] == 'failed'
+    raise SystemCallError, 'image inspect failed.' if image_details['inspectStatus'] == 'failed'
     sleep 5
   end
 end
@@ -69,7 +69,7 @@ When(/^I wait at most (\d+) seconds until all "([^"]*)" container images are bui
   repeat_until_timeout(timeout: timeout.to_i, message: 'at least one image was not built correctly') do
     step 'I follow the left menu "Images > Image List"'
     step 'I wait until I do not see "There are no entries to show." text'
-    raise 'error detected while building images' if has_xpath?('//tr[td[text()=\'Container Image\']][td//*[contains(@title, \'Failed\')]]')
+    raise SystemCallError, 'error detected while building images' if has_xpath?('//tr[td[text()=\'Container Image\']][td//*[contains(@title, \'Failed\')]]')
     break if has_xpath?('//tr[td[text()=\'Container Image\']][td//*[contains(@title, \'Built\')]]', count: count)
     sleep 5
   end
@@ -117,17 +117,17 @@ Then(/^the list of packages of image "([^"]*)" with version "([^"]*)" is not emp
       break
     end
   end
-  raise 'unable to find the image id' if image_id.zero?
+  raise ScriptError, 'unable to find the image id' if image_id.zero?
 
   image_details = $api_test.image.get_details(image_id)
   log "Image Details: #{image_details}"
-  raise 'the list of image packages is empty' if (image_details['installedPackages']).zero?
+  raise ScriptError, 'the list of image packages is empty' if (image_details['installedPackages']).zero?
 end
 
 Then(/^the image "([^"]*)" with version "([^"]*)" doesn't exist via API calls$/) do |image_non_exist, version|
   images_list = $api_test.image.list_images
   images_list.each do |element|
-    raise "#{image_non_exist} should not exist anymore" if element['name'] == image_non_exist && element['version'] == version.strip
+    raise ScriptError, "#{image_non_exist} should not exist anymore" if element['name'] == image_non_exist && element['version'] == version.strip
   end
 end
 
@@ -140,14 +140,14 @@ end
 
 When(/^I list image store types and image stores via API$/) do
   store_type = $api_test.image.store.list_image_store_types
-  raise 'We have only type support for Registry and OS Image Store type! New method added?! please update the tests' unless store_type.length == 2
-  raise "imagestore label type should be 'registry' but is #{store_type[0]['label']}" unless store_type[0]['label'] == 'registry'
-  raise "imagestore label type should be 'os_image' but is #{store_type[1]['label']}" unless store_type[1]['label'] == 'os_image'
+  raise ScriptError, 'We have only type support for Registry and OS Image Store type! New method added?! please update the tests' unless store_type.length == 2
+  raise ScriptError, "imagestore label type should be 'registry' but is #{store_type[0]['label']}" unless store_type[0]['label'] == 'registry'
+  raise ScriptError, "imagestore label type should be 'os_image' but is #{store_type[1]['label']}" unless store_type[1]['label'] == 'os_image'
 
   registry_list = $api_test.image.store.list_image_stores
   log "Image Stores: #{registry_list}"
-  raise "Label #{registry_list[0]['label']} is different than 'galaxy-registry'" unless registry_list[0]['label'] == 'galaxy-registry'
-  raise "URI #{registry_list[0]['uri']} is different than '#{$no_auth_registry}'" unless registry_list[0]['uri'] == $no_auth_registry.to_s
+  raise ScriptError, "Label #{registry_list[0]['label']} is different than 'galaxy-registry'" unless registry_list[0]['label'] == 'galaxy-registry'
+  raise ScriptError, "URI #{registry_list[0]['uri']} is different than '#{$no_auth_registry}'" unless registry_list[0]['uri'] == $no_auth_registry.to_s
 end
 
 When(/^I set and get details of image store via API$/) do
@@ -161,8 +161,8 @@ When(/^I set and get details of image store via API$/) do
   $api_test.image.store.set_details('Norimberga', details_store)
   # test getDetails call
   details = $api_test.image.store.get_details('Norimberga')
-  raise "uri should be Germania but is #{details['uri']}" unless details['uri'] == 'Germania'
-  raise "username should be empty but is #{details['username']}" unless details['username'] == ''
+  raise ScriptError, "uri should be Germania but is #{details['uri']}" unless details['uri'] == 'Germania'
+  raise ScriptError, "username should be empty but is #{details['username']}" unless details['username'] == ''
   $api_test.image.store.delete('Norimberga')
 end
 
@@ -181,11 +181,11 @@ When(/^I create and delete profile custom values via API$/) do
   values['arancio'] = 'arancia API tests'
   $api_test.image.profile.set_custom_values('fakeone', values)
   pro_det = $api_test.image.profile.get_custom_values('fakeone')
-  raise "setting custom profile value failed: #{pro_det['arancio']} != 'arancia API tests'" unless pro_det['arancio'] == 'arancia API tests'
+  raise ScriptError, "setting custom profile value failed: #{pro_det['arancio']} != 'arancia API tests'" unless pro_det['arancio'] == 'arancia API tests'
   pro_type = $api_test.image.profile.list_image_profile_types
-  raise "Number of image profile types is #{pro_type.length}" unless pro_type.length == 2
-  raise "type #{pro_type[0]} is not dockerfile" unless pro_type[0] == 'dockerfile'
-  raise "type #{pro_type[1]} is not kiwi" unless pro_type[1] == 'kiwi'
+  raise ScriptError, "Number of image profile types is #{pro_type.length}" unless pro_type.length == 2
+  raise ScriptError, "type #{pro_type[0]} is not dockerfile" unless pro_type[0] == 'dockerfile'
+  raise ScriptError, "type #{pro_type[1]} is not kiwi" unless pro_type[1] == 'kiwi'
   key = ['arancio']
   $api_test.image.profile.delete_custom_values('fakeone', key)
 end
@@ -194,7 +194,7 @@ When(/^I list image profiles via API$/) do
   ima_profiles = $api_test.image.profile.list_image_profiles
   log ima_profiles
   imagelabel = ima_profiles.select { |image| image['label'] = 'fakeone' }
-  raise "label of container should be fakeone! #{imagelabel[0]['label']} != 'fakeone'" unless imagelabel[0]['label'] == 'fakeone'
+  raise ScriptError, "label of container should be fakeone! #{imagelabel[0]['label']} != 'fakeone'" unless imagelabel[0]['label'] == 'fakeone'
 end
 
 When(/^I set and get profile details via API$/) do
@@ -204,7 +204,7 @@ When(/^I set and get profile details via API$/) do
   details['activationKey'] = ''
   $api_test.image.profile.set_details('fakeone', details)
   cont_detail = $api_test.image.profile.get_details('fakeone')
-  raise "label test fail! #{cont_detail['label']} != 'fakeone'" unless cont_detail['label'] == 'fakeone'
-  raise "imagetype test fail! #{cont_detail['imageType']} != 'dockerfile'" unless cont_detail['imageType'] == 'dockerfile'
+  raise ScriptError, "label test fail! #{cont_detail['label']} != 'fakeone'" unless cont_detail['label'] == 'fakeone'
+  raise ScriptError, "imagetype test fail! #{cont_detail['imageType']} != 'dockerfile'" unless cont_detail['imageType'] == 'dockerfile'
   $api_test.image.profile.delete('fakeone')
 end

--- a/testsuite/features/step_definitions/file_management_steps.rb
+++ b/testsuite/features/step_definitions/file_management_steps.rb
@@ -69,7 +69,7 @@ When(/^I bootstrap "([^"]*)" using bootstrap script with activation key "([^"]*)
   output, = target.run(cmd, verbose: true)
   unless output.include? key
     log output
-    raise "Key: #{key} not included"
+    raise ScriptError, "Key: #{key} not included"
   end
 
   # Run bootstrap script and check for result
@@ -77,12 +77,12 @@ When(/^I bootstrap "([^"]*)" using bootstrap script with activation key "([^"]*)
   source = File.dirname(__FILE__) + '/../upload_files/' + boostrap_script
   dest = '/tmp/' + boostrap_script
   return_code = file_inject(target, source, dest)
-  raise 'File injection failed' unless return_code.zero?
+  raise ScriptError, 'File injection failed' unless return_code.zero?
   system_name = get_system_name(host)
   output, = target.run("sed -i '/^set timeout /c\\set timeout #{DEFAULT_TIMEOUT}' /tmp/#{boostrap_script} && expect -f /tmp/#{boostrap_script} #{system_name}", verbose: true)
   unless output.include? '-bootstrap complete-'
     log output.encode('utf-8', invalid: :replace, undef: :replace, replace: '_')
-    raise 'Bootstrap didn\'t finish properly'
+    raise ScriptError, 'Bootstrap didn\'t finish properly'
   end
 end
 

--- a/testsuite/features/step_definitions/lock_packages_on_client.rb
+++ b/testsuite/features/step_definitions/lock_packages_on_client.rb
@@ -16,22 +16,22 @@ end
 Then(/^package "(.*?)" is reported as locked$/) do |pkg|
   find(:xpath, "(//a[text()='#{pkg}'])[1]")
   locked_pkgs = all(:xpath, '//i[@class=\'fa fa-lock\']/../a')
-  raise 'No packages locked' if locked_pkgs.empty?
-  raise "Package #{pkg} not found as locked" unless locked_pkgs.find { |a| a.text =~ /^#{pkg}/ }
+  raise ScriptError, 'No packages locked' if locked_pkgs.empty?
+  raise ScriptError, "Package #{pkg} not found as locked" unless locked_pkgs.find { |a| a.text =~ /^#{pkg}/ }
 end
 
 Then(/^package "(.*?)" is reported as unlocked$/) do |pkg|
   find(:xpath, "(//a[text()='#{pkg}'])[1]")
   locked_pkgs = all(:xpath, '//i[@class=\'fa fa-lock\']/../a')
 
-  raise "Package #{pkg} found as locked" if locked_pkgs.find { |a| a.text =~ /^#{pkg}/ }
+  raise ScriptError, "Package #{pkg} found as locked" if locked_pkgs.find { |a| a.text =~ /^#{pkg}/ }
 end
 
 Then(/^the package scheduled is "(.*?)"$/) do |pkg|
   match = find(:xpath, '//li[@class=\'list-group-item\']//li')
 
-  raise 'List of packages not found' unless match
-  raise "Package #{pkg} not found" unless match.text =~ /^#{pkg}/
+  raise ScriptError, 'List of packages not found' unless match
+  raise ScriptError, "Package #{pkg} not found" unless match.text =~ /^#{pkg}/
 end
 
 Then(/^the action status is "(.*?)"$/) do |status|
@@ -83,5 +83,5 @@ Then(/^only packages "(.*?)" are reported as pending to be unlocked$/) do |pkgs|
                 "span[@class='label label-info' and contains(text(), 'Unlocking...')]]"
   matches = all(:xpath, xpath_query)
 
-  raise "Matches count #{matches.size} is different than packages count #{pkgs.size}" if matches.size != pkgs.size
+  raise ScriptError, "Matches count #{matches.size} is different than packages count #{pkgs.size}" if matches.size != pkgs.size
 end

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -10,13 +10,13 @@
 
 Then(/^I should see a "(.*)" text in the content area$/) do |text|
   within('#spacewalk-content') do
-    raise "Text '#{text}' not found" unless check_text_and_catch_request_timeout_popup?(text)
+    raise ScriptError, "Text '#{text}' not found" unless check_text_and_catch_request_timeout_popup?(text)
   end
 end
 
 Then(/^I should not see a "(.*)" text in the content area$/) do |text|
   within('#spacewalk-content') do
-    raise "Text '#{text}' found" unless has_no_content?(text)
+    raise ScriptError, "Text '#{text}' found" unless has_no_content?(text)
   end
 end
 
@@ -33,23 +33,23 @@ When(/^I click on "([^"]+)" in tree item "(.*?)"$/) do |button, item|
 end
 
 Then(/^the current path is "([^"]*)"$/) do |arg1|
-  raise "Path #{current_path} different than #{arg1}" unless current_path == arg1
+  raise ScriptError, "Path #{current_path} different than #{arg1}" unless current_path == arg1
 end
 
 When(/^I wait until I see "([^"]*)" text$/) do |text|
-  raise "Text '#{text}' not found" unless check_text_and_catch_request_timeout_popup?(text, timeout: DEFAULT_TIMEOUT)
+  raise ScriptError, "Text '#{text}' not found" unless check_text_and_catch_request_timeout_popup?(text, timeout: DEFAULT_TIMEOUT)
 end
 
 When(/^I wait until I do not see "([^"]*)" text$/) do |text|
-  raise "Text '#{text}' found" unless has_no_text?(text, wait: DEFAULT_TIMEOUT)
+  raise ScriptError, "Text '#{text}' found" unless has_no_text?(text, wait: DEFAULT_TIMEOUT)
 end
 
 When(/^I wait at most (\d+) seconds until I see "([^"]*)" text$/) do |seconds, text|
-  raise "Text '#{text}' not found" unless check_text_and_catch_request_timeout_popup?(text, timeout: seconds.to_i)
+  raise ScriptError, "Text '#{text}' not found" unless check_text_and_catch_request_timeout_popup?(text, timeout: seconds.to_i)
 end
 
 When(/^I wait until I see "([^"]*)" text or "([^"]*)" text$/) do |text1, text2|
-  raise "Text '#{text1}' or '#{text2}' not found" unless check_text_and_catch_request_timeout_popup?(text1, text2: text2, timeout: DEFAULT_TIMEOUT)
+  raise ScriptError, "Text '#{text1}' or '#{text2}' not found" unless check_text_and_catch_request_timeout_popup?(text1, text2: text2, timeout: DEFAULT_TIMEOUT)
 end
 
 When(/^I wait until I see "([^"]*)" (text|regex), refreshing the page$/) do |text, type|
@@ -93,7 +93,7 @@ When(/^I wait at most (\d+) seconds until the event is completed, refreshing the
   next if has_content?('This action\'s status is: Completed.', wait: 3)
   repeat_until_timeout(timeout: timeout.to_i, message: 'Event not yet completed') do
     break if has_content?('This action\'s status is: Completed.', wait: 3)
-    raise 'Event failed' if has_content?('This action\'s status is: Failed.', wait: 3)
+    raise SystemCallError, 'Event failed' if has_content?('This action\'s status is: Failed.', wait: 3)
     current = Time.now
     if current - last > 150
       log "#{current} Still waiting for action to complete..."
@@ -110,7 +110,7 @@ When(/^I wait at most (\d+) seconds until the event is completed, refreshing the
 end
 
 When(/^I wait until I see the name of "([^"]*)", refreshing the page$/) do |host|
-  raise 'Overview System page didn\'t load' unless has_content?('Download CSV') || has_content?('Keys')
+  raise ScriptError, 'Overview System page didn\'t load' unless has_content?('Download CSV') || has_content?('Keys')
   system_name = get_system_name(host)
   step %(I wait until I see the "#{system_name}" system, refreshing the page)
 end
@@ -172,12 +172,12 @@ end
 #
 When(/^I check "([^"]*)"$/) do |identifier|
   check(identifier)
-  raise "Checkbox #{identifier} not checked." unless has_checked_field?(identifier)
+  raise ScriptError, "Checkbox #{identifier} not checked." unless has_checked_field?(identifier)
 end
 
 When(/^I uncheck "([^"]*)"$/) do |identifier|
   uncheck(identifier)
-  raise "Checkbox #{identifier} not unchecked." if has_checked_field?(identifier)
+  raise ScriptError, "Checkbox #{identifier} not unchecked." if has_checked_field?(identifier)
 end
 
 When(/^I select "([^"]*)" from "([^"]*)"$/) do |option, field|
@@ -196,9 +196,9 @@ end
 When(/^I select "(.*?)" from "([^"]*)" dropdown/) do |selection, label|
   # let the the select2js box filter open the hidden options
   xpath_query = "//select[@name='#{label}']"
-  raise "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query).click
+  raise ScriptError, "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query).click
   # select the desired option
-  raise "#{label} #{selection} not found" unless find(:xpath, "//select[@name='#{label}']/option[contains(text(), '#{selection}')]").click
+  raise ScriptError, "#{label} #{selection} not found" unless find(:xpath, "//select[@name='#{label}']/option[contains(text(), '#{selection}')]").click
 end
 
 When(/^I select the parent channel for the "([^"]*)" from "([^"]*)"$/) do |client, from|
@@ -227,7 +227,7 @@ end
 When(/^I (include|exclude) the recommended child channels$/) do |action|
   toggle = "//span[@class='pointer']"
   step 'I wait at most 10 seconds until I see "include recommended" text'
-  raise 'The toggle is not present' unless page.has_xpath?(toggle, wait: 5)
+  raise ScriptError, 'The toggle is not present' unless page.has_xpath?(toggle, wait: 5)
   if action == 'include'
     toggle_off = '//i[contains(@class, \'fa-toggle-off\')]'
     find(:xpath, toggle).click if page.has_xpath?(toggle_off, wait: 5)
@@ -296,13 +296,11 @@ end
 #
 # Click on a button and confirm in alert box
 When(/^I click on "([^"]*)" and confirm$/) do |text|
-  begin
-    accept_alert do
-      step %(I click on "#{text}")
-    end
-  rescue Capybara::ModalNotFound
-    warn 'Modal not found'
+  accept_alert do
+    step %(I click on "#{text}")
   end
+rescue Capybara::ModalNotFound
+  warn 'Modal not found'
 end
 
 #
@@ -327,7 +325,7 @@ When(/^I follow "([^"]*)" in the (.+)$/) do |arg1, arg2|
   tag = case arg2
         when /tab bar|tabs/ then 'header'
         when /content area/ then 'section'
-        else raise "Unknown element with description '#{arg2}'"
+        else raise ScriptError, "Unknown element with description '#{arg2}'"
         end
   within(:xpath, "//#{tag}") do
     step %(I follow "#{arg1}")
@@ -338,7 +336,7 @@ When(/^I follow first "([^"]*)" in the (.+)$/) do |arg1, arg2|
   tag = case arg2
         when /tab bar|tabs/ then 'header'
         when /content area/ then 'section'
-        else raise "Unknown element with description '#{arg2}'"
+        else raise ScriptError, "Unknown element with description '#{arg2}'"
         end
   within(:xpath, "//#{tag}") do
     step "I follow first \"#{arg1}\""
@@ -409,7 +407,7 @@ Given(/^I am not authorized$/) do
   ensure
     visit Capybara.app_host
   end
-  raise 'Button \'Sign In\' not visible' unless find_button('Sign In').visible?
+  raise ScriptError, 'Button \'Sign In\' not visible' unless find_button('Sign In').visible?
 end
 
 When(/^I go to the home page$/) do
@@ -418,7 +416,7 @@ end
 
 Given(/^I access the host the first time$/) do
   visit Capybara.app_host
-  raise "Text 'Create #{product} Administrator' not found" unless check_text_and_catch_request_timeout_popup?("Create #{product} Administrator")
+  raise ScriptError, "Text 'Create #{product} Administrator' not found" unless check_text_and_catch_request_timeout_popup?("Create #{product} Administrator")
 end
 
 # Menu permission check
@@ -468,7 +466,7 @@ When(/^I select the hostname of "([^"]*)" from "([^"]*)"((?: if present)?)$/) do
   begin
     system_name = get_system_name(host)
   rescue
-    raise "Host #{host} not found" if if_present.empty?
+    raise KeyError, "Host #{host} not found" if if_present.empty?
     log "Host #{host} is not deployed, not trying to select it"
     next
   end
@@ -492,7 +490,7 @@ end
 Then(/^I wait until table row for "([^"]*)" contains "([^"]*)"$/) do |arg1, arg2|
   xpath_query = "//div[@class=\"table-responsive\"]/table/tbody/tr[.//*[contains(.,'#{arg1}')]]"
   within(:xpath, xpath_query) do
-    raise "xpath: #{xpath_query} has no content #{arg2}" unless check_text_and_catch_request_timeout_popup?(arg2, timeout: DEFAULT_TIMEOUT)
+    raise ScriptError, "xpath: #{xpath_query} has no content #{arg2}" unless check_text_and_catch_request_timeout_popup?(arg2, timeout: DEFAULT_TIMEOUT)
   end
 end
 
@@ -501,22 +499,22 @@ Then(/^the table row for "([^"]*)" should( not)? contain "([^"]*)" icon$/) do |r
   when 'retracted'
     content_selector = 'i[class*=\'errata-retracted\']'
   else
-    raise "Unsupported icon '#{icon}' in the step definition"
+    raise ScriptError, "Unsupported icon '#{icon}' in the step definition"
   end
 
   xpath_query = "//div[@class=\"table-responsive\"]/table/tbody/tr[.//*[contains(.,'#{row}')]]"
   within(:xpath, xpath_query) do
     if should_not
-      raise "xpath: #{xpath_query} has no icon #{icon}" unless has_no_css?(content_selector, wait: 2)
+      raise ScriptError, "xpath: #{xpath_query} has no icon #{icon}" unless has_no_css?(content_selector, wait: 2)
     else
-      raise "xpath: #{xpath_query} has no icon #{icon}" unless has_css?(content_selector, wait: 2)
+      raise ScriptError, "xpath: #{xpath_query} has no icon #{icon}" unless has_css?(content_selector, wait: 2)
     end
   end
 end
 
 When(/^I wait at most ([0-9]+) seconds until table row for "([^"]*)" contains button "([^"]*)"$/) do |timeout, text, button|
   xpath_query = "//tr[td[contains(., '#{text}')]]/td/descendant::*[self::a or self::button][@title='#{button}']"
-  raise "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query, wait: timeout.to_f)
+  raise ScriptError, "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query, wait: timeout.to_f)
 end
 
 When(/^I wait until table row for "([^"]*)" contains button "([^"]*)"$/) do |text, button|
@@ -525,11 +523,11 @@ end
 
 When(/^I wait until table row contains a "([^"]*)" text$/) do |text|
   xpath_query = "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{text}')]]"
-  raise "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query, wait: DEFAULT_TIMEOUT)
+  raise ScriptError, "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query, wait: DEFAULT_TIMEOUT)
 end
 
 When(/^I wait until button "([^"]*)" becomes enabled$/) do |text|
-  raise "Button '#{text}' still disabled after #{DEFAULT_TIMEOUT} seconds" unless find_button(text, disabled: false, wait: DEFAULT_TIMEOUT)
+  raise ScriptError, "Button '#{text}' still disabled after #{DEFAULT_TIMEOUT} seconds" unless find_button(text, disabled: false, wait: DEFAULT_TIMEOUT)
 end
 
 # login, logout steps
@@ -554,7 +552,7 @@ Given(/^I am authorized as "([^"]*)" with password "([^"]*)"$/) do |user, passwd
     # No need to logout
   end
 
-  raise 'Login page is not correctly loaded' unless has_field?('username')
+  raise ScriptError, 'Login page is not correctly loaded' unless has_field?('username')
   fill_in('username', with: user)
   fill_in('password', with: passwd)
   click_button_and_wait('Sign In', match: :first)
@@ -571,26 +569,26 @@ When(/^I sign out$/) do
 end
 
 Then(/^I should not be authorized$/) do
-  raise 'User is authorized' if has_xpath?('//a[@href=\'/rhn/Logout.do\']')
+  raise ScriptError, 'User is authorized' if has_xpath?('//a[@href=\'/rhn/Logout.do\']')
 end
 
 Then(/^I should be logged in$/) do
   xpath_query = '//a[@href=\'/rhn/Logout.do\']'
   # Check if the user is logged in, using the specified wait_time
-  raise 'User is not logged in' unless has_selector?(:xpath, xpath_query, wait: Capybara.default_max_wait_time * 2)
+  raise ScriptError, 'User is not logged in' unless has_selector?(:xpath, xpath_query, wait: Capybara.default_max_wait_time * 2)
 end
 
 Then(/^I am logged in$/) do
-  raise 'User is not logged in' unless find(:xpath, '//a[@href=\'/rhn/Logout.do\']').visible?
+  raise ScriptError, 'User is not logged in' unless find(:xpath, '//a[@href=\'/rhn/Logout.do\']').visible?
   # text = "You have just created your first #{product} user. To finalize your installation please use the Setup Wizard"
   # Workaround: Ignore the fact that the message is not shown
   # TODO: restore this as soon as the related issue is fixed: https://github.com/SUSE/spacewalk/issues/19369
-  # raise 'The welcome message is not shown' unless has_content?(text)
+  # raise ScriptError, 'The welcome message is not shown' unless has_content?(text)
 end
 
 Then(/^I should see an update in the list$/) do
   xpath_query = '//div[@class="table-responsive"]/table/tbody/tr/td/a'
-  raise "xpath: #{xpath_query} not found" unless has_xpath?(xpath_query)
+  raise ScriptError, "xpath: #{xpath_query} not found" unless has_xpath?(xpath_query)
 end
 
 When(/^I check test channel$/) do
@@ -603,7 +601,7 @@ end
 
 Then(/^I should see "([^"]*)" systems selected for SSM$/) do |arg|
   within(:xpath, '//span[@id="spacewalk-set-system_list-counter"]') do
-    raise "There are not #{arg} systems selected" unless check_text_and_catch_request_timeout_popup?(arg)
+    raise ScriptError, "There are not #{arg} systems selected" unless check_text_and_catch_request_timeout_popup?(arg)
   end
 end
 
@@ -611,26 +609,26 @@ end
 # Test for a text in the whole page
 #
 Then(/^I should see a "([^"]*)" text$/) do |text|
-  raise "Text '#{text}' not found" unless check_text_and_catch_request_timeout_popup?(text)
+  raise ScriptError, "Text '#{text}' not found" unless check_text_and_catch_request_timeout_popup?(text)
 end
 
 Then(/^I should see a "([^"]*)" text or "([^"]*)" text$/) do |text1, text2|
-  raise "Text '#{text1}' and '#{text2}' not found" unless check_text_and_catch_request_timeout_popup?(text1, text2: text2)
+  raise ScriptError, "Text '#{text1}' and '#{text2}' not found" unless check_text_and_catch_request_timeout_popup?(text1, text2: text2)
 end
 
 Then(/^I should see "([^"]*)" short hostname$/) do |host|
   system_name = get_system_name(host).partition('.').first
-  raise "Hostname #{system_name} is not present" unless check_text_and_catch_request_timeout_popup?(system_name)
+  raise ScriptError, "Hostname #{system_name} is not present" unless check_text_and_catch_request_timeout_popup?(system_name)
 end
 
 Then(/^I should see "([^"]*)" hostname$/) do |host|
   system_name = get_system_name(host)
-  raise "Hostname #{system_name} is not present" unless check_text_and_catch_request_timeout_popup?(system_name)
+  raise ScriptError, "Hostname #{system_name} is not present" unless check_text_and_catch_request_timeout_popup?(system_name)
 end
 
 Then(/^I should not see "([^"]*)" hostname$/) do |host|
   system_name = get_system_name(host)
-  raise "Hostname #{system_name} is present" if check_text_and_catch_request_timeout_popup?(system_name)
+  raise ScriptError, "Hostname #{system_name} is present" if check_text_and_catch_request_timeout_popup?(system_name)
 end
 
 #
@@ -638,13 +636,13 @@ end
 #
 Then(/^I should see "([^"]*)" in the textarea$/) do |text|
   within('textarea') do
-    raise "Text '#{text}' not found" unless check_text_and_catch_request_timeout_popup?(text)
+    raise ScriptError, "Text '#{text}' not found" unless check_text_and_catch_request_timeout_popup?(text)
   end
 end
 
 Then(/^I should see "([^"]*)" or "([^"]*)" in the textarea$/) do |text1, text2|
   within('textarea') do
-    raise "Text '#{text1}' and '#{text2}' not found" unless check_text_and_catch_request_timeout_popup?(text1, text2: text2)
+    raise ScriptError, "Text '#{text1}' and '#{text2}' not found" unless check_text_and_catch_request_timeout_popup?(text1, text2: text2)
   end
 end
 
@@ -652,32 +650,32 @@ end
 # Test for a text in the whole page using regexp
 #
 Then(/^I should see a text like "([^"]*)"$/) do |title|
-  raise "Regular expression '#{title}' not found" unless has_content?(Regexp.new(title))
+  raise ScriptError, "Regular expression '#{title}' not found" unless has_content?(Regexp.new(title))
 end
 
 #
 # Test for a text not allowed in the whole page
 #
 Then(/^I should not see a "([^"]*)" text$/) do |text|
-  raise "Text '#{text}' found on the page" unless has_no_content?(text)
+  raise ScriptError, "Text '#{text}' found on the page" unless has_no_content?(text)
 end
 
 #
 # Test for a visible link in the whole page
 #
 Then(/^I should see a "([^"]*)" link$/) do |text|
-  raise "Link #{text} is not visible" unless has_link?(text)
+  raise ScriptError, "Link #{text} is not visible" unless has_link?(text)
 end
 
 #
 # Validate link is gone
 #
 Then(/^I should not see a "([^"]*)" link$/) do |arg1|
-  raise "Link #{arg1} is present" unless has_no_link?(arg1)
+  raise ScriptError, "Link #{arg1} is present" unless has_no_link?(arg1)
 end
 
 Then(/^I should see a "([^"]*)" button$/) do |arg1|
-  raise "Link #{arg1} is not visible" unless find_button(arg1).visible?
+  raise ScriptError, "Link #{arg1} is not visible" unless find_button(arg1).visible?
 end
 
 Then(/^I should see a "(.*?)" link in the text$/) do |linktext, text|
@@ -688,19 +686,19 @@ end
 
 Then(/^I should see a "([^"]*)" text in element "([^"]*)"$/) do |text, element|
   within(:xpath, "//div[@id=\"#{element}\" or @class=\"#{element}\"]") do
-    raise "Text '#{text}' not found in #{element}" unless check_text_and_catch_request_timeout_popup?(text)
+    raise ScriptError, "Text '#{text}' not found in #{element}" unless check_text_and_catch_request_timeout_popup?(text)
   end
 end
 
 Then(/^I should not see a "([^"]*)" text in element "([^"]*)"$/) do |text, element|
   within(:xpath, "//div[@id=\"#{element}\" or @class=\"#{element}\"]") do
-    raise "Text '#{text}' found in #{element}" if check_text_and_catch_request_timeout_popup?(text)
+    raise ScriptError, "Text '#{text}' found in #{element}" if check_text_and_catch_request_timeout_popup?(text)
   end
 end
 
 Then(/^I should see a "([^"]*)" or "([^"]*)" text in element "([^"]*)"$/) do |text1, text2, element|
   within(:xpath, "//div[@id=\"#{element}\" or @class=\"#{element}\"]") do
-    raise "Texts #{text1} and #{text2} not found in #{element}" unless check_text_and_catch_request_timeout_popup?(text1, text2: text2)
+    raise ScriptError, "Texts #{text1} and #{text2} not found in #{element}" unless check_text_and_catch_request_timeout_popup?(text1, text2: text2)
   end
 end
 
@@ -753,7 +751,7 @@ Then(/^I should see a "([^"]*)" link in the (left menu|tab bar|tabs|content area
         when /left menu/ then 'aside'
         when /tab bar|tabs/ then 'header'
         when /content area/ then 'section'
-        else raise "Unknown element with description '#{arg2}'"
+        else raise ScriptError, "Unknown element with description '#{arg2}'"
         end
   within(:xpath, "//#{tag}") do
     step "I should see a \"#{arg1}\" link"
@@ -765,7 +763,7 @@ Then(/^I should not see a "([^"]*)" link in the (.+)$/) do |arg1, arg2|
         when /left menu/ then 'aside'
         when /tab bar|tabs/ then 'header'
         when /content area/ then 'section'
-        else raise "Unknown element with description '#{arg2}'"
+        else raise ScriptError, "Unknown element with description '#{arg2}'"
         end
   within(:xpath, "//#{tag}") do
     step "I should not see a \"#{arg1}\" link"
@@ -782,12 +780,12 @@ end
 
 Then(/^I should see a "([^"]*)" button in "([^"]*)" form$/) do |arg1, arg2|
   within(:xpath, "//form[@id='#{arg2}' or @name=\"#{arg2}\"]") do
-    raise "Button #{arg1} not found" unless find_button(arg1)
+    raise ScriptError, "Button #{arg1} not found" unless find_button(arg1)
   end
 end
 
 Then(/^I should not see a warning sign$/) do
-  raise 'Warning detected' unless page.has_no_xpath?('//*[contains(@class, \'fa fa-li fa-exclamation-triangle text-warning\')]')
+  raise ScriptError, 'Warning detected' unless page.has_no_xpath?('//*[contains(@class, \'fa fa-li fa-exclamation-triangle text-warning\')]')
 end
 
 Then(/^I select the "([^"]*)" repo$/) do |repo|
@@ -889,7 +887,7 @@ end
 When(/^I check row with "([^"]*)" and "([^"]*)" in the list$/) do |text1, text2|
   top_level_xpath_query = "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{text1}')] and .//td[contains(.,'#{text2}')]]//input[@type='checkbox']"
   row = find(:xpath, top_level_xpath_query)
-  raise "xpath: #{top_level_xpath_query} not found" if row.nil?
+  raise ScriptError, "xpath: #{top_level_xpath_query} not found" if row.nil?
 
   row.set(true)
 end
@@ -897,7 +895,7 @@ end
 When(/^I uncheck row with "([^"]*)" and "([^"]*)" in the list$/) do |text1, text2|
   top_level_xpath_query = "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{text1}')] and .//td[contains(.,'#{text2}')]]//input[@type='checkbox']"
   row = find(:xpath, top_level_xpath_query, match: :first)
-  raise "xpath: #{top_level_xpath_query} not found" if row.nil?
+  raise ScriptError, "xpath: #{top_level_xpath_query} not found" if row.nil?
 
   row.set(false)
 end
@@ -912,7 +910,7 @@ end
 When(/^I check "([^"]*)" in the list$/) do |text|
   top_level_xpath_query = "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{text}')]]//input[@type='checkbox']"
   row = find(:xpath, top_level_xpath_query, match: :first)
-  raise "xpath: #{top_level_xpath_query} not found" if row.nil?
+  raise ScriptError, "xpath: #{top_level_xpath_query} not found" if row.nil?
 
   row.set(true)
 end
@@ -926,7 +924,7 @@ Then(/^option "([^"]*)" is selected as "([^"]*)"$/) do |option, field|
   # Custom React selector
   next if has_xpath?("//*[contains(@class, 'data-testid-#{field}-child__value-container')]/*[contains(text(),'#{option}')]")
 
-  raise "#{option} is not selected as #{field}"
+  raise ScriptError, "#{option} is not selected as #{field}"
 end
 
 #
@@ -945,21 +943,21 @@ end
 # Test if a radio button is checked
 #
 Then(/^radio button "([^"]*)" should be checked$/) do |arg1|
-  raise "#{arg1} is unchecked" unless has_checked_field?(arg1)
+  raise ScriptError, "#{arg1} is unchecked" unless has_checked_field?(arg1)
 end
 
 #
 # Test if a checkbox is checked
 #
 Then(/^I should see "([^"]*)" as checked$/) do |arg1|
-  raise "#{arg1} is unchecked" unless has_checked_field?(arg1)
+  raise ScriptError, "#{arg1} is unchecked" unless has_checked_field?(arg1)
 end
 
 #
 # Test if a checkbox is unchecked
 #
 Then(/^I should see "([^"]*)" as unchecked$/) do |arg1|
-  raise "#{arg1} is checked" unless has_unchecked_field?(arg1)
+  raise ScriptError, "#{arg1} is checked" unless has_unchecked_field?(arg1)
 end
 
 #
@@ -975,19 +973,19 @@ end
 
 # identifier must be the value of name, ID or other element attribute, not the shown text
 Then(/^I should see "([^"]*)" in field identified by "([^"]*)"$/) do |text, field|
-  raise "'#{text}' not found in #{field}" unless find_field(field, with: /#{text}/).visible?
+  raise ScriptError, "'#{text}' not found in #{field}" unless find_field(field, with: /#{text}/).visible?
 end
 
 Then(/^I should see a "([^"]*)" field in "([^"]*)" form$/) do |field, form|
   within(:xpath, "//form[@id=\"#{form}\"] | //form[@name=\"#{form}\"]") do
-    raise "Field #{field} not found" unless find_field(field, match: :first).visible?
+    raise ScriptError, "Field #{field} not found" unless find_field(field, match: :first).visible?
   end
 end
 
 Then(/^I should see a "([^"]*)" editor in "([^"]*)" form$/) do |editor, form|
   within(:xpath, "//form[@id=\"#{form}\"] | //form[@name=\"#{form}\"]") do
-    raise "xpath: textarea##{editor} not found" unless find("textarea##{editor}", visible: false)
-    raise "css: ##{editor}-editor not found" unless has_css?("##{editor}-editor")
+    raise ScriptError, "xpath: textarea##{editor} not found" unless find("textarea##{editor}", visible: false)
+    raise ScriptError, "css: ##{editor}-editor not found" unless has_css?("##{editor}-editor")
   end
 end
 
@@ -997,7 +995,7 @@ end
 
 Then(/^I should see (\d+) "([^"]*)" fields in "([^"]*)" form$/) do |count, name, id|
   within(:xpath, "//form[@id=\"#{id}\" or  @name=\"#{id}\"]") do
-    raise "#{id} form has not #{count} fields with name #{name}" unless has_field?(name, count: count.to_i)
+    raise ScriptError, "#{id} form has not #{count} fields with name #{name}" unless has_field?(name, count: count.to_i)
   end
 end
 
@@ -1019,12 +1017,10 @@ When(/^I click on "([^"]*)" in "([^"]*)" modal$/) do |btn, title|
   # We wait until the element is not shown, because
   # the fade out animation might still be in progress
   repeat_until_timeout(message: "The #{title} modal dialog is still present") do
-    begin
-      break if has_no_xpath?(path, wait: 1)
-    rescue Selenium::WebDriver::Error::StaleElementReferenceError
-      # We need to consider the case that after obtaining the element it is detached from the page document
-      break
-    end
+    break if has_no_xpath?(path, wait: 1)
+  rescue Selenium::WebDriver::Error::StaleElementReferenceError
+    # We need to consider the case that after obtaining the element it is detached from the page document
+    break
   end
 end
 
@@ -1034,7 +1030,7 @@ When(/^I wait at most (\d+) seconds until I see modal containing "([^"]*)" text$
     '/ancestor::div[contains(@class, "modal-dialog")]'
 
   dialog = find(:xpath, path, wait: timeout.to_i)
-  raise "#{title} modal did not appear" unless dialog
+  raise ScriptError, "#{title} modal did not appear" unless dialog
 end
 
 # Check a Prometheus exporter
@@ -1059,7 +1055,7 @@ When(/^I visit "([^"]*)" endpoint of this "([^"]*)"$/) do |service, host|
                                when 'Prometheus apache exporter' then [9117, 'http', '', 'Apache Exporter']
                                when 'Prometheus postgres exporter' then [9187, 'http', '', 'Postgres Exporter']
                                when 'Grafana' then [3000, 'http', '', 'Grafana Labs']
-                               else raise "Unknown port for service #{service}"
+                               else raise ScriptError, "Unknown port for service #{service}"
                                end
   # debian based systems don't come with curl installed
   if (os_family.include? 'debian') || (os_family.include? 'ubuntu')
@@ -1092,13 +1088,11 @@ When(/^I close the modal dialog$/) do
 end
 
 When(/^I refresh the page$/) do
-  begin
-    accept_prompt do
-      execute_script 'window.location.reload()'
-    end
-  rescue Capybara::ModalNotFound
-    # ignored
+  accept_prompt do
+    execute_script 'window.location.reload()'
   end
+rescue Capybara::ModalNotFound
+  # ignored
 end
 
 When(/^I make a list of the existing systems$/) do
@@ -1170,7 +1164,7 @@ Then(/^I should see "([^"]*)" hostname as first search result$/) do |host|
   within(:xpath, '//section') do
     row = find(:xpath, '//div[@class=\'table-responsive\']/table/tbody/tr[.//td]', match: :first)
     within(row) do
-      raise "Text '#{system_name}' not found" unless check_text_and_catch_request_timeout_popup?(system_name)
+      raise ScriptError, "Text '#{system_name}' not found" unless check_text_and_catch_request_timeout_popup?(system_name)
     end
   end
 end

--- a/testsuite/features/step_definitions/retail_steps.rb
+++ b/testsuite/features/step_definitions/retail_steps.rb
@@ -78,7 +78,7 @@ When(/^I set up the private network on the terminals$/) do
   nodes.each do |node|
     next if node.nil?
     return_code = file_inject(node, source, dest)
-    raise 'File injection failed' unless return_code.zero?
+    raise ScriptError, 'File injection failed' unless return_code.zero?
     node.run('netplan apply')
   end
   # PXE boot minion
@@ -90,7 +90,7 @@ end
 Then(/^terminal "([^"]*)" should have got a retail network IP address$/) do |host|
   node = get_target(host)
   output, return_code = node.run('ip -4 address show eth1')
-  raise "Terminal #{host} did not get an address on eth1: #{output}" unless return_code.zero? and output.include? net_prefix
+  raise SystemCallError, "Terminal #{host} did not get an address on eth1: #{output}" unless return_code.zero? and output.include? net_prefix
 end
 
 Then(/^name resolution should work on terminal "([^"]*)"$/) do |host|
@@ -100,13 +100,13 @@ Then(/^name resolution should work on terminal "([^"]*)"$/) do |host|
   # direct name resolution
   %w[proxy.example.org dns.google.com].each do |dest|
     output, return_code = node.run("host #{dest}", check_errors: false)
-    raise "Direct name resolution of #{dest} on terminal #{host} doesn't work: #{output}" unless return_code.zero?
+    raise SystemCallError, "Direct name resolution of #{dest} on terminal #{host} doesn't work: #{output}" unless return_code.zero?
     log "#{output}"
   end
   # reverse name resolution
   [node.private_ip, '8.8.8.8'].each do |dest|
     output, return_code = node.run("host #{dest}", check_errors: false)
-    raise "Reverse name resolution of #{dest} on terminal #{host} doesn't work: #{output}" unless return_code.zero?
+    raise SystemCallError, "Reverse name resolution of #{dest} on terminal #{host} doesn't work: #{output}" unless return_code.zero?
     log "#{output}"
   end
 end
@@ -122,7 +122,7 @@ When(/^I restart the network on the PXE boot minion$/) do
   source = File.dirname(__FILE__) + '/../upload_files/' + file
   dest = '/tmp/' + file
   return_code = file_inject(get_target('proxy'), source, dest)
-  raise 'File injection failed' unless return_code.zero?
+  raise ScriptError, 'File injection failed' unless return_code.zero?
   # We have no direct access to the PXE boot minion
   # so we run the command from the proxy
   get_target('proxy').run("expect -f /tmp/#{file} #{ipv6}")
@@ -146,7 +146,7 @@ When(/^I reboot the (Retail|Cobbler) terminal "([^"]*)"$/) do |context, host|
   source = File.dirname(__FILE__) + '/../upload_files/' + file
   dest = '/tmp/' + file
   return_code = file_inject(get_target('proxy'), source, dest)
-  raise 'File injection failed' unless return_code.zero?
+  raise ScriptError, 'File injection failed' unless return_code.zero?
   get_target('proxy').run("expect -f /tmp/#{file} #{ipv6} #{context}")
 end
 
@@ -158,8 +158,8 @@ When(/^I create bootstrap script for "([^"]+)" hostname and set the activation k
 
   get_target('proxy').run("sed -i '/^ACTIVATION_KEYS=/c\\ACTIVATION_KEYS=#{key}' /srv/www/htdocs/pub/bootstrap/bootstrap.sh")
   output, _code = get_target('proxy').run('cat /srv/www/htdocs/pub/bootstrap/bootstrap.sh')
-  raise "Key: #{key} not included" unless output.include? key
-  raise "Hostname: #{host} not included" unless output.include? host
+  raise ScriptError, "Key: #{key} not included" unless output.include? key
+  raise ScriptError, "Hostname: #{host} not included" unless output.include? host
 end
 
 When(/^I bootstrap pxeboot minion via bootstrap script on the proxy$/) do
@@ -167,7 +167,7 @@ When(/^I bootstrap pxeboot minion via bootstrap script on the proxy$/) do
   source = File.dirname(__FILE__) + '/../upload_files/' + file
   dest = '/tmp/' + file
   return_code = file_inject(get_target('proxy'), source, dest)
-  raise 'File injection failed' unless return_code.zero?
+  raise ScriptError, 'File injection failed' unless return_code.zero?
   ipv4 = net_prefix + ADDRESSES['pxeboot_minion']
   get_target('proxy').run("expect -f /tmp/#{file} #{ipv4}", verbose: true)
 end
@@ -181,7 +181,7 @@ When(/^I install the GPG key of the test packages repository on the PXE boot min
   source = File.dirname(__FILE__) + '/../upload_files/' + file
   dest = '/tmp/' + file
   return_code = file_inject(get_target('server'), source, dest)
-  raise 'File injection failed' unless return_code.zero?
+  raise ScriptError, 'File injection failed' unless return_code.zero?
   system_name = get_system_name('pxeboot_minion')
   get_target('server').run("salt-cp #{system_name} #{dest} #{dest}")
   get_target('server').run("salt #{system_name} cmd.run 'rpmkeys --import #{dest}'")
@@ -192,7 +192,7 @@ When(/^I wait until Salt client is inactive on the PXE boot minion$/) do
   source = File.dirname(__FILE__) + '/../upload_files/' + file
   dest = '/tmp/' + file
   return_code = file_inject(get_target('proxy'), source, dest)
-  raise 'File injection failed' unless return_code.zero?
+  raise ScriptError, 'File injection failed' unless return_code.zero?
   ipv4 = net_prefix + ADDRESSES['pxeboot_minion']
   get_target('proxy').run("expect -f /tmp/#{file} #{ipv4}")
 end
@@ -201,7 +201,7 @@ When(/^I prepare the retail configuration file on server$/) do
   source = File.dirname(__FILE__) + '/../upload_files/massive-import-terminals.yml'
   dest = '/tmp/massive-import-terminals.yml'
   return_code = file_inject(get_target('server'), source, dest)
-  raise "File #{file} couldn't be copied to server" unless return_code.zero?
+  raise ScriptError, "File #{file} couldn't be copied to server" unless return_code.zero?
 
   sed_values = "s/<PROXY_HOSTNAME>/#{get_target('proxy').full_hostname}/; "
   sed_values << "s/<NET_PREFIX>/#{net_prefix}/; "
@@ -483,5 +483,5 @@ end
 Then(/^the image for "([^"]*)" should exist on the branch server$/) do |host|
   image = compute_kiwi_profile_name(host)
   images, _code = get_target('proxy').run('ls /srv/saltboot/image/')
-  raise "Image #{image} for #{host} does not exist" unless images.include? image
+  raise ScriptError, "Image #{image} for #{host} does not exist" unless images.include? image
 end

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -161,7 +161,7 @@ end
 Then(/^"(.*?)" should have been reformatted$/) do |host|
   system_name = get_system_name(host)
   output, _code = get_target('server').run("salt #{system_name} file.file_exists /intact")
-  raise "Minion #{host} is intact" unless output.include? 'False'
+  raise ScriptError, "Minion #{host} is intact" unless output.include? 'False'
 end
 
 # user salt steps
@@ -194,7 +194,7 @@ end
 Then(/^I should see "([^"]*)" in the command output for "([^"]*)"$/) do |text, host|
   system_name = get_system_name(host)
   within("pre[id='#{system_name}-results']") do
-    raise "Text '#{text}' not found in the results of #{system_name}" unless check_text_and_catch_request_timeout_popup?(text)
+    raise ScriptError, "Text '#{text}' not found in the results of #{system_name}" unless check_text_and_catch_request_timeout_popup?(text)
   end
 end
 
@@ -255,11 +255,11 @@ When(/^I ([^ ]*) the "([^"]*)" formula$/) do |action, formula|
   # DOM refreshes content of chooseFormulas element by accessing it. Then conditions are evaluated properly.
   find('#chooseFormulas')['innerHTML']
   if has_xpath?(xpath_query, wait: 2)
-    raise "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query, wait: 2).click
+    raise ScriptError, "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query, wait: 2).click
   else
     xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-check-square-o']" if action == 'check'
     xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-square-o']" if action == 'uncheck'
-    raise "xpath: #{xpath_query} not found" unless has_xpath?(xpath_query, wait: 2)
+    raise ScriptError, "xpath: #{xpath_query} not found" unless has_xpath?(xpath_query, wait: 2)
   end
 end
 
@@ -269,7 +269,7 @@ Then(/^the "([^"]*)" formula should be ([^ ]*)$/) do |formula, state|
   xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-check-square-o']" if state == 'unchecked'
   # DOM refreshes content of chooseFormulas element by accessing it. Then conditions are evaluated properly.
   find('#chooseFormulas')['innerHTML']
-  raise "Checkbox is not #{state}" if has_xpath?(xpath_query)
+  raise ScriptError, "Checkbox is not #{state}" if has_xpath?(xpath_query)
   xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-check-square-o']" if state == 'checked'
   xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-square-o']" if state == 'unchecked'
   assert has_xpath?(xpath_query), 'Checkbox could not be found'
@@ -284,13 +284,13 @@ Then(/^the timezone on "([^"]*)" should be "([^"]*)"$/) do |minion, timezone|
   output, _code = node.run('date +%Z')
   result = output.strip
   result = 'CET' if result == 'CEST'
-  raise "The timezone #{timezone} is different to #{result}" unless result == timezone
+  raise ScriptError, "The timezone #{timezone} is different to #{result}" unless result == timezone
 end
 
 Then(/^the keymap on "([^"]*)" should be "([^"]*)"$/) do |minion, keymap|
   node = get_target(minion)
   output, _code = node.run('grep \'KEYMAP=\' /etc/vconsole.conf')
-  raise "The keymap #{keymap} is different to the output: #{output.strip}" unless output.strip == "KEYMAP=#{keymap}"
+  raise ScriptError, "The keymap #{keymap} is different to the output: #{output.strip}" unless output.strip == "KEYMAP=#{keymap}"
 end
 
 Then(/^the language on "([^"]*)" should be "([^"]*)"$/) do |minion, language|
@@ -298,7 +298,7 @@ Then(/^the language on "([^"]*)" should be "([^"]*)"$/) do |minion, language|
   output, _code = node.run('grep \'RC_LANG=\' /etc/sysconfig/language')
   unless output.strip == "RC_LANG=\"#{language}\""
     output, _code = node.run('grep \'LANG=\' /etc/locale.conf')
-    raise "The language #{language} is different to the output: #{output.strip}" unless output.strip == "LANG=#{language}"
+    raise ScriptError, "The language #{language} is different to the output: #{output.strip}" unless output.strip == "LANG=#{language}"
   end
 end
 
@@ -323,21 +323,21 @@ end
 Then(/^the pillar data for "([^"]*)" should be "([^"]*)" on "([^"]*)"$/) do |key, value, minion|
   output, _code = pillar_get(key, minion)
   if value == ''
-    raise "Output has more than one line: #{output}" unless output.split("\n").length == 1
+    raise ScriptError, "Output has more than one line: #{output}" unless output.split("\n").length == 1
   else
-    raise "Output value wasn't found: #{output}" unless output.split("\n").length > 1
-    raise "Output value is different than #{value}: #{output}" unless output.split("\n")[1].strip == value
+    raise ScriptError, "Output value wasn't found: #{output}" unless output.split("\n").length > 1
+    raise ScriptError, "Output value is different than #{value}: #{output}" unless output.split("\n")[1].strip == value
   end
 end
 
 Then(/^the pillar data for "([^"]*)" should contain "([^"]*)" on "([^"]*)"$/) do |key, value, minion|
   output, _code = pillar_get(key, minion)
-  raise "Output doesn't contain #{value}: #{output}" unless output.include? value
+  raise ScriptError, "Output doesn't contain #{value}: #{output}" unless output.include? value
 end
 
 Then(/^the pillar data for "([^"]*)" should not contain "([^"]*)" on "([^"]*)"$/) do |key, value, minion|
   output, _code = pillar_get(key, minion)
-  raise "Output contains #{value}: #{output}" if output.include? value
+  raise ScriptError, "Output contains #{value}: #{output}" if output.include? value
 end
 
 Then(/^the pillar data for "([^"]*)" should be empty on "([^"]*)"$/) do |key, minion|
@@ -379,13 +379,13 @@ end
 When(/^I reject "([^"]*)" from the Pending section$/) do |host|
   system_name = get_system_name(host)
   xpath_query = "//tr[td[contains(.,'#{system_name}')]]//button[@title = 'Reject']"
-  raise "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query).click
+  raise ScriptError, "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query).click
 end
 
 When(/^I delete "([^"]*)" from the Rejected section$/) do |host|
   system_name = get_system_name(host)
   xpath_query = "//tr[td[contains(.,'#{system_name}')]]//button[@title = 'Delete']"
-  raise "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query).click
+  raise ScriptError, "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query).click
 end
 
 When(/^I see "([^"]*)" fingerprint$/) do |host|
@@ -393,13 +393,13 @@ When(/^I see "([^"]*)" fingerprint$/) do |host|
   salt_call = use_salt_bundle ? 'venv-salt-call' : 'salt-call'
   output, _code = node.run("#{salt_call} --local key.finger")
   fing = output.split("\n")[1].strip!
-  raise "Text: #{fing} not found" unless check_text_and_catch_request_timeout_popup?(fing)
+  raise ScriptError, "Text: #{fing} not found" unless check_text_and_catch_request_timeout_popup?(fing)
 end
 
 When(/^I accept "([^"]*)" key$/) do |host|
   system_name = get_system_name(host)
   xpath_query = "//tr[td[contains(.,'#{system_name}')]]//button[@title = 'Accept']"
-  raise "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query).click
+  raise ScriptError, "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query).click
 end
 
 When(/^I refresh page until I see "(.*?)" hostname as text$/) do |minion|
@@ -448,7 +448,7 @@ Then(/^the salt event log on server should contain no failures$/) do
   source = "#{File.dirname(__FILE__)}/../upload_files/#{file}"
   dest = "/tmp/#{file}"
   return_code = file_inject(get_target('server'), source, dest)
-  raise 'File injection failed' unless return_code.zero?
+  raise ScriptError, 'File injection failed' unless return_code.zero?
   # print failures from salt event log
   output, _code = get_target('server').run("python3 /tmp/#{file}")
   count_failures = output.to_s.scan(/false/).length
@@ -456,7 +456,7 @@ Then(/^the salt event log on server should contain no failures$/) do
   # Ignore the error if there is only the expected failure from min_salt_lock_packages.feature
   ignore_error = false
   ignore_error = output.include?('remove lock') if count_failures == 1 && !$build_validation
-  raise "\nFound #{count_failures} failures in salt event log:\n#{output}\n" if count_failures.nonzero? && !ignore_error
+  raise ScriptError, "\nFound #{count_failures} failures in salt event log:\n#{output}\n" if count_failures.nonzero? && !ignore_error
 end
 
 # salt-ssh steps
@@ -540,7 +540,7 @@ end
 When(/^I delete the package download endpoint pillar file from the server$/) do
   filepath = '/srv/pillar/pkg_endpoint.sls'
   return_code = file_delete(get_target('server'), filepath)
-  raise 'File deletion failed' unless return_code.zero?
+  raise ScriptError, 'File deletion failed' unless return_code.zero?
 end
 
 When(/^I install "([^"]*)" to custom formula metadata directory "([^"]*)"$/) do |file, formula|
@@ -549,7 +549,7 @@ When(/^I install "([^"]*)" to custom formula metadata directory "([^"]*)"$/) do 
 
   get_target('server').run('mkdir -p /srv/formula_metadata/' + formula)
   return_code = file_inject(get_target('server'), source, dest)
-  raise 'File injection failed' unless return_code.zero?
+  raise ScriptError, 'File injection failed' unless return_code.zero?
   get_target('server').run('chmod 644 ' + dest)
 end
 

--- a/testsuite/features/step_definitions/setup_steps.rb
+++ b/testsuite/features/step_definitions/setup_steps.rb
@@ -7,7 +7,7 @@
 # setup wizard
 
 Then(/^HTTP proxy verification should have succeeded$/) do
-  raise 'Success icon not found' unless find('i.text-success', wait: DEFAULT_TIMEOUT)
+  raise ScriptError, 'Success icon not found' unless find('i.text-success', wait: DEFAULT_TIMEOUT)
 end
 
 When(/^I enter the address of the HTTP proxy as "([^"]*)"$/) do |hostname|
@@ -15,7 +15,7 @@ When(/^I enter the address of the HTTP proxy as "([^"]*)"$/) do |hostname|
 end
 
 When(/^I ask to add new credentials$/) do
-  raise 'Click on plus icon failed' unless find('i.fa-plus-circle').click
+  raise ScriptError, 'Click on plus icon failed' unless find('i.fa-plus-circle').click
 end
 
 When(/^I enter the SCC credentials$/) do
@@ -29,25 +29,25 @@ end
 When(/^I wait until the SCC credentials are valid$/) do
   scc_username, scc_password = ENV['SCC_CREDENTIALS'].split('|')
   within(:xpath, "//h3[contains(text(), '#{scc_username}')]/../..") do
-    raise 'Success icon not found' unless find('i.text-success', wait: 30)
+    raise ScriptError, 'Success icon not found' unless find('i.text-success', wait: 30)
   end
 end
 
 Then(/^the credentials for "([^"]*)" should be invalid$/) do |user|
   within(:xpath, "//h3[contains(text(), '#{user}')]/../..") do
-    raise 'Failure icon not found' unless find('i.text-danger', wait: DEFAULT_TIMEOUT)
+    raise ScriptError, 'Failure icon not found' unless find('i.text-danger', wait: DEFAULT_TIMEOUT)
   end
 end
 
 When(/^I make the credentials for "([^"]*)" primary$/) do |user|
   within(:xpath, "//h3[contains(text(), '#{user}')]/../..") do
-    raise 'Click on star icon failed' unless find('i.fa-star-o').click
+    raise ScriptError, 'Click on star icon failed' unless find('i.fa-star-o').click
   end
 end
 
 Then(/^the credentials for "([^"]*)" should be primary$/) do |user|
   within(:xpath, "//h3[contains(text(), '#{user}')]/../..") do
-    raise 'Star icon not selected' unless find('i.fa-star')
+    raise ScriptError, 'Star icon not selected' unless find('i.fa-star')
   end
 end
 
@@ -62,28 +62,28 @@ end
 
 When(/^I ask to delete the credentials for "([^"]*)"$/) do |user|
   within(:xpath, "//h3[contains(text(), '#{user}')]/../..") do
-    raise 'Click on trash icon failed' unless find('i.fa-trash-o').click
+    raise ScriptError, 'Click on trash icon failed' unless find('i.fa-trash-o').click
   end
 end
 
 When(/^I view the subscription list for "([^"]*)"$/) do |user|
   within(:xpath, "//h3[contains(text(), '#{user}')]/../..") do
-    raise 'Click on list icon failed' unless find('i.fa-th-list').click
+    raise ScriptError, 'Click on list icon failed' unless find('i.fa-th-list').click
   end
 end
 
 When(/^I select "(.*?)" in the dropdown list of the architecture filter$/) do |architecture|
   # let the the select2js box filter open the hidden options
   xpath_query = '//div[@id=\'s2id_product-arch-filter\']/ul/li/input'
-  raise "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query).click
+  raise ScriptError, "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query).click
   # select the desired option
-  raise "Architecture #{architecture} not found" unless find(:xpath, "//div[@id='select2-drop']/ul/li/div[contains(text(), '#{architecture}')]").click
+  raise ScriptError, "Architecture #{architecture} not found" unless find(:xpath, "//div[@id='select2-drop']/ul/li/div[contains(text(), '#{architecture}')]").click
 end
 
 When(/^I (deselect|select) "([^\"]*)" as a product$/) do |select, product|
   # click on the checkbox to select the product
   xpath = "//span[contains(text(), '#{product}')]/ancestor::div[contains(@class, 'product-details-wrapper')]/div/input[@type='checkbox']"
-  raise "xpath: #{xpath} not found" unless find(:xpath, xpath).set(select == 'select')
+  raise ScriptError, "xpath: #{xpath} not found" unless find(:xpath, xpath).set(select == 'select')
 end
 
 When(/^I wait at most (\d+) seconds until the tree item "([^"]+)" has no sub-list$/) do |timeout, item|
@@ -100,14 +100,14 @@ end
 
 When(/^I wait at most (\d+) seconds until the tree item "([^"]+)" contains "([^"]+)" text$/) do |timeout, item, text|
   within(:xpath, "//span[contains(text(), '#{item}')]/ancestor::div[contains(@class, 'product-details-wrapper')]") do
-    raise "could not find text #{text} for tree item #{item}" unless check_text_and_catch_request_timeout_popup?(text, timeout: timeout.to_i)
+    raise ScriptError, "could not find text #{text} for tree item #{item}" unless check_text_and_catch_request_timeout_popup?(text, timeout: timeout.to_i)
   end
 end
 
 When(/^I wait at most (\d+) seconds until the tree item "([^"]+)" contains "([^"]+)" button$/) do |timeout, item, button|
   xpath_query = "//span[contains(text(), '#{item}')]/"\
       "ancestor::div[contains(@class, 'product-details-wrapper')]/descendant::*[@title='#{button}']"
-  raise "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query, wait: timeout.to_i)
+  raise ScriptError, "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query, wait: timeout.to_i)
 end
 
 When(/^I open the sub-list of the product "(.*?)"((?: if present)?)$/) do |product, if_present|
@@ -115,25 +115,25 @@ When(/^I open the sub-list of the product "(.*?)"((?: if present)?)$/) do |produ
   begin
     find(:xpath, xpath).click
   rescue Capybara::ElementNotFound
-    raise "xpath: #{xpath} not found" if if_present.empty?
+    raise ScriptError, "xpath: #{xpath} not found" if if_present.empty?
   end
 end
 
 When(/^I select the addon "(.*?)"$/) do |addon|
   # click on the checkbox of the sublist to select the addon product
   xpath = "//span[contains(text(), '#{addon}')]/ancestor::div[contains(@class, 'product-details-wrapper')]/div/input[@type='checkbox']"
-  raise "xpath: #{xpath} not found" unless find(:xpath, xpath).set(true)
+  raise ScriptError, "xpath: #{xpath} not found" unless find(:xpath, xpath).set(true)
 end
 
 Then(/^I should see that the "(.*?)" product is "(.*?)"$/) do |product, recommended|
   xpath = "//span[text()[normalize-space(.) = '#{product}'] and ./span/text() = '#{recommended}']"
-  raise "xpath: #{xpath} not found" unless find(:xpath, xpath)
+  raise ScriptError, "xpath: #{xpath} not found" unless find(:xpath, xpath)
 end
 
 Then(/^I should see the "(.*?)" selected$/) do |product|
   xpath = "//span[contains(text(), '#{product}')]/ancestor::div[contains(@class, 'product-details-wrapper')]"
   within(:xpath, xpath) do
-    raise "#{find(:xpath, '.')['data-identifier']} is not checked" unless find(:xpath, './div/input[@type=\'checkbox\']').checked?
+    raise ScriptError, "#{find(:xpath, '.')['data-identifier']} is not checked" unless find(:xpath, './div/input[@type=\'checkbox\']').checked?
   end
 end
 
@@ -153,44 +153,44 @@ When(/^I wait until I see "(.*?)" product has been added$/) do |product|
 end
 
 When(/^I click the Add Product button$/) do
-  raise 'xpath: button#addProducts not found' unless find('button#addProducts').click
+  raise ScriptError, 'xpath: button#addProducts not found' unless find('button#addProducts').click
 end
 
 Then(/^the SLE15 (SP3|SP4|SP5) product should be added$/) do |sp_version|
   output, _code = get_target('server').run('echo -e "admin\nadmin\n" | mgr-sync list channels', check_errors: false, buffer_size: 1_000_000)
   log "Products list:\n#{output}"
   match = "[I] SLE-Product-SLES15-#{sp_version}-Pool for x86_64 SUSE Linux Enterprise Server 15 #{sp_version} x86_64 [sle-product-sles15-#{sp_version.downcase}-pool-x86_64]"
-  raise "Not included:\n #{match}" unless output.include? match
+  raise ScriptError, "Not included:\n #{match}" unless output.include? match
   match = "[I] SLE-Module-Basesystem15-#{sp_version}-Updates for x86_64 Basesystem Module 15 #{sp_version} x86_64 [sle-module-basesystem15-#{sp_version.downcase}-updates-x86_64]"
-  raise "Not included:\n #{match}" unless output.include? match
+  raise ScriptError, "Not included:\n #{match}" unless output.include? match
   match = "[I] SLE-Module-Server-Applications15-#{sp_version}-Pool for x86_64 Server Applications Module 15 #{sp_version} x86_64 [sle-module-server-applications15-#{sp_version.downcase}-pool-x86_64]"
-  raise "Not included:\n #{match}" unless output.include? match
+  raise ScriptError, "Not included:\n #{match}" unless output.include? match
 end
 
 When(/^I click the channel list of product "(.*?)"$/) do |product|
   xpath = "//span[contains(text(), '#{product}')]/ancestor::div[contains(@class, 'product-details-wrapper')]/div/button[contains(@class, 'showChannels')]"
-  raise "xpath: #{xpath} not found" unless find(:xpath, xpath).click
+  raise ScriptError, "xpath: #{xpath} not found" unless find(:xpath, xpath).click
 end
 
 # configuration management steps
 
 Then(/^I should see a table line with "([^"]*)", "([^"]*)", "([^"]*)"$/) do |arg1, arg2, arg3|
   within(:xpath, "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{arg1}')]]") do
-    raise "Link #{arg2} not found" unless find_link(arg2)
-    raise "Link #{arg3} not found" unless find_link(arg3)
+    raise ScriptError, "Link #{arg2} not found" unless find_link(arg2)
+    raise ScriptError, "Link #{arg3} not found" unless find_link(arg3)
   end
 end
 
 Then(/^I should see a table line with "([^"]*)", "([^"]*)"$/) do |arg1, arg2|
   within(:xpath, "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{arg1}')]]") do
-    raise "Link #{arg2} not found" unless find_link(arg2)
+    raise ScriptError, "Link #{arg2} not found" unless find_link(arg2)
   end
 end
 
 Then(/^a table line should contain system "([^"]*)", "([^"]*)"$/) do |host, text|
   system_name = get_system_name(host)
   within(:xpath, "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{system_name}')]]") do
-    raise "Text #{text} not found" unless find_all(:xpath, "//td[contains(., '#{text}')]")
+    raise ScriptError, "Text #{text} not found" unless find_all(:xpath, "//td[contains(., '#{text}')]")
   end
 end
 
@@ -241,14 +241,14 @@ end
 Then(/^I should see "([^"]*)" at least (\d+) minutes after I scheduled an action$/) do |text, minutes|
   # TODO: is there a better way then page.all ?
   elements = all('div', text: text)
-  raise "Text #{text} not found in the page" if elements.nil?
+  raise ScriptError, "Text #{text} not found in the page" if elements.nil?
   match = elements[0].text.match(/#{text}\s*(\d+\/\d+\/\d+ \d+:\d+:\d+ (AM|PM)+ [^\s]+)/)
-  raise "No element found matching text '#{text}'" if match.nil?
+  raise ScriptError, "No element found matching text '#{text}'" if match.nil?
   text_time = DateTime.strptime("#{match.captures[0]}", '%m/%d/%C %H:%M:%S %p %Z')
-  raise 'Time the action was scheduled not found in memory' unless defined?($moments) and $moments['schedule_action']
+  raise ScriptError, 'Time the action was scheduled not found in memory' unless defined?($moments) and $moments['schedule_action']
   initial = $moments['schedule_action']
   after = initial + Rational(1, 1440) * minutes.to_i
-  raise "#{text_time.to_s} is not #{minutes} minutes later than '#{initial.to_s}'" unless (text_time + Rational(1, 1440)) >= after
+  raise ScriptError, "#{text_time.to_s} is not #{minutes} minutes later than '#{initial.to_s}'" unless (text_time + Rational(1, 1440)) >= after
 end
 
 Given(/^I have a valid token for organization "([^"]*)"$/) do |org|
@@ -282,12 +282,12 @@ Then(/^I should see the toggler "([^"]*)"$/) do |target_status|
   case target_status
   when 'enabled'
     xpath = '//i[contains(@class, \'fa-toggle-on\')]'
-    raise "xpath: #{xpath} not found" unless find(:xpath, xpath)
+    raise ScriptError, "xpath: #{xpath} not found" unless find(:xpath, xpath)
   when 'disabled'
     xpath = '//i[contains(@class, \'fa-toggle-off\')]'
-    raise "xpath: #{xpath} not found" unless find(:xpath, xpath)
+    raise ScriptError, "xpath: #{xpath} not found" unless find(:xpath, xpath)
   else
-    raise 'Invalid target status.'
+    raise NotImplementedError, 'Invalid target status.'
   end
 end
 
@@ -295,12 +295,12 @@ When(/^I click on the "([^"]*)" toggler$/) do |target_status|
   case target_status
   when 'enabled'
     xpath = '//i[contains(@class, \'fa-toggle-on\')]'
-    raise "xpath: #{xpath} not found" unless find(:xpath, xpath).click
+    raise ScriptError, "xpath: #{xpath} not found" unless find(:xpath, xpath).click
   when 'disabled'
     xpath = '//i[contains(@class, \'fa-toggle-off\')]'
-    raise "xpath: #{xpath} not found" unless find(:xpath, xpath).click
+    raise ScriptError, "xpath: #{xpath} not found" unless find(:xpath, xpath).click
   else
-    raise 'Invalid target status.'
+    raise NotImplementedError, 'Invalid target status.'
   end
 end
 
@@ -312,11 +312,11 @@ Then(/^I should see the child channel "([^"]*)" "([^"]*)"$/) do |target_channel,
 
   case target_status
   when 'selected'
-    raise "#{channel_checkbox_id} is not selected" unless has_checked_field?(channel_checkbox_id)
+    raise ScriptError, "#{channel_checkbox_id} is not selected" unless has_checked_field?(channel_checkbox_id)
   when 'unselected'
-    raise "#{channel_checkbox_id} is selected" if has_checked_field?(channel_checkbox_id)
+    raise ScriptError, "#{channel_checkbox_id} is selected" if has_checked_field?(channel_checkbox_id)
   else
-    raise 'Invalid target status.'
+    raise NotImplementedError, 'Invalid target status.'
   end
 end
 
@@ -329,11 +329,11 @@ Then(/^I should see the child channel "([^"]*)" "([^"]*)" and "([^"]*)"$/) do |t
 
   case target_status
   when 'selected'
-    raise "#{channel_checkbox_id} is not selected" unless has_checked_field?(channel_checkbox_id, disabled: true)
+    raise ScriptError, "#{channel_checkbox_id} is not selected" unless has_checked_field?(channel_checkbox_id, disabled: true)
   when 'unselected'
-    raise "#{channel_checkbox_id} is selected" if has_checked_field?(channel_checkbox_id, disabled: true)
+    raise ScriptError, "#{channel_checkbox_id} is selected" if has_checked_field?(channel_checkbox_id, disabled: true)
   else
-    raise 'Invalid target status.'
+    raise NotImplementedError, 'Invalid target status.'
   end
 end
 
@@ -343,7 +343,7 @@ When(/^I select the child channel "([^"]*)"$/) do |target_channel|
   xpath = "//label[contains(text(), '#{target_channel}')]"
   channel_checkbox_id = find(:xpath, xpath)['for']
 
-  raise "Field #{channel_checkbox_id} is checked" if has_checked_field?(channel_checkbox_id)
+  raise ScriptError, "Field #{channel_checkbox_id} is checked" if has_checked_field?(channel_checkbox_id)
   find(:xpath, "//input[@id='#{channel_checkbox_id}']").click
 end
 
@@ -364,9 +364,9 @@ Then(/^I should see "([^"]*)" "([^"]*)" for the "([^"]*)" channel$/) do |target_
 
   case target_status
   when 'selected'
-    raise "xpath: #{xpath} is not selected" if find(:xpath, xpath)['checked'].nil?
+    raise ScriptError, "xpath: #{xpath} is not selected" if find(:xpath, xpath)['checked'].nil?
   when 'unselected'
-    raise "xpath: #{xpath} is selected" unless find(:xpath, xpath)['checked'].nil?
+    raise ScriptError, "xpath: #{xpath} is selected" unless find(:xpath, xpath)['checked'].nil?
   else
     log "Target status #{target_status} not supported"
   end
@@ -379,10 +379,10 @@ Then(/^the notification badge and the table should count the same amount of mess
 
   if table_notifications_count == '0'
     log 'All notification-messages are read, I expect no notification badge'
-    raise "xpath: #{badge_xpath} found" if has_xpath?(badge_xpath)
+    raise ScriptError, "xpath: #{badge_xpath} found" if has_xpath?(badge_xpath)
   else
     log 'Unread notification-messages count = ' + table_notifications_count
-    raise "xpath: #{badge_xpath} not found" unless find(:xpath, badge_xpath)
+    raise ScriptError, "xpath: #{badge_xpath} not found" unless find(:xpath, badge_xpath)
   end
 end
 
@@ -425,7 +425,7 @@ end
 When(/^I delete it via the "([^"]*)" button$/) do |target_button|
   if count_table_items != '0'
     xpath_for_delete_button = "//button[@title='#{target_button}']"
-    raise "xpath: #{xpath_for_delete_button} not found" unless find(:xpath, xpath_for_delete_button).click
+    raise ScriptError, "xpath: #{xpath_for_delete_button} not found" unless find(:xpath, xpath_for_delete_button).click
 
     step 'I wait until I see "1 message deleted successfully." text'
   end
@@ -434,7 +434,7 @@ end
 When(/^I mark as read it via the "([^"]*)" button$/) do |target_button|
   if count_table_items != '0'
     xpath_for_read_button = "//button[@title='#{target_button}']"
-    raise "xpath: #{xpath_for_read_button} not found" unless find(:xpath, xpath_for_read_button).click
+    raise ScriptError, "xpath: #{xpath_for_read_button} not found" unless find(:xpath, xpath_for_read_button).click
 
     step 'I wait until I see "1 message read status updated successfully." text'
   end
@@ -455,7 +455,7 @@ When(/^I check for failed events on history event page$/) do
     end
   end
   count_failures = failings.length
-  raise "\nFailures in event history found:\n\n#{failings}" if count_failures.nonzero?
+  raise ScriptError, "\nFailures in event history found:\n\n#{failings}" if count_failures.nonzero?
 end
 
 Then(/^I should see a list item with text "([^"]*)" and a (success|failing|warning|pending|refreshing) bullet$/) do |text, bullet_type|

--- a/testsuite/features/step_definitions/smdba_steps.rb
+++ b/testsuite/features/step_definitions/smdba_steps.rb
@@ -172,7 +172,7 @@ When(/^I restore database from the backup$/) do
   log "\n*** Restoring database from the backup. This will may take a while. ***\n\n"
   output, code = get_target('server').run('smdba backup-restore')
   log "#{output}\n\n"
-  raise 'Restore Failed' unless code.zero?
+  raise SystemCallError, 'Restore Failed' unless code.zero?
 end
 
 Then(/^I disable backup in the directory "(.*?)"$/) do |_arg1|

--- a/testsuite/features/support/http_client.rb
+++ b/testsuite/features/support/http_client.rb
@@ -77,10 +77,10 @@ class HttpClient
         end
       end
     unless answer.status == 200
-      raise "Unexpected HTTP status code #{answer.status}" if answer.body.empty?
+      raise ScriptError, "Unexpected HTTP status code #{answer.status}" if answer.body.empty?
 
       json_body = JSON.parse(answer.body)
-      raise "Unexpected HTTP status code #{answer.status}, message: #{json_body['message']}"
+      raise ScriptError, "Unexpected HTTP status code #{answer.status}, message: #{json_body['message']}"
     end
 
     # Return either new session cookie or HTTP body
@@ -96,7 +96,7 @@ class HttpClient
       session_cookie
     else
       json_body = JSON.parse(answer.body)
-      raise "API failure: #{json_body['message']}" unless json_body['success']
+      raise ScriptError, "API failure: #{json_body['message']}" unless json_body['success']
 
       json_body['result']
     end

--- a/testsuite/features/support/kubernetes.rb
+++ b/testsuite/features/support/kubernetes.rb
@@ -21,7 +21,7 @@ def generate_certificate(name, fqdn)
                 '    name: uyuni-ca-issuer\\n'\
                 '    kind: Issuer'
   _out, return_code = get_target('server').run_local("echo -e \"#{certificate}\" | kubectl apply -f -")
-  raise "Failed to define #{name} Certificate resource" unless return_code.zero?
+  raise SystemCallError, "Failed to define #{name} Certificate resource" unless return_code.zero?
 
   # cert-manager takes some time to generate the secret, wait for it before continuing
   repeat_until_timeout(timeout: 600, message: "Kubernetes uyuni-#{name}-cert secret has not been defined") do
@@ -36,10 +36,10 @@ def generate_certificate(name, fqdn)
   ca_path = '/tmp/ca.crt'
 
   _out, return_code = get_target('server').run_local("kubectl get secret uyuni-#{name}-cert -o jsonpath='{.data.tls\\.crt}' | base64 -d >#{crt_path}")
-  raise "Failed to store #{name} certificate" unless return_code.zero?
+  raise SystemCallError, "Failed to store #{name} certificate" unless return_code.zero?
 
   _out, return_code = get_target('server').run_local("kubectl get secret uyuni-#{name}-cert -o jsonpath='{.data.tls\\.key}' | base64 -d >#{key_path}")
-  raise "Failed to store #{name} key" unless return_code.zero?
+  raise SystemCallError, "Failed to store #{name} key" unless return_code.zero?
 
   get_target('server').run_local("kubectl get secret uyuni-#{name}-cert -o jsonpath='{.data.ca\\.crt}' | base64 -d >#{ca_path}")
   [crt_path, key_path, ca_path]

--- a/testsuite/features/support/lavanda.rb
+++ b/testsuite/features/support/lavanda.rb
@@ -85,56 +85,56 @@ module LavandaBasic
 
   # getter functions, executed on testsuite
   def hostname
-    raise 'empty hostname, something wrong' if @in_hostname.empty?
+    raise KeyError, 'empty hostname, something wrong' if @in_hostname.empty?
     @in_hostname
   end
 
   ##
   # It raises an exception if the hostname is empty, otherwise it returns the hostname.
   def full_hostname
-    raise 'empty hostname, something wrong' if @in_full_hostname.empty?
+    raise KeyError, 'empty hostname, something wrong' if @in_full_hostname.empty?
     @in_full_hostname
   end
 
   ##
   # It raises an exception if the private_ip is empty, otherwise it returns the private_ip.
   def private_ip
-    raise 'empty private_ip, something wrong' if @in_private_ip.empty?
+    raise KeyError, 'empty private_ip, something wrong' if @in_private_ip.empty?
     @in_private_ip
   end
 
   ##
   # It returns the public IP address of the machine.
   def public_ip
-    raise 'empty public_ip, something wrong' if @in_public_ip.empty?
+    raise KeyError, 'empty public_ip, something wrong' if @in_public_ip.empty?
     @in_public_ip
   end
 
   ##
   # Verifies the private interface instance variable. Raises an error if it's empty.
   def private_interface
-    raise 'empty private_interface, something wrong' if @in_private_interface.empty?
+    raise KeyError, 'empty private_interface, something wrong' if @in_private_interface.empty?
     @in_private_interface
   end
 
   ##
   # Verifies the public interface instance variable. Raises an error if it's empty.
   def public_interface
-    raise 'empty public_interface, something wrong' if @in_public_interface.empty?
+    raise KeyError, 'empty public_interface, something wrong' if @in_public_interface.empty?
     @in_public_interface
   end
 
   ##
   # Verifies the os_family instance variable. Raises an error if it's empty.
   def os_family
-    raise 'empty os_family, something wrong' if @in_os_family.empty?
+    raise KeyError, 'empty os_family, something wrong' if @in_os_family.empty?
     @in_os_family
   end
 
   ##
   # Verifies the os_version instance variable. Raises an error if it's empty.
   def os_version
-    raise 'empty os_version, something wrong' if @in_os_version.empty?
+    raise KeyError, 'empty os_version, something wrong' if @in_os_version.empty?
     @in_os_version
   end
 
@@ -174,7 +174,7 @@ module LavandaBasic
       out, _lo, _rem, code = test_and_store_results_together(cmd, user, timeout, buffer_size)
     end
     if check_errors
-      raise "FAIL: #{cmd} returned status code = #{code}.\nOutput:\n#{out}" unless successcodes.include?(code)
+      raise ScriptError, "FAIL: #{cmd} returned status code = #{code}.\nOutput:\n#{out}" unless successcodes.include?(code)
     end
     STDOUT.puts "#{cmd} returned status code = #{code}.\nOutput:\n'#{out}'" if verbose
     if separated_results
@@ -241,7 +241,7 @@ module LavandaBasic
       code, _remote = inject_file(local_file, tmp_file, user, dots)
       if code.zero?
         _out, code = run_local("uyunictl cp --user #{user} #{tmp_file} server:#{remote_file}")
-        raise "Failed to copy #{tmp_file} to container" unless code.zero?
+        raise ScriptError, "Failed to copy #{tmp_file} to container" unless code.zero?
       end
       run_local("rm -r #{tmp_folder}")
     else
@@ -263,9 +263,9 @@ module LavandaBasic
       tmp_folder, _code = run_local('mktemp -d')
       tmp_file = File.join(tmp_folder.strip, File.basename(remote_file))
       _out, code = run_local("uyunictl cp --user #{user} server:#{remote_file} #{tmp_file}")
-      raise "Failed to extract #{remote_file} from container" unless code.zero?
+      raise ScriptError, "Failed to extract #{remote_file} from container" unless code.zero?
       code, _remote = extract_file(tmp_file, local_file, user, dots)
-      raise "Failed to extract #{tmp_file} from host" unless code.zero?
+      raise ScriptError, "Failed to extract #{tmp_file} from host" unless code.zero?
       run_local("rm -r #{tmp_folder}")
     else
       code, _local = extract_file(remote_file, local_file, user, dots)

--- a/testsuite/features/support/namespaces/system.rb
+++ b/testsuite/features/support/namespaces/system.rb
@@ -21,12 +21,12 @@ class NamespaceSystem
   # utility: retrieve server ID
   def retrieve_server_id(server)
     systems = list_systems
-    raise 'Cannot list systems' if systems.nil?
+    raise StandardError, 'Cannot list systems' if systems.nil?
 
     server_id = systems
                 .select { |s| s['name'] == server }
                 .map { |s| s['id'] }.first
-    raise "Cannot find #{server}" if server_id.nil?
+    raise StandardError, "Cannot find #{server}" if server_id.nil?
 
     server_id
   end

--- a/testsuite/features/support/twopence_env.rb
+++ b/testsuite/features/support/twopence_env.rb
@@ -6,7 +6,7 @@ require 'twopence'
 require_relative 'twopence_init'
 
 # Raise a warning if any of these environment variables is missing
-raise 'Server IP address or domain name variable empty' if ENV['SERVER'].nil?
+raise ArgumentError, 'Server IP address or domain name variable empty' if ENV['SERVER'].nil?
 
 warn 'Proxy IP address or domain name variable empty' if ENV['PROXY'].nil?
 unless $build_validation


### PR DESCRIPTION
## What does this PR change?

Passing always a Exception class will prevent to warn this Cop https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/RaiseException

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were refactored

- [x] **DONE**

## Links

Ports:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
