### PR TITLE
Remove concurrent dependency in favor of java.util.concurrent

### DIFF
--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -148,7 +148,7 @@
              bcprov bcpg stringtree-json postgresql-jdbc ongres-scram/client ongres-scram/common
              ${stringprep-jars} taglibs-standard-impl taglibs-standard-jstlel
              taglibs-standard-spec logdriver quartz slf4j-api log4j/log4j-slf4j-impl
-             concurrent velocity-engine-core simple-core  mockobjects mockobjects-core mockobjects-jdk1.4-j2ee1.3 strutstest" />
+             velocity-engine-core simple-core  mockobjects mockobjects-core mockobjects-jdk1.4-j2ee1.3 strutstest" />
 
   <!-- deps needed for testing, but required to build -->
   <property name="test.build.jar.dependencies" value="junit ${log4j-jars} regexp ${jmock-jars} postgresql-jdbc" />
@@ -166,7 +166,7 @@
   <property name="build.jar.dependencies"
       value="ant ant-junit ${ant-contrib.path} antlr  ${test.build.jar.dependencies}
       ${common.jar.dependencies} ${tomcat-jars} ${jasper-jars}
-       concurrent xalan-j2" />
+       xalan-j2" />
 
   <property name="run.jar.dependencies"
       value="antlr objectweb-asm/asm ${cglib-jar} ${c3p0} commons-discovery dom4j ${jaf} ${jta11-jars} ojdbc14 sitemesh
@@ -204,14 +204,14 @@
              stringtree-json postgresql-jdbc ongres-scram/client ongres-scram/common
              ${stringprep-jars} taglibs-standard-impl taglibs-standard-jstlel
              taglibs-standard-spec quartz ${suse-common-jars} velocity-engine-core
-             concurrent simple-core snakeyaml simple-xml ${commons-jexl}" />
+             simple-core snakeyaml simple-xml ${commons-jexl}" />
 
   <property name="dist.jar.dependencies"
       value="antlr objectweb-asm/asm bcel ${c3p0} ${cglib-jar}
              commons-collections commons-beanutils commons-cli commons-codec
              commons-digester commons-discovery commons-el commons-fileupload commons-io
              ${commons-lang} commons-logging ${commons-compress}
-             ${commons-validator} concurrent dom4j ${hibernate5deps} ${jta11-jars}
+             ${commons-validator} dom4j ${hibernate5deps} ${jta11-jars}
              ${jaf} ${jasper-jars} ${javamail} ${jaxb} jdom ${other-jars}
              ${tomcat-jars} ${log4j-jars} redstone-xmlrpc-client redstone-xmlrpc
              oro quartz stringtree-json sitemesh ${struts-jars}

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -29,7 +29,6 @@
         <dependency org="suse" name="commons-logging" rev="1.2" />
         <dependency org="suse" name="commons-validator" rev="1.3.1" />
         <dependency org="suse" name="commons-compress" rev="1.26.0" />
-        <dependency org="suse" name="concurrent" rev="1.3.4" />
         <dependency org="suse" name="concurrentlinkedhashmap-lru" rev="1.3.2" />
         <dependency org="suse" name="dom4j" rev="2.1.4" />
         <dependency org="suse" name="ehcache-core" rev="2.10.1" />

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -83,8 +83,6 @@ artifacts:
   - artifact: commons-compress
     package: apache-commons-compress
     repository: Leap
-  - artifact: concurrent
-    repository: Uyuni_Other
   - artifact: concurrentlinkedhashmap-lru
     repository: Uyuni_Other
   - artifact: dom4j

--- a/java/code/src/com/redhat/rhn/common/messaging/MessageQueue.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/MessageQueue.java
@@ -77,16 +77,9 @@ import java.util.stream.Stream;
  * A class that passes messages from the sender to an action class
  */
 public class MessageQueue {
-
-    /**
-     * Logger for this class
-     */
-    private static Logger logger = LogManager.getLogger(MessageQueue.class);
-
-    private static final Map<Class<? extends EventMessage>, List<MessageAction>> ACTIONS =
-            new HashMap<>();
-    private static BlockingQueue<Runnable> messages = new LinkedBlockingQueue<>();
-    private static Thread dispatcherThread = null;
+    private static final Logger LOGGER = LogManager.getLogger(MessageQueue.class);
+    private static final Map<Class<? extends EventMessage>, List<MessageAction>> ACTIONS = new HashMap<>();
+    private static final BlockingQueue<Runnable> MESSAGE_QUEUE = new LinkedBlockingQueue<>();
     private static MessageDispatcher dispatcher = null;
     private static int messageCount;
 
@@ -102,8 +95,8 @@ public class MessageQueue {
      * @param msg EventMessage to publish to queue.
      */
     public static void publish(EventMessage msg) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("publish(EventMessage) - start: {}", msg.getClass().getName());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("publish(EventMessage) - start: {}", msg.getClass().getName());
         }
         if (!isMessaging()) {
             startMessaging();
@@ -112,25 +105,25 @@ public class MessageQueue {
             synchronized (ACTIONS) {
                 List<MessageAction> handlers = ACTIONS.get(msg.getClass());
                 if (handlers != null && !handlers.isEmpty()) {
-                    logger.debug("creating ActionExecutor");
+                    LOGGER.debug("creating ActionExecutor");
                     ActionExecutor executor = new ActionExecutor(handlers, msg);
                     try {
-                        messages.put(executor);
+                        MESSAGE_QUEUE.put(executor);
                         messageCount++;
                     }
                     catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
-                        logger.error(e.getMessage(), e);
+                        LOGGER.error(e.getMessage(), e);
                     }
                 }
                 else {
-                    logger.debug("handlers is null, not processing!");
+                    LOGGER.debug("handlers is null, not processing!");
                 }
             }
         }
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("publish(EventMessage) - end");
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("publish(EventMessage) - end");
         }
     }
 
@@ -144,7 +137,7 @@ public class MessageQueue {
     }
 
     static ActionExecutor popEventMessage() throws InterruptedException {
-        ActionExecutor retval = (ActionExecutor) messages.poll(500, TimeUnit.MILLISECONDS);
+        ActionExecutor retval = (ActionExecutor) MESSAGE_QUEUE.poll(500, TimeUnit.MILLISECONDS);
         if (retval != null) {
             synchronized (ACTIONS) {
                 messageCount--;
@@ -157,19 +150,19 @@ public class MessageQueue {
      * Start the messaging system
      */
     public static synchronized void startMessaging() {
-        if (logger.isDebugEnabled()) {
-            logger.debug("startMessaging() - start");
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("startMessaging() - start");
         }
         if (isMessaging()) {
             return;
         }
         dispatcher = new MessageDispatcher();
-        dispatcherThread = new Thread(dispatcher);
+        Thread dispatcherThread = new Thread(dispatcher);
         dispatcherThread.setName("RHN Message Dispatcher");
         dispatcherThread.setDaemon(false);
         dispatcherThread.start();
-        if (logger.isDebugEnabled()) {
-            logger.debug("startMessaging() - end");
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("startMessaging() - end");
         }
     }
 
@@ -177,12 +170,12 @@ public class MessageQueue {
      * Stop the messaging system
      */
     public static synchronized void stopMessaging() {
-        if (logger.isDebugEnabled()) {
-            logger.debug("stopMessaging() - start");
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("stopMessaging() - start");
         }
         dispatcher.stop();
-        if (logger.isDebugEnabled()) {
-            logger.debug("stopMessaging() - end");
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("stopMessaging() - end");
         }
     }
 
@@ -200,8 +193,8 @@ public class MessageQueue {
      * @param eventType type of event.
      */
     public static void registerAction(MessageAction act, Class<? extends EventMessage> eventType) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("registerAction(MessageAction, Class) - : {} class: {}", act, eventType.getName());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("registerAction(MessageAction, Class) - : {} class: {}", act, eventType.getName());
         }
         synchronized (ACTIONS) {
             List<MessageAction> handlers = ACTIONS.computeIfAbsent(eventType, k -> new ArrayList<>());
@@ -215,15 +208,15 @@ public class MessageQueue {
      * @param eventType Type of event.
      */
     public static void deRegisterAction(MessageAction act, Class<? extends EventMessage> eventType) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("deRegisterAction(MessageAction, Class) - start");
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("deRegisterAction(MessageAction, Class) - start");
         }
         synchronized (ACTIONS) {
             List<MessageAction> handlers = ACTIONS.get(eventType);
             handlers.remove(act);
         }
-        if (logger.isDebugEnabled()) {
-            logger.debug("deRegisterAction(MessageAction, Class) - end");
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("deRegisterAction(MessageAction, Class) - end");
         }
     }
 
@@ -233,8 +226,8 @@ public class MessageQueue {
      * @return String[] array of registered events.
      */
     public static String[] getRegisteredEventNames() {
-        if (logger.isDebugEnabled()) {
-            logger.debug("getRegisteredEventNames() - start");
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("getRegisteredEventNames() - start");
         }
         String[] retval = null;
         synchronized (ACTIONS) {
@@ -248,8 +241,8 @@ public class MessageQueue {
             }
         }
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("getRegisteredEventNames() - end - null");
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("getRegisteredEventNames() - end - null");
         }
         return retval;
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/HubReportDbUpdateDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/HubReportDbUpdateDriver.java
@@ -42,17 +42,11 @@ public class HubReportDbUpdateDriver extends AbstractQueueDriver<MgrServerInfo> 
     private static Set<MgrServerInfo> currentMgrServerInfos = Collections.synchronizedSet(new HashSet<>());
     private Logger log;
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void setLogger(Logger loggerIn) {
         this.log = loggerIn;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Logger getLogger() {
         return log;
@@ -75,9 +69,6 @@ public class HubReportDbUpdateDriver extends AbstractQueueDriver<MgrServerInfo> 
         return new HashSet<>(mgrServerInfos);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public List<MgrServerInfo> getCandidates() {
         synchronized (currentMgrServerInfos) {
@@ -94,26 +85,17 @@ public class HubReportDbUpdateDriver extends AbstractQueueDriver<MgrServerInfo> 
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public int getMaxWorkers() {
         return Config.get()
                 .getInt(ConfigDefaults.REPORT_DB_HUB_WORKERS, 2);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public QueueWorker makeWorker(MgrServerInfo workItem) {
         return new HubReportDbUpdateWorker(log, workItem);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean isBlockingTaskQueue() {
         return true;

--- a/java/code/src/com/redhat/rhn/taskomatic/task/HubReportDbUpdateDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/HubReportDbUpdateDriver.java
@@ -115,22 +115,6 @@ public class HubReportDbUpdateDriver extends AbstractQueueDriver<MgrServerInfo> 
      * {@inheritDoc}
      */
     @Override
-    public boolean canContinue() {
-        return true;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void initialize() {
-        //empty
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public boolean isBlockingTaskQueue() {
         return true;
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/HubReportDbUpdateDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/HubReportDbUpdateDriver.java
@@ -18,7 +18,7 @@ import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.server.MgrServerInfo;
-import com.redhat.rhn.taskomatic.task.threaded.QueueDriver;
+import com.redhat.rhn.taskomatic.task.threaded.AbstractQueueDriver;
 import com.redhat.rhn.taskomatic.task.threaded.QueueWorker;
 
 import org.apache.logging.log4j.Logger;
@@ -37,7 +37,7 @@ import javax.persistence.criteria.CriteriaQuery;
 /**
  * Hub Reporting DB Task Driver
  */
-public class HubReportDbUpdateDriver implements QueueDriver<MgrServerInfo> {
+public class HubReportDbUpdateDriver extends AbstractQueueDriver<MgrServerInfo> {
 
     private static Set<MgrServerInfo> currentMgrServerInfos = Collections.synchronizedSet(new HashSet<>());
     private Logger log;

--- a/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataCacheDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataCacheDriver.java
@@ -34,9 +34,6 @@ public class ErrataCacheDriver extends AbstractQueueDriver<Task> {
 
     private Logger logger = null;
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public List<Task> getCandidates() {
         List<Task> tasks = TaskFactory.getTaskListByNameLike(ErrataCacheWorker.BY_CHANNEL);
@@ -47,33 +44,21 @@ public class ErrataCacheDriver extends AbstractQueueDriver<Task> {
         return tasks;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Logger getLogger() {
         return logger;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void setLogger(Logger loggerIn) {
         logger = loggerIn;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public int getMaxWorkers() {
         return Config.get().getInt("taskomatic.errata_cache_workers", 2);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public QueueWorker makeWorker(Task task) {
         return new ErrataCacheWorker(task, logger);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataCacheDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataCacheDriver.java
@@ -60,7 +60,7 @@ public class ErrataCacheDriver extends AbstractQueueDriver<Task> {
     }
 
     @Override
-    public QueueWorker makeWorker(Task task) {
+    protected QueueWorker makeWorker(Task task) {
         return new ErrataCacheWorker(task, logger);
     }
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataCacheDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataCacheDriver.java
@@ -17,7 +17,7 @@ package com.redhat.rhn.taskomatic.task.errata;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.domain.task.Task;
 import com.redhat.rhn.domain.task.TaskFactory;
-import com.redhat.rhn.taskomatic.task.threaded.QueueDriver;
+import com.redhat.rhn.taskomatic.task.threaded.AbstractQueueDriver;
 import com.redhat.rhn.taskomatic.task.threaded.QueueWorker;
 
 import org.apache.logging.log4j.Logger;
@@ -30,7 +30,7 @@ import java.util.Set;
 /**
  * Driver for the threaded errata cache update queue
  */
-public class ErrataCacheDriver implements QueueDriver<Task> {
+public class ErrataCacheDriver extends AbstractQueueDriver<Task> {
 
     private Logger logger = null;
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataCacheDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataCacheDriver.java
@@ -38,14 +38,6 @@ public class ErrataCacheDriver extends AbstractQueueDriver<Task> {
      * {@inheritDoc}
      */
     @Override
-    public boolean canContinue() {
-        return true;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public List<Task> getCandidates() {
         List<Task> tasks = TaskFactory.getTaskListByNameLike(ErrataCacheWorker.BY_CHANNEL);
         tasks.addAll(consolidateTasks(
@@ -88,14 +80,6 @@ public class ErrataCacheDriver extends AbstractQueueDriver<Task> {
     }
 
     /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void initialize() {
-        // empty
-    }
-
-    /**
      * Reduce a given list of tasks to a list with unique data fields. Data is either
      * a system id or a channel id depending on the type of tasks given in.
      *
@@ -111,13 +95,5 @@ public class ErrataCacheDriver extends AbstractQueueDriver<Task> {
             }
         }
         return consolidated;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean isBlockingTaskQueue() {
-        return false;
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataQueueDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataQueueDriver.java
@@ -35,7 +35,7 @@ public class ErrataQueueDriver extends AbstractQueueDriver<Map<String, Long>> {
     private Logger logger = null;
 
     @Override
-    public List<Map<String, Long>> getCandidates() {
+    protected List<Map<String, Long>> getCandidates() {
         SelectMode select = ModeFactory.getMode(TaskConstants.MODE_NAME,
                 TaskConstants.TASK_QUERY_ERRATA_QUEUE_FIND_CANDIDATES);
         try {
@@ -62,7 +62,7 @@ public class ErrataQueueDriver extends AbstractQueueDriver<Map<String, Long>> {
     }
 
     @Override
-    public QueueWorker makeWorker(Map<String, Long> workItem) {
+    protected QueueWorker makeWorker(Map<String, Long> workItem) {
         return new ErrataQueueWorker(workItem, logger);
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataQueueDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataQueueDriver.java
@@ -38,14 +38,6 @@ public class ErrataQueueDriver extends AbstractQueueDriver<Map<String, Long>> {
      * {@inheritDoc}
      */
     @Override
-    public boolean canContinue() {
-        return true;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public List<Map<String, Long>> getCandidates() {
         SelectMode select = ModeFactory.getMode(TaskConstants.MODE_NAME,
                 TaskConstants.TASK_QUERY_ERRATA_QUEUE_FIND_CANDIDATES);
@@ -87,22 +79,5 @@ public class ErrataQueueDriver extends AbstractQueueDriver<Map<String, Long>> {
     @Override
     public QueueWorker makeWorker(Map<String, Long> workItem) {
         return new ErrataQueueWorker(workItem, logger);
-    }
-
-    /**
-    *
-    * {@inheritDoc}
-    */
-    @Override
-    public void initialize() {
-        // empty
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean isBlockingTaskQueue() {
-        return false;
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataQueueDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataQueueDriver.java
@@ -19,7 +19,7 @@ import com.redhat.rhn.common.db.datasource.ModeFactory;
 import com.redhat.rhn.common.db.datasource.SelectMode;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.taskomatic.task.TaskConstants;
-import com.redhat.rhn.taskomatic.task.threaded.QueueDriver;
+import com.redhat.rhn.taskomatic.task.threaded.AbstractQueueDriver;
 import com.redhat.rhn.taskomatic.task.threaded.QueueWorker;
 
 import org.apache.logging.log4j.Logger;
@@ -30,7 +30,7 @@ import java.util.Map;
 /**
  * Driver for the threaded errata queue
  */
-public class ErrataQueueDriver implements QueueDriver<Map<String, Long>> {
+public class ErrataQueueDriver extends AbstractQueueDriver<Map<String, Long>> {
 
     private Logger logger = null;
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataQueueDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataQueueDriver.java
@@ -34,9 +34,6 @@ public class ErrataQueueDriver extends AbstractQueueDriver<Map<String, Long>> {
 
     private Logger logger = null;
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public List<Map<String, Long>> getCandidates() {
         SelectMode select = ModeFactory.getMode(TaskConstants.MODE_NAME,
@@ -49,33 +46,21 @@ public class ErrataQueueDriver extends AbstractQueueDriver<Map<String, Long>> {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void setLogger(Logger loggerIn) {
         logger = loggerIn;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Logger getLogger() {
         return logger;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public int getMaxWorkers() {
         return Config.get().getInt("taskomatic.errata_queue_workers", 2);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public QueueWorker makeWorker(Map<String, Long> workItem) {
         return new ErrataQueueWorker(workItem, logger);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataDriver.java
@@ -38,9 +38,6 @@ public class ChannelRepodataDriver extends AbstractQueueDriver<Map<String, Objec
 
     private Logger logger = null;
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void initialize() {
         WriteMode resetChannelRepodata = ModeFactory.getWriteMode(TaskConstants.MODE_NAME,
@@ -61,9 +58,6 @@ public class ChannelRepodataDriver extends AbstractQueueDriver<Map<String, Objec
         }
     }
 
-    /**
-     * @return Returns candidates
-     */
     @Override
     public List<Map<String, Object>> getCandidates() {
         SelectMode select = ModeFactory.getMode(TaskConstants.MODE_NAME,
@@ -77,35 +71,21 @@ public class ChannelRepodataDriver extends AbstractQueueDriver<Map<String, Objec
         return Collections.emptyList();
     }
 
-    /**
-     * @return Returns Logger
-     */
     @Override
     public Logger getLogger() {
         return logger;
     }
-
-    /**
-     * {@inheritDoc}
-     */
 
     @Override
     public void setLogger(Logger loggerIn) {
         logger = loggerIn;
     }
 
-    /**
-     * @return Returns max workers
-     */
     @Override
     public int getMaxWorkers() {
         return ConfigDefaults.get().getTaskoChannelRepodataWorkers();
     }
 
-    /**
-     * @param workItem work item
-     * @return Returns channel repodata worker object
-     */
     @Override
     public QueueWorker makeWorker(Map<String, Object> workItem) {
         return new ChannelRepodataWorker(workItem, getLogger());

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataDriver.java
@@ -62,14 +62,6 @@ public class ChannelRepodataDriver extends AbstractQueueDriver<Map<String, Objec
     }
 
     /**
-     * @return Returns boolean canContinue
-     */
-    @Override
-    public boolean canContinue() {
-        return true;
-    }
-
-    /**
      * @return Returns candidates
      */
     @Override
@@ -117,13 +109,5 @@ public class ChannelRepodataDriver extends AbstractQueueDriver<Map<String, Objec
     @Override
     public QueueWorker makeWorker(Map<String, Object> workItem) {
         return new ChannelRepodataWorker(workItem, getLogger());
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean isBlockingTaskQueue() {
-        return false;
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataDriver.java
@@ -59,7 +59,7 @@ public class ChannelRepodataDriver extends AbstractQueueDriver<Map<String, Objec
     }
 
     @Override
-    public List<Map<String, Object>> getCandidates() {
+    protected List<Map<String, Object>> getCandidates() {
         SelectMode select = ModeFactory.getMode(TaskConstants.MODE_NAME,
                 TaskConstants.TASK_QUERY_REPOMD_DRIVER_QUERY);
 
@@ -87,7 +87,7 @@ public class ChannelRepodataDriver extends AbstractQueueDriver<Map<String, Objec
     }
 
     @Override
-    public QueueWorker makeWorker(Map<String, Object> workItem) {
+    protected QueueWorker makeWorker(Map<String, Object> workItem) {
         return new ChannelRepodataWorker(workItem, getLogger());
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataDriver.java
@@ -20,7 +20,7 @@ import com.redhat.rhn.common.db.datasource.SelectMode;
 import com.redhat.rhn.common.db.datasource.WriteMode;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.taskomatic.task.TaskConstants;
-import com.redhat.rhn.taskomatic.task.threaded.QueueDriver;
+import com.redhat.rhn.taskomatic.task.threaded.AbstractQueueDriver;
 import com.redhat.rhn.taskomatic.task.threaded.QueueWorker;
 
 import org.apache.logging.log4j.Logger;
@@ -34,7 +34,7 @@ import java.util.Map;
  *
  *
  */
-public class ChannelRepodataDriver implements QueueDriver<Map<String, Object>> {
+public class ChannelRepodataDriver extends AbstractQueueDriver<Map<String, Object>> {
 
     private Logger logger = null;
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataWorker.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataWorker.java
@@ -97,6 +97,7 @@ public class ChannelRepodataWorker implements QueueWorker {
      */
     @Override
     public void run() {
+        logger.info("Starting worker for channel {}", channelLabelToProcess);
         // if a channel has a EnvironmentTarget associated, we update it too
         Optional<SoftwareEnvironmentTarget> envTarget = ContentProjectFactory
                 .lookupEnvironmentTargetByChannelLabel(channelLabelToProcess);
@@ -145,6 +146,7 @@ public class ChannelRepodataWorker implements QueueWorker {
             parentQueue.changeRun(null);
         }
         finally {
+            logger.info("Worker for channel {} has completed", channelLabelToProcess);
             parentQueue.workerDone();
             HibernateFactory.closeSession();
         }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshservice/SSHServiceDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshservice/SSHServiceDriver.java
@@ -28,7 +28,7 @@ import com.redhat.rhn.taskomatic.task.TaskConstants;
 import com.redhat.rhn.taskomatic.task.checkin.CheckinCandidatesResolver;
 import com.redhat.rhn.taskomatic.task.checkin.SystemCheckinUtils;
 import com.redhat.rhn.taskomatic.task.checkin.SystemSummary;
-import com.redhat.rhn.taskomatic.task.threaded.QueueDriver;
+import com.redhat.rhn.taskomatic.task.threaded.AbstractQueueDriver;
 import com.redhat.rhn.taskomatic.task.threaded.QueueWorker;
 
 import com.suse.manager.utils.SaltUtils;
@@ -47,7 +47,7 @@ import java.util.Set;
 /**
  * Provide services for salt ssh clients
  */
-public class SSHServiceDriver implements QueueDriver<SystemSummary> {
+public class SSHServiceDriver extends AbstractQueueDriver<SystemSummary> {
 
     // Synchronized set of systems we are currently talking to
     private static final Set<SystemSummary> CURRENT_SYSTEMS = Collections.synchronizedSet(new HashSet<>());

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshservice/SSHServiceDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshservice/SSHServiceDriver.java
@@ -91,7 +91,7 @@ public class SSHServiceDriver extends AbstractQueueDriver<SystemSummary> {
     }
 
     @Override
-    public List<SystemSummary> getCandidates() {
+    protected List<SystemSummary> getCandidates() {
         List<SystemSummary> candidates = new LinkedList<>();
 
         // Find Salt systems currently rebooting,
@@ -150,7 +150,7 @@ public class SSHServiceDriver extends AbstractQueueDriver<SystemSummary> {
     }
 
     @Override
-    public QueueWorker makeWorker(SystemSummary system) {
+    protected QueueWorker makeWorker(SystemSummary system) {
         return new SSHServiceWorker(getLogger(), system,
                 GlobalInstanceHolder.SALT_API,
                 GlobalInstanceHolder.SALT_API.getSaltSSHService(),

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshservice/SSHServiceDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshservice/SSHServiceDriver.java
@@ -179,14 +179,6 @@ public class SSHServiceDriver extends AbstractQueueDriver<SystemSummary> {
      * {@inheritDoc}
      */
     @Override
-    public boolean canContinue() {
-        return true;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public void setLogger(Logger loggerIn) {
         this.log = loggerIn;
     }
@@ -245,13 +237,5 @@ public class SSHServiceDriver extends AbstractQueueDriver<SystemSummary> {
         HashMap<String, Object> params = new HashMap<>();
         params.put("job_label", JOB_LABEL);
         return delete.executeUpdate(params);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean isBlockingTaskQueue() {
-        return false;
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshservice/SSHServiceDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshservice/SSHServiceDriver.java
@@ -71,9 +71,6 @@ public class SSHServiceDriver extends AbstractQueueDriver<SystemSummary> {
         return CURRENT_SYSTEMS;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void initialize() {
         this.checkinCandidatesResolver = new CheckinCandidatesResolver(
@@ -93,9 +90,6 @@ public class SSHServiceDriver extends AbstractQueueDriver<SystemSummary> {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public List<SystemSummary> getCandidates() {
         List<SystemSummary> candidates = new LinkedList<>();
@@ -155,9 +149,6 @@ public class SSHServiceDriver extends AbstractQueueDriver<SystemSummary> {
         return candidates;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public QueueWorker makeWorker(SystemSummary system) {
         return new SSHServiceWorker(getLogger(), system,
@@ -167,25 +158,16 @@ public class SSHServiceDriver extends AbstractQueueDriver<SystemSummary> {
                 GlobalInstanceHolder.SALT_UTILS);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public int getMaxWorkers() {
         return Config.get().getInt(WORKER_THREADS_KEY, Config.get().getInt("taskomatic.ssh_push_workers", 2));
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void setLogger(Logger loggerIn) {
         this.log = loggerIn;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Logger getLogger() {
         return log;

--- a/java/code/src/com/redhat/rhn/taskomatic/task/systems/SystemsOverviewUpdateDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/systems/SystemsOverviewUpdateDriver.java
@@ -43,7 +43,7 @@ public class SystemsOverviewUpdateDriver extends AbstractQueueDriver<Long> {
     }
 
     @Override
-    public List<Long> getCandidates() {
+    protected List<Long> getCandidates() {
         // Candidates are system IDs, deduplicated to avoid useless updates
         return TaskFactory.getTaskListByNameLike(TASK_NAME).stream()
             .map(task -> task.getData())
@@ -57,7 +57,7 @@ public class SystemsOverviewUpdateDriver extends AbstractQueueDriver<Long> {
     }
 
     @Override
-    public QueueWorker makeWorker(Long sid) {
+    protected QueueWorker makeWorker(Long sid) {
         return new SystemsOverviewUpdateWorker(sid, logger);
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/systems/SystemsOverviewUpdateDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/systems/SystemsOverviewUpdateDriver.java
@@ -16,7 +16,7 @@ package com.redhat.rhn.taskomatic.task.systems;
 
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.domain.task.TaskFactory;
-import com.redhat.rhn.taskomatic.task.threaded.QueueDriver;
+import com.redhat.rhn.taskomatic.task.threaded.AbstractQueueDriver;
 import com.redhat.rhn.taskomatic.task.threaded.QueueWorker;
 
 import org.apache.logging.log4j.Logger;
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 /**
  * Driver for the threaded system overview update queue
  */
-public class SystemsOverviewUpdateDriver implements QueueDriver<Long> {
+public class SystemsOverviewUpdateDriver extends AbstractQueueDriver<Long> {
 
     public static final String TASK_NAME = "update_system_overview";
     private Logger logger = null;

--- a/java/code/src/com/redhat/rhn/taskomatic/task/systems/SystemsOverviewUpdateDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/systems/SystemsOverviewUpdateDriver.java
@@ -60,19 +60,4 @@ public class SystemsOverviewUpdateDriver extends AbstractQueueDriver<Long> {
     public QueueWorker makeWorker(Long sid) {
         return new SystemsOverviewUpdateWorker(sid, logger);
     }
-
-    @Override
-    public boolean canContinue() {
-        return true;
-    }
-
-    @Override
-    public void initialize() {
-        // Empty
-    }
-
-    @Override
-    public boolean isBlockingTaskQueue() {
-        return false;
-    }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/ChannelRepodataTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/ChannelRepodataTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.taskomatic.task.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
+import com.redhat.rhn.manager.channel.ChannelManager;
+import com.redhat.rhn.taskomatic.TaskoFactory;
+import com.redhat.rhn.taskomatic.domain.TaskoRun;
+import com.redhat.rhn.taskomatic.domain.TaskoSchedule;
+import com.redhat.rhn.taskomatic.domain.TaskoTemplate;
+import com.redhat.rhn.taskomatic.task.ChannelRepodata;
+import com.redhat.rhn.taskomatic.task.RhnJob;
+import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
+
+import org.hibernate.type.IntegerType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.quartz.JobExecutionContext;
+
+import java.util.List;
+import java.util.function.BooleanSupplier;
+import java.util.stream.Collectors;
+
+public class ChannelRepodataTest extends JMockBaseTestCaseWithUser {
+
+    private JobExecutionContext jobContext;
+
+    private ChannelRepodata channelRepodata;
+
+    @BeforeEach
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        channelRepodata = new ChannelRepodata();
+        jobContext = mock(JobExecutionContext.class);
+    }
+
+    @AfterEach
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+
+        // Delete all the runs we created
+        TaskoFactory.listRunsByBunch("channel-repodata-bunch")
+            .forEach(TaskoFactory::deleteRun);
+    }
+
+    @Test
+    public void canProcessRepositoriesDataForChannel() throws Exception {
+        // A commit will happen in taskomatic, so we need to clean up everything in the end
+        commitHappened();
+
+        // Fill in the rhnRepoRegenQueue table to request the repodata generation execution
+        Channel testChannel = ChannelFactoryTest.createTestChannel(user);
+        ChannelManager.queueChannelChange(testChannel.getLabel(), "createchannel", "createchannel");
+
+        // Create the run for the task
+        TaskoRun firstRun = createTaskomaticTaskRun("channel-repodata-default", ChannelRepodata.class);
+        channelRepodata.execute(jobContext, firstRun);
+
+        // Wait for the worker to process the channel
+        assertConditionWithRetries("Channel has been processed", () -> isChannelProcessed(testChannel), 500, 10);
+
+        // Still the run we created should be in status RUNNING, as the driver is not blocking the task queue
+        firstRun = HibernateFactory.reload(firstRun);
+        assertEquals(TaskoRun.STATUS_RUNNING, firstRun.getStatus());
+        assertNull(firstRun.getEndTime());
+
+        // Subsequent run should mark the first run as FINISHED
+        TaskoRun secondRun = createTaskomaticTaskRun("channel-repodata-default", ChannelRepodata.class);
+        channelRepodata.execute(jobContext, secondRun);
+
+        firstRun = HibernateFactory.reload(firstRun);
+        secondRun = HibernateFactory.reload(secondRun);
+
+        assertEquals(TaskoRun.STATUS_SKIPPED, secondRun.getStatus());
+        assertEquals(TaskoRun.STATUS_FINISHED, firstRun.getStatus());
+        assertNotNull(firstRun.getEndTime());
+    }
+
+    private static boolean isChannelProcessed(Channel channel) {
+        Integer items = (Integer) HibernateFactory.getSession()
+            .createSQLQuery("SELECT COUNT(*) AS count FROM rhnRepoRegenQueue WHERE channel_label = :label")
+            .addScalar("count", IntegerType.INSTANCE)
+            .setParameter("label", channel.getLabel())
+            .getSingleResult();
+
+        return items == 0;
+    }
+
+    private static TaskoRun createTaskomaticTaskRun(String scheduleLabel, Class<? extends RhnJob> taskClass) {
+        List<TaskoSchedule> schedules = TaskoFactory.listScheduleByLabel(scheduleLabel);
+        assertEquals(1, schedules.size(), "Expected exactly one schedule with label " + scheduleLabel);
+
+        List<TaskoTemplate> templates = schedules.get(0).getBunch().getTemplates()
+            .stream()
+            .filter(template -> taskClass.getName().equals(template.getTask().getTaskClass()))
+            .collect(Collectors.toList());
+        assertEquals(1, templates.size(), "Expected exactly one template with task " + taskClass.getName());
+
+        TaskoRun taskoRun = new TaskoRun(null, templates.get(0), schedules.get(0).getId());
+        TaskoFactory.save(taskoRun);
+        return taskoRun;
+    }
+
+    private static void assertConditionWithRetries(String name, BooleanSupplier condition, long waitTime, int retries)
+        throws InterruptedException {
+        for (int i = 0; i < retries; i++) {
+            boolean result = condition.getAsBoolean();
+            if (result) {
+                return;
+            }
+
+            Thread.sleep(waitTime);
+        }
+
+        fail("Unable to verify condition '" + name + "' after " + retries + " attempt");
+    }
+
+}

--- a/java/code/src/com/redhat/rhn/taskomatic/task/threaded/AbstractQueueDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/threaded/AbstractQueueDriver.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.taskomatic.task.threaded;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+public abstract class AbstractQueueDriver<T> implements QueueDriver<T> {
+
+    private final Queue<T> workItemsQueue = new LinkedList<>();
+
+    @Override
+    public int fetchCandidates() {
+        workItemsQueue.addAll(getCandidates());
+        return workItemsQueue.size();
+    }
+
+    @Override
+    public boolean hasCandidates() {
+        return !workItemsQueue.isEmpty();
+    }
+
+    @Override
+    public QueueWorker nextWorker() {
+        T workItem = workItemsQueue.remove();
+        return makeWorker(workItem);
+    }
+
+    /**
+     * Retrieves the list of work items to "prime" the queue
+     * @return list of work items
+     */
+    protected abstract List<T> getCandidates();
+
+    /**
+     * Create a worker instance to work on a particular work item
+     * @param workItem object contained in the list returned from getCandidates()
+     * @return worker instance
+     */
+    protected abstract QueueWorker makeWorker(T workItem);
+}

--- a/java/code/src/com/redhat/rhn/taskomatic/task/threaded/QueueDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/threaded/QueueDriver.java
@@ -16,8 +16,6 @@ package com.redhat.rhn.taskomatic.task.threaded;
 
 import org.apache.logging.log4j.Logger;
 
-import java.util.List;
-
 /**
  * "Driver" for a work queue of worker threads
  * @param <T> type of the queue driver candidates
@@ -37,10 +35,16 @@ public interface QueueDriver<T> {
     Logger getLogger();
 
     /**
-     * List of work items to "prime" the queue
-     * @return list of work items
+     * Retrieves the work items and "prime" the queue
+     * @return the number of work items fetched
      */
-    List<T> getCandidates();
+    int fetchCandidates();
+
+    /**
+     * Check if the queue has additional work item candidates
+     * @return true if work items are available in the queue
+     */
+    boolean hasCandidates();
 
     /**
      * Maximum number of worker threads to run
@@ -49,11 +53,10 @@ public interface QueueDriver<T> {
     int getMaxWorkers();
 
     /**
-     * Create a worker instance to work on a particular work item
-     * @param workItem object contained in the list returned from getCandidates()
+     * Create a worker instance to work on the next work item of the queue
      * @return worker instance
      */
-    QueueWorker makeWorker(T workItem);
+    QueueWorker nextWorker();
 
     /**
      * Logic to tell the queue when to stop running

--- a/java/code/src/com/redhat/rhn/taskomatic/task/threaded/QueueDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/threaded/QueueDriver.java
@@ -64,12 +64,16 @@ public interface QueueDriver<T> {
      * This method can return false to cause the queue to stop early.
      * @return true if processing can continue, otherwise false
      */
-    boolean canContinue();
+    default boolean canContinue() {
+        return true;
+    }
 
     /**
      * Actions that has to be executed, when queue is created
      */
-    void initialize();
+    default void initialize() {
+        // Do nothing by default
+    }
 
     /**
      * Specify if this is a blocking worker thread

--- a/java/code/src/com/redhat/rhn/taskomatic/task/threaded/TaskQueue.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/threaded/TaskQueue.java
@@ -29,12 +29,12 @@ import java.util.concurrent.TimeUnit;
  */
 public class TaskQueue {
 
+    private final byte[] emptyQueueWait = new byte[0];
     private final String queueName;
     private QueueDriver queueDriver;
     private ThreadPoolExecutor executor = null;
     private int executingWorkers = 0;
     private int queueSize = 0;
-    private byte[] emptyQueueWait = new byte[0];
     private boolean taskQueueDone = true;
     private TaskoRun queueRun = null;
 
@@ -149,6 +149,7 @@ public class TaskQueue {
                 waitForEmptyQueue();
             }
             catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 queueDriver.getLogger().error(e.getMessage(), e);
                 HibernateFactory.commitTransaction();
                 HibernateFactory.closeSession();
@@ -182,10 +183,9 @@ public class TaskQueue {
      */
     public void waitForEmptyQueue() throws InterruptedException {
         synchronized (emptyQueueWait) {
-            if (queueSize == 0) {
-                return;
+            while (queueSize != 0) {
+                emptyQueueWait.wait();
             }
-            emptyQueueWait.wait();
         }
     }
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/threaded/TaskQueue.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/threaded/TaskQueue.java
@@ -17,7 +17,6 @@ package com.redhat.rhn.taskomatic.task.threaded;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.taskomatic.domain.TaskoRun;
 
-import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -117,14 +116,12 @@ public class TaskQueue {
     public void run() {
         shutdownExecutor();
         BlockingQueue<Runnable> workers = new LinkedBlockingQueue<>();
-        List<?> candidates = queueDriver.getCandidates();
-        queueSize += candidates.size();
+        queueSize += queueDriver.fetchCandidates();
         if (queueSize > 0) {
             queueDriver.getLogger().info("In the queue: {}", queueSize);
         }
-        while (!candidates.isEmpty() && queueDriver.canContinue()) {
-            Object candidate = candidates.remove(0);
-            QueueWorker worker = queueDriver.makeWorker(candidate);
+        while (queueDriver.hasCandidates() && queueDriver.canContinue()) {
+            QueueWorker worker = queueDriver.nextWorker();
             worker.setParentQueue(this);
             try {
                 queueDriver.getLogger().debug("Putting worker");

--- a/java/code/src/com/redhat/rhn/taskomatic/task/threaded/TaskQueueFactory.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/threaded/TaskQueueFactory.java
@@ -68,7 +68,7 @@ public class TaskQueueFactory {
         synchronized (queues) {
             retval = queues.get(name);
             if (retval == null) {
-                retval = new TaskQueue();
+                retval = new TaskQueue(name);
                 QueueDriver<?> driver = driverClass.getDeclaredConstructor().newInstance();
                 driver.setLogger(loggerIn);
                 driver.initialize();

--- a/java/code/src/com/redhat/rhn/taskomatic/task/threaded/TaskThreadFactory.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/threaded/TaskThreadFactory.java
@@ -15,20 +15,36 @@
 package com.redhat.rhn.taskomatic.task.threaded;
 
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * ThreadFactory impl for Taskomatic
  */
 public class TaskThreadFactory implements ThreadFactory {
 
+    private final AtomicInteger threadNumberSequence = new AtomicInteger(0);
+
+    private final String queueName;
+
+    /**
+     * Create a thread factory
+     * @param queueNameIn the name of the queue
+     */
+    public TaskThreadFactory(String queueNameIn) {
+        this.queueName = queueNameIn;
+    }
+
     /**
      * {@inheritDoc}
      */
     @Override
     public Thread newThread(Runnable task) {
-        Thread retval = new Thread(task);
-        retval.setDaemon(true);
-        return retval;
+        int taskNumber = threadNumberSequence.incrementAndGet();
+
+        Thread thread = new Thread(task);
+        thread.setName("TaskQueue-" + queueName + "-" + taskNumber);
+        thread.setDaemon(true);
+        return thread;
     }
 
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/threaded/TaskThreadFactory.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/threaded/TaskThreadFactory.java
@@ -14,7 +14,7 @@
  */
 package com.redhat.rhn.taskomatic.task.threaded;
 
-import EDU.oswego.cs.dl.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadFactory;
 
 /**
  * ThreadFactory impl for Taskomatic

--- a/java/licenses/concurrent.txt
+++ b/java/licenses/concurrent.txt
@@ -1,1 +1,0 @@
-Public domain as specified on http://gee.cs.oswego.edu/dl/classes/EDU/oswego/cs/dl/util/concurrent/intro.html

--- a/java/spacewalk-java.changes.mackdk.drop-concurrent
+++ b/java/spacewalk-java.changes.mackdk.drop-concurrent
@@ -1,0 +1,1 @@
+- Removed concurrent dependency

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -93,7 +93,6 @@ BuildRequires:  mvn(net.bytebuddy:byte-buddy-dep) >= 1.14
 BuildRequires:  c3p0 >= 0.9.1
 BuildRequires:  cglib
 BuildRequires:  classmate
-BuildRequires:  concurrent
 BuildRequires:  dom4j
 BuildRequires:  dwr >= 3
 BuildRequires:  glassfish-activation
@@ -182,7 +181,6 @@ Requires:       c3p0 >= 0.9.1
 Requires:       cglib
 Requires:       classmate
 Requires:       cobbler
-Requires:       concurrent
 Requires:       dwr >= 3
 Requires:       glassfish-activation
 Requires:       glassfish-jaxb-api
@@ -363,7 +361,6 @@ Requires:       c3p0 >= 0.9.1
 Requires:       cglib
 Requires:       classmate
 Requires:       cobbler
-Requires:       concurrent
 Requires:       hibernate-commons-annotations
 Requires:       httpcomponents-client
 Requires:       httpcomponents-core


### PR DESCRIPTION
## What does this PR change?

This PR removes the dependency on concurrent since those APIs have been part of standard java since version 1.5. This PR also improves the `QueueDriver` interface and decouple the handling logic so that `TaskQueue` no longer requires knowledge of the `QueueDriver` implementation details.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests" (Test skipped, there are no changes to test)
