### PR TITLE
Fix conversion to string if branchid is numeric in PXEEvent

### DIFF
--- a/java/code/src/com/suse/manager/saltboot/PXEEvent.java
+++ b/java/code/src/com/suse/manager/saltboot/PXEEvent.java
@@ -59,7 +59,7 @@ public class PXEEvent {
     }
 
     public String getSaltbootGroup() {
-        return (String)data.get("minion_id_prefix");
+        return String.valueOf(data.get("minion_id_prefix"));
     }
 
     public String getRoot() {

--- a/java/code/src/com/suse/manager/saltboot/test/PXEEventTest.java
+++ b/java/code/src/com/suse/manager/saltboot/test/PXEEventTest.java
@@ -67,6 +67,8 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
     private static final String SALTBOOT_FORMULA = "formula-saltboot";
     private static final String BOOT_IMAGE = "POS_Image_JeOS7-7.0.0-1";
     private static final String SALTBOOT_GROUP = "groupPrefix";
+    private static final String MAC_ADDRESS = "00:11:22:33:44:55";
+
 
     @Override
     @BeforeEach
@@ -97,11 +99,11 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
         MockConnection.clear();
     }
 
-    private Map<String, Object> createTestData(String minionId, String saltbootGroup, String root, String saltDevice,
+    private Map<String, Object> createTestData(String minionId, Object saltbootGroup, String root, String saltDevice,
                                   String bootImage, String kernelOptions, boolean includeMACs) {
         Map<String, Object> data = new HashMap<>();
         Map<String, Object> innerData = new HashMap<>();
-        if (!saltbootGroup.isEmpty()) {
+        if (saltbootGroup != null) {
             innerData.put("minion_id_prefix", saltbootGroup);
         }
         if (!root.isEmpty()) {
@@ -118,7 +120,7 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
         }
         if (includeMACs) {
             Map<String, Object> hwAddrs = new HashMap<>();
-            hwAddrs.put("eth1", "00:11:22:33:44:55");
+            hwAddrs.put("eth1", MAC_ADDRESS);
             hwAddrs.put("lo", "00:00:00:00:00:00");
             innerData.put("hwaddr_interfaces", hwAddrs);
         }
@@ -177,7 +179,7 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
             assertEquals(BOOT_IMAGE, e.getBootImage());
             // Localhost device should be parsed out
             assertEquals(1, e.getHwAddresses().size());
-            assertEquals(e.getHwAddresses().get(0), "00:11:22:33:44:55");
+            assertEquals(MAC_ADDRESS, e.getHwAddresses().get(0));
         });
     }
 
@@ -287,7 +289,7 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
             assertEquals(BOOT_IMAGE, e.getBootImage());
             // Localhost device should be parsed out
             assertEquals(1, e.getHwAddresses().size());
-            assertEquals(e.getHwAddresses().get(0), "00:11:22:33:44:55");
+            assertEquals(MAC_ADDRESS, e.getHwAddresses().get(0));
         });
     }
 
@@ -317,7 +319,39 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
             assertEquals(BOOT_IMAGE, e.getBootImage());
             // Localhost device should be parsed out
             assertEquals(1, e.getHwAddresses().size());
-            assertEquals(e.getHwAddresses().get(0), "00:11:22:33:44:55");
+            assertEquals(MAC_ADDRESS, e.getHwAddresses().get(0));
+        });
+    }
+
+    /**
+     * Tests parsing {@link PXEEvent} when branch id is numeric
+     */
+    @Test
+    public void testParseBranchIdIsNumeric() {
+        Event event = mock(Event.class);
+        Integer branchId = 12345;
+        Map<String, Object> data = createTestData(MINION_ID, branchId, "root=/dev/sda1",
+                "/dev/sda1", BOOT_IMAGE, "custom=option", true);
+        context().checking(new Expectations() {{
+            allowing(event).getTag();
+            will(returnValue("suse/manager/pxe_update"));
+            allowing(event).getData();
+            will(returnValue(data));
+        }});
+
+        Optional<PXEEvent> parsed = PXEEvent.parse(event);
+
+        assertTrue(parsed.isPresent());
+        parsed.ifPresent(e -> {
+            assertEquals(MINION_ID, e.getMinionId());
+            assertEquals(String.valueOf(branchId), e.getSaltbootGroup());
+            assertEquals("root=/dev/sda1", e.getRoot());
+            assertEquals(Optional.of("/dev/sda1"), e.getSaltDevice());
+            assertEquals(Optional.of("custom=option"), e.getKernelParameters());
+            assertEquals(BOOT_IMAGE, e.getBootImage());
+            // Localhost device should be parsed out
+            assertEquals(1, e.getHwAddresses().size());
+            assertEquals(MAC_ADDRESS, e.getHwAddresses().get(0));
         });
     }
 

--- a/java/spacewalk-java.changes.oholecek.pxe_event_branchid_fix
+++ b/java/spacewalk-java.changes.oholecek.pxe_event_branchid_fix
@@ -1,0 +1,1 @@
+- Fix conversion to string if branchid is numeric in PXEEvent


### PR DESCRIPTION
## What does this PR change?

Backport of https://github.com/SUSE/spacewalk/pull/22746

When retail branch id is numeric only, json data in salt event are serialized to the Double instead of String and we need explicit conversion. This PR adds it.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Fixes #
Tracks https://github.com/SUSE/spacewalk/pull/22746

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
