### PR TITLE
QE: Rename Fake Base Channel and Fake Child Channel to fix ambiguity issues

### DIFF
--- a/testsuite/features/github_validation/init_clients/sle_minion.feature
+++ b/testsuite/features/github_validation/init_clients/sle_minion.feature
@@ -21,7 +21,7 @@ Feature: Bootstrap a Salt minion via the GUI
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "Fake-Base-Channel"
+    And I check radio button "Fake-Base-Channel-SUSE-like"
     And I wait until I do not see "Loading..." text
     And I check "Fake-RPM-SUSE-Channel"
     And I click on "Next"

--- a/testsuite/features/github_validation/init_clients/sle_ssh_minion.feature
+++ b/testsuite/features/github_validation/init_clients/sle_ssh_minion.feature
@@ -23,7 +23,7 @@ Feature: Bootstrap a Salt host managed via salt-ssh
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "Fake-Base-Channel"
+    And I check radio button "Fake-Base-Channel-SUSE-like"
     And I wait until I do not see "Loading..." text
     And I check "Fake-RPM-SUSE-Channel"
     And I click on "Next"

--- a/testsuite/features/init_clients/min_rhlike_salt.feature
+++ b/testsuite/features/init_clients/min_rhlike_salt.feature
@@ -44,7 +44,7 @@ Feature: Bootstrap a Red Hat-like minion and do some basic operations on it
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "Fake-Base-Channel"
+    And I check radio button "Fake-Base-Channel-SUSE-like"
     And I wait until I do not see "Loading..." text
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text

--- a/testsuite/features/reposync/srv_create_fake_channels.feature
+++ b/testsuite/features/reposync/srv_create_fake_channels.feature
@@ -31,26 +31,26 @@ Feature: Create fake channels
   Scenario: Add a fake base channel for x86_64
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
-    And I enter "Fake-Base-Channel" as "Channel Name"
-    And I enter "fake-base-channel" as "Channel Label"
+    And I enter "Fake-Base-Channel-SUSE-like" as "Channel Name"
+    And I enter "fake-base-channel-suse-like" as "Channel Label"
     And I select "None" from "Parent Channel"
     And I select "x86_64" from "Architecture:"
     And I enter "Base channel for testing" as "Channel Summary"
     And I enter "No more description for base channel." as "Channel Description"
     And I click on "Create Channel"
-    Then I should see a "Channel Fake-Base-Channel created." text
+    Then I should see a "Channel Fake-Base-Channel-SUSE-like created." text
 
   Scenario: Add a fake child channel into the fake base channel x86_64
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
-    And I enter "Fake-Child-Channel" as "Channel Name"
-    And I enter "fake_child_channel" as "Channel Label"
-    And I select "Fake-Base-Channel" from "Parent Channel"
+    And I enter "Fake-Child-Channel-SUSE-like" as "Channel Name"
+    And I enter "fake-child-channel-suse-like" as "Channel Label"
+    And I select "Fake-Base-Channel-SUSE-like" from "Parent Channel"
     And I select "x86_64" from "Architecture:"
     And I enter "Child channel for testing" as "Channel Summary"
-    And I enter "Description for Fake Child Channel." as "Channel Description"
+    And I enter "Description for Fake Child Channel SUSE like." as "Channel Description"
     And I click on "Create Channel"
-    Then I should see a "Channel Fake-Child-Channel created." text
+    Then I should see a "Channel Fake-Child-Channel-SUSE-like created." text
 
 @sle_minion
   Scenario: Add a SUSE fake child channel to the SUSE Product base channel

--- a/testsuite/features/secondary/allcli_software_channels.feature
+++ b/testsuite/features/secondary/allcli_software_channels.feature
@@ -19,12 +19,12 @@ Feature: Channel subscription via SSM
     And I follow "channel memberships" in the content area
     Then I should see a "Base Channel" text
     And I should see a "Next" text
-    When I select "Fake-Base-Channel" from drop-down in table line with "SLE-Product-SLES15-SP4-Pool for x86_64"
+    When I select "Fake-Base-Channel-SUSE-like" from drop-down in table line with "SLE-Product-SLES15-SP4-Pool for x86_64"
     And I click on "Next"
     Then I should see a "Child Channels" text
-    And I should see a "Fake-Base-Channel" text
+    And I should see a "Fake-Base-Channel-SUSE-like" text
     And I should see a "1 system(s) to subscribe" text
-    When I choose radio button "Subscribe" for child channel "Fake-Child-Channel"
+    When I choose radio button "Subscribe" for child channel "Fake-Child-Channel-SUSE-like"
     And I click on "Next"
     Then I should see a "Channel Changes Overview" text
     And I should see a "1 system(s) to subscribe" text
@@ -45,12 +45,12 @@ Feature: Channel subscription via SSM
     And I follow "channel memberships" in the content area
     Then I should see a "Base Channel" text
     And I should see a "Next" text
-    When I select "Fake-Base-Channel" from drop-down in table line with "openSUSE Leap 15.5 (x86_64)"
+    When I select "Fake-Base-Channel-SUSE-like" from drop-down in table line with "openSUSE Leap 15.5 (x86_64)"
     And I click on "Next"
     Then I should see a "Child Channels" text
-    And I should see a "Fake-Base-Channel" text
+    And I should see a "Fake-Base-Channel-SUSE-like" text
     And I should see a "1 system(s) to subscribe" text
-    When I choose radio button "Subscribe" for child channel "Fake-Child-Channel"
+    When I choose radio button "Subscribe" for child channel "Fake-Child-Channel-SUSE-like"
     And I click on "Next"
     Then I should see a "Channel Changes Overview" text
     And I should see a "1 system(s) to subscribe" text
@@ -111,24 +111,24 @@ Feature: Channel subscription via SSM
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    Then radio button "Fake-Base-Channel" should be checked
+    Then radio button "Fake-Base-Channel-SUSE-like" should be checked
     And I wait until I do not see "Loading..." text
-    And I should see "Fake-Child-Channel" as checked
+    And I should see "Fake-Child-Channel-SUSE-like" as checked
 
 @sle_minion
 @susemanager
   Scenario: Check the new channels are enabled on the SLES minion
     When I refresh the metadata for "sle_minion"
     Then "2" channels should be enabled on "sle_minion"
-    And channel "Fake-Base-Channel" should be enabled on "sle_minion"
-    And channel "Fake-Child-Channel" should be enabled on "sle_minion"
+    And channel "Fake-Base-Channel-SUSE-like" should be enabled on "sle_minion"
+    And channel "Fake-Child-Channel-SUSE-like" should be enabled on "sle_minion"
 
 @uyuni
   Scenario: Check the new channels are enabled on the SLES minion
     When I refresh the metadata for "sle_minion"
     Then "2" channels should be enabled on "sle_minion"
-    And channel "Fake-Base-Channel" should be enabled on "sle_minion"
-    And channel "Fake-Child-Channel" should be enabled on "sle_minion"
+    And channel "Fake-Base-Channel-SUSE-like" should be enabled on "sle_minion"
+    And channel "Fake-Child-Channel-SUSE-like" should be enabled on "sle_minion"
 
 @rhlike_minion
   Scenario: System default channel can't be determined on the Red Hat-like minion
@@ -138,7 +138,7 @@ Feature: Channel subscription via SSM
     Then I should see "1" systems selected for SSM
     When I follow the left menu "Systems > System Set Manager > Overview"
     And I follow "channel memberships" in the content area
-    And I select "System Default Base Channel" from drop-down in table line with "Fake-Base-Channel"
+    And I select "System Default Base Channel" from drop-down in table line with "Fake-Base-Channel-SUSE-like"
     And I click on "Next"
     Then I should see a "Child Channels" text
     And I should see a "Couldn't determine new base channel" text
@@ -158,7 +158,7 @@ Feature: Channel subscription via SSM
     Given I am on the Systems overview page of this "rhlike_minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
-    Then radio button "Fake-Base-Channel" should be checked
+    Then radio button "Fake-Base-Channel-SUSE-like" should be checked
 
 @deblike_minion
   Scenario: System default channel can't be determined on the Debian-like minion

--- a/testsuite/features/secondary/min_recurring_action.feature
+++ b/testsuite/features/secondary/min_recurring_action.feature
@@ -145,9 +145,9 @@ Feature: Recurring Actions
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "Fake-Base-Channel"
+    And I check radio button "Fake-Base-Channel-SUSE-like"
     And I wait until I do not see "Loading..." text
-    And I check "Fake-Child-Channel"
+    And I check "Fake-Child-Channel-SUSE-like"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"

--- a/testsuite/features/secondary/min_rhlike_openscap_audit.feature
+++ b/testsuite/features/secondary/min_rhlike_openscap_audit.feature
@@ -87,7 +87,7 @@ Feature: OpenSCAP audit of Red Hat-like Salt minion
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "Fake-Base-Channel"
+    And I check radio button "Fake-Base-Channel-SUSE-like"
     And I wait until I do not see "Loading..." text
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text

--- a/testsuite/features/secondary/min_rhlike_ssh.feature
+++ b/testsuite/features/secondary/min_rhlike_ssh.feature
@@ -61,7 +61,7 @@ Feature: Bootstrap a SSH-managed Red Hat-like minion and do some basic operation
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "Fake-Base-Channel"
+    And I check radio button "Fake-Base-Channel-SUSE-like"
     And I wait until I do not see "Loading..." text
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
@@ -117,7 +117,7 @@ Feature: Bootstrap a SSH-managed Red Hat-like minion and do some basic operation
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "Fake-Base-Channel"
+    And I check radio button "Fake-Base-Channel-SUSE-like"
     And I wait until I do not see "Loading..." text
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text

--- a/testsuite/features/secondary/srv_content_lifecycle.feature
+++ b/testsuite/features/secondary/srv_content_lifecycle.feature
@@ -139,9 +139,9 @@ Feature: Content lifecycle
     Then I should see a "Build (0)" text
     When I click on "Attach/Detach Sources"
     And I uncheck "Vendors"
-    And I add the "Fake-Base-Channel" channel to sources
+    And I add the "Fake-Base-Channel-SUSE-like" channel to sources
     And I click on "Save"
-    Then I wait until I see "Fake-Base-Channel" text
+    Then I wait until I see "Fake-Base-Channel-SUSE-like" text
     And I wait until I see "Build (1)" text
     And I should see a "Version 2: (draft - not built) - Check the changes below" text
     When I click on "Build (1)"
@@ -171,12 +171,12 @@ Feature: Content lifecycle
 @susemanager
   Scenario: Cleanup: remove the created channels
     When I delete these channels with spacewalk-remove-channel:
-      |clp_label-prod_label-fake-base-channel|
-      |clp_label-prod_label-sle-product-sles15-sp4-updates-x86_64|
-      |clp_label-qa_label-fake-base-channel|
-      |clp_label-qa_label-sle-product-sles15-sp4-updates-x86_64|
-      |clp_label-dev_label-fake-base-channel|
-      |clp_label-dev_label-sle-product-sles15-sp4-updates-x86_64|
+      | clp_label-prod_label-fake-base-channel-suse-like           |
+      | clp_label-prod_label-sle-product-sles15-sp4-updates-x86_64 |
+      | clp_label-qa_label-fake-base-channel-suse-like             |
+      | clp_label-qa_label-sle-product-sles15-sp4-updates-x86_64   |
+      | clp_label-dev_label-fake-base-channel-suse-like            |
+      | clp_label-dev_label-sle-product-sles15-sp4-updates-x86_64|
     And I delete these channels with spacewalk-remove-channel:
       |clp_label-prod_label-sle-product-sles15-sp4-pool-x86_64|
       |clp_label-qa_label-sle-product-sles15-sp4-pool-x86_64|
@@ -187,11 +187,11 @@ Feature: Content lifecycle
 @uyuni
   Scenario: Cleanup: remove the created channels
     When I delete these channels with spacewalk-remove-channel:
-      | clp_label-prod_label-fake-base-channel        |
-      | clp_label-prod_label-opensuse_leap15_5-x86_64 |
-      | clp_label-qa_label-fake-base-channel          |
-      | clp_label-qa_label-opensuse_leap15_5-x86_64   |
-      | clp_label-dev_label-fake-base-channel         |
-      | clp_label-dev_label-opensuse_leap15_5-x86_64  |
+      | clp_label-prod_label-fake-base-channel-suse-like |
+      | clp_label-prod_label-opensuse_leap15_5-x86_64    |
+      | clp_label-qa_label-fake-base-channel-suse-like   |
+      | clp_label-qa_label-opensuse_leap15_5-x86_64      |
+      | clp_label-dev_label-fake-base-channel-suse-like  |
+      | clp_label-dev_label-opensuse_leap15_5-x86_64     |
     And I list channels with spacewalk-remove-channel
     Then I shouldn't get "clp_label"

--- a/testsuite/features/secondary/srv_delete_channel_from_ui.feature
+++ b/testsuite/features/secondary/srv_delete_channel_from_ui.feature
@@ -8,7 +8,7 @@
 # If the deletion of "Clone of Fake-RPM-SUSE-Channel" fails, these features will have failing scenarios.
 # - features/secondary/srv_dist_channel_mapping.feature
 # - features/secondary/srv_patches_page.feature
-# If the deletion of "Clone of Fake-Base-Channel" fails, these features will have failing scenarios.
+# If the deletion of "Clone of Fake-Base-Channel-SUSE-like" fails, these features will have failing scenarios.
 
 @scope_configuration_channels
 Feature: Delete channels with child or clone is not allowed
@@ -21,39 +21,39 @@ Feature: Delete channels with child or clone is not allowed
   Scenario: Clone the first channel before deletion from UI test
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Clone Channel"
-    And I select "Fake-Base-Channel" as the origin channel
+    And I select "Fake-Base-Channel-SUSE-like" as the origin channel
     And I click on "Clone Channel"
     Then I should see a "Create Software Channel" text
     And I should see a "Current state of the channel" text
     When I click on "Clone Channel"
-    Then I should see a "Clone of Fake-Base-Channel" text
+    Then I should see a "Clone of Fake-Base-Channel-SUSE-like" text
 
   Scenario: Clone the second channel using first channel as base
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Clone Channel"
-    And I select "Clone of Fake-Base-Channel" as the origin channel
+    And I select "Clone of Fake-Base-Channel-SUSE-like" as the origin channel
     And I click on "Clone Channel"
     Then I should see a "Create Software Channel" text
     And I should see a "Current state of the channel" text
     When I click on "Clone Channel"
-    Then I should see a "Clone of Clone of Fake-Base-Channel" text
+    Then I should see a "Clone of Clone of Fake-Base-Channel-SUSE-like" text
 
   Scenario: Try to delete channel with clone
     When I follow the left menu "Software > Manage > Channels"
-    And I follow "Clone of Fake-Base-Channel"
+    And I follow "Clone of Fake-Base-Channel-SUSE-like"
     And I follow "Delete software channel"
     And I check "unsubscribeSystems"
     And I click on "Delete Channel"
-    Then I should see a "Clone of Fake-Base-Channel" text
+    Then I should see a "Clone of Fake-Base-Channel-SUSE-like" text
     And I should see a "Unable to delete channel" text
 
   Scenario: Delete channel without clones neither children
     When I follow the left menu "Software > Manage > Channels"
-    And I follow "Clone of Clone of Fake-Base-Channel"
+    And I follow "Clone of Clone of Fake-Base-Channel-SUSE-like"
     And I follow "Delete software channel"
     And I check "unsubscribeSystems"
     And I click on "Delete Channel"
-    Then I should see a "Clone of Clone of Fake-Base-Channel" text
+    Then I should see a "Clone of Clone of Fake-Base-Channel-SUSE-like" text
     And I should see a "has been deleted" text
 
   Scenario: Clone a child channel to the clone of x86_64 test channel
@@ -63,17 +63,17 @@ Feature: Delete channels with child or clone is not allowed
     And I click on "Clone Channel"
     Then I should see a "Create Software Channel" text
     And I should see a "Current state of the channel" text
-    When I select "Clone of Fake-Base-Channel" from "Parent Channel"
+    When I select "Clone of Fake-Base-Channel-SUSE-like" from "Parent Channel"
     And I click on "Clone Channel"
     Then I should see a "Clone of Fake-RPM-SUSE-Channel" text
 
   Scenario: Try delete channel with child
     When I follow the left menu "Software > Manage > Channels"
-    And I follow "Clone of Fake-Base-Channel"
+    And I follow "Clone of Fake-Base-Channel-SUSE-like"
     And I follow "Delete software channel"
     And I check "unsubscribeSystems"
     And I click on "Delete Channel"
-    Then I should see a "Clone of Fake-Base-Channel" text
+    Then I should see a "Clone of Fake-Base-Channel-SUSE-like" text
     And I should see a "channel has child channels associated" text
     And I should see a "must delete those channels first before deleting the parent." text
 
@@ -88,9 +88,9 @@ Feature: Delete channels with child or clone is not allowed
 
   Scenario: Cleanup: remove cloned parent channel
     When I follow the left menu "Software > Manage > Channels"
-    And I follow "Clone of Fake-Base-Channel"
+    And I follow "Clone of Fake-Base-Channel-SUSE-like"
     And I follow "Delete software channel"
     And I check "unsubscribeSystems"
     And I click on "Delete Channel"
-    Then I should see a "Clone of Fake-Base-Channel" text
+    Then I should see a "Clone of Fake-Base-Channel-SUSE-like" text
     And I should see a "has been deleted." text

--- a/testsuite/features/secondary/srv_dist_channel_mapping.feature
+++ b/testsuite/features/secondary/srv_dist_channel_mapping.feature
@@ -104,7 +104,7 @@ Feature: Distribution Channel Mapping
     And I select "Fake-Base-Channel-Debian-like" from "channel_label" dropdown
     And I click on "Update Mapping"
     Then I should see the text "Ubuntu 22.04.01 LTS modified" in the Operating System field
-    And I should see the text "fake-base-channel" in the Channel Label field
+    And I should see the text "fake-base-channel-suse-like" in the Channel Label field
 
 @scc_credentials
   Scenario: Update map for IA-32 SUSE clients using amd deb test channel

--- a/testsuite/features/secondary/srv_manage_channels_page.feature
+++ b/testsuite/features/secondary/srv_manage_channels_page.feature
@@ -13,14 +13,14 @@ Feature: Managing channels
   Scenario: Fail when trying to add a duplicate channel
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
-    And I enter "Fake-Base-Channel" as "Channel Name"
-    And I enter "fake-base-channel" as "Channel Label"
+    And I enter "Fake-Base-Channel-SUSE-like" as "Channel Name"
+    And I enter "fake-base-channel-suse-like" as "Channel Label"
     And I select "None" from "Parent Channel"
     And I select "x86_64" from "Architecture:"
     And I enter "Base channel for testing" as "Channel Summary"
     And I enter "No more desdcription for base channel." as "Channel Description"
     And I click on "Create Channel"
-    Then I should see a "The channel name 'Fake-Base-Channel' is already in use, please enter a different name" text
+    Then I should see a "The channel name 'Fake-Base-Channel-SUSE-like' is already in use, please enter a different name" text
 
   Scenario: Fail when trying to use invalid characters in the channel label
     When I follow the left menu "Software > Manage > Channels"

--- a/testsuite/features/secondary/srv_patches_page.feature
+++ b/testsuite/features/secondary/srv_patches_page.feature
@@ -80,7 +80,7 @@ Feature: Patches page
     And I should see a "Test Topic" text
     And I should see a "Test Description" text
     And I should see a "Test Solution" text
-    And I should see a "Fake-Base-Channel" link
+    And I should see a "Fake-Base-Channel-SUSE-like" link
     And I should see a "Test Summary" link
     And I should see a "keywords, test" text
     And I should see a "Test Reference" text
@@ -88,7 +88,7 @@ Feature: Patches page
 
   Scenario: Assert that patch is now in test base channel
     When I follow the left menu "Software > Channel List > All"
-    And I follow "Fake-Base-Channel"
+    And I follow "Fake-Base-Channel-SUSE-like"
     And I follow "Patches" in the content area
     Then I should see a "Test Patch" text
 

--- a/testsuite/features/secondary/srv_push_package.feature
+++ b/testsuite/features/secondary/srv_push_package.feature
@@ -11,12 +11,12 @@ Feature: Push a package with unset vendor
 
   Scenario: Push a package with unset vendor
     When I copy unset package file on server
-    And I push package "/root/subscription-tools-1.0-0.noarch.rpm" into "fake-base-channel" channel
-    Then I should see package "subscription-tools-1.0-0.noarch" in channel "Fake-Base-Channel"
+    And I push package "/root/subscription-tools-1.0-0.noarch.rpm" into "fake-base-channel-suse-like" channel
+    Then I should see package "subscription-tools-1.0-0.noarch" in channel "Fake-Base-Channel-SUSE-like"
 
   Scenario: Check vendor of package displayed in web UI
     When I follow the left menu "Software > Channel List > All"
-    And I follow "Fake-Base-Channel"
+    And I follow "Fake-Base-Channel-SUSE-like"
     And I follow "Packages"
     And I follow "subscription-tools-1.0-0.noarch"
     Then I should see a "Vendor:" text

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -594,7 +594,7 @@ Then(/^I should see an update in the list$/) do
 end
 
 When(/^I check test channel$/) do
-  step 'I check "Fake-Base-Channel" in the list'
+  step 'I check "Fake-Base-Channel-SUSE-like" in the list'
 end
 
 When(/^I check "([^"]*)" patch$/) do |arg1|

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -331,10 +331,10 @@ BASE_CHANNEL_BY_CLIENT = { 'SUSE Manager' =>
                             },
                            'Fake' =>
                              {
-                               'sle_minion' => 'Fake-Base-Channel',
-                               'pxeboot_minion' => 'Fake-Base-Channel',
-                               'proxy' => 'Fake-Base-Channel',
-                               'buildhost' => 'Fake-Base-Channel'
+                               'sle_minion' => 'Fake-Base-Channel-SUSE-like',
+                               'pxeboot_minion' => 'Fake-Base-Channel-SUSE-like',
+                               'proxy' => 'Fake-Base-Channel-SUSE-like',
+                               'buildhost' => 'Fake-Base-Channel-SUSE-like'
                              } }.freeze
 
 # Used for creating activation keys
@@ -358,7 +358,7 @@ LABEL_BY_BASE_CHANNEL = { 'SUSE Manager' =>
                             'SLE-Micro-5.3-Pool for x86_64' => 'sle-micro-5.3-pool-x86_64',
                             'SLE-Micro-5.4-Pool for x86_64' => 'sle-micro-5.4-pool-x86_64',
                             'almalinux9 for x86_64' => 'no-appstream-alma-9-result-almalinux9-x86_64',
-                            'Fake-Base-Channel' => 'fake-base-channel',
+                            'Fake-Base-Channel-SUSE-like' => 'fake-base-channel-suse-like',
                             'RHEL x86_64 Server 7' => 'rhel-x86_64-server-7',
                             'EL9-Pool for x86_64' => 'no-appstream-liberty-9-result-el9-pool-x86_64',
                             'oraclelinux9 for x86_64' => 'no-appstream-oracle-9-result-oraclelinux9-x86_64',
@@ -388,7 +388,7 @@ LABEL_BY_BASE_CHANNEL = { 'SUSE Manager' =>
                             'SLE-Micro-5.3-Pool for x86_64' => 'sle-micro-5.3-pool-x86_64',
                             'SLE-Micro-5.4-Pool for x86_64' => 'sle-micro-5.4-pool-x86_64',
                             'AlmaLinux 9 (x86_64)' => 'no-appstream-alma-9-result-almalinux9-x86_64',
-                            'Fake-Base-Channel' => 'fake-base-channel',
+                            'Fake-Base-Channel-SUSE-like' => 'fake-base-channel-suse-like',
                             'CentOS 7 (x86_64)' => 'centos7-x86_64',
                             'EL9-Pool for x86_64' => 'no-appstream-liberty-9-result-el9-pool-x86_64',
                             'Oracle Linux 9 (x86_64)' => 'no-appstream-oracle-9-result-oraclelinux9-x86_64',
@@ -422,7 +422,7 @@ CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = { 'SUSE Manager' =>
                                             'SLE-Micro-5.3-Pool for x86_64' => 'SLE-MICRO-5.3-x86_64',
                                             'SLE-Micro-5.4-Pool for x86_64' => 'SLE-MICRO-5.4-x86_64',
                                             'almalinux9 for x86_64' => 'almalinux-9-x86_64',
-                                            'Fake-Base-Channel' => 'fake-base-channel-x86_64',
+                                            'Fake-Base-Channel-SUSE-like' => 'fake-base-channel-suse-like',
                                             'RHEL x86_64 Server 7' => 'RES7-x86_64',
                                             'EL9-Pool for x86_64' => 'SUSE-LibertyLinux9-x86_64',
                                             'oraclelinux9 for x86_64' => 'oracle-9-x86_64',
@@ -452,7 +452,7 @@ CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = { 'SUSE Manager' =>
                                             'SLE-Micro-5.3-Pool for x86_64' => 'SLE-MICRO-5.3-x86_64',
                                             'SLE-Micro-5.4-Pool for x86_64' => 'SLE-MICRO-5.4-x86_64',
                                             'AlmaLinux 9 (x86_64)' => 'almalinux-9-x86_64-uyuni',
-                                            'Fake-Base-Channel' => 'fake-base-channel-x86_64',
+                                            'Fake-Base-Channel-SUSE-like' => 'fake-base-channel-suse-like',
                                             'CentOS 7 (x86_64)' => 'centos-7-x86_64-uyuni',
                                             'EL9-Pool for x86_64' => 'SUSE-LibertyLinux9-x86_64',
                                             'Oracle Linux 9 (x86_64)' => 'oracle-9-x86_64-uyuni',
@@ -877,8 +877,8 @@ CHANNEL_TO_SYNCH_BY_OS_PRODUCT_VERSION = {
     ],
   'fake' =>
     %w[
-      fake-base-channel
-      fake_child_channel
+      fake-base-channel-suse-like
+      fake-child-channel-suse-like
       fake-base-channel-i586
       fake-child-channel-i586
       test-base-channel-x86_64


### PR DESCRIPTION
## What does this PR change?

Rename Fake Base Channel and Fake Child Channel to fix ambiguity issues

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
