### PR TITLE
QE: Fix log file extraction scenario

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -465,8 +465,8 @@ When(/^I extract the log files from all our active nodes$/) do
   rescue StandardError
     # Catch exceptions silently
   end
-  $node_by_host.each do |_host, node|
-    next if node.nil?
+  $node_by_host.each do |host, node|
+    next if node.nil? || %w[salt_migration_minion localhost *-ctl].include?(host)
 
     STDOUT.puts "Node: #{node.full_hostname}"
     extract_logs_from_node(node)

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -209,11 +209,7 @@ def extract_logs_from_node(node)
   os_family = node.os_family
   node.run('zypper --non-interactive install tar') if os_family =~ /^opensuse/ && !$is_container_provider
   node.run('journalctl > /var/log/messages', check_errors: false)
-  if node.full_hostname.include?('-srv')
-    node.run('salt-call --local grains.items | tee -a /var/log/salt_grains', verbose: true, check_errors: false)
-  else
-    node.run('venv-salt-call --local grains.items | tee -a /var/log/salt_grains', verbose: true, check_errors: false)
-  end
+  node.run('venv-salt-call --local grains.items | tee -a /var/log/salt_grains', verbose: true, check_errors: false) unless $host_by_node[node] == 'server'
   node.run("tar cfvJP /tmp/#{node.full_hostname}-logs.tar.xz /var/log/ || [[ $? -eq 1 ]]")
   `mkdir logs` unless Dir.exist?('logs')
   code = file_extract(node, "/tmp/#{node.full_hostname}-logs.tar.xz", "logs/#{node.full_hostname}-logs.tar.xz")

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -209,7 +209,11 @@ def extract_logs_from_node(node)
   os_family = node.os_family
   node.run('zypper --non-interactive install tar') if os_family =~ /^opensuse/ && !$is_container_provider
   node.run('journalctl > /var/log/messages', check_errors: false)
-  node.run('venv-salt-call --local grains.items | tee -a /var/log/salt_grains', verbose: true, check_errors: false)
+  if node.full_hostname.include?('-srv')
+    node.run('salt-call --local grains.items | tee -a /var/log/salt_grains', verbose: true, check_errors: false)
+  else
+    node.run('venv-salt-call --local grains.items | tee -a /var/log/salt_grains', verbose: true, check_errors: false)
+  end
   node.run("tar cfvJP /tmp/#{node.full_hostname}-logs.tar.xz /var/log/ || [[ $? -eq 1 ]]")
   `mkdir logs` unless Dir.exist?('logs')
   code = file_extract(node, "/tmp/#{node.full_hostname}-logs.tar.xz", "logs/#{node.full_hostname}-logs.tar.xz")


### PR DESCRIPTION
## What does this PR change?

This fixes our `Extract the logs from all our clients` scenario.
![image](https://github.com/uyuni-project/uyuni/assets/12104291/8ae9d839-2ec3-45a9-88b4-d4100e005cc7)
![image](https://github.com/uyuni-project/uyuni/assets/12104291/d4e76039-179c-41a6-abdf-38224d3026c7)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links

- Manager 4.3: 
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
