### PR TITLE
Fix the evaluation of mgr_install_flavor_check in openSUSE

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/packages/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/init.sls
@@ -2,7 +2,7 @@ include:
   - util.syncstates
   - .packages_{{ grains['machine_id'] }}
 
-{%- if grains['os_family'] == 'Suse' and grains['osmajorrelease']|int > 11 and not grains['oscodename'] == 'openSUSE Leap 15.3'%}
+{%- if grains['os_family'] == 'Suse' and grains['osmajorrelease']|int > 11 and not grains['oscodename'] == 'openSUSE Leap 15.3' %}
 mgr_install_products:
   product.all_installed:
     - refresh: True
@@ -15,7 +15,7 @@ mgr_install_products:
 {%- endif %}
 {%- endif %}
 
-{%- if grains['os_family'] == 'Suse' and grains['instance_id'] is defined and "opensuse" not in grains['oscodename']|lower%}
+{%- if grains['os_family'] == 'Suse' and grains['instance_id'] is defined and "openSUSE" not in grains['oscodename'] %}
 {# install flavor check tool in cloud instances to be able to detect payg instances #}
 mgr_install_flavor_check:
   pkg.installed:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.obarrios.fix-mgr_install_flavor_check-salt-state-for-opensuse
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.obarrios.fix-mgr_install_flavor_check-salt-state-for-opensuse
@@ -1,0 +1,1 @@
+- Fix the evaluation of mgr_install_flavor_check salt state for openSUSE


### PR DESCRIPTION
## What does this PR change?

The evaluation of the salt state mgr_install_flavor_check was incorrect in our GH acceptance tests, where we deploy in a container an openSUSE 15.5 Salt minion.
This PR aims to fix it by removing the change to lowercase, being more explicit in the evaluation.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Ports:
- Manager-4.3 https://github.com/SUSE/spacewalk/pull/23007

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
