### PR TITLE
fix SLE-Micro PAYG detection

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygAuthDataExtractor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygAuthDataExtractor.java
@@ -56,7 +56,7 @@ public class PaygAuthDataExtractor {
         .create();
 
     public enum OsSpecificExtractor {
-        SLES_EXTRACTOR("SLES", "sudo python3", "script/payg_extract_repo_data.py"),
+        SLES_EXTRACTOR("SLE", "sudo python3", "script/payg_extract_repo_data.py"),
         RHEL_EXTRACTOR("RHEL", "sudo /usr/libexec/platform-python", "script/rhui_extract_repo_data.py"),
         RHEL7_EXTRACTOR("RHEL7", "sudo python", "script/rhui7_extract_repo_data.py");
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/payg/script/detect_os.sh
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/payg/script/detect_os.sh
@@ -5,7 +5,9 @@
 MAJ_VER=$(echo $VERSION_ID | awk -F. '{print $1}')
 
 if [ $ID == "sles" -a $MAJ_VER -ge 12 ]; then
-  echo "SLES"
+  echo "SLE"
+elif [ $ID == "sle-micro" -a $MAJ_VER -ge 5 ]; then
+  echo "SLE"
 elif [ $ID == "rhel" -a  $MAJ_VER -ge 8 ]; then
   echo "RHEL"
 elif [ $ID == "rhel" ]; then

--- a/java/spacewalk-java.changes.mc.Manager-4.3-sle-micro-payg-os-detection
+++ b/java/spacewalk-java.changes.mc.Manager-4.3-sle-micro-payg-os-detection
@@ -1,0 +1,1 @@
+- fix SLE-Micro PAYG detection


### PR DESCRIPTION
## What does this PR change?

PAYG Connection feature has a os detection to differentiate between SLES, RHEL 7, 8 and 9.
SLE-Micro does not match the SLES detection. This PR fix this and will perform the same detection as on SLES.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **add explanation**

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/23014

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
