### PR TITLE
Scope off VSCode editor settings, update outdated spec

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,13 @@
 {
     "typescript.tsdk": "./web/html/src/node_modules/typescript/lib",
-    "editor.tabSize": 2,
-    "files.insertFinalNewline": true,
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint",
-    "editor.formatOnSave": true,
-    // Only run Prettier if the configuration is properly resolved
-    "prettier.requireConfig": true
+    "[javascript][javascriptreact][typescript][typescriptreact][json][jsonc][css][less][scss][html]": {
+        "editor.tabSize": 2,
+        "files.insertFinalNewline": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.formatOnSave": true,
+    },
+    "css.lint.emptyRules": "ignore",
+    "less.lint.emptyRules": "ignore",
+    "scss.lint.emptyRules": "ignore",
+    "prettier.requireConfig": true,
 }


### PR DESCRIPTION
## What does this PR change?

See title.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: devtools

- [x] **DONE**

## Test coverage
- No tests: devtools

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/pull/7820#discussion_r1392350207

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
