### PR TITLE
Improve web client logging

### DIFF
--- a/java/code/src/com/suse/scc/client/SCCWebClient.java
+++ b/java/code/src/com/suse/scc/client/SCCWebClient.java
@@ -173,16 +173,16 @@ public class SCCWebClient implements SCCClient {
             throws SCCClientException {
 
         PaginatedResult<List<T>> firstPage = request(endpoint, SCCClientUtils.toListType(resultType), "GET");
-        LOG.info("Pages: {}", firstPage.numPages);
+        LOG.info("GET: {}{} Pages: {}", config.getUrl(), endpoint, firstPage.numPages);
 
         List<CompletableFuture<PaginatedResult<List<T>>>> futures = Stream.iterate(2, i -> i + 1)
                 .limit(Math.max(0, firstPage.numPages - 1)).map(pageNum -> {
             String e = endpoint + "?page=" + pageNum;
             CompletableFuture<PaginatedResult<List<T>>> get = CompletableFuture.supplyAsync(() -> {
                 try {
-                    LOG.info("Start Page: {}", pageNum);
+                    LOG.debug("Start Page: {}", pageNum);
                     PaginatedResult<List<T>> page = request(e, SCCClientUtils.toListType(resultType), "GET");
-                    LOG.info("End Page: {}", pageNum);
+                    LOG.debug("End Page: {}", pageNum);
                     return page;
                 }
                 catch (SCCClientException e1) {
@@ -225,7 +225,7 @@ public class SCCWebClient implements SCCClient {
         HttpDelete request = new HttpDelete(url);
         addHeaders(request);
         BufferedReader streamReader = null;
-        LOG.debug("Send DELETE to {}", url);
+        LOG.info("Send DELETE to {}", url);
 
         try {
             // Connect and parse the response on success
@@ -268,8 +268,8 @@ public class SCCWebClient implements SCCClient {
         Map<String, List<SCCUpdateSystemJson>> payload = Map.of("systems", systems);
         request.setEntity(new StringEntity(gson.toJson(payload), ContentType.APPLICATION_JSON));
 
+        LOG.info("Send PUT to {}{}", config.getUrl(), "/connect/organizations/systems");
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Send PUT to {}", config.getUrl() + "/connect/organizations/systems");
             LOG.debug(gson.toJson(payload));
         }
 
@@ -307,8 +307,8 @@ public class SCCWebClient implements SCCClient {
         Map<String, Collection<SCCRegisterSystemJson>> payload = Map.of("systems", systems);
         request.setEntity(new StringEntity(gson.toJson(payload), ContentType.APPLICATION_JSON));
 
+        LOG.info("Send PUT to {}{}", config.getUrl(), "/connect/organizations/systems");
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Send PUT to {}", config.getUrl() + "/connect/organizations/systems");
             LOG.debug(gson.toJson(payload));
         }
 
@@ -350,8 +350,8 @@ public class SCCWebClient implements SCCClient {
         request.setEntity(new StringEntity(gson.toJson(Map.of("virtualization_hosts", virtHostInfo)),
                 ContentType.APPLICATION_JSON));
 
+        LOG.info("Send PUT to {}{}", config.getUrl(), "/connect/organizations/virtualization_hosts");
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Send PUT to {}", config.getUrl() + "/connect/organizations/virtualization_hosts");
             LOG.debug(gson.toJson(Map.of("virtualization_hosts", virtHostInfo)));
         }
 

--- a/java/code/src/com/suse/scc/client/SCCWebClient.java
+++ b/java/code/src/com/suse/scc/client/SCCWebClient.java
@@ -86,7 +86,7 @@ public class SCCWebClient implements SCCClient {
      *
      * @param <T> the generic type
      */
-    private class PaginatedResult<T> {
+    private static class PaginatedResult<T> {
 
         /** The result. */
         private final T result;
@@ -178,7 +178,7 @@ public class SCCWebClient implements SCCClient {
         List<CompletableFuture<PaginatedResult<List<T>>>> futures = Stream.iterate(2, i -> i + 1)
                 .limit(Math.max(0, firstPage.numPages - 1)).map(pageNum -> {
             String e = endpoint + "?page=" + pageNum;
-            CompletableFuture<PaginatedResult<List<T>>> get = CompletableFuture.supplyAsync(() -> {
+            return CompletableFuture.supplyAsync(() -> {
                 try {
                     LOG.debug("Start Page: {}", pageNum);
                     PaginatedResult<List<T>> page = request(e, SCCClientUtils.toListType(resultType), "GET");
@@ -189,11 +189,10 @@ public class SCCWebClient implements SCCClient {
                     throw new RuntimeException(e1);
                 }
             }, executor);
-            return get;
         }).collect(Collectors.toList());
 
         CompletableFuture<Void> voidCompletableFuture = CompletableFuture.allOf(
-                futures.toArray(new CompletableFuture[futures.size()]));
+                futures.toArray(new CompletableFuture[0]));
         voidCompletableFuture.join();
         return Stream.concat(
                 Stream.of(firstPage),


### PR DESCRIPTION
## What does this PR change?

Improve logging for SCC Web Client. Log URLs in info level and more data in debug.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue https://github.com/SUSE/spacewalk/issues/22943

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
