### PR TITLE
Use https to access the API in spacewalk-common-channels and mgr-sync

### DIFF
--- a/susemanager/src/mgr_sync/config.py
+++ b/susemanager/src/mgr_sync/config.py
@@ -44,7 +44,7 @@ class Config(object):
         self._config = ConfigObj()
         self._config[Config.USER] = ''
         self._config[Config.PASSWORD] = ''
-        self._config[Config.HOST] = socket.getfqdn()
+        self._config[Config.HOST] = "localhost"
         self._config[Config.PORT] = 80
         self._config[Config.URI] = "/rpc/api"
         self._config[Config.TOKEN] = ''

--- a/susemanager/src/mgr_sync/mgr_sync.py
+++ b/susemanager/src/mgr_sync/mgr_sync.py
@@ -42,9 +42,16 @@ class MgrSync(object):  # pylint: disable=too-few-public-methods
 
     def __init__(self):
         self.config = Config()
-        url = "http://{0}:{1}{2}".format(self.config.host,
-                                         self.config.port,
-                                         self.config.uri)
+
+        # Use http on localhost by default to avoid hairpins when running in kubernetes
+        scheme = "http"
+        if self.config.host not in ["localhost", "127.0.0.1"]:
+            scheme = "https"
+            self.config.port = 443
+        url = "{0}://{1}:{2}{3}".format(scheme,
+                                        self.config.host,
+                                        self.config.port,
+                                        self.config.uri)
         self.conn = xmlrpc_client.ServerProxy(url)
         self.auth = Authenticator(connection=self.conn,
                                   user=self.config.user,

--- a/susemanager/susemanager.changes.cbosdo.https-tools-fix
+++ b/susemanager/susemanager.changes.cbosdo.https-tools-fix
@@ -1,0 +1,1 @@
+- Use http for localhost and https for other FQDN

--- a/utils/spacewalk-common-channels
+++ b/utils/spacewalk-common-channels
@@ -110,7 +110,9 @@ class ExtOptionParser(OptionParser):
 
 
 def connect(user, password, server):
-    server_url = "http://%s/rpc/api" % server
+    server_url = "https://%s/rpc/api" % server
+    if server in ["localhost", "127.0.0.1"]:
+        server_url = "http://%s/rpc/api" % server
 
     if options.verbose and options.verbose > 2:
         client_verbose = options.verbose - 2

--- a/utils/spacewalk-utils.changes.cbosdo.https-tools-fix
+++ b/utils/spacewalk-utils.changes.cbosdo.https-tools-fix
@@ -1,0 +1,2 @@
+- Use http for localhost and https for other FQDN: 
+  spacewalk-common-channels


### PR DESCRIPTION
## What does this PR change?

In some cases the http port seems not available for the XML-RPC API. Use `http://localhost:80` by default for those tools and https when using the server's FQDN.

Using `localhost` helps reducing the possible hairpins when running in a container environment.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: tools defaults, partly covered by e2e tests

- [X] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/5565

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
