### PR TITLE
Use SLES instead of Leap for Uyuni test since support is not ready ye…

### DIFF
--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -35,18 +35,17 @@ Feature: PXE boot a terminal with Cobbler
     And I click on "Apply Highstate"
     And I wait until event "Apply highstate scheduled by admin" is completed
 
-  @susemanager
   Scenario: Install TFTP boot package on the server
     When I install package tftpboot-installation on the server
     And I wait for "tftpboot-installation-SLE-15-SP4-x86_64" to be installed on "server"
 
-  @uyuni
-  Scenario: Install TFTP boot package on the server
-    When I install package tftpboot-installation on the server
-    And I wait for "tftpboot-installation-openSUSE-Leap-15.5-x86_64" to be installed on "server"
-
 # TODO: use this code when we start testing Cobbler with Leap
-#@uyuni
+#  @susemanager
+#  Scenario: Install TFTP boot package on the server
+#    When I install package tftpboot-installation on the server
+#    And I wait for "tftpboot-installation-SLE-15-SP4-x86_64" to be installed on "server"
+#
+# @uyuni
 # Scenario: Install TFTP boot package on the server
 #   When I install package tftpboot-installation on the server
 #   And I wait for "tftpboot-installation-openSUSE-Leap-15.5-x86_64" to be installed on "server"
@@ -150,15 +149,20 @@ Feature: PXE boot a terminal with Cobbler
     And I click on "Delete Distribution"
     Then I should not see a "SLE-15-SP4-TFTP" text
 
-  @susemanager
-  Scenario: Cleanup: Remove the TFTP boot package from the server
-    When I remove package "tftpboot-installation-SLE-15-SP4-x86_64" from this "server" without error control
-    And I wait for "tftpboot-installation-SLE-15-SP4-x86_64" to be uninstalled on "server"
+   Scenario: Cleanup: Remove TFTP boot package on the server
+    When I remove package tftpboot-installation from the server
+    Then "tftpboot-installation-SLE-15-SP4-x86_64" should not be installed on "server"
 
-  @uyuni
-  Scenario: Cleanup: Remove the TFTP boot package from the server
-    When I remove package "tftpboot-installation-openSUSE-Leap-15.5-x86_64" from this "server" without error control
-    And I wait for "tftpboot-installation-openSUSE-Leap-15.5-x86_64" to be uninstalled on "server"
+# TODO: use this code when we start testing Cobbler with Leap
+#  @susemanager
+#  Scenario: Cleanup: Remove the TFTP boot package from the server
+#    When I remove package "tftpboot-installation-SLE-15-SP4-x86_64" from this "server" without error control
+#    And I wait for "tftpboot-installation-SLE-15-SP4-x86_64" to be uninstalled on "server"
+#
+#  @uyuni
+#  Scenario: Cleanup: Remove the TFTP boot package from the server
+#    When I remove package "tftpboot-installation-openSUSE-Leap-15.5-x86_64" from this "server" without error control
+#    And I wait for "tftpboot-installation-openSUSE-Leap-15.5-x86_64" to be uninstalled on "server"
 
   Scenario: Cleanup: delete the PXE boot minion
     Given I navigate to the Systems overview page of this "pxeboot_minion"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -914,7 +914,14 @@ When(/^I install package tftpboot-installation on the server$/) do
   server = get_target('server')
   os_version = server.os_version
   if product == 'Uyuni'
-    server.run("zypper --non-interactive install tftpboot-installation-openSUSE-Leap-#{os_version}-x86_64", check_errors: false, verbose: true)
+    # TODO Remove the following rpm installation of SLES in Uyuni when we switch to Leap and switch to the zypper command
+    # server.run("zypper --non-interactive install tftpboot-installation-openSUSE-Leap-#{os_version}-x86_64", check_errors: false, verbose: true)
+    output, _code = server.run('find /var/spacewalk/packages -name tftpboot-installation-SLE-15-SP4-x86_64-*.noarch.rpm')
+    packages = output.split("\n")
+    pattern = '/tftpboot-installation-([^/]+)*.noarch.rpm'
+    # Reverse sort the package name to get the latest version first and install it
+    package = packages.min { |a, b| b.match(pattern)[0] <=> a.match(pattern)[0] }
+    server.run("rpm -i #{package}", check_errors: false)
   else
     output, _code = server.run('find /var/spacewalk/packages -name tftpboot-installation-SLE-15-SP4-x86_64-*.noarch.rpm')
     packages = output.split("\n")
@@ -922,6 +929,28 @@ When(/^I install package tftpboot-installation on the server$/) do
     # Reverse sort the package name to get the latest version first and install it
     package = packages.min { |a, b| b.match(pattern)[0] <=> a.match(pattern)[0] }
     server.run("rpm -i #{package}", check_errors: false)
+  end
+end
+
+When(/^I remove package tftpboot-installation from the server$/) do
+  server = get_target('server')
+  os_version = server.os_version
+  if product == 'Uyuni'
+    # TODO Remove the following rpm uninstallation of SLES in Uyuni when we switch to Leap and switch to the zypper command
+    # server.run("zypper --non-interactive remove tftpboot-installation-openSUSE-Leap-#{os_version}-x86_64", check_errors: false, verbose: true)
+    output, _code = server.run('find /var/spacewalk/packages -name tftpboot-installation-SLE-15-SP4-x86_64-*.noarch.rpm')
+    packages = output.split("\n")
+    pattern = '/tftpboot-installation-([^/]+)*.noarch.rpm'
+    # Reverse sort the package name to get the latest version first and install it
+    package = packages.min { |a, b| b.match(pattern)[0] <=> a.match(pattern)[0] }
+    server.run("rpm -e #{package}", check_errors: false)
+  else
+    output, _code = server.run('find /var/spacewalk/packages -name tftpboot-installation-SLE-15-SP4-x86_64-*.noarch.rpm')
+    packages = output.split("\n")
+    pattern = '/tftpboot-installation-([^/]+)*.noarch.rpm'
+    # Reverse sort the package name to get the latest version first and install it
+    package = packages.min { |a, b| b.match(pattern)[0] <=> a.match(pattern)[0] }
+    server.run("rpm -e #{package}", check_errors: false)
   end
 end
 


### PR DESCRIPTION
…t for TFTP

## What does this PR change?

Fixes test to use SLES rpm for TFTP instead of Leap since we still expect SLES paths in the Autoinstallation profile etc. Leap support is not ready yet. We have to wait to switch to Leap.

This is still a draft it reduces the red tests but doesn't fix the feature and there needs a fix in the cleanup of the rpm to reduce another at least. 

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes not exactly this https://github.com/SUSE/spacewalk/issues/18970 but reduces the red tests in that feature.
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
