### PR TITLE
remove static rolled back by a different PR

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
@@ -489,7 +489,7 @@ public class DownloadController {
      * @return the token
      */
     @SuppressWarnings({"javasecurity:S5145"}) // controlled by log level
-    private static String getTokenFromRequest(Request request) {
+    private String getTokenFromRequest(Request request) {
         Set<String> queryParams = request.queryParams();
         if (LOG.isDebugEnabled()) {
             LOG.debug("URL: {}", request.url());


### PR DESCRIPTION
## What does this PR change?

My PR made the methods not static. A second PR rolled it back by accident and created this syntax error.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fix syntax error introduced by https://github.com/uyuni-project/uyuni/pull/7885

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
