### PR TITLE
QE: Fix child channels synchronization

### DIFF
--- a/testsuite/features/reposync/srv_create_fake_channels.feature
+++ b/testsuite/features/reposync/srv_create_fake_channels.feature
@@ -3,7 +3,7 @@
 #
 # This feature can cause failures in:
 # - features/reposync/srv_create_activationkey.feature
-# - features/core/srv_create_fake_repositories.feature
+# - features/reposync/srv_create_fake_repositories.feature
 # - features/init_client/sle_minion.feature
 # - features/init_client/sle_ssh_minion.feature
 # - features/init_client/min_rhlike.feature

--- a/testsuite/features/reposync/srv_create_fake_repositories.feature
+++ b/testsuite/features/reposync/srv_create_fake_repositories.feature
@@ -44,14 +44,14 @@ Feature: Create fake repositories for each fake child channel
 
   Scenario: Add the fake RPM repository to the Test child channel
     When I follow the left menu "Software > Manage > Channels"
-    And I follow "Test-Base-Channel-x86_64"
+    And I follow "Test-Child-Channel-x86_64"
     And I enter "file:///etc/pki/rpm-gpg/uyuni-tools-gpg-pubkey-0d20833e.key" as "GPG key URL"
     And I click on "Update Channel"
-    Then I should see a "Channel Test-Base-Channel-x86_64 updated" text
+    Then I should see a "Channel Test-Child-Channel-x86_64 updated" text
     When I follow "Repositories" in the content area
     And I select the "fake-rpm-repo" repo
     And I click on "Save Repositories"
-    Then I should see a "Test-Base-Channel-x86_64 repository information was successfully updated" text
+    Then I should see a "Test-Child-Channel-x86_64 repository information was successfully updated" text
 
 @rhlike_minion
   Scenario: Add the fake RPM repository to the RedHat-like base channel
@@ -76,14 +76,23 @@ Feature: Create fake repositories for each fake child channel
 
   Scenario: Add the repository to the i586 channel
     When I follow the left menu "Software > Manage > Channels"
-    And I follow "Fake-Base-Channel-i586"
+    And I follow "Fake-Child-Channel-i586"
     And I enter "file:///etc/pki/rpm-gpg/uyuni-tools-gpg-pubkey-0d20833e.key" as "GPG key URL"
     And I click on "Update Channel"
-    Then I should see a "Channel Fake-Base-Channel-i586 updated" text
+    Then I should see a "Channel Fake-Child-Channel-i586 updated" text
     When I follow "Repositories" in the content area
     And I select the "fake-i586-repo" repo
     And I click on "Save Repositories"
-    Then I should see a "Fake-Base-Channel-i586 repository information was successfully updated" text
+    Then I should see a "Fake-Child-Channel-i586 repository information was successfully updated" text
+
+@sle_minion
+  Scenario: Add the repository to the SUSE-like child channel
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Fake-Child-Channel-SUSE-like"
+    And I follow "Repositories" in the content area
+    And I select the "fake-rpm-repo" repo
+    And I click on "Save Repositories"
+    Then I should see a "Fake-Child-Channel-SUSE-like repository information was successfully updated" text
 
 @deblike_minion
   Scenario: Create a fake repository for Debian-like

--- a/testsuite/features/reposync/srv_sync_fake_channels.feature
+++ b/testsuite/features/reposync/srv_sync_fake_channels.feature
@@ -46,16 +46,39 @@ Feature: Synchronize fake channels
     Then I should see a "Repository sync scheduled for Test-Base-Channel-x86_64." text
     And I wait until the channel "test-base-channel-x86_64" has been synced
 
-  Scenario: Synchronize Fake-Base-Channel-i586 channel
+  Scenario: Synchronize Fake-Child-Channel-i586 channel
     Given I am authorized for the "Admin" section
     When I follow the left menu "Software > Manage > Channels"
-    And I follow "Fake-Base-Channel-i586"
+    And I follow "Fake-Child-Channel-i586"
     And I follow "Repositories" in the content area
     And I follow "Sync"
     And I wait at most 60 seconds until I do not see "Repository sync is running." text, refreshing the page
     And I click on "Sync Now"
-    Then I should see a "Repository sync scheduled for Fake-Base-Channel-i586." text
-    And I wait until the channel "fake-base-channel-i586" has been synced
+    Then I should see a "Repository sync scheduled for Fake-Child-Channel-i586." text
+    And I wait until the channel "fake-child-channel-i586" has been synced
+
+  Scenario: Synchronize Test-Child-Channel-x86_64 channel
+    Given I am authorized for the "Admin" section
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Test-Child-Channel-x86_64"
+    And I follow "Repositories" in the content area
+    And I follow "Sync"
+    And I wait at most 60 seconds until I do not see "Repository sync is running." text, refreshing the page
+    And I click on "Sync Now"
+    Then I should see a "Repository sync scheduled for Test-Child-Channel-x86_64." text
+    And I wait until the channel "test-child-channel-x86_64" has been synced
+
+@sle_minion
+  Scenario: Synchronize Fake-Child-Channel-SUSE-like channel
+    Given I am authorized for the "Admin" section
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Fake-Child-Channel-SUSE-like"
+    And I follow "Repositories" in the content area
+    And I follow "Sync"
+    And I wait at most 60 seconds until I do not see "Repository sync is running." text, refreshing the page
+    And I click on "Sync Now"
+    Then I should see a "Repository sync scheduled for Fake-Child-Channel-SUSE-like." text
+    And I wait until the channel "fake-child-channel-suse-like" has been synced
 
 @deblike_minion
   Scenario: Synchronize Fake-Base-Channel-Debian-like channel

--- a/testsuite/features/secondary/srv_channel_api.feature
+++ b/testsuite/features/secondary/srv_channel_api.feature
@@ -36,4 +36,4 @@ Feature: API "channel" namespace and sub-namespaces
     Then "foobar" should not get listed with a call of listSoftwareChannels
 
   Scenario: Check last synchronization of a synced channel
-    Then channel "fake-base-channel-i586" should have attribute "yumrepo_last_sync" that is a date
+    Then channel "fake-child-channel-i586" should have attribute "yumrepo_last_sync" that is a date


### PR DESCRIPTION
## What does this PR change?

This PR adds the fake repository to the child channels in case the fake distributions have both base and child channels.
After that, it forces the synchronization of the child channels in order to be populated with the content of the fake repositories.
Additionally, it removes a leftover `testsuite/features/core/srv_create_fake_repositories.feature`

This aims to solve an issue in several cases, where we were expecting to have certain packages, but the channels were empty and so the systems doesn't have updates available:

![image](https://github.com/SUSE/spacewalk/assets/2827771/fb3928b5-4631-44c1-af62-f4003fb180f3)

Feature:Recurring Actions
![image](https://github.com/SUSE/spacewalk/assets/2827771/0be78540-0de3-4e60-81b1-cfb97586f684)


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Uyuni https://github.com/SUSE/spacewalk/pull/23039

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
