### PR TITLE
Convert time to integer before using

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -249,14 +249,6 @@ When(/^I enter "([^"]*)" as "([^"]*)"$/) do |text, field|
 end
 
 When(/^I enter (\d+) minutes from now as "([^"]*)"$/) do |minutes_to_add, field|
-  # Ensure 'minutes_to_add' is a string representation of an integer
-  minutes_to_add = minutes_to_add.to_s
-
-  # Validate that 'minutes_to_add' is a valid integer string
-  unless minutes_to_add.match?(/^\d+$/)
-    raise ArgumentError, "Invalid input: '#{minutes_to_add}' is not a valid integer."
-  end
-
   future_time = get_future_time(minutes_to_add)
   fill_in(field, with: future_time, fill_options: { clear: :backspace })
   log "Execution time: #{future_time}"

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -249,6 +249,14 @@ When(/^I enter "([^"]*)" as "([^"]*)"$/) do |text, field|
 end
 
 When(/^I enter (\d+) minutes from now as "([^"]*)"$/) do |minutes_to_add, field|
+  # Ensure 'minutes_to_add' is a string representation of an integer
+  minutes_to_add = minutes_to_add.to_s
+
+  # Validate that 'minutes_to_add' is a valid integer string
+  unless minutes_to_add.match?(/^\d+$/)
+    raise ArgumentError, "Invalid input: '#{minutes_to_add}' is not a valid integer."
+  end
+
   future_time = get_future_time(minutes_to_add)
   fill_in(field, with: future_time, fill_options: { clear: :backspace })
   log "Execution time: #{future_time}"

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -483,8 +483,9 @@ end
 
 # Get a time in the future, adding the minutes passed as parameter
 def get_future_time(minutes_to_add)
+  raise TypeError, 'minutes_to_add should be an Integer' unless minutes_to_add.is_a?(Integer)
   now = Time.new
-  future_time = now + 60 * minutes_to_add.to_i
+  future_time = now + 60 * minutes_to_add
   future_time.strftime('%H:%M').to_s.strip
 end
 

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -484,7 +484,7 @@ end
 # Get a time in the future, adding the minutes passed as parameter
 def get_future_time(minutes_to_add)
   now = Time.new
-  future_time = now + 60 * Integer(minutes_to_add, 10)
+  future_time = now + 60 * minutes_to_add.to_i
   future_time.strftime('%H:%M').to_s.strip
 end
 

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -484,7 +484,7 @@ end
 # Get a time in the future, adding the minutes passed as parameter
 def get_future_time(minutes_to_add)
   now = Time.new
-  future_time = now + 60 * minutes_to_add.to_i
+  future_time = now + 60 * Integer(minutes_to_add, 10)
   future_time.strftime('%H:%M').to_s.strip
 end
 


### PR DESCRIPTION
## What does this PR change?

Convert time to integer before using in commonlib. Enforce it so it's not a string. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes no issue, directly from testsuite review.
Tracks no 4.3 needed, the method doesn't exist in 4.3

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
