### PR TITLE
Fix single apostrophe curly interpolation bug, add linting rule to detect it

### DIFF
--- a/web/html/src/.eslintrc.js
+++ b/web/html/src/.eslintrc.js
@@ -34,6 +34,7 @@ module.exports = {
     "@typescript-eslint/no-redeclare": ["error"],
     // TODO: Eventually this should be "error"
     "local-rules/no-raw-date": "warn",
+    "local-rules/intl-apostrophe-curly": "error",
     // TODO: Eventually we should enforce this as well
     // "no-eq-null": "error",
     // TODO: This needs to be reworked with Typescript support in mind

--- a/web/html/src/components/package/PackageListActionScheduler.tsx
+++ b/web/html/src/components/package/PackageListActionScheduler.tsx
@@ -79,7 +79,7 @@ export class PackageListActionScheduler extends React.Component<Props, State> {
         const msg = MessagesUtils.info(
           this.state.actionChain ? (
             <span>
-              {t("Action has been successfully added to the action chain <link>'{name}'</link>.", {
+              {t('Action has been successfully added to the action chain <link>"{name}"</link>.', {
                 name: this.state.actionChain.text,
                 link: (str) => <ActionChainLink id={data}>{str}</ActionChainLink>,
               })}

--- a/web/html/src/eslint-local-rules/index.js
+++ b/web/html/src/eslint-local-rules/index.js
@@ -1,5 +1,7 @@
 const noRawDate = require("./no-raw-date");
+const intlApostropheCurly = require("./intl-apostrophe-curly");
 
 module.exports = {
   "no-raw-date": noRawDate,
+  "intl-apostrophe-curly": intlApostropheCurly,
 };

--- a/web/html/src/eslint-local-rules/intl-apostrophe-curly.js
+++ b/web/html/src/eslint-local-rules/intl-apostrophe-curly.js
@@ -1,0 +1,45 @@
+module.exports = {
+  // See https://eslint.org/docs/developer-guide/working-with-rules#rule-basics
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "A single apostrophe followed by a curly brace will not work as variable interpolation, a single apostrophe is used as the escape characted by the message syntax.",
+      category: "Possible Errors",
+      recommended: true,
+    },
+    fixable: false,
+    schema: [],
+  },
+  create: function (context) {
+    return {
+      // See https://eslint.org/docs/latest/extend/selectors
+      "CallExpression[callee.name='t'] > Literal": function (node) {
+        const value = node.value;
+        if (typeof value !== "string") {
+          return;
+        }
+
+        // Match a single apostrophe followed by a curly, ignore double apostrophe followed by a curly
+        // See https://formatjs.io/docs/core-concepts/icu-syntax/#quoting--escaping
+        const matches = Array.from(value.matchAll(/[^']'{/g));
+        matches.forEach((match) => {
+          context.report({
+            node: node,
+            message: `This curly brace will be inserted verbatim and no variable interpolation will occur. A single apostrophe is used as the escape characters in the message syntax, similar to a backslash in Bash. See https://formatjs.io/docs/core-concepts/icu-syntax/#quoting--escaping`,
+            loc: {
+              start: {
+                line: node.loc.start.line,
+                column: node.loc.start.column + match.index + 2,
+              },
+              end: {
+                line: node.loc.start.line,
+                column: node.loc.start.column + match.index + 4,
+              },
+            },
+          });
+        });
+      },
+    };
+  },
+};

--- a/web/html/src/manager/admin/setup/products/products.tsx
+++ b/web/html/src/manager/admin/setup/products/products.tsx
@@ -286,7 +286,7 @@ class ProductsPageWrapper extends React.Component {
               </>
             )),
             true,
-            t("The following channel installations for '{product}' failed. Please check log files.", { product })
+            t('The following channel installations for "{product}" failed. Please check log files.', { product })
           );
         }
         this.setState({

--- a/web/html/src/manager/images/image-view-overview.tsx
+++ b/web/html/src/manager/images/image-view-overview.tsx
@@ -462,7 +462,7 @@ class ImageInfo extends React.Component<ImageInfoProps, ImageInfoState> {
         </table>
         <PopUp
           id="instance-details-popup"
-          title={t("Instance Details for '{name}'", { name: this.state.instancePopupContent.name })}
+          title={t('Instance Details for "{name}"', { name: this.state.instancePopupContent.name })}
           content={this.state.instancePopupContent.content}
         />
       </div>

--- a/web/html/src/manager/images/image-view.tsx
+++ b/web/html/src/manager/images/image-view.tsx
@@ -747,7 +747,7 @@ class ImageViewList extends React.Component<ImageViewListProps, ImageViewListSta
         />
         <PopUp
           id="instance-details-popup"
-          title={t("Instance Details for '{name}'", { name: this.state.instancePopupContent.name })}
+          title={t('Instance Details for "{name}"', { name: this.state.instancePopupContent.name })}
           content={this.state.instancePopupContent.content}
         />
       </div>

--- a/web/html/src/manager/maintenance/edit/calendar-edit.tsx
+++ b/web/html/src/manager/maintenance/edit/calendar-edit.tsx
@@ -112,7 +112,7 @@ const MaintenanceCalendarEdit = forwardRef((props: CalendarEditProps, ref) => {
       }
       validateUrl(params.url)
         ? props.onEdit(params)
-        : props.messages(MessagesUtils.error(t("Url '{url}' is invalid", { url: params.url })));
+        : props.messages(MessagesUtils.error(t('Url "{url}" is invalid', { url: params.url })));
     },
   }));
 

--- a/web/html/src/manager/state/highstate.tsx
+++ b/web/html/src/manager/state/highstate.tsx
@@ -61,7 +61,7 @@ class Highstate extends React.Component<HighstateProps, HighstateState> {
         const msg = MessagesUtils.info(
           this.state.actionChain ? (
             <span>
-              {t("Action has been successfully added to the action chain <link>'{name}'</link>.", {
+              {t('Action has been successfully added to the action chain <link>"{name}"</link>.', {
                 name: this.state.actionChain.text,
                 link: (str) => <ActionChainLink id={data}>{str}</ActionChainLink>,
               })}


### PR DESCRIPTION
## What does this PR change?

Fixes the issue outlined in https://github.com/SUSE/spacewalk/pull/23026 in other similar places, also adds linting to detect it elsewhere.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
