### PR TITLE
QE: Don't sync test-base-channel as it doesnt contains any repo

### DIFF
--- a/testsuite/features/reposync/srv_sync_fake_channels.feature
+++ b/testsuite/features/reposync/srv_sync_fake_channels.feature
@@ -35,17 +35,6 @@ Feature: Synchronize fake channels
     Then "orion-dummy-1.1-1.1.x86_64.rpm" package should have been stored
     And solver file for "fake-rpm-suse-channel" should reference "orion-dummy-1.1-1.1.x86_64.rpm"
 
-  Scenario: Synchronize Test-Base-Channel-x86_64 channel
-    Given I am authorized for the "Admin" section
-    When I follow the left menu "Software > Manage > Channels"
-    And I follow "Test-Base-Channel-x86_64"
-    And I follow "Repositories" in the content area
-    And I follow "Sync"
-    And I wait at most 60 seconds until I do not see "Repository sync is running." text, refreshing the page
-    And I click on "Sync Now"
-    Then I should see a "Repository sync scheduled for Test-Base-Channel-x86_64." text
-    And I wait until the channel "test-base-channel-x86_64" has been synced
-
   Scenario: Synchronize Fake-Child-Channel-i586 channel
     Given I am authorized for the "Admin" section
     When I follow the left menu "Software > Manage > Channels"


### PR DESCRIPTION
## What does this PR change?

Don't sync the test-base-channel as it doesn't contain anymore a test repository, instead, we included it on its child channel.
If we do, Uyuni will show an error.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage

- Cucumber tests were removed

- [x] **DONE**

## Links

- Manager-4.3 Already part of https://github.com/SUSE/spacewalk/pull/23039

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
