### PR TITLE
Change srv_rename_hostname back to secondary so it does not always run

### DIFF
--- a/testsuite/run_sets/finishing.yml
+++ b/testsuite/run_sets/finishing.yml
@@ -9,7 +9,6 @@
 
 # IMMUTABLE ORDER
 # this feature is destructive for other features, so it is better at the end
-- features/secondary/srv_rename_hostname.feature
 - features/finishing/srv_smdba.feature
 # these features are needed for gathering log/debug info
 - features/finishing/srv_debug.feature

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -61,5 +61,6 @@
 - features/secondary/srv_cobbler_buildiso.feature
 - features/secondary/srv_cobbler_profile.feature
 - features/secondary/min_salt_migration.feature
+- features/secondary/srv_rename_hostname.feature
 
 ## Secondary features END ##


### PR DESCRIPTION
## What does this PR change?

Currently it runs even if core fails, which of course the test fails and it takes way too long. At the end of secondary should be fine. 

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered


- [x] **DONE**

## Links

Fixes no issue, directly from testsuite review
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
