### PR TITLE
Fix location of rpm

### DIFF
--- a/testsuite/features/reposync/srv_sync_fake_channels.feature
+++ b/testsuite/features/reposync/srv_sync_fake_channels.feature
@@ -132,7 +132,7 @@ Feature: Synchronize fake channels
 
   Scenario: Reposync handles wrong encoding on RPM attributes
     When I follow the left menu "Software > Manage > Channels"
-    And I follow "Fake-Child-Channel-SUSE-like"
+    And I follow "Test-Child-Channel-x86_64"
     And I follow "Packages" in the content area
     And I follow "List / Remove Packages"
     And I wait until I see "blackhole-dummy" text, refreshing the page

--- a/testsuite/features/reposync/srv_sync_fake_channels.feature
+++ b/testsuite/features/reposync/srv_sync_fake_channels.feature
@@ -131,9 +131,10 @@ Feature: Synchronize fake channels
     And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
 
   Scenario: Reposync handles wrong encoding on RPM attributes
-    When I follow the left menu "Software > Channel List"
-    And I follow "Test-Base-Channel-x86_64"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Fake-Child-Channel-SUSE-like"
     And I follow "Packages" in the content area
+    And I follow "List / Remove Packages"
     And I wait until I see "blackhole-dummy" text, refreshing the page
 
 @deblike_minion


### PR DESCRIPTION
## What does this PR change?

Fix location of rpms, now they are in the child channels and this is the way to navigate there, otherwise only the base channels are visible.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes no issue, directly from testsuite review.
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
