### PR TITLE
Improved the paginated queries for syncing the reporting database

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/ChannelReport_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/ChannelReport_queries.xml
@@ -16,7 +16,7 @@
 
 
 <mode name="Channel" class="">
-    <query params="offset, limit">
+    <query params="channel_id, limit">
           SELECT rhnchannel.id AS channel_id
                       , rhnchannel.name
                       , rhnchannel.label
@@ -37,23 +37,25 @@
                       LEFT JOIN rhnchannel rhnparentchannel ON rhnchannel.parent_channel = rhnparentchannel.id
                       LEFT JOIN rhnchannelcloned ON rhnchannel.id = rhnchannelcloned.id
                       LEFT JOIN web_customer ON rhnchannel.org_id = web_customer.id
-        ORDER BY channel_id OFFSET :offset LIMIT :limit
+           WHERE rhnchannel.id &gt; :channel_id
+        ORDER BY channel_id
+           FETCH FIRST :limit ROWS WITH TIES
   </query>
 </mode>
 
 <mode name="ChannelPackage" class="">
-    <query params="offset, limit">
-          SELECT rhnchannel.id AS channel_id
-                      , rhnpackage.id AS package_id
-            FROM rhnchannel
-                      INNER JOIN rhnchannelpackage ON rhnchannel.id = rhnchannelpackage.channel_id
-                      INNER JOIN rhnpackage ON rhnpackage.id = rhnchannelpackage.package_id
-        ORDER BY channel_id, package_id OFFSET :offset LIMIT :limit
+    <query params="channel_id, package_id, limit">
+          SELECT rhnchannelpackage.channel_id AS channel_id
+                      , rhnchannelpackage.package_id AS package_id
+            FROM rhnchannelpackage
+           WHERE (rhnchannelpackage.channel_id, rhnchannelpackage.package_id) &gt; (:channel_id, :package_id)
+        ORDER BY channel_id, package_id
+           FETCH FIRST :limit ROWS WITH TIES
     </query>
 </mode>
 
 <mode name="ChannelErrata" class="">
-    <query params="offset, limit">
+    <query params="channel_id, errata_id, limit">
           SELECT rhnchannel.id AS channel_id
                     , rhnerrata.id AS errata_id
                     , rhnchannel.label AS channel_label
@@ -61,24 +63,28 @@
             FROM rhnchannelerrata
                     INNER JOIN rhnchannel ON rhnchannelerrata.channel_id = rhnchannel.id
                     INNER JOIN rhnerrata ON rhnchannelerrata.errata_id = rhnerrata.id
-        ORDER BY channel_id, errata_id OFFSET :offset LIMIT :limit
+           WHERE (rhnchannel.id, rhnerrata.id) &gt; (:channel_id, :errata_id)
+        ORDER BY channel_id, errata_id
+           FETCH FIRST :limit ROWS WITH TIES
     </query>
 </mode>
 
 <mode name="ChannelRepository" class="">
-    <query params="offset, limit">
+    <query params="channel_id, repository_id, limit">
           SELECT rhnchannelcontentsource.channel_id
                     , rhnchannelcontentsource.source_id AS repository_id
                     , rhncontentsource.label AS repository_label
             FROM rhnchannelcontentsource
                     INNER JOIN rhncontentsource ON rhnchannelcontentsource.source_id = rhncontentsource.id
                     INNER JOIN rhncontentsourcetype ON rhncontentsource.type_id = rhncontentsourcetype.id
-        ORDER BY channel_id, repository_id OFFSET :offset LIMIT :limit
+           WHERE (rhnchannelcontentsource.channel_id, rhnchannelcontentsource.source_id) &gt; (:channel_id, :repository_id)
+        ORDER BY channel_id, repository_id
+           FETCH FIRST :limit ROWS WITH TIES
     </query>
 </mode>
 
 <mode name="Errata" class="">
-    <query params="offset, limit">
+    <query params="errata_id, limit">
           SELECT rhnerrata.id AS errata_id
                       , rhnerrata.advisory_name
                       , rhnerrata.advisory_type
@@ -106,12 +112,14 @@
                       LEFT JOIN rhnerratakeyword rb ON rhnerrata.id = rb.errata_id AND rb.keyword = 'reboot_suggested'
                       LEFT JOIN rhnerratakeyword rs ON rhnerrata.id = rs.errata_id AND rs.keyword = 'restart_suggested'
                       LEFT JOIN web_customer ON rhnerrata.org_id = web_customer.id
-        ORDER BY errata_id OFFSET :offset LIMIT :limit
+           WHERE rhnerrata.id &gt; :errata_id
+        ORDER BY errata_id
+           FETCH FIRST :limit ROWS WITH TIES
   </query>
 </mode>
 
 <mode name="Package" class="">
-    <query params="offset, limit">
+    <query params="package_id, limit">
           SELECT rhnpackage.id AS package_id
                       , rhnpackagename.name
                       , rhnpackageevr.epoch
@@ -129,12 +137,14 @@
                       LEFT JOIN rhnpackageevr ON rhnpackage.evr_id = rhnpackageevr.id
                       LEFT JOIN rhnpackagearch ON rhnpackage.package_arch_id = rhnpackagearch.id
                       LEFT JOIN web_customer ON rhnpackage.org_id = web_customer.id
-        ORDER BY package_id OFFSET :offset LIMIT :limit
+           WHERE rhnpackage.id &gt; :package_id
+        ORDER BY package_id
+           FETCH FIRST :limit ROWS WITH TIES
   </query>
 </mode>
 
 <mode name="Repository" class="">
-    <query params="offset, limit">
+    <query params="repository_id, limit">
           SELECT rhncontentsource.id AS repository_id
                     , rhncontentsource.label
                     , rhncontentsource.source_url AS url
@@ -144,7 +154,9 @@
             FROM rhncontentsource
                     INNER JOIN rhncontentsourcetype ON rhncontentsource.type_id = rhncontentsourcetype.id
                     LEFT JOIN web_customer ON rhncontentsource.org_id = web_customer.id
-        ORDER BY repository_id OFFSET :offset LIMIT :limit
+           WHERE rhncontentsource.id &gt; :repository_id
+        ORDER BY repository_id
+           FETCH FIRST :limit ROWS WITH TIES
     </query>
 </mode>
 

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/GeneralReport_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/GeneralReport_queries.xml
@@ -15,32 +15,36 @@
 <datasource_modes>
 
 <mode name="SystemGroup">
-    <query params="offset, limit">
-            SELECT rhnservergroup.id AS system_group_id
-                      , rhnservergroup.name
-                      , rhnservergroup.description
-                      , rhnservergroup.current_members
-                      , web_customer.name AS organization
-              FROM rhnservergroup
-                      INNER JOIN web_customer ON rhnservergroup.org_id = web_customer.id
-             WHERE rhnservergroup.group_type IS NULL
-        ORDER BY rhnservergroup.id OFFSET :offset LIMIT :limit
+    <query params="system_group_id, limit">
+          SELECT rhnservergroup.id AS system_group_id
+                    , rhnservergroup.name
+                    , rhnservergroup.description
+                    , rhnservergroup.current_members
+                    , web_customer.name AS organization
+            FROM rhnservergroup
+                    INNER JOIN web_customer ON rhnservergroup.org_id = web_customer.id
+           WHERE rhnservergroup.group_type IS NULL
+                    AND rhnservergroup.id  &gt; :system_group_id
+        ORDER BY system_group_id
+           FETCH FIRST :limit ROWS WITH TIES
     </query>
 </mode>
 
 <mode name="SystemGroupPermission" class="">
-    <query params="offset, limit">
+    <query params="system_group_id, account_id, limit">
           SELECT rhnUserServerGroupPerms.server_group_id AS system_group_id
                     , rhnUserServerGroupPerms.user_id AS account_id
                     , rhnServerGroup.name AS group_name
             FROM rhnUserServerGroupPerms
                     INNER JOIN rhnServerGroup ON rhnUserServerGroupPerms.server_group_id = rhnServerGroup.id
-        ORDER BY system_group_id, account_id OFFSET :offset LIMIT :limit
+           WHERE (rhnUserServerGroupPerms.server_group_id, rhnUserServerGroupPerms.user_id) &gt; (:system_group_id, :account_id)
+        ORDER BY system_group_id, account_id
+           FETCH FIRST :limit ROWS WITH TIES
     </query>
 </mode>
 
 <mode name="Account" class="">
-    <query params="offset, limit">
+    <query params="account_id, limit">
           WITH latest_state_change AS (
                SELECT rhnWebContactChangeLog.web_contact_id
                             , rhnWebContactChangeState.label
@@ -48,6 +52,7 @@
                             INNER JOIN rhnWebContactChangeState ON rhnWebContactChangeLog.change_state_id = rhnWebContactChangeState.id
                             LEFT JOIN rhnWebContactChangeLog older ON ( rhnWebContactChangeLog.web_contact_id = older.web_contact_id AND rhnWebContactChangeLog.date_completed &lt; older.date_completed )
               WHERE older.date_completed IS NULL
+                            AND rhnWebContactChangeLog.web_contact_id &gt; :account_id
           )
           SELECT web_contact.id AS account_id
                     , web_contact.login AS username
@@ -65,12 +70,14 @@
                     INNER JOIN web_user_personal_info ON web_contact.id = web_user_personal_info.web_user_id
                     INNER JOIN rhnUserInfo ON web_contact.id = rhnUserInfo.user_id
                     LEFT JOIN latest_state_change ON web_contact.id = latest_state_change.web_contact_id
-        ORDER BY account_id OFFSET :offset LIMIT :limit
+           WHERE web_contact.id &gt; :account_id
+        ORDER BY account_id
+           FETCH FIRST :limit ROWS WITH TIES
     </query>
 </mode>
 
 <mode name="AccountGroup" class="">
-    <query params="offset, limit">
+    <query params="account_id, account_group_id, limit">
           SELECT web_contact.id AS account_id
                     , rhnusergroupmembers.user_group_id AS account_group_id
                     , web_contact.login AS username
@@ -82,7 +89,9 @@
                     INNER JOIN web_contact ON web_contact.id = rhnusergroupmembers.user_id
                     INNER JOIN rhnusergroup ON rhnusergroupmembers.user_group_id = rhnusergroup.id
                     INNER JOIN rhnusergrouptype ON rhnusergroup.group_type = rhnusergrouptype.id
-        ORDER BY account_id, account_group_id OFFSET :offset LIMIT :limit
+           WHERE (web_contact.id, rhnusergroupmembers.user_group_id) &gt; (:account_id, :account_group_id)
+        ORDER BY account_id, account_group_id
+           FETCH FIRST :limit ROWS WITH TIES
     </query>
 </mode>
 

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/ScapReport_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/ScapReport_queries.xml
@@ -15,7 +15,7 @@
 <datasource_modes>
 
 <mode name="XccdScan">
-    <query params="offset, limit">
+    <query params="scan_id, limit">
           SELECT rhnxccdftestresult.id AS scan_id
                     , rhnxccdftestresult.server_id AS system_id
                     , rhnactionscap.action_id AS action_id
@@ -37,6 +37,7 @@
                     INNER JOIN rhnxccdfprofile ON rhnxccdftestresult.profile_id = rhnxccdfprofile.id
                     INNER JOIN rhnxccdfruleresult ON rhnxccdftestresult.id = rhnxccdfruleresult.testresult_id
                     INNER JOIN rhnxccdfruleresulttype ON rhnxccdfruleresult.result_id = rhnxccdfruleresulttype.id
+           WHERE rhnxccdftestresult.id &gt; :scan_id
         GROUP BY rhnxccdftestresult.id
                     , rhnxccdftestresult.server_id
                     , rhnactionscap.action_id
@@ -46,12 +47,13 @@
                     , rhnxccdfprofile.identifier
                     , rhnxccdfprofile.title
                     , rhnxccdftestresult.end_time
-        ORDER BY rhnxccdftestresult.id OFFSET :offset LIMIT :limit
+        ORDER BY scan_id
+           FETCH FIRST :limit ROWS WITH TIES
     </query>
 </mode>
 
 <mode name="XccdScanResult">
-    <query params="offset, limit">
+    <query params="scan_id, rule_id, ident_id, limit">
         WITH ruleresult_idrefs AS (
             SELECT rim.rresult_id
                        , rim.ident_id
@@ -60,6 +62,7 @@
                        INNER JOIN rhnxccdfident xi ON rim.ident_id = xi.id
                        INNER JOIN rhnxccdfidentsystem xis ON xi.identsystem_id = xis.id
              WHERE xis.system = '#IDREF#'
+                        AND rim.rresult_id &gt; :rule_id
         )
         SELECT rhnxccdfruleresult.testresult_id AS scan_id
                    , rhnxccdfruleresult.id AS rule_id
@@ -76,7 +79,9 @@
                    LEFT JOIN rhnxccdfruleidentmap ON rhnxccdfruleidentmap.rresult_id = ruleresult_idrefs.rresult_id AND rhnxccdfruleidentmap.ident_id != ruleresult_idrefs.ident_id
                    LEFT JOIN rhnxccdfident on rhnxccdfruleidentmap.ident_id = rhnxccdfident.id
                    LEFT JOIN rhnxccdfidentsystem on rhnxccdfident.identsystem_id = rhnxccdfidentsystem.id
-        ORDER BY scan_id, rule_id, ident_id OFFSET :offset LIMIT :limit
+           WHERE (rhnxccdfruleresult.testresult_id, rhnxccdfruleresult.id, COALESCE(rhnxccdfruleidentmap.ident_id, ruleresult_idrefs.ident_id)) &gt; (:scan_id, :rule_id, :ident_id)
+        ORDER BY scan_id, rule_id, ident_id
+           FETCH FIRST :limit ROWS WITH TIES
     </query>
 </mode>
 

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/SystemReport_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/SystemReport_queries.xml
@@ -15,7 +15,7 @@
 <datasource_modes>
 
 <mode name="System" class="">
-  <query params="offset, limit">
+    <query params="system_id, limit">
         SELECT rhnserver.id AS system_id
                     , rhnserver.name AS profile_name
                     , rhnserver.hostname
@@ -52,24 +52,28 @@
                     LEFT JOIN rhnserverpath ON rhnserver.id = rhnserverpath.server_id
                     INNER JOIN rhnserverarch ON rhnserver.server_arch_id = rhnserverarch.id
                     INNER JOIN web_customer ON rhnserver.org_id = web_customer.id
-        ORDER BY system_id OFFSET :offset LIMIT :limit
-  </query>
+           WHERE rhnserver.id &gt; :system_id
+        ORDER BY system_id
+           FETCH FIRST :limit ROWS WITH TIES
+    </query>
 </mode>
 
 <mode name="SystemConfigChannel" class="">
-    <query params="offset, limit">
+    <query params="system_id, config_channel_id, limit">
           SELECT rhnserverconfigchannel.server_id AS system_id
                     , rhnserverconfigchannel.config_channel_id
                     , rhnconfigchannel.name
                     , rhnserverconfigchannel.position
             FROM rhnserverconfigchannel
                     INNER JOIN rhnconfigchannel ON rhnserverconfigchannel.config_channel_id = rhnconfigchannel.id
-        ORDER BY system_id, config_channel_id OFFSET :offset LIMIT :limit
-  </query>
+           WHERE (rhnserverconfigchannel.server_id, rhnserverconfigchannel.config_channel_id) &gt; (:system_id, :config_channel_id)
+        ORDER BY system_id, config_channel_id
+           FETCH FIRST :limit ROWS WITH TIES
+    </query>
 </mode>
 
 <mode name="SystemEntitlement" class="">
-    <query params="offset, limit">
+    <query params="system_id, system_group_id, limit">
           SELECT rhnservergroupmembers.server_id AS system_id
                     , rhnservergroupmembers.server_group_id AS system_group_id
                     , rhnservergroup.name
@@ -83,12 +87,14 @@
                     INNER JOIN web_customer ON rhnservergroup.org_id = web_customer.id
                     INNER JOIN rhnservergrouptype ON rhnservergroup.group_type = rhnservergrouptype.id
            WHERE rhnservergroup.group_type IS NOT NULL
-        ORDER BY system_id, server_group_id OFFSET :offset LIMIT :limit
-  </query>
+                    AND (rhnservergroupmembers.server_id, rhnservergroupmembers.server_group_id) &gt; (:system_id, :system_group_id)
+        ORDER BY system_id, system_group_id
+        FETCH FIRST :limit ROWS WITH TIES
+    </query>
 </mode>
 
 <mode name="SystemGroupMember" class="">
-    <query params="offset, limit">
+    <query params="system_id, system_group_id, limit">
           SELECT rhnservergroupmembers.server_id AS system_id
                     , rhnservergroupmembers.server_group_id AS system_group_id
                     , rhnservergroup.name AS group_name
@@ -97,12 +103,14 @@
                     INNER JOIN rhnserver ON rhnservergroupmembers.server_id = rhnserver.id
                     INNER JOIN rhnservergroup ON rhnservergroupmembers.server_group_id = rhnservergroup.id
            WHERE rhnservergroup.group_type IS NULL
-        ORDER BY server_id, server_group_id OFFSET :offset LIMIT :limit
-  </query>
+                    AND (rhnservergroupmembers.server_id, rhnservergroupmembers.server_group_id) &gt; (:system_id, :system_group_id)
+        ORDER BY system_id, system_group_id
+           FETCH FIRST :limit ROWS WITH TIES
+    </query>
 </mode>
 
 <mode name="SystemNetInterface" class="">
-    <query params="offset, limit">
+    <query params="system_id, interface_id, limit">
           SELECT server_id AS system_id
                     , id AS interface_id
                     , name
@@ -110,12 +118,14 @@
                     , module
                     , COALESCE(is_primary, 'N') = 'Y' AS primary_interface
             FROM rhnservernetinterface
-        ORDER BY system_id, interface_id OFFSET :offset LIMIT :limit
+           WHERE (server_id, id) &gt; (:system_id, :interface_id)
+        ORDER BY system_id, interface_id
+           FETCH FIRST :limit ROWS WITH TIES
     </query>
 </mode>
 
 <mode name="SystemNetAddressV4" class="">
-    <query params="offset, limit">
+    <query params="system_id, interface_id, address, limit">
           SELECT rhnservernetinterface.server_id AS system_id
                     , rhnservernetinterface.id AS interface_id
                     , rhnservernetaddress4.address
@@ -123,12 +133,14 @@
                     , rhnservernetaddress4.broadcast
             FROM rhnservernetinterface
                     INNER JOIN rhnservernetaddress4 ON rhnservernetinterface.id = rhnservernetaddress4.interface_id
-        ORDER BY system_id, interface_id, address OFFSET :offset LIMIT :limit
+           WHERE (rhnservernetinterface.server_id, rhnservernetinterface.id, rhnservernetaddress4.address) &gt; (:system_id, :interface_id, :address)
+        ORDER BY system_id, interface_id, address
+           FETCH FIRST :limit ROWS WITH TIES
     </query>
 </mode>
 
 <mode name="SystemNetAddressV6" class="">
-    <query params="offset, limit">
+    <query params="system_id, interface_id, address, limit">
           SELECT rhnservernetinterface.server_id AS system_id
                     , rhnservernetinterface.id AS interface_id
                     , rhnservernetaddress6.address
@@ -136,12 +148,14 @@
                     , rhnservernetaddress6.scope
             FROM rhnservernetinterface
                     INNER JOIN rhnservernetaddress6 ON rhnservernetinterface.id = rhnservernetaddress6.interface_id
-        ORDER BY system_id, interface_id, address OFFSET :offset LIMIT :limit
+        WHERE (rhnservernetinterface.server_id, rhnservernetinterface.id, rhnservernetaddress6.address) &gt; (:system_id, :interface_id, :address)
+        ORDER BY system_id, interface_id, address
+           FETCH FIRST :limit ROWS WITH TIES
     </query>
 </mode>
 
 <mode name="SystemVirtualData" class="">
-    <query params="offset, limit">
+    <query params="instance_id, limit">
           SELECT rhnvirtualinstance.id AS instance_id
                     , rhnvirtualinstance.host_system_id
                     , rhnvirtualinstance.virtual_system_id
@@ -156,12 +170,14 @@
                     INNER JOIN rhnvirtualinstanceinfo ON rhnvirtualinstance.id = rhnvirtualinstanceinfo.instance_id
                     INNER JOIN rhnvirtualinstancetype ON rhnvirtualinstanceinfo.instance_type = rhnvirtualinstancetype.id
                     INNER JOIN rhnvirtualinstancestate ON rhnvirtualinstanceinfo.state = rhnvirtualinstancestate.id
-        ORDER BY host_system_id, virtual_system_id OFFSET :offset LIMIT :limit
-  </query>
+           WHERE rhnvirtualinstance.id &gt; :instance_id
+        ORDER BY instance_id
+           FETCH FIRST :limit ROWS WITH TIES
+    </query>
 </mode>
 
 <mode name="SystemChannel" class="">
-    <query params="offset, limit">
+    <query params="system_id, channel_id, limit">
           SELECT rhnserverchannel.server_id AS system_id
                     , rhnserverchannel.channel_id
                     , rhnchannel.name
@@ -173,28 +189,33 @@
                     INNER JOIN rhnchannel ON rhnserverchannel.channel_id=rhnchannel.id
                     INNER JOIN rhnchannelarch ON rhnchannel.channel_arch_id=rhnchannelarch.id
                     LEFT JOIN rhnchannel rhnparentchannel ON rhnchannel.parent_channel=rhnparentchannel.id
-        ORDER BY system_id, channel_id OFFSET :offset LIMIT :limit
+           WHERE (rhnserverchannel.server_id, rhnserverchannel.channel_id) &gt; (:system_id, :channel_id)
+        ORDER BY system_id, channel_id
+           FETCH FIRST :limit ROWS WITH TIES
   </query>
 </mode>
 
 <mode name="SystemOutdated" class="">
-    <query params="offset, limit">
+    <query params="system_id, limit">
           SELECT rhnserverneededcache.server_id AS system_id
                     , count(distinct rhnpackage.name_id) AS packages_out_of_date
                     , count(distinct rhnserverneededcache.errata_id) AS errata_out_of_date
             FROM rhnpackage, rhnserverneededcache
            WHERE rhnserverneededcache.package_id = rhnpackage.id
+                    AND rhnserverneededcache.server_id &gt; :system_id
         GROUP BY rhnserverneededcache.server_id
-        ORDER BY system_id OFFSET :offset LIMIT :limit
-  </query>
+        ORDER BY system_id
+           FETCH FIRST :limit ROWS WITH TIES
+    </query>
 </mode>
 
 <mode name="SystemAction" class="">
-    <query params="offset, limit">
+    <query params="system_id, action_id, limit">
           WITH action_errata AS (
             SELECT rhnactionerrataupdate.action_id, rhnerrata.advisory
               FROM rhnactionerrataupdate
                         INNER JOIN rhnerrata ON rhnactionerrataupdate.errata_id = rhnerrata.id
+             WHERE rhnactionerrataupdate.action_id &gt; :action_id
           ), action_package AS (
             SELECT rhnactionpackage.action_id
                       , CONCAT(rhnpackagename.name, '-' || evr_t_as_vre_simple(rhnpackageevr.evr), '.' || rhnpackagearch.label) AS package_name
@@ -202,21 +223,25 @@
                       INNER JOIN rhnpackagename ON rhnactionpackage.name_id = rhnpackagename.id
                       LEFT JOIN rhnpackageevr ON rhnactionpackage.evr_id = rhnpackageevr.id
                       LEFT JOIN rhnpackagearch ON rhnactionpackage.package_arch_id = rhnpackagearch.id
+             WHERE rhnactionpackage.action_id &gt; :action_id
           ), action_configfiles AS (
             SELECT rhnactionconfigrevision.action_id, rhnactionconfigrevision.server_id, rhnconfigfilename.path
               FROM rhnactionconfigrevision
                       LEFT JOIN rhnconfigrevision ON rhnactionconfigrevision.config_revision_id = rhnconfigrevision.id
                       LEFT JOIN rhnconfigfile ON rhnconfigrevision.config_file_id = rhnconfigfile.id
                       LEFT JOIN rhnconfigfilename ON rhnconfigfile.config_file_name_id = rhnconfigfilename.id
+             WHERE (rhnactionconfigrevision.server_id, rhnactionconfigrevision.action_id) &gt; (:system_id, :action_id)
           ), action_ksdata AS (
             SELECT DISTINCT rhnkickstartsessionhistory.action_id, rhnksdata.label
               FROM rhnkickstartsessionhistory
                       INNER JOIN rhnkickstartsession ON rhnkickstartsessionhistory.kickstart_session_id = rhnkickstartsession.id
                       INNER JOIN rhnksdata ON rhnkickstartsession.kickstart_id = rhnksdata.id
+             WHERE rhnkickstartsessionhistory.action_id &gt; :action_id
           ), action_xccdtestresult AS (
             SELECT rhnactionscap.action_id, rhnxccdftestresult.server_id, rhnxccdftestresult.identifier
               FROM rhnactionscap
                       LEFT JOIN rhnxccdftestresult ON rhnxccdftestresult.action_scap_id = rhnactionscap.id
+             WHERE (rhnxccdftestresult.server_id, rhnactionscap.action_id) &gt; (:system_id, :action_id)
           )
           SELECT rhnserveraction.server_id AS system_id
                       , rhnserveraction.action_id
@@ -263,12 +288,14 @@
                       LEFT JOIN rhnactionstatus ON rhnserveraction.status = rhnactionstatus.id
                       LEFT JOIN rhnactiontype ON rhnaction.action_type = rhnactiontype.id
                       LEFT JOIN action_xccdtestresult ON action_xccdtestresult.server_id = rhnserveraction.server_id AND action_xccdtestresult.action_id = rhnserveraction.action_id
-        ORDER BY system_id, action_id OFFSET :offset LIMIT :limit
-  </query>
+           WHERE (rhnserveraction.server_id, rhnserveraction.action_id) &gt; (:system_id, :action_id)
+        ORDER BY system_id, action_id
+           FETCH FIRST :limit ROWS WITH TIES
+    </query>
 </mode>
 
 <mode name="SystemHistory" class="">
-    <query params="offset, limit">
+    <query params="system_id, history_id, limit">
           SELECT rhnserverhistory.server_id AS system_id
                       , rhnserverhistory.id as history_id
                       , rhnserver.hostname
@@ -288,12 +315,14 @@
 
             FROM rhnserverhistory
                       LEFT JOIN rhnserver ON rhnserverhistory.server_id = rhnserver.id
-        ORDER BY rhnserverhistory.id OFFSET :offset LIMIT :limit
-</query>
+           WHERE (rhnserverhistory.server_id, rhnserverhistory.id) &gt; (:system_id, :history_id)
+        ORDER BY system_id, history_id
+           FETCH FIRST :limit ROWS WITH TIES
+    </query>
 </mode>
 
 <mode name="SystemErrata" class="">
-    <query params="offset, limit">
+    <query params="system_id, errata_id, limit">
           SELECT rhnserverneedederratacache.server_id AS system_id
                       , rhnserverneedederratacache.errata_id
                       , rhnserver.hostname
@@ -302,12 +331,14 @@
             FROM rhnserverneedederratacache
                       INNER JOIN rhnserver ON rhnserverneedederratacache.server_id = rhnserver.id
                       INNER JOIN rhnerrata ON rhnserverneedederratacache.errata_id = rhnerrata.id
-        ORDER BY system_id, errata_id OFFSET :offset LIMIT :limit
-  </query>
+           WHERE (rhnserverneedederratacache.server_id, rhnserverneedederratacache.errata_id) &gt; (:system_id, :errata_id)
+        ORDER BY system_id, errata_id
+           FETCH FIRST :limit ROWS WITH TIES
+    </query>
 </mode>
 
 <mode name="SystemPackageInstalled" class="">
-    <query params="offset, limit">
+    <query params="system_id, name, limit">
           SELECT rhnServerPackage.server_id AS system_id
                     , rhnPackageName.name
                     , rhnPackageEvr.epoch
@@ -319,48 +350,53 @@
                     INNER JOIN rhnPackageName ON rhnServerPackage.name_id = rhnPackageName.id
                     INNER JOIN rhnPackageEvr ON rhnServerPackage.evr_id = rhnPackageEvr.id
                     INNER JOIN rhnPackageArch ON rhnServerPackage.package_arch_id = rhnPackageArch.id
-        ORDER BY system_id, name OFFSET :offset LIMIT :limit
+           WHERE (rhnServerPackage.server_id, rhnPackageName.name) &gt; (:system_id, :name)
+        ORDER BY system_id, name
+           FETCH FIRST :limit ROWS WITH TIES
     </query>
 </mode>
 
-<mode name="SystemPackageUpdateIDs" class="">
+<mode name="SystemPackageUpdate_Ids" class="">
     <query>
         SELECT DISTINCT server_id AS id FROM rhnserverneededcache
     </query>
 </mode>
 
 <mode name="SystemPackageUpdate_byId" class="">
-    <query params="id, offset, limit">
+    <query params="id, package_id, limit">
         WITH latest AS (
           SELECT rhnserverneededcache.server_id, rhnPackage.name_id, MAX(rhnPackageEvr.evr) AS evr
-          FROM rhnserverneededcache
-          INNER JOIN rhnPackage ON rhnserverneededcache.package_id = rhnPackage.id
-          INNER JOIN rhnPackageEvr on rhnPackage.evr_id = rhnPackageEvr.id
-          WHERE rhnserverneededcache.server_id = :id
-          GROUP BY rhnserverneededcache.server_id, rhnPackage.name_id
+            FROM rhnserverneededcache
+                    INNER JOIN rhnPackage ON rhnserverneededcache.package_id = rhnPackage.id
+                    INNER JOIN rhnPackageEvr on rhnPackage.evr_id = rhnPackageEvr.id
+           WHERE rhnserverneededcache.server_id = :id
+                    AND rhnPackage.id &gt; :package_id
+        GROUP BY rhnserverneededcache.server_id, rhnPackage.name_id
         )
-        SELECT DISTINCT rhnserverneededcache.server_id AS system_id
-                      , rhnserverneededcache.package_id
-                      , rhnpackagename.name
-                      , rhnpackageevr.epoch
-                      , rhnpackageevr.version
-                      , rhnpackageevr.release
-                      , rhnpackagearch.label AS arch
-                      , rhnpackageevr.type
-                      , rhnpackageevr.evr = latest.evr AS is_latest
-        FROM rhnserverneededcache
-        INNER JOIN rhnpackage ON rhnserverneededcache.package_id = rhnpackage.id
-        INNER JOIN rhnpackageevr ON rhnpackage.evr_id = rhnpackageevr.id
-        INNER JOIN rhnpackagename ON rhnpackage.name_id = rhnpackagename.id
-        INNER JOIN rhnpackagearch ON rhnpackage.package_arch_id = rhnpackagearch.id
-        INNER JOIN latest ON (latest.server_id = rhnserverneededcache.server_id AND latest.name_id = rhnpackage.name_id)
-        WHERE rhnserverneededcache.server_id = :id
-        ORDER BY system_id, name, package_id OFFSET :offset LIMIT :limit
+          SELECT DISTINCT rhnserverneededcache.server_id AS system_id
+                    , rhnserverneededcache.package_id
+                    , rhnpackagename.name
+                    , rhnpackageevr.epoch
+                    , rhnpackageevr.version
+                    , rhnpackageevr.release
+                    , rhnpackagearch.label AS arch
+                    , rhnpackageevr.type
+                    , rhnpackageevr.evr = latest.evr AS is_latest
+            FROM rhnserverneededcache
+                    INNER JOIN rhnpackage ON rhnserverneededcache.package_id = rhnpackage.id
+                    INNER JOIN rhnpackageevr ON rhnpackage.evr_id = rhnpackageevr.id
+                    INNER JOIN rhnpackagename ON rhnpackage.name_id = rhnpackagename.id
+                    INNER JOIN rhnpackagearch ON rhnpackage.package_arch_id = rhnpackagearch.id
+                    INNER JOIN latest ON (latest.server_id = rhnserverneededcache.server_id AND latest.name_id = rhnpackage.name_id)
+           WHERE rhnserverneededcache.server_id = :id
+                    AND rhnserverneededcache.package_id &gt; :package_id
+        ORDER BY package_id
+           FETCH FIRST :limit ROWS WITH TIES
     </query>
 </mode>
 
 <mode name="SystemCustomInfo" class="">
-    <query params="offset, limit">
+    <query params="organization, system_id, key, limit">
           SELECT rhnserver.id AS system_id
                     , web_customer.name AS organization
                     , rhncustomdatakey.label AS key
@@ -370,7 +406,9 @@
                     INNER JOIN web_customer ON rhnserver.org_id = web_customer.id
                     INNER JOIN rhnservercustomdatavalue ON rhnserver.id = rhnservercustomdatavalue.server_id
                     INNER JOIN rhncustomdatakey ON rhnservercustomdatavalue.key_id = rhncustomdatakey.id
-        ORDER BY organization, system_id, key OFFSET :offset LIMIT :limit
+           WHERE (web_customer.name, rhnserver.id, rhncustomdatakey.label) &gt; (:organization, :system_id, :key)
+        ORDER BY organization, system_id, key
+           FETCH FIRST :limit ROWS WITH TIES
     </query>
 </mode>
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ReportDBHelper.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ReportDBHelper.java
@@ -46,6 +46,22 @@ public class ReportDBHelper {
     }
 
     /**
+     * Update the query parameters map getting the value of the filter field from the last entry of the data batch.
+     *
+     * @param parametersMap the parameters map to update
+     * @param dataBatch the data batch
+     * @param fieldSet the set of fields to update
+     */
+    public void updateParameters(Map<String, Object> parametersMap, DataResult<Map<String, Object>> dataBatch,
+                                 Set<String> fieldSet) {
+        // Update each filters of the parametersMap based on the last entry of the batch so that
+        // we can filter all the rows we have already extracted
+        for (String filterField : fieldSet) {
+            parametersMap.put(filterField, dataBatch.get(dataBatch.size() - 1).get(filterField));
+        }
+    }
+
+    /**
      * Returns the result of a query in a stream of batches.
      * @param query select query
      * @param batchSize max size of a batch

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ReportDbUpdateTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ReportDbUpdateTask.java
@@ -31,6 +31,7 @@ import org.hibernate.Session;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -41,6 +42,27 @@ public class ReportDbUpdateTask extends RhnJavaJob {
     private static final String SYSTEM_REPORT_QUERIES = "SystemReport_queries";
     private static final String CHANNEL_REPORT_QUERIES = "ChannelReport_queries";
     private static final String SCAP_REPORT_QUERIES = "ScapReport_queries";
+    // Common fields
+    private static final String SYSTEM_ID = "system_id";
+    private static final String HISTORY_ID = "history_id";
+    private static final String ACTION_ID = "action_id";
+    private static final String CHANNEL_ID = "channel_id";
+    private static final String CONFIG_CHANNEL_ID = "config_channel_id";
+    private static final String INSTANCE_ID = "instance_id";
+    private static final String INTERFACE_ID = "interface_id";
+    private static final String SYSTEM_GROUP_ID = "system_group_id";
+    private static final String ADDRESS = "address";
+    private static final String ERRATA_ID = "errata_id";
+    private static final String NAME = "name";
+    private static final String ORGANIZATION = "organization";
+    private static final String KEY = "key";
+    public static final String ACCOUNT_ID = "account_id";
+    public static final String ACCOUNT_GROUP_ID = "account_group_id";
+    public static final String SCAN_ID = "scan_id";
+    public static final String RULE_ID = "rule_id";
+    public static final String IDENT_ID = "ident_id";
+    public static final String PACKAGE_ID = "package_id";
+    public static final String REPOSITORY_ID = "repository_id";
 
     private final int batchSize;
 
@@ -63,79 +85,73 @@ public class ReportDbUpdateTask extends RhnJavaJob {
         this.batchSize = batchSizeIn;
     }
 
-    private void fillReportDbTable(Session session, String xmlName, String tableName) {
-        TimeUtils.logTime(log, "Refreshing table " + tableName, () -> {
-            SelectMode query = ModeFactory.getMode(xmlName, tableName, Map.class);
-
-            // Remove all the existing data
-            log.debug("Deleting existing data in table {}", tableName);
-            WriteMode delete = dbHelper.generateDelete(session, tableName);
-            delete.executeUpdate(Map.of("mgm_id", LOCAL_MGM_ID));
-
-            // Extract the first batch
-            DataResult<Map<String, Object>> firstBatch = query.execute(Map.of("offset", 0, "limit", batchSize));
-            if (!firstBatch.isEmpty()) {
-                // Generate the insert using the column name retrieved from the select
-                Set<String> columnParameters = firstBatch.get(0).keySet();
-                WriteMode insert = dbHelper.generateInsertWithDate(session, tableName, LOCAL_MGM_ID, columnParameters);
-
-                insert.executeUpdates(firstBatch);
-                log.debug("Extracted {} rows for table {}", firstBatch.size(), tableName);
-
-                // Iterate further if we can have additional rows
-                if (firstBatch.size() == batchSize) {
-                    dbHelper.<Map<String, Object>>batchStream(query, batchSize, batchSize)
-                            .forEach(batch -> {
-                                insert.executeUpdates(batch);
-                                log.debug("Extracted {} rows more for table {}", firstBatch.size(), tableName);
-                            });
-                }
-            }
-            else {
-                log.debug("No data extracted for table {}", tableName);
-            }
-        });
-    }
-
     @Override
     public void execute(JobExecutionContext arg0) throws JobExecutionException {
         ConnectionManager rcm = ConnectionManagerFactory.localReportingConnectionManager();
         ReportDbHibernateFactory rh = new ReportDbHibernateFactory(rcm);
 
         try {
-            fillReportDbTable(rh.getSession(), GENERAL_REPORT_QUERIES, "SystemGroup");
-            fillReportDbTable(rh.getSession(), GENERAL_REPORT_QUERIES, "SystemGroupPermission");
-            fillReportDbTable(rh.getSession(), GENERAL_REPORT_QUERIES, "Account");
-            fillReportDbTable(rh.getSession(), GENERAL_REPORT_QUERIES, "AccountGroup");
+            fillReportDbTable(rh.getSession(), GENERAL_REPORT_QUERIES, "SystemGroup",
+                Map.of(SYSTEM_GROUP_ID, 0));
+            fillReportDbTable(rh.getSession(), GENERAL_REPORT_QUERIES, "SystemGroupPermission",
+                Map.of(SYSTEM_GROUP_ID, 0, ACCOUNT_ID, 0));
+            fillReportDbTable(rh.getSession(), GENERAL_REPORT_QUERIES, "Account",
+                Map.of(ACCOUNT_ID, 0));
+            fillReportDbTable(rh.getSession(), GENERAL_REPORT_QUERIES, "AccountGroup",
+                Map.of(ACCOUNT_ID, 0, ACCOUNT_GROUP_ID, 0));
 
-            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "System");
-            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemHistory");
-            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemAction");
-            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemChannel");
-            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemConfigChannel");
-            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemVirtualData");
-            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemNetInterface");
-            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemNetAddressV4");
-            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemNetAddressV6");
-            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemOutdated");
-            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemGroupMember");
-            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemEntitlement");
-            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemErrata");
-            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemPackageInstalled");
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "System",
+                Map.of(SYSTEM_ID, 0));
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemHistory",
+                Map.of(SYSTEM_ID, 0, HISTORY_ID, 0));
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemAction",
+                Map.of(SYSTEM_ID, 0, ACTION_ID, 0));
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemChannel",
+                Map.of(SYSTEM_ID, 0, CHANNEL_ID, 0));
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemConfigChannel",
+                Map.of(SYSTEM_ID, 0, CONFIG_CHANNEL_ID, 0));
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemVirtualData",
+                Map.of(INSTANCE_ID, 0));
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemNetInterface",
+                Map.of(SYSTEM_ID, 0, INTERFACE_ID, 0));
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemNetAddressV4",
+                Map.of(SYSTEM_ID, 0, INTERFACE_ID, 0, ADDRESS, ""));
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemNetAddressV6",
+                Map.of(SYSTEM_ID, 0, INTERFACE_ID, 0, ADDRESS, ""));
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemOutdated",
+                Map.of(SYSTEM_ID, 0));
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemGroupMember",
+                Map.of(SYSTEM_ID, 0, SYSTEM_GROUP_ID, 0));
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemEntitlement",
+                Map.of(SYSTEM_ID, 0, SYSTEM_GROUP_ID, 0));
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemErrata",
+                Map.of(SYSTEM_ID, 0, ERRATA_ID, 0));
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemPackageInstalled",
+                Map.of(SYSTEM_ID, 0, NAME, ""));
             fillReportDbTableById(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemPackageUpdate",
-                    "SystemPackageUpdateIDs");
-            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemCustomInfo");
+                Map.of(PACKAGE_ID, 0));
+            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemCustomInfo",
+                Map.of(ORGANIZATION, "", SYSTEM_ID, 0, KEY, ""));
 
-            fillReportDbTable(rh.getSession(), CHANNEL_REPORT_QUERIES, "Channel");
-            fillReportDbTable(rh.getSession(), CHANNEL_REPORT_QUERIES, "ChannelErrata");
-            fillReportDbTable(rh.getSession(), CHANNEL_REPORT_QUERIES, "ChannelPackage");
-            fillReportDbTable(rh.getSession(), CHANNEL_REPORT_QUERIES, "ChannelRepository");
-            fillReportDbTable(rh.getSession(), CHANNEL_REPORT_QUERIES, "Errata");
-            fillReportDbTable(rh.getSession(), CHANNEL_REPORT_QUERIES, "Package");
-            fillReportDbTable(rh.getSession(), CHANNEL_REPORT_QUERIES, "Repository");
+            fillReportDbTable(rh.getSession(), CHANNEL_REPORT_QUERIES, "Channel",
+                Map.of(CHANNEL_ID, 0));
+            fillReportDbTable(rh.getSession(), CHANNEL_REPORT_QUERIES, "ChannelErrata",
+                Map.of(CHANNEL_ID, 0, ERRATA_ID, 0));
+            fillReportDbTable(rh.getSession(), CHANNEL_REPORT_QUERIES, "ChannelPackage",
+                Map.of(CHANNEL_ID, 0, PACKAGE_ID, 0));
+            fillReportDbTable(rh.getSession(), CHANNEL_REPORT_QUERIES, "ChannelRepository",
+                Map.of(CHANNEL_ID, 0, REPOSITORY_ID, 0));
+            fillReportDbTable(rh.getSession(), CHANNEL_REPORT_QUERIES, "Errata",
+                Map.of(ERRATA_ID, 0));
+            fillReportDbTable(rh.getSession(), CHANNEL_REPORT_QUERIES, "Package",
+                Map.of(PACKAGE_ID, 0));
+            fillReportDbTable(rh.getSession(), CHANNEL_REPORT_QUERIES, "Repository",
+                Map.of(REPOSITORY_ID, 0));
 
-            fillReportDbTable(rh.getSession(), SCAP_REPORT_QUERIES, "XccdScan");
-            fillReportDbTable(rh.getSession(), SCAP_REPORT_QUERIES, "XccdScanResult");
+            fillReportDbTable(rh.getSession(), SCAP_REPORT_QUERIES, "XccdScan",
+                Map.of(SCAN_ID, 0));
+            fillReportDbTable(rh.getSession(), SCAP_REPORT_QUERIES, "XccdScanResult",
+                Map.of(SCAN_ID, 0, RULE_ID, 0, IDENT_ID, 0));
 
             dbHelper.analyzeReportDb(rh.getSession());
 
@@ -158,9 +174,25 @@ public class ReportDbUpdateTask extends RhnJavaJob {
         }
     }
 
-    private void fillReportDbTableById(Session session, String xmlName, String tableName, String idsQuery) {
+    private void fillReportDbTable(Session session, String xmlName, String tableName, Map<String, Object> filterMap) {
         TimeUtils.logTime(log, "Refreshing table " + tableName, () -> {
-            SelectMode queryData = ModeFactory.getMode(xmlName, idsQuery, Map.class);
+            // Remove all the existing data
+            log.debug("Deleting existing data in table {}", tableName);
+            WriteMode delete = dbHelper.generateDelete(session, tableName);
+            delete.executeUpdate(Map.of("mgm_id", LOCAL_MGM_ID));
+
+            // Extract the first batch using the given filters, only adding the batch size as number of rows limit
+            Map<String, Object> parametersMap = new HashMap<>(filterMap);
+            parametersMap.put("limit", batchSize);
+
+            fillTableInBatches(session, xmlName, tableName, tableName, parametersMap, filterMap.keySet());
+        });
+    }
+
+    private void fillReportDbTableById(Session session, String xmlName, String tableName,
+                                       Map<String, Object> filterMap) {
+        TimeUtils.logTime(log, "Refreshing table " + tableName, () -> {
+            SelectMode queryData = ModeFactory.getMode(xmlName, tableName + "_Ids", Map.class);
 
             // Remove all the existing data
             log.debug("Deleting existing data in table {}", tableName);
@@ -168,42 +200,50 @@ public class ReportDbUpdateTask extends RhnJavaJob {
             delete.executeUpdate(Map.of("mgm_id", LOCAL_MGM_ID));
 
             // Get the full data set first
-            @SuppressWarnings("unchecked")
             DataResult<Map<String, Long>> dataSet = queryData.execute();
             if (dataSet.isEmpty()) {
                 log.debug("No data extracted for table {}", tableName);
                 return;
             }
 
-            SelectMode query = ModeFactory.getMode(xmlName, tableName + "_byId", Map.class);
             for (Map<String, Long> data : dataSet) {
                 Long id = data.get("id");
 
-                // Extract the first batch
-                @SuppressWarnings("unchecked")
-                DataResult<Map<String, Object>> firstBatch = query.execute(
-                        Map.of("id", id, "offset", 0, "limit", batchSize));
-                if (firstBatch.isEmpty()) {
-                    log.debug("No data extracted for table {}", tableName);
-                    continue;
-                }
-                // Generate the insert using the column name retrieved from the select
-                Set<String> columnParameters = firstBatch.get(0).keySet();
-                WriteMode insert = dbHelper.generateInsertWithDate(session, tableName, LOCAL_MGM_ID, columnParameters);
+                Map<String, Object> parametersMap = new HashMap<>(filterMap);
+                parametersMap.put("id", id);
+                parametersMap.put("limit", batchSize);
 
-                insert.executeUpdates(firstBatch);
-                log.debug("Extracted {} rows for table {} and id {}", firstBatch.size(), tableName, id);
-
-                // Iterate further if we can have additional rows
-                if (firstBatch.size() == batchSize) {
-                    dbHelper.<Map<String, Object>>batchStream(query, batchSize, batchSize)
-                            .forEach(batch -> {
-                                insert.executeUpdates(batch);
-                                log.debug("Extracted {} rows more for table {}", firstBatch.size(), tableName);
-                            });
-                }
+                fillTableInBatches(session, xmlName, tableName + "_byId", tableName, parametersMap, filterMap.keySet());
             }
         });
+    }
+
+    private void fillTableInBatches(Session session, String xmlName, String queryName, String tableName,
+                                    Map<String, Object> parametersMap, Set<String> mutableFieldsSet) {
+        SelectMode query = ModeFactory.getMode(xmlName, queryName, Map.class);
+        DataResult<Map<String, Object>> dataBatch = query.execute(parametersMap);
+        if (dataBatch.isEmpty()) {
+            log.debug("No data extracted for table {}", tableName);
+            return;
+        }
+
+        // Generate the insert using the column name retrieved from the select
+        Set<String> columnParameters = dataBatch.get(0).keySet();
+        WriteMode insert = dbHelper.generateInsertWithDate(session, tableName, LOCAL_MGM_ID, columnParameters);
+
+        insert.executeUpdates(dataBatch);
+        log.debug("Extracted {} rows for table {}", dataBatch.size(), tableName);
+
+        // Iterate further if we can have additional rows
+        while (dataBatch.size() >= batchSize) {
+            dbHelper.updateParameters(parametersMap, dataBatch, mutableFieldsSet);
+
+            dataBatch = query.execute(parametersMap);
+            if (!dataBatch.isEmpty()) {
+                log.debug("Extracted {} rows more for table {}", dataBatch.size(), tableName);
+                insert.executeUpdates(dataBatch);
+            }
+        }
     }
 
     @Override

--- a/java/spacewalk-java.changes.mackdk.improve-pagination-reportdb
+++ b/java/spacewalk-java.changes.mackdk.improve-pagination-reportdb
@@ -1,0 +1,2 @@
+- Improved the performances of paginated queries when syncing the 
+  reporting database (bsc#1211912, bsc#1213079)


### PR DESCRIPTION
## What does this PR change?

This PR changes the way we execute the queries, using the FETCH FIRST approach and specifying a filter in the WHERE clause. With this approach each subsequent batch iteration will extract fewer rows hence perform better.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/23054

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
