### PR TITLE
disable test repo after usage

### DIFF
--- a/testsuite/features/secondary/min_recurring_action.feature
+++ b/testsuite/features/secondary/min_recurring_action.feature
@@ -199,6 +199,7 @@ Feature: Recurring Actions
   Scenario: Cleanup: subscribe system back to default base channel
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
+    And I disable repository "test_repo_rpm_pool" on this "sle_minion" without error control
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
     And I check default base channel radio button of this "sle_minion"
@@ -225,6 +226,7 @@ Feature: Recurring Actions
   Scenario: Cleanup: subscribe system back to default base channel
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
+    And I disable repository "test_repo_rpm_pool" on this "sle_minion" without error control
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
     And I check default base channel radio button of this "sle_minion"


### PR DESCRIPTION
## What does this PR change?

A testrepo was added at recurring action test and not removed again.
This cause errors in later tests when counting the assigned repos

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/23055

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
