### PR TITLE
More testsuite fixes

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/BaseSearchAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/BaseSearchAction.java
@@ -156,6 +156,7 @@ public abstract class BaseSearchAction extends RhnAction {
                                           escapedSearchString));
             }
             else {
+                LOG.error("Search failed: ", e);
                 errors.add(ActionMessages.GLOBAL_MESSAGE,
                     new ActionMessage("packages.search.could_not_execute_query",
                                       escapedSearchString));

--- a/search-server/spacewalk-search/src/java/com/redhat/satellite/search/index/IndexManager.java
+++ b/search-server/spacewalk-search/src/java/com/redhat/satellite/search/index/IndexManager.java
@@ -451,7 +451,7 @@ public class IndexManager {
             else if (indexName.compareTo(BuilderFactory.HARDWARE_DEVICE_TYPE) == 0) {
                 pr = new HardwareDeviceResult(x, hits.score(x), doc);
             }
-            else if (indexName.compareTo(BuilderFactory.SNAPSHOT_TAG_TYPE)  == 0) {
+            else if (indexName.compareTo(BuilderFactory.SNAPSHOT_TAG_TYPE) == 0) {
                 pr = new SnapshotTagResult(x, hits.score(x), doc);
             }
             else if (indexName.compareTo(BuilderFactory.SERVER_CUSTOM_INFO_TYPE) == 0) {
@@ -463,12 +463,19 @@ public class IndexManager {
                         doc.getField("identifier").stringValue(),
                         hits.score(x));
             }
-            else {
+            else if (indexName.compareTo(BuilderFactory.SERVER_TYPE) == 0) {
                 pr = new Result(x,
                         doc.getField("id").stringValue(),
                         doc.getField("name").stringValue(),
                         hits.score(x),
                         doc.getField("uuid").stringValue());
+            }
+            else {
+                //Type Errata and Package
+                pr = new Result(x,
+                        doc.getField("id").stringValue(),
+                        doc.getField("name").stringValue(),
+                        hits.score(x));
             }
             if (log.isDebugEnabled()) {
                 log.debug("Hit[" + x + "] Score = " + hits.score(x) + ", Result = " + pr);

--- a/testsuite/features/secondary/proxy_as_pod_basic_tests.feature
+++ b/testsuite/features/secondary/proxy_as_pod_basic_tests.feature
@@ -126,9 +126,9 @@ Feature: Register and test a Containerized Proxy
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "Fake-Base-Channel"
+    And I check radio button "Fake-Base-Channel-SUSE-like"
     And I wait until I do not see "Loading..." text
-    And I check "Fake-Child-Channel"
+    And I check "Fake-Child-Channel-SUSE-like"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -231,7 +231,7 @@ When(/^vendor change should be enabled for [^"]* on "([^"]*)"$/) do |host|
   next_day_rotated_log = "#{current_log}-#{day_after}.xz"
   begin
     _, return_code = node.run("xzdec #{next_day_rotated_log} | grep -- #{pattern}")
-  rescue Scr
+  rescue ScriptError
     _, return_code = node.run("grep -- #{pattern} #{current_log} || xzdec #{rotated_log} | grep -- #{pattern}")
   end
   raise ScriptError, 'Vendor change option not found in logs' unless return_code.zero?


### PR DESCRIPTION
## What does this PR change?

Fix more testsuite errors

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

These tests or errors do not exist in 4.3

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
