### PR TITLE
Fix NPE when creating PXE config for an unmanaged profile

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/ScheduleKickstartWizardAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/ScheduleKickstartWizardAction.java
@@ -65,6 +65,7 @@ import org.cobbler.SystemRecord;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -945,7 +946,7 @@ public class ScheduleKickstartWizardAction extends RhnWizardAction {
      * him if he's sure first.
      */
     protected boolean showDiskWarning(KickstartData data, DynaActionForm form) {
-        Set<KickstartCommand> commands = data.getOptions();
+        Set<KickstartCommand> commands = data == null ? Collections.emptySet() : data.getOptions();
         boolean containsClearpartCommand = false;
         for (KickstartCommand command : commands) {
             if (command.getCommandName() != null &&

--- a/java/spacewalk-java.changes.welder.bsc1217223
+++ b/java/spacewalk-java.changes.welder.bsc1217223
@@ -1,0 +1,1 @@
+- Fix NPE when creating PXE config for an unmanaged profile (bsc#1217223)


### PR DESCRIPTION
## What does this PR change?

Clicking on `Create PXE installation configuration` after selecting a non SUSE Manager manager profile was causing a NPE when checking if the "disk warning" should be shown. This PR fixes the NPE.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/23048

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
