### PR TITLE
QE: Clear SSM as pre-requisite for channel subscription tests

### DIFF
--- a/testsuite/features/secondary/allcli_software_channels_dependencies.feature
+++ b/testsuite/features/secondary/allcli_software_channels_dependencies.feature
@@ -8,6 +8,9 @@ Feature: Channel subscription with recommended or required dependencies
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
+  Scenario: Pre-requisite: remove remaining systems from SSM after software channel tests
+    When I click on the clear SSM button
+
 @susemanager
   Scenario: Play with recommended and required child channels selection for a single system
     Given I am on the Systems overview page of this "sle_minion"


### PR DESCRIPTION
## What does this PR change?

Clear SSM as pre-requisite for channel subscription tests

This will assure that other previous features failing, not running the clean-up scenarios, will not cause this feature to fail due to previous selected systems.

Example:
![image](https://github.com/uyuni-project/uyuni/assets/2827771/fa7d4174-52b2-473c-ad84-9d0946e4dd43)


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were improved

- [x] **DONE**

## Links

Ports:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
