### PR TITLE
QE: Attempt to fix a Capybara issue related to the xpath paramater value

### DIFF
--- a/testsuite/features/secondary/min_retracted_patches.feature
+++ b/testsuite/features/secondary/min_retracted_patches.feature
@@ -53,7 +53,7 @@ Feature: Retracted patches
     Then I should see a "No systems." text
     When I remove package "rute-dummy" from this "sle_minion"
     And I wait until package "rute-dummy" is removed from "sle_minion" via spacecmd
-   
+
   Scenario: Target systems for stable packages should not be empty
     When I follow the left menu "Software > Channel List > All"
     And I follow "Show All Child Channels"
@@ -61,8 +61,8 @@ Feature: Retracted patches
     And I follow "Packages" in the content area
     And I follow "rute-dummy-2.0-1.2.x86_64"
     And I follow "Target Systems"
-    And I refresh page until I see "sle_minion" hostname as text
-   
+    And I wait until I see the name of "sle_minion", refreshing the page
+
   Scenario: Target systems for retracted packages should be empty
     When I follow the left menu "Software > Channel List > All"
     And I follow "Show All Child Channels"
@@ -97,7 +97,7 @@ Feature: Retracted patches
     Then the table row for "rute-dummy-0815" should contain "retracted" icon
     And the table row for "rute-dummy-0816" should not contain "retracted" icon
     And the table row for "rute-dummy-0817" should contain "retracted" icon
- 
+
   Scenario: Retracted packages in the channel packages list
     When I follow the left menu "Software > Channel List > All"
     And I follow "Show All Child Channels"
@@ -110,7 +110,7 @@ Feature: Retracted patches
   Scenario: SSM: Retracted package should not be available for installation
     When I follow the left menu "Systems > System List > All"
     And I click on the clear SSM button
-    And I check the "sle_minion" client 
+    And I check the "sle_minion" client
     And I follow the left menu "Systems > System Set Manager > Overview"
     And I follow "Packages" in the content area
     And I follow "Install"

--- a/testsuite/features/secondary/min_salt_minions_page.feature
+++ b/testsuite/features/secondary/min_salt_minions_page.feature
@@ -34,7 +34,7 @@ Feature: Management of minion keys
     And I restart salt-minion on "sle_minion"
     And I wait at most 10 seconds until Salt master sees "sle_minion" as "unaccepted"
     And I follow the left menu "Salt > Keys"
-    And I refresh page until I see "sle_minion" hostname as text
+    And I wait until I see the name of "sle_minion", refreshing the page
     Then I should see a "Fingerprint" text
     And I see "sle_minion" fingerprint
     And I should see a "pending" text
@@ -47,7 +47,7 @@ Feature: Management of minion keys
     # we stop the service so the minion does not resubmit its key spontaneously
     When I stop salt-minion on "sle_minion"
     And I delete "sle_minion" from the Rejected section
-    And I refresh page until I do not see "sle_minion" hostname as text
+    And I wait until I do not see the name of "sle_minion", refreshing the page
 
   Scenario: Accepted minion shows up as a registered system
     When I start salt-minion on "sle_minion"

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -20,16 +20,12 @@ Then(/^I should not see a "(.*)" text in the content area$/) do |text|
   end
 end
 
-When(/^I click on "([^"]+)" in row "([^"]+)"$/) do |link, item|
-  within(:xpath, "//tr[td[contains(.,'#{item}')]]") do
-    click_link_or_button_and_wait(link)
-  end
+When(/^I click on "([^"]+)" in row "([^"]+)"$/) do |text, item|
+  find_and_wait_click(:xpath, "//tr[td[contains(.,'#{item}')]]/*[contains(text(),'#{text}')]").click
 end
 
-When(/^I click on "([^"]+)" in tree item "(.*?)"$/) do |button, item|
-  within(:xpath, "//span[contains(text(), '#{item}')]/ancestor::div[contains(@class, 'product-details-wrapper')]") do
-    click_link_or_button_and_wait(button)
-  end
+When(/^I click on "([^"]+)" in tree item "(.*?)"$/) do |text, item|
+  find(:xpath, "//span[contains(text(), '#{item}')]/ancestor::div[contains(@class, 'product-details-wrapper')]/*[contains(text(),'#{text}')]").click
 end
 
 Then(/^the current path is "([^"]*)"$/) do |arg1|
@@ -281,7 +277,7 @@ end
 # Click on a button
 #
 When(/^I click on "([^"]*)"$/) do |text|
-  click_button_and_wait(text, match: :first)
+  click_button(text, match: :first)
 end
 
 #
@@ -289,7 +285,7 @@ end
 # the given "id"
 When(/^I click on "([^"]*)" in element "([^"]*)"$/) do |text, element_id|
   within(:xpath, "//div[@id=\"#{element_id}\"]") do
-    click_button_and_wait(text, match: :first)
+    click_button(text, match: :first)
   end
 end
 
@@ -307,40 +303,36 @@ end
 # Click on a link
 #
 When(/^I follow "([^"]*)"$/) do |text|
-  click_link_and_wait(text)
+  click_link(text)
 end
 
 #
 # Click on the first link
 #
 When(/^I follow first "([^"]*)"$/) do |text|
-  click_link_and_wait(text, match: :first)
+  click_link(text, match: :first)
 end
 
 #
 # Click on a link which appears inside of <div> with
 # the given "id"
 
-When(/^I follow "([^"]*)" in the (.+)$/) do |arg1, arg2|
-  tag = case arg2
+When(/^I follow "([^"]*)" in the (.+)$/) do |text, scope|
+  tag = case scope
         when /tab bar|tabs/ then 'header'
         when /content area/ then 'section'
-        else raise ScriptError, "Unknown element with description '#{arg2}'"
+        else raise ScriptError, "Unknown element with description '#{scope}'"
         end
-  within(:xpath, "//#{tag}") do
-    step %(I follow "#{arg1}")
-  end
+  find_and_wait_click(:xpath, "//#{tag}//*[text()[contains(.,'#{text}')]]").click
 end
 
-When(/^I follow first "([^"]*)" in the (.+)$/) do |arg1, arg2|
-  tag = case arg2
+When(/^I follow first "([^"]*)" in the (.+)$/) do |text, scope|
+  tag = case scope
         when /tab bar|tabs/ then 'header'
         when /content area/ then 'section'
-        else raise ScriptError, "Unknown element with description '#{arg2}'"
+        else raise ScriptError, "Unknown element with description '#{scope}'"
         end
-  within(:xpath, "//#{tag}") do
-    step "I follow first \"#{arg1}\""
-  end
+  find_and_wait_click(:xpath, "//#{tag}//*[text()[contains(.,'#{text}')]]", match: :first).click
 end
 
 When(/^I follow "([^"]*)" on "(.*?)" row$/) do |text, host|
@@ -555,7 +547,7 @@ Given(/^I am authorized as "([^"]*)" with password "([^"]*)"$/) do |user, passwd
   raise ScriptError, 'Login page is not correctly loaded' unless has_field?('username')
   fill_in('username', with: user)
   fill_in('password', with: passwd)
-  click_button_and_wait('Sign In', match: :first)
+  click_button('Sign In', match: :first)
 
   step 'I should be logged in'
 end
@@ -1138,7 +1130,7 @@ end
 
 # In case of a search reindex not having finished yet, keep retrying until successful search or timeout
 When(/^I click on the search button$/) do
-  click_button_and_wait('Search', match: :first)
+  click_button('Search', match: :first)
   # after a search reindex, the UI will show a "Could not connect to search server" followed by a false "No matches found" for a while
   if has_text?('Could not connect to search server.', wait: 0)
     repeat_until_timeout(message: 'Could not perform a successful search after reindexation', timeout: 10) do

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -402,18 +402,6 @@ When(/^I accept "([^"]*)" key$/) do |host|
   raise ScriptError, "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query).click
 end
 
-When(/^I refresh page until I see "(.*?)" hostname as text$/) do |minion|
-  within('#spacewalk-content') do
-    step %(I wait until I see the name of "#{minion}", refreshing the page)
-  end
-end
-
-When(/^I refresh page until I do not see "(.*?)" hostname as text$/) do |minion|
-  within('#spacewalk-content') do
-    step %(I wait until I do not see the name of "#{minion}", refreshing the page)
-  end
-end
-
 When(/^I list packages with "(.*?)"$/) do |str|
   find('input#package-search').set(str)
   repeat_until_timeout(timeout: 60, retries: 30, message: 'Search button not enabled', report_result: true) do

--- a/testsuite/features/step_definitions/setup_steps.rb
+++ b/testsuite/features/step_definitions/setup_steps.rb
@@ -132,9 +132,7 @@ end
 
 Then(/^I should see the "(.*?)" selected$/) do |product|
   xpath = "//span[contains(text(), '#{product}')]/ancestor::div[contains(@class, 'product-details-wrapper')]"
-  within(:xpath, xpath) do
-    raise ScriptError, "#{find(:xpath, '.')['data-identifier']} is not checked" unless find(:xpath, './div/input[@type=\'checkbox\']').checked?
-  end
+  raise ScriptError, "#{find(:xpath, xpath)['data-identifier']} is not checked" unless find(:xpath, "#{xpath}/div/input[@type='checkbox']").checked?
 end
 
 When(/^I wait until I see "(.*?)" product has been added$/) do |product|
@@ -175,23 +173,20 @@ end
 # configuration management steps
 
 Then(/^I should see a table line with "([^"]*)", "([^"]*)", "([^"]*)"$/) do |arg1, arg2, arg3|
-  within(:xpath, "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{arg1}')]]") do
-    raise ScriptError, "Link #{arg2} not found" unless find_link(arg2)
-    raise ScriptError, "Link #{arg3} not found" unless find_link(arg3)
-  end
+  xpath = "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{arg1}')]]"
+  raise ScriptError, "Link #{arg2} not found" unless find("#{xpath}//*[text()[contains(.,'#{arg2}')]]")
+  raise ScriptError, "Link #{arg3} not found" unless find("#{xpath}//*[text()[contains(.,'#{arg3}')]]")
 end
 
 Then(/^I should see a table line with "([^"]*)", "([^"]*)"$/) do |arg1, arg2|
-  within(:xpath, "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{arg1}')]]") do
-    raise ScriptError, "Link #{arg2} not found" unless find_link(arg2)
-  end
+  xpath = "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{arg1}')]]//*[text()[contains(.,'#{arg2}')]]"
+  raise ScriptError, "Link #{arg2} not found" unless find(xpath)
 end
 
 Then(/^a table line should contain system "([^"]*)", "([^"]*)"$/) do |host, text|
   system_name = get_system_name(host)
-  within(:xpath, "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{system_name}')]]") do
-    raise ScriptError, "Text #{text} not found" unless find_all(:xpath, "//td[contains(., '#{text}')]")
-  end
+  xpath = "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{system_name}')]]//td[contains(., '#{text}')]"
+  raise ScriptError, "Text #{text} not found" unless find_all(:xpath, xpath)
 end
 
 # Register client
@@ -415,10 +410,8 @@ Then(/^I check the first notification message$/) do
   if count_table_items == '0'
     log 'There are no notification messages, nothing to do then'
   else
-    within(:xpath, '//section') do
-      row = find(:xpath, '//div[@class="table-responsive"]/table/tbody/tr[.//td]', match: :first)
-      row.find(:xpath, './/input[@type="checkbox"]', match: :first).set(true)
-    end
+    row = find(:xpath, '//section//div[@class="table-responsive"]/table/tbody/tr[.//td]', match: :first)
+    row.find(:xpath, './/input[@type="checkbox"]', match: :first).set(true)
   end
 end
 

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -112,33 +112,6 @@ def format_detail(message, last_result, report_result)
   "#{formatted_message}#{formatted_result}"
 end
 
-def click_button_and_wait(locator = nil, **options)
-  click_button(locator, options)
-  begin
-    warn 'Timeout: Waiting AJAX transition (click link)' unless has_no_css?('.senna-loading', wait: 20)
-  rescue StandardError => e
-    STDOUT.puts e.message # Skip errors related to .senna-loading element
-  end
-end
-
-def click_link_and_wait(locator = nil, **options)
-  click_link(locator, options)
-  begin
-    warn 'Timeout: Waiting AJAX transition (click link)' unless has_no_css?('.senna-loading', wait: 20)
-  rescue StandardError => e
-    STDOUT.puts e.message # Skip errors related to .senna-loading element
-  end
-end
-
-def click_link_or_button_and_wait(locator = nil, **options)
-  click_link_or_button(locator, options)
-  begin
-    warn 'Timeout: Waiting AJAX transition (click link)' unless has_no_css?('.senna-loading', wait: 20)
-  rescue StandardError => e
-    STDOUT.puts e.message # Skip errors related to .senna-loading element
-  end
-end
-
 # Capybara Node Element extension to override click method, clicking and then waiting for ajax transition
 module CapybaraNodeElementExtension
   def click


### PR DESCRIPTION
## What does this PR change?

This is an attempt to fix this kind of issue:

```
undefined method `map' for true:TrueClass[0m
Did you mean?  tap (NoMethodError)[0m
./features/support/commonlib.rb:150:in `click_link_and_wait'[0m
./features/step_definitions/navigation_steps.rb:321:in `/^I follow "([^"]*)"$/'[0m
```

When this error is raised, is because our Capybara method is receiving a "True" boolean value as a parameter on the Capybara method, when it's expecting a "XPath format" value.
I have the gut feeling this is somehow related to the usage of "within", it seems to always be triggered in cases where we use a "within" statement.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were refactored

- [x] **DONE**

## Links

Ports:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
