### PR TITLE
QE: Assign correct channel to RH-like systems

### DIFF
--- a/testsuite/features/init_clients/min_rhlike_salt.feature
+++ b/testsuite/features/init_clients/min_rhlike_salt.feature
@@ -44,7 +44,7 @@ Feature: Bootstrap a Red Hat-like minion and do some basic operations on it
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "Fake-Base-Channel-SUSE-like"
+    And I check radio button "Fake-Base-Channel-RH-like"
     And I wait until I do not see "Loading..." text
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text

--- a/testsuite/features/secondary/allcli_software_channels.feature
+++ b/testsuite/features/secondary/allcli_software_channels.feature
@@ -138,7 +138,7 @@ Feature: Channel subscription via SSM
     Then I should see "1" systems selected for SSM
     When I follow the left menu "Systems > System Set Manager > Overview"
     And I follow "channel memberships" in the content area
-    And I select "System Default Base Channel" from drop-down in table line with "Fake-Base-Channel-SUSE-like"
+    And I select "System Default Base Channel" from drop-down in table line with "Fake-Base-Channel-RH-like"
     And I click on "Next"
     Then I should see a "Child Channels" text
     And I should see a "Couldn't determine new base channel" text
@@ -158,7 +158,7 @@ Feature: Channel subscription via SSM
     Given I am on the Systems overview page of this "rhlike_minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
-    Then radio button "Fake-Base-Channel-SUSE-like" should be checked
+    Then radio button "Fake-Base-Channel-RH-like" should be checked
 
 @deblike_minion
   Scenario: System default channel can't be determined on the Debian-like minion

--- a/testsuite/features/secondary/min_rhlike_openscap_audit.feature
+++ b/testsuite/features/secondary/min_rhlike_openscap_audit.feature
@@ -87,7 +87,7 @@ Feature: OpenSCAP audit of Red Hat-like Salt minion
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "Fake-Base-Channel-SUSE-like"
+    And I check radio button "Fake-Base-Channel-RH-like"
     And I wait until I do not see "Loading..." text
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text

--- a/testsuite/features/secondary/min_rhlike_ssh.feature
+++ b/testsuite/features/secondary/min_rhlike_ssh.feature
@@ -61,7 +61,7 @@ Feature: Bootstrap a SSH-managed Red Hat-like minion and do some basic operation
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "Fake-Base-Channel-SUSE-like"
+    And I check radio button "Fake-Base-Channel-RH-like"
     And I wait until I do not see "Loading..." text
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
@@ -117,7 +117,7 @@ Feature: Bootstrap a SSH-managed Red Hat-like minion and do some basic operation
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "Fake-Base-Channel-SUSE-like"
+    And I check radio button "Fake-Base-Channel-RH-like"
     And I wait until I do not see "Loading..." text
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text

--- a/testsuite/features/secondary/srv_maintenance_windows.feature
+++ b/testsuite/features/secondary/srv_maintenance_windows.feature
@@ -98,10 +98,8 @@ Feature: Maintenance windows
 
   Scenario: Remove a package and update package list
     When I remove package "virgo-dummy" from this "rhlike_minion" without error control
-    Given I am on the Systems overview page of this "rhlike_minion"
-    When I follow "Software" in the content area
-    And I click on "Update Package List"
-    And I wait until event "Package List Refresh scheduled by admin" is completed
+    And I refresh packages list via spacecmd on "rhlike_minion"
+    And I wait until refresh package list on "rhlike_minion" is finished
 
   Scenario: Schedule package installation action
     Given I am on the Systems overview page of this "rhlike_minion"


### PR DESCRIPTION
## What does this PR change?

Assign correct channel to RH-like systems

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were fixed

- [x] **DONE**

## Links

Ports:
- Manager-4.3 https://github.com/SUSE/spacewalk/pull/23064

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
