### PR TITLE
QE: Fix the number of channels expected

### DIFF
--- a/testsuite/features/secondary/min_change_software_channel.feature
+++ b/testsuite/features/secondary/min_change_software_channel.feature
@@ -45,7 +45,7 @@ Feature: Assign child channel to a system
 @uyuni
   Scenario: Check old channels are still enabled on the system before channel change completes
     When I refresh the metadata for "sle_minion"
-    Then "9" channels should be enabled on "sle_minion"
+    Then "8" channels should be enabled on "sle_minion"
     And channel "openSUSE Leap 15.5 (x86_64)" should be enabled on "sle_minion"
 
 @susemanager
@@ -113,7 +113,7 @@ Feature: Assign child channel to a system
 @uyuni
   Scenario: Check the new channels are enabled on the system
     When I refresh the metadata for "sle_minion"
-    Then "10" channels should be enabled on "sle_minion"
+    Then "9" channels should be enabled on "sle_minion"
     And channel "openSUSE Leap 15.5 (x86_64)" should be enabled on "sle_minion"
     And channel "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)" should be enabled on "sle_minion"
 


### PR DESCRIPTION
## What does this PR change?

Fix the number of enabled repositories expected in the feature "Assign child channel to a system".
It has been decreased by one because we [recently](https://github.com/uyuni-project/uyuni/pull/7906) fixed another collateral issue where we forgot to disable an injected test repository.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were fixed

- [x] **DONE**

## Links

It seems it doesn't need a port.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
