### PR TITLE
QE: Fix a typo on the pod proxy test

### DIFF
--- a/testsuite/features/secondary/proxy_as_pod_basic_tests.feature
+++ b/testsuite/features/secondary/proxy_as_pod_basic_tests.feature
@@ -165,7 +165,6 @@ Feature: Register and test a Containerized Proxy
     And I enter "milkyway-dummy" as the filtered package name
     And I click on the filter button
     And I wait until I see "Clear filter to see all" text
-    And I check the package for "milkyway-dummy" in the list
     And I check "milkyway-dummy" in the list
     And I click on "Remove Packages"
     Then I wait until I see "Confirm Package Removal" text


### PR DESCRIPTION
## What does this PR change?

Fix a typo on the pod proxy test.
As `And I check the package for "..." in the list` as a step wrapping `And I check "..." in the list` for a particular host.
In our case after the refactor that has been made recently, we want to directly set a particular package.


![image](https://github.com/uyuni-project/uyuni/assets/2827771/28bb0ecc-c727-4d7b-9f0a-ac7c9a363c4c)


![image](https://github.com/uyuni-project/uyuni/assets/2827771/06484c03-36f4-4f1d-a533-3a01ddb89efe)


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were fixed

- [x] **DONE**

## Links

Ports:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
