### PR TITLE
QE: Fix the rescue of a wrong API call

### DIFF
--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -26,7 +26,7 @@ When(/^I call system\.bootstrap\(\) on unknown host, I should get an API fault$/
   exception_thrown = false
   begin
     $api_test.system.bootstrap_system('imprettysureidontexist', '', false)
-  rescue
+  rescue SystemCallError
     exception_thrown = true
   end
   assert(exception_thrown, 'Exception must be thrown for non-existing host.')
@@ -36,7 +36,7 @@ When(/^I call system\.bootstrap\(\) on a Salt minion with saltSSH = true, but wi
   exception_thrown = false
   begin
     $api_test.system.bootstrap_system(get_target('sle_minion').full_hostname, '1-SUSE-KEY-x86_64', true)
-  rescue
+  rescue SystemCallError
     exception_thrown = true
   end
   assert(exception_thrown, 'Exception must be thrown for non-compatible activation keys.')

--- a/testsuite/features/support/http_client.rb
+++ b/testsuite/features/support/http_client.rb
@@ -96,7 +96,7 @@ class HttpClient
       session_cookie
     else
       json_body = JSON.parse(answer.body)
-      raise ScriptError, "API failure: #{json_body['message']}" unless json_body['success']
+      raise SystemCallError, "API failure: #{json_body['message']}" unless json_body['success']
 
       json_body['result']
     end


### PR DESCRIPTION
## What does this PR change?

Fixing this step, because we must specify the exception to catch:

![image](https://github.com/uyuni-project/uyuni/assets/2827771/3e06780a-ff7e-4fcc-b527-e2d4c4207375)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage

- Cucumber tests were fixed

- [x] **DONE**

## Links

Ports:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
