### PR TITLE
Fix susemanager-branding-oss and spacewalk-web rpm

### DIFF
--- a/susemanager-branding-oss/susemanager-branding-oss.changes.mbussolotto.branding_oss_build_fix
+++ b/susemanager-branding-oss/susemanager-branding-oss.changes.mbussolotto.branding_oss_build_fix
@@ -1,0 +1,1 @@
+- Fix missing folders in spec file

--- a/susemanager-branding-oss/susemanager-branding-oss.spec
+++ b/susemanager-branding-oss/susemanager-branding-oss.spec
@@ -17,7 +17,9 @@
 
 
 %if 0%{?suse_version}
-%global wwwdocroot /usr/share/susemanager/www/htdocs
+%global susemanager_shared_path /usr/share/susemanager
+%global wwwroot %{susemanager_shared_path}/www
+%global wwwdocroot %{wwwroot}/htdocs
 %else
 %global wwwdocroot %{_localstatedir}/www/html
 %endif
@@ -68,6 +70,11 @@ install -m 644 license.txt $RPM_BUILD_ROOT/%_defaultdocdir/susemanager/
 %docdir %_defaultdocdir/susemanager
 %dir %_defaultdocdir/susemanager
 %_defaultdocdir/susemanager/license.txt
+%if 0%{?suse_version}
+%dir %{susemanager_shared_path}
+%dir %{wwwroot}
+%endif
+%dir %{wwwdocroot}
 %dir %{wwwdocroot}/help
 %{wwwdocroot}/help/eula.html
 

--- a/web/spacewalk-web.changes.mbussolotto.el9_package
+++ b/web/spacewalk-web.changes.mbussolotto.el9_package
@@ -1,0 +1,1 @@
+- Fix EL9 rpm

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -16,9 +16,9 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
+%if 0%{?suse_version}
 %define shared_path /usr/share/susemanager
 %define shared_www_path %{shared_path}/www
-%if 0%{?suse_version}
 %define www_path %{shared_www_path}/htdocs
 %define apache_user wwwrun
 %define apache_group www
@@ -252,8 +252,10 @@ sed -i -e 's/^web.theme_default =.*$/web.theme_default = susemanager-light/' $RP
 
 %files -n spacewalk-html -f spacewalk-web.lang
 %defattr(644,root,root,755)
+%if 0%{?suse_version}
 %dir %{shared_path}
 %dir %{shared_www_path}
+%endif
 %dir %{www_path}
 %dir %{www_path}/css
 %{www_path}/css/*.{css,js}


### PR DESCRIPTION
## What does this PR change?

Fix missing folders in susemanager-branding-oss spec file and spacewalk-web rpm

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed
- [x] **DONE**

## Test coverage
- No tests
- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
