### PR TITLE
Ensure correct snakeyaml version is required

### DIFF
--- a/java/spacewalk-java.changes.mackdk.enforce-snakeyaml-version
+++ b/java/spacewalk-java.changes.mackdk.enforce-snakeyaml-version
@@ -1,0 +1,1 @@
+- Enforce snakeyaml version requirement (bsc#1215166)

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -136,7 +136,7 @@ BuildRequires:  salt-netapi-client >= 0.20
 BuildRequires:  simple-core
 BuildRequires:  simple-xml
 BuildRequires:  sitemesh
-BuildRequires:  snakeyaml
+BuildRequires:  snakeyaml >= 1.33
 BuildRequires:  spark-core
 BuildRequires:  spark-template-jade
 BuildRequires:  statistics
@@ -222,7 +222,7 @@ Requires:       salt-netapi-client >= 0.20
 Requires:       simple-core
 Requires:       simple-xml
 Requires:       sitemesh
-Requires:       snakeyaml
+Requires:       snakeyaml >= 1.33
 Requires:       spacewalk-branding
 Requires:       spacewalk-java-config
 Requires:       spacewalk-java-jdbc


### PR DESCRIPTION
## What does this PR change?

This PR enforces the version of snakeyaml in the spec file. We are requiring version 1.33 since commit https://github.com/uyuni-project/uyuni/commit/f9fef7149d92c13918a7acc82f046b80c6881d34 that introduced the usage of `LoadOptions.setCodePointLimit()`

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: no code changes

- [X] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/22504

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
