### PR TITLE
QE: Fix ISO mounting step and add SHA256 checksum verification 

### DIFF
--- a/testsuite/features/build_validation/add_non_MU_repositories/centos7_minion_add_iso.feature
+++ b/testsuite/features/build_validation/add_non_MU_repositories/centos7_minion_add_iso.feature
@@ -5,7 +5,7 @@
 Feature: Add the CentOS 7 distribution custom repositories
 
   Scenario: Download the iso of CentOS 7 DVD and mount it on the server
-    When I mount as "centos-7-iso" the ISO from "http://mirror.chpc.utah.edu/pub/centos/7/isos/x86_64/CentOS-7-x86_64-DVD-2009.iso" in the server
+    When I mount as "centos-7-iso" the ISO from "http://mirror.chpc.utah.edu/pub/centos/7/isos/x86_64/CentOS-7-x86_64-DVD-2009.iso" in the server, validating its checksum
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section

--- a/testsuite/features/build_validation/add_non_MU_repositories/rocky8_minion_add_iso_and_build_clm.feature
+++ b/testsuite/features/build_validation/add_non_MU_repositories/rocky8_minion_add_iso_and_build_clm.feature
@@ -8,7 +8,7 @@ Feature: Add the Rocky 8 distribution custom repositories
   I want to filter them out to remove the modules information
 
   Scenario: Download the iso of Rocky 8 DVD and mount it on the server
-    When I mount as "rocky-8-iso" the ISO from "http://mirror.chpc.utah.edu/pub/rocky/8/isos/x86_64/Rocky-x86_64-dvd.iso" in the server
+    When I mount as "rocky-8-iso" the ISO from "http://mirror.chpc.utah.edu/pub/rocky/8/isos/x86_64/Rocky-x86_64-dvd.iso" in the server, validating its checksum
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -23,7 +23,7 @@ end
 When(/^I mount as "([^"]+)" the ISO from "([^"]+)" in the server$/) do |name, url|
   # When using a mirror it is automatically mounted at /mirror
   if $mirror
-    iso_path = url.sub(/^http:.*\/pub/, '/mirror/pub')
+    iso_path = url.sub(/^https?:\/\/[^\/]+/, '/mirror')
   else
     iso_path = "/tmp/#{name}.iso"
     get_target('server').run("wget --no-check-certificate -O #{iso_path} #{url}", timeout: 1500)

--- a/testsuite/features/support/file_management.rb
+++ b/testsuite/features/support/file_management.rb
@@ -1,0 +1,53 @@
+# Copyright (c) 2019-2023 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+# Attempts to retrieve the SHA256 checksum for a file inside a given directory or download it
+# from the same domain the file has been downloaded from.
+# Returns the path to the checksum or nil if none has been found/downloaded
+def get_checksum_path(dir, original_file_name, file_url)
+  checksum_file_names = %W[CHECKSUM SHA256SUMS sha256sum.txt #{original_file_name}.CHECKSUM #{original_file_name}.sha256]
+
+  # When using a mirror, the checksum file should be present and in the same directory of the file
+  if $mirror
+    checksum_file_names.each do |name|
+      checksum_path = "#{dir}/#{name}"
+      _output, code = get_target('server').run("test -e #{checksum_path}", check_errors: false)
+      return checksum_path if code.zero?
+    end
+  # Attempt to download the checksum file
+  else
+    base_url = file_url.delete_suffix(original_file_name)
+
+    checksum_file_names.each do |name|
+      checksum_url = base_url + name
+      _output, code = get_target('server').run("cd #{dir} && wget --no-check-certificate #{checksum_url}", check_errors: false, timeout: 1500)
+      return "#{dir}/#{name}" if code.zero?
+    end
+  end
+
+  # No checksum file found or downloaded
+  nil
+end
+
+# Computes the SHA256 checksum for the file at the given path and verifies it against a checksum file.
+# The original file name is used to retrieve the correct checksum entry
+def validate_checksum_with_file(original_file_name, file_path, checksum_path)
+  # Search the checksum file for what should be the only non-comment line containing the original file name
+  checksum_line, _code = get_target('server').run("grep -v '^#' #{checksum_path} | grep '#{original_file_name}'")
+  raise "SHA256 checksum entry for #{original_file_name} not found in #{checksum_path}" unless checksum_line
+
+  # This relies on the fact that SHA256 hashes have a fixed length of 64 hexadecimal characters to extract the checksum
+  # and address any issue related to a checksum file having a different internal format compared to the standard
+  checksum_match = checksum_line.match(/\b([0-9a-fA-F]{64})\b/)
+  raise "SHA256 checksum not found in entry: #{checksum_line}" unless checksum_match
+
+  expected_checksum = checksum_match[1]
+  validate_checksum(file_path, expected_checksum)
+end
+
+# Computes the SHA256 checksum of the file at the given path and returns a boolean representing whether it
+# matches the expected checksum or not
+def validate_checksum(file_path, expected_checksum)
+  file_checksum, _code = get_target('server').run("sha256sum -b #{file_path} | awk '{print $1}'")
+  file_checksum.strip == expected_checksum
+end

--- a/testsuite/features/support/file_management.rb
+++ b/testsuite/features/support/file_management.rb
@@ -1,32 +1,47 @@
-# Copyright (c) 2019-2023 SUSE LLC
+# Copyright (c) 2023 SUSE LLC
 # Licensed under the terms of the MIT license.
+
+require 'net/http'
 
 # Attempts to retrieve the SHA256 checksum for a file inside a given directory or download it
 # from the same domain the file has been downloaded from.
-# Returns the path to the checksum or nil if none has been found/downloaded
+# Returns the path to the checksum file.
 def get_checksum_path(dir, original_file_name, file_url)
   checksum_file_names = %W[CHECKSUM SHA256SUMS sha256sum.txt #{original_file_name}.CHECKSUM #{original_file_name}.sha256]
 
+  server = get_target('server')
   # When using a mirror, the checksum file should be present and in the same directory of the file
   if $mirror
-    checksum_file_names.each do |name|
-      checksum_path = "#{dir}/#{name}"
-      _output, code = get_target('server').run("test -e #{checksum_path}", check_errors: false)
-      return checksum_path if code.zero?
-    end
+    output, _code = server.run("ls -1 #{dir}")
+    files = output.split("\n")
+    checksum_file = files.find { |file| checksum_file_names.include?(file) }
+
+    raise "SHA256 checksum file not found in #{dir}" unless checksum_file
+
+    "#{dir}/#{checksum_file}"
   # Attempt to download the checksum file
   else
     base_url = file_url.delete_suffix(original_file_name)
+    uri = URI.parse(base_url)
+
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = (uri.scheme == 'https')
+    base_path = uri.path
 
     checksum_file_names.each do |name|
-      checksum_url = base_url + name
-      _output, code = get_target('server').run("cd #{dir} && wget --no-check-certificate #{checksum_url}", check_errors: false, timeout: 1500)
-      return "#{dir}/#{name}" if code.zero?
-    end
-  end
+      # check the URL for the checksum file actually exists and if it does download it on the server
+      checksum_path = base_path + name
+      request = Net::HTTP::Head.new(checksum_path)
+      response = http.request(request)
 
-  # No checksum file found or downloaded
-  nil
+      if response.is_a?(Net::HTTPSuccess)
+        _output, code = server.run("cd #{dir} && wget --no-check-certificate #{checksum_url}", timeout: 10)
+        return "#{dir}/#{name}" if code.zero?
+      end
+    end
+
+    raise "No SHA256 checksum file to download found for file at #{file_url}"
+  end
 end
 
 # Computes the SHA256 checksum for the file at the given path and verifies it against a checksum file.


### PR DESCRIPTION
## What does this PR change?

[spacewalk #20573](https://github.com/SUSE/spacewalk/issues/20573) Add SHA256 checksum verification when mounting images

[spacewalk #20900](https://github.com/SUSE/spacewalk/issues/20900) Fix mounting ISO step when using a mirror

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were fixed and edited

- [x] **DONE**

## Links

Ports:

- Manager 4.3


- [ ] **DONE**

## Changelogs

- [x] No changelog needed


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
