### PR TITLE
Followup to move all package files from /srv for Enterprise Linux compatibililty

### DIFF
--- a/branding/spacewalk-branding.changes.sbluhm.refactoring_srv
+++ b/branding/spacewalk-branding.changes.sbluhm.refactoring_srv
@@ -1,0 +1,1 @@
+- Adapted Enterprise Linux for /usr/share/susemanager structure.

--- a/branding/spacewalk-branding.changes.sbluhm.refactoring_srv
+++ b/branding/spacewalk-branding.changes.sbluhm.refactoring_srv
@@ -1,1 +1,2 @@
 - Adapted Enterprise Linux for /usr/share/susemanager structure.
+- Removed package conflict /usr/share/susemanager/www between other packages.

--- a/branding/spacewalk-branding.spec
+++ b/branding/spacewalk-branding.spec
@@ -20,13 +20,13 @@
 %global debug_package %{nil}
 
 %if 0%{?fedora} || 0%{?rhel} >= 7
-%global susemanager_shared_path /usr/share/susemanager
+%global susemanager_shared_path  %{_datadir}/susemanager
 %global wwwroot %{susemanager_shared_path}/www
 %global tomcat_path %{wwwroot}/tomcat
 %global wwwdocroot %{wwwroot}/www/html
 %else
 %if 0%{?sle_version}
-%global susemanager_shared_path /usr/share/susemanager
+%global susemanager_shared_path  %{_datadir}/susemanager
 %global wwwroot %{susemanager_shared_path}/www
 %global tomcat_path %{wwwroot}/tomcat
 %global wwwdocroot %{wwwroot}/htdocs

--- a/branding/spacewalk-branding.spec
+++ b/branding/spacewalk-branding.spec
@@ -19,22 +19,10 @@
 
 %global debug_package %{nil}
 
-%if 0%{?fedora} || 0%{?rhel} >= 7
 %global susemanager_shared_path  %{_datadir}/susemanager
 %global wwwroot %{susemanager_shared_path}/www
 %global tomcat_path %{wwwroot}/tomcat
 %global wwwdocroot %{wwwroot}/www/html
-%else
-%if 0%{?sle_version}
-%global susemanager_shared_path  %{_datadir}/susemanager
-%global wwwroot %{susemanager_shared_path}/www
-%global tomcat_path %{wwwroot}/tomcat
-%global wwwdocroot %{wwwroot}/htdocs
-%else
-%global tomcat_path %{_var}/lib/tomcat6
-%global wwwdocroot %{_var}/www/html
-%endif
-%endif
 
 Name:           spacewalk-branding
 Version:        4.4.1

--- a/branding/spacewalk-branding.spec
+++ b/branding/spacewalk-branding.spec
@@ -84,8 +84,8 @@ ln -s %{_datadir}/rhn/lib/java-branding.jar %{buildroot}%{tomcat_path}/webapps/r
 %{_datadir}/rhn/lib/java-branding.jar
 %{tomcat_path}/webapps/rhn/WEB-INF/lib/java-branding.jar
 %license LICENSE
-%attr(775,tomcat,tomcat) %dir %{susemanager_shared_path}
-%attr(775,tomcat,tomcat) %dir %{wwwroot}
+%dir %{susemanager_shared_path}
+%dir %{wwwroot}
 %attr(775,tomcat,tomcat) %dir %{wwwdocroot}
 %attr(775,tomcat,tomcat) %dir %{tomcat_path}
 %attr(775,tomcat,tomcat) %dir %{tomcat_path}/webapps

--- a/branding/spacewalk-branding.spec
+++ b/branding/spacewalk-branding.spec
@@ -20,8 +20,10 @@
 %global debug_package %{nil}
 
 %if 0%{?fedora} || 0%{?rhel} >= 7
-%global tomcat_path %{_var}/lib/tomcat
-%global wwwdocroot %{_var}/www/html
+%global susemanager_shared_path /usr/share/susemanager
+%global wwwroot %{susemanager_shared_path}/www
+%global tomcat_path %{wwwroot}/tomcat
+%global wwwdocroot %{wwwroot}/www/html
 %else
 %if 0%{?sle_version}
 %global susemanager_shared_path /usr/share/susemanager
@@ -94,7 +96,6 @@ ln -s %{_datadir}/rhn/lib/java-branding.jar %{buildroot}%{tomcat_path}/webapps/r
 %{_datadir}/rhn/lib/java-branding.jar
 %{tomcat_path}/webapps/rhn/WEB-INF/lib/java-branding.jar
 %license LICENSE
-%if 0%{?suse_version}
 %attr(775,tomcat,tomcat) %dir %{susemanager_shared_path}
 %attr(775,tomcat,tomcat) %dir %{wwwroot}
 %attr(775,tomcat,tomcat) %dir %{wwwdocroot}
@@ -105,6 +106,5 @@ ln -s %{_datadir}/rhn/lib/java-branding.jar %{buildroot}%{tomcat_path}/webapps/r
 %attr(775,tomcat,tomcat) %dir %{tomcat_path}/webapps/rhn/WEB-INF/lib/
 %dir %{_prefix}/share/rhn
 %dir %{_prefix}/share/rhn/lib
-%endif
 
 %changelog

--- a/java/build.xml
+++ b/java/build.xml
@@ -553,7 +553,7 @@
   </target>
 
   <target name="install-tomcat">
-       <property name="webapp-dir" value="/var/lib/tomcat/webapps/" />
+       <property name="webapp-dir" value="/usr/share/susemanager/www/tomcat/webapps/" />
     <!--
      - initializing prefix otherwise webapp is not copied to tomcat directory
      -->

--- a/java/spacewalk-java.changes.sbluhm.refactoring_srv
+++ b/java/spacewalk-java.changes.sbluhm.refactoring_srv
@@ -1,0 +1,1 @@
+- Adapted Enterprise Linux for /usr/share/susemanager structure.

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -28,7 +28,6 @@
 %define run_checkstyle  0
 %define omit_tests      1
 
-%define shareddir       %{_datadir}
 %define susemanagershareddir       %{_datadir}/susemanager
 %define serverdir       %{susemanagershareddir}/www
 %define salt_user_group salt

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -28,19 +28,19 @@
 %define run_checkstyle  0
 %define omit_tests      1
 
-%if 0%{?suse_version}
-%define shareddir       /usr/share
-%define susemanagershareddir       /usr/share/susemanager
+%define shareddir       %{_datadir}
+%define susemanagershareddir       %{_datadir}/susemanager
 %define serverdir       %{susemanagershareddir}/www
+%define salt_user_group salt
+
+%if 0%{?suse_version}
 %define userserverdir       /srv
 %define apache_group    www
-%define salt_user_group salt
 %define apache2         apache2
 %define java_version    11
 %else
-%define serverdir       %{_sharedstatedir}
+%define userserverdir       %{_sharedstatedir}
 %define apache_group    apache
-%define salt_user_group salt
 %define apache2         httpd
 %define java_version    1:11
 %endif

--- a/python/spacewalk/spacewalk-backend.changes.sbluhm.refactoring_srv
+++ b/python/spacewalk/spacewalk-backend.changes.sbluhm.refactoring_srv
@@ -1,1 +1,1 @@
-- Adapted Enterprise Linux for /usr/share/susemanager structure.
+- Reverted documentroot variable to be the common webserver location.

--- a/python/spacewalk/spacewalk-backend.changes.sbluhm.refactoring_srv
+++ b/python/spacewalk/spacewalk-backend.changes.sbluhm.refactoring_srv
@@ -1,0 +1,1 @@
+- Adapted Enterprise Linux for /usr/share/susemanager structure.

--- a/python/spacewalk/spacewalk-backend.spec
+++ b/python/spacewalk/spacewalk-backend.spec
@@ -25,13 +25,13 @@
 %global rhnconf %{_sysconfdir}/rhn
 %global m2crypto m2crypto
 %global python3rhnroot %{python3_sitelib}/spacewalk
-%global documentroot /usr/share/susemanager/www/htdocs
 
 %if 0%{?fedora} || 0%{?rhel}
 %global apacheconfd %{_sysconfdir}/httpd/conf.d
 %global apache_user root
 %global apache_group root
 %global apache_pkg httpd
+%global documentroot %{_localstatedir}/www/html
 %global m2crypto python3-m2crypto
 %global sslrootcert %{_sysconfdir}/pki/ca-trust/source/anchors/
 %endif
@@ -41,6 +41,7 @@
 %global apache_user wwwrun
 %global apache_group www
 %global apache_pkg apache2
+%global documentroot /srv/www/htdocs
 %global m2crypto python3-M2Crypto
 %global sslrootcert %{_sysconfdir}/pki/trust/anchors/
 %endif

--- a/python/spacewalk/spacewalk-backend.spec
+++ b/python/spacewalk/spacewalk-backend.spec
@@ -25,13 +25,13 @@
 %global rhnconf %{_sysconfdir}/rhn
 %global m2crypto m2crypto
 %global python3rhnroot %{python3_sitelib}/spacewalk
+%global documentroot /usr/share/susemanager/www/htdocs
 
 %if 0%{?fedora} || 0%{?rhel}
 %global apacheconfd %{_sysconfdir}/httpd/conf.d
 %global apache_user root
 %global apache_group root
 %global apache_pkg httpd
-%global documentroot %{_localstatedir}/www/html
 %global m2crypto python3-m2crypto
 %global sslrootcert %{_sysconfdir}/pki/ca-trust/source/anchors/
 %endif
@@ -41,7 +41,6 @@
 %global apache_user wwwrun
 %global apache_group www
 %global apache_pkg apache2
-%global documentroot /usr/share/susemanager/www/htdocs
 %global m2crypto python3-M2Crypto
 %global sslrootcert %{_sysconfdir}/pki/trust/anchors/
 %endif

--- a/spacewalk/certs-tools/rhn_bootstrap.py
+++ b/spacewalk/certs-tools/rhn_bootstrap.py
@@ -63,10 +63,11 @@ elif os.path.exists('/usr/share/rhn/server') \
 DEFAULT_CA_CERT_PATH = '/usr/share/rhn/'+CA_CRT_NAME
 
 initCFG('server')
+DOC_ROOT = CFG.DOCUMENTROOT
 
 initCFG('java')
 
-DEFAULT_APACHE_PUB_DIRECTORY = '/srv/www/htdocs/pub'
+DEFAULT_APACHE_PUB_DIRECTORY = DOC_ROOT + '/pub'
 DEFAULT_OVERRIDES = 'client-config-overrides.txt'
 DEFAULT_SCRIPT = 'bootstrap.sh'
 

--- a/spacewalk/certs-tools/rhn_bootstrap.py
+++ b/spacewalk/certs-tools/rhn_bootstrap.py
@@ -63,11 +63,11 @@ elif os.path.exists('/usr/share/rhn/server') \
 DEFAULT_CA_CERT_PATH = '/usr/share/rhn/'+CA_CRT_NAME
 
 initCFG('server')
-DOC_ROOT = CFG.DOCUMENTROOT
+PUB_ROOT = CFG.DOCUMENTROOT
 
 initCFG('java')
 
-DEFAULT_APACHE_PUB_DIRECTORY = DOC_ROOT + '/pub'
+DEFAULT_APACHE_PUB_DIRECTORY = PUB_ROOT + '/pub'
 DEFAULT_OVERRIDES = 'client-config-overrides.txt'
 DEFAULT_SCRIPT = 'bootstrap.sh'
 

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes.sbluhm.refactoring_srv
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes.sbluhm.refactoring_srv
@@ -1,1 +1,1 @@
-- Revert hardcoded folder.
+- Revert hardcoded folder and renamed variable for clarity.

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes.sbluhm.refactoring_srv
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes.sbluhm.refactoring_srv
@@ -1,0 +1,1 @@
+- Revert hardcoded folder.

--- a/spacewalk/config/spacewalk-config.changes.sbluhm.refactoring_srv
+++ b/spacewalk/config/spacewalk-config.changes.sbluhm.refactoring_srv
@@ -1,0 +1,1 @@
+- Adapted Enterprise Linux for /usr/share/susemanager structure.

--- a/spacewalk/config/spacewalk-config.spec
+++ b/spacewalk/config/spacewalk-config.spec
@@ -78,6 +78,10 @@ mv usr $RPM_BUILD_ROOT/
 %if 0%{?suse_version}
 export NO_BRP_STALE_LINK_ERROR=yes
 mv $RPM_BUILD_ROOT/etc/httpd $RPM_BUILD_ROOT%{apacheconfdir}
+%else
+sed -i 's|srv/www/htdocs|var/www/html|g' $RPM_BUILD_ROOT%{apacheconfdir}/conf.d/z-public.conf
+sed -i 's|/usr/share/apache2/|/usr/share/httpd/|g' $RPM_BUILD_ROOT%{apacheconfdir}/conf.d/zz-spacewalk-www.conf
+
 %endif
 
 touch $RPM_BUILD_ROOT/%{_sysconfdir}/rhn/rhn.conf

--- a/susemanager-branding-oss/susemanager-branding-oss.changes.sbluhm.refactoring_srv
+++ b/susemanager-branding-oss/susemanager-branding-oss.changes.sbluhm.refactoring_srv
@@ -1,0 +1,1 @@
+- Replaced /usr/share with macro %{_datadir}.

--- a/susemanager-branding-oss/susemanager-branding-oss.spec
+++ b/susemanager-branding-oss/susemanager-branding-oss.spec
@@ -16,13 +16,9 @@
 #
 
 
-%if 0%{?suse_version}
 %global susemanager_shared_path /usr/share/susemanager
 %global wwwroot %{susemanager_shared_path}/www
 %global wwwdocroot %{wwwroot}/htdocs
-%else
-%global wwwdocroot %{_localstatedir}/www/html
-%endif
 
 Name:           susemanager-branding-oss
 Version:        4.4.1
@@ -70,10 +66,8 @@ install -m 644 license.txt $RPM_BUILD_ROOT/%_defaultdocdir/susemanager/
 %docdir %_defaultdocdir/susemanager
 %dir %_defaultdocdir/susemanager
 %_defaultdocdir/susemanager/license.txt
-%if 0%{?suse_version}
 %dir %{susemanager_shared_path}
 %dir %{wwwroot}
-%endif
 %dir %{wwwdocroot}
 %dir %{wwwdocroot}/help
 %{wwwdocroot}/help/eula.html

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.sbluhm.refactoring_srv
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.sbluhm.refactoring_srv
@@ -1,0 +1,1 @@
+- Revert hardcoded symbolic link.

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.sbluhm.refactoring_srv
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.sbluhm.refactoring_srv
@@ -1,1 +1,1 @@
-- Revert hardcoded symbolic link.
+- Revert hardcoded symbolic link and renamed variable for clarity

--- a/susemanager-utils/susemanager-sls/susemanager-sls.spec
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.spec
@@ -22,7 +22,7 @@
 %endif
 
 %if 0%{?suse_version}
-%global serverdir  /usr/share/susemanager
+%global serverdir  /srv
 %global wwwdocroot %{serverdir}/www/htdocs
 %else
 %global serverdir  %{_localstatedir}
@@ -129,7 +129,7 @@ py.test%{?rhel:-3}
 
 %post
 # HACK! Create broken link when it will be replaces with the real file
-ln -sf /srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT \
+ln -sf %{wwwdocroot}/pub/RHN-ORG-TRUSTED-SSL-CERT \
    /usr/share/susemanager/salt/certs/RHN-ORG-TRUSTED-SSL-CERT 2>&1 ||:
 
 %posttrans

--- a/susemanager-utils/susemanager-sls/susemanager-sls.spec
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.spec
@@ -23,10 +23,10 @@
 
 %if 0%{?suse_version}
 %global serverdir  /srv
-%global wwwdocroot %{serverdir}/www/htdocs
+%global wwwpubroot %{serverdir}/www/htdocs
 %else
 %global serverdir  %{_localstatedir}
-%global wwwdocroot %{serverdir}/www/html
+%global wwwpubroot %{serverdir}/www/html
 %endif
 
 Name:           susemanager-sls
@@ -129,7 +129,7 @@ py.test%{?rhel:-3}
 
 %post
 # HACK! Create broken link when it will be replaces with the real file
-ln -sf %{wwwdocroot}/pub/RHN-ORG-TRUSTED-SSL-CERT \
+ln -sf %{wwwpubroot}/pub/RHN-ORG-TRUSTED-SSL-CERT \
    /usr/share/susemanager/salt/certs/RHN-ORG-TRUSTED-SSL-CERT 2>&1 ||:
 
 %posttrans

--- a/susemanager/susemanager.changes.sbluhm.refactoring_srv
+++ b/susemanager/susemanager.changes.sbluhm.refactoring_srv
@@ -1,0 +1,1 @@
+- Replaced %{_datarootdir} with %{_datadir} for consistency.

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -42,7 +42,7 @@
 %global wwwroot %{serverdir}/www
 %endif
 
-%global sharedwwwroot %{_datarootdir}/susemanager/www
+%global sharedwwwroot %{_datadir}/susemanager/www
 %global reporoot %{sharedwwwroot}/pub
 
 %global debug_package %{nil}

--- a/web/spacewalk-web.changes.sbluhm.refactoring_srv
+++ b/web/spacewalk-web.changes.sbluhm.refactoring_srv
@@ -1,0 +1,1 @@
+- Adapted Enterprise Linux for /usr/share/susemanager structure.

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -16,22 +16,16 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
-%if 0%{?suse_version}
-%define shared_path /usr/share/susemanager
+%define shared_path %{_datadir}/susemanager
 %define shared_www_path %{shared_path}/www
 %define www_path %{shared_www_path}/htdocs
+
 %if 0%{?suse_version}
-%define apache_user wwwrun
 %define apache_group www
 %else
-%if 0%{?rhel}
-%define apache_user root
-%define apache_group root
-%else
-%define apache_user apache
 %define apache_group apache
 %endif
-%endif
+
 %{!?rhel: %global sbinpath /sbin}%{?rhel: %global sbinpath %{_sbindir}}
 %{!?nodejs_sitelib:%define nodejs_sitelib %{_prefix}/lib/node_modules}
 
@@ -252,10 +246,8 @@ sed -i -e 's/^web.theme_default =.*$/web.theme_default = susemanager-light/' $RP
 
 %files -n spacewalk-html -f spacewalk-web.lang
 %defattr(644,root,root,755)
-%if 0%{?suse_version}
 %dir %{shared_path}
 %dir %{shared_www_path}
-%endif
 %dir %{www_path}
 %dir %{www_path}/css
 %{www_path}/css/*.{css,js}

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -20,10 +20,10 @@
 %define shared_path /usr/share/susemanager
 %define shared_www_path %{shared_path}/www
 %define www_path %{shared_www_path}/htdocs
+%if 0%{?suse_version}
 %define apache_user wwwrun
 %define apache_group www
 %else
-%define www_path %{_var}/www/html
 %if 0%{?rhel}
 %define apache_user root
 %define apache_group root


### PR DESCRIPTION
## What does this PR change?

1. Continues the activities for https://github.com/uyuni-project/uyuni/pull/7651 to align Enterprise Linux installations to the same destination.
2. Reverted some changes.
3. Renamed two variables in code to clarify their usage.
4. Fixed a regression in spacewalk-branding (folder permissions in spec file were different to other packages)


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

Manually tested an EL9 install and waited for UI to come up.

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
