### PR TITLE
GH Validation: Cache Ruby gems for the controller inside the container image

### DIFF
--- a/testsuite/dockerfiles/controller-dev/Dockerfile
+++ b/testsuite/dockerfiles/controller-dev/Dockerfile
@@ -37,3 +37,4 @@ RUN zypper ref -f && \
     zypper clean -a
 COPY etc_pam.d_sshd /etc/pam.d/sshd
 CMD ssh-keygen -A && /usr/sbin/sshd -De
+RUN curl https://raw.githubusercontent.com/uyuni-project/uyuni/master/testsuite/Gemfile -o Gemfile && bundle.ruby2.5 install && rm Gemfile


### PR DESCRIPTION
## What does this PR change?

To speed up our workflow, here we cache the Ruby gems for the controller at the building container image time.
So, once the workflow is running, most of the Ruby gems are already cached.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed
- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

No ports

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
