### PR TITLE
Run sonarcloud scan as workflow_run

### DIFF
--- a/.github/workflows/java-checkstyle.yml
+++ b/.github/workflows/java-checkstyle.yml
@@ -5,11 +5,23 @@ on:
     branches:
       - master
     paths:
+      # We also trigger on non-java code changes since this triggers sonarcloud scanner after
+      - '**.py'
+      - 'web/html/src/**.ts'
+      - 'web/html/src/**.tsx'
       - 'java/**.java'
       - 'java/**.xml'
       - '.github/workflows/java-checkstyle.yml'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
     paths:
+      # We also trigger on non-java code changes since this triggers sonarcloud scanner after
+      - '**.py'
+      - 'web/html/src/**.ts'
+      - 'web/html/src/**.tsx'
       - 'java/**.java'
       - 'java/**.xml'
       - '.github/workflows/java-checkstyle.yml'
@@ -36,3 +48,13 @@ jobs:
 
     - name: Run checkstyle
       run: ant -f java/manager-build.xml checkstyle
+
+    - name: Compress build results
+      run: tar cf java-build.tar.gz java/build
+
+    - name: Archive Java build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: java-built-files
+        path: |
+          java-build.tar.gz

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,54 +1,76 @@
-name: Sonarcloud analysis
+name: Sonarcloud scan
 
 on:
-  push:
-    branches:
-    - master
-    paths:
-      - 'java/**.java'
-      - 'java/**.xml'
-      - '**.py'
-      - 'web/html/src/**.ts'
-      - 'web/html/src/**.tsx'
-  pull_request:
-    paths:
-      - 'java/**.java'
-      - 'java/**.xml'
-      - '**.py'
-      - 'web/html/src/**.ts'
-      - 'web/html/src/**.tsx'
+  workflow_run:
+    workflows: [Java checkstyle]
+    types: [completed]
 
 jobs:
-  sonarcloud:
+
+  sonarcloud-scan:
     runs-on: ubuntu-latest
-    container: registry.opensuse.org/systemsmanagement/uyuni/master/docker/containers/uyuni-master-pgsql:latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
 
-    - name: Cache dependencies
-      id: cache-dependencies
-      uses: actions/cache@v3
-      with:
-        path: java/lib
-        key: ${{ runner.os }}-java-lib-${{ hashFiles('java/buildconf/ivy/*.*') }}
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
 
-    - name: Resolve dependencies
-      if: steps.cache-dependencies.outputs.cache-hit != 'true'
-      run: |
-        ant -f java/manager-build.xml ivy
+      - name: Download Java built artifact
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "java-built-files"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/java-built-files.zip`, Buffer.from(download.data));
 
-    - name: Compile Java
-      run: ant -f java/manager-build.xml compile
+      - name: Unzip java built artifact
+        run: |
+          unzip java-built-files.zip
 
-    - name: SonarCloud Scan
-      uses: sonarsource/sonarcloud-github-action@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SONAR_TOKEN: ${{ secrets.SONARQUBE_AUTH_UYUNI }}
-        args: >
-          -Dsonar.junit.reportPaths=""
-          -Dsonar.coverage.jacoco.xmlReportPaths=""
-          -Dsonar.pullrequest.key=${{ github.event.number }}
-          -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }}
-          -Dsonar.pullrequest.base=${{ github.base_ref }}
+      - name: Cache dependencies
+        id: cache-dependencies
+        uses: actions/cache@v3
+        with:
+          path: java/lib
+          key: ${{ runner.os }}-java-lib-${{ hashFiles('java/buildconf/ivy/*.*') }}
+
+      - name: Resolve dependencies
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
+        run: |
+          docker run -v $PWD:/src -w /src \
+            registry.opensuse.org/systemsmanagement/uyuni/master/docker/containers/uyuni-master-pgsql:latest \
+            ant -f java/manager-build.xml ivy
+
+      - name: Unpacking the build results
+        run: tar xf java-build.tar.gz
+
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONARQUBE_AUTH_UYUNI }}
+        with:
+          args: >
+            -Dsonar.junit.reportPaths=""
+            -Dsonar.coverage.jacoco.xmlReportPaths=""
+            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
+            -Dsonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }}
+            -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }}
+            -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}


### PR DESCRIPTION
## What does this PR change?

The Java-checkstyle workflow run as unprivileged on the PR branch and upload the build results as artifacts.

When it succeeds the sonarcloud scan workflow uses those artifacts and run the scan on the target branch to avoid security issues and access the token. Using `workflow_run` as a trigger is the trick but that means the checkstyle workflow has to run on all PRs changing code even if there is no Java change.

## Links

Fixes https://github.com/SUSE/spacewalk/issues/22986

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
