### PR TITLE
sonarcloud: get the java dependencies from the artifact

### DIFF
--- a/.github/workflows/java-checkstyle.yml
+++ b/.github/workflows/java-checkstyle.yml
@@ -50,7 +50,7 @@ jobs:
       run: ant -f java/manager-build.xml checkstyle
 
     - name: Compress build results
-      run: tar cf java-build.tar.gz java/build
+      run: tar cf java-build.tar.gz java/build java/lib
 
     - name: Archive Java build artifacts
       uses: actions/upload-artifact@v3

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -44,20 +44,6 @@ jobs:
         run: |
           unzip java-built-files.zip
 
-      - name: Cache dependencies
-        id: cache-dependencies
-        uses: actions/cache@v3
-        with:
-          path: java/lib
-          key: ${{ runner.os }}-java-lib-${{ hashFiles('java/buildconf/ivy/*.*') }}
-
-      - name: Resolve dependencies
-        if: steps.cache-dependencies.outputs.cache-hit != 'true'
-        run: |
-          docker run -v $PWD:/src -w /src \
-            registry.opensuse.org/systemsmanagement/uyuni/master/docker/containers/uyuni-master-pgsql:latest \
-            ant -f java/manager-build.xml ivy
-
       - name: Unpacking the build results
         run: tar xf java-build.tar.gz
 


### PR DESCRIPTION
## What does this PR change?

Running ant on the PR code in the sonarcloud job is dangerous: getting the java dependencies out of the existing artifact will do the trick.


## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
