### PR TITLE
Limit the checkstyle and sonarcloud workflow runs on pushes

### DIFF
--- a/.github/workflows/java-checkstyle.yml
+++ b/.github/workflows/java-checkstyle.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
     paths:
-      # We also trigger on non-java code changes since this triggers sonarcloud scanner after
-      - '**.py'
-      - 'web/html/src/**.ts'
-      - 'web/html/src/**.tsx'
       - 'java/**.java'
       - 'java/**.xml'
       - '.github/workflows/java-checkstyle.yml'

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -9,7 +9,7 @@ jobs:
 
   sonarcloud-scan:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
 
     steps:
 


### PR DESCRIPTION
## What does this PR change?

On a push sonarcloud scanner would need to be called differently and the results would have to be checked in sonarcloud. For those reason the sonarcloud workflow is now disabled on pushes.

On pushes, we then don't need to run the java-checkstyle workflow on non java file changes.

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
