### PR TITLE
QE: Fix system name for virtualization tests, as VM is not twopence node

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -367,6 +367,9 @@ def get_system_name(host)
     system_name = 'sle15sp4terminal.example.org' if system_name.nil?
   when 'containerized_proxy'
     system_name = get_target('proxy').full_hostname.sub('pxy', 'pod-pxy')
+  # needed for the virtualizion tests, as the VM isn't an initialized twopence node
+  when 'test-vm2'
+    system_name = 'test-vm2'
   else
     node = get_target(host)
     system_name = node.full_hostname

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -367,12 +367,13 @@ def get_system_name(host)
     system_name = 'sle15sp4terminal.example.org' if system_name.nil?
   when 'containerized_proxy'
     system_name = get_target('proxy').full_hostname.sub('pxy', 'pod-pxy')
-  # needed for the virtualizion tests, as the VM isn't an initialized twopence node
-  when 'test-vm2'
-    system_name = 'test-vm2'
   else
-    node = get_target(host)
-    system_name = node.full_hostname
+    if $node_by_host.key? host
+      node = get_target(host)
+      system_name = node.full_hostname
+    else
+      system_name = host
+    end
   end
   system_name
 end


### PR DESCRIPTION
## What does this PR change?

When attempting to get the system name for the virtualized VM, this creates an issue as it isn't an initalized twopence node. Adding the VM to the special cases should fix that.

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/21347
Ports(s): 4.3 https://github.com/SUSE/spacewalk/pull/23099

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
