### PR TITLE
Bug 1216657 - Playbook name shown as `{name}` instead of actual name

### DIFF
--- a/web/html/src/manager/minion/ansible/schedule-playbook.tsx
+++ b/web/html/src/manager/minion/ansible/schedule-playbook.tsx
@@ -104,7 +104,7 @@ export default function SchedulePlaybook({ playbook, onBack }: SchedulePlaybookP
   return (
     <>
       <Messages items={messages} />
-      <InnerPanel title={t("Playbook '{name}'", { name: playbook.name })} icon="fa-file-text-o" buttons={buttons}>
+      <InnerPanel title={t('Playbook "{name}"', { name: playbook.name })} icon="fa-file-text-o" buttons={buttons}>
         <div className="panel panel-default">
           <div className="panel-heading">
             <div>

--- a/web/spacewalk-web.changes.mikeletux.22929
+++ b/web/spacewalk-web.changes.mikeletux.22929
@@ -1,0 +1,1 @@
+- Fix issue displaying Ansible playbook name (bsc#1216657) 


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/23026

## GUI diff

Port of https://github.com/SUSE/spacewalk/pull/23026

- [x] **DONE**

## Documentation
- No docs needed

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/22929

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
