### PR TITLE
Fix spacewalk-branding rpm

### DIFF
--- a/branding/spacewalk-branding.changes.mbussolotto.fix_branding_rpm
+++ b/branding/spacewalk-branding.changes.mbussolotto.fix_branding_rpm
@@ -1,1 +1,1 @@
-- fix spacewalk-branding rpm
+- Fix spacewalk-branding wwwdocroot path

--- a/branding/spacewalk-branding.changes.mbussolotto.fix_branding_rpm
+++ b/branding/spacewalk-branding.changes.mbussolotto.fix_branding_rpm
@@ -1,0 +1,1 @@
+- fix spacewalk-branding rpm

--- a/branding/spacewalk-branding.spec
+++ b/branding/spacewalk-branding.spec
@@ -22,7 +22,7 @@
 %global susemanager_shared_path  %{_datadir}/susemanager
 %global wwwroot %{susemanager_shared_path}/www
 %global tomcat_path %{wwwroot}/tomcat
-%global wwwdocroot %{wwwroot}/www/html
+%global wwwdocroot %{wwwroot}/htdocs
 
 Name:           spacewalk-branding
 Version:        4.4.1


### PR DESCRIPTION
## What does this PR change?

Fix spacewalk-branding rpm
I tried these changes here https://build.opensuse.org/package/show/home:mbussolotto:branches:systemsmanagement:Uyuni:Master/spacewalk-branding

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed
- [x] **DONE**

## Test coverage
- No tests
- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
