### PR TITLE
Remove spacewalk-branding conflict to spacewalk-html

### DIFF
--- a/branding/spacewalk-branding.spec
+++ b/branding/spacewalk-branding.spec
@@ -86,7 +86,7 @@ ln -s %{_datadir}/rhn/lib/java-branding.jar %{buildroot}%{tomcat_path}/webapps/r
 %license LICENSE
 %dir %{susemanager_shared_path}
 %dir %{wwwroot}
-%attr(775,tomcat,tomcat) %dir %{wwwdocroot}
+%dir %{wwwdocroot}
 %attr(775,tomcat,tomcat) %dir %{tomcat_path}
 %attr(775,tomcat,tomcat) %dir %{tomcat_path}/webapps
 %attr(775,tomcat,tomcat) %dir %{tomcat_path}/webapps/rhn


### PR DESCRIPTION
## What does this PR change?
Removes the `tomcat` ownership from folder /usr/share/susemanager/www/htdocs

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

Manual install tested on epel9-x86_64

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Skipping changelogs, if that is OK. I think we have enough on this topic.

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
