### PR TITLE
Removed unused and deprecated/removed platform.dist import

### DIFF
--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes.sbluhm.removedist
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes.sbluhm.removedist
@@ -1,0 +1,1 @@
+- Removed unused and deprecated/removed platform.dist import.

--- a/client/rhel/spacewalk-client-tools/src/up2date_client/up2dateErrors.py
+++ b/client/rhel/spacewalk-client-tools/src/up2date_client/up2dateErrors.py
@@ -27,7 +27,6 @@ if not hasattr(t, 'ugettext'):
     t.ugettext = t.gettext
 _ = t.ugettext
 import OpenSSL
-from platform import dist
 from rhn.stringutils import ustr
 from up2date_client import config
 from up2date_client import up2dateLog


### PR DESCRIPTION
## What does this PR change?

Removed unused and deprecated/removed platform.dist import

It is deprecated and not being used. So might as well remove it.

(It will cause issues in future Python versions)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Ports(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
