### PR TITLE
Rely on obs prjconf to set wanted postgresql version

### DIFF
--- a/spacewalk/package/spacewalk.changes.oholecek.prjconf_based_postgres
+++ b/spacewalk/package/spacewalk.changes.oholecek.prjconf_based_postgres
@@ -1,0 +1,1 @@
+- Allow postgresql version dependency to be set in project config

--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -109,20 +109,10 @@ Provides:       spacewalk-db-virtual = %{version}-%{release}
 Requires:       spacewalk-backend-sql-postgresql
 Requires:       spacewalk-java-postgresql
 Requires:       perl(DBD::Pg)
-%if 0%{?sle_version}
-%if 0%{?sle_version} >= 150400
-Requires:       postgresql14
-Requires:       postgresql14-contrib
-# we do not support postgresql versions > 14.x yet
-Conflicts:      postgresql-implementation >= 15
-Conflicts:      postgresql-contrib-implementation >= 15
-%else # not sle_version >= 150400
-Requires:       postgresql13
-Requires:       postgresql13-contrib
-# we do not support postgresql versions > 13.x yet
-Conflicts:      postgresql-implementation >= 14
-Conflicts:      postgresql-contrib-implementation >= 14
-%endif # if sle_version >= 150400
+%if 0%{?suse_version}
+# Actual version set by prjconf
+Requires:       postgresql-implementation = %{postgresql_version}
+Requires:       postgresql-contrib-implementation = %{postgresql_version}
 %else # not a supported SUSE version or alternative OS.
 Requires:       postgresql14
 Requires:       postgresql14-contrib

--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -110,7 +110,8 @@ Requires:       spacewalk-backend-sql-postgresql
 Requires:       spacewalk-java-postgresql
 Requires:       perl(DBD::Pg)
 %if 0%{?suse_version}
-# Actual version set by prjconf
+# Actual version set by prjconf, default is 14
+%{!?postgresql_version: %global postgresql_version 14}
 Requires:       postgresql-implementation = %{postgresql_version}
 Requires:       postgresql-contrib-implementation = %{postgresql_version}
 %else # not a supported SUSE version or alternative OS.

--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -114,6 +114,8 @@ Requires:       perl(DBD::Pg)
 %{!?postgresql_version: %global postgresql_version 14}
 Requires:       postgresql-implementation = %{postgresql_version}
 Requires:       postgresql-contrib-implementation = %{postgresql_version}
+Conflicts:      postgresql-implementation > %{postgresql_version}
+Conflicts:      postgresql-contrib-implementation > %{postgresql_version}
 %else # not a supported SUSE version or alternative OS.
 Requires:       postgresql14
 Requires:       postgresql14-contrib

--- a/spacewalk/spacewalk-setup-postgresql/spacewalk-setup-postgresql.changes.oholecek.prjconf_based_postgres
+++ b/spacewalk/spacewalk-setup-postgresql/spacewalk-setup-postgresql.changes.oholecek.prjconf_based_postgres
@@ -1,0 +1,1 @@
+- Allow postgresql version dependency to be set in project config

--- a/spacewalk/spacewalk-setup-postgresql/spacewalk-setup-postgresql.spec
+++ b/spacewalk/spacewalk-setup-postgresql/spacewalk-setup-postgresql.spec
@@ -28,13 +28,9 @@ Source0:        https://github.com/spacewalkproject/spacewalk/archive/%{name}-%{
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 %if 0%{?suse_version}
-%if 0%{?sle_version} >= 150400
-Requires:       postgresql14-contrib
-Requires:       postgresql14-server
-%else
-Requires:       postgresql13-contrib
-Requires:       postgresql13-server
-%endif
+# Actual version set by prjconf
+Requires:       postgresql-contrib-implementation = %{postgresql_version}
+Requires:       postgresql-server-implementation = %{postgresql_version}
 %else
 Requires:       postgresql-contrib >= 12
 Requires:       postgresql-server > 12

--- a/spacewalk/spacewalk-setup-postgresql/spacewalk-setup-postgresql.spec
+++ b/spacewalk/spacewalk-setup-postgresql/spacewalk-setup-postgresql.spec
@@ -28,7 +28,8 @@ Source0:        https://github.com/spacewalkproject/spacewalk/archive/%{name}-%{
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 %if 0%{?suse_version}
-# Actual version set by prjconf
+# Actual version set by prjconf, default is 14
+%{!?postgresql_version: %global postgresql_version 14}
 Requires:       postgresql-contrib-implementation = %{postgresql_version}
 Requires:       postgresql-server-implementation = %{postgresql_version}
 %else

--- a/spacewalk/uyuni-setup-reportdb/uyuni-setup-reportdb.changes.oholecek.prjconf_based_postgres
+++ b/spacewalk/uyuni-setup-reportdb/uyuni-setup-reportdb.changes.oholecek.prjconf_based_postgres
@@ -1,0 +1,1 @@
+- Allow postgresql version dependency to be set in project config

--- a/spacewalk/uyuni-setup-reportdb/uyuni-setup-reportdb.spec
+++ b/spacewalk/uyuni-setup-reportdb/uyuni-setup-reportdb.spec
@@ -27,13 +27,9 @@ Source0:        https://github.com/uyuni-project/uyuni/archive/%{name}-%{version
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 %if 0%{?suse_version}
-%if 0%{?sle_version} >= 150400
-Requires:       postgresql14-contrib
-Requires:       postgresql14-server
-%else
-Requires:       postgresql13-contrib
-Requires:       postgresql13-server
-%endif
+# Actual version set by prjconf
+Requires:       postgresql-contrib-implementation = %{postgresql_version}
+Requires:       postgresql-server-implementation = %{postgresql_version}
 %else
 Requires:       postgresql-contrib >= 12
 Requires:       postgresql-server > 12

--- a/spacewalk/uyuni-setup-reportdb/uyuni-setup-reportdb.spec
+++ b/spacewalk/uyuni-setup-reportdb/uyuni-setup-reportdb.spec
@@ -27,7 +27,8 @@ Source0:        https://github.com/uyuni-project/uyuni/archive/%{name}-%{version
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 %if 0%{?suse_version}
-# Actual version set by prjconf
+# Actual version set by prjconf, default is 14
+%{!?postgresql_version: %global postgresql_version 14}
 Requires:       postgresql-contrib-implementation = %{postgresql_version}
 Requires:       postgresql-server-implementation = %{postgresql_version}
 %else


### PR DESCRIPTION
## What does this PR change?

This PR changes dependency handling of postgresql requires to be set by OBS/IBS project config instead of hardcoded in the spec file.

Project config for the projects should be modified like following:

```
Macros:
%postgresql_version 15
:Macros
```

depending on what version we want for given project.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: **add explanation**

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23091
Ports(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
