### PR TITLE
QE: Move the disable of Scheduled reposync task

### DIFF
--- a/testsuite/run_sets/build_validation/build_validation_reposync.yml
+++ b/testsuite/run_sets/build_validation/build_validation_reposync.yml
@@ -2,7 +2,7 @@
 
 ## Product synchronization features BEGIN ###
 
+- features/build_validation/reposync/srv_disable_scheduled_reposync.feature
 - features/build_validation/reposync/srv_sync_all_products.feature
 
 ## Product synchronization features END ###
-

--- a/testsuite/run_sets/build_validation/build_validation_wait_for_product_reposync.yml
+++ b/testsuite/run_sets/build_validation/build_validation_wait_for_product_reposync.yml
@@ -1,7 +1,0 @@
-# This file describes the order of features in a Build Validation test suite run.
-
-## Wait for product channels synchronization BEGIN ###
-
-- features/build_validation/reposync/srv_disable_scheduled_reposync.feature
-
-## Wait for product channels synchronization END ###


### PR DESCRIPTION
## What does this PR change?

Move inside the reposync stage the disable the scheduled task for reposync.
Note: This need to be merged together with a removal of the rake task call inside the Jenkins Pipeline.

https://github.com/SUSE/susemanager-ci/pull/1037

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage

- Cucumber tests were modified

- [x] **DONE**

## Links

Ports(s): https://github.com/SUSE/spacewalk/pull/23118

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
