### PR TITLE
Prevent installation of packages with same name in a single action

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -1958,11 +1958,8 @@ public class ActionManager extends BaseManager {
 
         for (Map<String, Long> map : packageMaps) {
 
-            Map<String, Long> newMap = map.entrySet().stream()
-                 .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue()));
-
             Map<String, Long> previous = packageMapsWithoutDuplicated.put(
-                    newMap.get("name_id").toString(), newMap);
+                    map.get("name_id").toString(), map);
 
             if (previous != null) {
                 String previousNevra = PackageManager.buildPackageNevra(

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -127,7 +127,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * ActionManager - the singleton class used to provide Business Operations

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -1953,27 +1953,27 @@ public class ActionManager extends BaseManager {
     }
 
 
-    private static List<Map<String, Object>> removeDuplicatedName(List<Map<String, Long>> packageMaps) {
-        Map<String, Map<String, Object>> packageMapsWithoutDuplicated = new HashMap<>();
+    private static List<Map<String, ? extends Object>> removeDuplicatedName(List<Map<String, Long>> packageMaps) {
+        Map<String, Map<String, Long>> packageMapsWithoutDuplicated = new HashMap<>();
 
         for (Map<String, Long> map : packageMaps) {
 
-            Map<String, Object> newMap = map.entrySet().stream()
-                 .collect(Collectors.toMap(Map.Entry::getKey, e -> (Object)e.getValue()));
+            Map<String, Long> newMap = map.entrySet().stream()
+                 .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue()));
 
-            Map<String, Object> previous = packageMapsWithoutDuplicated.put(
+            Map<String, Long> previous = packageMapsWithoutDuplicated.put(
                     newMap.get("name_id").toString(), newMap);
 
             if (previous != null) {
                 String previousNevra = PackageManager.buildPackageNevra(
-                        Long.valueOf(previous.get("name_id").toString()),
-                        Long.valueOf(previous.get("evr_id").toString()),
-                        Long.valueOf(previous.get("arch_id").toString()));
+                        previous.get("name_id"),
+                        previous.get("evr_id"),
+                        previous.get("arch_id"));
 
                 String currentNevra = PackageManager.buildPackageNevra(
-                        Long.valueOf(map.get("name_id").toString()),
-                        Long.valueOf(map.get("evr_id").toString()),
-                        Long.valueOf(map.get("arch_id").toString()));
+                        map.get("name_id"),
+                        map.get("evr_id"),
+                        map.get("arch_id"));
 
                 log.warn("Package {}, will be not be installed cause also {} has been " +
                         "provided. This is because " +
@@ -1997,7 +1997,7 @@ public class ActionManager extends BaseManager {
             List<Map<String, Long>> packageMaps) {
         if (packageMaps != null) {
 
-            List<Map<String, Object>> uniquePackagesMaps = removeDuplicatedName(packageMaps);
+            List<Map<String,? extends Object>> uniquePackagesMaps = removeDuplicatedName(packageMaps);
 
             List<Map<String, Object>> paramList =
                 actions.stream().flatMap(action -> {

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -1997,7 +1997,7 @@ public class ActionManager extends BaseManager {
             List<Map<String, Long>> packageMaps) {
         if (packageMaps != null) {
 
-            List<Map<String,? extends Object>> uniquePackagesMaps = removeDuplicatedName(packageMaps);
+            List<Map<String, ? extends Object>> uniquePackagesMaps = removeDuplicatedName(packageMaps);
 
             List<Map<String, Object>> paramList =
                 actions.stream().flatMap(action -> {

--- a/java/spacewalk-java.changes.mbussolotto.name_id
+++ b/java/spacewalk-java.changes.mbussolotto.name_id
@@ -1,2 +1,2 @@
 - Prevent installation of packages with same name 
-  in a single action
+  in a single action (bsc#1214791)

--- a/java/spacewalk-java.changes.mbussolotto.name_id
+++ b/java/spacewalk-java.changes.mbussolotto.name_id
@@ -1,0 +1,2 @@
+- Prevent installation of packages with same name 
+  in a single action


### PR DESCRIPTION
## What does this PR change?

It might happens that a package changes architecture (e.g. from `x86_64` and `noarch`). In that case an upgrade off all the packages would try to install both packages, but this scenario it's not supported by salt (it's not possible to `pkg.install` packages with the same name in a single state).

This changes prevents this failure excluding packages with duplicated name and logging a warning.

Example:
![Screenshot from 2023-11-28 09-48-47](https://github.com/uyuni-project/uyuni/assets/4320859/bdac8fbb-91c6-4e67-94be-eb40867ca89f)

**Now**
![before_1](https://github.com/uyuni-project/uyuni/assets/4320859/e41ed25c-6631-4da2-b543-7301f94de3ad)

```
----------
          ID: pkg_installed
    Function: pkg.installed
        Name: pkg_installed
      Result: false
     Comment: An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/salt/state.py", line 2402, in call
    *cdata["args"], **cdata["kwargs"]
  File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 149, in __call__
    return self.loader.run(run_func, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 1234, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/contextvars/__init__.py", line 38, in run
    return callable(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 1249, in _run_as
    return _func_or_method(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 1282, in wrapper
    return f(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/states/pkg.py", line 1715, in installed
    **kwargs
  File "/usr/lib/python3.6/site-packages/salt/states/pkg.py", line 584, in _find_install_targets
    desired = _repack_pkgs(pkgs, normalize=normalize)
  File "/usr/lib/python3.6/site-packages/salt/modules/pkg_resource.py", line 40, in _repack_pkgs
    pkgs
salt.exceptions.SaltInvocationError: You are passing a list of packages that contains duplicated packages names: [{'virgo-dummy.noarch': '2.0-3.1'}, {'virgo-dummy.x86_64': '1.0-3.1'}]. This cannot be processed. In case you are targeting different versions of the same package, please target them individually

     Started: 10:51:43.558362
    Duration: 6733.173
         SLS: packages.pkginstall
     Changed: {}
```

**After these changes**
![after](https://github.com/uyuni-project/uyuni/assets/4320859/0b7b49df-542b-4560-90ab-c4575c5c939b)
```
----------
          ID: pkg_installed
    Function: pkg.installed
        Name: pkg_installed
      Result: true
     Comment: The following packages were installed/updated: virgo-dummy=2.0-3.1
     Started: 18:42:16.038283
    Duration: 10134.45
         SLS: packages.pkginstall
     Changed: virgo-dummy:
                  old: ''
                  new:
                  -   version: '2.0'
                      release: '3.1'
                      arch: noarch
                      install_date_time_t: 1.701106944E9
                      epoch: null
              
```

```
uyuni:~ # grep -nir warn /var/log/rhn/rhn_web_ui.log  | tail -n1
4:2023-11-28 10:07:09,693 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-9] WARN  com.redhat.rhn.manager.action.ActionManager - Package virgo-dummy-1.0-3.1.x86_64, will be not be installed cause also virgo-dummy-2.0-3.1.noarch has been provided. This is because salt fails installing to package with the same name. If the installed package is not the one desired, you can install it the correct one after.

```


## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed
- [x] **DONE**

## Test coverage
- Already covered by `testPackageUpdate` but it was a false positive.

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/22432

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
