### PR TITLE
Include reboot info beacon in the bootstrap script for transactional systems

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -968,6 +968,10 @@ if [ -n "$SNAPSHOT_ID" ]; then
 module_executors:
   - transactional_update
   - direct_call
+# Include beacon to check for pending transactions indicating that a reboot is necessary
+beacons:
+  reboot_info:
+    - interval: 10
 EOF
 fi # -n SNAPSHOT_ID
 fi # REGISTER_THIS_BOX eq 1

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes.welder.fix-mgr-bootstrap-sle-micro
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes.welder.fix-mgr-bootstrap-sle-micro
@@ -1,0 +1,1 @@
+- Include reboot info beacon in the bootstrap script for transactional systems (bsc#1217588)


### PR DESCRIPTION
## What does this PR change?

The reboot info beacon is not being installed when bootstraping a transactional system via script. The reason is that `mgr-bootstrap` is not using the same `transactional_update.conf` file as WebUI. This PR includes the beacon configuration in `rhn_bootstrap_strings.py` to solve the issue.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: shell script

- [x] **DONE**

## Links

Issue(s): 
Ports(s): 

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
