### PR TITLE
make python3-looseversion optional in SUSE bootrap repo

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -212,7 +212,7 @@ PKGLIST15_SALT_NO_BUNDLE = [
     "salt-minion",
     "python3-apipkg*",
     "python3-iniconfig*",
-    "python3-looseversion",
+    "python3-looseversion*",
     "python3-jmespath",
     "xz",
 ]

--- a/susemanager/susemanager.changes.mbussolotto.bootstrap_repo_missing_package
+++ b/susemanager/susemanager.changes.mbussolotto.bootstrap_repo_missing_package
@@ -1,0 +1,1 @@
+- make python3-looseversion optional in SUSE bootrap repo (bsc#1215120)


### PR DESCRIPTION
## What does this PR change?

`python3-looseversion` was added on bootstrap repo by https://github.com/uyuni-project/uyuni/pull/7197 but it's not present in `15GA` and this cause issue on bootstrap repo creation. Mark it as optional should fix the problem.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/22521

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
