### PR TITLE
PAYG better visible feedback when the server is not compliant

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/notification/NotificationMessage.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/NotificationMessage.java
@@ -160,7 +160,7 @@ public class NotificationMessage implements Serializable {
             case EndOfLifePeriod: return "End of Life Period";
             case SubscriptionWarning: return "Subscription Warning";
             case UpdateAvailable: return "Updates are Available";
-            case PaygNotCompliantWarning: return "Pay-as-you-go not compliant warning";
+            case PaygNotCompliantWarning: return "PAYG instance is not compliant";
             default: return getType().name();
         }
     }

--- a/java/code/src/com/redhat/rhn/domain/notification/NotificationMessage.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/NotificationMessage.java
@@ -23,6 +23,7 @@ import com.redhat.rhn.domain.notification.types.NotificationData;
 import com.redhat.rhn.domain.notification.types.NotificationType;
 import com.redhat.rhn.domain.notification.types.OnboardingFailed;
 import com.redhat.rhn.domain.notification.types.PaygAuthenticationUpdateFailed;
+import com.redhat.rhn.domain.notification.types.PaygNotCompliantWarning;
 import com.redhat.rhn.domain.notification.types.StateApplyFailed;
 import com.redhat.rhn.domain.notification.types.SubscriptionWarning;
 import com.redhat.rhn.domain.notification.types.UpdateAvailable;
@@ -137,6 +138,8 @@ public class NotificationMessage implements Serializable {
                 return new Gson().fromJson(getData(), SubscriptionWarning.class);
             case UpdateAvailable:
                 return new Gson().fromJson(getData(), UpdateAvailable.class);
+            case PaygNotCompliantWarning:
+                return new Gson().fromJson(getData(), PaygNotCompliantWarning.class);
             default: throw new RuntimeException("Notification type not found");
         }
     }
@@ -157,6 +160,7 @@ public class NotificationMessage implements Serializable {
             case EndOfLifePeriod: return "End of Life Period";
             case SubscriptionWarning: return "Subscription Warning";
             case UpdateAvailable: return "Updates are Available";
+            case PaygNotCompliantWarning: return "Pay-as-you-go not compliant warning";
             default: return getType().name();
         }
     }

--- a/java/code/src/com/redhat/rhn/domain/notification/PaygNotCompliantWarning.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/PaygNotCompliantWarning.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.domain.notification;
+
+import com.redhat.rhn.common.localization.LocalizationService;
+import com.redhat.rhn.domain.notification.types.NotificationData;
+import com.redhat.rhn.domain.notification.types.NotificationType;
+
+public class PaygNotCompliantWarning implements NotificationData {
+    private static final LocalizationService LOCALIZATION_SERVICE = LocalizationService.getInstance();
+
+    @Override
+    public NotificationMessage.NotificationMessageSeverity getSeverity() {
+        return NotificationMessage.NotificationMessageSeverity.warning;
+    }
+
+    @Override
+    public NotificationType getType() {
+        return NotificationType.PaygNotCompliantWarning;
+    }
+
+    @Override
+    public String getSummary() {
+        return LOCALIZATION_SERVICE.getMessage("notification.paygnotcompliantwarning.summary");
+    }
+
+    @Override
+    public String getDetails() {
+        return LOCALIZATION_SERVICE.getMessage("notification.paygnotcompliantwarning.detail");
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/notification/types/NotificationType.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/NotificationType.java
@@ -27,4 +27,5 @@ public enum NotificationType {
     EndOfLifePeriod,
     SubscriptionWarning,
     UpdateAvailable,
+    PaygNotCompliantWarning,
 }

--- a/java/code/src/com/redhat/rhn/domain/notification/types/PaygNotCompliantWarning.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/PaygNotCompliantWarning.java
@@ -13,11 +13,10 @@
  * in this software or its documentation.
  */
 
-package com.redhat.rhn.domain.notification;
+package com.redhat.rhn.domain.notification.types;
 
 import com.redhat.rhn.common.localization.LocalizationService;
-import com.redhat.rhn.domain.notification.types.NotificationData;
-import com.redhat.rhn.domain.notification.types.NotificationType;
+import com.redhat.rhn.domain.notification.NotificationMessage;
 
 public class PaygNotCompliantWarning implements NotificationData {
     private static final LocalizationService LOCALIZATION_SERVICE = LocalizationService.getInstance();

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -9442,6 +9442,12 @@ For a detailed analysis, please refer to the log files.</source>
       <trans-unit id="notification.subscriptionwarning.detail">
         <source>You have subscriptions that are expiring soon or already expired. Please check the &lt;a href="/rhn/manager/subscription-matching"&gt;Subscription Matching&lt;/a&gt; page.</source>
       </trans-unit>
+      <trans-unit id="notification.paygnotcompliantwarning.summary">
+        <source>@@PRODUCT_NAME@@ PAYG instance is not compliant.</source>
+      </trans-unit>
+      <trans-unit id="notification.paygnotcompliantwarning.detail">
+        <source>This @@PRODUCT_NAME@@ PAYG instance is not compliant. Some @@PRODUCT_NAME@@ functions will be disabled. Please check with your system administrator.</source>
+      </trans-unit>
       <trans-unit id="notification.updateavailable.summary">
         <source>Updates are available.</source>
       </trans-unit>

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -8345,6 +8345,12 @@ Follow this url to see the full list of inactive systems:
           To amend this situation, please add SCC credentials &lt;a href="/rhn/admin/setup/MirrorCredentials.do"&gt;here&lt;/a&gt;.
         </source>
       </trans-unit>
+      <trans-unit id="message.payg.errornotcompliant" xml:space="preserve">
+        <source>
+          This @@PRODUCT_NAME@@ Pay-as-you-go instance is not compliant and some of its functions will be disabled. Please contact your administrator to
+          amend the situation before continuing using the product.
+        </source>
+      </trans-unit>
       <trans-unit id="message.payg.errorbyosnosccssm" xml:space="preserve">
         <source>
 @@PRODUCT_NAME@@ is not able to manage these instances since there are one or more Bring-your-own-subscription and no SCC credentials are set.

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -8347,7 +8347,7 @@ Follow this url to see the full list of inactive systems:
       </trans-unit>
       <trans-unit id="message.payg.errornotcompliant" xml:space="preserve">
         <source>
-          This @@PRODUCT_NAME@@ Pay-as-you-go instance is not compliant and some of its functions will be disabled. Please contact your administrator to
+          This @@PRODUCT_NAME@@ PAYG is not compliant and some of its functions will be disabled. Please contact your administrator to
           amend the situation before continuing using the product.
         </source>
       </trans-unit>

--- a/java/code/src/com/redhat/rhn/frontend/strings/template/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/template/StringResource_en_US.xml
@@ -265,7 +265,8 @@ click the "Details" tab.
         </context-group>
       </trans-unit>
       <trans-unit id="dailysummary.email.body" xml:space="preserve">
-        <source>This is the @@PRODUCT_NAME@@ Status Report for your account {0}, as of {1}.
+        <source>{7}
+This is the @@PRODUCT_NAME@@ Status Report for your account {0}, as of {1}.
 
 This email will be sent when any of the following apply:
 
@@ -284,8 +285,6 @@ https://{4}/rhn/account/UserPreferences.do
 Thank you for using @@PRODUCT_NAME@@.
 {5}
 {6}
-
-{7}
 </source>
         <context-group name="ctx">
           <context context-type="sourcefile">Taskomatic task: DailySummary.java</context>
@@ -303,7 +302,8 @@ Thank you for using @@PRODUCT_NAME@@.
       </trans-unit>
       <trans-unit id="dailysummary.email.notpaygcompliant" xml:space="preserve">
           <source>Warning: This @@PRODUCT_NAME@@ Pay-as-you-go instance is not compliant and some of its functions are disabled.
-Please contact your administrator to amend the situation before continuing using the product.</source>
+Please contact your administrator to amend the situation before continuing using the product.
+          </source>
       </trans-unit>
       <trans-unit id="email.forgotten.password" xml:space="preserve">
         <source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/template/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/template/StringResource_en_US.xml
@@ -284,6 +284,8 @@ https://{4}/rhn/account/UserPreferences.do
 Thank you for using @@PRODUCT_NAME@@.
 {5}
 {6}
+
+{7}
 </source>
         <context-group name="ctx">
           <context context-type="sourcefile">Taskomatic task: DailySummary.java</context>
@@ -295,8 +297,13 @@ Thank you for using @@PRODUCT_NAME@@.
              {4} = hostname
              {5} = emailFooter from template db
              {6} = email account info from template db
+             {7} = Pay-as-you-go warning if the instance is not compliant
           </context>
         </context-group>
+      </trans-unit>
+      <trans-unit id="dailysummary.email.notpaygcompliant" xml:space="preserve">
+          <source>Warning: This @@PRODUCT_NAME@@ Pay-as-you-go instance is not compliant and some of its functions are disabled.
+Please contact your administrator to amend the situation before continuing using the product.</source>
       </trans-unit>
       <trans-unit id="email.forgotten.password" xml:space="preserve">
         <source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/template/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/template/StringResource_en_US.xml
@@ -296,12 +296,12 @@ Thank you for using @@PRODUCT_NAME@@.
              {4} = hostname
              {5} = emailFooter from template db
              {6} = email account info from template db
-             {7} = Pay-as-you-go warning if the instance is not compliant
+             {7} = PAYG warning if the instance is not compliant
           </context>
         </context-group>
       </trans-unit>
       <trans-unit id="dailysummary.email.notpaygcompliant" xml:space="preserve">
-          <source>Warning: This @@PRODUCT_NAME@@ Pay-as-you-go instance is not compliant and some of its functions are disabled.
+          <source>Warning: This @@PRODUCT_NAME@@ PAYG instance is not compliant and some of its functions are disabled.
 Please contact your administrator to amend the situation before continuing using the product.
           </source>
       </trans-unit>

--- a/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
@@ -22,9 +22,9 @@ import com.redhat.rhn.common.db.datasource.WriteMode;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.notification.NotificationMessage;
-import com.redhat.rhn.domain.notification.PaygNotCompliantWarning;
 import com.redhat.rhn.domain.notification.UserNotificationFactory;
 import com.redhat.rhn.domain.notification.types.EndOfLifePeriod;
+import com.redhat.rhn.domain.notification.types.PaygNotCompliantWarning;
 import com.redhat.rhn.domain.notification.types.SubscriptionWarning;
 import com.redhat.rhn.domain.notification.types.UpdateAvailable;
 import com.redhat.rhn.domain.org.OrgFactory;
@@ -165,7 +165,8 @@ public class DailySummary extends RhnJavaJob {
         // This notification will be process only if SUMA is PAYG but is not compliant
         if (cloudPaygManager.isPaygInstance() && !cloudPaygManager.isCompliant()) {
             NotificationMessage notificationMessage =
-                    UserNotificationFactory.createNotificationMessage(new PaygNotCompliantWarning());
+                    UserNotificationFactory.createNotificationMessage(
+                            new PaygNotCompliantWarning());
             UserNotificationFactory.storeNotificationMessageFor(notificationMessage,
                     Collections.singleton(RoleFactory.ORG_ADMIN), Optional.empty());
         }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
@@ -56,6 +56,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 
 import javax.xml.stream.XMLStreamException;
@@ -168,7 +169,7 @@ public class DailySummary extends RhnJavaJob {
                     UserNotificationFactory.createNotificationMessage(
                             new PaygNotCompliantWarning());
             UserNotificationFactory.storeNotificationMessageFor(notificationMessage,
-                    Collections.singleton(RoleFactory.ORG_ADMIN), Optional.empty());
+                    Set.of(), Optional.empty()); // This notification will be sent to everyone
         }
     }
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
@@ -56,7 +56,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.TreeMap;
 
 import javax.xml.stream.XMLStreamException;
@@ -169,7 +168,7 @@ public class DailySummary extends RhnJavaJob {
                     UserNotificationFactory.createNotificationMessage(
                             new PaygNotCompliantWarning());
             UserNotificationFactory.storeNotificationMessageFor(notificationMessage,
-                    Set.of(), Optional.empty()); // This notification will be sent to everyone
+                    Collections.emptySet(), Optional.empty()); // This notification will be sent to everyone
         }
     }
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
@@ -511,7 +511,7 @@ public class DailySummary extends RhnJavaJob {
         args[6] = OrgFactory.EMAIL_ACCOUNT_INFO.getValue();
 
         if (cloudPaygManager.isPaygInstance() && !cloudPaygManager.isCompliant()) {
-            args[7] = ls.getMessage("dailysummary.email.notpaygcompliant");
+            args[7] = String.format("%s\n", ls.getMessage("dailysummary.email.notpaygcompliant"));
         }
         else {
             args[7] = "";

--- a/java/spacewalk-java.changes.mikeletux.warning-message-payg-non-compliant
+++ b/java/spacewalk-java.changes.mikeletux.warning-message-payg-non-compliant
@@ -1,0 +1,1 @@
+* Add notification in daily email as well as in SUMA home page when SUMA Payg is not compliant

--- a/web/html/src/manager/notifications/notification-messages.tsx
+++ b/web/html/src/manager/notifications/notification-messages.tsx
@@ -60,6 +60,10 @@ const _MESSAGE_TYPE = {
     id: "UpdateAvailable",
     text: t("Update Notification"),
   },
+  PaygNotCompliantWarning: {
+    id: "PaygNotCompliantWarning",
+    text: t("Payg Not Compliant Warning"),
+  },
 };
 
 function reloadData(dataUrlSlice: string) {

--- a/web/html/src/manager/notifications/notification-messages.tsx
+++ b/web/html/src/manager/notifications/notification-messages.tsx
@@ -62,7 +62,7 @@ const _MESSAGE_TYPE = {
   },
   PaygNotCompliantWarning: {
     id: "PaygNotCompliantWarning",
-    text: t("Payg Not Compliant Warning"),
+    text: t("PAYG instance is not compliant"),
   },
 };
 

--- a/web/spacewalk-web.changes.mikeletux.23079
+++ b/web/spacewalk-web.changes.mikeletux.23079
@@ -1,0 +1,1 @@
+- Add support for `PaygNotCompliantWarning` notification


### PR DESCRIPTION
## What does this PR change?
Port of https://github.com/SUSE/spacewalk/pull/23079

## GUI diff

Port of https://github.com/SUSE/spacewalk/pull/23079

- [x] **DONE**

## Documentation
I think this doesn't need documentation as it is just a warning that's given to the user if it is not payg compliant.

- [x] **DONE**

## Test coverage
No tests added since it's just some warning messages.

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/22382
Ports(s): [# **add downstream PR(s), if any**](https://github.com/SUSE/spacewalk/pull/23079)

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
