### PR TITLE
GH-actions: run secondary tests more often to detect flaky tests

### DIFF
--- a/.github/workflows/acceptance_tests_secondary.yml
+++ b/.github/workflows/acceptance_tests_secondary.yml
@@ -9,7 +9,7 @@ on:
       - '.github/workflows/acceptance_tests_common.yml'
       - '!java/*.changes*'
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 */2 * * *'
 jobs:
   test-uyuni:
     uses: ./.github/workflows/acceptance_tests_common.yml

--- a/.github/workflows/acceptance_tests_secondary_parallel.yml
+++ b/.github/workflows/acceptance_tests_secondary_parallel.yml
@@ -9,7 +9,7 @@ on:
       - '.github/workflows/acceptance_tests_common.yml'
       - '!java/*.changes*'
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 */2 * * *'
 jobs:
   test-uyuni:
     uses: ./.github/workflows/acceptance_tests_common.yml


### PR DESCRIPTION
## What does this PR change?

GH-actions: run secondary tests more often to detect flaky tests


## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
