### PR TITLE
DB upgrade fix from 4.3: rhnTaskQueue now has an id

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes.cbosdonnat.43-upgrade-fix
+++ b/schema/spacewalk/susemanager-schema.changes.cbosdonnat.43-upgrade-fix
@@ -1,0 +1,1 @@
+- Adjust upgrade script to work from a 4.3

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.1-to-susemanager-schema-4.4.2/003-system_checkin_threshold.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.1-to-susemanager-schema-4.4.2/003-system_checkin_threshold.sql
@@ -2,7 +2,7 @@ INSERT INTO rhnConfiguration (key, description, value, default_value)
 SELECT 'system_checkin_threshold', 'Number of days before reporting a system as inactive', null, 1
 WHERE NOT EXISTS (SELECT 1 FROM rhnConfiguration WHERE key = 'system_checkin_threshold');
 
-INSERT INTO rhnTaskQueue (org_id, task_name, task_data)
-SELECT id, 'upgrade_satellite_system_threshold_conf', 0
+INSERT INTO rhnTaskQueue (id, org_id, task_name, task_data)
+SELECT NEXTVAL('rhn_task_queue_id_seq'), id, 'upgrade_satellite_system_threshold_conf', 0
 FROM web_customer
 WHERE id = 1;


### PR DESCRIPTION
## What does this PR change?

See title

## Test coverage
- No tests: manual 4.3 migration tests

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
