### PR TITLE
CI: retry ivy build if it fails

### DIFF
--- a/testsuite/podman_runner/09_build_server_code.sh
+++ b/testsuite/podman_runner/09_build_server_code.sh
@@ -7,7 +7,30 @@ sudo -i podman exec uyuni-server-all-in-one-test bash -c "[ -d /usr/share/susema
 sudo -i podman exec uyuni-server-all-in-one-test bash -c "[ -d /usr/share/susemanager/www/htdocs ] || mkdir -p /usr/share/susemanager/www/htdocs"
 sudo -i podman exec uyuni-server-all-in-one-test bash -c "[ -d /usr/share/susemanager/www/tomcat/webapps ] || mkdir -p /usr/share/susemanager/www/tomcat/webapps"
 
-sudo -i podman exec uyuni-server-all-in-one-test bash -c "cd /java && ant -f manager-build.xml ivy refresh-branding-jar deploy-local"
+# WORKAROUND: If ivy build fails, try again, because 50% of times fails when
+# downloading the new jar files from download.opensuse.org.
+# 
+# build.opensuse.org publishes our packages into download.opensuse.org. However,
+# this is not a "static" directory. If packages get rebuild, old packages are
+# removed, new packages are published and new metadata is created. Then, the
+# whole thing is updated in the download.opensuse.org mirrors all around the
+# world.
+#
+# Packages from devel repos can get rebuild any time, i.e. when their
+# dependencies are updates (i.e. java).
+# 
+# Thus, the repos from devel projects that are published into
+# download.opensuse.org, are not stable, their metadata can get rebuilt at any
+# time, packages are removed, etc. and plus, this takes time to be propagated,
+# so mirrors are very often outdated, have outdated metadata or outdated
+# packages, or both.
+#
+# So, we can not consider download.opensuse.org reliable for devel projects.
+# While we do not have a mirror for the jar files, the easiest workaround is
+# to try again and hope it succeeds.
+
+sudo -i podman exec uyuni-server-all-in-one-test bash -c "cd /java && ant -f manager-build.xml ivy || ant -f manager-build.xml ivy || ant -f manager-build.xml ivy"
+sudo -i podman exec uyuni-server-all-in-one-test bash -c "cd /java && ant -f manager-build.xml refresh-branding-jar deploy-local"
 sudo -i podman exec uyuni-server-all-in-one-test bash -c "set -xe;cd /web/html/src;[ -d dist ] || mkdir dist;yarn install --force --ignore-optional --production=true --frozen-lockfile;yarn autoclean --force;yarn build:novalidate; rsync -a dist/ /usr/share/susemanager/www/htdocs/"
 sudo -i podman exec uyuni-server-all-in-one-test bash -c "rctomcat restart"
 


### PR DESCRIPTION
## What does this PR change?

50% of the time, downloading new jars from the open build service is failing. If the "ivy build" fails, try again a couple of times.
## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
