### PR TITLE
Fix RHEL base channel names for bootstrapping

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1393,7 +1393,7 @@ DATA = {
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/res/7/bootstrap/'
     },
     'RHEL7-x86_64-uyuni' : {
-        'BASECHANNEL' : 'rhel7-pool-x86_64', 'PKGLIST' : RES7 + RES7_X86,
+        'BASECHANNEL' : 'rhel7-pool-uyuni-x86_64', 'PKGLIST' : RES7 + RES7_X86,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/res/7/bootstrap/'
     },
     'SLE-ES8-x86_64' : {
@@ -1405,7 +1405,7 @@ DATA = {
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/res/8/bootstrap/'
     },
     'RHEL8-x86_64-uyuni' : {
-        'BASECHANNEL' : 'rhel8-pool-x86_64', 'PKGLIST' : RES8 + RES8_X86,
+        'BASECHANNEL' : 'rhel8-pool-uyuni-x86_64', 'PKGLIST' : RES8 + RES8_X86,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/res/8/bootstrap/'
     },
     'SUSE-LibertyLinux9-x86_64' : {
@@ -1417,7 +1417,7 @@ DATA = {
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/res/9/bootstrap/'
     },
     'RHEL9-x86_64-uyuni' : {
-        'BASECHANNEL' : 'rhel9-pool-x86_64', 'PKGLIST' : RES9,
+        'BASECHANNEL' : 'rhel9-pool-uyuni-x86_64', 'PKGLIST' : RES9,
         'DEST' : DOCUMENT_ROOT + '/pub/repositories/res/9/bootstrap/'
     },
     'alibaba-2-x86_64-uyuni': {

--- a/susemanager/susemanager.changes.witek.fix_rhel
+++ b/susemanager/susemanager.changes.witek.fix_rhel
@@ -1,0 +1,1 @@
+- Fix RHEL base channel name for bootstraping


### PR DESCRIPTION
## What does this PR change?

Sets the correct base channel name for RHEL bootstrapping.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pull/2674)

- [x] **DONE**

## Test coverage
- No tests: we do not provide tests for this

- [x] **DONE**

## Links

Issue(s): #7844

- [x] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
