### PR TITLE
QE: fix uptime validation test

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -103,24 +103,34 @@ Then(/^the uptime for "([^"]*)" should be correct$/) do |host|
   eleven_hours_in_seconds = 39_600 # 11 hours * 60 minutes * 60 seconds
   rounded_uptime_days = ((uptime[:seconds] + eleven_hours_in_seconds) / 86_400.0).round # 60 seconds * 60 minutes * 24 hours
 
+  # select the text in the time HTML element associated with 'Last Booted'
+  ui_uptime_text = find(:xpath, '//td[contains(text(), "Last Booted")]/following-sibling::td/time').text
+  raise ScriptError, "Uptime text for host '#{host}' not found" unless ui_uptime_text
+
+  # we may have to accept as valid slightly different messages to account for rounding operations resulting in off by one errors
+  valid_uptime_messages = []
+  diffs = [-1, 0, +1]
   # the moment.js library being used has some weird rules, which these conditionals follow
   if (uptime[:days] >= 1 && rounded_uptime_days < 2) || (uptime[:days] < 1 && rounded_uptime_hours >= 22) # shows "a day ago" after 22 hours and before it's been 1.5 days
-    step 'I should see a "a day ago" text'
+    valid_uptime_messages << 'a day ago'
   elsif rounded_uptime_hours > 1 && rounded_uptime_hours <= 21
-    step %(I should see a "#{rounded_uptime_hours} hours ago" text)
+    valid_uptime_messages = diffs.map { |n| "#{rounded_uptime_hours + n} hours ago" }
   elsif rounded_uptime_minutes >= 45 && rounded_uptime_hours == 1 # shows "an hour ago" from 45 minutes onwards up to 1.5 hours
-    step 'I should see a "an hour ago" text'
+    valid_uptime_messages << 'an hour ago'
   elsif rounded_uptime_minutes > 1 && rounded_uptime_hours <= 1
-    step %(I should see a "#{rounded_uptime_minutes} minutes ago" text)
+    valid_uptime_messages += diffs.map { |n| "#{rounded_uptime_minutes + n} minutes ago" }
   elsif uptime[:seconds] >= 45 && rounded_uptime_minutes == 1
-    step 'I should see a "a minute ago" text'
+    valid_uptime_messages << 'a minute ago'
   elsif uptime[:seconds] < 45
-    step 'I should see a "a few seconds ago" text'
-  elsif rounded_uptime_days < 25
-    step %(I should see a "#{rounded_uptime_days} days ago" text) # shows "a month ago" from 25 days onwards
+    valid_uptime_messages << 'a few seconds ago'
+  elsif rounded_uptime_days < 25 # shows "a month ago" from 25 days onwards
+    valid_uptime_messages += diffs.map { |n| "#{rounded_uptime_days + n} days ago" }
   else
-    step 'I should see a "a month ago" text'
+    valid_uptime_messages << 'a month ago'
   end
+
+  check = valid_uptime_messages.find { |message| message == ui_uptime_text }
+  raise ScriptError, "Expected uptime message to be one of #{valid_uptime_messages} - found '#{ui_uptime_text}'" unless check
 end
 
 Then(/^I should see several text fields$/) do


### PR DESCRIPTION
Fixes https://github.com/SUSE/spacewalk/issues/22311

## What does this PR change?

We have a step trying to confront the uptime displayed in the web UI with the one obtained from the host's /proc/uptime.
Right now, It expects the exact same value to be displayed but roundings, delays and a JS library get in the way resulting in a very flaky test.

We can probably afford to have some room for +/- 1 variations between the 2 counters, in some cases.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: "only internal and user invisible changes"

- [x] **DONE**

## Test coverage

- One step used in the tests has been fixed

- [x] **DONE**

## Links

Issue card: https://github.com/SUSE/spacewalk/issues/22311

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

