### PR TITLE
Partial revert of 1491df55f68c

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -232,7 +232,15 @@ When(/^I remove "([^"]*)" from salt minion config directory on "([^"]*)"$/) do |
 end
 
 When(/^I configure salt minion on "([^"]*)"$/) do |host|
-  content = %( master: #{get_target('server').full_hostname} server_id_use_crc: adler32 enable_legacy_startup_events: False enable_fqdns_grains: False start_event_grains: - machine_id - saltboot_initrd - susemanager)
+  content = %(
+master: #{get_target('server').full_hostname}
+server_id_use_crc: adler32
+enable_legacy_startup_events: False
+enable_fqdns_grains: False
+start_event_grains:
+  - machine_id
+  - saltboot_initrd
+  - susemanager)
   step %(I store "#{content}" into file "susemanager.conf" in salt minion config directory on "#{host}")
 end
 


### PR DESCRIPTION
## What does this PR change?

Partial revert of 1491df55f68

Missing linefeeds prevented venv-salt-minion from starting

We can make rubocop happy another time.

Edit: rubocop does not even seem to bother....


## Links

Ports:
 * 4.3: not applicable


## Changelogs

- [x] No changelog needed
