### PR TITLE
We do build tests on SLE 15 SP4 even on Uyuni branch

### DIFF
--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -36,7 +36,6 @@ Feature: PXE boot a terminal with Cobbler
     And I wait until event "Apply highstate scheduled by admin" is completed
 
   # We currently test Cobbler with SLES 15 SP4, even on Uyuni
-  @susemanager
   Scenario: Install TFTP boot package on the server
     When I install package tftpboot-installation on the server
     And I wait for "tftpboot-installation-SLE-15-SP4-x86_64" to be installed on "server"


### PR DESCRIPTION
## What does this PR change?

We do build tests on SLE 15 SP4, even on Uyuni branch.

This `@susemanager` tag was probably left by mistake in the revert a1124059a5602476aa8074fcd0d1fc0644229fa2.


## Links

Ports:
 * 4.3: https://github.com/SUSE/spacewalk/pull/23159


## Changelogs

- [x] No changelog needed
