### PR TITLE
Partially revert "How to merge properly and small simplifications (#8009)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,8 @@ After:
 - [ ] **DONE**
 
 ## Documentation
-- No documentation needed: **add explanation. This can't be used if there is a GUI diff**, one can be "only internal and user invisible changes"
+- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
+- No documentation needed: only internal and user invisible changes
 - Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
 - API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
 - (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)
@@ -21,8 +22,10 @@ After:
 - [ ] **DONE**
 
 ## Test coverage
-- No tests: **add explanation** (one explanation can be "already covered")
-- Tests were added: **specify unit and/or cucumber**
+- No tests: **add explanation**
+- No tests: already covered
+- Unit tests were added
+- Cucumber tests were added
 
 - [ ] **DONE**
 


### PR DESCRIPTION
## What does this PR change?

This partially reverts commit c89a16dca78a2abd095c9228425659558ab79c61, as discussed at the retrospective.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: This is doc, somehow

- [x] **DONE**

## Test coverage
- No tests: Doc

- [x] **DONE**

## Links

Issue(s): None
Ports(s): https://github.com/SUSE/spacewalk/pull/23163

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
