### PR TITLE
Install tftpboot for SLES 15 SP4 on all products

### DIFF
--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -320,15 +320,10 @@ Feature: Manage KVM virtual machines via the GUI
     And I should see a "test-net2" virtual network on "kvm_server"
     And "test-net2" virtual network on "kvm_server" should have "192.168.128.1" IPv4 address with 24 prefix
 
-@susemanager
-  Scenario: Install TFTP boot package on the server
+  # We currently test KVM with SLES 15 SP4, even on Uyuni
+  Scenario: Install the TFTP boot package on the server for KVM tests
     When I install package tftpboot-installation on the server
     And I wait for "tftpboot-installation-SLE-15-SP4-x86_64" to be installed on "server"
-
-@uyuni
- Scenario: Install TFTP boot package on the server
-   When I install package tftpboot-installation on the server
-   And I wait for "tftpboot-installation-openSUSE-Leap-15.5-x86_64" to be installed on "server"
 
 @virthost_kvm
   Scenario: Edit a virtual network
@@ -433,15 +428,9 @@ Feature: Manage KVM virtual machines via the GUI
     And I click on "Delete Distribution"
     Then I should not see a "SLE-15-SP4-KVM" text
 
-@susemanager
-  Scenario: Cleanup: Remove the TFTP boot package from the server
+  Scenario: Cleanup: Remove the TFTP boot package from the server after KVM tests
     When I remove package "tftpboot-installation-SLE-15-SP4-x86_64" from this "server" without error control
     And I wait for "tftpboot-installation-SLE-15-SP4-x86_64" to be uninstalled on "server"
-
-@uyuni
-  Scenario: Cleanup: Remove the TFTP boot package from the server
-    When I remove package "tftpboot-installation-openSUSE-Leap-15.5-x86_64" from this "server" without error control
-    And I wait for "tftpboot-installation-openSUSE-Leap-15.5-x86_64" to be uninstalled on "server"
 
   Scenario: Cleanup: Stop virtual network
     Given I am on the "Virtualization" page of this "kvm_server"

--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -36,15 +36,9 @@ Feature: PXE boot a terminal with Cobbler
     And I wait until event "Apply highstate scheduled by admin" is completed
 
   # We currently test Cobbler with SLES 15 SP4, even on Uyuni
-  Scenario: Install TFTP boot package on the server
+  Scenario: Install the TFTP boot package on the server for Cobbler tests
     When I install package tftpboot-installation on the server
     And I wait for "tftpboot-installation-SLE-15-SP4-x86_64" to be installed on "server"
-
-# TODO: use this code when we start testing Cobbler with Leap
-#@uyuni
-# Scenario: Install TFTP boot package on the server
-#   When I install package tftpboot-installation on the server
-#   And I wait for "tftpboot-installation-openSUSE-Leap-15.5-x86_64" to be installed on "server"
 
   Scenario: Create auto installation distribution
     When I follow the left menu "Systems > Autoinstallation > Distributions"
@@ -145,8 +139,8 @@ Feature: PXE boot a terminal with Cobbler
     And I click on "Delete Distribution"
     Then I should not see a "SLE-15-SP4-TFTP" text
 
-  Scenario: Cleanup: remove TFTP boot package from the server
-    And I remove package "tftpboot-installation-SLE-15-SP4-x86_64" from this "server" without error control
+  Scenario: Cleanup: remove the TFTP boot package from the server after Cobbler tests
+    When I remove package "tftpboot-installation-SLE-15-SP4-x86_64" from this "server" without error control
     And I wait for "tftpboot-installation-SLE-15-SP4-x86_64" to be uninstalled on "server"
 
   Scenario: Cleanup: delete the PXE boot minion

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -928,16 +928,17 @@ end
 
 When(/^I install package tftpboot-installation on the server$/) do
   server = get_target('server')
-  os_version = server.os_version
   if product == 'Uyuni'
-    server.run("zypper --non-interactive install tftpboot-installation-openSUSE-Leap-#{os_version}-x86_64", check_errors: false, verbose: true)
-  else
+    # On Uyuni, the server runs on openSUSE Leap, but we must use SLE-15-SP4 on the build host and terminal
     output, _code = server.run('find /var/spacewalk/packages -name tftpboot-installation-SLE-15-SP4-x86_64-*.noarch.rpm')
     packages = output.split("\n")
     pattern = '/tftpboot-installation-([^/]+)*.noarch.rpm'
-    # Reverse sort the package name to get the latest version first and install it
+    # Reverse sort the package names to get the latest version first
     package = packages.min { |a, b| b.match(pattern)[0] <=> a.match(pattern)[0] }
-    server.run("rpm -i #{package}", check_errors: false)
+    server.run("rpm -i #{package}", verbose: true)
+  else
+    # On SUSE Manager, the server, build host and terminal all run on SLE 15 SP4, so let's install it directly
+    server.run('zypper --non-interactive install tftpboot-installation-SLE-15-SP4-x86_64', verbose: true)
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

* use tftpboot package for SLES 15 SP4 even on Uyuni
* makes identical title for 2 scenarios differ


## Links

Ports:
 * 4.3: https://github.com/SUSE/spacewalk/pull/23177


## Changelogs

- [x] No changelog needed
