### PR TITLE
Add option to disable remote commands from web UI

### DIFF
--- a/java/buildconf/test/rhn.conf.postgresql-example
+++ b/java/buildconf/test/rhn.conf.postgresql-example
@@ -162,3 +162,6 @@ java.salt_check_download_tokens = true
 
 # for scc registration tests
 server.susemanager.scc_backup_srv_usr = 52156f60-8aa2-4165-8645-367efdc2a510
+
+# Disable remote commands from UI
+java.disable_remote_commands_from_ui = false

--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -62,6 +62,7 @@ public class ConfigDefaults {
     public static final String WEB_SMTP_USER = "java.smtp_user";
     public static final String WEB_SMTP_PASS = "java.smtp_pass";
     public static final String WEB_DISABLE_UPDATE_STATUS = "java.disable_update_status";
+    public static final String WEB_DISABLE_REMOTE_COMMANDS_FROM_UI = "java.disable_remote_commands_from_ui";
 
     public static final String ERRATA_CACHE_COMPUTE_THRESHOLD
     = "errata_cache_compute_threshold";

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -23,6 +23,7 @@ import static java.util.stream.Collectors.toSet;
 import com.redhat.rhn.FaultException;
 import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.client.ClientCertificate;
+import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.db.datasource.Row;
@@ -4967,6 +4968,10 @@ public class SystemHandler extends BaseHandler {
     public Integer scheduleScriptRun(User loggedInUser, String label, List<Integer>
             sids, String username, String groupname, Integer timeout, String script,
                                      Date earliestOccurrence) {
+
+        if (Config.get().getBoolean(ConfigDefaults.WEB_DISABLE_REMOTE_COMMANDS_FROM_UI)) {
+            throw new PermissionCheckFailureException("Running remote scripts has been disabled");
+        }
 
         ScriptActionDetails scriptDetails = ActionManager.createScript(username, groupname,
                 timeout.longValue(), script);

--- a/java/code/src/com/suse/manager/webui/controllers/MinionController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/MinionController.java
@@ -22,7 +22,10 @@ import static com.suse.manager.webui.utils.SparkApplicationHelper.withUserAndSer
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withUserPreferences;
 import static spark.Spark.get;
 
+import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.db.datasource.DataResult;
+import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.MinionServer;
@@ -166,6 +169,9 @@ public class MinionController {
      * @return the ModelAndView object to render the page
      */
     public static ModelAndView cmd(Request request, Response response) {
+        if (Config.get().getBoolean(ConfigDefaults.WEB_DISABLE_REMOTE_COMMANDS_FROM_UI)) {
+            throw new PermissionException("Remote command is disabled");
+        }
         request.session().removeAttribute(MinionsAPI.SALT_CMD_RUN_TARGETS);
         return new ModelAndView(new HashMap<>(), "templates/minion/cmd.jade");
     }

--- a/java/code/src/com/suse/manager/webui/menu/MenuTree.java
+++ b/java/code/src/com/suse/manager/webui/menu/MenuTree.java
@@ -74,7 +74,7 @@ public class MenuTree {
         if (checkAcl(user, "user_authenticated()")) {
             nodes.add(getHomeNode(adminRoles));
             nodes.add(getSystemsNode(user, adminRoles));
-            nodes.add(getSaltNode(adminRoles));
+            nodes.add(getSaltNode(user, adminRoles));
             nodes.add(getImagesNode(adminRoles));
             nodes.add(getPatchesNode(user));
             nodes.add(getSoftwareNode(user, adminRoles));
@@ -238,10 +238,11 @@ public class MenuTree {
                     .withVisibility(adminRoles.get("org")));
     }
 
-    private MenuItem getSaltNode(Map<String, Boolean> adminRoles) {
+    private MenuItem getSaltNode(User user, Map<String, Boolean> adminRoles) {
         return new MenuItem("Salt").withIcon("spacewalk-icon-salt")
                 .addChild(new MenuItem("Keys").withPrimaryUrl("/rhn/manager/systems/keys"))
-                .addChild(new MenuItem("Remote Commands").withPrimaryUrl("/rhn/manager/systems/cmd"))
+                .addChild(new MenuItem("Remote Commands").withPrimaryUrl("/rhn/manager/systems/cmd")
+                        .withVisibility(checkAcl(user, "not is(java.disable_remote_commands_from_ui)")))
                 .addChild(new MenuItem("Formula Catalog").withPrimaryUrl("/rhn/manager/formula-catalog")
                         .withVisibility(adminRoles.get("org")));
     }

--- a/java/code/webapp/WEB-INF/nav/ssm.xml
+++ b/java/code/webapp/WEB-INF/nav/ssm.xml
@@ -104,7 +104,7 @@
                 acl="all_systems_in_set_have_feature(ftr_package_refresh)"/>
         <rhn-tab name="ssm.misc.index.tabs.maintenanceschedule" url="/rhn/manager/systems/ssm/maintenance"/>
         <rhn-tab name="Remote Command" url="/rhn/systems/ssm/provisioning/RemoteCommand.do"
-                acl="all_systems_in_set_have_feature(ftr_remote_command)"/>
+                acl="all_systems_in_set_have_feature(ftr_remote_command); not is(java.disable_remote_commands_from_ui)"/>
         <rhn-tab name="ssm.misc.index.tabs.custom" url="/rhn/systems/ssm/misc/CustomValue.do"
                 acl="all_systems_in_set_have_feature(ftr_system_custom_values)"/>
         <rhn-tab name="ssm.misc.index.tabs.lockunlock" url="/rhn/systems/ssm/misc/LockUnlockSystem.do"

--- a/java/code/webapp/WEB-INF/nav/system_detail.xml
+++ b/java/code/webapp/WEB-INF/nav/system_detail.xml
@@ -7,7 +7,7 @@
       <rhn-tab-url>/rhn/systems/details/RebootSystem.do</rhn-tab-url>
     </rhn-tab>
     <rhn-tab name="Properties" url="/rhn/systems/details/Edit.do" />
-    <rhn-tab name="Remote Command" acl="system_feature(ftr_remote_command)">
+    <rhn-tab name="Remote Command" acl="system_feature(ftr_remote_command); not is(java.disable_remote_commands_from_ui)">
       <rhn-tab-url>/rhn/systems/details/SystemRemoteCommand.do</rhn-tab-url>
     </rhn-tab>
     <rhn-tab name="Connection" url="/rhn/systems/details/Connection.do" acl="org_has_proxies()"/>

--- a/java/code/webapp/WEB-INF/struts-config.xml
+++ b/java/code/webapp/WEB-INF/struts-config.xml
@@ -3467,7 +3467,7 @@
             type="com.redhat.rhn.frontend.action.systems.SystemRemoteCommandAction"
             className="com.redhat.rhn.frontend.struts.RhnActionMapping">
         <set-property property="acls"
-                      value="system_feature(ftr_remote_command)"/>
+                      value="system_feature(ftr_remote_command); not is(java.disable_remote_commands_from_ui)"/>
         <forward name="default"
                  path="/WEB-INF/pages/systems/system-remote-command.jsp" />
      </action>
@@ -7673,6 +7673,7 @@
             type="com.redhat.rhn.frontend.action.ssm.ProvisioningRemoteCommand"
             className="com.redhat.rhn.frontend.struts.RhnActionMapping">
         <set-property property="postRequiredIfSubmitted" value="true" />
+        <set-property property="acls" value="not is(java.disable_remote_commands_from_ui)"/>
         <forward name="default"
                  path="/WEB-INF/pages/ssm/provisioning-remote-command.jsp"/>
     </action>

--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -264,3 +264,6 @@ java.disable_update_status = 0
 # cause a direct shutdown which makes it impossible for salt to return the result back, resulting in a failed
 # action
 java.reboot_delay = 3
+
+# Disable remote commands from UI
+java.disable_remote_commands_from_ui = false

--- a/java/spacewalk-java.changes.parlt.remote-command-restriction
+++ b/java/spacewalk-java.changes.parlt.remote-command-restriction
@@ -1,0 +1,1 @@
+- Add config option to disable remote commands from web UI (bsc#1217869)


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/23176

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
