### PR TITLE
Cancel action api more info

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/schedule/ScheduleHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/schedule/ScheduleHandler.java
@@ -79,7 +79,9 @@ public class ScheduleHandler extends BaseHandler {
             return BaseHandler.VALID;
         }
         catch (ActionIsChildException e) {
-            throw new UnsupportedOperationException(locService.getMessage("api.schedule.cannotcancelchild"));
+            throw new UnsupportedOperationException(String.format("%s%n%s",
+                    locService.getMessage("api.schedule.cannotcancelchild"),
+                    e.getMessage()));
         }
         catch (com.redhat.rhn.taskomatic.TaskomaticApiException e) {
             throw new TaskomaticApiException(e.getMessage());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/schedule/test/ScheduleHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/schedule/test/ScheduleHandlerTest.java
@@ -377,7 +377,9 @@ public class ScheduleHandlerTest extends BaseHandlerTestCase {
 
         UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
             () -> handler.cancelActions(admin, List.of(child.getId().intValue())));
-        assertEquals("Cannot cancel an action with a pending prerequisite.", exception.getMessage());
+        String expected = String.format("Cannot cancel an action with a pending prerequisite.%n" +
+                "To cancel the whole chain, please cancel Action %d%n", parent.getId());
+        assertEquals(expected, exception.getMessage());
     }
 
     @Test

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -363,7 +363,22 @@ public class ActionManager extends BaseManager {
                                               .filter(sa -> serverIds.isEmpty() || serverIds.contains(sa.getServerId()))
                                               .anyMatch(sa -> !ActionFactory.STATUS_FAILED.equals(sa.getStatus()));
         if (hasValidPrerequisite) {
-            throw new ActionIsChildException();
+            StringBuilder message = new StringBuilder();
+            for (Action a : actions) {
+                Action p = a.getPrerequisite();
+                Long lastId = a.getId();
+                do {
+                    if (p != null) {
+                        lastId = p.getId();
+                    }
+                    else {
+                        break;
+                    }
+                    p = p.getPrerequisite();
+                } while (p != null);
+                message.append(String.format("To cancel the whole chain, please cancel Action %d%n", lastId));
+            }
+            throw new ActionIsChildException(message.toString());
         }
 
         Set<Action> actionsToDelete = concat(

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -577,9 +577,12 @@ public class SaltUtils {
             }
             Map<String, StateApplyResult<CmdResult>> stateApplyResult = Json.GSON.fromJson(jsonResult,
                     new TypeToken<Map<String, StateApplyResult<CmdResult>>>() { }.getType());
-            CmdResult result = stateApplyResult.entrySet().stream()
-                    .findFirst().map(e -> e.getValue().getChanges())
-                    .orElseGet(CmdResult::new);
+            CmdResult result = new CmdResult();
+            if (stateApplyResult != null) {
+                result = stateApplyResult.entrySet().stream()
+                        .findFirst().map(e -> e.getValue().getChanges())
+                        .orElseGet(CmdResult::new);
+            }
             ScriptRunAction scriptAction = (ScriptRunAction) action;
             ScriptResult scriptResult = Optional.ofNullable(
                     scriptAction.getScriptActionDetails().getResults())

--- a/java/spacewalk-java.changes.mc.Manager-4.3-cancle-action-api-more-info
+++ b/java/spacewalk-java.changes.mc.Manager-4.3-cancle-action-api-more-info
@@ -1,0 +1,2 @@
+- when cancel an action which has prerequisites, return hints to
+  get the first action id which can be canceled (bsc#1216988)


### PR DESCRIPTION
## What does this PR change?

When cancel an action with pre-requisite actions failed, show in the error message the first action which can be canceld.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Ports(s): https://github.com/SUSE/spacewalk/pull/23174

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
