### PR TITLE
Fix ULN Download for dnf repos

### DIFF
--- a/python/spacewalk/satellite_tools/repo_plugins/yum_dnf_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_dnf_src.py
@@ -128,7 +128,7 @@ class ContentSource(zypper_ContentSource):
         self.sslcacert = ca_cert_file
         self.sslclientcert = client_cert_file
         self.sslclientkey = client_key_file
-        self.http_headers = {}
+        self.http_headers = http_headers if http_headers is not None else {}
 
         self.dnfbase = dnf.Base()
         self.dnfbase.conf.read(yumsrc_conf)
@@ -253,6 +253,11 @@ class ContentSource(zypper_ContentSource):
         self.digest = hashlib.sha256(dnf_repo_url.encode("utf8")).hexdigest()[:16]
         self.dnfbase.repos.add(repo)
         self.repoid = repo.id
+        headers = tuple()
+        for key in self.http_headers:
+            headers = headers + (key + ": " + self.http_headers[key],)
+        self.dnfbase.repos[self.repoid].set_http_headers(headers)
+
         # Try loading the repo configuration
         try:
             self.dnfbase.repos[self.repoid].load()

--- a/python/spacewalk/satellite_tools/repo_plugins/yum_dnf_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_dnf_src.py
@@ -208,7 +208,13 @@ class ContentSource(zypper_ContentSource):
         self.dnfbase.close()
 
     def setup_repo(
-        self, repo, no_mirrors, ca_cert_file, client_cert_file, client_key_file
+        self,
+        repo,
+        no_mirrors,
+        ca_cert_file,
+        client_cert_file,
+        client_key_file,
+        uln_repo=False,
     ):
         """
         Setup repository and fetch metadata

--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -534,7 +534,7 @@ class ContentSource:
         client_cert_file=None,
         client_key_file=None,
         channel_arch="",
-        http_headers={},
+        http_headers=None,
     ):
         """
         Plugin constructor.
@@ -558,7 +558,7 @@ class ContentSource:
         self.sslcacert = ca_cert_file
         self.sslclientcert = client_cert_file
         self.sslclientkey = client_key_file
-        self.http_headers = http_headers
+        self.http_headers = http_headers if http_headers is not None else {}
 
         # keep authtokens for mirroring
         # pylint: disable-next=invalid-name,unused-variable

--- a/python/spacewalk/spacewalk-backend.changes.sbluhm.fixULN
+++ b/python/spacewalk/spacewalk-backend.changes.sbluhm.fixULN
@@ -1,0 +1,1 @@
+- Added ULN repo feature to dnf repo plugin.


### PR DESCRIPTION
## What does this PR change?

This PR adds ULN repo downloads to the dnf repo plugin:
1. Replace ULN paths with http paths.
2. Accept ULN authentication header and pass it on to dnf (can be enhanced later to accept custom headers).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Ports(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
