### PR TITLE
preflight.sh: Write SELinux policy if needed

### DIFF
--- a/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
+++ b/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
@@ -14,7 +14,12 @@ if ! [ "${SH_NAME}" = "bash" ]; then
 fi
 
 REPO_HOST=$1
-REPO_PORT=$2
+if [[ $2 =~ "^[0-9]$" ]]; then
+   REPO_PORT=$2
+else
+   echo 'Error: $2 (REPO_PORT) must be an integer.' >2
+   exit 254
+fi
 FAIL_ON_ERROR=1
 if [ "$3" = "1" ]; then
     FAIL_ON_ERROR=0
@@ -199,6 +204,20 @@ elif [ "${INSTALLER}" = "apt" ]; then
         CLIENT_REPO_URL="${CLIENT_REPOS_ROOT}/${A_CLIENT_CODE_BASE}/${A_CLIENT_VARIANT_ID}/bootstrap"
     else
         CLIENT_REPO_URL="${CLIENT_REPOS_ROOT}/${A_CLIENT_CODE_BASE}/${A_CLIENT_CODE_MAJOR_VERSION}/${A_CLIENT_CODE_MINOR_VERSION}/bootstrap"
+    fi
+fi
+
+SELINUX_POLICY_FILENAME="salt_ssh_port_forwarding.cil"
+function selinux_policy_loaded {
+    semodule -l | grep -x $SELINUX_POLICY_FILENAME
+}
+
+# Our SSH tunnel uses a custom port and we must configure SELinux to account for it
+if [[ $REPO_HOST == "localhost" ]] && command -v selinuxenabled && selinuxenabled; then
+    if ! selinux_policy_loaded; then
+        echo "(portcon tcp ${REPO_PORT} (system_u object_r ssh_port_t ((s0)(s0))))" >$SELINUX_POLICY_FILENAME
+        if ! semodule -i $SELINUX_POLICY_FILENAME; then
+			exit_with_message_code "Error: Failed to install SELinux policy." 7
     fi
 fi
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.agraul.ssh-tunnel-add-selinux-policy
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.agraul.ssh-tunnel-add-selinux-policy
@@ -1,0 +1,2 @@
+- Dynamically load an SELinux policy for "Push via SSH tunnel" for SELinux
+  enabled clients. This policy allows communication over a custom SSH port.


### PR DESCRIPTION
## What does this PR change?

SSH Push in the "tunnel" flavor can conflict with SELinux policies shipped by operating systems. The default policies are not aware of the additional port we need for the tunnel.

The preflight.sh script is executed at the beginning of bootstrapping to download the Salt Bundle and allow Salt code execution. To allow for this download, a custom policy is written when SELinux is enabled and the system is managed via a tunnel. The policy is only written and loaded once.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): #
Ports(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
