### PR TITLE
Sanitize request URLs for the 404 template (bsc#1216754)

### DIFF
--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -84,6 +84,8 @@ import com.suse.manager.webui.services.iface.VirtManager;
 
 import org.apache.http.HttpStatus;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 
 import spark.ModelAndView;
@@ -247,7 +249,8 @@ public class Router implements SparkApplication {
             if (isJson(response) || isApiRequest(request)) {
                 return json(response, Collections.singletonMap("message", "404 Not found"));
             }
-            var data = Collections.singletonMap("currentUrl", request.pathInfo());
+            var data = Collections.singletonMap("currentUrl",
+                    URLEncoder.encode(request.pathInfo(), StandardCharsets.UTF_8));
             return jade.render(new ModelAndView(data, "templates/errors/404.jade"));
         });
 
@@ -257,7 +260,8 @@ public class Router implements SparkApplication {
                 response.body(json(response, Collections.singletonMap("message", "404 Not found")));
             }
             else {
-                var data = Collections.singletonMap("currentUrl", request.pathInfo());
+                var data = Collections.singletonMap("currentUrl",
+                        URLEncoder.encode(request.pathInfo(), StandardCharsets.UTF_8));
                 response.body(jade.render(new ModelAndView(data, "templates/errors/404.jade")));
             }
         });

--- a/java/spacewalk-java.changes.cbbayburt.bsc1216754
+++ b/java/spacewalk-java.changes.cbbayburt.bsc1216754
@@ -1,0 +1,1 @@
+- Safeguard request URLs against tempering (bsc#1216754)

--- a/web/html/src/manager/errors/not-found.tsx
+++ b/web/html/src/manager/errors/not-found.tsx
@@ -38,4 +38,7 @@ const NotFound = ({ currentUrl }) => (
 );
 
 export const renderer = (id: string, { currentUrl }) =>
-  SpaRenderer.renderNavigationReact(<NotFound currentUrl={currentUrl} />, document.getElementById(id));
+  SpaRenderer.renderNavigationReact(
+    <NotFound currentUrl={decodeURIComponent(currentUrl)} />,
+    document.getElementById(id)
+  );

--- a/web/spacewalk-web.changes.cbbayburt.bsc1216754
+++ b/web/spacewalk-web.changes.cbbayburt.bsc1216754
@@ -1,0 +1,1 @@
+- Safeguard request URLs against tempering (bsc#1216754)


### PR DESCRIPTION
The `404.jade` template passes the request URLs directly to JS, which allows arbitrary code injection via request URLs. This patch encodes the URLs to safeguard against injections.

Port of: https://github.com/SUSE/spacewalk/pull/23010

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
