### PR TITLE
Remove duplicates and reorder containers module

### DIFF
--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -647,12 +647,10 @@ CHANNEL_TO_SYNCH_BY_OS_PRODUCT_VERSION = {
     %w[
       sle-product-sles15-sp4-pool-x86_64
       sle-manager-tools15-pool-x86_64-sp4
-      sle-module-containers15-sp4-pool-x86_64
       sle-module-basesystem15-sp4-pool-x86_64
       sle-module-server-applications15-sp4-pool-x86_64
       sle-product-sles15-sp4-updates-x86_64
       sle-manager-tools15-updates-x86_64-sp4
-      sle-module-containers15-sp4-updates-x86_64
       sle-module-basesystem15-sp4-updates-x86_64
       sle-module-server-applications15-sp4-updates-x86_64
       sle15-sp4-installer-updates-x86_64
@@ -779,12 +777,10 @@ CHANNEL_TO_SYNCH_BY_OS_PRODUCT_VERSION = {
       sle-product-sles15-sp3-ltss-updates-x86_64
       sle-product-sles15-sp3-pool-x86_64
       sle-manager-tools15-pool-x86_64-sp3
-      sle-module-containers15-sp3-pool-x86_64
       sle-module-basesystem15-sp3-pool-x86_64
       sle-module-server-applications15-sp3-pool-x86_64
       sle-product-sles15-sp3-updates-x86_64
       sle-manager-tools15-updates-x86_64-sp3
-      sle-module-containers15-sp3-updates-x86_64
       sle-module-basesystem15-sp3-updates-x86_64
       sle-module-server-applications15-sp3-updates-x86_64
       sle15-sp3-installer-updates-x86_64
@@ -803,8 +799,6 @@ CHANNEL_TO_SYNCH_BY_OS_PRODUCT_VERSION = {
       sle-manager-tools15-updates-x86_64-sp4
       sle-module-basesystem15-sp4-pool-x86_64
       sle-module-basesystem15-sp4-updates-x86_64
-      sle-module-containers15-sp4-pool-x86_64
-      sle-module-containers15-sp4-updates-x86_64
       sle-module-desktop-applications15-sp4-pool-x86_64
       sle-module-desktop-applications15-sp4-updates-x86_64
       sle-module-devtools15-sp4-pool-x86_64
@@ -813,6 +807,8 @@ CHANNEL_TO_SYNCH_BY_OS_PRODUCT_VERSION = {
       sle-module-server-applications15-sp4-updates-x86_64
       sle-product-sles15-sp4-pool-x86_64
       sle-product-sles15-sp4-updates-x86_64
+      sle-module-containers15-sp4-pool-x86_64
+      sle-module-containers15-sp4-updates-x86_64
       sles15-sp4-uyuni-client-x86_64
     ],
   'sles15-sp5' =>
@@ -822,8 +818,6 @@ CHANNEL_TO_SYNCH_BY_OS_PRODUCT_VERSION = {
       sle-manager-tools15-updates-x86_64-sp5
       sle-module-basesystem15-sp5-pool-x86_64
       sle-module-basesystem15-sp5-updates-x86_64
-      sle-module-containers15-sp5-pool-x86_64
-      sle-module-containers15-sp5-updates-x86_64
       sle-module-desktop-applications15-sp5-pool-x86_64
       sle-module-desktop-applications15-sp5-updates-x86_64
       sle-module-devtools15-sp5-pool-x86_64
@@ -832,6 +826,8 @@ CHANNEL_TO_SYNCH_BY_OS_PRODUCT_VERSION = {
       sle-module-server-applications15-sp5-updates-x86_64
       sle-product-sles15-sp5-pool-x86_64
       sle-product-sles15-sp5-updates-x86_64
+      sle-module-containers15-sp5-pool-x86_64
+      sle-module-containers15-sp5-updates-x86_64
       sles15-sp5-uyuni-client-x86_64
     ],
   'res7' =>


### PR DESCRIPTION
## What does this PR change?

We have duplicate modules in some products, including the default. So I removed the duplicate.

The containers also depend on basesystem being there so it takes forever and silently fails in the end (nothing in the reposync logs) so the module fails to be there if it's in the wrong order. I moved it almost at the end to be sure the right order is used. 

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): no issue directly from testsuite review
Ports(s): 4.3: https://github.com/SUSE/spacewalk/pull/23210

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
