### PR TITLE
PGDATA variable is unset, so pass the path with -D option

### DIFF
--- a/java/scripts/docker-testing-pgsql.sh
+++ b/java/scripts/docker-testing-pgsql.sh
@@ -28,4 +28,4 @@ cp buildconf/test/rhn.conf.postgresql-example buildconf/test/rhn.conf
 ant -f manager-build.xml refresh-branding-jar $TARGET
 
 # Postgres shutdown (avoid stale memory by shmget())
-su - postgres -c "/usr/lib/postgresql/bin/pg_ctl stop" ||:
+su - postgres -c "/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data/ stop" ||:

--- a/python/test/docker-backend-pgsql-tests.sh
+++ b/python/test/docker-backend-pgsql-tests.sh
@@ -1,10 +1,10 @@
 #! /bin/bash
 
 /sbin/sysctl -w kernel.shmmax=4067832832
-su - postgres -c '/usr/lib/postgresql/bin/pg_ctl start'
+su - postgres -c '/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data/ start'
 cp /root/rhn.conf /etc/rhn/rhn.conf
 mkdir -p /manager/python/spacewalk/reports
 pytest -v --junit-xml /manager/python/spacewalk/reports/pgsql_tests.xml /manager/python/test/integration/
 EXIT=$?
-su - postgres -c '/usr/lib/postgresql/bin/pg_ctl stop'
+su - postgres -c '/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data/ stop'
 exit $?

--- a/susemanager-utils/testing/docker/scripts/generate-reportdb-docs.sh
+++ b/susemanager-utils/testing/docker/scripts/generate-reportdb-docs.sh
@@ -45,8 +45,8 @@ export PATH=/manager/schema/spacewalk/:/manager/spacewalk/setup/bin/:$PATH
 
 export SYSTEMD_NO_WRAP=1
 
-su - postgres -c "/usr/lib/postgresql/bin/pg_ctl stop" ||:
-su - postgres -c "/usr/lib/postgresql/bin/pg_ctl start" ||:
+su - postgres -c "/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data/ stop" ||:
+su - postgres -c "/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data/ start" ||:
 
 # this copy the latest schema from the git into the system
 cp -r /manager/schema /tmp

--- a/susemanager-utils/testing/docker/scripts/init-pgsql-db4eclipse.sh
+++ b/susemanager-utils/testing/docker/scripts/init-pgsql-db4eclipse.sh
@@ -20,8 +20,8 @@ echo $PERLLIB
 
 export SYSTEMD_NO_WRAP=1
 #sysctl -w kernel.shmmax=18446744073709551615
-su - postgres -c "/usr/lib/postgresql/bin/pg_ctl stop" ||:
-su - postgres -c "/usr/lib/postgresql/bin/pg_ctl start" ||:
+su - postgres -c "/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data/ stop" ||:
+su - postgres -c "/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data/ start" ||:
 
 # this copy the latest schema from the git into the system
 ./build-schema.sh
@@ -44,7 +44,7 @@ fi
 # run the schema upgrade from git repo
 if ! /manager/schema/spacewalk/spacewalk-schema-upgrade -y; then
     cat /var/log/spacewalk/schema-upgrade/schema-from-*.log
-    su - postgres -c "/usr/lib/postgresql/bin/pg_ctl stop" ||:
+    su - postgres -c "/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data/ stop" ||:
     exit 1
 fi
 
@@ -73,10 +73,10 @@ fi
 # run the schema upgrade from git repo
 if ! /manager/schema/spacewalk/spacewalk-schema-upgrade -y --reportdb; then
     cat /var/log/spacewalk/schema-upgrade/schema-from-*.log
-    su - postgres -c "/usr/lib/postgresql/bin/pg_ctl stop" ||:
+    su - postgres -c "/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data/ stop" ||:
     exit 1
 fi
 
-su - postgres -c "/usr/lib/postgresql/bin/pg_ctl stop" ||:
+su - postgres -c "/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data/ stop" ||:
 su - postgres -c '/usr/lib/postgresql/bin/postgres -D /var/lib/pgsql/data'
 

--- a/susemanager-utils/testing/docker/scripts/reportdb_schema_idempotency_test_pgsql.py
+++ b/susemanager-utils/testing/docker/scripts/reportdb_schema_idempotency_test_pgsql.py
@@ -153,7 +153,7 @@ def manage_postgresql(action):
     actions = ['start', 'stop']
     if action not in actions:
         raise "Invalid action for the PostgreSQL service"
-    if run_command("/usr/bin/su - postgres -c '/usr/lib/postgresql/bin/pg_ctl %s'" % action):
+    if run_command("/usr/bin/su - postgres -c '/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data/ %s'" % action):
         print("PostgreSQL %sed" % action)
     else:
         raise RuntimeError("Could not %s PostgreSQL!" % action)

--- a/susemanager-utils/testing/docker/scripts/reset_pgsql_database.sh
+++ b/susemanager-utils/testing/docker/scripts/reset_pgsql_database.sh
@@ -15,8 +15,8 @@ echo $PERLLIB
 
 export SYSTEMD_NO_WRAP=1
 sysctl -w kernel.shmmax=18446744073709551615
-su - postgres -c "/usr/lib/postgresql/bin/pg_ctl stop" ||:
-su - postgres -c "/usr/lib/postgresql/bin/pg_ctl start"
+su - postgres -c "/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data/ stop" ||:
+su - postgres -c "/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data/ start"
 
 touch /var/lib/rhn/rhn-satellite-prep/etc/rhn/rhn.conf
 touch /etc/rhn/rhn.conf

--- a/susemanager-utils/testing/docker/scripts/schema_idempotency_test_pgsql.py
+++ b/susemanager-utils/testing/docker/scripts/schema_idempotency_test_pgsql.py
@@ -153,7 +153,7 @@ def manage_postgresql(action):
     actions = ['start', 'stop']
     if action not in actions:
         raise "Invalid action for the PostgreSQL service"
-    if run_command("/usr/bin/su - postgres -c '/usr/lib/postgresql/bin/pg_ctl %s'" % action):
+    if run_command("/usr/bin/su - postgres -c '/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data/ %s'" % action):
         print("PostgreSQL %sed" % action)
     else:
         raise RuntimeError("Could not %s PostgreSQL!" % action)

--- a/susemanager-utils/testing/docker/scripts/schema_migration_reportdb_test_pgsql.sh
+++ b/susemanager-utils/testing/docker/scripts/schema_migration_reportdb_test_pgsql.sh
@@ -50,8 +50,8 @@ echo $PERLLIB
 
 export SYSTEMD_NO_WRAP=1
 sysctl -w kernel.shmmax=18446744073709551615
-su - postgres -c "/usr/lib/postgresql/bin/pg_ctl stop" ||:
-su - postgres -c "/usr/lib/postgresql/bin/pg_ctl start"
+su - postgres -c "/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data/ stop" ||:
+su - postgres -c "/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data/ start"
 
 touch /var/lib/rhn/rhn-satellite-prep/etc/rhn/rhn.conf
 # SUSE Manager initialization
@@ -82,9 +82,9 @@ fi
 # run the schema upgrade from git repo
 if ! /manager/schema/spacewalk/spacewalk-schema-upgrade -y --reportdb; then
     cat /var/log/spacewalk/reportdb-schema-upgrade/schema-from-*.log
-    su - postgres -c "/usr/lib/postgresql/bin/pg_ctl stop"
+    su - postgres -c "/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data/ stop"
     exit 1
 fi
 
 # Postgres shutdown (avoid stale memory by shmget())
-su - postgres -c "/usr/lib/postgresql/bin/pg_ctl stop"
+su - postgres -c "/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data/ stop"

--- a/susemanager-utils/testing/docker/scripts/schema_migration_test_pgsql.sh
+++ b/susemanager-utils/testing/docker/scripts/schema_migration_test_pgsql.sh
@@ -50,8 +50,8 @@ echo $PERLLIB
 
 export SYSTEMD_NO_WRAP=1
 sysctl -w kernel.shmmax=18446744073709551615
-su - postgres -c "/usr/lib/postgresql/bin/pg_ctl stop" ||:
-su - postgres -c "/usr/lib/postgresql/bin/pg_ctl start"
+su - postgres -c "/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data/ stop" ||:
+su - postgres -c "/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data/ start"
 
 touch /var/lib/rhn/rhn-satellite-prep/etc/rhn/rhn.conf
 # SUSE Manager initialization
@@ -81,9 +81,9 @@ fi
 # run the schema upgrade from git repo
 if ! /manager/schema/spacewalk/spacewalk-schema-upgrade -y; then
     cat /var/log/spacewalk/schema-upgrade/schema-from-*.log
-    su - postgres -c "/usr/lib/postgresql/bin/pg_ctl stop"
+    su - postgres -c "/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data/ stop"
     exit 1
 fi
 
 # Postgres shutdown (avoid stale memory by shmget())
-su - postgres -c "/usr/lib/postgresql/bin/pg_ctl stop"
+su - postgres -c "/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data/ stop"


### PR DESCRIPTION
## What does this PR change?

PGDATA variable is unset, so pass the path with -D option

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed
- [x] **DONE**

## Test coverage
- No tests
- [x] **DONE**

## Links

Issue(s): #
Ports(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
