### PR TITLE
monitor the salt queue handling the results

### DIFF
--- a/java/code/src/com/suse/manager/metrics/PrometheusExporter.java
+++ b/java/code/src/com/suse/manager/metrics/PrometheusExporter.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 import org.quartz.Scheduler;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.ThreadPoolExecutor;
 
 import io.prometheus.client.exporter.HTTPServer;
@@ -61,6 +62,17 @@ public enum PrometheusExporter {
     public void registerThreadPool(ThreadPoolExecutor pool, String poolId) {
         if (ENABLED) {
             new ThreadPoolCollector(pool, poolId).register();
+        }
+    }
+
+    /**
+     * Registers a thread pool list for monitoring.
+     * @param pool a thread pool list
+     * @param poolId a unique ID for the pool
+     */
+    public void registerThreadPoolList(List<ThreadPoolExecutor> pool, String poolId) {
+        if (ENABLED) {
+            new ThreadPoolListCollector(pool, poolId).register();
         }
     }
 

--- a/java/code/src/com/suse/manager/metrics/ThreadPoolListCollector.java
+++ b/java/code/src/com/suse/manager/metrics/ThreadPoolListCollector.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.metrics;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import io.prometheus.client.Collector;
+
+/**
+ * Collector for a List of ThreadPool.
+ */
+public class ThreadPoolListCollector extends Collector {
+
+    private final List<ThreadPoolExecutor> pool;
+    private final String poolId;
+
+    /**
+     * Standard constructor.
+     * @param poolIn a thread pool
+     * @param poolIdIn a unique ID for the pool
+     */
+    public ThreadPoolListCollector(List<ThreadPoolExecutor> poolIn, String poolIdIn) {
+        this.pool = poolIn;
+        this.poolId = poolIdIn;
+    }
+
+    @Override
+    public List<MetricFamilySamples> collect() {
+        List<MetricFamilySamples> out = new ArrayList<>();
+
+        out.add(CustomCollectorUtils.counterFor("thread_pool_threads",
+                "Threads total count",
+                this.pool.stream().map(ThreadPoolExecutor::getPoolSize).mapToInt(p -> p).sum(),
+                this.poolId));
+        out.add(CustomCollectorUtils.gaugeFor("thread_pool_threads_active",
+                "Active threads count",
+                this.pool.stream().map(ThreadPoolExecutor::getActiveCount).mapToInt(p -> p).sum(),
+                this.poolId));
+        out.add(CustomCollectorUtils.counterFor("thread_pool_task_count",
+                "Number of tasks ever submitted",
+                this.pool.stream().map(ThreadPoolExecutor::getTaskCount).mapToLong(p -> p).sum(),
+                this.poolId));
+        out.add(CustomCollectorUtils.counterFor("thread_pool_completed_task_count",
+                "Number of tasks ever completed",
+                this.pool.stream().map(ThreadPoolExecutor::getCompletedTaskCount).mapToLong(p -> p).sum(),
+                this.poolId));
+
+        return out;
+    }
+}

--- a/java/code/src/com/suse/manager/metrics/ThreadPoolListCollector.java
+++ b/java/code/src/com/suse/manager/metrics/ThreadPoolListCollector.java
@@ -20,7 +20,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.stream.IntStream;
 
 import io.prometheus.client.Collector;
-import io.prometheus.client.GaugeMetricFamily;
+import io.prometheus.client.CounterMetricFamily;
 
 /**
  * Collector for a List of ThreadPool.
@@ -60,9 +60,10 @@ public class ThreadPoolListCollector extends Collector {
                 "Number of tasks ever completed",
                 this.pool.stream().map(ThreadPoolExecutor::getCompletedTaskCount).mapToLong(p -> p).sum(),
                 this.poolId));
-        GaugeMetricFamily family = new GaugeMetricFamily(poolId + "_" + "usage", "Queue usage", List.of("queue"));
+        CounterMetricFamily family = new CounterMetricFamily(poolId + "_" + "task_usage", "Task queue usage",
+                List.of("queue"));
         IntStream.range(0, this.pool.size())
-                .forEach(i -> family.addMetric(List.of(String.format("%d", i)), this.pool.get(i).getActiveCount()));
+                .forEach(i -> family.addMetric(List.of(String.format("%d", i)), this.pool.get(i).getTaskCount()));
         out.add(family);
 
         return out;

--- a/java/code/src/com/suse/manager/metrics/ThreadPoolListCollector.java
+++ b/java/code/src/com/suse/manager/metrics/ThreadPoolListCollector.java
@@ -17,8 +17,10 @@ package com.suse.manager.metrics;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.stream.IntStream;
 
 import io.prometheus.client.Collector;
+import io.prometheus.client.GaugeMetricFamily;
 
 /**
  * Collector for a List of ThreadPool.
@@ -58,6 +60,10 @@ public class ThreadPoolListCollector extends Collector {
                 "Number of tasks ever completed",
                 this.pool.stream().map(ThreadPoolExecutor::getCompletedTaskCount).mapToLong(p -> p).sum(),
                 this.poolId));
+        GaugeMetricFamily family = new GaugeMetricFamily(poolId + "_" + "usage", "Queue usage", List.of("queue"));
+        IntStream.range(0, this.pool.size())
+                .forEach(i -> family.addMetric(List.of(String.format("%d", i)), this.pool.get(i).getActiveCount()));
+        out.add(family);
 
         return out;
     }

--- a/java/code/src/com/suse/manager/reactor/PGEventStream.java
+++ b/java/code/src/com/suse/manager/reactor/PGEventStream.java
@@ -27,6 +27,7 @@ import com.redhat.rhn.domain.reactor.SaltEventFactory;
 import com.redhat.rhn.frontend.events.TransactionHelper;
 
 import com.suse.manager.metrics.PrometheusExporter;
+import com.suse.salt.netapi.datatypes.Event;
 import com.suse.salt.netapi.event.AbstractEventStream;
 import com.suse.salt.netapi.exception.SaltException;
 import com.suse.salt.netapi.parser.JsonParser;
@@ -67,14 +68,14 @@ public class PGEventStream extends AbstractEventStream implements PGNotification
     private final PGConnection connection;
     private final List<ThreadPoolExecutor> executorServices = IntStream.range(0, THREAD_POOL_SIZE + 1).mapToObj(i ->
         new ThreadPoolExecutor(
-            1,
-            1,
-            0L,
-            TimeUnit.MILLISECONDS,
+                1,
+                1,
+                0L,
+                TimeUnit.MILLISECONDS,
                 new LinkedBlockingQueue<>(),
-            new BasicThreadFactory.Builder()
-                .namingPattern(i == 0 ? "salt-global-event-thread-%d" : String.format("salt-event-thread-%d", i))
-                .build()
+                new BasicThreadFactory.Builder()
+                    .namingPattern(i == 0 ? "salt-global-event-thread-%d" : String.format("salt-event-thread-%d", i))
+                    .build()
         )
     ).collect(Collectors.toList());
 
@@ -202,7 +203,9 @@ public class PGEventStream extends AbstractEventStream implements PGNotification
     }
 
     /**
-     * Reads one or more events from suseSaltEvent and notifies listeners (typically, {@link PGEventListener}).
+     * Reads one or more events from suseSaltEvent and notifies listeners
+     * (typically, {@link PGEventListener#notify(Event)}).
+     *
      * @param uncommittedEvents used to keep track of events being processed
      * @param queue the index of the thread processing the events
      */

--- a/java/spacewalk-java.changes.mc.monitor-salt_queue
+++ b/java/spacewalk-java.changes.mc.monitor-salt_queue
@@ -1,0 +1,1 @@
+- expose the monitoring data for the salt queue handling the salt results


### PR DESCRIPTION
## What does this PR change?

expose the data for the salt queue handling the salt return events

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- https://github.com/uyuni-project/uyuni-docs/pull/2693

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Ports(s): https://github.com/SUSE/spacewalk/pull/23225

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
