### PR TITLE
Bump version in web/conf/rhn_web.conf and add missing migration paths

### DIFF
--- a/web/conf/rhn_web.conf
+++ b/web/conf/rhn_web.conf
@@ -63,7 +63,7 @@ web.version = 4.4.0 Alpha1
 # the version of Uyuni to show at the WebUI, it will be prepended
 # to web.version as version for the SPECs, when building them
 # for Uyuni
-web.version.uyuni =  2023.10
+web.version.uyuni =  2023.12
 
 web.buildtimestamp = _OBS_BUILD_TIMESTAMP_
 

--- a/web/spacewalk-web.changes.raul.update_rhnwebversion_check_migrationpaths
+++ b/web/spacewalk-web.changes.raul.update_rhnwebversion_check_migrationpaths
@@ -1,1 +1,1 @@
-- Update the version in the WebUI
+- Update the version in the WebUI to 2023.12

--- a/web/spacewalk-web.changes.raul.update_rhnwebversion_check_migrationpaths
+++ b/web/spacewalk-web.changes.raul.update_rhnwebversion_check_migrationpaths
@@ -1,0 +1,1 @@
+- Update the version in the WebUI


### PR DESCRIPTION
Bump version in web/conf/rhn_web.conf and add missing migration paths from both previous Uyuni and SUSE Manager

## What does this PR change?

Bump version in web/conf/rhn_web.conf and add missing migration paths from both previous Uyuni and SUSE Manager

## GUI diff

In web-ui, before logging in:

Before: 2023.10

After: 2023.12

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Related to [#22851](https://github.com/SUSE/spacewalk/issues/22851)

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
