### PR TITLE
Revert PR 8042

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -637,10 +637,6 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I enter "SUSE Manager Proxy 4.3" as the filtered product description
     And I select "SUSE Manager Proxy 4.3 x86_64" as a product
     Then I should see the "SUSE Manager Proxy 4.3 x86_64" selected
-    When I open the sub-list of the product "SUSE Manager Proxy 4.3 x86_64"
-    And I open the sub-list of the product "Basesystem Module 15 SP4 x86_64"
-    And I select "Containers Module 15 SP4 x86_64" as a product
-    Then I should see the "Containers Module 15 SP4 x86_64" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
     And I wait until I see "SUSE Manager Proxy 4.3 x86_64" product has been added

--- a/testsuite/features/reposync/allcli_update_activationkeys.feature
+++ b/testsuite/features/reposync/allcli_update_activationkeys.feature
@@ -27,6 +27,8 @@ Feature: Update activation keys
     And I wait until "SLE-Module-DevTools15-SP4-Updates for x86_64" has been checked
     And I wait until "SLE-Module-Desktop-Applications15-SP4-Pool for x86_64" has been checked
     And I wait until "SLE-Module-Desktop-Applications15-SP4-Updates for x86_64" has been checked
+    And I check "SLE-Module-Containers15-SP4-Pool for x86_64"
+    And I wait until "SLE-Module-Containers15-SP4-Updates for x86_64" has been checked
     And I check "Fake-RPM-SUSE-Channel"
     And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE Test Key x86_64 has been modified" text
@@ -161,6 +163,8 @@ Feature: Update activation keys
     And I wait until "SLE-Module-DevTools15-SP4-Updates for x86_64" has been checked
     And I wait until "SLE-Module-Desktop-Applications15-SP4-Pool for x86_64" has been checked
     And I wait until "SLE-Module-Desktop-Applications15-SP4-Updates for x86_64" has been checked
+    And I check "SLE-Module-Containers15-SP4-Pool for x86_64"
+    And I wait until "SLE-Module-Containers15-SP4-Updates for x86_64" has been checked
     And I click on "Update Activation Key"
     Then I should see a "Activation key Build host Key x86_64 has been modified" text
 
@@ -180,6 +184,8 @@ Feature: Update activation keys
     And I wait until "SLE-Module-DevTools15-SP4-Updates for x86_64" has been checked
     And I wait until "SLE-Module-Desktop-Applications15-SP4-Pool for x86_64" has been checked
     And I wait until "SLE-Module-Desktop-Applications15-SP4-Updates for x86_64" has been checked
+    And I check "SLE-Module-Containers15-SP4-Pool for x86_64"
+    And I wait until "SLE-Module-Containers15-SP4-Updates for x86_64" has been checked
     And I click on "Update Activation Key"
     Then I should see a "Activation key Terminal Key x86_64 has been modified" text
 

--- a/testsuite/features/reposync/reference_srv_check_reposync.feature
+++ b/testsuite/features/reposync/reference_srv_check_reposync.feature
@@ -35,6 +35,7 @@ Feature: Reposync works as expected
     And I wait until the channel "sle-module-server-applications15-sp4-updates-x86_64" has been synced
     And I wait until the channel "sle-module-desktop-applications15-sp4-updates-x86_64" has been synced
     And I wait until the channel "sle-module-devtools15-sp4-updates-x86_64" has been synced
+    And I wait until the channel "sle-module-containers15-sp4-pool-x86_64" has been synced
 
 @uyuni
   Scenario: Check reposync of openSUSE Leap 15.5 channels being finished

--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -57,6 +57,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I select "Development Tools Module 15 SP4 x86_64" as a product
     Then I should see the "Desktop Applications Module 15 SP4 x86_64" selected
     And I should see the "Development Tools Module 15 SP4 x86_64" selected
+    When I select "Containers Module 15 SP4 x86_64" as a product
+    Then I should see the "Containers Module 15 SP4 x86_64" selected
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 15 SP4 x86_64" product has been added
     Then the SLE15 SP4 product should be added
@@ -83,6 +85,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I select "Development Tools Module 15 SP4 x86_64" as a product
     Then I should see the "Desktop Applications Module 15 SP4 x86_64" selected
     And I should see the "Development Tools Module 15 SP4 x86_64" selected
+    When I select "Containers Module 15 SP4 x86_64" as a product
+    Then I should see the "Containers Module 15 SP4 x86_64" selected
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 15 SP4 x86_64" product has been added
     Then the SLE15 SP4 product should be added
@@ -105,10 +109,6 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I enter "SUSE Manager Proxy 4.3" as the filtered product description
     And I select "SUSE Manager Proxy 4.3 x86_64" as a product
     Then I should see the "SUSE Manager Proxy 4.3 x86_64" selected
-    When I open the sub-list of the product "SUSE Manager Proxy 4.3 x86_64"
-    And I open the sub-list of the product "Basesystem Module 15 SP4 x86_64"
-    And I select "Containers Module 15 SP4 x86_64" as a product
-    Then I should see the "Containers Module 15 SP4 x86_64" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
     And I wait until I see "SUSE Manager Proxy 4.3 x86_64" product has been added

--- a/testsuite/features/secondary/allcli_software_channels.feature
+++ b/testsuite/features/secondary/allcli_software_channels.feature
@@ -201,6 +201,7 @@ Feature: Channel subscription via SSM
     And I wait until I do not see "Loading..." text
     And I include the recommended child channels
     And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"
+    And I check "SLE-Module-Containers15-SP4-Pool for x86_64"
     And I check "Fake-RPM-SUSE-Channel"
     And I wait until I do not see "Loading..." text
     And I wait until I see "SLE15-SP4-Installer-Updates for x86_64" text

--- a/testsuite/features/secondary/allcli_software_channels_dependencies.feature
+++ b/testsuite/features/secondary/allcli_software_channels_dependencies.feature
@@ -23,11 +23,11 @@ Feature: Channel subscription with recommended or required dependencies
     Then I should see the child channel "SLE-Product-SLES15-SP4-Updates for x86_64" "selected" and "disabled"
     When I exclude the recommended child channels
     Then I should see the toggler "disabled"
-    And I should see a "Desktop Applications Module 15 SP4 x86_64" text
-    And I should see the child channel "Desktop Applications Module 15 SP4 x86_64" "unselected"
+    And I should see a "SLE-Module-Containers15-SP4-Pool for x86_64" text
+    And I should see the child channel "SLE-Module-Containers15-SP4-Pool for x86_64" "unselected"
     # check the a child channel selection that requires some channel trigger the selection of it
-    When I select the child channel "Desktop Applications Module 15 SP4 x86_64"
-    Then I should see the child channel "Desktop Applications Module 15 SP4 x86_64" "selected"
+    When I select the child channel "SLE-Module-Containers15-SP4-Pool for x86_64"
+    Then I should see the child channel "SLE-Module-Containers15-SP4-Pool for x86_64" "selected"
     # check a recommended channel not yet selected is checked  by the recommended toggler
     When I click on the "disabled" toggler
     Then I should see the child channel "SLE-Module-Server-Applications15-SP4-Pool for x86_64" "selected"

--- a/testsuite/features/secondary/min_recurring_action.feature
+++ b/testsuite/features/secondary/min_recurring_action.feature
@@ -213,6 +213,8 @@ Feature: Recurring Actions
     And I wait until "SLE-Module-DevTools15-SP4-Updates for x86_64" has been checked
     And I wait until "SLE-Module-Desktop-Applications15-SP4-Pool for x86_64" has been checked
     And I wait until "SLE-Module-Desktop-Applications15-SP4-Updates for x86_64" has been checked
+    And I check "SLE-Module-Containers15-SP4-Pool for x86_64"
+    And I wait until "SLE-Module-Containers15-SP4-Updates for x86_64" has been checked
     And I check "Fake-RPM-SUSE-Channel"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text

--- a/testsuite/features/secondary/proxy_as_pod_basic_tests.feature
+++ b/testsuite/features/secondary/proxy_as_pod_basic_tests.feature
@@ -190,6 +190,8 @@ Feature: Register and test a Containerized Proxy
     And I wait until "SLE-Module-DevTools15-SP4-Updates for x86_64" has been checked
     And I wait until "SLE-Module-Desktop-Applications15-SP4-Pool for x86_64" has been checked
     And I wait until "SLE-Module-Desktop-Applications15-SP4-Updates for x86_64" has been checked
+    And I check "SLE-Module-Containers15-SP4-Pool for x86_64"
+    And I wait until "SLE-Module-Containers15-SP4-Updates for x86_64" has been checked
     And I check "Fake-RPM-SUSE-Channel"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -658,6 +658,8 @@ CHANNEL_TO_SYNCH_BY_OS_PRODUCT_VERSION = {
       sle-module-desktop-applications15-sp4-updates-x86_64
       sle-module-devtools15-sp4-pool-x86_64
       sle-module-devtools15-sp4-updates-x86_64
+      sle-module-containers15-sp4-pool-x86_64
+      sle-module-containers15-sp4-updates-x86_64
     ],
   'almalinux9' =>
     %w[
@@ -786,6 +788,8 @@ CHANNEL_TO_SYNCH_BY_OS_PRODUCT_VERSION = {
       sle-module-desktop-applications15-sp3-updates-x86_64
       sle-module-devtools15-sp3-pool-x86_64
       sle-module-devtools15-sp3-updates-x86_64
+      sle-module-containers15-sp3-pool-x86_64
+      sle-module-containers15-sp3-updates-x86_64
       sles15-sp3-uyuni-client-x86_64
     ],
   'sles15-sp4' =>
@@ -940,10 +944,6 @@ CHANNEL_TO_SYNCH_BY_OS_PRODUCT_VERSION = {
       sle-product-suse-manager-proxy-4.3-updates-x86_64
       sle-module-suse-manager-proxy-4.3-pool-x86_64
       sle-module-suse-manager-proxy-4.3-updates-x86_64
-      sle-module-basesystem15-sp4-pool-x86_64-proxy-4.3
-      sle-module-basesystem15-sp4-updates-x86_64-proxy-4.3
-      sle-module-containers15-sp4-pool-x86_64-proxy-4.3
-      sle-module-containers15-sp4-updates-x86_64-proxy-4.3
     ],
   'suma-retail-branch-server-43' =>
     %w[
@@ -951,12 +951,6 @@ CHANNEL_TO_SYNCH_BY_OS_PRODUCT_VERSION = {
       sle-product-suse-manager-retail-branch-server-4.3-updates-x86_64
       sle-module-suse-manager-retail-branch-server-4.3-pool-x86_64
       sle-module-suse-manager-retail-branch-server-4.3-updates-x86_64
-      sle-module-basesystem15-sp4-pool-x86_64-smrbs-4.3
-      sle-module-basesystem15-sp4-updates-x86_64-smrbs-4.3
-      sle-module-server-applications15-sp4-pool-x86_64-smrbs-4.3
-      sle-module-server-applications15-sp4-updates-x86_64-smrbs-4.3
-      sle-module-suse-manager-proxy-4.3-pool-x86_64-smrbs
-      sle-module-suse-manager-proxy-4.3-updates-x86_64-smrbs
     ],
   'uyuni-proxy' =>
     %w[


### PR DESCRIPTION
## What does this PR change?

This PR reverts commit "BV: We only need containers module on the POD Proxy VM".

Containers are needed on build host to test Docker.


## Links

Ports:
 * 4.3: https://github.com/SUSE/spacewalk/pull/23234

Note: in the 4.3 port, I have left alone the additions to `proxy_as_pod_basic_tests.feature`.


## Changelogs

- [x] No changelog needed
