### PR TITLE
Improve payg detection

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/packages/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/init.sls
@@ -27,4 +27,15 @@ mgr_install_flavor_check:
 {%- else %}
       - mgrcompat: sync_states
 {%- endif %}
+
+mgr_refresh_grains:
+{%- if grains.get('__suse_reserved_saltutil_states_support', False) %}
+  saltutil.sync_grains:
+{%- else %}
+  mgrcompat.module_run:
+    - name: saltutil.sync_grains
+{%- endif %}
+    - reload_grains: true
+    - onchanges:
+      - pkg: mgr_install_flavor_check
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/src/grains/public_cloud.py
+++ b/susemanager-utils/susemanager-sls/src/grains/public_cloud.py
@@ -155,7 +155,10 @@ def is_payg_instance():
         return ret
 
     if result == "PAYG":
+        log.debug("This minion is a PAYG instance. Adding grains: is_payg_instance = True")
         ret['is_payg_instance'] = True
+    else:
+        log.debug("This minion is a BYOS instance.")
 
     return ret
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mc.Manager-4.3-improve-payg-detection
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mc.Manager-4.3-improve-payg-detection
@@ -1,0 +1,1 @@
+- improve PAYG instance detection (bsc#1217784)


### PR DESCRIPTION
## What does this PR change?

when instance-flavor-check tool gets installed, the grain is not directly updated as it is kind of static data.
Calling `util.syncgrains` should update them for the next call.

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: manual

- [x] **DONE**

## Links

Ports(s): https://github.com/SUSE/spacewalk/pull/23154

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
