### PR TITLE
Remove grub2-x86_64-efi package from server container image

### DIFF
--- a/containers/server-image/Dockerfile
+++ b/containers/server-image/Dockerfile
@@ -16,12 +16,13 @@ RUN echo "rpm.install.excludedocs = yes" >>/etc/zypp/zypp.conf
 
 # Main packages
 RUN zypper ref && zypper --non-interactive up
+
+# TODO Add grub2-x86_64-efi package once it is available for all architectures
 RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-licenses --force-resolution \
     ${PRODUCT_PATTERN_PREFIX}_server \
     ${PRODUCT_PATTERN_PREFIX}_retail \
     spacewalk-utils-extras \
     shim \
-    grub2-x86_64-efi \
     ed \
     susemanager-tftpsync \
     golang-github-prometheus-node_exporter \

--- a/containers/server-image/server-image.changes.cbosdonnat.noefi
+++ b/containers/server-image/server-image.changes.cbosdonnat.noefi
@@ -1,0 +1,1 @@
+- Remove grub2-x86_64-efi package from server container image


### PR DESCRIPTION
## What does this PR change?

In order to build for more than x86_64 images we need to drop this package for now as it is not available on the other architectures.

This is only a temporary solution since this prevents UEFI PXE booting of systems.

## Links

Somehow related to https://github.com/SUSE/spacewalk/issues/23049

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
