### PR TITLE
Avoid blocking Taskomatic thread when waiting for queued action

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/SubscribeChannelsActionTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/SubscribeChannelsActionTest.java
@@ -103,6 +103,8 @@ public class SubscribeChannelsActionTest extends JMockBaseTestCaseWithUser {
             allowing(ctx).getJobDetail();
             will(returnValue(jobDetail));
 
+            allowing(ctx).getTrigger();
+
             JobDataMap dataMap = new JobDataMap();
             dataMap.putAsString("action_id", action.getId());
             dataMap.putAsString("user_id", user.getId());

--- a/java/spacewalk-java.changes.welder.avoid-blocking-taskomatic-thread
+++ b/java/spacewalk-java.changes.welder.avoid-blocking-taskomatic-thread
@@ -1,0 +1,1 @@
+- Avoid blocking Taskomatic thread when waiting for queued action (bsc#1211560)


### PR DESCRIPTION
## What does this PR change?

The `while` loop with a `Thread.sleep` inside keeps blocking Taskomatic thread in some not reproducible scenarios, this PR aims to remove the thread blocking.

The strategy is to reschedule the Job if the action is not ready in database.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: legacy code

- [x] **DONE**

## Links

Issue(s): #
Ports(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
