### PR TITLE
spacecmd: use localhost without ssl when running on the server

### DIFF
--- a/spacecmd/spacecmd.changes.cbosdonnat.localhost-nossl
+++ b/spacecmd/spacecmd.changes.cbosdonnat.localhost-nossl
@@ -1,0 +1,1 @@
+- Use localhost without ssl when running on the server

--- a/spacecmd/src/bin/spacecmd
+++ b/spacecmd/src/bin/spacecmd
@@ -156,7 +156,8 @@ if __name__ == '__main__':
         if shell.options.server:
             shell.config['server'] = shell.options.server
         else:
-            shell.config['server'] = get_localhost_fqdn()
+            shell.config['server'] = "localhost"
+            shell.config['nossl'] = True
 
         # don't automatically create config files passed via --config
         if shell.options.config:


### PR DESCRIPTION
## What does this PR change?

Getting the FQDN will provide useless results when running in the server container. In order to avoid hairpins and SSL trouble, use http://localhost to connect to the API by default in this case.

## Links

Issue(s): #
Ports(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
