### PR TITLE
Fix missing action chain schedule initial value

### DIFF
--- a/web/html/src/manager/schedule-options/action-chain-picker.tsx
+++ b/web/html/src/manager/schedule-options/action-chain-picker.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Combobox } from "components/combobox";
 
@@ -14,6 +14,15 @@ type Props = {
 export const ActionChainPicker = (props: Props) => {
   const [selectedId, setSelectedId] = useState(props.actionChains[0]?.id || "");
 
+  useEffect(() => {
+    setInteropValue(selectedId);
+  }, []);
+
+  // This module needs to interface with legacy fields in schedule-options.jspf
+  const setInteropValue = (value: string) => {
+    document.getElementById("action-chain")?.setAttribute("value", value);
+  };
+
   return (
     <Combobox
       options={props.actionChains}
@@ -25,8 +34,7 @@ export const ActionChainPicker = (props: Props) => {
         return { id: cut, value: cut, label };
       }}
       onSelect={(item) => {
-        // This module needs to interface with legacy fields in schedule-options.jspf
-        document.getElementById("action-chain")?.setAttribute("value", item.id);
+        setInteropValue(item.id);
         setSelectedId(item.id);
       }}
       onFocus={() => {

--- a/web/spacewalk-web.changes.eth.select-interop
+++ b/web/spacewalk-web.changes.eth.select-interop
@@ -1,0 +1,1 @@
+- Fix missing action chain schedule initial value


### PR DESCRIPTION
## What does this PR change?

A regression in https://github.com/uyuni-project/uyuni/pull/7701 caused the initial value of the schedule picker not being set without interacting with the picker. This PR is a quick fix for it while I look into the underlying cause.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: fixes Cucumber test

- [x] **DONE**

## Links

https://suse.slack.com/archives/C02DDMY6R0R/p1703001720936379
https://github.com/SUSE/spacewalk/issues/23243

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
