### PR TITLE
provide total number of CPUs for SLE Micro systems

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/product/test/SUSEProductTestUtils.java
+++ b/java/code/src/com/redhat/rhn/domain/product/test/SUSEProductTestUtils.java
@@ -293,6 +293,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
      *
      * SLES12 SP1 x86_64
      * SLE-HA12 SP1 x86_64
+     * SLE-Micro 5.4 x86_64
      */
     public static void createVendorSUSEProducts() {
         ChannelFamily cfsles = ChannelFamilyFactory.lookupByLabel("7261", null);
@@ -309,6 +310,14 @@ public class SUSEProductTestUtils extends HibernateFactory {
             cfha.setLabel("SLE-HAE-X86");
             cfha.setName("SUSE Linux Enterprise High Availability Extension (x86)");
             TestUtils.saveAndFlush(cfha);
+        }
+
+        ChannelFamily cfslem = ChannelFamilyFactory.lookupByLabel("MICROOS-X86", null);
+        if (cfslem == null) {
+            cfslem = new ChannelFamily();
+            cfslem.setLabel("MICROOS-X86");
+            cfslem.setName("SUSE Linux Enterprise Micro X86");
+            TestUtils.saveAndFlush(cfslem);
         }
 
         SUSEProduct product = new SUSEProduct();
@@ -384,6 +393,17 @@ public class SUSEProductTestUtils extends HibernateFactory {
         product.setProductId(1340);
         //product.setChannelFamily(cfsles);
         product.setBase(false);
+        product.setReleaseStage(ReleaseStage.released);
+        TestUtils.saveAndFlush(product);
+
+        product = new SUSEProduct();
+        product.setName("sle-micro");
+        product.setVersion("5.4");
+        product.setFriendlyName("SUSE Linux Enterprise Micro 5.4 x86_64");
+        product.setArch(PackageFactory.lookupPackageArchByLabel("x86_64"));
+        product.setProductId(2574);
+        product.setChannelFamily(cfslem);
+        product.setBase(true);
         product.setReleaseStage(ReleaseStage.released);
         TestUtils.saveAndFlush(product);
     }

--- a/java/spacewalk-java.changes.mc.subscription-matching-vcores-for-slemicro
+++ b/java/spacewalk-java.changes.mc.subscription-matching-vcores-for-slemicro
@@ -1,0 +1,3 @@
+- provide total number of CPUs for SLE Micro systems to subscription matcher
+  when it is not used as hypervisor to match vCore subscriptions correctly
+  (bsc#1218074)


### PR DESCRIPTION
## What does this PR change?

MicroOS is counted by number of vCores when it is not used as hypervisor.
Provide total number of CPUs to the subscription matcher input in this case.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23212
Ports(s): https://github.com/SUSE/spacewalk/pull/23273

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
