### PR TITLE
Proxy: add ingress routes and rules for traefik

### DIFF
--- a/containers/proxy-helm/proxy-helm.changes.cbosdonnat.traefik
+++ b/containers/proxy-helm/proxy-helm.changes.cbosdonnat.traefik
@@ -1,0 +1,1 @@
+- Add ingress and routes for traefik

--- a/containers/proxy-helm/templates/ingress.yaml
+++ b/containers/proxy-helm/templates/ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: uyuni-proxy-ingress-nossl
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+  {{- if eq .Values.ingress "nginx" }}
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+  {{- else if eq .Values.ingress "traefik" }}
+    traefik.ingress.kubernetes.io/router.tls: "false"
+    traefik.ingress.kubernetes.io/router.entrypoints: "web"
+  {{- end }}
+  labels:
+    app: uyuni-proxy
+spec:
+  rules:
+  - host: {{ .Values.fqdn }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: uyuni-proxy-tcp
+            port:
+              number: 80
+        path: /
+        pathType: Prefix

--- a/containers/proxy-helm/templates/k3s-ingress-routes.yaml
+++ b/containers/proxy-helm/templates/k3s-ingress-routes.yaml
@@ -1,0 +1,73 @@
+{{- if eq .Values.ingress "traefik" }}
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: ssl-router
+  namespace: "{{ .Release.Namespace }}"
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: HostSNI(`*`)
+      services:
+      - name: uyuni-proxy-tcp
+        port: 443
+  tls:
+    passthrough: true
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: ssh-router
+  namespace: "{{ .Release.Namespace }}"
+spec:
+  entryPoints:
+    - ssh 
+  routes:
+    - match: HostSNI(`*`)
+      services:
+      - name: uyuni-proxy-tcp
+        port: 8022
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: salt-publish-router
+  namespace: "{{ .Release.Namespace }}"
+spec:
+  entryPoints:
+    - salt-publish
+  routes:
+    - match: HostSNI(`*`)
+      services:
+      - name: uyuni-proxy-tcp
+        port: 4505
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: salt-request-router
+  namespace: "{{ .Release.Namespace }}"
+spec:
+  entryPoints:
+    - salt-request
+  routes:
+    - match: HostSNI(`*`)
+      services:
+      - name: uyuni-proxy-tcp
+        port: 4506
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteUDP
+metadata:
+  name: tftp-router
+  namespace: "{{ .Release.Namespace }}"
+spec:
+  entryPoints:
+    - tftp
+  routes:
+    - services:
+      - name: uyuni-proxy-udp
+        port: 69
+{{- end }}
+

--- a/containers/proxy-helm/values.yaml
+++ b/containers/proxy-helm/values.yaml
@@ -17,6 +17,10 @@ images:
 ##
 pullPolicy: "Always"
 
+## ingress defines the ingress that is used in the cluster.
+## It can be either "nginx", "traefik" or any other value.
+ingress: "traefik"
+
 persistentVolume:
     ## uyuni proxy overall Persistent Volume access modes
     ## Must match those of existing PV or dynamic provisioner


### PR DESCRIPTION
## What does this PR change?

For now the proxy installation on kubernetes required disabling traefik and using metallb for the network part. This commit adds the IngressRouteTCP, IngressRouteUDP and Ingress resources to use with traefik.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation

- [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pull/2685)

- [X] **DONE**

## Test coverage
- No tests: proxy tests will have to be changed later with the all-containers approach

- [X] **DONE**

## Links

Needed for PR https://github.com/uyuni-project/uyuni-tools/pull/96

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
