### PR TITLE
fix exception when removing a debian package (bsc#1216781)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
@@ -337,6 +337,22 @@ ORDER BY UPPER(C.name)
   </query>
 </write-mode>
 
+<write-mode name="cleanup_package_predepends">
+    <query params="pid">
+        DELETE from
+        rhnPackagePreDepends
+        where package_id = :pid
+    </query>
+</write-mode>
+
+<write-mode name="cleanup_package_breaks">
+    <query params="pid">
+        DELETE from
+        rhnPackageBreaks
+        where package_id = :pid
+    </query>
+</write-mode>
+
 <write-mode name="cleanup_package_caps">
   <query params="pid">
 DELETE FROM

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageBreaks.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageBreaks.java
@@ -20,7 +20,7 @@ import javax.persistence.Entity;
 import javax.persistence.Table;
 
 /**
- * PackagePreDepends
+ * PackageBreaks
  */
 @Entity
 @Table(name = "rhnPackageBreaks")

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageSupplements.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageSupplements.java
@@ -20,7 +20,7 @@ import javax.persistence.Entity;
 import javax.persistence.Table;
 
 /**
- * PackagePreDepends
+ * PackageSupplements
  */
 @Entity
 @Table(name = "rhnPackageSupplements")

--- a/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
+++ b/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
@@ -93,7 +93,7 @@ public class PackageManager extends BaseManager {
 
     private static final String[]
         CLEANUP_QUERIES = {"requires", "provides", "conflicts", "obsoletes",
-            "recommends", "suggests", "supplements", "enhances",
+            "recommends", "suggests", "supplements", "enhances", "predepends", "breaks",
             "channels", "files", "caps", "changelogs"};
 
     /**

--- a/java/spacewalk-java.changes.mc.Manager-4.3-fix-removing-deb-packages
+++ b/java/spacewalk-java.changes.mc.Manager-4.3-fix-removing-deb-packages
@@ -1,0 +1,1 @@
+- fix exception when removing a debian package (bsc#1216781)


### PR DESCRIPTION
## What does this PR change?

When removing a debian package via API, some dependencies are not cleaned up before removing the main package.
This can lead into ClassCast exceptions.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Ports(s): https://github.com/SUSE/spacewalk/pull/23246

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
