### PR TITLE
Credentials hierarchy - Additional fixes

### DIFF
--- a/python/spacewalk/spacewalk-backend.changes.mackdk.credentials-hierarchy
+++ b/python/spacewalk/spacewalk-backend.changes.mackdk.credentials-hierarchy
@@ -1,0 +1,1 @@
+- Updated query to the new credentials structure

--- a/schema/spacewalk/susemanager-schema.changes.mackdk.credentials-hierarchy
+++ b/schema/spacewalk/susemanager-schema.changes.mackdk.credentials-hierarchy
@@ -1,1 +1,1 @@
-- Refactor Credentials to a proper class hierarchy
+- Refactor susecredentials to support the new hierarchy

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.19-to-susemanager-schema-4.3.20/001-add-rhui-credential-type.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.19-to-susemanager-schema-4.3.20/001-add-rhui-credential-type.sql
@@ -1,4 +1,11 @@
-insert into suseCredentialsType (id, label, name)
-  select sequence_nextval('suse_credtype_id_seq'), 'rhui', 'Red Hat Update Infrastructure'
-  where not exists(select 1 from suseCredentialsType where label = 'rhui');
-
+DO $$
+  BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'susecredentialstype') THEN
+      insert into suseCredentialsType (id, label, name)
+        select sequence_nextval('suse_credtype_id_seq'), 'rhui', 'Red Hat Update Infrastructure'
+        where not exists(select 1 from suseCredentialsType where label = 'rhui');
+    ELSE
+      RAISE NOTICE 'suseCredentialsType does not exists';
+    END IF;
+  END;
+$$;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.7-to-susemanager-schema-4.3.8/300-payg-database-changes.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.7-to-susemanager-schema-4.3.8/300-payg-database-changes.sql
@@ -68,9 +68,17 @@ CREATE SEQUENCE IF NOT EXISTS susecloudrmthost_id_seq;
 ---------------------------
 -- Add new credentials type
 ---------------------------
-insert into suseCredentialsType (id, label, name)
-  select sequence_nextval('suse_credtype_id_seq'), 'cloudrmt', 'Cloud RMT network'
-  where not exists(select 1 from suseCredentialsType where label = 'cloudrmt');
+DO $$
+  BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'susecredentialstype') THEN
+      insert into suseCredentialsType (id, label, name)
+        select sequence_nextval('suse_credtype_id_seq'), 'cloudrmt', 'Cloud RMT network'
+        where not exists(select 1 from suseCredentialsType where label = 'cloudrmt');
+    ELSE
+      RAISE NOTICE 'suseCredentialsType does not exists';
+    END IF;
+  END;
+$$;
 
 --------------------------------
 -- Update suse credentials Table

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.9-to-susemanager-schema-4.3.10/002-add-suseUyuniServerInfo.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.9-to-susemanager-schema-4.3.10/002-add-suseUyuniServerInfo.sql
@@ -9,9 +9,17 @@
 -- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 --
 
-insert into suseCredentialsType (id, label, name)
-  select sequence_nextval('suse_credtype_id_seq'), 'reportcreds', 'Reporting DB Credentials'
-   where not exists(select 1 from suseCredentialsType where label = 'reportcreds');
+DO $$
+  BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'susecredentialstype') THEN
+      insert into suseCredentialsType (id, label, name)
+        select sequence_nextval('suse_credtype_id_seq'), 'reportcreds', 'Reporting DB Credentials'
+         where not exists(select 1 from suseCredentialsType where label = 'reportcreds');
+    ELSE
+      RAISE NOTICE 'suseCredentialsType does not exists';
+    END IF;
+  END;
+$$;
 
 
 CREATE TABLE IF NOT EXISTS suseMgrServerInfo

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.6-to-susemanager-schema-4.4.7/001-add-rhui-credential-type.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.6-to-susemanager-schema-4.4.7/001-add-rhui-credential-type.sql
@@ -1,4 +1,11 @@
-insert into suseCredentialsType (id, label, name)
-  select sequence_nextval('suse_credtype_id_seq'), 'rhui', 'Red Hat Update Infrastructure'
-  where not exists(select 1 from suseCredentialsType where label = 'rhui');
-
+DO $$
+  BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'susecredentialstype') THEN
+      insert into suseCredentialsType (id, label, name)
+        select sequence_nextval('suse_credtype_id_seq'), 'rhui', 'Red Hat Update Infrastructure'
+        where not exists(select 1 from suseCredentialsType where label = 'rhui');
+    ELSE
+      RAISE NOTICE 'suseCredentialsType does not exists';
+    END IF;
+  END;
+$$;

--- a/spacewalk/setup/spacewalk-setup.changes.mackdk.credentials-hierarchy
+++ b/spacewalk/setup/spacewalk-setup.changes.mackdk.credentials-hierarchy
@@ -1,0 +1,1 @@
+- Updated query to the new credentials structure

--- a/susemanager-utils/supportutils-plugin-susemanager/supportutils-plugin-susemanager.changes.mackdk.credentials-hierarchy
+++ b/susemanager-utils/supportutils-plugin-susemanager/supportutils-plugin-susemanager.changes.mackdk.credentials-hierarchy
@@ -1,0 +1,1 @@
+- Updated query to the new credentials structure


### PR DESCRIPTION
## What does this PR change?

This PR fixes the sql scripts idempotency and adds the missing changelogs. 

Please note that the  fix is up to the database schema 4.3.0, if the idempotency test is started from an earlier version, it might still fail. Currently, our tooling is using 4.3.8 as starting point.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: No code change

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
