### PR TITLE
Remove wrong parenthesis

### DIFF
--- a/spacewalk/setup/bin/spacewalk-setup
+++ b/spacewalk/setup/bin/spacewalk-setup
@@ -857,7 +857,7 @@ sub populate_initial_configs {
 
       # SCC - write to DB
       my $st = sprintf("insert into suseCredentials (id, user_id, type, username, password, url)
-                        values (sequence_nextval('suse_credentials_id_seq'), NULL, 'scc'),
+                        values (sequence_nextval('suse_credentials_id_seq'), NULL, 'scc',
                                  '%s', '%s', '%s');",
                        $answers->{'scc-user'},
                        encode_base64($answers->{'scc-pass'}),


### PR DESCRIPTION
## What does this PR change?

Remove the left-over parenthesis remained by mistake after the query update. This fixes the issue when setting up the database.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: setup script

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
