### PR TITLE
QE: Workaround to navigate to the KVM Host, as the API call fails due to SSL issues

### DIFF
--- a/testsuite/features/secondary/srv_rename_hostname.feature
+++ b/testsuite/features/secondary/srv_rename_hostname.feature
@@ -57,9 +57,11 @@ Feature: Reconfigure the server's hostname
 
 @virthost_kvm
   # WORKAROUND: Use the webUI instead of Salt like with the other minions above
-  # The Salt call always failed for unknown reasons
+  # The Salt call always failed for unknown reasons.
+  # WORKAROUND: Use the webUI steps instead of the API call,
+  # as it fails due to an SSL error, even if we established a new connection.
   Scenario: Apply high state on the virthost to populate new server CA
-    Given I am on the Systems overview page of this "kvm_server"
+    Given I navigate to the Systems overview page of this "kvm_server"
     When I follow "States" in the content area
     And I click on "Apply Highstate"
     Then I should see a "Applying the highstate has been scheduled." text


### PR DESCRIPTION
## What does this PR change?

This PR changes the way to navigate to the KVM Host overview page. Instead of relying on the URL generated after obtaining the ID of that system through an API Call, we will navigate through web elements, interacting with the web.

We see this issue:
```
SSL_connect returned=1 errno=0 state=error: certificate verify failed (unspecified certificate verification error) (Faraday::SSLError)
/usr/lib64/ruby/2.5.0/net/protocol.rb:44:in `connect_nonblock'
/usr/lib64/ruby/2.5.0/net/protocol.rb:44:in `ssl_socket_connect'
/usr/lib64/ruby/2.5.0/net/http.rb:985:in `connect'
/usr/lib64/ruby/2.5.0/net/http.rb:920:in `do_start'
/usr/lib64/ruby/2.5.0/net/http.rb:909:in `start'
/usr/lib64/ruby/gems/2.5.0/gems/faraday-net_http-1.0.1/lib/faraday/adapter/net_http.rb:146:in `request_via_request_method'
/usr/lib64/ruby/gems/2.5.0/gems/faraday-net_http-1.0.1/lib/faraday/adapter/net_http.rb:131:in `request_with_wrapped_block'
/usr/lib64/ruby/gems/2.5.0/gems/faraday-net_http-1.0.1/lib/faraday/adapter/net_http.rb:122:in `perform_request'
/usr/lib64/ruby/gems/2.5.0/gems/faraday-net_http-1.0.1/lib/faraday/adapter/net_http.rb:66:in `block in call'
/usr/lib64/ruby/gems/2.5.0/gems/faraday-1.10.0/lib/faraday/adapter.rb:50:in `connection'
/usr/lib64/ruby/gems/2.5.0/gems/faraday-net_http-1.0.1/lib/faraday/adapter/net_http.rb:64:in `call'
/usr/lib64/ruby/gems/2.5.0/gems/faraday-1.10.0/lib/faraday/request/url_encoded.rb:25:in `call'
/usr/lib64/ruby/gems/2.5.0/gems/faraday-1.10.0/lib/faraday/rack_builder.rb:154:in `build_response'
/usr/lib64/ruby/gems/2.5.0/gems/faraday-1.10.0/lib/faraday/connection.rb:516:in `run_request'
/usr/lib64/ruby/gems/2.5.0/gems/faraday-1.10.0/lib/faraday/connection.rb:281:in `post'
/root/spacewalk/testsuite/features/support/http_client.rb:72:in `call'
/root/spacewalk/testsuite/features/support/api_test.rb:65:in `block (2 levels) in call'
/root/spacewalk/testsuite/features/support/api_test.rb:64:in `synchronize'
/root/spacewalk/testsuite/features/support/api_test.rb:64:in `block in call'
features/secondary/srv_rename_hostname.feature:64:in `I am on the Systems overview page of this "kvm_server"'
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were workarounded

- [x] **DONE**

## Links

Ports:
- [Manager-4.3](https://github.com/SUSE/spacewalk/pull/23319) (Even if not strictly necessary, as on SUMA 4.3 we use XML connections where we don't have SSL issues)

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
