### PR TITLE
Remove includesls macro definition and usage as not relevant

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/certs/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/init.sls
@@ -2,11 +2,7 @@ mgr_absent_ca_package:
   pkg.removed:
     - name: rhn-org-trusted-ssl-cert
 
-{% macro includesls(os_family) -%}
-{% include 'certs/{0}.sls'.format(os_family) -%}
-{%- endmacro %}
-{% set sls = includesls(grains['os_family']|lower) -%}
-{{ sls }}
+{% include 'certs/{0}.sls'.format(grains['os_family']|lower) %}
 
 mgr_proxy_ca_cert_symlink:
   file.symlink:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.vzhestkov.fix-certs-include
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.vzhestkov.fix-certs-include
@@ -1,0 +1,1 @@
+- Remove includesls macro usage as not relevant anymore


### PR DESCRIPTION
## What does this PR change?

There is no need to define and use distinct macro for just a simple task to include SLS.
So removing it.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: no proper tests for this part, highstate apply will fail for the client if the state is wrong

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
