### PR TITLE
Fix backport client type

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -165,7 +165,6 @@ def get_client_type(name)
   end
 end
 
-
 def find_and_wait_click(*args, **options, &optional_filter_block)
   element = find(*args, options, &optional_filter_block)
   element.extend(CapybaraNodeElementExtension)

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -165,6 +165,7 @@ def get_client_type(name)
   end
 end
 
+
 def find_and_wait_click(*args, **options, &optional_filter_block)
   element = find(*args, options, &optional_filter_block)
   element.extend(CapybaraNodeElementExtension)

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -157,6 +157,14 @@ module CapybaraNodeElementExtension
   end
 end
 
+def get_client_type(name)
+  if name.include? '_client'
+    'traditional'
+  else
+    'salt'
+  end
+end
+
 def find_and_wait_click(*args, **options, &optional_filter_block)
   element = find(*args, options, &optional_filter_block)
   element.extend(CapybaraNodeElementExtension)


### PR DESCRIPTION
## What does this PR change?

After the backport from manager43 to uyuni oif the BV stabilities changes, one function is missing.
Add it to uyuni

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered


- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
