### PR TITLE
Add option to catch timeout

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -113,8 +113,7 @@ def check_text_and_catch_request_timeout_popup?(text1, text2: nil, timeout: Capy
       return false
     end
   else
-    has_text?(text1, wait: timeout)
-    has_text?(text2, wait: timeout) if text2
+    return has_text?(text1, wait: timeout) || (!text2.nil? && has_text?(text2, wait: timeout))
   end
 end
 

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -96,19 +96,25 @@ rescue StandardError => e
 end
 
 def check_text_and_catch_request_timeout_popup?(text1, text2: nil, timeout: Capybara.default_max_wait_time)
-  start_time = Time.now
-  repeat_until_timeout(message: "'#{text1}' still not visible", timeout: DEFAULT_TIMEOUT) do
-    while Time.now - start_time <= timeout
-      return true if has_text?(text1, wait: 4)
-      return true if !text2.nil? && has_text?(text2, wait: 4)
-      next unless has_text?('Request has timed out', wait: 0)
+  if $catch_timeout_message
+    start_time = Time.now
+    repeat_until_timeout(message: "'#{text1}' still not visible", timeout: DEFAULT_TIMEOUT) do
+      while Time.now - start_time <= timeout
+        return true if has_text?(text1, wait: 4)
+        return true if !text2.nil? && has_text?(text2, wait: 4)
 
-      log 'Request timeout found, performing reload'
-      click_button('reload the page')
-      start_time = Time.now
-      raise TimeoutError, "Request timeout message still present after #{Capybara.default_max_wait_time} seconds." unless has_no_text?('Request has timed out')
+        if has_text?('Request has timed out', wait: 0)
+          log 'Request timeout found, performing reload'
+          click_button('reload the page')
+          start_time = Time.now
+          raise "Request timeout message still present after #{Capybara.default_max_wait_time} seconds." unless has_no_text?('Request has timed out')
+        end
+      end
+      return false
     end
-    return false
+  else
+    has_text?(text1, wait: timeout)
+    has_text?(text2, wait: timeout) if text2
   end
 end
 

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -60,6 +60,7 @@ $is_container_provider = ENV['PROVIDER'].include? 'podman'
 $is_container_server = %w[k3s podman].include? ENV.fetch('CONTAINER_RUNTIME', '')
 $is_using_build_image = ENV.fetch('IS_USING_BUILD_IMAGE', false)
 $is_using_scc_repositories = (ENV.fetch('IS_USING_SCC_REPOSITORIES', 'False') != 'False')
+$catch_timeout_message = (ENV.fetch('CATCH_TIMEOUT_MESSAGE', 'False') == 'True')
 
 # QAM and Build Validation pipelines will provide a json file including all custom (MI) repositories
 custom_repos_path = "#{File.dirname(__FILE__)}/../upload_files/custom_repositories.json"


### PR DESCRIPTION
## What does this PR change?
Backport catch_timeout_message option to uyuni

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
