### PR TITLE
Change org for orphan vendor packages via taskomatic

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Task_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Task_queries.xml
@@ -813,4 +813,15 @@ select sa.action_id, sa.server_id
   </query>
 </write-mode>
 
+<write-mode name="taskomatic_change_org_for_orphan_vendor_packages">
+  <query params="org_id">
+    UPDATE rhnPackage
+       SET org_id = :org_id
+     WHERE id IN (SELECT p.id
+                    FROM rhnPackage p
+               LEFT JOIN rhnChannelPackage cp ON p.id = cp.package_id
+                   WHERE p.org_id IS NULL and cp.channel_id IS NULL)
+  </query>
+</write-mode>
+
 </datasource_modes>

--- a/java/code/src/com/redhat/rhn/taskomatic/task/TaskConstants.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/TaskConstants.java
@@ -215,5 +215,8 @@ public class TaskConstants {
     public static final String TASK_QUERY_CHANNEL_PACKAGE_EXTRATAGS =
             "repomdgenerator_channel_package_extratags";
 
+    public static final String TASK_QUERY_PKGCLEANUP_ORPHAN_VENDOR_PKG_CHANGE_ORG =
+            "taskomatic_change_org_for_orphan_vendor_packages";
+
     private TaskConstants() { }
 }

--- a/java/spacewalk-java.changes.mc.change-org-for-orphen-vendor-packages-via-taskomatic
+++ b/java/spacewalk-java.changes.mc.change-org-for-orphen-vendor-packages-via-taskomatic
@@ -1,0 +1,1 @@
+- change org for orphan vendor packages that an admin can delete them (bsc#1216781)

--- a/python/spacewalk/satellite_tools/reposync.py
+++ b/python/spacewalk/satellite_tools/reposync.py
@@ -1204,7 +1204,6 @@ class RepoSync(object):
                 log(0, "    {} packages linked".format(count))
             self.regen = True
             self.regenerate_bootstrap_repo = True
-        self._normalize_orphan_vendor_packages()
         return failed_packages
 
     def twisted_batch_indexes(self, total_size, batch_size):
@@ -1457,29 +1456,6 @@ class RepoSync(object):
                     pack_status = ' . '
 
             log(0, "    " + pack_status + pack_full_name + pack_size + pack_hash_info)
-
-    def _normalize_orphan_vendor_packages(self):
-        # Sometimes reposync disassociates vendor packages (org_id = 0) from
-        # channels.
-        # These orphans are then hard to work with in spacewalk (nobody has
-        # permissions to view/delete them). We workaround this issue by
-        # assigning such packages to the default organization, so that they can
-        # be deleted using the existing orphan-deleting procedure.
-        h = rhnSQL.prepare("""
-            UPDATE rhnPackage
-            SET org_id = 1
-            WHERE id IN (SELECT p.id
-                         FROM rhnPackage p LEFT JOIN rhnChannelPackage cp
-                         ON p.id = cp.package_id
-                         WHERE p.org_id IS NULL and cp.channel_id IS NULL)
-        """)
-        affected_row_count = h.execute()
-        if (affected_row_count > 0):
-            log(
-                0,
-                "Transferred {} orphaned vendor packages to the default organization"
-                .format(affected_row_count)
-            )
 
     def match_package_checksum(self, md_pack, db_pack):
         """compare package checksum"""

--- a/python/spacewalk/spacewalk-backend.changes.mc.change-org-for-orphen-vendor-packages-via-taskomatic
+++ b/python/spacewalk/spacewalk-backend.changes.mc.change-org-for-orphen-vendor-packages-via-taskomatic
@@ -1,0 +1,1 @@
+- remove normalize_orphan_vendor_packages and move it to taskomatic (bsc#1216781)

--- a/python/test/unit/spacewalk/satellite_tools/test_reposync.py
+++ b/python/test/unit/spacewalk/satellite_tools/test_reposync.py
@@ -242,7 +242,6 @@ class RepoSyncTest(unittest.TestCase):
     @patch("spacewalk.satellite_tools.reposync.log2", Mock())
     @patch("spacewalk.satellite_tools.reposync.os", os)
     @patch("spacewalk.satellite_tools.reposync.log", Mock())
-    @patch("spacewalk.satellite_tools.reposync.RepoSync._normalize_orphan_vendor_packages", Mock())
     @patch("spacewalk.satellite_tools.reposync.ThreadedDownloader")
     @patch("spacewalk.satellite_tools.reposync.multiprocessing.Pool")
     def test_import_packages_excludes_failed_pkgs(self, pool, downloader):


### PR DESCRIPTION
## What does this PR change?

When vendor packages were removed from a repo, they become orphan but cannot be removed by an admin as long as they are not belong to an organization.
To solve this, a org change statement was added to reposync.
This had some side effects when a package moved from one repo to another as it become first orphan, change the org and when it appears in the new repo it does not match the org and is downloaded and created again.

This PR move the functionality to taskomatic and it should be executed only once per day.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/22944 
Ports(s): https://github.com/SUSE/spacewalk/pull/23334

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
