### PR TITLE
Set RemoveIPC=no for logind to stop removing IPC mechanisms by systemd

### DIFF
--- a/containers/init-image/Dockerfile
+++ b/containers/init-image/Dockerfile
@@ -27,6 +27,13 @@ CMD ["/usr/lib/systemd/systemd"]
 RUN mkdir -p /etc/systemd/system.conf.d/ && \
     printf "[Manager]\nLogColor=no" > \
         /etc/systemd/system.conf.d/01-nocolor.conf
+
+# disabled as recommended by postgresql until we need to run systemd in container
+# https://wiki.postgresql.org/wiki/Systemd
+RUN mkdir -p /etc/systemd/logind.conf.d/ && \
+    printf "[Login]\nRemoveIPC=no" > \
+        /etc/systemd/logind.conf.d/disable-removeipc.conf
+
 RUN systemctl disable getty@tty1.service
 
 ARG PRODUCT=Uyuni

--- a/containers/init-image/init-image.changes.oholecek.disable-removeipc
+++ b/containers/init-image/init-image.changes.oholecek.disable-removeipc
@@ -1,0 +1,1 @@
+- Set RemoveIPC=no for logind to stop removing IPC mechanisms by systemd


### PR DESCRIPTION
## What does this PR change?

SLE adds a specific systemd branding which sets `RemoveIPC=no` for logind. We don't have this in the container and result is postgres unable to communicate with clients manifesting by error:

```
FATAL:  could not open shared memory segment "/PostgreSQL.241200488": No such file or directory
```

This PR adds directive `RemoveIPC=no` and fixes above mentioned issue.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Issue(s): #
Ports(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
