### PR TITLE
Use the same UID and GID for postgres as upstream does

### DIFF
--- a/containers/init-image/Dockerfile
+++ b/containers/init-image/Dockerfile
@@ -6,19 +6,20 @@ ARG INIT_BASE=opensuse/leap:15.5
 FROM $INIT_BASE
 
 # Create stable static UID and GID for salt, tomcat, apache (wwwrun), postgres, ...
+# postgresql UID/GID 999 to be compatible with upstream
 RUN groupadd -r --gid 10550 susemanager && \
   groupadd -r --gid 10551 tomcat && \
   groupadd -r --gid 10552 www && \
   groupadd -r --gid 10553 wwwrun && \
   groupadd -r --gid 10554 salt && \
   groupadd -r --gid 10555 tftp && \
-  groupadd -r --gid 10556 postgres
+  groupadd -r --gid 999 postgres
 
 RUN useradd -r -s /usr/sbin/nologin -G susemanager,www -g tomcat -d /usr/share/tomcat --uid 10551 tomcat && \
   useradd -r -s /usr/sbin/nologin -G susemanager,www -g wwwrun -d /var/lib/wwwrun --uid 10552 wwwrun && \
   useradd -r -s /usr/sbin/nologin -G susemanager -g salt -d /var/lib/salt --uid 10554 salt && \
   useradd -r -s /usr/sbin/nologin -g tftp -d /srv/tftpboot --uid 10555 tftp && \
-  useradd -r -s /usr/bin/bash -g postgres -d /var/lib/pgsql --uid 10556 postgres
+  useradd -r -s /usr/bin/bash -g postgres -d /var/lib/pgsql --uid 999 postgres
 
 # Fill the image with content and clean the cache(s)
 RUN set -euo pipefail; zypper -n in --no-recommends systemd gzip; zypper -n clean; rm -rf /var/log/*

--- a/containers/init-image/init-image.changes.oholecek.upstream-pgsql-user
+++ b/containers/init-image/init-image.changes.oholecek.upstream-pgsql-user
@@ -1,0 +1,1 @@
+- Use 999 for postgresql UID/GID, same as upstream and rancher


### PR DESCRIPTION
## What does this PR change?

Inspecting postgresql upstream container image I noticed they too create hardcoded UID and GIDs for postgres user, however they chose to use 999 [0]. This PR sync our values to theirs.

0: https://github.com/docker-library/postgres/blob/master/16/bookworm/Dockerfile#L13

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): #
Ports(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
