### PR TITLE
QE: refactor check_text_and_catch_request_timeout_popup?

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -96,24 +96,23 @@ rescue StandardError => e
 end
 
 def check_text_and_catch_request_timeout_popup?(text1, text2: nil, timeout: Capybara.default_max_wait_time)
-  if $catch_timeout_message
-    start_time = Time.now
-    repeat_until_timeout(message: "'#{text1}' still not visible", timeout: DEFAULT_TIMEOUT) do
-      while Time.now - start_time <= timeout
-        return true if has_text?(text1, wait: 4)
-        return true if !text2.nil? && has_text?(text2, wait: 4)
+  return has_text?(text1, wait: timeout) || (!text2.nil? && has_text?(text2, wait: timeout)) unless $catch_timeout_message
 
-        if has_text?('Request has timed out', wait: 0)
-          log 'Request timeout found, performing reload'
-          click_button('reload the page')
-          start_time = Time.now
-          raise "Request timeout message still present after #{Capybara.default_max_wait_time} seconds." unless has_no_text?('Request has timed out')
-        end
-      end
-      return false
+  start_time = Time.now
+  repeat_until_timeout(message: "'#{text1}' still not visible", timeout: DEFAULT_TIMEOUT) do
+    while Time.now - start_time <= timeout
+      return true if has_text?(text1, wait: 4)
+      return true if !text2.nil? && has_text?(text2, wait: 4)
+
+      next unless has_text?('Request has timed out', wait: 0)
+
+      log 'Request timeout found, performing reload'
+      click_button('reload the page')
+      start_time = Time.now
+      raise "Request timeout message still present after #{Capybara.default_max_wait_time} seconds." unless has_no_text?('Request has timed out')
+
     end
-  else
-    return has_text?(text1, wait: timeout) || (!text2.nil? && has_text?(text2, wait: timeout))
+    return false
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

Refactor the check_text_and_catch_request_timeout_popup? function to comply with Rubocop

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- A function used by the Cucumber testsuite has been edited

- [x] **DONE**

## Links

Backport - Manager 4.3: https://github.com/SUSE/spacewalk/pull/23340

- [x] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
