### PR TITLE
fix setting scc password during setup

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/credentials/PasswordBasedCredentials.java
+++ b/java/code/src/com/redhat/rhn/domain/credentials/PasswordBasedCredentials.java
@@ -33,7 +33,7 @@ public abstract class PasswordBasedCredentials extends BaseCredentials {
      * Return the decoded password.
      * @return the password
      */
-    @Column(name = "password")
+    @Transient
     public String getPassword() {
         if (this.encodedPassword != null) {
             return new String(Base64.decodeBase64(this.encodedPassword.getBytes()));
@@ -41,7 +41,7 @@ public abstract class PasswordBasedCredentials extends BaseCredentials {
         return null;
     }
 
-    @Transient
+    @Column(name = "password")
     protected String getEncodedPassword() {
         return this.encodedPassword;
     }

--- a/java/code/src/com/redhat/rhn/domain/credentials/test/CredentialsTest.java
+++ b/java/code/src/com/redhat/rhn/domain/credentials/test/CredentialsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.domain.credentials.test;
+
+import static com.redhat.rhn.domain.role.RoleFactory.ORG_ADMIN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.domain.credentials.CredentialsFactory;
+import com.redhat.rhn.domain.credentials.SCCCredentials;
+import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
+import com.redhat.rhn.testing.UserTestUtils;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+public class CredentialsTest extends JMockBaseTestCaseWithUser {
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        UserTestUtils.addUserRole(user, ORG_ADMIN);
+    }
+
+    @Test
+    public void testSCCCredentials() throws Exception {
+        SCCCredentials sccCreds = CredentialsFactory.createSCCCredentials("admin", "secret");
+        CredentialsFactory.storeCredentials(sccCreds);
+        HibernateFactory.getSession().flush();
+
+        Optional<SCCCredentials> loadedSccCreds = CredentialsFactory.lookupSCCCredentialsById(sccCreds.getId());
+        SCCCredentials creds = loadedSccCreds.orElseThrow();
+
+        assertEquals("admin", creds.getUsername());
+        assertEquals("secret", creds.getPassword());
+
+        Optional r = HibernateFactory.getSession()
+                .createSQLQuery("select password from suseCredentials where username = 'admin';")
+                .uniqueResultOptional();
+        // this prove that we really store encoded content in DB
+        assertEquals("c2VjcmV0", r.orElseThrow().toString());
+    }
+}

--- a/spacewalk/setup/bin/spacewalk-setup
+++ b/spacewalk/setup/bin/spacewalk-setup
@@ -854,15 +854,14 @@ sub populate_initial_configs {
           Spacewalk::Setup::read_config(Spacewalk::Setup::DEFAULT_SUSEMANAGER_CONF, \%mgrDefaults);
       }
       $mgrDefaults{'scc_url'} = Spacewalk::Setup::DEFAULT_SCC_URL if (not $mgrDefaults{'scc_url'});
+      my $sccpasswdenc = encode_base64($answers->{'scc-pass'});
+      chomp($sccpasswdenc); # encode_base64 add \n at the end
 
       # SCC - write to DB
       my $st = sprintf("insert into suseCredentials (id, user_id, type, username, password, url)
                         values (sequence_nextval('suse_credentials_id_seq'), NULL, 'scc',
                                  '%s', '%s', '%s');",
-                       $answers->{'scc-user'},
-                       encode_base64($answers->{'scc-pass'}),
-                       $mgrDefaults{'scc_url'}
-                      );
+                       $answers->{'scc-user'}, $sccpasswdenc, $mgrDefaults{'scc_url'});
       Spacewalk::Setup::system_or_exit(["/bin/bash", "-c",
                                         "echo \"$st\" | spacewalk-sql --select-mode - 2>&1"],
                                        1, "*** Setup Organization Credentials failed.");

--- a/spacewalk/setup/spacewalk-setup.changes.mcalmer.Manager-4.3-fix-setting-scc-passwd
+++ b/spacewalk/setup/spacewalk-setup.changes.mcalmer.Manager-4.3-fix-setting-scc-passwd
@@ -1,0 +1,1 @@
+- fix setting scc password during setup


### PR DESCRIPTION
## What does this PR change?

Seems that encode_base64() append a final newline at the end of the output which break setting the scc password in DB during setup.

Additionally we store the encoded password in the password column. This mapping was missing after the refactoring of the credentials classes.
The old code stored the password not encoded and when loading an encoded password it encoded it again and authentication failed.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- already covered
- added unit test

- [x] **DONE**

## Links

Ports(s): https://github.com/SUSE/spacewalk/pull/23342

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
