### PR TITLE
Containers module needed for SLE 15 SP4 build host

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -146,6 +146,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I open the sub-list of the product "Desktop Applications Module 15 SP4 x86_64"
     And I select "Development Tools Module 15 SP4 x86_64" as a product
     Then I should see the "Development Tools Module 15 SP4 x86_64" selected
+    When I select "Containers Module 15 SP4 x86_64" as a product
+    Then I should see the "Containers Module 15 SP4 x86_64" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
     And I wait until I see "SUSE Linux Enterprise Server 15 SP4 x86_64" product has been added
@@ -673,6 +675,10 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I enter "SUSE Manager Proxy 4.3" as the filtered product description
     And I select "SUSE Manager Proxy 4.3 x86_64" as a product
     Then I should see the "SUSE Manager Proxy 4.3 x86_64" selected
+    When I open the sub-list of the product "SUSE Manager Proxy 4.3 x86_64"
+    And I open the sub-list of the product "Basesystem Module 15 SP4 x86_64"
+    And I select "Containers Module 15 SP4 x86_64" as a product
+    Then I should see the "Containers Module 15 SP4 x86_64" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
     And I wait until I see "SUSE Manager Proxy 4.3 x86_64" product has been added
@@ -699,6 +705,10 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I enter "SUSE Manager Retail Branch Server 4.3" as the filtered product description
     And I select "SUSE Manager Retail Branch Server 4.3 x86_64" as a product
     Then I should see the "SUSE Manager Retail Branch Server 4.3 x86_64" selected
+    When I open the sub-list of the product "SUSE Manager Retail Branch Server 4.3 x86_64"
+    And I open the sub-list of the product "Basesystem Module 15 SP4 x86_64"
+    And I select "Containers Module 15 SP4 x86_64" as a product
+    Then I should see the "Containers Module 15 SP4 x86_64" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
     And I wait until I see "SUSE Manager Retail Branch Server 4.3 x86_64" product has been added


### PR DESCRIPTION
## What does this PR change?

Apparently, we added the containers channels to the list of channels to wait for (in `support/constants.rb`), but in the case of BV forgot to trigger the corresponding synchronization.

This resulted in a wait until timeout for the containers module.



## Links

Ports:
 * 4.3: SUSE/spacewalk#23351


## Changelogs

- [x] No changelog needed
