### PR TITLE
Don't test compressed files checksums in debian files

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/DebReleaseWriterTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/DebReleaseWriterTest.java
@@ -90,14 +90,12 @@ public class DebReleaseWriterTest extends BaseTestCaseWithUser {
                 "Description: TestChannel description\n" +
                 "MD5Sum:\n" +
                 " d41d8cd98f00b204e9800998ecf8427e 0 Packages\n" +
-                " 3970e82605c7d109bb348fc94e9eecc0 20 Packages.gz\n" +
                 "SHA1:\n" +
                 " da39a3ee5e6b4b0d3255bfef95601890afd80709 0 Packages\n" +
-                " e03849ea786b9f7b28a35c17949e85a93eb1cff1 20 Packages.gz\n" +
                 "SHA256:\n" +
-                " e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 0 Packages\n" +
-                " f5d031af01f137ae07fa71720fab94d16cc8a2a59868766002918b7c240f3967 20 Packages.gz\n";
-        assertEquals(rel, releaseContent);
+                " e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 0 Packages\n";
+        // Remove the compressed file checksums as those may vary
+        assertEquals(rel, releaseContent.replaceAll(" [^ ]+ [^ ]+ Packages.gz\n", ""));
     }
 
     @Override


### PR DESCRIPTION
## What does this PR change?

Fix java 17 related unit tests failures

## Test coverage
- No tests: already covered

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
