### PR TITLE
Fix apidoc link

### DIFF
--- a/java/buildconf/apidoc/jsp/handler.txt
+++ b/java/buildconf/apidoc/jsp/handler.txt
@@ -38,9 +38,9 @@ $handler.name
 #foreach( $call in $handler.calls )
 
 #if($call.deprecated)
-<h3 class="deprecated"><a name="$call.name" href="#top">Method: $call.name</a></h3>
+<h3 class="deprecated"><a name="$call.name" href="#$call.name">Method: $call.name</a></h3>
 #else
-<h3> <a name="$call.name" href="#top">Method: $call.name</a></h3>
+<h3> <a name="$call.name" href="#$call.name">Method: $call.name</a></h3>
 #end
 
 <div>

--- a/java/spacewalk-java.changes.mseidl.apidoc-link-fix
+++ b/java/spacewalk-java.changes.mseidl.apidoc-link-fix
@@ -1,0 +1,1 @@
+- fix apidoc link from #top to $call.name (bsc#1213507)


### PR DESCRIPTION
## What does this PR change?
Fixes apidoc link to point to self instead of top.

https://bugzilla.suse.com/show_bug.cgi?id=1213507
#22448 

merged in 4.3
**add description**

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed:

- [ ] **DONE**

## Test coverage
- No tests:

- [ ] **DONE**

## Links

Issue(s): #
Ports(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
