### PR TITLE
Add type adapters for virtual guests creation action details

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationCreateGuestAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationCreateGuestAction.java
@@ -14,9 +14,14 @@
  */
 package com.redhat.rhn.domain.action.virtualization;
 
+import com.redhat.rhn.frontend.context.Context;
+
 import com.suse.manager.virtualization.GuestCreateDetails;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * CreateAction - Class representing TYPE_VIRTUALIZATION_CREATE
@@ -40,7 +45,14 @@ public class VirtualizationCreateGuestAction extends BaseVirtualizationGuestActi
      * This function should only be used by hibernate.
      */
     public String getDetailsAsString() {
-        return details != null ? details.toJson() : null;
+        if (details != null) {
+            if (details.getEarliest().isEmpty()) {
+                ZoneId zoneId = Context.getCurrentContext().getTimezone().toZoneId();
+                details.setEarliest(Optional.of(LocalDateTime.ofInstant(getEarliestAction().toInstant(), zoneId)));
+            }
+            return details.toJson();
+        }
+        return null;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/test/VirtualizationActionsTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/test/VirtualizationActionsTest.java
@@ -36,6 +36,7 @@ import com.redhat.rhn.domain.action.virtualization.VirtualizationSetVcpusGuestAc
 import com.redhat.rhn.domain.action.virtualization.VirtualizationShutdownGuestAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationStartGuestAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationSuspendGuestAction;
+import com.redhat.rhn.frontend.context.Context;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 
 import com.suse.manager.virtualization.GuestCreateDetails;
@@ -50,6 +51,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 public class VirtualizationActionsTest extends BaseTestCaseWithUser {
@@ -159,6 +161,8 @@ public class VirtualizationActionsTest extends BaseTestCaseWithUser {
      */
     @Test
     public void testCreateLookup() throws Exception {
+        Context.getCurrentContext().setTimezone(TimeZone.getDefault());
+
         VirtualizationCreateGuestAction a1 = (VirtualizationCreateGuestAction)ActionFactoryTest
                 .createAction(user, ActionFactory.TYPE_VIRTUALIZATION_CREATE);
         a1.setDetails(new GuestCreateDetails());

--- a/java/code/src/com/suse/manager/virtualization/GuestCreateDetails.java
+++ b/java/code/src/com/suse/manager/virtualization/GuestCreateDetails.java
@@ -14,6 +14,8 @@
  */
 package com.suse.manager.virtualization;
 
+import com.suse.manager.reactor.utils.LocalDateTimeISOAdapter;
+import com.suse.manager.reactor.utils.OptionalTypeAdapterFactory;
 import com.suse.manager.webui.controllers.virtualization.gson.VirtualGuestsUpdateActionJson;
 
 import com.google.gson.Gson;
@@ -21,12 +23,18 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
 
+import java.time.LocalDateTime;
+
 /**
  * Represents the data stored for the VM create or update actions.
  */
 public class GuestCreateDetails extends VirtualGuestsUpdateActionJson {
 
-    private static final Gson GSON = new GsonBuilder().create();
+    private static final Gson GSON = new GsonBuilder()
+            .registerTypeAdapter(LocalDateTime.class, new LocalDateTimeISOAdapter())
+            .registerTypeAdapterFactory(new OptionalTypeAdapterFactory())
+            .serializeNulls()
+            .create();
 
     @SerializedName("remove_disks")
     private boolean removeDisks;


### PR DESCRIPTION
## What does this PR change?

Without the type adapters Gson tries to access Optional fields using introspection and that is no longer possible in Java 17.

The side effect shown here is that the LocalDateTime, even wrapped in Optional, cannot be null: the type adapter for LocalDateTime considers null as invalid.

This is then worked around for the virtual guests creation action details: those values as used when the type is transfered between the UI and the backend, but not when persisted in the DB.

## Test coverage
- No tests: already covered

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
