### PR TITLE
Fix schema upgrade

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes.nadvornik.schema-upgrade
+++ b/schema/spacewalk/susemanager-schema.changes.nadvornik.schema-upgrade
@@ -1,0 +1,1 @@
+- Fix schema upgrade

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.1-to-susemanager-schema-4.4.2/003-system_checkin_threshold.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.1-to-susemanager-schema-4.4.2/003-system_checkin_threshold.sql
@@ -4,7 +4,7 @@ WHERE NOT EXISTS (SELECT 1 FROM rhnConfiguration WHERE key = 'system_checkin_thr
 
 DO $$
   BEGIN
-    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'rhnTaskQueue' AND column_name = 'id') THEN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'rhntaskqueue' AND column_name = 'id') THEN
         INSERT INTO rhnTaskQueue (id, org_id, task_name, task_data)
         SELECT NEXTVAL('rhn_task_queue_id_seq'), id, 'upgrade_satellite_system_threshold_conf', 0
         FROM web_customer


### PR DESCRIPTION
## What does this PR change?

The schema upgrade from 4.3 fails on this, because information_schema.columns is case sensitive.
```
susemanager=# SELECT 1 FROM information_schema.columns WHERE table_name = 'rhnTaskQueue' AND column_name = 'id';
 ?column? 
----------
(0 rows)

susemanager=# SELECT 1 FROM information_schema.columns WHERE table_name = 'rhntaskqueue' AND column_name = 'id';
 ?column? 
----------
        1
(1 row)

```
## GUI diff

No difference.

## Documentation
- No documentation needed: fix

## Links


## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
