### PR TITLE
change schedule of system-profile-refresh

### DIFF
--- a/schema/spacewalk/common/data/rhnTaskoSchedule.sql
+++ b/schema/spacewalk/common/data/rhnTaskoSchedule.sql
@@ -186,11 +186,11 @@ VALUES (sequence_nextval('rhn_tasko_schedule_id_seq'), 'update-reporting-hub-def
         (SELECT id FROM rhnTaskoBunch WHERE name='mgr-update-reporting-hub-bunch'),
         current_timestamp, '0 30 1 ? * *');
 
--- Once a month at the 15th at 5am
+-- Once a month at the 2nd Saturday at 5am
 
 INSERT INTO rhnTaskoSchedule (id, job_label, bunch_id, active_from, cron_expr)
 VALUES (sequence_nextval('rhn_tasko_schedule_id_seq'), 'system-profile-refresh-default',
         (SELECT id FROM rhnTaskoBunch WHERE name='system-profile-refresh-bunch'),
-        current_timestamp, '0 0 5 15 * ?');
+        current_timestamp, '0 0 5 ? * SAT#2');
 
 commit;

--- a/schema/spacewalk/susemanager-schema.changes.mc.Manager-4.3-change-hwrefresh-schedule
+++ b/schema/spacewalk/susemanager-schema.changes.mc.Manager-4.3-change-hwrefresh-schedule
@@ -1,0 +1,2 @@
+- change schedule of system-profile-refresh to run on the 2nd saturday
+  of a month to not collide with normal working times (bsc#1215769)

--- a/schema/spacewalk/upgrade/susemanager-schema-5.0.3-to-susemanager-schema-5.0.4/200-change-sys-profile-refresh-schedule.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.0.3-to-susemanager-schema-5.0.4/200-change-sys-profile-refresh-schedule.sql
@@ -1,0 +1,7 @@
+-- Once a month at the 2nd Saturday at 5am
+UPDATE rhnTaskoSchedule
+  SET cron_expr = '0 0 5 ? * SAT#2'
+WHERE job_label = 'system-profile-refresh-default'
+  AND bunch_id = (SELECT id FROM rhnTaskoBunch WHERE name='system-profile-refresh-bunch')
+  AND cron_expr = '0 0 5 15 * ?';
+


### PR DESCRIPTION
## What does this PR change?

change schedule of system-profile-refresh to run on the 2nd saturday
of a month to not collide with normal working times

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No change needed

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Ports(s): https://github.com/SUSE/spacewalk/pull/23378

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
