### PR TITLE
GH Validation: Run the workflow for all PRs, but only run the scripts depending changed files

### DIFF
--- a/.github/workflows/acceptance_tests_common.yml
+++ b/.github/workflows/acceptance_tests_common.yml
@@ -13,8 +13,25 @@ env:
   UYUNI_VERSION: master
   CUCUMBER_PUBLISH_TOKEN: ${{ secrets.CUCUMBER_PUBLISH_TOKEN }}
 jobs:
+  paths-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      require_acceptance_tests: ${{ steps.filter.outputs.require_acceptance_tests }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            require_acceptance_tests:
+              - 'java/**'
+              - 'web/html/src/**'
+              - 'testsuite/**'
+              - '!.github/workflows/**'
   test-uyuni:
     runs-on: ubuntu-22.04
+    needs: paths-filter
+    if: needs.paths-filter.outputs.require_acceptance_tests == 'true'
     steps:
       - name: fix podman
         run: sudo apt install podman=3.4.4+ds1-1ubuntu1 --allow-downgrades

--- a/.github/workflows/acceptance_tests_secondary.yml
+++ b/.github/workflows/acceptance_tests_secondary.yml
@@ -1,13 +1,10 @@
 name: acceptance-tests-secondary
 on:
   pull_request:
-    paths:
-      - 'java/**'
-      - 'web/html/src/**'
-      - 'testsuite/**'
-      - '.github/workflows/acceptance_tests_secondary.yml'
-      - '.github/workflows/acceptance_tests_common.yml'
-      - '!java/*.changes*'
+    types:
+      - opened
+      - reopened
+      - synchronize
   schedule:
     - cron: '0 */12 * * *'
 jobs:

--- a/.github/workflows/acceptance_tests_secondary_parallel.yml
+++ b/.github/workflows/acceptance_tests_secondary_parallel.yml
@@ -1,13 +1,10 @@
 name: acceptance-tests-secondary-parallel
 on:
   pull_request:
-    paths:
-      - 'java/**'
-      - 'web/html/src/**'
-      - 'testsuite/**'
-      - '.github/workflows/acceptance_tests_secondary_parallel.yml'
-      - '.github/workflows/acceptance_tests_common.yml'
-      - '!java/*.changes*'
+    types:
+      - opened
+      - reopened
+      - synchronize
   schedule:
     - cron: '0 */12 * * *'
 jobs:


### PR DESCRIPTION
## What does this PR change?

Run the workflow for all PRs, but only run the scripts depending changed files

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

No ports

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
