### PR TITLE
Uyuni proxy is based on leap 15.5

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -732,8 +732,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
 
 @uyuni
 @proxy
-  Scenario: Add Uyuni Leap 15.4 Proxy, including Uyuni Client Tools
-    When I use spacewalk-common-channel to add channel "opensuse_leap15_4 opensuse_leap15_4-non-oss opensuse_leap15_4-non-oss-updates opensuse_leap15_4-updates opensuse_leap15_4-backports-updates opensuse_leap15_4-sle-updates uyuni-proxy-stable-leap-154 opensuse_leap15_4-uyuni-client-devel" with arch "x86_64"
+  Scenario: Add Uyuni Leap 15.5 Proxy, including Uyuni Client Tools
+    When I use spacewalk-common-channel to add channel "opensuse_leap15_5 opensuse_leap15_5-non-oss opensuse_leap15_5-non-oss-updates opensuse_leap15_5-updates opensuse_leap15_5-backports-updates opensuse_leap15_5-sle-updates uyuni-proxy-stable-leap-155 opensuse_leap15_5-uyuni-client-devel" with arch "x86_64"
     And I wait until all synchronized channels for "uyuni-proxy" have finished
 
 @susemanager

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -958,14 +958,14 @@ CHANNEL_TO_SYNCH_BY_OS_PRODUCT_VERSION = {
     ],
   'uyuni-proxy' =>
     %w[
-      opensuse_leap15_4
-      opensuse_leap15_4-non-oss
-      opensuse_leap15_4-non-oss-updates
-      opensuse_leap15_4-updates
-      opensuse_leap15_4-backports-updates
-      opensuse_leap15_4-sle-updates
+      opensuse_leap15_5
+      opensuse_leap15_5-non-oss
+      opensuse_leap15_5-non-oss-updates
+      opensuse_leap15_5-updates
+      opensuse_leap15_5-backports-updates
+      opensuse_leap15_5-sle-updates
       uyuni-proxy-devel-leap-x86_64
-      opensuse_leap15_4-uyuni-client-devel
+      opensuse_leap15_5-uyuni-client-devel
     ],
   'uyuni-retail-branch-server' =>
     %w[


### PR DESCRIPTION
## What does this PR change?

We probably forgot to update this when we switched from 15.4 to 15.5.


## Links

Ports:
 * 4.3: SUSE/spacewalk#23391


## Changelogs

- [x] No changelog needed
