### PR TITLE
Add missing changelogs entries and bugzilla references from SUSE Manager 4.3

### DIFF
--- a/java/spacewalk-java.changes.juliogonzalez.4.3-sync
+++ b/java/spacewalk-java.changes.juliogonzalez.4.3-sync
@@ -1,0 +1,3 @@
+- Fix issue of non-installed package listed as errata package
+  update candidates (bsc#1212904)
+- Fix the use of page size preference in systems and packages lists (bsc#1217209)

--- a/schema/spacewalk/susemanager-schema.changes.juliogonzalez.4.3-sync
+++ b/schema/spacewalk/susemanager-schema.changes.juliogonzalez.4.3-sync
@@ -1,0 +1,1 @@
+- Improve performance of System (bsc#1211254)

--- a/search-server/spacewalk-search/spacewalk-search.changes.juliogonzalez.4.3-sync
+++ b/search-server/spacewalk-search/spacewalk-search.changes.juliogonzalez.4.3-sync
@@ -1,0 +1,1 @@
+- update dependencies after package rename

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -30,7 +30,7 @@ Mon Sep 18 14:41:33 CEST 2023 - rosuna@suse.com
   * Mask uyuni roster module password on logs
   * Don't install product packages on openSUSE clients
   * keep original traditional stack tools for RHEL7 RHUI connection
-  * Retry loading of pillars from DB on connection error
+  * Retry loading of pillars from DB on connection error (bsc#1214186)
   * Use recurse stratedy to merge formula pillar with existing pillars
   * Prevent product installation from being executed before executing product migration (bsc#1210475)
   * Include automatic migration from Salt 3000 to Salt Bundle in highstate
@@ -86,7 +86,7 @@ Mon Jan 23 08:30:18 CET 2023 - jgonzalez@suse.com
   * filter out libvirt engine events (bsc#1206146)
   * Improve _mgractionchains.conf logs
   * install SUSE Liberty v2 GPG key
-  * Detect bootstrap repository path for SLE Micro
+  * Detect bootstrap repository path for SLE Micro (bsc#1206294)
   * Fix reboot info beacon installation
   * Add state to properly configure the reboot action for transactional systems
   * enforce installation of the PTF GPG key package
@@ -132,7 +132,7 @@ Wed Sep 28 11:14:52 CEST 2022 - jgonzalez@suse.com
   * fix syntax error - remove trailing colon (bsc#1203049)
   * Add mgrnet salt module with mgrnet.dns_fqnd function implementation
     allowing to get all possible FQDNs from DNS (bsc#1199726)
-  * Copy grains file with util.mgr_switch_to_venv_minion state apply
+  * Copy grains file with util.mgr_switch_to_venv_minion state apply (bsc#1203056)
   * Remove the message 'rpm: command not found' on using Salt SSH
     with Debian based systems which has no Salt Bundle
 

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -91,7 +91,8 @@ Mon Jan 23 08:31:18 CET 2023 - jgonzalez@suse.com
   * fix bootstrap repo definition for SUSE Liberty Linux 9 and RHEL9
     (bsc#1207136)
   * fix tools channel detection on Uyuni
-  * add bootstrap repository definitions for SLE-Micro 5.1, 5.2 and 5.3
+  * add bootstrap repository definitions for SLE-Micro 5.1, 5.2 and
+    5.3 (bsc#1209557)
 
 -------------------------------------------------------------------
 Wed Dec 14 14:15:50 CET 2022 - jgonzalez@suse.com

--- a/susemanager/susemanager.changes.juliogonzalez.4.3-sync
+++ b/susemanager/susemanager.changes.juliogonzalez.4.3-sync
@@ -1,0 +1,2 @@
+- Make python3-extras as dependency of python3-luibxml2 (optional, as SLES 15 does
+  not have it and it is only required on SP4 or greater) (bsc#1204437)

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -66,11 +66,11 @@ Wed Apr 19 12:48:03 CEST 2023 - marina.latini@suse.com
 
 - version 4.4.10-1
   * fix an issue where the datetimepicker shows wrong date (bsc#1209231)
-  * Fix datetime picker appearing behind modal edge
+  * Fix datetime picker appearing behind modal edge (bsc#1209703)
   * Refactor Software / Manage / Packages to use SQL paging (bsc#1206725)
   * Fix UI inconsistencies in susemanager-light and susemanager-dark
     theme
-  * Deprecate jQuery datepicker, integrate React datepicker
+  * Deprecate jQuery datepicker, integrate React datepicker (bsc#1209689)
 
 -------------------------------------------------------------------
 Tue Feb 28 15:34:47 CET 2023 - jgonzalez@suse.com

--- a/web/spacewalk-web.changes.juliogonzalez.4.3-sync
+++ b/web/spacewalk-web.changes.juliogonzalez.4.3-sync
@@ -1,0 +1,1 @@
+- Fix the use of page size preference in systems and packages lists (bsc#1217209)


### PR DESCRIPTION
## What does this PR change?

Add missing changelogs entries and bugzilla references from SUSE Manager 4.3, in preparation for 5.0

NOTE: `Changelogs / Test changelog entries (pull_request_target) Failing after 12s ` need to be ignored, as I really need to directly change "master" files, to add missing bscs.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Changelogs

- [x] **DONE**

## Test coverage
- No tests: Changelogs

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23387

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
