### PR TITLE
Fix the reference label in container images

### DIFF
--- a/containers/hub-xmlrpc-api-image/Dockerfile
+++ b/containers/hub-xmlrpc-api-image/Dockerfile
@@ -14,14 +14,16 @@ ARG REFERENCE_PREFIX="registry.opensuse.org/uyuni"
 
 # Build Service required labels
 # labelprefix=org.opensuse.uyuni.hub-xmlrpc-api
+LABEL org.opencontainers.image.name=hub-xmlrpc-api-image
 LABEL org.opencontainers.image.title="${PRODUCT} Hub XML-RPC API container"
 LABEL org.opencontainers.image.description="${PRODUCT} Hub XML-RPC API image"
 LABEL org.opencontainers.image.created="%BUILDTIME%"
 LABEL org.opencontainers.image.vendor="${VENDOR}"
 LABEL org.opencontainers.image.url="${URL}"
-LABEL org.opencontainers.image.version="5.0.0"
+LABEL org.opencontainers.image.version=5.0.0
 LABEL org.openbuildservice.disturl="%DISTURL%"
-LABEL org.opensuse.reference="${REFERENCE_PREFIX}/server:5.0.0.%RELEASE%"
+LABEL org.opensuse.reference="${REFERENCE_PREFIX}/hub-xmlrpc-api:${PRODUCT_VERSION}.%RELEASE%"
 # endlabelprefix
+LABEL org.uyuni.version="${PRODUCT_VERSION}"
 
 CMD ["/usr/bin/hub-xmlrpc-api"]

--- a/containers/hub-xmlrpc-api-image/hub-xmlrpc-api.changes.cbosdonnat.versions-fix
+++ b/containers/hub-xmlrpc-api-image/hub-xmlrpc-api.changes.cbosdonnat.versions-fix
@@ -1,0 +1,2 @@
+- Use product version in reference label
+- Add missing image name label

--- a/containers/init-image/Dockerfile
+++ b/containers/init-image/Dockerfile
@@ -52,7 +52,7 @@ LABEL org.opencontainers.image.vendor="${VENDOR}"
 LABEL org.opencontainers.image.url="${URL}"
 LABEL org.opencontainers.image.version=5.0.1
 LABEL org.openbuildservice.disturl="%DISTURL%"
-LABEL org.opensuse.reference="${REFERENCE_PREFIX}/init:5.0.1.%RELEASE%"
+LABEL org.opensuse.reference="${REFERENCE_PREFIX}/init:${PRODUCT_VERSION}.%RELEASE%"
 # endlabelprefix
 
 HEALTHCHECK --interval=5s --timeout=5s --retries=5 CMD ["/usr/bin/systemctl", "is-active", "multi-user.target"]

--- a/containers/init-image/init-image.changes.cbosdonnat.versions-fix
+++ b/containers/init-image/init-image.changes.cbosdonnat.versions-fix
@@ -1,0 +1,2 @@
+- Use product version in reference label
+- Fix the container version labels

--- a/containers/proxy-httpd-image/Dockerfile
+++ b/containers/proxy-httpd-image/Dockerfile
@@ -52,8 +52,9 @@ LABEL org.opencontainers.image.url="${URL}"
 LABEL org.opencontainers.image.name=proxy-httpd-image
 LABEL org.opencontainers.image.version=5.0.0
 LABEL org.openbuildservice.disturl="%DISTURL%"
-LABEL org.opensuse.reference="${REFERENCE_PREFIX}/proxy-httpd:5.0.0.%RELEASE%"
+LABEL org.opensuse.reference="${REFERENCE_PREFIX}/proxy-httpd:${PRODUCT_VERSION}.%RELEASE%"
 # endlabelprefix
+LABEL org.uyuni.version="${PRODUCT_VERSION}"
 
 # http(s)
 EXPOSE 80/tcp

--- a/containers/proxy-httpd-image/proxy-httpd-image.changes.cbosdonnat.versions-fix
+++ b/containers/proxy-httpd-image/proxy-httpd-image.changes.cbosdonnat.versions-fix
@@ -1,0 +1,1 @@
+- Use product version in reference label

--- a/containers/proxy-salt-broker-image/Dockerfile
+++ b/containers/proxy-salt-broker-image/Dockerfile
@@ -43,8 +43,9 @@ LABEL org.opencontainers.image.url="${URL}"
 LABEL org.opencontainers.image.name=proxy-salt-broker-image
 LABEL org.opencontainers.image.version=5.0.0
 LABEL org.openbuildservice.disturl="%DISTURL%"
-LABEL org.opensuse.reference="${REFERENCE_PREFIX}/proxy-salt-broker:5.0.0.%RELEASE%"
+LABEL org.opensuse.reference="${REFERENCE_PREFIX}/proxy-salt-broker:${PRODUCT_VERSION}.%RELEASE%"
 # endlabelprefix
+LABEL org.uyuni.version="${PRODUCT_VERSION}"
 
 # Salt
 EXPOSE 4505/tcp

--- a/containers/proxy-salt-broker-image/proxy-salt-broker-image.changes.cbosdonnat.versions-fix
+++ b/containers/proxy-salt-broker-image/proxy-salt-broker-image.changes.cbosdonnat.versions-fix
@@ -1,0 +1,1 @@
+- Use product version in reference label

--- a/containers/proxy-squid-image/Dockerfile
+++ b/containers/proxy-squid-image/Dockerfile
@@ -57,8 +57,9 @@ LABEL org.opencontainers.image.url="${URL}"
 LABEL org.opencontainers.image.name=proxy-squid-image
 LABEL org.opencontainers.image.version=5.0.0
 LABEL org.openbuildservice.disturl="%DISTURL%"
-LABEL org.opensuse.reference="${REFERENCE_PREFIX}/proxy-squid:5.0.0.%RELEASE%"
+LABEL org.opensuse.reference="${REFERENCE_PREFIX}/proxy-squid:${PRODUCT_VERSION}.%RELEASE%"
 # endlabelprefix
+LABEL org.uyuni.version="${PRODUCT_VERSION}"
 
 # Squid
 EXPOSE 8080/tcp

--- a/containers/proxy-squid-image/proxy-squid-image.changes.cbosdonnat.versions-fix
+++ b/containers/proxy-squid-image/proxy-squid-image.changes.cbosdonnat.versions-fix
@@ -1,0 +1,1 @@
+- Use product version in reference label

--- a/containers/proxy-ssh-image/Dockerfile
+++ b/containers/proxy-ssh-image/Dockerfile
@@ -48,8 +48,9 @@ LABEL org.opencontainers.image.url="${URL}"
 LABEL org.opencontainers.image.name=proxy-ssh-image
 LABEL org.opencontainers.image.version=5.0.0
 LABEL org.openbuildservice.disturl="%DISTURL%"
-LABEL org.opensuse.reference="${REFERENCE_PREFIX}/proxy-ssh:5.0.0.%RELEASE%"
+LABEL org.opensuse.reference="${REFERENCE_PREFIX}/proxy-ssh:${PRODUCT_VERSION}.%RELEASE%"
 # endlabelprefix
+LABEL org.uyuni.version="${PRODUCT_VERSION}"
 
 # SSH port
 EXPOSE 22

--- a/containers/proxy-ssh-image/proxy-ssh-image.changes.cbosdonnat.versions-fix
+++ b/containers/proxy-ssh-image/proxy-ssh-image.changes.cbosdonnat.versions-fix
@@ -1,0 +1,1 @@
+- Use product version in reference label

--- a/containers/proxy-tftpd-image/Dockerfile
+++ b/containers/proxy-tftpd-image/Dockerfile
@@ -47,8 +47,9 @@ LABEL org.opencontainers.image.url="${URL}"
 LABEL org.opencontainers.image.name=proxy-tftpd-image
 LABEL org.opencontainers.image.version=5.0.0
 LABEL org.openbuildservice.disturl="%DISTURL%"
-LABEL org.opensuse.reference="${REFERENCE_PREFIX}/proxy-tftpd:5.0.0.%RELEASE%"
+LABEL org.opensuse.reference="${REFERENCE_PREFIX}/proxy-tftpd:${PRODUCT_VERSION}.%RELEASE%"
 # endlabelprefix
+LABEL org.uyuni.version="${PRODUCT_VERSION}"
 
 # tftp
 EXPOSE 69/udp

--- a/containers/proxy-tftpd-image/proxy-tftpd-image.changes.cbosdonnat.versions-fix
+++ b/containers/proxy-tftpd-image/proxy-tftpd-image.changes.cbosdonnat.versions-fix
@@ -1,0 +1,1 @@
+- Use product version in reference label

--- a/containers/server-image/Dockerfile
+++ b/containers/server-image/Dockerfile
@@ -91,8 +91,9 @@ LABEL org.opencontainers.image.vendor="${VENDOR}"
 LABEL org.opencontainers.image.url="${URL}"
 LABEL org.opencontainers.image.version=5.0.0
 LABEL org.openbuildservice.disturl="%DISTURL%"
-LABEL org.opensuse.reference="${REFERENCE_PREFIX}/server:5.0.0.%RELEASE%"
+LABEL org.opensuse.reference="${REFERENCE_PREFIX}/server:${PRODUCT_VERSION}.%RELEASE%"
 # endlabelprefix
+LABEL org.uyuni.version="${PRODUCT_VERSION}"
 
 CMD ["/usr/lib/systemd/systemd"]
 HEALTHCHECK --interval=5s --timeout=5s --retries=5 CMD ["/usr/bin/systemctl", "is-active", "multi-user.target"]

--- a/containers/server-image/server-image.changes.cbosdonnat.versions-fix
+++ b/containers/server-image/server-image.changes.cbosdonnat.versions-fix
@@ -1,0 +1,1 @@
+- Use product version in reference label

--- a/containers/server-migration-14-16-image/Dockerfile
+++ b/containers/server-migration-14-16-image/Dockerfile
@@ -28,6 +28,7 @@ LABEL org.opencontainers.image.vendor="${VENDOR}"
 LABEL org.opencontainers.image.url="${URL}"
 LABEL org.opencontainers.image.version=5.0.0
 LABEL org.openbuildservice.disturl="%DISTURL%"
-LABEL org.opensuse.reference="${REFERENCE_PREFIX}/server-migration:5.0.0.%RELEASE%"
+LABEL org.opensuse.reference="${REFERENCE_PREFIX}/server-migration:${PRODUCT_VERSION}.%RELEASE%"
 # endlabelprefix
+LABEL org.uyuni.version="${PRODUCT_VERSION}"
 

--- a/containers/server-migration-14-16-image/Dockerfile
+++ b/containers/server-migration-14-16-image/Dockerfile
@@ -20,7 +20,7 @@ ARG REFERENCE_PREFIX="registry.opensuse.org/uyuni"
 
 # Build Service required labels
 # labelprefix=org.opensuse.uyuni.server-migration-14-16
-LABEL org.opencontainers.image.name=server-migration-image
+LABEL org.opencontainers.image.name=server-migration-14-16-image
 LABEL org.opencontainers.image.title="${PRODUCT} server migration container"
 LABEL org.opencontainers.image.description="${PRODUCT} server migration image"
 LABEL org.opencontainers.image.created="%BUILDTIME%"

--- a/containers/server-migration-14-16-image/server-migration-14-16-image.changes.cbosdonnat.versions-fix
+++ b/containers/server-migration-14-16-image/server-migration-14-16-image.changes.cbosdonnat.versions-fix
@@ -1,0 +1,1 @@
+- Use product version in reference label


### PR DESCRIPTION
## What does this PR change?

The reference label value needs to match the build tag and then contain the product version.

The ARG PRODUCT_VERSION is appended when pushing the image to OBS.

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/22011

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
