### PR TITLE
Mention the missing sync for Retail in Uyuni

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -755,6 +755,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I see "SUSE Manager Retail Branch Server 4.3 x86_64" product has been added
     And I wait until all synchronized channels for "suma-retail-branch-server-43" have finished
 
+# There are no channels for Retail under Uyuni
+
   Scenario: Detect product loading issues from the UI in Build Validation
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -966,14 +966,8 @@ CHANNEL_TO_SYNCH_BY_OS_PRODUCT_VERSION = {
       opensuse_leap15_5-sle-updates
       uyuni-proxy-devel-leap-x86_64
       opensuse_leap15_5-uyuni-client-devel
-    ],
-  'uyuni-retail-branch-server' =>
-    %w[
-      sle-product-suse-manager-retail-branch-server-4.3-pool-x86_64
-      sle-product-suse-manager-retail-branch-server-4.3-updates-x86_64
-      sle-module-suse-manager-retail-branch-server-4.3-pool-x86_64
-      sle-module-suse-manager-retail-branch-server-4.3-updates-x86_64
     ]
+  # There are no channels for Retail under Uyuni
 }.freeze
 
 EMPTY_CHANNELS = %w[sle-module-suse-manager-retail-branch-server-4.3-updates-x86_64].freeze


### PR DESCRIPTION
## What does this PR change?

This PR addresses the reposync for Retail in the Uyuni case.

According to Ondrej, the existing Uyuni channels contain all the Retail packages, so this PRs just adds two comments stating there is nothing to do.


## Links

Ports:
 * 4.3: SUSE/spacewalk#23404


## Changelogs

- [x] No changelog needed
