### PR TITLE
Remove pxe-default-image requirement from spacewalk-common when building the package on SLE

### DIFF
--- a/spacewalk/package/spacewalk.changes.juliogonzalez.remove-pxe-image-requirement
+++ b/spacewalk/package/spacewalk.changes.juliogonzalez.remove-pxe-image-requirement
@@ -1,0 +1,2 @@
+- Remove the requirement for pxe-default image on SUSE Linux Enterprise,
+  as it is not provided anymore for SUSE Manager 5.0

--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -70,7 +70,7 @@ Requires:       spacewalk-backend-xmlrpc
 Requires:       spacewalk-certs-tools
 
 # Misc
-%if !0%{?opensuse}
+%if 0%{?opensuse}
 Requires:       pxe-default-image
 %endif
 Requires:       spacewalk-config

--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -70,7 +70,7 @@ Requires:       spacewalk-backend-xmlrpc
 Requires:       spacewalk-certs-tools
 
 # Misc
-%if !0%{?rhel}
+%if !0%{?opensuse}
 Requires:       pxe-default-image
 %endif
 Requires:       spacewalk-config


### PR DESCRIPTION
## What does this PR change?

Remove pxe-default-image requirement from spacewalk-common when building on SLE, as PXE images are not provided anymore for SUSE Manager 5.0

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Card: A card should be already created by @admd for the doc team.

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/22011

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
