### PR TITLE
Add sleep time before rebooting transactional systems after bootstraping

### DIFF
--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.welder.bsc1218146
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.welder.bsc1218146
@@ -1,0 +1,1 @@
+- Add sleep time before rebooting transactional systems after bootstraping (bsc#1218146)


### PR DESCRIPTION
## What does this PR change?

It introduces a delay before rebooting transactional systems post-bootstrap. This addresses cases where the system would reboot before Salt had a chance to send the results of applying the bootstrap state. Such occurrences resulted in error messages appearing in the WebUI, even though the bootstrap operation was actually successful.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: sls files only

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23248

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
