### PR TITLE
Use product version in reference label

### DIFF
--- a/containers/server-migration-14-16-image/Dockerfile
+++ b/containers/server-migration-14-16-image/Dockerfile
@@ -28,6 +28,7 @@ LABEL org.opencontainers.image.vendor="${VENDOR}"
 LABEL org.opencontainers.image.url="${URL}"
 LABEL org.opencontainers.image.version=5.0.0
 LABEL org.openbuildservice.disturl="%DISTURL%"
-LABEL org.opensuse.reference="${REFERENCE_PREFIX}/server-migration:5.0.0.%RELEASE%"
+LABEL org.opensuse.reference="${REFERENCE_PREFIX}/server-migration:${PRODUCT_VERSION}.%RELEASE%"
 # endlabelprefix
+LABEL org.uyuni.version="${PRODUCT_VERSION}"
 

--- a/containers/server-migration-14-16-image/server-migration-14-16-image.changes.deneb-alpha.server-migration-14-16_tagging
+++ b/containers/server-migration-14-16-image/server-migration-14-16-image.changes.deneb-alpha.server-migration-14-16_tagging
@@ -1,0 +1,1 @@
+- Use product version in reference label


### PR DESCRIPTION
## What does this PR change?

The reference label value needs to match the build tag and then contain the product version.

The ARG PRODUCT_VERSION is appended when pushing the image to OBS.

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/22011

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
