### PR TITLE
use ById mechanism for SystemPackageInstalled report db table

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/SystemReport_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/SystemReport_queries.xml
@@ -337,22 +337,29 @@
     </query>
 </mode>
 
-<mode name="SystemPackageInstalled" class="">
-    <query params="system_id, name, limit">
-          SELECT rhnServerPackage.server_id AS system_id
-                    , rhnPackageName.name
-                    , rhnPackageEvr.epoch
-                    , rhnPackageEvr.version
-                    , rhnPackageEvr.release
-                    , rhnPackageArch.label AS arch
-                    , rhnPackageEvr.type
-            FROM rhnServerPackage
-                    INNER JOIN rhnPackageName ON rhnServerPackage.name_id = rhnPackageName.id
-                    INNER JOIN rhnPackageEvr ON rhnServerPackage.evr_id = rhnPackageEvr.id
-                    INNER JOIN rhnPackageArch ON rhnServerPackage.package_arch_id = rhnPackageArch.id
-           WHERE (rhnServerPackage.server_id, rhnPackageName.name) &gt; (:system_id, :name)
-        ORDER BY system_id, name
-           FETCH FIRST :limit ROWS WITH TIES
+<mode name="SystemPackageInstalled_Ids" class="">
+    <query>
+        SELECT DISTINCT server_id AS id FROM rhnserverpackage
+    </query>
+</mode>
+
+<mode name="SystemPackageInstalled_byId" class="">
+    <query params="id, name, limit">
+        SELECT rhnServerPackage.server_id AS system_id
+             , rhnPackageName.name
+             , rhnPackageEvr.epoch
+             , rhnPackageEvr.version
+             , rhnPackageEvr.release
+             , rhnPackageArch.label AS arch
+             , rhnPackageEvr.type
+        FROM rhnServerPackage
+            INNER JOIN rhnPackageName ON rhnServerPackage.name_id = rhnPackageName.id
+            INNER JOIN rhnPackageEvr ON rhnServerPackage.evr_id = rhnPackageEvr.id
+            INNER JOIN rhnPackageArch ON rhnServerPackage.package_arch_id = rhnPackageArch.id
+        WHERE rhnServerPackage.server_id = :id
+          AND rhnPackageName.name &gt; :name
+        ORDER BY name
+            FETCH FIRST :limit ROWS WITH TIES
     </query>
 </mode>
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ReportDbUpdateTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ReportDbUpdateTask.java
@@ -126,8 +126,8 @@ public class ReportDbUpdateTask extends RhnJavaJob {
                 Map.of(SYSTEM_ID, 0, SYSTEM_GROUP_ID, 0));
             fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemErrata",
                 Map.of(SYSTEM_ID, 0, ERRATA_ID, 0));
-            fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemPackageInstalled",
-                Map.of(SYSTEM_ID, 0, NAME, ""));
+            fillReportDbTableById(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemPackageInstalled",
+                Map.of(NAME, ""));
             fillReportDbTableById(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemPackageUpdate",
                 Map.of(PACKAGE_ID, 0));
             fillReportDbTable(rh.getSession(), SYSTEM_REPORT_QUERIES, "SystemCustomInfo",


### PR DESCRIPTION
## What does this PR change?

Another improvement on top of #23054 which use the ById variant also for SystemPackageInstalled table.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Ports(s): https://github.com/SUSE/spacewalk/pull/23325

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
