### PR TITLE
Revert reordering of license tags for spacewalk-html

### DIFF
--- a/web/spacewalk-web.changes.deneb-alpha.fix_spacewalk-html_license
+++ b/web/spacewalk-web.changes.deneb-alpha.fix_spacewalk-html_license
@@ -1,0 +1,1 @@
+- Revert reordering of license tags for spacewalk-html

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -64,7 +64,7 @@ but it does generate a number of sub-packages.
 
 %package -n spacewalk-html
 Summary:        HTML document files for Spacewalk
-License:        0BSD AND (Apache-2.0 OR MPL-2.0) AND BSD-3-Clause AND GPL-2.0-only AND ISC AND LGPL-3.0-or-later AND MIT AND MPL-2.0
+License:        (MPL-2.0 OR Apache-2.0) AND 0BSD AND BSD-3-Clause AND GPL-2.0-only AND ISC AND LGPL-3.0-or-later AND MIT AND MPL-2.0
 Group:          Applications/Internet
 Requires:       httpd
 Requires:       spacewalk-branding


### PR DESCRIPTION
## What does this PR change?

Revert reordering of license tags for `spacewalk-html`. 

This is a follow-up of https://github.com/uyuni-project/uyuni/pull/8120 needed because the reordering of the license tag done by spec-cleaner is breaking the  `manager-Head-dev-javascript-lint` on the CI with
~~~
$ yarn -s check-package && NODE_OPTIONS="--trace-warnings --trace-deprecation --unhandled-rejections=strict" node build
WARN: Currently installed ace-builds version 1.3.3 only matches expected version ajaxorg/ace-builds#v1.3.3 when coerced
clean-webpack-plugin: /manager/web/html/src/dist has been removed.
(node:200) [DEP_WEBPACK_COMPILATION_ASSETS] DeprecationWarning: Compilation.assets will be frozen in future, all modifications are deprecated.
BREAKING CHANGE: No more changes should happen to Compilation.assets after sealing the Compilation.
	Do changes to assets earlier, e. g. in Compilation.hooks.processAssets.
	Make sure to select an appropriate stage from Compilation.PROCESS_ASSETS_STAGE_*.
    at /manager/web/html/src/node_modules/copy-webpack-plugin/dist/postProcessPattern.js:144:38
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Promise.all (index 0)
    at async Promise.all (index 1)
spacewalk-web.spec was updated successfully with the following licenses for spacewalk-html: (MPL-2.0 OR Apache-2.0) AND 0BSD AND BSD-3-Clause AND GPL-2.0-only AND ISC AND LGPL-3.0-or-later AND MIT AND MPL-2.0
error: object directory /srv/mirror/uyuni.git/objects does not exist; check .git/objects/info/alternates
susemanager-utils/susemanager-sls/salt/certs/openeuler.sls
testsuite/run_sets/reference_init_clients.yml
web/spacewalk-web.spec

                It seems changes to license and/or spec files haven't been committed.
                Please run "yarn build" again and commit the following files: web/spacewalk-web.spec
error Command failed with exit code 1.
~~~

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/22011

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
