### PR TITLE
QE: refactor verification of a system's subscribed channels

### DIFF
--- a/testsuite/features/secondary/allcli_software_channels.feature
+++ b/testsuite/features/secondary/allcli_software_channels.feature
@@ -215,7 +215,7 @@ Feature: Channel subscription via SSM
     Then I should see a "Changing the channels has been scheduled." text
     When I follow "scheduled" in the content area
     And I wait until I see "1 system successfully completed this action." text, refreshing the page
-    Then channel "SLE15-SP4-Installer-Updates for x86_64" should not be enabled on "sle_minion"
+    Then channel "SLE15-SP4-Installer-Updates for x86_64" should be disabled on "sle_minion"
 
 @sle_minion
 @uyuni
@@ -239,7 +239,7 @@ Feature: Channel subscription via SSM
     Then I should see a "Changing the channels has been scheduled." text
     When I follow "scheduled" in the content area
     And I wait until I see "1 system successfully completed this action." text, refreshing the page
-    Then channel "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)" should not be enabled on "sle_minion"
+    Then channel "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)" should be disabled on "sle_minion"
 
   Scenario: Cleanup: remove remaining systems from SSM after channel subscription tests
     When I click on the clear SSM button

--- a/testsuite/features/secondary/min_change_software_channel.feature
+++ b/testsuite/features/secondary/min_change_software_channel.feature
@@ -135,7 +135,7 @@ Feature: Assign child channel to a system
     Then I should see a "Changing the channels has been scheduled." text
     When I follow "scheduled" in the content area
     And I wait until I see "1 system successfully completed this action." text, refreshing the page
-    Then channel "SLE15-SP4-Installer-Updates for x86_64" should not be enabled on "sle_minion"
+    Then channel "SLE15-SP4-Installer-Updates for x86_64" should be disabled on "sle_minion"
 
 @uyuni
   Scenario: Cleanup: subscribe the system back to previous channels
@@ -159,4 +159,4 @@ Feature: Assign child channel to a system
     Then I should see a "Changing the channels has been scheduled." text
     When I follow "scheduled" in the content area
     And I wait until I see "1 system successfully completed this action." text, refreshing the page
-    Then channel "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)" should not be enabled on "sle_minion"
+    Then channel "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)" should be disabled on "sle_minion"

--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2023 SUSE LLC
+# Copyright (c) 2015-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 ### This file contains the definitions for all steps concerning the API.
@@ -176,6 +176,33 @@ Then(/^channel "([^"]*)" should not have attribute "([^"]*)"$/) do |label, attr|
   ret = $api_test.channel.software.get_details(label)
   assert(ret)
   assert_equal(false, ret.key?(attr))
+end
+
+Then(/^channel "([^"]*)" should be (enabled|disabled) on "([^"]*)"$/) do |channel, state, host|
+  node = get_target(host)
+  system_id = get_system_id(node)
+
+  channels = $api_test.channel.software.list_system_channels(system_id)
+
+  assert_equal(state == 'enabled', channels.include?(channel))
+end
+
+Then(/^"(\d+)" channels should be enabled on "([^"]*)"$/) do |count, host|
+  node = get_target(host)
+  system_id = get_system_id(node)
+
+  channels = $api_test.channel.software.list_system_channels(system_id)
+
+  assert_equal(count, channels.size)
+end
+
+Then(/^"(\d+)" channels with prefix "([^"]*)" should be enabled on "([^"]*)"$/) do |count, prefix, host|
+  node = get_target(host)
+  system_id = get_system_id(node)
+
+  channels = $api_test.channel.software.list_system_channels(system_id)
+
+  assert_equal(count, channels.select { |channel| channel.start_with?(prefix) }.size)
 end
 
 ## activationkey namespace

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -482,31 +482,6 @@ When(/^I install the needed packages for highstate in build host$/) do
   get_target('build_host').run("zypper --non-interactive in #{packages}", timeout: 600)
 end
 
-Then(/^channel "([^"]*)" should be enabled on "([^"]*)"$/) do |channel, host|
-  node = get_target(host)
-  node.run("zypper lr -E | grep '#{channel}'")
-end
-
-Then(/^channel "([^"]*)" should not be enabled on "([^"]*)"$/) do |channel, host|
-  node = get_target(host)
-  _out, code = node.run("zypper lr -E | grep '#{channel}'", check_errors: false)
-  raise ScriptError, "'#{channel}' was not expected but was found." if code.to_i.zero?
-end
-
-Then(/^"(\d+)" channels should be enabled on "([^"]*)"$/) do |count, host|
-  node = get_target(host)
-  node.run('zypper lr -E | tail -n +5', verbose: true)
-  out, _code = node.run('zypper lr -E | tail -n +5 | wc -l')
-  raise ScriptError, "Expected #{count} channels enabled but found #{out}." unless count.to_i == out.to_i
-end
-
-Then(/^"(\d+)" channels with prefix "([^"]*)" should be enabled on "([^"]*)"$/) do |count, prefix, host|
-  node = get_target(host)
-  node.run("zypper lr -E | tail -n +5 | grep '#{prefix}'", verbose: true)
-  out, _code = node.run("zypper lr -E | tail -n +5 | grep '#{prefix}' | wc -l")
-  raise ScriptError, "Expected #{count} channels enabled but found #{out}." unless count.to_i == out.to_i
-end
-
 # metadata steps
 Then(/^I should have '([^']*)' in the patch metadata for "([^"]*)"$/) do |text, host|
   node = get_target(host)

--- a/testsuite/features/support/namespaces/channel.rb
+++ b/testsuite/features/support/namespaces/channel.rb
@@ -160,7 +160,7 @@ class NamespaceChannelSoftware
   end
 
   ##
-  # Lists the labels of channels the system with the given system ID is subscribed to
+  # Lists the name of channels the system with the given system ID is subscribed to
   #
   # Args:
   #   system_id: The ID of the system.

--- a/testsuite/features/support/namespaces/channel.rb
+++ b/testsuite/features/support/namespaces/channel.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023 SUSE LLC.
+# Copyright (c) 2022-2024 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 # Channel namespace
@@ -157,5 +157,15 @@ class NamespaceChannelSoftware
   def list_user_repos
     repos = @test.call('channel.software.listUserRepos', sessionKey: @test.token)
     repos.map { |key| key['label'] }
+  end
+
+  ##
+  # Lists the labels of channels the system with the given system ID is subscribed to
+  #
+  # Args:
+  #   system_id: The ID of the system.
+  def list_system_channels(system_id)
+    channels = @test.call('channel.software.listSystemChannels', sessionKey: @test.token, sid: system_id)
+    channels.map { |channel| channel['name'] }
   end
 end


### PR DESCRIPTION
## What does this PR change?

Closes https://github.com/SUSE/spacewalk/issues/22908

Do not evaluate the number of enabled repositories and instead use an API call to retrieve the number of subscribed channels.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Step definitions used by some Cucumber tests were edited

- [x] **DONE**

## Links

Issue(s):  https://github.com/SUSE/spacewalk/issues/22908
Ports(s): Manager 4.3 https://github.com/SUSE/spacewalk/pull/23619

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"