### PR TITLE
Prevent XXE attacks in ScapManager

### DIFF
--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -175,12 +175,12 @@
   <property name="build.jar.dependencies"
       value="ant ant-junit ${ant-contrib.path} antlr  ${test.build.jar.dependencies}
       ${common.jar.dependencies} ${tomcat-jars} ${jasper-jars}
-       concurrent xalan-j2" />
+       concurrent saxon10" />
 
   <property name="run.jar.dependencies"
       value="antlr objectweb-asm/asm ${cglib-jar} ${c3p0} commons-discovery dom4j ${jaf} ${jta11-jars} ojdbc14 sitemesh
              taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec
-             xalan-j2 xalan-j2-serializer xerces-j2 ${common.jar.dependencies}" />
+             saxon10 xerces-j2 ${common.jar.dependencies}" />
 
   <!-- =================== RPM build, use jpackage syntax ======================= -->
   <!-- property name="install.test.jar.dependencies"
@@ -197,12 +197,12 @@
 
   <property name="install.build.jar.dependencies"
       value="ant ant/ant-junit ${ant-contrib.path} antlr ${jasper-jars} ${test.build.jar.dependencies}
-      ${install.common.jar.dependencies} xalan-j2" />
+      ${install.common.jar.dependencies} saxon10" />
 
   <property name="install.run.jar.dependencies"
       value="antlr objectweb-asm/asm ${cglib-jar} ${c3p0} commons-discovery dom4j ${jaf} ${jta11-jars} sitemesh
              taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec
-             xalan-j2 xalan-j2-serializer xerces-j2 ${install.common.jar.dependencies}" />
+             saxon10 xerces-j2 ${install.common.jar.dependencies}" />
 
   <property name="install.common.jar.dependencies"
       value="bcel ${cglib-jar} commons-beanutils commons-cli commons-codec
@@ -227,7 +227,7 @@
              taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec
              postgresql-jdbc ongres-scram/client ongres-scram/common ${stringprep-jars}
              snakeyaml simple-xml ${suse-common-jars} ${suse-runtime-jars}
-	     xalan-j2 xalan-j2-serializer xerces-j2 simple-core ${ehcache}" />
+	         saxon10 xerces-j2 simple-core ${ehcache}" />
 
   <property name="taskomatic.jar.dependencies"
       value="${dist.jar.dependencies} jsch" />

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -98,8 +98,7 @@
         <dependency org="suse" name="taglibs-standard-jstlel" rev="1.2.5" />
         <dependency org="suse" name="taglibs-standard-spec" rev="1.2.5" />
         <dependency org="suse" name="woodstox-core-asl" rev="4.4.2" />
-        <dependency org="suse" name="xalan-j2" rev="2.7.2" />
-        <dependency org="suse" name="xalan-j2-serializer" rev="2.7.2" />
+        <dependency org="suse" name="saxon10" rev="10.9" />
         <dependency org="suse" name="xerces-j2" rev="2.12.2" />
         <dependency org="suse" name="xmlsec" rev="2.0.7" />
         <dependency org="suse" name="glassfish-jaxb-api" rev="2.4.0" />

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -285,12 +285,8 @@ artifacts:
   - artifact: woodstox-core-asl
     package: woodstox
     repository: Uyuni_Other
-  - artifact: xalan-j2
-    jar: xalan-j2.jar
-    repository: Leap
-  - artifact: xalan-j2-serializer
-    package: xalan-j2
-    repository: Leap
+  - artifact: saxon10
+    repository: Leap_sle
   - artifact: xerces-j2
     repository: Leap
   - artifact: xmlsec

--- a/java/code/src/com/redhat/rhn/common/util/StringUtil.java
+++ b/java/code/src/com/redhat/rhn/common/util/StringUtil.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.xml.utils.XMLChar;
+import org.apache.xerces.util.XMLChar;
 import org.stringtree.json.JSONReader;
 import org.stringtree.json.JSONWriter;
 

--- a/java/code/src/com/redhat/rhn/manager/audit/ScapManager.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/ScapManager.java
@@ -72,9 +72,10 @@ import java.util.Optional;
 
 import javax.xml.XMLConstants;
 import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
+
+import net.sf.saxon.jaxp.SaxonTransformerFactory;
 
 /**
  * ScapManager
@@ -464,9 +465,10 @@ public class ScapManager extends BaseManager {
         StreamSource in = new StreamSource(resultsXml);
         try (OutputStream resumeOut = new FileOutputStream(output)) {
             StreamResult out = new StreamResult(resumeOut);
-            TransformerFactory factory = TransformerFactory.newInstance();
+            SaxonTransformerFactory factory = new SaxonTransformerFactory();
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
             Transformer transformer = factory.newTransformer(xslStream);
             transformer.transform(in, out);
         }

--- a/java/code/src/com/redhat/rhn/manager/audit/ScapManager.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/ScapManager.java
@@ -70,6 +70,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import javax.xml.XMLConstants;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
@@ -464,6 +465,8 @@ public class ScapManager extends BaseManager {
         try (OutputStream resumeOut = new FileOutputStream(output)) {
             StreamResult out = new StreamResult(resumeOut);
             TransformerFactory factory = TransformerFactory.newInstance();
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
             Transformer transformer = factory.newTransformer(xslStream);
             transformer.transform(in, out);
         }

--- a/java/manager-build.xml
+++ b/java/manager-build.xml
@@ -175,7 +175,7 @@
         <exclude name="**/tomcat*-servlet*" />
         <exclude name="**/jspapi*" />
         <exclude name="**/websocket-api*" />
-        <exclude name="**/checkstyle*" />
+        <exclude name="**/all*" />
         <exclude name="**/jacocoant*" />
       </fileset>
     </copy>

--- a/java/spacewalk-java.changes.cbosdonnat.xxe-prevention
+++ b/java/spacewalk-java.changes.cbosdonnat.xxe-prevention
@@ -1,0 +1,1 @@
+- Prevent XXE in SCAP transformations

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -147,7 +147,7 @@ BuildRequires:  tomcat-lib >= 7
 BuildRequires:  tomcat-taglibs-standard
 BuildRequires:  uyuni-base-server
 BuildRequires:  woodstox
-BuildRequires:  xalan-j2
+BuildRequires:  saxon10
 BuildRequires:  xmlsec
 BuildRequires:  (google-gson >= 2.2.4 with google-gson < 2.10.0)
 BuildRequires:  mvn(org.apache.velocity:velocity-engine-core) >= 2.2
@@ -236,7 +236,7 @@ Requires:       system-lock-formula
 Requires:       tomcat-lib >= 7
 Requires:       tomcat-taglibs-standard
 Requires:       woodstox
-Requires:       xalan-j2 >= 2.6.0
+Requires:       saxon10
 Requires:       xerces-j2
 Requires:       xmlsec
 Requires:       (/sbin/unix2_chkpwd or /usr/sbin/unix2_chkpwd)
@@ -376,7 +376,7 @@ Requires:       spacewalk-java-lib = %{version}
 Requires:       statistics
 Requires:       susemanager-frontend-libs >= 2.1.5
 Requires:       tomcat-taglibs-standard
-Requires:       xalan-j2 >= 2.6.0
+Requires:       saxon10 
 Requires:       xerces-j2
 Requires:       (/sbin/unix2_chkpwd or /usr/sbin/unix2_chkpwd)
 Requires:       mvn(org.hibernate:hibernate-c3p0)


### PR DESCRIPTION
## What does this PR change?

Use Saxon10 to disable loading external DTDs and schemas.

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/19448

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
