### PR TITLE
Enable aarch64 builds for susemanager-branding-oss for SUSE Manager

### DIFF
--- a/susemanager-branding-oss/susemanager-branding-oss.changes.juliogonzalez.branding-oss-susemanager-5.0
+++ b/susemanager-branding-oss/susemanager-branding-oss.changes.juliogonzalez.branding-oss-susemanager-5.0
@@ -1,0 +1,1 @@
+- Build susemanager-branding-oss for aarch64 and SUSE Manager

--- a/susemanager-branding-oss/susemanager-branding-oss.spec
+++ b/susemanager-branding-oss/susemanager-branding-oss.spec
@@ -31,10 +31,9 @@ Source0:        %{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 %if 0%{?sle_version} && !0%{?is_opensuse}
-# SUSE Manager does not support aarch64 for the server
-ExcludeArch:    aarch64
 BuildRequires:  SUSE-Manager-Server-release
 %else
+# This package is not needed for Uyuni, so we do not build it
 ExcludeArch:    i586 x86_64 ppc64le s390x aarch64
 %endif
 Provides:       susemanager-branding = %{version}


### PR DESCRIPTION
## What does this PR change?

This package is not needed for Uyuni, so we keep it disabled.

It requires @deneb-alpha to fix product definitions for the upper case, and so they generate 5.0 release packages.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: There should be another card to do the doc for other architectures.

- [x] **DONE**

## Test coverage
- No tests: We build the package and have monitor jobs for this.

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/22011

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
