### PR TITLE
preflight.sh: Fix REPO_PORT condition syntax

### DIFF
--- a/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
+++ b/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
@@ -14,10 +14,10 @@ if ! [ "${SH_NAME}" = "bash" ]; then
 fi
 
 REPO_HOST=$1
-if [[ $2 =~ "^[0-9]$" ]]; then
+if [[ $2 =~ ^[0-9]+$ ]]; then
    REPO_PORT=$2
 else
-   echo 'Error: $2 (REPO_PORT) must be an integer.' >2
+   echo 'Error: $2 (REPO_PORT) must be an integer.' >&2
    exit 254
 fi
 FAIL_ON_ERROR=1
@@ -217,7 +217,8 @@ if [[ $REPO_HOST == "localhost" ]] && command -v selinuxenabled && selinuxenable
     if ! selinux_policy_loaded; then
         echo "(portcon tcp ${REPO_PORT} (system_u object_r ssh_port_t ((s0)(s0))))" >$SELINUX_POLICY_FILENAME
         if ! semodule -i $SELINUX_POLICY_FILENAME; then
-			exit_with_message_code "Error: Failed to install SELinux policy." 7
+            exit_with_message_code "Error: Failed to install SELinux policy." 7
+        fi
     fi
 fi
 


### PR DESCRIPTION
## What does this PR change?
In Bash, the string to the right of the =~ operator is interpreted as a POSIX extended regular expression. A quoted expression is matched literally, therefore we can't quote the string on the right side.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23369
Old PR causing the issues: https://github.com/uyuni-project/uyuni/pull/8034
Ports(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
