### PR TITLE
Missing reposync for rocky 9 on uyuni

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -590,7 +590,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @rocky8_minion
   Scenario: Add Rocky Linux 8
     When I use spacewalk-common-channel to add channel "rockylinux8 rockylinux8-appstream rockylinux8-extras rockylinux8-uyuni-client-devel" with arch "x86_64"
-    And I wait until all synchronized channels for "res8" have finished
+    And I wait until all synchronized channels for "rockylinux-8" have finished
 
 @susemanager
 @rocky9_minion
@@ -604,6 +604,12 @@ Feature: Synchronize products in the products page of the Setup Wizard
     Then I should see the "Rocky Linux 9 x86_64" selected
     When I click the Add Product button
     And I wait until I see "Rocky Linux 9 x86_64" product has been added
+    And I wait until all synchronized channels for "rockylinux-9" have finished
+
+@uyuni
+@rocky9_minion
+  Scenario: Add Rocky Linux 9
+    When I use spacewalk-common-channel to add channel "rockylinux9 rockylinux9-appstream rockylinux9-extras rockylinux9-uyuni-client-devel" with arch "x86_64"
     And I wait until all synchronized channels for "rockylinux-9" have finished
 
 @ubuntu2004_minion

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -665,6 +665,7 @@ CHANNEL_TO_SYNCH_BY_OS_PRODUCT_VERSION = {
   'almalinux9' =>
     %w[
       almalinux9-appstream-x86_64
+      almalinux9-extras-x86_64
       almalinux9-x86_64
       almalinux9-uyuni-client-x86_64
     ],
@@ -716,12 +717,14 @@ CHANNEL_TO_SYNCH_BY_OS_PRODUCT_VERSION = {
   'rockylinux-8' =>
     %w[
       rockylinux-8-appstream-x86_64
+      rockylinux-8-extras-x86_64
       rockylinux-8-x86_64
       rockylinux8-uyuni-client-x86_64
     ],
   'rockylinux-9' =>
     %w[
       rockylinux-9-appstream-x86_64
+      rockylinux-9-extras-x86_64
       rockylinux-9-x86_64
       rockylinux9-uyuni-client-x86_64
     ],


### PR DESCRIPTION
## What does this PR change?

* add missing scenario for rocky9 under uyuni
* make package lists in constants match with the ones in feature
* fix waiting for RES 8


## Links

Ports:
 * 4.3: SUSE/spacewalk#23422


## Changelogs

- [x] No changelog needed
