### PR TITLE
Fix reposync package filtering

### DIFF
--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -939,7 +939,15 @@ password={passwd}
             pkglist = self._get_solvable_dependencies(pkglist)
 
             # Do not pull in dependencies if there're explicitly excluded
-            pkglist = self._filter_packages(pkglist, filters, True)
+            #
+            # bsc#1217874: If we use exclude_only here, when a filter uses
+            # both the include (+) and exclude (-) flags in combination,
+            # and there is an overlap between these flags, the exclude (-)
+            # filter takes precedence. For instance, with the filters
+            # "-* +any_package_name*", all packages are removed, failing to
+            # include the package explicitly declared in the + flag.
+            #
+            pkglist = self._filter_packages(pkglist, filters)
             self.num_excluded = self.num_packages - len(pkglist)
 
         return pkglist

--- a/python/spacewalk/spacewalk-backend.changes.welder.fix-package-filtering
+++ b/python/spacewalk/spacewalk-backend.changes.welder.fix-package-filtering
@@ -1,0 +1,1 @@
+- Fix reposync package filtering (bsc#1217874)


### PR DESCRIPTION
## What does this PR change?

It removes `exclude_only` when calling `_filter_packages` function to fix the behavior of reposync when a filter uses both the include (+) and exclude (-) flags in combination, and there is an overlap between these flags. In this case the exclude (-)
filter was taking precedence. For instance, with the filters "-* +any_package_name*", all packages are removed, failing to
include the package explicitly declared in the + flag.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23169

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
