### PR TITLE
Temporary use a dummy EULA for SUSE Manager

### DIFF
--- a/susemanager-branding-oss/susemanager-branding-oss.changes.juliogonzalez.branding-non-eula
+++ b/susemanager-branding-oss/susemanager-branding-oss.changes.juliogonzalez.branding-non-eula
@@ -1,0 +1,2 @@
+- Include a dummy license temporary, for SUSE Manager 5.0 Alpha1
+  and Alpha2, until we can figure out how to manage it

--- a/susemanager-branding-oss/susemanager-branding-oss.spec
+++ b/susemanager-branding-oss/susemanager-branding-oss.spec
@@ -48,10 +48,12 @@ SUSE Manager oss flavors.
 %setup -q
 
 %build
-cp /usr/share/licenses/product/SUSE-Manager-Server/license.txt license.txt
-echo "<p>" > eula.html
-cat license.txt | sed 's/^$/<\/p><p>/' >> eula.html
-echo "</p>" >> eula.html
+echo "dummy" > license.txt
+echo "<html><head><title>dummy</title></head><body>dummy</body></html>" > eula.html
+#cp /usr/share/licenses/product/SUSE-Manager-Server/license.txt license.txt
+#echo "<p>" > eula.html
+#cat license.txt | sed 's/^$/<\/p><p>/' >> eula.html
+#echo "</p>" >> eula.html
 
 %install
 mkdir -p $RPM_BUILD_ROOT/%{wwwdocroot}/help/


### PR DESCRIPTION
## What does this PR change?

Temporary use a dummy EULA for SUSE Manager. For SUSE Manager Alpha1 and Alpha2 until we figure out how to handle it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Temporary workaround

- [x] **DONE**

## Test coverage
- No tests: AFAIK no test checks the licenses

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/22011

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
