### PR TITLE
handle not existing known_host file in permission check

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/bootstrap/AbstractMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/bootstrap/AbstractMinionBootstrapper.java
@@ -54,6 +54,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -136,6 +137,10 @@ public abstract class AbstractMinionBootstrapper {
 
         try {
             if (prc.waitFor() != 0) {
+                String error = new String(prc.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
+                if (error.contains("No such file or directory")) {
+                    return true;
+                }
                 throw new CommandExecutionException("Error running command: " + cmd, prc);
             }
         }

--- a/java/spacewalk-java.changes.mc.Manager-4.3-fix-known_hosts-test
+++ b/java/spacewalk-java.changes.mc.Manager-4.3-fix-known_hosts-test
@@ -1,0 +1,1 @@
+- handle not existing known_host file in permission check


### PR DESCRIPTION
## What does this PR change?

We might have now an existing /var/lib/salt/.ssh directory, but no `known_hosts` file in it.
We cannot directly check for file exists as we do not have permissions to read the directory.
We need to ignore this error so we check for the message

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Ports(s): https://github.com/SUSE/spacewalk/pull/23438

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
