### PR TITLE
SCC renamed SLES ES 7 to SUSE Liberty Linux 7

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -487,16 +487,16 @@ Feature: Synchronize products in the products page of the Setup Wizard
 
 @susemanager
 @centos7_minion
-  Scenario: Add SUSE Linux Enterprise Server with Expanded Support 7
+  Scenario: Add SUSE Liberty Linux 7
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "currently running" text
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Linux Enterprise Server with Expanded Support 7" as the filtered product description
-    And I select "SUSE Linux Enterprise Server with Expanded Support 7" as a product
-    Then I should see the "SUSE Linux Enterprise Server with Expanded Support 7" selected
+    And I enter "SUSE Liberty Linux 7" as the filtered product description
+    And I select "SUSE Liberty Linux 7 x86_64" as a product
+    Then I should see the "SUSE Liberty Linux 7 x86_64" selected
     When I click the Add Product button
-    And I wait until I see "SUSE Linux Enterprise Server with Expanded Support 7" product has been added
+    And I wait until I see "SUSE Liberty Linux 7 x86_64" product has been added
     And I wait until all synchronized channels for "res7" have finished
 
 @uyuni


### PR DESCRIPTION
## What does this PR change?

Again, renaming products.


## Links

Ports:
 * 4.3: SUSE/spacewalk#23442


## Changelogs

- [x] No changelog needed
