### PR TITLE
QE: Fix openSSL parameters in hostname rename test

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1585,7 +1585,7 @@ end
 
 When(/^I check all certificates after renaming the server hostname$/) do
   # get server certificate serial to compare it with the other minions
-  command_server = "openssl x509 --noout --text -in /etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT | grep -A1 'Serial' | grep -v 'Serial'"
+  command_server = "openssl x509 -noout -text -in /etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT | grep -A1 'Serial' | grep -v 'Serial'"
   server_cert_serial, result_code = get_target('server').run(command_server)
   server_cert_serial.strip!
   log "Server certificate serial: #{server_cert_serial}"
@@ -1610,7 +1610,7 @@ When(/^I check all certificates after renaming the server hostname$/) do
       end
     get_target(target).run("test -s #{certificate}", successcodes: [0], check_errors: true)
 
-    command_minion = "openssl x509 --noout --text -in #{certificate} | grep -A1 'Serial' | grep -v 'Serial'"
+    command_minion = "openssl x509 -noout -text -in #{certificate} | grep -A1 'Serial' | grep -v 'Serial'"
     minion_cert_serial, result_code = get_target(target).run(command_minion)
 
     raise ScriptError, "#{target}: Error getting server certificate serial!" unless result_code.zero?


### PR DESCRIPTION
## What does this PR change?

According to the manpage/help of OpenSSL, there are only parameters with one dash and not 2. I am not sure why it manually works with 2 dashes but in the test suite it fails.


## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage

- Cucumber tests were edited

- [x] **DONE**

## Links

Issue(s): #
Ports(s): # https://github.com/SUSE/spacewalk/pull/23451

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
