### PR TITLE
set product_tree tag to Beta and change the config value to SUMA5.0

### DIFF
--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -229,7 +229,7 @@ java.mgr_sync_max_connections = 4
 java.max_changelog_entries = 20
 
 # Determins which product tree variation to use.
-java.product_tree_tag = SUMA4.3
+java.product_tree_tag = SUMA5.0
 
 # If true, login is enabled via Single Sign-On (SSO)
 java.sso = false

--- a/java/spacewalk-java.changes.mc.product_tree-tag-50
+++ b/java/spacewalk-java.changes.mc.product_tree-tag-50
@@ -1,0 +1,3 @@
+- to prepare for the next SUSE Manager version set product_tree tag to
+  Beta and change the config value to SUMA5.0
+

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -550,6 +550,8 @@ install -m 644 conf/rhn_java_sso.conf $RPM_BUILD_ROOT%{_prefix}/share/rhn/config
 # Adjust product tree tag
 %if 0%{?is_opensuse}
 sed -i -e 's/^java.product_tree_tag =.*$/java.product_tree_tag = Uyuni/' $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_java.conf
+%else
+sed -i -e 's/^java.product_tree_tag =.*$/java.product_tree_tag = Beta/' $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_java.conf
 %endif
 # Adjust languages
 sed -i -e '/# NOTE: for the RPMs this is defined at the SPEC!/d' $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_java.conf


### PR DESCRIPTION
## What does this PR change?

Prepare for the next SUSE Manager major version, set product_tree tag to Beta and change the config value to SUMA5.0

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered
  @uyuni-project/qe This change will make the "Beta Client Tools Channels" visible in the Product Page. This needs to be handled in the testsuite. 

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
