### PR TITLE
Fix NullPointerException when checking for duplicate credentials

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/channel/test/ChannelFamilyTest.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/test/ChannelFamilyTest.java
@@ -65,10 +65,21 @@ public class ChannelFamilyTest extends BaseTestCaseWithUser {
      * @return the channel family
      */
     public static ChannelFamily ensureChannelFamilyExists(User user, String label) {
+        return ensureChannelFamilyExists(user, label, label);
+    }
+
+    /**
+     * Utility method that ensures that a channel family exists.
+     * @param user the user
+     * @param label the label
+     * @param name the name
+     * @return the channel family
+     */
+    public static ChannelFamily ensureChannelFamilyExists(User user, String label, String name) {
         ChannelFamily cf = ChannelFamilyFactory.lookupByLabel(label, null);
         if (cf == null) {
             cf = ChannelFamilyFactoryTest.createTestChannelFamily(user, true, TestUtils.randomString());
-            cf.setName(label);
+            cf.setName(name);
             cf.setLabel(label);
             ChannelFamilyFactory.save(cf);
         }

--- a/java/code/src/com/redhat/rhn/manager/setup/MirrorCredentialsManager.java
+++ b/java/code/src/com/redhat/rhn/manager/setup/MirrorCredentialsManager.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -133,7 +134,7 @@ public class MirrorCredentialsManager {
         // Check if the supplied user name already exists in stored credentials
         for (SCCCredentials existingCred : CredentialsFactory.listSCCCredentials()) {
             if (existingCred.getUsername().equals(creds.getUser()) &&
-                    (!creds.getId().equals(existingCred.getId()))) {
+                    (!Objects.equals(existingCred.getId(), creds.getId()))) {
                 throw new MirrorCredentialsNotUniqueException("Username already exists");
             }
         }

--- a/java/code/src/com/redhat/rhn/manager/setup/SubscriptionDto.java
+++ b/java/code/src/com/redhat/rhn/manager/setup/SubscriptionDto.java
@@ -30,6 +30,17 @@ public class SubscriptionDto {
      * Constructor.
      *
      * @param nameIn the name
+     * @param startDateIn the start date
+     * @param endDateIn the end date
+     */
+    public SubscriptionDto(String nameIn, Date startDateIn, Date endDateIn) {
+        this(nameIn, null, null, startDateIn, endDateIn);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param nameIn the name
      * @param productClassIn the product class
      * @param consumedIn consumed
      * @param startDateIn the start date

--- a/java/code/src/com/redhat/rhn/manager/setup/test/MirrorCredentialsManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/setup/test/MirrorCredentialsManagerTest.java
@@ -16,11 +16,13 @@ package com.redhat.rhn.manager.setup.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.rhn.manager.content.ContentSyncException;
 import com.redhat.rhn.manager.setup.MirrorCredentialsDto;
 import com.redhat.rhn.manager.setup.MirrorCredentialsManager;
+import com.redhat.rhn.manager.setup.MirrorCredentialsNotUniqueException;
 import com.redhat.rhn.testing.RhnMockStrutsTestCase;
 import com.redhat.rhn.testing.TestUtils;
 
@@ -137,6 +139,16 @@ public class MirrorCredentialsManagerTest extends RhnMockStrutsTestCase {
         assertTrue(credsManager.findMirrorCredentials(creds2.getId()).isPrimary());
     }
 
+    @Test
+    public void throwsExceptionIfCredentialsWithSameUsernameAlreadyExists() {
+        MirrorCredentialsDto creds = storeTestCredentials();
+
+        Exception ex = assertThrows(MirrorCredentialsNotUniqueException.class,
+            () -> storeTestCredentials(creds.getUser(), creds.getPassword()));
+
+        assertEquals("Username already exists", ex.getMessage());
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -160,14 +172,25 @@ public class MirrorCredentialsManagerTest extends RhnMockStrutsTestCase {
     }
 
     /**
-     * Store test credentials for a given id.
-     *
-     * @param id the id of stored credentials
+     * Store test credentials.
+     * @return a DTO representing the created credentials
      */
     private MirrorCredentialsDto storeTestCredentials() throws ContentSyncException {
+        return storeTestCredentials("testuser-" + TestUtils.randomString(), "testpass-" + TestUtils.randomString());
+    }
+
+    /**
+     * Store test credentials for a given id.
+     *
+     * @param userIn the username
+     * @param passwordIn the password
+
+     * @return a DTO representing the created credentials
+     */
+    private MirrorCredentialsDto storeTestCredentials(String userIn, String passwordIn) throws ContentSyncException {
         MirrorCredentialsDto creds = new MirrorCredentialsDto();
-        creds.setUser("testuser-" + TestUtils.randomString());
-        creds.setPassword("testpass-" + TestUtils.randomString());
+        creds.setUser(userIn);
+        creds.setPassword(passwordIn);
         long dbId = credsManager.storeMirrorCredentials(creds, request);
         creds.setId(dbId);
         return creds;

--- a/java/code/src/com/redhat/rhn/manager/setup/test/MirrorCredentialsManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/setup/test/MirrorCredentialsManagerTest.java
@@ -16,20 +16,31 @@ package com.redhat.rhn.manager.setup.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.redhat.rhn.domain.channel.test.ChannelFamilyTest;
+import com.redhat.rhn.frontend.xmlrpc.sync.content.ContentSyncSource;
 import com.redhat.rhn.manager.content.ContentSyncException;
+import com.redhat.rhn.manager.content.ContentSyncManager;
 import com.redhat.rhn.manager.setup.MirrorCredentialsDto;
 import com.redhat.rhn.manager.setup.MirrorCredentialsManager;
 import com.redhat.rhn.manager.setup.MirrorCredentialsNotUniqueException;
+import com.redhat.rhn.manager.setup.SubscriptionDto;
 import com.redhat.rhn.testing.RhnMockStrutsTestCase;
 import com.redhat.rhn.testing.TestUtils;
+
+import com.suse.cloud.CloudPaygManager;
+import com.suse.scc.model.SCCSubscriptionJson;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -147,6 +158,63 @@ public class MirrorCredentialsManagerTest extends RhnMockStrutsTestCase {
             () -> storeTestCredentials(creds.getUser(), creds.getPassword()));
 
         assertEquals("Username already exists", ex.getMessage());
+    }
+
+    @Test
+    public void canRetrieveListOfSubscriptions() {
+        MirrorCredentialsDto creds = storeTestCredentials();
+
+        ChannelFamilyTest.ensureChannelFamilyExists(user, "MODULE", "SUSE Linux Enterprise Modules");
+        ChannelFamilyTest.ensureChannelFamilyExists(user, "SLE-M-T", "SUSE Manager Tools");
+        ChannelFamilyTest.ensureChannelFamilyExists(user, "SMS", "SUSE Manager Server");
+        ChannelFamilyTest.ensureChannelFamilyExists(user, "SMP", "SUSE Manager Proxy");
+
+        // Mock the content sync manager to return a known set of subscriptions
+        credsManager = new MirrorCredentialsManager(new CloudPaygManager(), new ContentSyncManager() {
+
+            @Override
+            public List<SCCSubscriptionJson> updateSubscriptions(ContentSyncSource source) throws ContentSyncException {
+                return List.of(
+                    new SCCSubscriptionJson("One", "ACTIVE", "2023-10-03T10:15:00.00Z", "2026-10-03T10:15:00.00Z",
+                        List.of("MODULE")
+                    ),
+                    new SCCSubscriptionJson("two", "EXPIRED", "2022-10-03T08:10:23.00Z", "2023-10-03T17:15:30.00Z",
+                        List.of("SLE-M-T")
+                    ),
+                    new SCCSubscriptionJson("three", "ACTIVE", "2023-06-20T00:00:00.00Z", "2025-06-20T00:00:00.00Z",
+                        List.of()
+                    ),
+                    new SCCSubscriptionJson("four", "ACTIVE", "2020-01-01T12:30:00.00Z", "2030-01-01T12:30:00.00Z",
+                        List.of("SMS", "SMP", "SMQ") // SMQ does not exist, code should use the label as is
+                    )
+                );
+            }
+        });
+
+        List<SubscriptionDto> subscriptions = credsManager.getSubscriptions(creds, request, true);
+
+        assertNotNull(subscriptions);
+        assertEquals(2, subscriptions.size()); // Only one and four should be included
+
+        assertEquals(subscriptions.get(0).getName(), "SUSE Linux Enterprise Modules");
+        assertEquals(
+            Date.from(LocalDateTime.of(2023, 10, 3, 10, 15, 0, 0).atOffset(ZoneOffset.UTC).toInstant()),
+            subscriptions.get(0).getStartDate()
+        );
+        assertEquals(
+            Date.from(LocalDateTime.of(2026, 10, 3, 10, 15, 0, 0).atOffset(ZoneOffset.UTC).toInstant()),
+            subscriptions.get(0).getEndDate()
+        );
+
+        assertEquals(subscriptions.get(1).getName(), "SUSE Manager Server OR SUSE Manager Proxy OR SMQ");
+        assertEquals(
+            Date.from(LocalDateTime.of(2020, 1, 1, 12, 30, 0, 0).atOffset(ZoneOffset.UTC).toInstant()),
+            subscriptions.get(1).getStartDate()
+        );
+        assertEquals(
+            Date.from(LocalDateTime.of(2030, 1, 1, 12, 30, 0, 0).atOffset(ZoneOffset.UTC).toInstant()),
+            subscriptions.get(1).getEndDate()
+        );
     }
 
     /**

--- a/java/code/src/com/suse/scc/model/SCCSubscriptionJson.java
+++ b/java/code/src/com/suse/scc/model/SCCSubscriptionJson.java
@@ -49,6 +49,30 @@ public class SCCSubscriptionJson {
     private List<String> skus = new ArrayList<>();
 
     /**
+     * Default constructor
+     */
+    public SCCSubscriptionJson() {
+    }
+
+    /**
+     * Constructor used in unit tests.
+     *
+     * @param nameIn the name of the subscription
+     * @param statusIn the status
+     * @param startsAtIn the start instant in ISO-8601 format
+     * @param expiresAtIn the expiration instant in ISO-8601 format
+     * @param productClassesIn the list of product classes labels
+     */
+    public SCCSubscriptionJson(String nameIn, String statusIn, String startsAtIn, String expiresAtIn,
+                               List<String> productClassesIn) {
+        this.name = nameIn;
+        this.status = statusIn;
+        this.startsAt = startsAtIn;
+        this.expiresAt = expiresAtIn;
+        this.productClasses = productClassesIn;
+    }
+
+    /**
      * @return the id
      */
     public Long getId() {

--- a/java/spacewalk-java.changes.mackdk.fix-npe-store-credentials
+++ b/java/spacewalk-java.changes.mackdk.fix-npe-store-credentials
@@ -1,0 +1,2 @@
+- Fixed issue when checking for credential duplication 
+  (bsc#1218957)

--- a/susemanager-utils/testing/docker/scripts/init-pgsql-db4eclipse.sh
+++ b/susemanager-utils/testing/docker/scripts/init-pgsql-db4eclipse.sh
@@ -2,6 +2,13 @@
 
 set -e
 
+# Check if the schema package is using the new directory structure, otherwise the upgrade files are in the old
+# place and so we need a symlink to make the schema upgrade script able to pick them up
+if [ ! -d /usr/share/susemanager/db ]; then
+    mkdir -p /usr/share/susemanager
+    ln -s /etc/sysconfig/rhn /usr/share/susemanager/db
+fi
+
 cd /manager/susemanager-utils/testing/docker/scripts/
 
 # Move Postgres database to tmpfs to speed initialization and testing up

--- a/susemanager-utils/testing/docker/scripts/init-pgsql-reportdb4eclipse.sh
+++ b/susemanager-utils/testing/docker/scripts/init-pgsql-reportdb4eclipse.sh
@@ -2,6 +2,13 @@
 
 set -e
 
+# Check if the schema package is using the new directory structure, otherwise the upgrade files are in the old
+# place and so we need a symlink to make the schema upgrade script able to pick them up
+if [ ! -d /usr/share/susemanager/db ]; then
+    mkdir -p /usr/share/susemanager
+    ln -s /etc/sysconfig/rhn /usr/share/susemanager/db
+fi
+
 cd /manager/susemanager-utils/testing/docker/scripts/
 
 # Move Postgres database to tmpfs to speed initialization and testing up


### PR DESCRIPTION
## What does this PR change?

This PR fixes a `NullPointerException` that happens when the user tries to create a new mirror credential using a username already associated with an existing credentials. Currently the code throws exception preventing the user to be notified about the error.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23459
Port(s): https://github.com/SUSE/spacewalk/pull/23474

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
