### PR TITLE
Add a warning message for interactive shells

### DIFF
--- a/containers/server-image/Dockerfile
+++ b/containers/server-image/Dockerfile
@@ -76,6 +76,10 @@ COPY taskomatic_jmx.conf /usr/lib/systemd/system/taskomatic.service.d/jmx.conf
 
 RUN chmod -R 755 /usr/bin/timezone_alignment.sh
 
+# Set a warning message for interactive shells
+COPY motd /etc/motd
+RUN echo "cat /etc/motd" >/etc/sh.shrc.local
+
 RUN systemctl enable prometheus-node_exporter; \
     systemctl enable uyuni-setup; \
     systemctl enable timezone_alignment;

--- a/containers/server-image/motd
+++ b/containers/server-image/motd
@@ -1,0 +1,9 @@
+===============================================================================
+!
+! This shell operates within a container environment, meaning that not all
+! modifications will be permanently saved in volumes.
+!
+! Please exercise caution when making changes, as some alterations may not
+! persist beyond the current session.
+!
+===============================================================================

--- a/containers/server-image/server-image.changes.cbosdonnat.shell-warning
+++ b/containers/server-image/server-image.changes.cbosdonnat.shell-warning
@@ -1,0 +1,1 @@
+- Add warning message for interactive shells


### PR DESCRIPTION
## What does this PR change?

To be very clear that entering a shell in a container may be dangerous, add a warning about the risk for interactive shells.

For sh shells we'll add `ENV=/etc/sh.shrc.local` in uyuni-tools. See https://github.com/uyuni-project/uyuni-tools/pull/133

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23455

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
