### PR TITLE
Testsuite: add 5.0 version in the product_version method

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -50,8 +50,8 @@ def product_version
 end
 
 def use_salt_bundle
-  # Use venv-salt-minion in Uyuni, or SUMA Head, 4.2 and 4.3
-  product == 'Uyuni' || %w[head 4.3 4.2].include?(product_version)
+  # Use venv-salt-minion in Uyuni, or SUMA Head, 5.0, 4.2 and 4.3
+  product == 'Uyuni' || %w[head 5.0 4.3 4.2].include?(product_version)
 end
 
 # WARN: It's working for /24 mask, but couldn't not work properly with others


### PR DESCRIPTION
## What does this PR change?

Adds 5.0 to the product version method of the testsuite.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed
- [ ] **DONE**

## Test coverage
- No tests
- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23081


- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
