### PR TITLE
Update help text for the custom repo filter field (bsc#1217874)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -9025,7 +9025,16 @@ Please note that some manual configuration of these scripts may still be require
         <source>Filters</source>
       </trans-unit>
       <trans-unit id="repos.jsp.filters.tip" xml:space="preserve">
-        <source>-zsh*,kernel +zsh-html</source>
+          <source>
+              &lt;strong&gt;Filter syntax:&lt;/strong&gt; &lt;code&gt;[+-]keyword[,keyword ...]&lt;/code&gt;&lt;br/&gt;
+              Use &lt;strong&gt;'+'&lt;/strong&gt; to include only the package names matching the keyword and
+              &lt;strong&gt;'-'&lt;/strong&gt; to exclude the package names matching the keyword. Multiple filters can be
+              separated with spaces. Filters are evaluated in the order that they are specified. Shell-style wildcards
+              are supported.&lt;br/&gt;&lt;br/&gt;
+              &lt;strong&gt;Example:&lt;/strong&gt; &lt;code&gt;+zsh*,kernel* -zsh-html&lt;/code&gt;&lt;br/&gt;
+              &lt;em&gt;* Only include packages named &lt;code&gt;zsh*&lt;/code&gt; and &lt;code&gt;kernel*&lt;/code&gt;,
+              except &lt;code&gt;zsh-html&lt;/code&gt;&lt;/em&gt;
+          </source>
       </trans-unit>
       <trans-unit id="repos.jsp.filters.error" xml:space="preserve">
         <source>Filter syntax is incorrect!</source>

--- a/java/code/webapp/WEB-INF/pages/channel/manage/repo/repodetails.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/manage/repo/repodetails.jsp
@@ -112,7 +112,7 @@
                         <div class="col-lg-6">
                             <html:text property="filters" styleClass="form-control"/>
                             <span class="help-block">
-                                <rhn:tooltip key="repos.jsp.filters.tip"/>
+                                <bean:message key="repos.jsp.filters.tip"/>
                             </span>
                         </div>
             </div>

--- a/java/spacewalk-java.changes.cbbayburt.bsc1217874
+++ b/java/spacewalk-java.changes.cbbayburt.bsc1217874
@@ -1,0 +1,1 @@
+- Update help text for the custom repo filter field (bsc#1217874)


### PR DESCRIPTION
The help text for the "Filters" field in the custom repo details form is not descriptive/correct. This PR adds a proper explanation and a correct example.

## GUI diff

Before:
![Screenshot from 2024-01-23 12-41-13](https://github.com/uyuni-project/uyuni/assets/1103552/a82b0ebb-173a-4602-993e-822ee0c211ad)


After:
![Screenshot from 2024-01-23 12-27-03](https://github.com/uyuni-project/uyuni/assets/1103552/41f3013a-cafb-4dde-9fd8-519fa8ceb62c)


## Documentation
- No documentation needed

## Test coverage
- No tests: static UI

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23169

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
