### PR TITLE
QE: return a SystemCallError on failing XMLRPC calls

### DIFF
--- a/testsuite/features/support/xmlrpc_client.rb
+++ b/testsuite/features/support/xmlrpc_client.rb
@@ -24,7 +24,8 @@ class XmlrpcClient
   #   params: A hash of parameters. The keys are the names of the parameters, and the values are the values of the
   # parameters.
   def call(name, params)
-    # TODO: What happens if params.nil?
     @xmlrpc_client.call(name, *params.values)
+  rescue XMLRPC::FaultException => e
+    raise SystemCallError, "API failure: #{e.message}"
   end
 end


### PR DESCRIPTION
## What does this PR change?

Closes https://github.com/SUSE/spacewalk/issues/23499
Read the card for a more in depth analysis.

Our testsuite expects a SystemCallError to be raised when an API call fails. At the moment, only the HTTP client does so.
This PR adds the same behavior to the XMLRPC client we have in our testsuite.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Files related to the Cucumber testsuite were modified

- [x] **DONE**

## Links

Issue(s):  https://github.com/SUSE/spacewalk/issues/23499
Ports(s): Manager 4.3 https://github.com/SUSE/spacewalk/pull/23505

- [x] **DONE**

## Changelogs

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
