### PR TITLE
QE: fix date-picker CSS selector

### DIFF
--- a/testsuite/features/step_definitions/datepicker_steps.rb
+++ b/testsuite/features/step_definitions/datepicker_steps.rb
@@ -74,7 +74,7 @@ When(/^I schedule action to (\d+) minutes from now$/) do |minutes|
   action_datetime = (DateTime.now + (Rational(1, 1440) * minutes.to_i) + Rational(59, 86_400)).strftime('%Y-%m-%dT%H:%M')
   action_date, action_time = action_datetime.split('T')
 
-  date_input = find('input[data-testid="date-picker"]]')
+  date_input = find('input[data-testid="date-picker"]')
   date_input.click
   # TODO: Switch this over to .clear once we update Selenium
   date_input.send_keys [:control, 'a'], :backspace, action_date, :enter


### PR DESCRIPTION
## What does this PR change?

Title
Related to https://github.com/SUSE/spacewalk/issues/23506

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- A step used in the Cucumber testsuite has been fixed

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23506
Ports(s): Manager 4.3

- [x] **DONE**

## Changelogs


- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

