### PR TITLE
Add getRelevantErrata endpoint that takes a list of sids

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -3486,6 +3486,45 @@ public class SystemHandler extends BaseHandler {
     }
 
     /**
+     * Returns a list of all errata that are relevant to the system.
+     *
+     * @param loggedInUser The current user
+     * @param sids The ids of the systems in question
+     * @return Returns an array of maps representing the errata that can be applied
+     * @throws FaultException A FaultException is thrown if the server corresponding to
+     * sid cannot be found.
+     *
+     * @apidoc.doc Returns a list of all errata that are relevant to the system.
+     * @apidoc.param #session_key()
+     * @apidoc.param #array_single("int", "sids")
+     * @apidoc.returntype
+     *      #return_array_begin()
+     *          #struct_begin("server_errata")
+     *              #prop_desc("string", "system_id", "The ID of the system")
+     *              #prop_array_begin_desc("errata", "An array of available errata infos")
+     *                  $ErrataOverviewSerializer
+     *              #prop_array_end()
+     *          #struct_end()
+     *      #array_end()
+     */
+    @ReadOnly
+    public List<Map<String, Object>> getRelevantErrata(User loggedInUser, List<Integer> sids) {
+        List<Map<String, Object>> result = new ArrayList<>();
+        List<Server> servers = this.xmlRpcSystemHelper.lookupServers(loggedInUser, sids);
+
+        for (Server server : servers) {
+          Map<String, Object> serverMap = new HashMap<>();
+          Long serverId = server.getId();
+          DataResult<ErrataOverview> serverResult = SystemManager.relevantErrata(loggedInUser, serverId);
+          serverMap.put("system_id", serverId.toString());
+          serverMap.put("errata", serverResult);
+          result.add(serverMap);
+        }
+
+        return result;
+    }
+
+    /**
      * Returns a list of all errata of the specified type that are relevant to the system.
      * @param loggedInUser The current user
      * @param sid serverId

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -3486,15 +3486,16 @@ public class SystemHandler extends BaseHandler {
     }
 
     /**
-     * Returns a list of all errata that are relevant to the system.
+     * Returns a list of all errata that are relevant to a list of systems.
      *
      * @param loggedInUser The current user
      * @param sids The ids of the systems in question
-     * @return Returns an array of maps representing the errata that can be applied
-     * @throws FaultException A FaultException is thrown if the server corresponding to
-     * sid cannot be found.
+     * @return Returns an array of maps representing the errata that can be applied to
+     * each system
+     * @throws FaultException A FaultException is thrown if the server in the list
+     * cannot be found.
      *
-     * @apidoc.doc Returns a list of all errata that are relevant to the system.
+     * @apidoc.doc Returns a list of all errata that are relevant to a list of systems.
      * @apidoc.param #session_key()
      * @apidoc.param #array_single("int", "sids")
      * @apidoc.returntype

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -1589,6 +1589,43 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
     }
 
     @Test
+    public void testGetRelevantErrataWithListOfSids() throws Exception {
+
+        Errata firstErrata = ErrataFactoryTest.createTestErrata(admin.getOrg().getId());
+        firstErrata.setAdvisoryType(ErrataFactory.ERRATA_TYPE_BUG);
+
+        Errata secondErrata = ErrataFactoryTest.createTestErrata(admin.getOrg().getId());
+        secondErrata.setAdvisoryType(ErrataFactory.ERRATA_TYPE_BUG);
+
+        TestUtils.flushAndEvict(firstErrata);
+        TestUtils.flushAndEvict(secondErrata);
+
+        Server firstServer = ServerFactoryTest.createTestServer(admin);
+        Server secondServer = ServerFactoryTest.createTestServer(admin);
+        ServerFactory.save(firstServer);
+        ServerFactory.save(secondServer);
+        TestUtils.flushAndEvict(firstServer);
+        TestUtils.flushAndEvict(secondServer);
+
+        UserFactory.save(admin);
+        TestUtils.flushAndEvict(admin);
+
+        Package packageOne = firstErrata.getPackages().iterator().next();
+        Package packageTwo = secondErrata.getPackages().iterator().next();
+
+        ErrataCacheManager.insertNeededErrataCache(
+                firstServer.getId(), firstErrata.getId(), packageOne.getId());
+        ErrataCacheManager.insertNeededErrataCache(
+                secondServer.getId(), secondErrata.getId(), packageTwo.getId());
+
+        List<Integer> sids = Arrays.asList(firstServer.getId().intValue(), secondServer.getId().intValue());
+
+        List<Map<String, Object>> list = handler.getRelevantErrata(admin, sids);
+
+        assertEquals(list.size(), 2);
+    }
+
+    @Test
     public void testGetRelevantErrataByType() {
         Server server = ServerFactoryTest.createTestServer(admin, true);
 

--- a/java/spacewalk-java.changes.dottorblaster.get-relevant-errata-multiple-sids
+++ b/java/spacewalk-java.changes.dottorblaster.get-relevant-errata-multiple-sids
@@ -1,0 +1,1 @@
+- new API endpoint for getRelevantErrata, taking multiple servers as argument


### PR DESCRIPTION
## What does this PR change?

Solves (at least I hope so) #8183.

Adds a new endpoint to the API that lets `getRelevantErrata` have a list of `sid`s as a parameter. 

## GUI diff

No difference.

Before:

After:

- [X] **DONE**

## Documentation
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- I hope I got it right!


- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Issue(s): #8183 

- [X] **DONE**

## Changelogs

I still need to write an entry.

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
