### PR TITLE
QE: Add testing for credential editing

### DIFF
--- a/testsuite/features/secondary/srv_scc_user_credentials.feature
+++ b/testsuite/features/secondary/srv_scc_user_credentials.feature
@@ -30,7 +30,7 @@ Feature: SCC user credentials in the Setup Wizard
     And I view the subscription list for "SCC user"
     And I wait until I see "No subscriptions available" text
     And I click on "Close"
-    
+
   Scenario: Enter duplicate SCC credentials
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Organization Credentials"
@@ -47,8 +47,18 @@ Feature: SCC user credentials in the Setup Wizard
     When I click on "Cancel"
     Then the credentials for "invalidname" should be invalid
 
-# TODO
-# A test to edit the credentials is missing
+  Scenario: Edit credentials
+    Given I am authorized for the "Admin" section
+    When I follow the left menu "Admin > Setup Wizard > Organization Credentials"
+    And I ask to edit the credentials for "invalidname"
+    And I enter "SCC user" as "edit-user"
+    And I enter "geekogeeko" as "edit-password"
+    And I click on "Save"
+    Then I should see a "Credentials with this username already exist" text
+    When I enter "invalidgeeko" as "edit-user"
+    And I click on "Save"
+    Then I should see a "invalidgeeko" text
+    And the credentials for "invalidgeeko" should be invalid
 
   Scenario: Cleanup: delete the new organization credentials
     When I follow the left menu "Admin > Setup Wizard > Organization Credentials"
@@ -56,7 +66,7 @@ Feature: SCC user credentials in the Setup Wizard
     And I ask to delete the credentials for "SCC user"
     And I click on "Delete" in "Are you sure you want to delete these credentials?" modal
     Then I wait until I do not see "SCC user" text
-    When I wait for the trash icon to appear for "invalidname"
-    And I ask to delete the credentials for "invalidname"
+    When I wait for the trash icon to appear for "invalidgeeko"
+    And I ask to delete the credentials for "invalidgeeko"
     And I click on "Delete" in "Are you sure you want to delete these credentials?" modal
-    Then I wait until I do not see "invalidname" text
+    Then I wait until I do not see "invalidgeeko" text

--- a/testsuite/features/step_definitions/setup_steps.rb
+++ b/testsuite/features/step_definitions/setup_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 SUSE LLC.
+# Copyright (c) 2024 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 ### This file contains all steps concerning setting up a test environment.

--- a/testsuite/features/step_definitions/setup_steps.rb
+++ b/testsuite/features/step_definitions/setup_steps.rb
@@ -61,6 +61,12 @@ When(/^I wait for the trash icon to appear for "([^"]*)"$/) do |user|
   end
 end
 
+When(/^I ask to edit the credentials for "([^"]*)"$/) do |user|
+  within(:xpath, "//h3[contains(text(), '#{user}')]/../..") do
+    raise ScriptError, 'Click on pencil icon failed' unless find('i.fa-pencil').click
+  end
+end
+
 When(/^I ask to delete the credentials for "([^"]*)"$/) do |user|
   within(:xpath, "//h3[contains(text(), '#{user}')]/../..") do
     raise ScriptError, 'Click on trash icon failed' unless find('i.fa-trash-o').click


### PR DESCRIPTION
## What does this PR change?
Credential editing was not being tested by the testsuite until now.
This additional scenario and the new step definition it depends on allow for testing of the credential-editing functionality, including behavior when entering an already existing name.

## GUI diff
No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s):
Ports(s):

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
