### PR TITLE
QE: Force FQDN check to run locally on the host

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -13,7 +13,7 @@ require 'date'
 
 Then(/^"([^"]*)" should have a FQDN$/) do |host|
   node = get_target(host)
-  result, return_code = node.run('date +%s; hostname -f; date +%s', check_errors: false)
+  result, return_code = node.run_local('date +%s; hostname -f; date +%s', check_errors: false)
   lines = result.split("\n")
   initial_time = lines[0]
   result = lines[1]


### PR DESCRIPTION
# What does this PR change?
There are issues when using only rum() where the command could potentially be executed inside a container instead of the host. With this change, we force the execution on the host.

`hotname -f` on our 5.0 does not return anything useful according to Cedric.


## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage
- Cucumber tests were edited

- [x] **DONE**

## Links

Issue(s): #
Ports(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!](<## What does this PR change?
