### PR TITLE
QE: Add removed FQDN server check

### DIFF
--- a/testsuite/features/core/allcli_sanity.feature
+++ b/testsuite/features/core/allcli_sanity.feature
@@ -6,6 +6,7 @@ Feature: Sanity checks
   I want to be sure to use a sane environment
 
   Scenario: The server is healthy
+    Then "proxy" should have a FQDN
     Then reverse resolution should work for "server"
     And the clock from "server" should be exact
     And service "apache2" is enabled on "server"


### PR DESCRIPTION
## What does this PR change?

This test was removed since it would have checked the FQDN of a container if we had one. With
https://github.com/uyuni-project/uyuni/pull/8210 this check now explicitly checks the FQDN on the host OS.


## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage
- Cucumber tests were edited

- [x] **DONE**

## Links

Issue(s): #
Ports(s): none

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!](<## What does this PR change?