### PR TITLE
QE: refactor and fix "Create and modify a System profile using the XML-RPC API" scenario

### DIFF
--- a/testsuite/features/secondary/srv_cobbler_profile.feature
+++ b/testsuite/features/secondary/srv_cobbler_profile.feature
@@ -91,9 +91,7 @@ Feature: Edit Cobbler profiles
     When I create a system record with name "isesystem_api" and kickstart label "iseprofile_api"
 
   Scenario: Create and modify a System profile using the XML-RPC API
-    # This should intentionally fail and XML-RPC should return an error here until
-    # https://github.com/uyuni-project/uyuni/pull/6676 gets merged by Ion
-    When I create and modify the kickstart system "isesystem_api" with hostname "ise-system.test" via XML-RPC
+    When I create and modify the kickstart system "isesystem_api" with kickstart label "iseprofile_api" and hostname "ise-system.test" via XML-RPC
       | inst.repo   | http://ise.cobbler.test |
       | self_update | http://ise.cobbler.test |
 

--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -550,9 +550,13 @@ Then(/^"([^"]*)" should be present in the result$/) do |profile_name|
   assert($output.select { |p| p['name'] == profile_name }.count == 1)
 end
 
-When(/^I create and modify the kickstart system "([^"]*)" with hostname "([^"]*)" via XML-RPC$/) do |name, hostname, values|
-  system_id = $api_test.system.create_system_profile(name, 'hostname' => hostname)
-  $stdout.puts "system_id: #{system_id}"
+When(/^I create and modify the kickstart system "([^"]*)" with kickstart label "([^"]*)" and hostname "([^"]*)" via XML-RPC$/) do |name, kslabel, hostname, values|
+  # even though it should not happen during a testsuite run, it is useful to know when debugging that
+  # this call will raise a SystemCallError if matching systems already exist, the Error message will include a list of the matchings system IDs
+  sid = $api_test.system.create_system_profile(name, 'hostname' => hostname)
+  $stdout.puts "system_id: #{sid}"
+
+  $api_test.system.create_system_record_with_sid(sid, kslabel)
   # this works only with a 2 column table where the key is in the left column
   variables = values.rows_hash
   $api_test.system.set_variables(system_id, variables)

--- a/testsuite/features/support/namespaces/system.rb
+++ b/testsuite/features/support/namespaces/system.rb
@@ -125,7 +125,7 @@ class NamespaceSystem
   end
 
   ##
-  # Creates a system record on the SUMA server.
+  # Creates a Cobbler system record for a system that is not registered on the SUMA server.
   #
   # Args:
   #   name: The name of the system record.
@@ -136,6 +136,16 @@ class NamespaceSystem
   # is the IP address.  For example: #TODO
   def create_system_record(name, kslabel, koptions, comment, netdevices)
     @test.call('system.createSystemRecord', sessionKey: @test.token, systemName: name, ksLabel: kslabel, kOptions: koptions, comment: comment, netDevices: netdevices)
+  end
+
+  ##
+  # Creates a cobbler system record with the specified kickstart label
+  #
+  # Args:
+  #   sid: The system id
+  #   kslabel: The kickstart label you want to use.
+  def create_system_record_with_sid(sid, kslabel)
+    @test.call('system.createSystemRecord', sessionKey: @test.token, sid: sid, ksLabel: kslabel)
   end
 
   ##

--- a/testsuite/features/support/namespaces/system.rb
+++ b/testsuite/features/support/namespaces/system.rb
@@ -139,7 +139,7 @@ class NamespaceSystem
   end
 
   ##
-  # Creates a cobbler system record with the specified kickstart label
+  # Creates a Cobbler system record with the specified kickstart label
   #
   # Args:
   #   sid: The system id


### PR DESCRIPTION
## What does this PR change?

Related to https://github.com/SUSE/spacewalk/issues/22651 - detailed info in the comments

Implement and add an API call to system.createSystemRecord using the SID and kickstart label

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- One Cucumber testsuite scenario and its step definition have been modified.

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/22651
Ports(s): Manager 4.3 https://github.com/SUSE/spacewalk/pull/23535

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [x] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
