### PR TITLE
import SUSE Manager Build Keys into the rpm keyring

### DIFF
--- a/spacewalk/admin/Makefile.admin
+++ b/spacewalk/admin/Makefile.admin
@@ -35,7 +35,8 @@ SCRIPTS = rhn-config-satellite.pl \
                rhn-install-ssl-cert.pl \
                salt-secrets-config.py
 
-SBIN_SCRIPTS = rhn-sat-restart-silent spacewalk-service spacewalk-startup-helper mgr-monitoring-ctl uyuni-update-config
+SBIN_SCRIPTS = rhn-sat-restart-silent spacewalk-service spacewalk-startup-helper mgr-monitoring-ctl uyuni-update-config \
+	       import-suma-build-keys
 
 CONF_FILES =
 

--- a/spacewalk/admin/import-suma-build-keys
+++ b/spacewalk/admin/import-suma-build-keys
@@ -3,6 +3,7 @@
 PUBRINGDIR="/var/lib/spacewalk/gpgdir"
 PUBRING="${PUBRINGDIR}/pubring.gpg"
 SUSERING="/usr/lib/susemanager/susemanager-build-keys.gpg"
+CUSTRING="/var/spacewalk/gpg/customer-build-keys.gpg"
 
 if [ ! -f ${PUBRING} ]; then
     touch ${PUBRING}
@@ -60,6 +61,65 @@ if [ "$c" = 0 -a "$d" = 0 ]; then
     echo "done."
 else
     echo "trusting the key from the file ${SUSERING}"
+    echo "returned an error. This should not happen. It may not be possible"
+    echo "to properly sync repositories using spacewalk-repo-sync."
+    exit -1
+fi
+
+if [ ! -s ${CUSTRING} ]; then
+    echo "No customer keyring to import"
+    exit 0
+fi
+
+echo -n "importing Customers build key to rpm keyring... "
+TF=`mktemp /tmp/gpg.XXXXXX`
+if [ -z "$TF" ]; then
+  echo "import-suma-build-keys: cannot make temporary file. Fatal error."
+  exit 20
+fi
+if [ -z "$HOME" ]; then
+  HOME=/root
+  export HOME
+fi
+if [ ! -d "$HOME" ]; then
+  mkdir "$HOME"
+fi
+
+gpg -q --batch --no-options --no-default-keyring --no-permission-warning \
+         --keyring ${CUSTRING}    --export -a > $TF
+e="$?"
+gpg -q --batch --no-options --no-default-keyring --no-permission-warning \
+         --keyring ${PUBRING}   --import < $TF
+f="$?"
+rm -f "$TF"
+if [ "$e" = 0 -a "$f" = 0 ]; then
+    echo "done."
+else
+    echo "importing the key from the file ${CUSTRING}"
+    echo "returned an error. This should not happen. It may not be possible"
+    echo "to properly verify the authenticity of rpm packages from 3rd party sources."
+    exit -1
+fi
+
+# we need to trust them, otherwise the verify will fail
+echo -n "Trusting Customers build keys... "
+TF=`mktemp /tmp/gpg.XXXXXX`
+if [ -z "$TF" ]; then
+  echo "import-suma-build-keys: cannot make temporary file. Fatal error."
+  exit 20
+fi
+gpg -q --batch --no-options --no-default-keyring --no-permission-warning \
+    --keyring ${CUSTRING} --list-keys --with-fingerprint \
+    --with-colons | grep fpr | awk -F: '{printf("%s:6:\n", $10);}' > $TF
+g="$?"
+gpg -q --batch --no-default-keyring --no-permission-warning \
+    --homedir ${PUBRINGDIR} --import-ownertrust < $TF
+h="$?"
+rm -f "$TF"
+if [ "$g" = 0 -a "$h" = 0 ]; then
+    echo "done."
+else
+    echo "trusting the key from the file ${CUSTRING}"
     echo "returned an error. This should not happen. It may not be possible"
     echo "to properly sync repositories using spacewalk-repo-sync."
     exit -1

--- a/spacewalk/admin/import-suma-build-keys
+++ b/spacewalk/admin/import-suma-build-keys
@@ -1,0 +1,67 @@
+#! /bin/bash
+
+PUBRINGDIR="/var/lib/spacewalk/gpgdir"
+PUBRING="${PUBRINGDIR}/pubring.gpg"
+SUSERING="/usr/lib/susemanager/susemanager-build-keys.gpg"
+
+if [ ! -f ${PUBRING} ]; then
+    touch ${PUBRING}
+fi
+echo -n "importing SUSE Manager build key to rpm keyring... "
+TF=`mktemp /tmp/gpg.XXXXXX`
+if [ -z "$TF" ]; then
+  echo "import-suma-build-keys: cannot make temporary file. Fatal error."
+  exit 20
+fi
+if [ -z "$HOME" ]; then
+  HOME=/root
+  export HOME
+fi
+if [ ! -d "$HOME" ]; then
+  mkdir "$HOME"
+fi
+gpg -q --batch --no-options < /dev/null > /dev/null 2>&1 || true
+# no kidding... gpg won't initialize correctly without being called twice.
+gpg < /dev/null > /dev/null 2>&1 || true
+gpg < /dev/null > /dev/null 2>&1 || true
+
+gpg -q --batch --no-options --no-default-keyring --no-permission-warning \
+         --keyring ${SUSERING}    --export -a > $TF
+a="$?"
+gpg -q --batch --no-options --no-default-keyring --no-permission-warning \
+         --keyring ${PUBRING}   --import < $TF
+b="$?"
+rm -f "$TF"
+if [ "$a" = 0 -a "$b" = 0 ]; then
+    echo "done."
+else
+    echo "importing the key from the file ${SUSERING}"
+    echo "returned an error. This should not happen. It may not be possible"
+    echo "to properly verify the authenticity of rpm packages from SUSE sources."
+    exit -1
+fi
+
+# we need to trust them, otherwise the verify will fail
+echo -n "Trusting SUSE Manager build keys... "
+TF=`mktemp /tmp/gpg.XXXXXX`
+if [ -z "$TF" ]; then
+  echo "import-suma-build-keys: cannot make temporary file. Fatal error."
+  exit 20
+fi
+gpg -q --batch --no-options --no-default-keyring --no-permission-warning \
+    --keyring ${SUSERING} --list-keys --with-fingerprint \
+    --with-colons | grep fpr | awk -F: '{printf("%s:6:\n", $10);}' > $TF
+c="$?"
+gpg -q --batch --no-default-keyring --no-permission-warning \
+    --homedir ${PUBRINGDIR} --import-ownertrust < $TF
+d="$?"
+rm -f "$TF"
+if [ "$c" = 0 -a "$d" = 0 ]; then
+    echo "done."
+else
+    echo "trusting the key from the file ${SUSERING}"
+    echo "returned an error. This should not happen. It may not be possible"
+    echo "to properly sync repositories using spacewalk-repo-sync."
+    exit -1
+fi
+

--- a/spacewalk/admin/import-suma-build-keys
+++ b/spacewalk/admin/import-suma-build-keys
@@ -51,7 +51,7 @@ if [ -z "$TF" ]; then
 fi
 gpg -q --batch --no-options --no-default-keyring --no-permission-warning \
     --keyring ${SUSERING} --list-keys --with-fingerprint \
-    --with-colons | grep fpr | awk -F: '{printf("%s:6:\n", $10);}' > $TF
+    --with-colons | awk -F: '/fpr/ {printf("%s:6:\n", $10);}' > $TF
 c="$?"
 gpg -q --batch --no-default-keyring --no-permission-warning \
     --homedir ${PUBRINGDIR} --import-ownertrust < $TF
@@ -110,7 +110,7 @@ if [ -z "$TF" ]; then
 fi
 gpg -q --batch --no-options --no-default-keyring --no-permission-warning \
     --keyring ${CUSTRING} --list-keys --with-fingerprint \
-    --with-colons | grep fpr | awk -F: '{printf("%s:6:\n", $10);}' > $TF
+    --with-colons | awk -F: '/fpr/ {printf("%s:6:\n", $10);}' > $TF
 g="$?"
 gpg -q --batch --no-default-keyring --no-permission-warning \
     --homedir ${PUBRINGDIR} --import-ownertrust < $TF

--- a/spacewalk/admin/spacewalk-admin.changes.mc.import-suma-build-keys
+++ b/spacewalk/admin/spacewalk-admin.changes.mc.import-suma-build-keys
@@ -1,0 +1,1 @@
+- import SUSE Manager Build Keys into the rpm keyring

--- a/spacewalk/admin/spacewalk-admin.spec
+++ b/spacewalk/admin/spacewalk-admin.spec
@@ -79,6 +79,7 @@ fi
 %{_sbindir}/spacewalk-startup-helper
 %{_sbindir}/spacewalk-service
 %{_sbindir}/uyuni-update-config
+%{_sbindir}/import-suma-build-keys
 %{_bindir}/rhn-config-satellite.pl
 %{_bindir}/rhn-config-schema.pl
 %{_bindir}/rhn-deploy-ca-cert.pl

--- a/spacewalk/admin/uyuni-update-config
+++ b/spacewalk/admin/uyuni-update-config
@@ -4,32 +4,52 @@
 import sys
 import os.path
 import uuid
+import subprocess
 from spacewalk.common.rhnConfig import initCFG, CFG
 
 initCFG('server.susemanager')
-try:
-    if CFG.scc_backup_srv_usr:
-        # nothing to do
-        sys.exit(0)
-except AttributeError:
-    # key does not exist, we need to create it
-    pass
 
-scc_cred_file = "/etc/zypp/credentials.d/SCCcredentials"
+def initSccLogin():
 
-uuidNum = None
-if os.path.exists(scc_cred_file):
-    with open(scc_cred_file, "r") as f:
-        for line in f:
-            if line.startswith("username"):
-                _k, v = line.split("=", 2)
-                uuidNum = v.strip()
-                break
-if not uuidNum:
-    # scc expects either a SCC machine login (must exists in SCC)
-    # or a UUID4 following rfc4122 to identify a anonyme proxy
-    uuidNum = str(uuid.uuid4())
-with open("/etc/rhn/rhn.conf", "a") as r:
-    r.write("\n")
-    r.write("server.susemanager.scc_backup_srv_usr = {}\n".format(uuidNum))
+    try:
+        if CFG.scc_backup_srv_usr:
+            # nothing to do
+            return
+    except AttributeError:
+        # key does not exist, we need to create it
+        pass
+
+    scc_cred_file = "/etc/zypp/credentials.d/SCCcredentials"
+
+    uuidNum = None
+    if os.path.exists(scc_cred_file):
+        with open(scc_cred_file, "r") as f:
+            for line in f:
+                if line.startswith("username"):
+                    _k, v = line.split("=", 2)
+                    uuidNum = v.strip()
+                    break
+    if not uuidNum:
+        # scc expects either a SCC machine login (must exists in SCC)
+        # or a UUID4 following rfc4122 to identify a anonyme proxy
+        uuidNum = str(uuid.uuid4())
+    with open("/etc/rhn/rhn.conf", "a") as r:
+        r.write("\n")
+        r.write("server.susemanager.scc_backup_srv_usr = {}\n".format(uuidNum))
+
+def importSumaGPGKeyring():
+
+    result = subprocess.run(
+            ["/usr/sbin/import-suma-build-keys"],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            encoding='utf-8')
+
+    if result.returncode:
+        sys.stdout.write("Failed to import SUSE Manager Build Keys\n")
+    sys.stdout.write("{}\n".format(result.stdout))
+    sys.stdout.flush()
+
+initSccLogin()
+importSumaGPGKeyring()
+
 sys.exit(0)


### PR DESCRIPTION
## What does this PR change?

When running Uyuni in container the SUSE Manager Build Keys will not get imported into the RPM DB as the `%post` script of the RPM package will not get executed.
This PR add this task to the startup of the container which give us the possibility to have a clean keyring available in the containers.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23524

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
