### PR TITLE
Don't change the /etc/motd at the end of the setup

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -1018,8 +1018,6 @@ if [ "$DO_SETUP" = "1" ]; then
 
     if [ -f $MANAGER_COMPLETE_HOOK ]; then
         $MANAGER_COMPLETE_HOOK
-    else
-        echo "You can access $PRODUCT_NAME via https://`hostname -f`" > /etc/motd
     fi
 fi
 wait_step

--- a/susemanager/susemanager.changes.cbosdonnat.no-motd
+++ b/susemanager/susemanager.changes.cbosdonnat.no-motd
@@ -1,0 +1,1 @@
+- Don't change /etc/motd in the setup (bsc#1219228)


### PR DESCRIPTION
## What does this PR change?

In a container the /etc/motd file is not persisted and defined in the container image, avoid writing this file in the setup.

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
