### PR TITLE
improve update systems via recurring states

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -9309,6 +9309,9 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
       <trans-unit id="internal_state.uptodate" xml:space="preserve">
         <source>Update the system, rebooting if required</source>
       </trans-unit>
+      <trans-unit id="internal_state.update-salt" xml:space="preserve">
+        <source>Perform a standalone Salt update</source>
+      </trans-unit>
       <trans-unit id="internal_state.util_syncbeacons" xml:space="preserve">
         <source>Sync Salt beacons to the target system</source>
       </trans-unit>

--- a/schema/spacewalk/common/data/suseInternalState.sql
+++ b/schema/spacewalk/common/data/suseInternalState.sql
@@ -40,3 +40,6 @@ INSERT INTO suseInternalState (id, name, label)
 
 INSERT INTO suseInternalState (id, name, label)
          VALUES (11, 'util.syncstates', 'Sync States');
+
+INSERT INTO suseInternalState (id, name, label)
+         VALUES (12, 'update-salt', 'Update Salt');

--- a/schema/spacewalk/susemanager-schema.changes.mcalmer.improve-uptodate
+++ b/schema/spacewalk/susemanager-schema.changes.mcalmer.improve-uptodate
@@ -1,0 +1,1 @@
+- add update-salt to internal state table

--- a/schema/spacewalk/upgrade/susemanager-schema-5.0.4-to-susemanager-schema-5.0.5/100-add-internal-state-update-salt.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.0.4-to-susemanager-schema-5.0.5/100-add-internal-state-update-salt.sql
@@ -1,0 +1,6 @@
+INSERT INTO suseInternalState (id, name, label)
+  SELECT 12, 'update-salt', 'Update Salt'
+   WHERE NOT EXISTS (
+	SELECT 1 FROM suseInternalState
+         WHERE id = 12
+   );

--- a/susemanager-utils/susemanager-sls/salt/update-salt.sls
+++ b/susemanager-utils/susemanager-sls/salt/update-salt.sls
@@ -1,0 +1,23 @@
+include:
+  - channels
+
+{%- if salt['pillar.get']('contact_method') not in ['ssh-push', 'ssh-push-tunnel'] %}
+mgr_keep_salt_up2date:
+  pkg.latest:
+    - refresh: True
+    - pkgs:
+{%- if salt['pkg.version']('salt-minion') %}
+      - salt-minion
+{%- if grains.os_family == 'Debian' %}
+      - salt-common
+{%- else %}
+      - salt
+      - python3-salt
+{%- endif %}
+{%- endif %}
+{%- if salt['pkg.version']('venv-salt-minion') %}
+      - venv-salt-minion
+{%- endif %}
+    - require:
+      - sls: channels
+{%- endif %}

--- a/susemanager-utils/susemanager-sls/salt/uptodate.sls
+++ b/susemanager-utils/susemanager-sls/salt/uptodate.sls
@@ -40,7 +40,7 @@ mgr_keep_system_up2date_pkgs:
       - sls: channels
       - pkg: mgr_keep_system_up2date_updatestack
 
-{%- if salt['pillar.get']('mgr_reboot_if_needed', True) %}
+{%- if salt['pillar.get']('mgr_reboot_if_needed', True) and salt['pillar.get']('custom_info:mgr_reboot_if_needed', 'true')|lower in ('true', '1', 'yes', 't') %}
 mgr_reboot_if_needed:
   cmd.run:
     - name: shutdown -r +5

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.improve-uptodate
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.improve-uptodate
@@ -1,0 +1,3 @@
+- improve updatestack update in uptodate state
+- add a standalone update-salt state
+- add pillar check to skip reboot_if_needed state


### PR DESCRIPTION
## What does this PR change?

Implement some improvements to update systems via recurring states.

- provide a standalone salt update state
- improve update stack update state
- check pillar to skip reboot_if_needed if not wanted

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Not needed, but added https://github.com/SUSE/spacewalk/issues/23573

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/22483
Ports(s): https://github.com/SUSE/spacewalk/pull/23577

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
