### PR TITLE
Bump Uyuni version in web/conf/rhn_web.conf and check schema migration paths

### DIFF
--- a/schema/reportdb/uyuni-reportdb-schema.changes.raul.bump_uyuni_version_2024.01_and_check_migration_paths
+++ b/schema/reportdb/uyuni-reportdb-schema.changes.raul.bump_uyuni_version_2024.01_and_check_migration_paths
@@ -1,0 +1,1 @@
+- Add missing migration paths to version 5.0.4

--- a/web/conf/rhn_web.conf
+++ b/web/conf/rhn_web.conf
@@ -63,7 +63,7 @@ web.version = 5.0.0 Alpha1
 # the version of Uyuni to show at the WebUI, it will be prepended
 # to web.version as version for the SPECs, when building them
 # for Uyuni
-web.version.uyuni =  2023.12
+web.version.uyuni =  2024.01
 
 web.buildtimestamp = _OBS_BUILD_TIMESTAMP_
 

--- a/web/spacewalk-web.changes.raul.bump_uyuni_version_2024.01_and_check_migration_paths
+++ b/web/spacewalk-web.changes.raul.bump_uyuni_version_2024.01_and_check_migration_paths
@@ -1,0 +1,1 @@
+- Bump the WebUI version to 5.0.4


### PR DESCRIPTION
Bump Uyuni version in web/conf/rhn_web.conf and check schema migration paths

## What does this PR change?

Bump Uyuni version in web/conf/rhn_web.conf and check schema migration paths:

```
raul@mordor:~/Documentos/gh-repos/git-repos-initial-clone/spacewalk_initial_clone/spacewalk (bump_uyuni_version_2024.01_and_check_migration_paths *$)$ grep Version schema/spacewalk/susemanager-schema.spec 
# license that conforms to the Open Source Definition (Version 1.9)
Version:        5.0.3
raul@mordor:~/Documentos/gh-repos/git-repos-initial-clone/spacewalk_initial_clone/spacewalk (bump_uyuni_version_2024.01_and_check_migration_paths *$)$ ls -ld schema/spacewalk/upgrade/susemanager-schema-5.0.3-to-susemanager-schema-5.0.4/
drwxr-xr-x 1 raul raul 86 ene 26 08:55 schema/spacewalk/upgrade/susemanager-schema-5.0.3-to-susemanager-schema-5.0.4/
raul@mordor:~/Documentos/gh-repos/git-repos-initial-clone/spacewalk_initial_clone/spacewalk (bump_uyuni_version_2024.01_and_check_migration_paths *$)$ ls -ld schema/spacewalk/upgrade/susemanager-schema-4.3.24-to-susemanager-schema-4.4.0/
drwxr-xr-x 1 raul raul 16 ene 26 08:55 schema/spacewalk/upgrade/susemanager-schema-4.3.24-to-susemanager-schema-4.4.0/

raul@mordor:~/Documentos/gh-repos/git-repos-initial-clone/spacewalk_initial_clone/spacewalk (bump_uyuni_version_2024.01_and_check_migration_paths *$)$ grep Version schema/reportdb/uyuni-reportdb-schema.spec 
# license that conforms to the Open Source Definition (Version 1.9)
Version:        5.0.3
raul@mordor:~/Documentos/gh-repos/git-repos-initial-clone/spacewalk_initial_clone/spacewalk (bump_uyuni_version_2024.01_and_check_migration_paths *$%)$ ls -ld schema/reportdb/upgrade/uyuni-reportdb-schema-4.3.9-to-uyuni-reportdb-schema-4.4.0
drwxr-xr-x 1 raul raul 16 ene 26 08:55 schema/reportdb/upgrade/uyuni-reportdb-schema-4.3.9-to-uyuni-reportdb-schema-4.4.0

```

## GUI diff

Before: 2023.12 in login page of web UI

After: 2024.01 instead

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Issue(s): #
Ports(s): # **add downstream PR(s), if any**
Related: [#2024.02 Uyuni release](https://github.com/SUSE/spacewalk/issues/23410)

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
